### PR TITLE
Add variant to exti call

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -51,7 +51,7 @@ class StatisticsRequesterTest {
         configureNoStoredStatistics()
         testee.initializeAtb()
         verify(mockService).atb()
-        verify(mockService).exti(ATB)
+        verify(mockService).exti(ATB_WITH_VARIANT)
         verify(mockStatisticsStore).atb = ATB_WITH_VARIANT
         verify(mockStatisticsStore).retentionAtb = ATB
     }
@@ -69,7 +69,7 @@ class StatisticsRequesterTest {
         configureNoStoredStatistics()
         testee.refreshRetentionAtb()
         verify(mockService).atb()
-        verify(mockService).exti(ATB)
+        verify(mockService).exti(ATB_WITH_VARIANT)
         verify(mockStatisticsStore).atb = ATB_WITH_VARIANT
         verify(mockStatisticsStore).retentionAtb = ATB
     }

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
@@ -43,7 +43,7 @@ class StatisticsRequester(private val store: StatisticsDataStore, private val se
             .flatMap {
                 store.atb = it.versionWithVariant
                 store.retentionAtb = it.version
-                service.exti(it.version)
+                service.exti(it.versionWithVariant)
             }
             .subscribe({
                 Timber.v("Atb initalization succeeded")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/578616594437384
Tech Design URL: N/A
CC:

**Description**:
Add variant to exti installation statistics call

**Steps to test this PR**:
1. Install the app
1. Watch for a networking call to exti e.g https://duckduckgo.com/exti/?atb=v79-3ma
1. Ensure the atb parameter in the exti call includes the atb variant e.g v79-3ma


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
