### PR TITLE
Clear out old disconnect data when new data available

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/db/TrackerDataDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/db/TrackerDataDao.kt
@@ -34,4 +34,7 @@ interface TrackerDataDao {
 
     @Query("Select count(*) from disconnect_tracker")
     fun count(): Int
+
+    @Query("DELETE FROM disconnect_tracker")
+    fun deleteAll()
 }


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/414730916066338/522562831442810

## Description
Clears out any existing `disconnect` data before persisting new data from the network

## Steps to Test this PR:
1. It's hard to test without debugging. 
1. Breakpoint `TrackerDataDownloader.disconnectDownload()` method
1. Test existing data ok with `trackerDataDao.getAll()`
1. Then manually execute `trackerDataDao.deleteAll()`, followed by `trackerDataDao.getAll()` again to ensure no results are then returned