### PR TITLE
feature/Remove destruction migration fallback

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
@@ -30,7 +30,6 @@ class DatabaseModule {
     @Singleton
     fun provideDatabase(context: Context): AppDatabase {
         return Room.databaseBuilder(context, AppDatabase::class.java, "app.db")
-                .fallbackToDestructiveMigration()
                 .build()
     }
 }


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/414730916066338/564093479267650

## Description
We can no longer rely on blowing away the DB when the schema changes. We need to properly write DB migrations from now on, and I'd like to be made aware of this need as early as possible.

Leaving the fallback in place is dangerous, as we are going to end up changing the DB, releasing and blowing away all the user's data.


## Steps to Test this PR:
1. Change the DB (edit an entity, for instance)
1. Run the app, and verify that the app does crash 

`java.lang.IllegalStateException: Room cannot verify the data integrity`