### PR TITLE
Feature/add settings home page

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
@@ -20,9 +20,14 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v4.app.ActivityOptionsCompat
 import android.support.v7.app.AppCompatActivity
+import android.view.Menu
+import android.view.MenuItem
+import com.duckduckgo.app.about.AboutDuckDuckGoActivity
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.intentText
+import com.duckduckgo.app.settings.SettingsActivity
+import kotlinx.android.synthetic.main.activity_home.*
 import kotlinx.android.synthetic.main.content_home.*
 
 class HomeActivity : AppCompatActivity() {
@@ -30,12 +35,18 @@ class HomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_home)
+        configureToolbar()
 
         searchInputBox.setOnClickListener { showSearchActivity() }
 
         if (savedInstanceState == null) {
             consumeSharedText(intent)
         }
+    }
+
+    private fun configureToolbar() {
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayShowTitleEnabled(false)
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -53,6 +64,40 @@ class HomeActivity : AppCompatActivity() {
         val intent = BrowserActivity.intent(this)
         val options = ActivityOptionsCompat.makeSceneTransitionAnimation(this, searchInputBox, getString(R.string.transition_url_input))
         startActivity(intent, options.toBundle())
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.menu_home_activity, menu)
+        return super.onCreateOptionsMenu(menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.settings_menu_item -> {
+                startActivityForResult(SettingsActivity.intent(this), SETTINGS_REQUEST_CODE)
+                true
+            }
+            else -> return super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        when(requestCode) {
+            SETTINGS_REQUEST_CODE -> onHandleSettingsResult(resultCode)
+            else -> super.onActivityResult(requestCode, resultCode, data)
+        }
+    }
+
+    private fun onHandleSettingsResult(resultCode: Int) {
+        when(resultCode) {
+            AboutDuckDuckGoActivity.RESULT_CODE_LOAD_ABOUT_DDG_WEB_PAGE -> {
+                startActivity(BrowserActivity.intent(this, getString(R.string.aboutUrl)))
+            }
+        }
+    }
+
+    companion object {
+        private const val SETTINGS_REQUEST_CODE = 100
     }
 
 }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -68,8 +68,10 @@ class SettingsActivity : DuckDuckGoActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         when(requestCode) {
             REQUEST_CODE_ABOUT_DDG -> {
-                setResult(AboutDuckDuckGoActivity.RESULT_CODE_LOAD_ABOUT_DDG_WEB_PAGE)
-                finish()
+                if(resultCode == AboutDuckDuckGoActivity.RESULT_CODE_LOAD_ABOUT_DDG_WEB_PAGE ) {
+                    setResult(resultCode)
+                    finish()
+                }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import com.duckduckgo.app.about.AboutDuckDuckGoActivity
+import com.duckduckgo.app.about.AboutDuckDuckGoActivity.Companion.RESULT_CODE_LOAD_ABOUT_DDG_WEB_PAGE
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.ViewModelFactory
@@ -66,13 +67,9 @@ class SettingsActivity : DuckDuckGoActivity() {
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        when(requestCode) {
-            REQUEST_CODE_ABOUT_DDG -> {
-                if(resultCode == AboutDuckDuckGoActivity.RESULT_CODE_LOAD_ABOUT_DDG_WEB_PAGE ) {
-                    setResult(resultCode)
-                    finish()
-                }
-            }
+        if(requestCode == REQUEST_CODE_ABOUT_DDG && resultCode == RESULT_CODE_LOAD_ABOUT_DDG_WEB_PAGE) {
+            setResult(resultCode)
+            finish()
         }
     }
 

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2017 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,13 +14,25 @@
   ~ limitations under the License.
   -->
 
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.duckduckgo.app.home.HomeActivity">
+    app:layout_scrollFlags="scroll|enterAlways"
+    tools:context="com.duckduckgo.app.browser.BrowserActivity"
+    tools:menu="menu_browser_activity">
 
-    <include layout="@layout/content_home"/>
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:theme="@style/TransparentToolbar"
+        app:layout_scrollFlags="scroll|enterAlways">
 
-</android.support.design.widget.CoordinatorLayout>
+    </android.support.v7.widget.Toolbar>
+
+    <include layout="@layout/content_home" />
+
+</android.support.constraint.ConstraintLayout>
+

--- a/app/src/main/res/menu/menu_home_activity.xml
+++ b/app/src/main/res/menu/menu_home_activity.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/settings_menu_item"
+        android:title="@string/settingsMenuItemTitle"
+        app:showAsAction="never" />
+
+</menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,5 +20,6 @@
     <color name="orange">#de5833</color>
     <color name="powderBlue">#50BFFF</color>
     <color name="midGreen">#3fa140</color>
+    <color name="transparent">#00000000</color>
 
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,6 +20,5 @@
     <color name="orange">#de5833</color>
     <color name="powderBlue">#50BFFF</color>
     <color name="midGreen">#3fa140</color>
-    <color name="transparent">#00000000</color>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -68,4 +68,8 @@
         <item name="android:textStyle">normal</item>
     </style>
 
+    <style name="TransparentToolbar" parent="ThemeOverlay.AppCompat.ActionBar">
+        <item name="android:colorControlNormal">@color/white</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/414730916066338/513409707430058

## Description
Add a way to get to the settings page from the home screen.


## Steps to Test this PR:
1. Launch the app
1. ensure there is a transparent toolbar on the home page
1. ensure there is an overflow menu, with an option to view "Settings"
1. ensure clicking on that takes you to settings
1. finally, navigate to settings, and then onto the about screen. from there, click the "more" hyperlink. Ensure you are shown the browser activity with the correct url, and that you can navigate "back" from this screen