### PR TITLE
Skip home screen if launched as an assist intent

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/home/HomeActivity.kt
@@ -55,7 +55,7 @@ class HomeActivity : DuckDuckGoActivity() {
         searchInputBox.setOnClickListener { showSearchActivity() }
 
         if (savedInstanceState == null) {
-            consumeSharedQuery(intent)
+            consumeIntentAction(intent)
         }
     }
 
@@ -76,20 +76,24 @@ class HomeActivity : DuckDuckGoActivity() {
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        consumeSharedQuery(intent)
+        consumeIntentAction(intent)
     }
 
-    private fun consumeSharedQuery(intent: Intent?) {
+    private fun consumeIntentAction(intent: Intent?) {
 
         if (intent == null) return
 
-        if (intent.hasExtra(KEY_SKIP_HOME)) {
+        if (shouldSkipHomeActivity(intent)) {
             startActivity(BrowserActivity.intent(this))
             return
         }
 
         val query = intent.intentText ?: return
         startActivity(BrowserActivity.intent(this, query))
+    }
+
+    private fun shouldSkipHomeActivity(intent: Intent) : Boolean {
+        return intent.hasExtra(KEY_SKIP_HOME) || intent.action == Intent.ACTION_ASSIST
     }
 
     private fun showSearchActivity() {


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/488551667048375/535704136592727

## Description
Capture the intent if launched as an assist action, and skip the home screen if so


## Steps to Test this PR:
1. Set up DDG as assist (instructions below)
1. Launch the app using the long press on the home button - ensure the app is immediately ready to query
1. With the app already running (try in various screens), do the same and ensure it works as expected

## Setting up DDG app as Assistant
Android 8: Android Settings > Apps & Notifications > Default-Apps > Assistant & Language > Assistant-App > select DuckDuckGo