### PR TITLE
Move ACRA activity definition to release variant only

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,11 +26,6 @@
             </intent-filter>
         </activity>
 
-        <activity
-            android:name="org.acra.dialog.CrashReportDialog"
-            tools:replace="android:theme"
-            android:theme="@style/CrashReportingDialogStyle" />
-
     </application>
 
 </manifest>

--- a/app/src/release/AndroidManifest.xml
+++ b/app/src/release/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2017 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest package="com.duckduckgo.app.browser"
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+
+    <application tools:ignore="GoogleAppIndexingWarning">
+
+        <activity
+            android:name="org.acra.dialog.CrashReportDialog"
+            tools:replace="android:theme"
+            android:theme="@style/CrashReportingDialogStyle" />
+
+    </application>
+
+</manifest>


### PR DESCRIPTION
Asana Issue URL: n/a

## Description
Noticed that the tools were (rightly) complaining about the definition of the crash reporting activity for DEBUG builds; it is only defined as a `RELEASE` dependency.

This PR moves the definition into a separate RELEASE-only manifest which is merged in during RELEASE builds.

## Steps to Test this PR:
1. Set build variant to `debug`
1. Open the `AndroidManifest.xml`
1. Ensure in the `merged manifest` tab, you **don't** see the ACRA activity

1. Set build variant to `release`
1. Open the `AndroidManifest.xml`
1. Ensure in the `merged manifest` tab, you **do** see the ACRA activity