### PR TITLE
Enable room schema generation, and add to source control

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,12 @@ android {
         versionName VERSION_NAME
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         archivesBaseName = "duckduckgo-$versionName"
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = ["room.schemaLocation": "$projectDir/schemas".toString()]
+            }
+        }
     }
     signingConfigs {
         release

--- a/app/schemas/com.duckduckgo.app.global.db.AppDatabase/2.json
+++ b/app/schemas/com.duckduckgo.app.global.db.AppDatabase/2.json
@@ -1,0 +1,71 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "e91e82a2b5c652807026be5f72a6c56e",
+    "entities": [
+      {
+        "tableName": "https_upgrade_domain",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "disconnect_tracker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `category` TEXT NOT NULL, `networkName` TEXT NOT NULL, `networkUrl` TEXT NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkName",
+            "columnName": "networkName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkUrl",
+            "columnName": "networkUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "url"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"e91e82a2b5c652807026be5f72a6c56e\")"
+    ]
+  }
+}


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/414730916066338/510868278192003

## Description
Enables Room DB schema generation.

This will be useful when we need to test DB schema migrations. Not needed now before proper release, as we just deleting the DB when there is a breaking change while in development.

As an ongoing exercise, if we up the DB version number, it will generate a new JSON schema for that new version, which should be added to source control.

## Steps to Test this PR:
1. Build the app.
1. Ensure JSON is generated under `app/schemas`