### PR TITLE
Start privacy grade observer when menu is inflated

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -88,12 +88,6 @@ class BrowserActivity : DuckDuckGoActivity() {
             it?.let { render(it) }
         })
 
-        viewModel.privacyGrade.observe(this, Observer<PrivacyGrade> {
-            it?.let {
-                privacyGradeMenu?.icon = getDrawable(it.icon())
-            }
-        })
-
         viewModel.url.observe(this, Observer {
             it?.let { webView.loadUrl(it) }
         })
@@ -318,6 +312,11 @@ class BrowserActivity : DuckDuckGoActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.menu_browser_activity, menu)
+        viewModel.privacyGrade.observe(this, Observer<PrivacyGrade> {
+            it?.let {
+                privacyGradeMenu?.icon = getDrawable(it.icon())
+            }
+        })
         return true
     }
 


### PR DESCRIPTION
Asana Issue URL: 
This relates to my previous stack PR
https://app.asana.com/0/361428290920652/532687991106939

## Description
Move privacy grade observer to onCreateMenuOptions so that privacy grade isn't updated before menu is available

## Steps to Test this PR:
1. Open settings
1. Tap the about page
1. The privacy grade should show without needing a reload