### PR TITLE
Add special handling for 3rd party keyboards which submit \n for done

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -28,11 +28,11 @@ import android.os.Build
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
 import android.text.Editable
-import android.view.KeyEvent
+import android.view.KeyEvent.KEYCODE_ENTER
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.EditorInfo.IME_ACTION_DONE
 import android.webkit.CookieManager
 import android.webkit.WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
 import android.webkit.WebView
@@ -277,7 +277,7 @@ class BrowserActivity : DuckDuckGoActivity(), BookmarkDialogCreationListener {
         }
 
         omnibarTextInput.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, keyEvent ->
-            if (actionId == EditorInfo.IME_ACTION_DONE || keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER) {
+            if (actionId == IME_ACTION_DONE || keyEvent?.keyCode == KEYCODE_ENTER) {
                 userEnteredQuery(omnibarTextInput.text.toString())
                 return@OnEditorActionListener true
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -261,19 +261,6 @@ class BrowserActivity : DuckDuckGoActivity(), BookmarkDialogCreationListener {
 
         omnibarTextInput.addTextChangedListener(object : TextChangedWatcher() {
 
-            override fun onTextChanged(
-                charSequence: CharSequence,
-                start: Int,
-                before: Int,
-                count: Int
-            ) {
-                // some 3rd party keyboards submit \n instead of an IME action
-                if (before == 0 && count == 1 && charSequence[start] == '\n') {
-                    omnibarTextInput.text.replace(start, start + 1, "")
-                    userEnteredQuery(omnibarTextInput.text.toString())
-                }
-            }
-
             override fun afterTextChanged(editable: Editable) {
                 viewModel.onOmnibarInputStateChanged(
                         omnibarTextInput.text.toString(),

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -290,8 +290,7 @@ class BrowserActivity : DuckDuckGoActivity(), BookmarkDialogCreationListener {
         }
 
         omnibarTextInput.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, keyEvent ->
-
-            if (actionId == EditorInfo.IME_ACTION_DONE || keyEvent.keyCode == KeyEvent.KEYCODE_ENTER) {
+            if (actionId == EditorInfo.IME_ACTION_DONE || keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER) {
                 userEnteredQuery(omnibarTextInput.text.toString())
                 return@OnEditorActionListener true
             }

--- a/app/src/main/res/layout/activity_browser.xml
+++ b/app/src/main/res/layout/activity_browser.xml
@@ -66,7 +66,7 @@
                             android:fontFamily="sans-serif-medium"
                             android:hint="@string/omnibarInputHint"
                             android:imeOptions="flagNoExtractUi|actionDone"
-                            android:inputType="textUri|textShortMessage|textNoSuggestions"
+                            android:inputType="textUri|textNoSuggestions"
                             android:maxLines="1"
                             android:paddingBottom="4dp"
                             android:paddingEnd="40dp"


### PR DESCRIPTION
Asana Issue URL: 
https://app.asana.com/0/488551667048375/533375498923960
https://app.asana.com/0/488551667048375/533891143524672

## Description
Done button doesn't submit query on some 3rd party software keyboards
This also tackles the crash reports for when `keyEvent` is `null`.


## Steps to Test this PR:
1. Install TouchPal (https://play.google.com/store/apps/details?id=com.cootek.smartinputv5&hl=en_GB)
1. Set TouchPal as the keyboard
1. Use the app, and ensure the query submits when you hit the software "Done" button