### PR TITLE
Fix crash when long pressing omnibar text

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -99,14 +99,14 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenViewModelNotifiedThatUrlFocusChangedGotFocusThenViewStateIsUpdated() {
-        testee.urlFocusChanged(true)
+    fun whenViewModelNotifiedThatUrlGotFocusThenViewStateIsUpdated() {
+        testee.onUrlInputStateChanged("", true)
         assertTrue(testee.viewState.value!!.isEditing)
     }
 
     @Test
-    fun whenViewModelNotifiedThatUrlFocusChangedLostFocusThenViewStateIsUpdated() {
-        testee.urlFocusChanged(false)
+    fun whenViewModelNotifiedThatUrlLostFocusThenViewStateIsUpdated() {
+        testee.onUrlInputStateChanged("", false)
         assertFalse(testee.viewState.value!!.isEditing)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -110,13 +110,17 @@ class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private fun showClearButton() {
-        clearUrlButton.show()
-        urlInput.updatePadding(paddingEnd = 40.toPx())
+        urlInput.post {
+            clearUrlButton.show()
+            urlInput.updatePadding(paddingEnd = 40.toPx())
+        }
     }
 
     private fun hideClearButton() {
-        clearUrlButton.hide()
-        urlInput.updatePadding(paddingEnd = 10.toPx())
+        urlInput.post {
+            clearUrlButton.hide()
+            urlInput.updatePadding(paddingEnd = 10.toPx())
+        }
     }
 
     private fun shouldUpdateUrl(viewState: BrowserViewModel.ViewState, url: String?) =
@@ -131,17 +135,13 @@ class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private fun configureUrlInput() {
-        urlInput.onFocusChangeListener = View.OnFocusChangeListener { _: View, hasFocus: Boolean ->
-            viewModel.urlFocusChanged(hasFocus)
-
-            if (hasFocus) {
-                viewModel.onUrlInputValueChanged(urlInput.text.toString(), urlInput.hasFocus())
-            }
+        urlInput.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus: Boolean ->
+            viewModel.onUrlInputStateChanged(urlInput.text.toString(), hasFocus)
         }
 
         urlInput.addTextChangedListener(object : TextChangedWatcher() {
             override fun afterTextChanged(editable: Editable) {
-                viewModel.onUrlInputValueChanged(urlInput.text.toString(), urlInput.hasFocus())
+                viewModel.onUrlInputStateChanged(urlInput.text.toString(), urlInput.hasFocus())
             }
         })
 
@@ -151,12 +151,6 @@ class BrowserActivity : DuckDuckGoActivity() {
                 return viewModel.userDismissedKeyboard()
             }
         }
-
-        urlInput.addTextChangedListener(object : TextChangedWatcher() {
-            override fun afterTextChanged(editable: Editable) {
-                viewModel.onUrlInputValueChanged(urlInput.text.toString(), urlInput.hasFocus())
-            }
-        })
 
         clearUrlButton.setOnClickListener { urlInput.setText("") }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -127,16 +127,7 @@ class BrowserViewModel(
 
     private fun currentViewState(): ViewState = viewState.value!!
 
-
-    fun urlFocusChanged(hasFocus: Boolean) {
-        if (!hasFocus) {
-            viewState.value = currentViewState().copy(isEditing = hasFocus, showClearButton = false)
-        } else {
-            viewState.value = currentViewState().copy(isEditing = hasFocus)
-        }
-    }
-
-    fun onUrlInputValueChanged(query: String, hasFocus: Boolean) {
+    fun onUrlInputStateChanged(query: String, hasFocus: Boolean) {
         val showClearButton = hasFocus && query.isNotEmpty()
         viewState.value = currentViewState().copy(isEditing = hasFocus, showClearButton = showClearButton)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
@@ -39,12 +39,7 @@ class KeyboardAwareEditText : AppCompatEditText {
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
 
         if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
-
-            if (onBackKeyListener != null) {
-                return onBackKeyListener!!.onBackKey()
-            }
-
-            return false
+            return onBackKeyListener?.onBackKey() ?: false
         }
 
         return super.onKeyPreIme(keyCode, event)
@@ -53,10 +48,10 @@ class KeyboardAwareEditText : AppCompatEditText {
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         super.onLayout(changed, left, top, right, bottom)
         if (showImeAfterFirstLayout) {
-            post({
+            post {
                 showKeyboard()
                 showImeAfterFirstLayout = false
-            })
+            }
         }
     }
 


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/488551667048375/498315314295393

## Description
Previously when long pressing text in the omnibar a crash occurred. 


## Steps to Test this PR:
1. Navigate to a webpage
1. Once it has finished loading, long press on the text in the omnibar. Be sure to long press the text itself, not just the text field.
1. The app should no longer crash