### PR TITLE
Add privacy grade to omnibar

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -165,14 +165,25 @@ class BrowserViewModelTest {
 
     @Test
     fun whenUrlChangedThenPrivacyGradeIsReset() {
-        testee.urlChanged("https://test.com")
+        testee.urlChanged("https://example.com")
         assertEquals(PrivacyGrade.B, testee.viewState.value!!.privacyGrade)
     }
 
     @Test
     fun whenTrackerDetectedThenPrivacyGradeIsUpdated() {
-        testee.urlChanged("https://test.com")
-        testee.trackerDetected(TrackingEvent("", "", null, true))
+        testee.urlChanged("https://example.com")
+        testee.trackerDetected(TrackingEvent("", "", null, false))
         assertEquals(PrivacyGrade.C, testee.viewState.value!!.privacyGrade)
+    }
+
+    @Test
+    fun whenInitialisedThenPrivacyGradeIsNotShown() {
+        assertFalse(testee.viewState.value!!.showPrivacyGrade)
+    }
+
+    @Test
+    fun whenUrlUpdatedThenPrivacyGradeIsShown() {
+        testee.urlChanged((""))
+        assertTrue(testee.viewState.value!!.showPrivacyGrade)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -20,11 +20,12 @@ import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
 import android.net.Uri
 import com.duckduckgo.app.browser.BrowserViewModel.NavigationCommand
-import com.duckduckgo.app.browser.BrowserViewModel.ViewState
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
+import com.duckduckgo.app.privacymonitor.model.PrivacyGrade
 import com.duckduckgo.app.privacymonitor.store.PrivacyMonitorRepository
 import com.duckduckgo.app.privacymonitor.store.TermsOfServiceStore
 import com.duckduckgo.app.trackerdetection.model.TrackerNetworks
+import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.nhaarman.mockito_kotlin.mock
 import org.junit.After
 import org.junit.Assert.*
@@ -41,7 +42,6 @@ class BrowserViewModelTest {
     @Suppress("unused")
     var instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    private lateinit var viewStateObserver: Observer<ViewState>
     private lateinit var queryObserver: Observer<String>
     private lateinit var navigationObserver: Observer<NavigationCommand>
     private lateinit var termsOfServiceStore: TermsOfServiceStore
@@ -55,20 +55,17 @@ class BrowserViewModelTest {
 
     @Before
     fun before() {
-        viewStateObserver = mock()
         queryObserver = mock()
         navigationObserver = mock()
         termsOfServiceStore = mock()
         testee = BrowserViewModel(testOmnibarConverter, DuckDuckGoUrlDetector(), termsOfServiceStore, TrackerNetworks(), PrivacyMonitorRepository())
         testee.query.observeForever(queryObserver)
-        testee.viewState.observeForever(viewStateObserver)
         testee.navigation.observeForever(navigationObserver)
     }
 
     @After
     fun after() {
         testee.query.removeObserver(queryObserver)
-        testee.viewState.removeObserver(viewStateObserver)
         testee.navigation.removeObserver(navigationObserver)
     }
 
@@ -158,5 +155,24 @@ class BrowserViewModelTest {
     fun whenUserDismissesKeyboardAfterBrowserShownThenShouldNotConsumeBackButtonEvent() {
         testee.urlChanged("")
         assertFalse(testee.userDismissedKeyboard())
+    }
+
+    @Test
+    fun whenLoadingStartedThenPrivacyGradeIsCleared() {
+        testee.loadingStarted()
+        assertNull(testee.viewState.value!!.privacyGrade)
+    }
+
+    @Test
+    fun whenUrlChangedThenPrivacyGradeIsReset() {
+        testee.urlChanged("https://test.com")
+        assertEquals(PrivacyGrade.B, testee.viewState.value!!.privacyGrade)
+    }
+
+    @Test
+    fun whenTrackerDetectedThenPrivacyGradeIsUpdated() {
+        testee.urlChanged("https://test.com")
+        testee.trackerDetected(TrackingEvent("", "", null, true))
+        assertEquals(PrivacyGrade.C, testee.viewState.value!!.privacyGrade)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModelTest.kt
@@ -130,7 +130,6 @@ class PrivacyDashboardViewModelTest {
         whenever(settingStore.privacyOn).thenReturn(false)
         val monitor = monitor()
         whenever(monitor.allTrackersBlocked).thenReturn(false)
-        whenever(monitor.majorNetworkCount).thenReturn(2)
         testee.onPrivacyMonitorChanged(monitor)
         assertEquals(getStringResource(R.string.privacyProtectionDisabled), testee.viewState.value?.heading)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -35,6 +35,8 @@ import com.duckduckgo.app.browser.omnibar.OnBackKeyListener
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.*
+import com.duckduckgo.app.privacymonitor.model.PrivacyGrade
+import com.duckduckgo.app.privacymonitor.model.PrivacyGrade.Companion.Grade
 import com.duckduckgo.app.privacymonitor.ui.PrivacyDashboardActivity
 import com.duckduckgo.app.privacymonitor.ui.PrivacyDashboardActivity.Companion.REQUEST_DASHBOARD
 import com.duckduckgo.app.privacymonitor.ui.PrivacyDashboardActivity.Companion.RESULT_RELOAD
@@ -110,6 +112,8 @@ class BrowserActivity : DuckDuckGoActivity() {
             true -> showClearButton()
             false -> hideClearButton()
         }
+
+        updatePrivacyGrade(viewState.privacyGrade)
     }
 
     private fun showClearButton() {
@@ -124,6 +128,17 @@ class BrowserActivity : DuckDuckGoActivity() {
             clearUrlButton.hide()
             urlInput.updatePadding(paddingEnd = 10.toPx())
         }
+    }
+
+    private fun updatePrivacyGrade(@Grade privacyGrade: Long?) {
+        val resource = when (privacyGrade) {
+            PrivacyGrade.A -> R.drawable.privacygrade_icon_a
+            PrivacyGrade.B -> R.drawable.privacygrade_icon_b
+            PrivacyGrade.C -> R.drawable.privacygrade_icon_c
+            PrivacyGrade.D -> R.drawable.privacygrade_icon_d
+            else -> R.drawable.privacygrade_icon_unknown
+        }
+        toolbar.menu.findItem(R.id.privacy_dashboard)?.icon = getDrawable(resource)
     }
 
     private fun shouldUpdateUrl(viewState: BrowserViewModel.ViewState, url: String?) =

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -113,7 +113,7 @@ class BrowserActivity : DuckDuckGoActivity() {
             false -> hideClearButton()
         }
 
-        updatePrivacyGrade(viewState.privacyGrade)
+        updatePrivacyGrade(viewState.privacyGrade, viewState.showPrivacyGrade)
     }
 
     private fun showClearButton() {
@@ -130,7 +130,7 @@ class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun updatePrivacyGrade(@Grade privacyGrade: Long?) {
+    private fun updatePrivacyGrade(@Grade privacyGrade: Long?, show: Boolean) {
         val resource = when (privacyGrade) {
             PrivacyGrade.A -> R.drawable.privacygrade_icon_a
             PrivacyGrade.B -> R.drawable.privacygrade_icon_b
@@ -138,7 +138,9 @@ class BrowserActivity : DuckDuckGoActivity() {
             PrivacyGrade.D -> R.drawable.privacygrade_icon_d
             else -> R.drawable.privacygrade_icon_unknown
         }
-        toolbar.menu.findItem(R.id.privacy_dashboard)?.icon = getDrawable(resource)
+        val menuItem = toolbar.menu.findItem(R.id.privacy_dashboard)
+        menuItem?.icon = getDrawable(resource)
+        menuItem?.isVisible = show
     }
 
     private fun shouldUpdateUrl(viewState: BrowserViewModel.ViewState, url: String?) =

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -21,9 +21,11 @@ import android.arch.lifecycle.ViewModel
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.privacymonitor.SiteMonitor
+import com.duckduckgo.app.privacymonitor.model.PrivacyGrade.Companion.Grade
 import com.duckduckgo.app.privacymonitor.model.TermsOfService
 import com.duckduckgo.app.privacymonitor.store.PrivacyMonitorRepository
 import com.duckduckgo.app.privacymonitor.store.TermsOfServiceStore
+import com.duckduckgo.app.privacymonitor.ui.improvedGrade
 import com.duckduckgo.app.trackerdetection.model.TrackerNetworks
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import timber.log.Timber
@@ -42,7 +44,8 @@ class BrowserViewModel(
             val url: String? = null,
             val isEditing: Boolean = false,
             val browserShowing: Boolean = false,
-            val showClearButton: Boolean = false
+            val showClearButton: Boolean = false,
+            @Grade val privacyGrade: Long? = null
     )
 
     /* Observable data for Activity to subscribe to */
@@ -94,7 +97,7 @@ class BrowserViewModel(
         Timber.v("Loading started")
         viewState.value = currentViewState().copy(isLoading = true)
         siteMonitor = null
-        postSiteMonitor()
+        onSiteMonitorChanged()
     }
 
     override fun loadingFinished() {
@@ -113,21 +116,22 @@ class BrowserViewModel(
         if (url != null) {
             val terms = termsOfServiceStore.retrieveTerms(url) ?: TermsOfService()
             siteMonitor = SiteMonitor(url, terms, trackerNetworks)
-            postSiteMonitor()
+            onSiteMonitorChanged()
         }
     }
 
     override fun trackerDetected(event: TrackingEvent) {
         siteMonitor?.trackerDetected(event)
-        postSiteMonitor()
+        onSiteMonitorChanged()
     }
 
     override fun pageHasHttpResources() {
         siteMonitor?.hasHttpResources = true
-        postSiteMonitor()
+        onSiteMonitorChanged()
     }
 
-    private fun postSiteMonitor() {
+    private fun onSiteMonitorChanged() {
+        viewState.postValue(currentViewState().copy(privacyGrade = siteMonitor?.improvedGrade))
         privacyMonitorRepository.privacyMonitor.postValue(siteMonitor)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -45,7 +45,8 @@ class BrowserViewModel(
             val isEditing: Boolean = false,
             val browserShowing: Boolean = false,
             val showClearButton: Boolean = false,
-            @Grade val privacyGrade: Long? = null
+            @Grade val privacyGrade: Long? = null,
+            val showPrivacyGrade: Boolean = false
     )
 
     /* Observable data for Activity to subscribe to */
@@ -107,7 +108,7 @@ class BrowserViewModel(
 
     override fun urlChanged(url: String?) {
         Timber.v("Url changed: $url")
-        var newViewState = currentViewState().copy(url = url, browserShowing = true)
+        var newViewState = currentViewState().copy(url = url, browserShowing = true, showPrivacyGrade = true)
 
         if (duckDuckGoUrlDetector.isDuckDuckGoUrl(url)) {
             newViewState = newViewState.copy(url = lastQuery)

--- a/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModel.kt
@@ -89,7 +89,7 @@ class PrivacyDashboardViewModel(private val context: Context,
     private fun updatePrivacyMonitor(monitor: PrivacyMonitor) {
         this.monitor = monitor
         viewState.value = viewState.value?.copy(
-                privacyBanner = privacyBanner(),
+                privacyBanner = privacyBanner(monitor.improvedGrade),
                 domain = monitor.uri?.host ?: "",
                 heading = headingText(),
                 httpsIcon = httpsIcon(monitor.https),
@@ -108,7 +108,7 @@ class PrivacyDashboardViewModel(private val context: Context,
             settingsStore.privacyOn = enabled
             viewState.value = viewState.value?.copy(
                     heading = headingText(),
-                    privacyBanner = privacyBanner(),
+                    privacyBanner = privacyBanner(monitor?.improvedGrade),
                     toggleEnabled = enabled
             )
         }
@@ -116,7 +116,7 @@ class PrivacyDashboardViewModel(private val context: Context,
 
     private fun headingText(): String {
         val monitor = monitor
-        if (monitor != null && monitor.allTrackersBlocked) {
+        if (monitor != null) {
             val before = monitor.grade
             val after = monitor.improvedGrade
             if (before != after) {
@@ -125,15 +125,6 @@ class PrivacyDashboardViewModel(private val context: Context,
         }
         val resource = if (settingsStore.privacyOn) R.string.privacyProtectionEnabled else R.string.privacyProtectionDisabled
         return context.getString(resource)
-    }
-
-    @DrawableRes
-    private fun privacyBanner(): Int {
-        val monitor = monitor ?: return R.drawable.privacygrade_banner_unknown
-        if (monitor.allTrackersBlocked) {
-            return privacyBanner(monitor.improvedGrade)
-        }
-        return privacyBanner(monitor.grade)
     }
 
     private fun privacyBanner(grade: Long?): Int {

--- a/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyMonitorGradeExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyMonitorGradeExtension.kt
@@ -35,7 +35,7 @@ val PrivacyMonitor.score: Int
         return score
     }
 
-val PrivacyMonitor.improvedScore: Int
+val PrivacyMonitor.potentialScore: Int
     get() = baseScore
 
 
@@ -50,13 +50,26 @@ private val PrivacyMonitor.baseScore: Int
         return score
     }
 
+val PrivacyMonitor.improvedScore: Int
+    get() {
+        if (allTrackersBlocked) {
+            return potentialScore
+        }
+        return score
+    }
+
 @PrivacyGrade.Companion.Grade
 val PrivacyMonitor.grade: Long
     get() = calculateGrade(score)
 
 @PrivacyGrade.Companion.Grade
+val PrivacyMonitor.potentialGrade: Long
+    get() = calculateGrade(potentialScore)
+
+@PrivacyGrade.Companion.Grade
 val PrivacyMonitor.improvedGrade: Long
     get() = calculateGrade(improvedScore)
+
 
 @PrivacyGrade.Companion.Grade
 private fun calculateGrade(score: Int): Long {

--- a/app/src/main/res/drawable/privacygrade_icon_a.xml
+++ b/app/src/main/res/drawable/privacygrade_icon_a.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2017 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="22dp"
+        android:height="22dp"
+        android:viewportWidth="22.0"
+        android:viewportHeight="22.0">
+    <path
+        android:pathData="M9.74,12.305h2.52l-1.25,-3.74z"
+        android:fillType="nonZero"
+        android:fillColor="#A7A8AB"/>
+    <path
+        android:pathData="M11,0C4.925,0 0,4.925 0,11s4.925,11 11,11 11,-4.925 11,-11A11,11 0,0 0,11 0zM13.45,15.965l-0.5,-1.43L9.045,14.535l-0.5,1.43L5.65,15.965l3.735,-9.93h3.23l3.735,9.93h-2.9z"
+        android:fillType="nonZero"
+        android:fillColor="#A7A8AB"/>
+</vector>

--- a/app/src/main/res/drawable/privacygrade_icon_b.xml
+++ b/app/src/main/res/drawable/privacygrade_icon_b.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2017 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="22dp"
+        android:height="22dp"
+        android:viewportWidth="22.0"
+        android:viewportHeight="22.0">
+    <path
+        android:pathData="M12.77,9.045a0.78,0.78 0,0 0,-0.875 -0.775h-2.5v1.545h2.5a0.77,0.77 0,0 0,0.875 -0.77zM12,12.05H9.405v1.68H12c0.615,0 1,-0.31 1,-0.845 0,-0.535 -0.39,-0.835 -1,-0.835z"
+        android:fillType="nonZero"
+        android:fillColor="#A7A8AB"/>
+    <path
+        android:pathData="M11,0C4.925,0 0,4.925 0,11s4.925,11 11,11 11,-4.925 11,-11A11,11 0,0 0,11 0zM12.65,15.965L6.845,15.965v-9.93L12.5,6.035c2,0 2.9,1.28 2.9,2.53a2.225,2.225 0,0 1,-1.695 2.28,2.375 2.375,0 0,1 1.89,2.425c-0.025,1.445 -0.995,2.695 -2.945,2.695z"
+        android:fillType="nonZero"
+        android:fillColor="#A7A8AB"/>
+</vector>

--- a/app/src/main/res/drawable/privacygrade_icon_c.xml
+++ b/app/src/main/res/drawable/privacygrade_icon_c.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2017 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="22dp"
+        android:height="22dp"
+        android:viewportWidth="22.0"
+        android:viewportHeight="22.0">
+    <path
+        android:pathData="M11,0C4.925,0 0,4.925 0,11s4.925,11 11,11 11,-4.925 11,-11A11,11 0,0 0,11 0zM11.5,13.875a2.385,2.385 0,0 0,2.13 -1.445l2.205,1.04a4.65,4.65 0,0 1,-4.335 2.665c-3.05,0 -5.375,-2.085 -5.375,-5.135S8.47,5.865 11.5,5.865A4.59,4.59 0,0 1,15.855 8.5L13.65,9.57a2.385,2.385 0,0 0,-2.15 -1.445A2.74,2.74 0,0 0,8.75 11a2.75,2.75 0,0 0,2.75 2.875z"
+        android:fillType="nonZero"
+        android:fillColor="#A7A8AB"/>
+</vector>

--- a/app/src/main/res/drawable/privacygrade_icon_d.xml
+++ b/app/src/main/res/drawable/privacygrade_icon_d.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2017 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="22dp"
+        android:height="22dp"
+        android:viewportWidth="22.0"
+        android:viewportHeight="22.0">
+    <path
+        android:pathData="M10.87,8.27H9.25v5.46h1.605A2.64,2.64 0,0 0,13.61 11a2.54,2.54 0,0 0,-2.74 -2.73z"
+        android:fillType="nonZero"
+        android:fillColor="#A7A8AB"/>
+    <path
+        android:pathData="M11,0C4.925,0 0,4.925 0,11s4.925,11 11,11 11,-4.925 11,-11A11,11 0,0 0,11 0zM10.87,15.965L6.69,15.965v-9.93h4.165c3.125,0 5.375,1.875 5.375,4.955s-2.23,4.975 -5.36,4.975z"
+        android:fillType="nonZero"
+        android:fillColor="#A7A8AB"/>
+</vector>

--- a/app/src/main/res/menu/menu_browser_activity.xml
+++ b/app/src/main/res/menu/menu_browser_activity.xml
@@ -21,6 +21,7 @@
     <item
         android:id="@+id/privacy_dashboard"
         app:showAsAction="ifRoom"
+        android:visible="false"
         android:icon="@drawable/privacygrade_icon_unknown"
         android:title="@string/privacyDashboard"/>
 


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/488551667048375/500109750623815

## Description
Currently we only show a "?" for the privacy grade as the user browses pages. This PR displays the privacy grade icon.


## Steps to Test this PR:
TEST ONE
1. Visit duckduckgo.com
1. Ensure the privacy toggle is on
1. Note the grade is A

TEST TWO
1. Visit cnn.com
1. Ensure the privacy toggle is on
1. Note that the grade in the omnibar shows an C (the upgraded grade not a D the original grade)
1. Repeat the test again with the toggle off
1. Note the grade is now D