### PR TITLE
Add deprecated shouldOverrideUrlLoading implementation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser
 
 import android.graphics.Bitmap
+import android.net.Uri
 import android.support.annotation.AnyThread
 import android.support.annotation.WorkerThread
 import android.webkit.WebResourceRequest
@@ -41,9 +42,29 @@ class BrowserWebViewClient @Inject constructor(
     private var currentUrl: String? = null
 
 
+    /**
+     * This is the new method of url overriding available from API 24 onwards
+     */
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-        if (requestRewriter.shouldRewriteRequest(request)) {
-            val newUri = requestRewriter.rewriteRequestWithCustomQueryParams(request.url)
+        val url = request.url
+        return shouldOverride(view, url)
+    }
+
+    /**
+     * * This is the old, deprecated method of url overriding available until API 23
+     */
+    @Suppress("OverridingDeprecatedMember")
+    override fun shouldOverrideUrlLoading(view: WebView, urlString: String): Boolean {
+        val url = Uri.parse(urlString)
+        return shouldOverride(view, url)
+    }
+
+    /**
+     * API-agnostic implementation of deciding whether to override url or not
+     */
+    private fun shouldOverride(view: WebView, url: Uri) : Boolean {
+        if (requestRewriter.shouldRewriteRequest(url)) {
+            val newUri = requestRewriter.rewriteRequestWithCustomQueryParams(url)
             view.loadUrl(newUri.toString())
             return true
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.browser
 
 import android.net.Uri
-import android.webkit.WebResourceRequest
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -47,8 +46,8 @@ class DuckDuckGoRequestRewriter @Inject constructor(private val duckDuckGoUrlDet
         return newUri
     }
 
-    fun shouldRewriteRequest(request: WebResourceRequest): Boolean =
-            duckDuckGoUrlDetector.isDuckDuckGoUrl(request.url) && !request.url.queryParameterNames.containsAll(arrayListOf(sourceParam, appVersionParam))
+    fun shouldRewriteRequest(uri: Uri): Boolean =
+            duckDuckGoUrlDetector.isDuckDuckGoUrl(uri) && !uri.queryParameterNames.containsAll(arrayListOf(sourceParam, appVersionParam))
 
     fun addCustomQueryParams(builder: Uri.Builder) {
         builder.appendQueryParameter(appVersionParam, formatAppVersion())


### PR DESCRIPTION
This allows the functionality for devices running below Android API 24

Asana Issue URL: https://app.asana.com/0/414730916066338/508841948388772
GitHub Issue URL: https://github.com/duckduckgo/Android/issues/79

## Description
We are missing the inclusion of a deprecated method, required to satisfy users running Android API 23 or below.

Reported through public GitHub issues.


## Steps to Test this PR:

Set breakpoints in `BrowserWebViewClient` inside both implementations of `shouldOverrideUrlLoading`

1. Run the app on a device API 24 or greater; ensure the correct method is called
1. Run the app on a device API 23 or lesser; ensure the correct method is called
1. In both cases above, ensure the URL overriding is correctly determined.