### PR TITLE
Fix keys for statistics so exti call is only made once

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-kapt'
 apply from: '../versioning.gradle'
 
 ext {
-    VERSION_NAME = "4.4.1"
+    VERSION_NAME = "4.4.2"
     USE_ORCHESTRATOR = project.hasProperty('orchestrator') ? project.property('orchestrator') : false
 }
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsSharedPreferences.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsSharedPreferences.kt
@@ -24,7 +24,7 @@ class StatisticsSharedPreferences @Inject constructor(private val context: Conte
     StatisticsDataStore {
 
     override val hasInstallationStatistics: Boolean
-        get() = preferences.contains(atb) && preferences.contains(retentionAtb)
+        get() = preferences.contains(KEY_ATB) && preferences.contains(KEY_RETENTION_ATB)
 
     override var atb: String?
         get() = preferences.getString(KEY_ATB, null)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/578616594437384

**Description**:
Fix incorrect shared preferences keys

**Steps to test this PR**:
1. On an app fresh install, note the exti request is made (either by watching traffic or adding a breakpoint to `initializeAtb` method)
1. Relaunch and note that it is not made a second time

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
