### PR TITLE
Allow omnibar queries to be submitted with the "enter" key

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -23,10 +23,11 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
+import android.view.KeyEvent.KEYCODE_ENTER
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.EditorInfo.IME_ACTION_DONE
 import android.webkit.WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
 import android.widget.TextView
 import com.duckduckgo.app.browser.BrowserViewModel.NavigationCommand.LANDING_PAGE
@@ -188,8 +189,8 @@ class BrowserActivity : DuckDuckGoActivity() {
 
         viewModel.registerWebViewListener(webViewClient, webChromeClient)
 
-        urlInput.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, _ ->
-            if (actionId == EditorInfo.IME_ACTION_DONE) {
+        urlInput.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, keyEvent ->
+            if (actionId == IME_ACTION_DONE || keyEvent.keyCode == KEYCODE_ENTER) {
                 userEnteredQuery()
                 return@OnEditorActionListener true
             }


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/488551667048375/497618874776656

## Description
Previously a user needed to tap the done button to submit a query. Pressing enter on a keyboard (as may happen when debugging on an emulator) did not work


## Steps to Test this PR:
1. Run the app on an emulator
1. Enter a search term in the omnibar
1. Press the computer's keyboard "enter" key to submit the query