### PR TITLE
Handle user entering empty query by not dismissing the keyboard

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -41,6 +41,7 @@ import android.widget.Toast
 import com.duckduckgo.app.bookmarks.ui.BookmarkAddEditDialogFragment
 import com.duckduckgo.app.bookmarks.ui.BookmarkAddEditDialogFragment.BookmarkDialogCreationListener
 import com.duckduckgo.app.bookmarks.ui.BookmarksActivity
+import com.duckduckgo.app.browser.BrowserViewModel.Command
 import com.duckduckgo.app.browser.autoComplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.app.browser.omnibar.OnBackKeyListener
 import com.duckduckgo.app.global.DuckDuckGoActivity
@@ -129,36 +130,43 @@ class BrowserActivity : DuckDuckGoActivity(), BookmarkDialogCreationListener {
         })
 
         viewModel.command.observe(this, Observer {
-            when (it) {
-                is BrowserViewModel.Command.Refresh -> webView.reload()
-                is BrowserViewModel.Command.Navigate -> {
-                    focusDummy.requestFocus()
-                    webView.loadUrl(it.url)
-                }
-                is BrowserViewModel.Command.LandingPage -> finishActivityAnimated()
-                is BrowserViewModel.Command.DialNumber -> {
-                    val intent = Intent(Intent.ACTION_DIAL)
-                    intent.data = Uri.parse("tel:${it.telephoneNumber}")
-                    launchExternalActivity(intent)
-                }
-                is BrowserViewModel.Command.SendEmail -> {
-                    val intent = Intent(Intent.ACTION_SENDTO)
-                    intent.data = Uri.parse(it.emailAddress)
-                    launchExternalActivity(intent)
-                }
-                is BrowserViewModel.Command.SendSms -> {
-                    val intent = Intent(Intent.ACTION_SENDTO, Uri.parse("smsto:${it.telephoneNumber}"))
-                    startActivity(intent)
-                }
-                is BrowserViewModel.Command.ShowKeyboard -> {
-                    Timber.i("Command: showing keyboard")
-                    omnibarTextInput.postDelayed({omnibarTextInput.showKeyboard()}, 300)
-                }
-                is BrowserViewModel.Command.ReinitialiseWebView -> {
-                    webView.clearHistory()
-                }
-            }
+            processCommand(it)
         })
+    }
+
+    private fun processCommand(it: Command?) {
+        when (it) {
+            Command.Refresh -> webView.reload()
+            is Command.Navigate -> {
+                focusDummy.requestFocus()
+                webView.loadUrl(it.url)
+            }
+            Command.LandingPage -> finishActivityAnimated()
+            is Command.DialNumber -> {
+                val intent = Intent(Intent.ACTION_DIAL)
+                intent.data = Uri.parse("tel:${it.telephoneNumber}")
+                launchExternalActivity(intent)
+            }
+            is Command.SendEmail -> {
+                val intent = Intent(Intent.ACTION_SENDTO)
+                intent.data = Uri.parse(it.emailAddress)
+                launchExternalActivity(intent)
+            }
+            is Command.SendSms -> {
+                val intent = Intent(Intent.ACTION_SENDTO, Uri.parse("smsto:${it.telephoneNumber}"))
+                startActivity(intent)
+            }
+            Command.ShowKeyboard -> {
+                omnibarTextInput.postDelayed({omnibarTextInput.showKeyboard()}, 300)
+            }
+            Command.HideKeyboard -> {
+                omnibarTextInput.hideKeyboard()
+                focusDummy.requestFocus()
+            }
+            Command.ReinitialiseWebView -> {
+                webView.clearHistory()
+            }
+        }
     }
 
     private fun configureAutoComplete() {
@@ -288,8 +296,6 @@ class BrowserActivity : DuckDuckGoActivity(), BookmarkDialogCreationListener {
     }
 
     private fun userEnteredQuery(query: String) {
-        omnibarTextInput.hideKeyboard()
-        focusDummy.requestFocus()
         viewModel.onUserSubmittedQuery(query)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -77,14 +77,15 @@ class BrowserViewModel(
     )
 
     sealed class Command {
-        class LandingPage : Command()
-        class Refresh : Command()
+        object LandingPage : Command()
+        object Refresh : Command()
         class Navigate(val url: String) : Command()
         class DialNumber(val telephoneNumber: String) : Command()
         class SendSms(val telephoneNumber: String) : Command()
         class SendEmail(val emailAddress: String) : Command()
-        class ShowKeyboard : Command()
-        class ReinitialiseWebView : Command()
+        object ShowKeyboard : Command()
+        object HideKeyboard : Command()
+        object ReinitialiseWebView : Command()
     }
 
     /* Observable data for Activity to subscribe to */
@@ -109,7 +110,7 @@ class BrowserViewModel(
     private var appConfigurationDownloaded = false
 
     init {
-        command.value = Command.ShowKeyboard()
+        command.value = Command.ShowKeyboard
         viewState.value = ViewState(canAddBookmarks = false)
         appConfigurationObservable.observeForever(appConfigurationObserver)
 
@@ -149,6 +150,8 @@ class BrowserViewModel(
         if (input.isBlank()) {
             return
         }
+
+        command.value = Command.HideKeyboard
 
         val trimmedInput = input.trim()
         url.value = buildUrl(trimmedInput)
@@ -294,14 +297,14 @@ class BrowserViewModel(
      */
     fun userDismissedKeyboard(): Boolean {
         if (!currentViewState().browserShowing) {
-            command.value = Command.LandingPage()
+            command.value = Command.LandingPage
             return true
         }
         return false
     }
 
     fun receivedDashboardResult(resultCode: Int) {
-        if (resultCode == RELOAD_RESULT_CODE) command.value = Command.Refresh()
+        if (resultCode == RELOAD_RESULT_CODE) command.value = Command.Refresh
     }
 
     @WorkerThread


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/413877547933099/536146347309401

## Description
Stop hiding the keyboard when the user enters an empty keyboard and hits the `done` button. 


## Steps to Test this PR:
1. Launch the app from the widget 
1. Hit the `done` button on the keyboard without typing any query
1. Verify nothing happens (keyboard remains visible; omnibar keeps focus; no navigation occurs)