### PR TITLE
Refresh webpage after privacy change

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModelTest.kt
@@ -109,13 +109,13 @@ class PrivacyDashboardViewModelTest {
         whenever(settingStore.privacyOn)
                 .thenReturn(true)
                 .thenReturn(false)
-        assertTrue(testee.shouldReloadPage)
+        assertTrue(testee.viewState.value!!.shouldReloadPage)
     }
 
     @Test
     fun whenPrivacyInitiallyOnAndUnchangedThenShouldReloadIsFalse() {
         whenever(settingStore.privacyOn).thenReturn(true)
-        assertFalse(testee.shouldReloadPage)
+        assertFalse(testee.viewState.value!!.shouldReloadPage)
     }
 
     @Test
@@ -123,13 +123,13 @@ class PrivacyDashboardViewModelTest {
         whenever(settingStore.privacyOn)
                 .thenReturn(false)
                 .thenReturn(true)
-        assertTrue(testee.shouldReloadPage)
+        assertTrue(testee.viewState.value!!.shouldReloadPage)
     }
 
     @Test
     fun whenPrivacyInitiallyOffAndUnchangedThenShouldReloadIsFalse() {
         whenever(settingStore.privacyOn).thenReturn(false)
-        assertFalse(testee.shouldReloadPage)
+        assertFalse(testee.viewState.value!!.shouldReloadPage)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardActivity.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.privacymonitor.ui
 
+import android.app.Activity
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
@@ -43,6 +44,10 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
     private val trackersRenderer = TrackersRenderer()
     private val upgradeRenderer = PrivacyUpgradeRenderer()
 
+    private val viewModel: PrivacyDashboardViewModel by lazy {
+        ViewModelProviders.of(this, viewModelFactory).get(PrivacyDashboardViewModel::class.java)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_privacy_dashboard)
@@ -65,20 +70,9 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
         }
     }
 
-    private val viewModel: PrivacyDashboardViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(PrivacyDashboardViewModel::class.java)
-    }
-
     private fun configureToolbar() {
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-    }
-
-    override fun onBackPressed() {
-        if (viewModel.shouldReloadPage) {
-            setResult(RELOAD_RESULT_CODE)
-        }
-        super.onBackPressed()
     }
 
     private fun render(viewState: ViewState) {
@@ -103,6 +97,7 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
         networkTrackerSummaryPill1.render(viewState.networkTrackerSummaryName1, viewState.networkTrackerSummaryPercent1)
         networkTrackerSummaryPill2.render(viewState.networkTrackerSummaryName2, viewState.networkTrackerSummaryPercent2)
         networkTrackerSummaryPill3.render(viewState.networkTrackerSummaryName3, viewState.networkTrackerSummaryPercent3)
+        updateActivityResult(viewState.shouldReloadPage)
     }
 
     private fun renderToggle(enabled: Boolean) {
@@ -128,6 +123,14 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
         if (requestCode == REQUEST_CODE_PRIVACY_PRACTICES && resultCode == PrivacyPracticesActivity.TOSDR_RESULT_CODE) {
             setResult(TOSDR_RESULT_CODE)
             finish()
+        }
+    }
+
+    private fun updateActivityResult(shouldReload: Boolean) {
+        if (shouldReload) {
+            setResult(RELOAD_RESULT_CODE)
+        } else {
+            setResult(Activity.RESULT_OK)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacymonitor/ui/PrivacyDashboardViewModel.kt
@@ -45,16 +45,20 @@ class PrivacyDashboardViewModel(private val settingsStore: PrivacySettingsStore,
             val networkTrackerSummaryName3: String?,
             val networkTrackerSummaryPercent1: Float,
             val networkTrackerSummaryPercent2: Float,
-            val networkTrackerSummaryPercent3: Float
+            val networkTrackerSummaryPercent3: Float,
+            val shouldReloadPage: Boolean
     )
 
     val viewState: MutableLiveData<ViewState> = MutableLiveData()
+    private var monitor: PrivacyMonitor? = null
 
     private val networkPercentsData: LiveData<Array<NetworkPercent>> = networkLeaderboardDao.networkPercents()
     private val networkPercentsObserver = Observer<Array<NetworkPercent>> { onNetworkPercentsChanged(it!!) }
+
     private val privacyInitiallyOn = settingsStore.privacyOn
 
-    private var monitor: PrivacyMonitor? = null
+    private val shouldReloadPage: Boolean
+        get() = privacyInitiallyOn != settingsStore.privacyOn
 
     init {
         resetViewState()
@@ -66,9 +70,6 @@ class PrivacyDashboardViewModel(private val settingsStore: PrivacySettingsStore,
         super.onCleared()
         networkPercentsData.removeObserver(networkPercentsObserver)
     }
-
-    val shouldReloadPage: Boolean
-        get() = privacyInitiallyOn != settingsStore.privacyOn
 
     fun onNetworkPercentsChanged(networkPercents: Array<NetworkPercent>) {
 
@@ -85,7 +86,6 @@ class PrivacyDashboardViewModel(private val settingsStore: PrivacySettingsStore,
                 networkTrackerSummaryPercent2 = if (showSummary) networkPercents[1].percent else 0.0f,
                 networkTrackerSummaryPercent3 = if (showSummary) networkPercents[2].percent else 0.0f
         )
-
     }
 
     fun onPrivacyMonitorChanged(monitor: PrivacyMonitor?) {
@@ -113,7 +113,8 @@ class PrivacyDashboardViewModel(private val settingsStore: PrivacySettingsStore,
                 networkTrackerSummaryName3 = null,
                 networkTrackerSummaryPercent1 = 0f,
                 networkTrackerSummaryPercent2 = 0f,
-                networkTrackerSummaryPercent3 = 0f
+                networkTrackerSummaryPercent3 = 0f,
+                shouldReloadPage = shouldReloadPage
         )
     }
 
@@ -133,7 +134,8 @@ class PrivacyDashboardViewModel(private val settingsStore: PrivacySettingsStore,
         if (enabled != viewState.value?.toggleEnabled) {
             settingsStore.privacyOn = enabled
             viewState.value = viewState.value?.copy(
-                    toggleEnabled = enabled
+                    toggleEnabled = enabled,
+                    shouldReloadPage = shouldReloadPage
             )
         }
     }


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/488551667048375/530408363493354

## Description
Refreshes the page when landing back on the browser after the PrivacyDashboard is toggled


## Steps to Test this PR:
1. Visit a webpage
1. Open the privacy dashboard
1. Toggle it
1. Return to the site - the page should refresh