### PR TITLE
Allow app to be default assistant

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,12 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
 
+            <!-- Allow app to be default assistant -->
+            <intent-filter>
+                <action android:name="android.intent.action.ASSIST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
         </activity>
 
         <activity


### PR DESCRIPTION
Asana Issue URL: 

Github Issue: Assistant App no longer working #142

## Description
Added intent to set this app as default assistant. Now you can open the app with a long press on the home button.


## Steps to Test this PR:
1. Set DuckDuckGo as deafult assistent  
Android 8: Android Settings > Apps & Notifications > Default-Apps > Assistant & Language > Assistant-App > select DuckDuckGo  
2. Long Press the home button  
3. DuckDuckGo opens