### PR TITLE
Add earlier attempt to dismiss keyboard to make activity transition nice

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -264,6 +264,7 @@ class BrowserActivity : DuckDuckGoActivity() {
     private fun clearViewPriorToAnimation() {
         acceptingRenderUpdates = false
         urlInput.text.clear()
+        urlInput.hideKeyboard()
         webView.hide()
     }
 


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/471012189846020/490474714901190

## Description
Attempt at making the back animation nicer by explicitly dismissing the keyboard sooner.


## Steps to Test this PR:
1. From landing page, goto search view
1. When the keyboard is showing, hit the back button to dismiss the keyboard
1. See if the animation is nice