### PR TITLE
Opt out of web view metrics

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,10 @@
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
 
+        <meta-data
+            android:name="android.webkit.WebView.MetricsOptOut"
+            android:value="true" />
+
         <activity
             android:name="com.duckduckgo.app.onboarding.ui.OnboardingActivity"
             android:label="@string/appName"


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/414730916066338/526690622695017

## Description
The default implementation of `WebView` will upload usage metrics to Google (if the user has consented). I can only assume we don't want this to happen.

>  WebView may upload anonymous diagnostic data to Google when the user has consented. This data helps Google improve WebView. Data is collected on a per-app basis for each app which has instantiated a WebView. An individual app can opt out of this feature by putting the following tag in its manifest:
>   
>   
`<meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />`
>
>   Data will only be uploaded for a given app if the user has consented AND the app has not opted out.

## Steps to Test this PR:
1.  Check the AndroidManifest.xml contains the appropriate meta-data flag to opt-out of this