### PR TITLE
SSLCertificateDialog: add license lines to code from Android

### DIFF
--- a/src/com/duckduckgo/mobile/android/dialogs/SSLCertificateDialog.java
+++ b/src/com/duckduckgo/mobile/android/dialogs/SSLCertificateDialog.java
@@ -1,5 +1,25 @@
 package com.duckduckgo.mobile.android.dialogs;
 
+/*
+ * This class is the implementation of a SSL certificate dialog.
+ *
+ * The file contains code from the Android project.
+ *
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import java.util.Date;
 
 import android.app.AlertDialog.Builder;


### PR DESCRIPTION
Add license text to file SSLCertificateDialog.java containing code from Android project.

The code from Android may be copyrightable or close enough arguments can be made, so I added its license to the file.

I checked out a branch from master since this is a quick fix.