### PR TITLE
Allow app to be default browser and receive shared urls from other browsers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,21 +14,43 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
+
         <activity
             android:name="com.duckduckgo.app.home.HomeActivity"
             android:label="@string/appName"
-            android:parentActivityName="com.duckduckgo.app.home.HomeActivity"
+            android:launchMode="singleTask"
             android:screenOrientation="fullSensor">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Allows app to become default browser -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+            </intent-filter>
+
+            <!-- Allows apps to consume links and text shared from other apps e.g chrome -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+
         </activity>
+
         <activity
             android:name=".BrowserActivity"
+            android:allowTaskReparenting="true"
             android:configChanges="keyboardHidden|orientation|screenSize"
+            android:parentActivityName="com.duckduckgo.app.home.HomeActivity"
             android:screenOrientation="fullSensor" />
+
         <activity
             android:name="com.duckduckgo.app.privacymonitor.ui.PrivacyDashboardActivity"
             android:label="@string/privacyDashboardActivityTitle"
@@ -37,7 +59,7 @@
         <activity
             android:name="com.duckduckgo.app.privacymonitor.ui.TrackerNetworksActivity"
             android:label="@string/networksActivityTitle"
-            android:parentActivityName="com.duckduckgo.app.privacymonitor.ui.TrackerNetworksActivity"
+            android:parentActivityName="com.duckduckgo.app.privacymonitor.ui.PrivacyDashboardActivity"
             android:screenOrientation="fullSensor" />
         <activity
             android:name="com.duckduckgo.app.privacymonitor.ui.PrivacyPracticesActivity"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -58,7 +58,7 @@ class BrowserViewModel(
     /* Observable data for Activity to subscribe to */
     val viewState: MutableLiveData<ViewState> = MutableLiveData()
     val privacyGrade: MutableLiveData<PrivacyGrade> = MutableLiveData()
-    val query: SingleLiveEvent<String> = SingleLiveEvent()
+    val url: SingleLiveEvent<String> = SingleLiveEvent()
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
     sealed class Command {
@@ -80,18 +80,18 @@ class BrowserViewModel(
     }
 
     fun onUserSubmittedQuery(input: String) {
-
         if (input.isBlank()) {
             return
         }
-
-        if (queryUrlConverter.isWebUrl(input)) {
-            query.value = queryUrlConverter.convertUri(input)
-        } else {
-            query.value = queryUrlConverter.convertQueryToUri(input).toString()
-        }
-
+        url.value = buildUrl(input)
         viewState.value = currentViewState().copy(showClearButton = false, omnibarText = input)
+    }
+
+    fun buildUrl(input: String): String {
+        if (queryUrlConverter.isWebUrl(input)) {
+            return queryUrlConverter.convertUri(input)
+        }
+        return queryUrlConverter.convertQueryToUri(input).toString()
     }
 
     override fun progressChanged(newProgress: Int) {
@@ -147,6 +147,10 @@ class BrowserViewModel(
     fun onOmnibarInputStateChanged(query: String, hasFocus: Boolean) {
         val showClearButton = hasFocus && query.isNotEmpty()
         viewState.value = currentViewState().copy(isEditing = hasFocus, showClearButton = showClearButton)
+    }
+
+    fun onSharedTextReceived(input: String) {
+        command.value = Navigate(buildUrl(input))
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
@@ -34,7 +34,6 @@ class KeyboardAwareEditText : AppCompatEditText {
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     var onBackKeyListener: OnBackKeyListener? = null
-    private var showImeAfterFirstLayout: Boolean = true
 
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
 
@@ -47,11 +46,8 @@ class KeyboardAwareEditText : AppCompatEditText {
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         super.onLayout(changed, left, top, right, bottom)
-        if (showImeAfterFirstLayout) {
-            post {
-                showKeyboard()
-                showImeAfterFirstLayout = false
-            }
+        if (isFocused) {
+            showKeyboard()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/IntentExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/IntentExtension.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global
+
+import android.content.Intent
+
+val Intent.intentText: String?
+    get() {
+        return data?.toString() ?: getStringExtra(Intent.EXTRA_TEXT)
+    }

--- a/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
@@ -16,21 +16,39 @@
 
 package com.duckduckgo.app.home
 
+import android.content.Intent
 import android.os.Bundle
 import android.support.v4.app.ActivityOptionsCompat
 import android.support.v7.app.AppCompatActivity
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.global.intentText
 import kotlinx.android.synthetic.main.content_home.*
 
 class HomeActivity : AppCompatActivity() {
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_home)
 
         searchInputBox.setOnClickListener { showSearchActivity() }
+
+        if (savedInstanceState == null) {
+            consumeSharedText(intent)
+        }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        consumeSharedText(intent)
+    }
+
+    private fun consumeSharedText(intent: Intent?) {
+        val sharedText = intent?.intentText
+        if (sharedText != null) {
+            val intent = BrowserActivity.intent(this, sharedText)
+            startActivity(intent)
+        }
     }
 
     private fun showSearchActivity() {


### PR DESCRIPTION
Asana Issue URL: 
https://app.asana.com/0/414730916066338/492769985844014
https://app.asana.com/0/414730916066338/364465928695406

## Description
Allows our app to be set as the default system browser. Also allows our app to open shared urls and text.

## Steps to Test this PR:
TEST ONE
1. Clear any default browsers you have set
1. Open an app with a url in it e.g SMS, evernote etc
1. Tap the link and select to open it with DuckDuckGo, select always
1. Ensure our app launches and opens the url
1. Ensure Duckduckgo is now the default browser (this can be checked under applications in settings)

TEST TWO
1. Open Chrome
1. Navigate to a page
1. Open the menu and select share
1. Select DuckDuckGo
1. Ensure our app launches and opens the url

TEST THREE
1. Open an application which contains text e.g email
1. Highlight some text and select share
1. Select DuckDuckGo
1. Ensure our app launches and the selected text is queries
  