### PR TITLE
Make text unselectable as it is breaking allCaps

### DIFF
--- a/app/src/main/res/layout/content_tracker_networks.xml
+++ b/app/src/main/res/layout/content_tracker_networks.xml
@@ -77,7 +77,7 @@
                     android:textColor="@color/warmGrey"
                     android:textSize="12sp"
                     android:textStyle="bold"
-                    android:textIsSelectable="true"
+                    android:textIsSelectable="false"
                     tools:text="8 TRACKERS BLOCKED"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"


### PR DESCRIPTION
Asana Issue URL: N/A

## Description
Fixes capitalisation on network list

## Steps to Test this PR:
1. Go to theguardian.com
1. Open the Privacy Dashboard
1. Open Tracker Networks
1. Ensure that the text under the domain is capitalised e.g "7 TRACKER NETWORKS BLOCKED"
  