### PR TITLE
Fix - #203 - Remove search from input bar

### DIFF
--- a/src/com/duckduckgo/mobile/android/activity/DuckDuckGo.java
+++ b/src/com/duckduckgo/mobile/android/activity/DuckDuckGo.java
@@ -241,7 +241,7 @@ public class DuckDuckGo extends AppCompatActivity {
                     if(getSearchField().getTrimmedText()!=null && getSearchField().getTrimmedText().length()!=0) {
                         searchOrGoToUrl(getSearchField().getTrimmedText());
 
-                        if(DDGControlVar.useExternalBrowser == DDGConstants.ALWAYS_EXTERNAL) {
+                        if(DDGControlVar.useExternalBrowser == DDGConstants.ALWAYS_EXTERNAL && !PreferencesManager.getRecordHistory()) {
                             DDGActionBarManager.getInstance().clearSearchBar();
                         }
                     }

--- a/src/com/duckduckgo/mobile/android/activity/DuckDuckGo.java
+++ b/src/com/duckduckgo/mobile/android/activity/DuckDuckGo.java
@@ -240,6 +240,10 @@ public class DuckDuckGo extends AppCompatActivity {
                 if(textView == getSearchField() && actionId != EditorInfo.IME_NULL) {
                     if(getSearchField().getTrimmedText()!=null && getSearchField().getTrimmedText().length()!=0) {
                         searchOrGoToUrl(getSearchField().getTrimmedText());
+
+                        if(DDGControlVar.useExternalBrowser == DDGConstants.ALWAYS_EXTERNAL) {
+                            DDGActionBarManager.getInstance().clearSearchBar();
+                        }
                     }
                 }
                 return false;


### PR DESCRIPTION
It is a Simple Fix to remove Search Term from Edit Text[DDGActionBarManager] When the result is opened in an External Browser.