### PR TITLE
Extract query from DDG url (rather than storing the last searched query)

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -101,13 +101,13 @@ class BrowserViewModelTest {
 
     @Test
     fun whenViewModelNotifiedThatUrlGotFocusThenViewStateIsUpdated() {
-        testee.onUrlInputStateChanged("", true)
+        testee.onOmnibarInputStateChanged("", true)
         assertTrue(testee.viewState.value!!.isEditing)
     }
 
     @Test
     fun whenViewModelNotifiedThatUrlLostFocusThenViewStateIsUpdated() {
-        testee.onUrlInputStateChanged("", false)
+        testee.onOmnibarInputStateChanged("", false)
         assertFalse(testee.viewState.value!!.isEditing)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -112,32 +112,32 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenNoUrlEverEnteredThenViewStateHasNull() {
-        assertNull(testee.viewState.value!!.url)
+    fun whenNoOmnibarTextEverEnteredThenViewStateHasNull() {
+        assertNull(testee.viewState.value!!.omnibarText)
     }
 
     @Test
     fun whenUrlChangedThenViewStateIsUpdated() {
         testee.urlChanged("duckduckgo.com")
-        assertEquals("duckduckgo.com", testee.viewState.value!!.url)
+        assertEquals("duckduckgo.com", testee.viewState.value!!.omnibarText)
     }
 
     @Test
     fun whenUrlChangedWithDuckDuckGoUrlContainingQueryThenUrlRewrittenToContainQuery() {
         testee.urlChanged("http://duckduckgo.com?q=test")
-        assertEquals("test", testee.viewState.value!!.url)
+        assertEquals("test", testee.viewState.value!!.omnibarText)
     }
 
     @Test
     fun whenUrlChangedWithDuckDuckGoUrlNotContainingQueryThenFullUrlShown() {
         testee.urlChanged("http://duckduckgo.com")
-        assertEquals("http://duckduckgo.com", testee.viewState.value!!.url)
+        assertEquals("http://duckduckgo.com", testee.viewState.value!!.omnibarText)
     }
 
     @Test
     fun whenUrlChangedWithNonDuckDuckGoUrlThenFullUrlShown() {
         testee.urlChanged("http://example.com")
-        assertEquals("http://example.com", testee.viewState.value!!.url)
+        assertEquals("http://example.com", testee.viewState.value!!.omnibarText)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -123,6 +123,24 @@ class BrowserViewModelTest {
     }
 
     @Test
+    fun whenUrlChangedWithDuckDuckGoUrlContainingQueryThenUrlRewrittenToContainQuery() {
+        testee.urlChanged("http://duckduckgo.com?q=test")
+        assertEquals("test", testee.viewState.value!!.url)
+    }
+
+    @Test
+    fun whenUrlChangedWithDuckDuckGoUrlNotContainingQueryThenFullUrlShown() {
+        testee.urlChanged("http://duckduckgo.com")
+        assertEquals("http://duckduckgo.com", testee.viewState.value!!.url)
+    }
+
+    @Test
+    fun whenUrlChangedWithNonDuckDuckGoUrlThenFullUrlShown() {
+        testee.urlChanged("http://example.com")
+        assertEquals("http://example.com", testee.viewState.value!!.url)
+    }
+
+    @Test
     fun whenViewModelGetsProgressUpdateThenViewStateIsUpdated() {
         testee.progressChanged(0)
         assertEquals(0, testee.viewState.value!!.progress)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
@@ -16,8 +16,7 @@
 
 package com.duckduckgo.app.browser
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 
@@ -43,6 +42,28 @@ class DuckDuckGoUrlDetectorTest {
     @Test
     fun whenCheckingFullDDGUrlThenIdentifiedAsDDGUrl() {
         assertTrue(testee.isDuckDuckGoUrl("https://duckduckgo.com/?q=test%20search&tappv=android_0_2_0&t=ddg_android"))
+    }
+
+    @Test
+    fun whenDDGUrlContainsQueryThenQueryCanBeExtracted() {
+        val query = testee.extractQuery("https://duckduck.com?q=test%20search")
+        assertEquals("test search", query)
+    }
+
+    @Test
+    fun whenDDGUrlDoesNotContainsQueryThenQueryIsNull() {
+        val query = testee.extractQuery("https://duckduck.com")
+        assertNull(query)
+    }
+
+    @Test
+    fun whenDDGUrlContainsQueryThenQueryDetected() {
+        assertTrue(testee.hasQuery("https://duckduck.com?q=test%20search"))
+    }
+
+    @Test
+    fun whenDDGUrlDoesNotContainsQueryThenQueryIsNotDetected() {
+        assertFalse(testee.hasQuery("https://duckduck.com"))
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -79,11 +79,11 @@ class BrowserActivity : DuckDuckGoActivity() {
 
         configureToolbar()
         configureWebView()
-        configureUrlInput()
+        configureOmnibarTextInput()
         configureDummyViewTouchHandler()
 
         if (shouldShowKeyboard()) {
-            urlInput.showKeyboard()
+            omnibarTextInput.showKeyboard()
         }
     }
 
@@ -101,8 +101,8 @@ class BrowserActivity : DuckDuckGoActivity() {
             false -> pageLoadingIndicator.hide()
         }
 
-        if (shouldUpdateUrl(viewState, viewState.url)) {
-            urlInput.setText(viewState.url)
+        if (shouldUpdateOmnibarTextInput(viewState, viewState.omnibarText)) {
+            omnibarTextInput.setText(viewState.omnibarText)
             appBarLayout.setExpanded(true, true)
         }
 
@@ -117,16 +117,16 @@ class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private fun showClearButton() {
-        urlInput.post {
-            clearUrlButton.show()
-            urlInput.updatePadding(paddingEnd = 40.toPx())
+        omnibarTextInput.post {
+            clearOmnibarInputButton.show()
+            omnibarTextInput.updatePadding(paddingEnd = 40.toPx())
         }
     }
 
     private fun hideClearButton() {
-        urlInput.post {
-            clearUrlButton.hide()
-            urlInput.updatePadding(paddingEnd = 10.toPx())
+        omnibarTextInput.post {
+            clearOmnibarInputButton.hide()
+            omnibarTextInput.updatePadding(paddingEnd = 10.toPx())
         }
     }
 
@@ -143,8 +143,8 @@ class BrowserActivity : DuckDuckGoActivity() {
         menuItem?.isVisible = show
     }
 
-    private fun shouldUpdateUrl(viewState: BrowserViewModel.ViewState, url: String?) =
-            viewState.url != null && !viewState.isEditing && urlInput.isDifferent(url)
+    private fun shouldUpdateOmnibarTextInput(viewState: BrowserViewModel.ViewState, omnibarInput: String?) =
+            viewState.omnibarText != null && !viewState.isEditing && omnibarTextInput.isDifferent(omnibarInput)
 
     private fun configureToolbar() {
         setSupportActionBar(toolbar)
@@ -154,30 +154,30 @@ class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun configureUrlInput() {
-        urlInput.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus: Boolean ->
-            viewModel.onUrlInputStateChanged(urlInput.text.toString(), hasFocus)
+    private fun configureOmnibarTextInput() {
+        omnibarTextInput.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus: Boolean ->
+            viewModel.onOmnibarInputStateChanged(omnibarTextInput.text.toString(), hasFocus)
         }
 
-        urlInput.addTextChangedListener(object : TextChangedWatcher() {
+        omnibarTextInput.addTextChangedListener(object : TextChangedWatcher() {
             override fun afterTextChanged(editable: Editable) {
-                viewModel.onUrlInputStateChanged(urlInput.text.toString(), urlInput.hasFocus())
+                viewModel.onOmnibarInputStateChanged(omnibarTextInput.text.toString(), omnibarTextInput.hasFocus())
             }
         })
 
-        urlInput.onBackKeyListener = object : OnBackKeyListener {
+        omnibarTextInput.onBackKeyListener = object : OnBackKeyListener {
             override fun onBackKey(): Boolean {
                 focusDummy.requestFocus()
                 return viewModel.userDismissedKeyboard()
             }
         }
 
-        clearUrlButton.setOnClickListener { urlInput.setText("") }
+        clearOmnibarInputButton.setOnClickListener { omnibarTextInput.setText("") }
     }
 
     private fun userEnteredQuery() {
-        viewModel.onUserSubmittedQuery(urlInput.text.toString())
-        urlInput.hideKeyboard()
+        viewModel.onUserSubmittedQuery(omnibarTextInput.text.toString())
+        omnibarTextInput.hideKeyboard()
         focusDummy.requestFocus()
     }
 
@@ -203,7 +203,7 @@ class BrowserActivity : DuckDuckGoActivity() {
 
         viewModel.registerWebViewListener(webViewClient, webChromeClient)
 
-        urlInput.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, keyEvent ->
+        omnibarTextInput.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, keyEvent ->
             if (actionId == IME_ACTION_DONE || keyEvent.keyCode == KEYCODE_ENTER) {
                 userEnteredQuery()
                 return@OnEditorActionListener true
@@ -287,8 +287,8 @@ class BrowserActivity : DuckDuckGoActivity() {
 
     private fun clearViewPriorToAnimation() {
         acceptingRenderUpdates = false
-        urlInput.text.clear()
-        urlInput.hideKeyboard()
+        omnibarTextInput.text.clear()
+        omnibarTextInput.hideKeyboard()
         webView.hide()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -41,7 +41,7 @@ class BrowserViewModel(
     data class ViewState(
             val isLoading: Boolean = false,
             val progress: Int = 0,
-            val url: String? = null,
+            val omnibarText: String? = null,
             val isEditing: Boolean = false,
             val browserShowing: Boolean = false,
             val showClearButton: Boolean = false,
@@ -82,7 +82,7 @@ class BrowserViewModel(
             query.value = queryUrlConverter.convertQueryToUri(input).toString()
         }
 
-        viewState.value = currentViewState().copy(showClearButton = false, url = input)
+        viewState.value = currentViewState().copy(showClearButton = false, omnibarText = input)
     }
 
     override fun progressChanged(newProgress: Int) {
@@ -106,10 +106,10 @@ class BrowserViewModel(
         Timber.v("Url changed: $url")
         if (url == null) return
 
-        var newViewState = currentViewState().copy(url = url, browserShowing = true, showPrivacyGrade = true)
+        var newViewState = currentViewState().copy(omnibarText = url, browserShowing = true, showPrivacyGrade = true)
 
         if (duckDuckGoUrlDetector.isDuckDuckGoUrl(url) && duckDuckGoUrlDetector.hasQuery(url)) {
-            newViewState = newViewState.copy(url = duckDuckGoUrlDetector.extractQuery(url))
+            newViewState = newViewState.copy(omnibarText = duckDuckGoUrlDetector.extractQuery(url))
         }
         viewState.value = newViewState
 
@@ -135,7 +135,7 @@ class BrowserViewModel(
 
     private fun currentViewState(): ViewState = viewState.value!!
 
-    fun onUrlInputStateChanged(query: String, hasFocus: Boolean) {
+    fun onOmnibarInputStateChanged(query: String, hasFocus: Boolean) {
         val showClearButton = hasFocus && query.isNotEmpty()
         viewState.value = currentViewState().copy(isEditing = hasFocus, showClearButton = showClearButton)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
@@ -22,15 +22,28 @@ import javax.inject.Inject
 
 class DuckDuckGoUrlDetector @Inject constructor() {
 
-    fun isDuckDuckGoUrl(uri: Uri?): Boolean {
-        if (uri == null) return false
-
+    fun isDuckDuckGoUrl(uri: Uri): Boolean {
         return "duckduckgo.com" == uri.host
     }
 
-    fun isDuckDuckGoUrl(uriString: String?): Boolean {
-        if (uriString == null) return false
+    fun isDuckDuckGoUrl(uriString: String): Boolean {
+        return isDuckDuckGoUrl(uriString.toUri())
+    }
 
-        return isDuckDuckGoUrl(Uri.parse(uriString))
+    fun hasQuery(uriString: String): Boolean {
+        return uriString.toUri().queryParameterNames.contains(queryParameter)
+    }
+
+    fun extractQuery(uriString: String): String? {
+        val uri = uriString.toUri()
+        return uri.getQueryParameter(queryParameter)
+    }
+
+    private companion object {
+        const val queryParameter = "q"
+    }
+
+    private fun String.toUri(): Uri {
+        return Uri.parse(this)
     }
 }

--- a/app/src/main/res/layout/activity_browser.xml
+++ b/app/src/main/res/layout/activity_browser.xml
@@ -56,7 +56,7 @@
                         android:layout_height="match_parent">
 
                         <com.duckduckgo.app.browser.omnibar.KeyboardAwareEditText
-                            android:id="@+id/urlInput"
+                            android:id="@+id/omnibarTextInput"
                             style="@style/Base.V7.Widget.AppCompat.EditText"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
@@ -82,7 +82,7 @@
                             tools:text="https://duckduckgo.com/?q=henr..https://duckduckgo.com/?q=henr.." />
 
                         <ImageView
-                            android:id="@+id/clearUrlButton"
+                            android:id="@+id/clearOmnibarInputButton"
                             android:layout_width="24dp"
                             android:layout_height="24dp"
                             android:layout_marginEnd="6dp"
@@ -92,9 +92,9 @@
                             android:src="@drawable/ic_cancel_24dp"
                             android:tint="#FFF"
                             android:visibility="gone"
-                            app:layout_constraintBottom_toBottomOf="@id/urlInput"
-                            app:layout_constraintEnd_toEndOf="@+id/urlInput"
-                            app:layout_constraintTop_toTopOf="@id/urlInput"
+                            app:layout_constraintBottom_toBottomOf="@id/omnibarTextInput"
+                            app:layout_constraintEnd_toEndOf="@+id/omnibarTextInput"
+                            app:layout_constraintTop_toTopOf="@id/omnibarTextInput"
                             tools:visibility="visible" />
 
                     </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Also, made some parameters non-null to simplify the logic in the DuckDuckGoUrlDetector class. There's only a single place that could have been supplying nulls, so handling that at the original call-site instead.

Asana Issue URL: https://app.asana.com/0/488551667048375/494978153394812

## Description
Fixing a bug where the omnibar would show the previous query erroneously under certain conditions.


## Steps to Test this PR:
1. Enter search query "test search" into omnibar (ensure "test search" is shown in the omnibar bar with the DDG search results page)
1. Enter "duckduckgo.com" (ensure full url containing "https://" is shown)
1. Enter term into the DDG web field; ensure the omnibar shows search query and not full url