### PR TITLE
Update maxcdn to stackpath

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/model/TrackerNetworks.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/model/TrackerNetworks.kt
@@ -36,7 +36,7 @@ class TrackerNetworks @Inject constructor() : Serializable {
                 TrackerNetwork("oracle", "oracle.com", 10, true),
                 TrackerNetwork("mediamath", "mediamath.com", 9, true),
                 TrackerNetwork("yahoo", "yahoo.com", 9, true),
-                TrackerNetwork("maxcdn", "maxcdn.com", 7, true),
+                TrackerNetwork("stackpath", "stackpath.com", 7, true),
                 TrackerNetwork("automattic", "automattic.com", 7, true)
         )
     }


### PR DESCRIPTION
Asana Issue URL: 
https://app.asana.com/0/inbox/361428290920650/504059114070396/503772744089477

## Description
Updates the maxcdn major tracker network entry (which currently does nothing) to stackpath to match upcoming changes to the disconnect list

## Steps to Test this PR:
We are still waiting on the server change for this. You can test it by pointing to my version of the json file. In TrackerListService.kt change the disconnect url entry to
`@GET("https://raw.githubusercontent.com/subsymbolic/disconnect-tracking-protection/f91c29eece76d889cfee9b2e2aaaae4f77f5b91a/services.json")`

1. Visit http://www.truthorfiction.com
1. Open the privacy dashboard
1. Note that there are now two major networks