### PR TITLE
Hiding privacy grade toolbar button when returning to home activity

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -467,6 +467,7 @@ class BrowserActivity : DuckDuckGoActivity(), BookmarkDialogCreationListener {
 
     private fun clearViewPriorToAnimation() {
         acceptingRenderUpdates = false
+        privacyGradeMenu?.isVisible = false
         omnibarTextInput.text.clear()
         omnibarTextInput.hideKeyboard()
         webView.hide()


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/413877547933099/502265450553619

## Description
Fixes a minor visual glitch when returning from the BrowserActivity to the HomeActivity. Without this fix, the privacy grade would flash up momentarily in an uninitialised state (showing `?`)


## Steps to Test this PR:
1. Navigate back from BrowserActivity to HomeActivity
1. Ensure the privacy grade button doesn't flash onscreen at all during the transition