### PR TITLE
(#216) Fix general info link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ We are excited that you want to help make DuckDuckGo Search & Stories better. So
 ## Additional Resources
 
 * [Issues](https://github.com/duckduckgo/android/issues)
-* [General info](http://help.dukgo.com/customer/portal/articles/378777-contributing)
+* [General info](https://duck.co/help/community/contributing)
 * [Chat](https://dukgo.com/blog/using-pidgin-with-xmpp-jabber)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
 * [General GitHub documentation](http://help.github.com/)


### PR DESCRIPTION
The earlier 'General info' link in contributing.md redirects to search results. This commit sets that to the right url.