### PR TITLE
Save "duckduckgo" cookies from being deleted when fire action invoked

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -32,6 +32,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.EditorInfo.IME_ACTION_DONE
+import android.webkit.CookieManager
 import android.webkit.WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
 import android.widget.TextView
 import android.widget.Toast
@@ -52,6 +53,7 @@ import org.jetbrains.anko.toast
 import org.jetbrains.anko.uiThread
 import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Provider
 
 
 class BrowserActivity : DuckDuckGoActivity() {
@@ -59,6 +61,7 @@ class BrowserActivity : DuckDuckGoActivity() {
     @Inject lateinit var webViewClient: BrowserWebViewClient
     @Inject lateinit var webChromeClient: BrowserChromeClient
     @Inject lateinit var viewModelFactory: ViewModelFactory
+    @Inject lateinit var cookieManagerProvider: Provider<CookieManager>
 
     private lateinit var popupMenu: BrowserPopupMenu
 
@@ -337,11 +340,11 @@ class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private fun launchFire() {
-        FireDialog(this, {
-            finishActivityAnimated()
-        }, {
-            applicationContext.toast(R.string.fireDataCleared)
-        }).show()
+        FireDialog(context = this,
+                clearStarted = { finishActivityAnimated() },
+                clearComplete = { applicationContext.toast(R.string.fireDataCleared) },
+                cookieManager = cookieManagerProvider.get()
+        ).show()
     }
 
     private fun launchPopupMenu() {

--- a/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
@@ -38,6 +38,7 @@ import javax.inject.Singleton
     (DatabaseModule::class),
     (JsonModule::class),
     (StringModule::class),
+    (BrowserModule::class),
     (BrowserAutoCompleteModule::class)
 ])
 interface AppComponent : AndroidInjector<DuckDuckGoApplication> {

--- a/app/src/main/java/com/duckduckgo/app/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/BrowserModule.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.di
+
+import android.webkit.CookieManager
+import dagger.Module
+import dagger.Provides
+
+@Module
+class BrowserModule {
+
+    @Provides
+    fun cookieManager(): CookieManager = CookieManager.getInstance()
+}

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -24,7 +24,10 @@ import android.webkit.WebView
 import com.duckduckgo.app.browser.R
 import kotlinx.android.synthetic.main.sheet_fire_clear_data.*
 
-class FireDialog(context: Context, clearStarted: (() -> Unit), clearComplete: (() -> Unit)) : BottomSheetDialog(context) {
+class FireDialog(context: Context,
+                 private val cookieManager: CookieManager,
+                 clearStarted: (() -> Unit),
+                 clearComplete: (() -> Unit)) : BottomSheetDialog(context) {
 
     init {
         val contentView = View.inflate(getContext(), R.layout.sheet_fire_clear_data, null)
@@ -47,8 +50,15 @@ class FireDialog(context: Context, clearStarted: (() -> Unit), clearComplete: ((
     }
 
     private fun clearCookies(clearAllCallback: (() -> Unit)) {
-        CookieManager.getInstance().removeAllCookies {
+        val ddgCookie = cookieManager.getCookie(DDG_URL)
+
+        cookieManager.removeAllCookies {
+            cookieManager.setCookie(DDG_URL, ddgCookie)
             clearAllCallback()
         }
+    }
+
+    companion object {
+        private const val DDG_URL = "duckduckgo.com"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
@@ -24,6 +24,7 @@ import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.webkit.CookieManager
 import com.duckduckgo.app.about.AboutDuckDuckGoActivity
 import com.duckduckgo.app.bookmarks.ui.BookmarksActivity
 import com.duckduckgo.app.browser.BrowserActivity
@@ -36,10 +37,15 @@ import kotlinx.android.synthetic.main.activity_home.*
 import kotlinx.android.synthetic.main.content_home.*
 import kotlinx.android.synthetic.main.popup_window_brower_menu.view.*
 import org.jetbrains.anko.toast
+import javax.inject.Inject
+import javax.inject.Provider
 
 class HomeActivity : AppCompatActivity() {
 
     private lateinit var popupMenu: BrowserPopupMenu
+
+    @Inject
+    lateinit var cookieManagerProvider: Provider<CookieManager>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -104,9 +110,10 @@ class HomeActivity : AppCompatActivity() {
     }
 
     private fun launchFire() {
-        FireDialog(this, {}, {
-            toast(R.string.fireDataCleared)
-        }).show()
+        FireDialog(context = this,
+                cookieManager = cookieManagerProvider.get(),
+                clearStarted = {},
+                clearComplete = { toast(R.string.fireDataCleared) }).show()
     }
 
     private fun launchPopupMenu() {


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/414730916066338/526624108986425

## Description
Settings for duckduckgo.com are held in cookies. These cookies should be the **only** cookies that can survive being burned by the fire action.


## Steps to Test this PR:
1. Perform a search to land on duckduckgo.com results page
1. Change `Safe Search` from `Strict` to `Moderate`
1. Log in to a website (one that will use cookies to remember you logged in)
1. 🔥  it all
1. Perform another search to land on duckduckgo.com results page
1. Ensure `Safe Search` has remembered your preference for `Moderate`
1. Return to the site you logged in
1. Ensure you are **not** still logged in