### PR TITLE
fixed crash caused by domain with only one part

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
@@ -18,9 +18,7 @@ package com.duckduckgo.app.httpsupgrade
 
 import android.net.Uri
 import com.duckduckgo.app.httpsupgrade.db.HttpsUpgradeDomainDao
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockito_kotlin.*
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -34,6 +32,20 @@ class HttpsUpgraderTest {
     fun before() {
         mockDao = mock()
         testee = HttpsUpgrader(mockDao)
+    }
+
+    @Test
+    fun whenHostContainsTwoPartsThenUpgradeStillChecksWildcard() {
+        whenever(mockDao.hasDomain("macpro.localhost")).thenReturn(false)
+        assertFalse(testee.shouldUpgrade(Uri.parse("http://macpro.localhost")))
+        verify(mockDao).hasDomain("*.localhost")
+    }
+
+    @Test
+    fun whenHostContainsSinglePartThenUpgradeStillChecksWildcard() {
+        whenever(mockDao.hasDomain("localhost")).thenReturn(false)
+        assertFalse(testee.shouldUpgrade(Uri.parse("http://localhost")))
+        verify(mockDao, times(1)).hasDomain(any())
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -21,6 +21,7 @@ import android.support.annotation.WorkerThread
 import com.duckduckgo.app.global.UrlScheme
 import com.duckduckgo.app.global.isHttps
 import com.duckduckgo.app.httpsupgrade.db.HttpsUpgradeDomainDao
+import timber.log.Timber
 import javax.inject.Inject
 
 class HttpsUpgrader @Inject constructor(private val dao: HttpsUpgradeDomainDao) {
@@ -50,8 +51,8 @@ class HttpsUpgrader @Inject constructor(private val dao: HttpsUpgradeDomainDao) 
             }
         }
 
-        domains.removeAt(0)
-        domains.removeAt(domains.size - 1)
+        domains.asReversed().removeAt(0)
+        Timber.d("domains $domains")
 
         for (domain in domains) {
             if (dao.hasDomain("*$domain")) {


### PR DESCRIPTION
Asana Issue URL:  https://app.asana.com/0/488551667048375/526624108986426

## Description

Treat domains with fewer parts with more caution.

## Steps to Test this PR:

1.  Launch the app and got to localhost - should not crash (will show Webview error page)
1.  Launch the app and got to macpro.localhost - should not crash (will show Webview error page)
1. Go to http://widgets.en.alibaba.com - upgraded to https (and then goes to a 404 page)
