### PR TITLE
(#245) Clearing cookies/cache doesn't clear local storage - privacy r…

### DIFF
--- a/src/com/duckduckgo/mobile/android/activity/DuckDuckGo.java
+++ b/src/com/duckduckgo/mobile/android/activity/DuckDuckGo.java
@@ -19,6 +19,7 @@ import android.text.TextWatcher;
 import android.util.Log;
 import android.view.*;
 import android.view.inputmethod.EditorInfo;
+import android.webkit.WebStorage;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -1158,6 +1159,11 @@ public class DuckDuckGo extends AppCompatActivity {
             default:
                 break;
         }
+    }
+
+    @Subscribe
+    public void onWebViewClearCacheEvent(WebViewClearCacheEvent event){
+        WebStorage.getInstance().deleteAllData();
     }
 
     @Subscribe


### PR DESCRIPTION
…isk.

(#245) Clearing cookies/cache doesn't clear local storage - privacy
risk.

Without this patch applied the application was not able to delete web
storage database. As mentioned in the bug it leaves a security risk for
the user. This patch fixes the problem by deleting Application Cache,
Web SQL Database and the HTML5 Web Storage APIs when clear cache is
clicked.

Problem Cause :- when user clicks clear cache in settings callback is
passed to "onConfirmDialogOkEvent"" but there there was no active
listener for "WebViewClearCacheEvent" (because WebFragment is still in
stopped state) hence clear cache was ignored completely.

Problem Measure :- Added "onWebViewClearCacheEvent" and called
Webstorage.deleteAllData() to remove cahces and Web DB. This fixed the
problem.