### PR TITLE
Fix landscape layout's squished controls; add scroll view to menu items

### DIFF
--- a/app/src/main/res/layout/popup_window_browser_menu.xml
+++ b/app/src/main/res/layout/popup_window_browser_menu.xml
@@ -24,11 +24,11 @@
         android:id="@+id/header"
         android:layout_width="0dp"
         android:layout_height="50dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
         android:background="@color/white"
         android:gravity="center"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
 
         <ImageButton
             android:id="@+id/backPopupMenuItem"
@@ -67,8 +67,8 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        app:layout_constraintTop_toBottomOf="@id/header"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/header">
 
         <LinearLayout
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/popup_window_browser_menu.xml
+++ b/app/src/main/res/layout/popup_window_browser_menu.xml
@@ -16,14 +16,16 @@
 
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/white">
 
     <LinearLayout
         android:id="@+id/header"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="50dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:background="@color/white"
         android:gravity="center"
         android:orientation="horizontal">
@@ -63,38 +65,45 @@
         android:background="@color/white_two"
         app:layout_constraintBottom_toBottomOf="@+id/header" />
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="20dp"
-        android:paddingTop="13dp"
-        app:layout_constraintTop_toBottomOf="@id/header">
+    <ScrollView
+        android:layout_width="match_parent"
+        app:layout_constraintTop_toBottomOf="@id/header"
+        android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/bookmarksPopupMenuItem"
-            style="@style/BrowserTextMenuItem"
-            android:enabled="false"
-            android:text="@string/bookmarksMenuTitle" />
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="20dp"
+            android:paddingTop="13dp">
 
-        <TextView
-            android:id="@+id/addBookmarksPopupMenuItem"
-            style="@style/BrowserTextMenuItem"
-            android:enabled="false"
-            android:text="@string/addBookmarkMenuTitle" />
+            <TextView
+                android:id="@+id/bookmarksPopupMenuItem"
+                style="@style/BrowserTextMenuItem"
+                android:enabled="false"
+                android:text="@string/bookmarksMenuTitle" />
 
-        <TextView
-            android:id="@+id/findInPageMenuItem"
-            style="@style/BrowserTextMenuItem"
-            android:enabled="false"
-            android:text="@string/find_in_page" />
+            <TextView
+                android:id="@+id/addBookmarksPopupMenuItem"
+                style="@style/BrowserTextMenuItem"
+                android:enabled="false"
+                android:text="@string/addBookmarkMenuTitle" />
 
-        <TextView
-            android:id="@+id/settingsPopupMenuItem"
-            style="@style/BrowserTextMenuItem"
-            android:enabled="false"
-            android:text="@string/settingsMenuItemTitle" />
+            <TextView
+                android:id="@+id/findInPageMenuItem"
+                style="@style/BrowserTextMenuItem"
+                android:enabled="false"
+                android:text="@string/find_in_page" />
 
-    </LinearLayout>
+            <TextView
+                android:id="@+id/settingsPopupMenuItem"
+                style="@style/BrowserTextMenuItem"
+                android:enabled="false"
+                android:text="@string/settingsMenuItemTitle" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Asana Issue URL: https://app.asana.com/0/488551667048375/567110983215934

## Description
Add scroll view to popup menu, and fix the horizontal squishing that happens to the back/forward/refresh controls on landscape.


## Steps to Test this PR:
1. Launch the popup menu in both portrait and landscape; verify the controls look good 
1. To test the scroll view, you will either need a small screen (in landscape most likely) or artificially create the problem by adding new menu items into `popup_window_browser_menu.xml`