### PR TITLE
Show "... type URL"

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="AppName">DuckDuckGo</string>
-    <string name="SearchString">Search DuckDuckGo</string>
+    <string name="SearchStringSmall">Search DDG or type URL</string>
+    <string name="SearchStringBig">Search DuckDuckGo or type URL</string>
     <string name="SettingsButtonContentDescription">Settings</string>
     <string name="HomeButtonContentDescription">Home</string>
     

--- a/src/com/duckduckgo/mobile/android/activity/DuckDuckGo.java
+++ b/src/com/duckduckgo/mobile/android/activity/DuckDuckGo.java
@@ -16,6 +16,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.*;
 import android.view.inputmethod.EditorInfo;
@@ -118,6 +119,7 @@ public class DuckDuckGo extends AppCompatActivity {
 	private FragmentManager fragmentManager;
 
     private Toolbar toolbar;
+	private DDGAutoCompleteTextView searchEditText;
 
 	private SharedPreferences sharedPreferences;
 		
@@ -173,6 +175,18 @@ public class DuckDuckGo extends AppCompatActivity {
         getWindow().getDecorView().setBackgroundColor(getResources().getColor(R.color.background));
         
         DDGUtils.displayStats = new DisplayStats(this);
+	    
+	//Dynamic Search Hint based on screen width
+        //Get Search box
+        searchEditText = (DDGAutoCompleteTextView) findViewById(R.id.searchEditText);
+        //Get screen width in pixels
+        DisplayMetrics displaymetrics = new DisplayMetrics();
+        getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
+        //Set Search Hint
+        if (displaymetrics.widthPixels < 480)   //Minimum size for full display
+            searchEditText.setHint(R.string.SearchStringSmall); //DDG
+        else
+            searchEditText.setHint(R.string.SearchStringBig);   //DuckDuckGo
 
         if(savedInstanceState != null)
         	savedState = true;


### PR DESCRIPTION
Change the ActionBar hint to **Search DuckDuckGo or type URL** when wide enough or **Search DDG or type URL**

- Because direct typing of URL works, as in a browser; lets the user know