### PR TITLE
Use toolbar as the popup menu's anchor view instead of toolbar menu item

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -387,8 +387,7 @@ class BrowserActivity : DuckDuckGoActivity(), BookmarkDialogCreationListener {
     }
 
     private fun launchPopupMenu() {
-        val anchorView = findViewById<View>(R.id.browser_popup_menu_item)
-        popupMenu.show(rootView, anchorView)
+        popupMenu.show(rootView, toolbar)
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
@@ -66,10 +66,12 @@ class HomeActivity : DuckDuckGoActivity() {
 
     private fun configurePopupMenu() {
         popupMenu = BrowserPopupMenu(layoutInflater)
-        popupMenu.contentView.backPopupMenuItem.isEnabled = false
-        popupMenu.contentView.forwardPopupMenuItem.isEnabled = false
-        popupMenu.contentView.refreshPopupMenuItem.isEnabled = false
-        popupMenu.contentView.addBookmarksPopupMenuItem.isEnabled = false
+        popupMenu.contentView.apply {
+            backPopupMenuItem.isEnabled = false
+            forwardPopupMenuItem.isEnabled = false
+            refreshPopupMenuItem.isEnabled = false
+            addBookmarksPopupMenuItem.isEnabled = false
+        }
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -123,8 +125,7 @@ class HomeActivity : DuckDuckGoActivity() {
     }
 
     private fun launchPopupMenu() {
-        val anchorView = findViewById(R.id.browser_popup_menu_item) as View
-        popupMenu.show(rootView, anchorView)
+        popupMenu.show(rootView, toolbar)
     }
 
     fun onBookmarksClicked(view: View) {


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/488551667048375/532221766945306

## Description
Some users are reporting that the popup menu crashes for them. It appears the view used as an _anchor_ is `null` for them.

Instead of trying to use the menu item itself, this PR switches to using the `toolbar` itself as the anchor, which should be visually identical but guaranteed to be non-null instead.


## Steps to Test this PR:
1. Hard to test unless you have a device which is crashing. But make sure it doesn't break anything or change the existing look and feel of the menu on both:
    1. HomeActivity
    1. BrowserActivity