### PR TITLE
Add dom storage to fix ebay search box

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -260,6 +260,7 @@ class BrowserActivity : DuckDuckGoActivity() {
 
         webView.settings.apply {
             javaScriptEnabled = true
+            domStorageEnabled = true
             loadWithOverviewMode = true
             useWideViewPort = true
             builtInZoomControls = true


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/488551667048375/530368950629129

## Description
Fixes ebay search bug by adding dom storage

## Steps to Test this PR:
1. Visit ebay.com
1. Start typing a search and note that autocomplete shows
1. Submit search and note that results are shown - previously nothing happened