### PR TITLE
Fix issue where progress indicator continued to show

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -178,20 +178,20 @@ class BrowserViewModelTest {
     @Test
     fun whenLoadingStartedThenPrivacyGradeIsCleared() {
         testee.loadingStarted()
-        assertNull(testee.viewState.value!!.privacyGrade)
+        assertNull(testee.privacyGrade.value)
     }
 
     @Test
     fun whenUrlChangedThenPrivacyGradeIsReset() {
         testee.urlChanged("https://example.com")
-        assertEquals(PrivacyGrade.B, testee.viewState.value!!.privacyGrade)
+        assertEquals(PrivacyGrade.B, testee.privacyGrade.value)
     }
 
     @Test
     fun whenTrackerDetectedThenPrivacyGradeIsUpdated() {
         testee.urlChanged("https://example.com")
         testee.trackerDetected(TrackingEvent("", "", null, false))
-        assertEquals(PrivacyGrade.C, testee.viewState.value!!.privacyGrade)
+        assertEquals(PrivacyGrade.C, testee.privacyGrade.value)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -36,7 +36,6 @@ import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.privacymonitor.model.PrivacyGrade
-import com.duckduckgo.app.privacymonitor.model.PrivacyGrade.Companion.Grade
 import com.duckduckgo.app.privacymonitor.ui.PrivacyDashboardActivity
 import com.duckduckgo.app.privacymonitor.ui.PrivacyDashboardActivity.Companion.REQUEST_DASHBOARD
 import com.duckduckgo.app.privacymonitor.ui.PrivacyDashboardActivity.Companion.RESULT_RELOAD
@@ -60,12 +59,19 @@ class BrowserActivity : DuckDuckGoActivity() {
         fun intent(context: Context): Intent = Intent(context, BrowserActivity::class.java)
     }
 
+    private val privacyGradeMenu: MenuItem?
+        get() = toolbar.menu.findItem(R.id.privacy_dashboard)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_browser)
 
         viewModel.viewState.observe(this, Observer<BrowserViewModel.ViewState> {
             it?.let { render(it) }
+        })
+
+        viewModel.privacyGrade.observe(this, Observer<PrivacyGrade> {
+            it?.let { renderPrivacyGrade(it) }
         })
 
         viewModel.query.observe(this, Observer {
@@ -114,7 +120,7 @@ class BrowserActivity : DuckDuckGoActivity() {
             false -> hideClearButton()
         }
 
-        updatePrivacyGrade(viewState.privacyGrade, viewState.showPrivacyGrade)
+        privacyGradeMenu?.isVisible = viewState.showPrivacyGrade
     }
 
     private fun showClearButton() {
@@ -131,7 +137,7 @@ class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun updatePrivacyGrade(@Grade privacyGrade: Long?, show: Boolean) {
+    private fun renderPrivacyGrade(privacyGrade: PrivacyGrade?) {
         val resource = when (privacyGrade) {
             PrivacyGrade.A -> R.drawable.privacygrade_icon_a
             PrivacyGrade.B -> R.drawable.privacygrade_icon_b
@@ -139,9 +145,7 @@ class BrowserActivity : DuckDuckGoActivity() {
             PrivacyGrade.D -> R.drawable.privacygrade_icon_d
             else -> R.drawable.privacygrade_icon_unknown
         }
-        val menuItem = toolbar.menu.findItem(R.id.privacy_dashboard)
-        menuItem?.icon = getDrawable(resource)
-        menuItem?.isVisible = show
+        privacyGradeMenu?.icon = getDrawable(resource)
     }
 
     private fun shouldUpdateOmnibarTextInput(viewState: BrowserViewModel.ViewState, omnibarInput: String?) =

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -21,7 +21,7 @@ import android.arch.lifecycle.ViewModel
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.privacymonitor.SiteMonitor
-import com.duckduckgo.app.privacymonitor.model.PrivacyGrade.Companion.Grade
+import com.duckduckgo.app.privacymonitor.model.PrivacyGrade
 import com.duckduckgo.app.privacymonitor.model.TermsOfService
 import com.duckduckgo.app.privacymonitor.model.improvedGrade
 import com.duckduckgo.app.privacymonitor.store.PrivacyMonitorRepository
@@ -45,12 +45,12 @@ class BrowserViewModel(
             val isEditing: Boolean = false,
             val browserShowing: Boolean = false,
             val showClearButton: Boolean = false,
-            @Grade val privacyGrade: Long? = null,
             val showPrivacyGrade: Boolean = false
     )
 
     /* Observable data for Activity to subscribe to */
     val viewState: MutableLiveData<ViewState> = MutableLiveData()
+    val privacyGrade: MutableLiveData<PrivacyGrade> = MutableLiveData()
     val query: SingleLiveEvent<String> = SingleLiveEvent()
     val navigation: SingleLiveEvent<NavigationCommand> = SingleLiveEvent()
 
@@ -129,7 +129,7 @@ class BrowserViewModel(
     }
 
     private fun onSiteMonitorChanged() {
-        viewState.postValue(currentViewState().copy(privacyGrade = siteMonitor?.improvedGrade))
+        privacyGrade.postValue(siteMonitor?.improvedGrade)
         privacyMonitorRepository.privacyMonitor.postValue(siteMonitor)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/privacymonitor/model/PrivacyGrade.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacymonitor/model/PrivacyGrade.kt
@@ -16,19 +16,10 @@
 
 package com.duckduckgo.app.privacymonitor.model
 
-import android.support.annotation.IntDef
 
-
-class PrivacyGrade {
-    companion object {
-        @IntDef(A, B, C, D)
-        @Retention(AnnotationRetention.SOURCE)
-        annotation class Grade
-
-        const val A = 0L
-        const val B = 1L
-        const val C = 2L
-        const val D = 3L
-        const val E = 4L
-    }
+enum class PrivacyGrade {
+    A,
+    B,
+    C,
+    D
 }

--- a/app/src/main/java/com/duckduckgo/app/privacymonitor/model/PrivacyMonitorGradeExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacymonitor/model/PrivacyMonitorGradeExtension.kt
@@ -56,17 +56,14 @@ val PrivacyMonitor.improvedScore: Int
         return score
     }
 
-@PrivacyGrade.Companion.Grade
-val PrivacyMonitor.grade: Long
+val PrivacyMonitor.grade: PrivacyGrade
     get() = calculateGrade(score)
 
-@PrivacyGrade.Companion.Grade
-val PrivacyMonitor.improvedGrade: Long
+val PrivacyMonitor.improvedGrade: PrivacyGrade
     get() = calculateGrade(improvedScore)
 
 
-@PrivacyGrade.Companion.Grade
-private fun calculateGrade(score: Int): Long {
+private fun calculateGrade(score: Int): PrivacyGrade {
     return when {
         score <= 0 -> PrivacyGrade.A
         score == 1 -> PrivacyGrade.B

--- a/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModel.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.privacymonitor.HttpsStatus
 import com.duckduckgo.app.privacymonitor.PrivacyMonitor
 import com.duckduckgo.app.privacymonitor.model.PrivacyGrade
-import com.duckduckgo.app.privacymonitor.model.PrivacyGrade.Companion.Grade
 import com.duckduckgo.app.privacymonitor.model.TermsOfService
 import com.duckduckgo.app.privacymonitor.model.grade
 import com.duckduckgo.app.privacymonitor.model.improvedGrade
@@ -125,7 +124,7 @@ class PrivacyDashboardViewModel(private val applicationContext: Context,
         return applicationContext.getString(resource)
     }
 
-    private fun privacyBanner(grade: Long?): Int {
+    private fun privacyBanner(grade: PrivacyGrade?): Int {
         if (settingsStore.privacyOn) {
             return privacyBannerOn(grade)
         }
@@ -133,7 +132,7 @@ class PrivacyDashboardViewModel(private val applicationContext: Context,
     }
 
     @DrawableRes
-    private fun privacyBannerOn(@Grade grade: Long?): Int {
+    private fun privacyBannerOn(grade: PrivacyGrade?): Int {
         return when (grade) {
             PrivacyGrade.A -> R.drawable.privacygrade_banner_a_on
             PrivacyGrade.B -> R.drawable.privacygrade_banner_b_on
@@ -144,7 +143,7 @@ class PrivacyDashboardViewModel(private val applicationContext: Context,
     }
 
     @DrawableRes
-    private fun privacyBannerOff(@Grade grade: Long?): Int {
+    private fun privacyBannerOff(grade: PrivacyGrade?): Int {
         return when (grade) {
             PrivacyGrade.A -> R.drawable.privacygrade_banner_a_off
             PrivacyGrade.B -> R.drawable.privacygrade_banner_b_off
@@ -155,12 +154,12 @@ class PrivacyDashboardViewModel(private val applicationContext: Context,
     }
 
     @DrawableRes
-    private fun privacyGradeIcon(@Grade grade: Long?): Int {
+    private fun privacyGradeIcon(grade: PrivacyGrade): Int {
         return when (grade) {
             PrivacyGrade.A -> R.drawable.privacygrade_icon_small_a
             PrivacyGrade.B -> R.drawable.privacygrade_icon_small_b
             PrivacyGrade.C -> R.drawable.privacygrade_icon_small_c
-            else -> R.drawable.privacygrade_icon_small_d
+            PrivacyGrade.D -> R.drawable.privacygrade_icon_small_d
         }
     }
 


### PR DESCRIPTION
Asana Issue URL:  https://app.asana.com/0/488551667048375/507672913295807

## Description
The progress bar was often failing to move to 100% and hide even after the page had finished loading. This was caused by mutable live data being updated by both set and post (thread safe) methods.

This PR moved the PrivacyGrade to its own live data object.

## Steps to Test this PR:
1. Browse to cnn.com
1. Note the progress indicator no longer stalls art 95%. It reaches 100% and then hides.