### PR TITLE
caused by minWidth=0; setting to 1 fixes crash with no visual changes

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,7 +20,7 @@
     </style>
 
     <style name="ActionButtonStyle" parent="@android:style/Widget.Holo.Light.ActionButton">
-        <item name="android:minWidth">0dp</item>
+        <item name="android:minWidth">1dp</item>
         <item name="android:paddingStart">8dp</item>
         <item name="android:paddingEnd">8dp</item>
     </style>


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/414730916066338/533891143524670

## Description
MinWidth set to 0 caused the crash. setting to 1 fixes the crash without changing anything visually


## Steps to Test this PR:
1. Test on a Samsung Lollipop device that long pressing on the URL doesn't break it (neither does double tapping) 