### PR TITLE
Initialise the privacy monitor live data directly in singleton instance

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -111,7 +111,6 @@ class BrowserViewModel(
     init {
         command.value = Command.ShowKeyboard()
         viewState.value = ViewState(canAddBookmarks = false)
-        privacyMonitorRepository.privacyMonitor = MutableLiveData()
         appConfigurationObservable.observeForever(appConfigurationObserver)
 
         configureAutoComplete()

--- a/app/src/main/java/com/duckduckgo/app/privacymonitor/store/PrivacyMonitorRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacymonitor/store/PrivacyMonitorRepository.kt
@@ -32,6 +32,6 @@ class PrivacyMonitorRepository @Inject constructor() {
      * using a guid as a key. The Browser/TabActivity could share the key
      * with the PrivacyDashboardActivity via the the intent bundle
      */
-    lateinit var privacyMonitor: MutableLiveData<PrivacyMonitor>
+    val privacyMonitor: MutableLiveData<PrivacyMonitor> = MutableLiveData()
 
 }


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/488551667048375/533891143524674

## Description
There's a crash report that privacy monitor was not initialised. the existing code initialised it only in one activity, and if the process died while the user was on another activity, this would not be initialised again.


## Steps to Test this PR:
1. Hard to test as it is hard to reproduce. Make sure the new implementation doesn't break anything around privacy grade.