### PR TITLE
Add flag so that users' typed text isn't used for personalisation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -25,7 +25,6 @@ import android.support.v4.view.NestedScrollingChildHelper
 import android.support.v4.view.ViewCompat
 import android.util.AttributeSet
 import android.view.MotionEvent
-import android.view.inputmethod.BaseInputConnection
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.webkit.WebView
@@ -50,8 +49,8 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild {
         isNestedScrollingEnabled = true
     }
 
-    override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection {
-        val inputConnection = BaseInputConnection(this, false)
+    override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
+        val inputConnection = super.onCreateInputConnection(outAttrs) ?: return null
 
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             addNoPersonalisedFlag(outAttrs)
@@ -63,7 +62,7 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild {
 
     @TargetApi(Build.VERSION_CODES.O)
     private fun addNoPersonalisedFlag(outAttrs: EditorInfo) {
-        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+        outAttrs.imeOptions = outAttrs.imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
     }
 
     @SuppressLint("ClickableViewAccessibility")

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -17,30 +17,53 @@
 package com.duckduckgo.app.browser
 
 import android.annotation.SuppressLint
+import android.annotation.TargetApi
 import android.content.Context
+import android.os.Build
 import android.support.v4.view.NestedScrollingChild
 import android.support.v4.view.NestedScrollingChildHelper
 import android.support.v4.view.ViewCompat
 import android.util.AttributeSet
 import android.view.MotionEvent
+import android.view.inputmethod.BaseInputConnection
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
 import android.webkit.WebView
 
 /**
- * NestedWebView which allows the WebView to hide the toolbar when placed in a CoordinatorLayout
+ * WebView subclass which allows the WebView to
+ *   - hide the toolbar when placed in a CoordinatorLayout
+ *   - add the flag so that users' typing isn't used for personalisation
  *
- * Based on https://github.com/takahirom/webview-in-coordinatorlayout
+ * Originally based on https://github.com/takahirom/webview-in-coordinatorlayout for scrolling behaviour
  */
-class NestedWebView : WebView, NestedScrollingChild {
+class DuckDuckGoWebView : WebView, NestedScrollingChild {
     private var lastY: Int = 0
     private val scrollOffset = IntArray(2)
     private val scrollConsumed = IntArray(2)
-    private var nestedOffetY: Int = 0
+    private var nestedOffsetY: Int = 0
     private var nestedScrollHelper: NestedScrollingChildHelper = NestedScrollingChildHelper(this)
 
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
     {
         isNestedScrollingEnabled = true
+    }
+
+    override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection {
+        val inputConnection = BaseInputConnection(this, false)
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            addNoPersonalisedFlag(outAttrs)
+        }
+
+        return inputConnection
+    }
+
+
+    @TargetApi(Build.VERSION_CODES.O)
+    private fun addNoPersonalisedFlag(outAttrs: EditorInfo) {
+        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -50,10 +73,10 @@ class NestedWebView : WebView, NestedScrollingChild {
         val event = MotionEvent.obtain(ev)
         val action = event.actionMasked
         if (action == MotionEvent.ACTION_DOWN) {
-            nestedOffetY = 0
+            nestedOffsetY = 0
         }
         val eventY = event.y.toInt()
-        event.offsetLocation(0f, nestedOffetY.toFloat())
+        event.offsetLocation(0f, nestedOffsetY.toFloat())
 
         when (action) {
             MotionEvent.ACTION_MOVE -> {
@@ -63,14 +86,14 @@ class NestedWebView : WebView, NestedScrollingChild {
                     deltaY -= scrollConsumed[1]
                     lastY = eventY - scrollOffset[1]
                     event.offsetLocation(0f, (-scrollOffset[1]).toFloat())
-                    nestedOffetY += scrollOffset[1]
+                    nestedOffsetY += scrollOffset[1]
                 }
 
                 returnValue = super.onTouchEvent(event)
 
                 if (dispatchNestedScroll(0, scrollOffset[1], 0, deltaY, scrollOffset)) {
                     event.offsetLocation(0f, scrollOffset[1].toFloat())
-                    nestedOffetY += scrollOffset[1]
+                    nestedOffsetY += scrollOffset[1]
                     lastY -= scrollOffset[1]
                 }
             }

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -104,7 +104,7 @@
                             android:elevation="4dp"
                             android:fontFamily="sans-serif-medium"
                             android:hint="@string/omnibarInputHint"
-                            android:imeOptions="flagNoExtractUi|actionDone"
+                            android:imeOptions="flagNoExtractUi|actionDone|flagNoPersonalizedLearning"
                             android:inputType="textUri|textNoSuggestions"
                             android:maxLines="1"
                             android:paddingBottom="4dp"

--- a/app/src/main/res/layout/include_duckduckgo_browser_webview.xml
+++ b/app/src/main/res/layout/include_duckduckgo_browser_webview.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<com.duckduckgo.app.browser.NestedWebView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.duckduckgo.app.browser.DuckDuckGoWebView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/browserWebView"
     android:layout_width="match_parent"
@@ -31,4 +31,4 @@
     android:visibility="gone"
     tools:visibility="visible">
 
-</com.duckduckgo.app.browser.NestedWebView>
+</com.duckduckgo.app.browser.DuckDuckGoWebView>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/search/587554197702895/567594137922103
Tech Design URL: 
CC: 

**Description**:
By default, any text the user types into the app can be used for personalisation by whichever keyboard is in use.

This PR will add the non-personalisation flag to request that doesn't happen for text typed in our app. Note, this isn't a guarantee and is just a request; the keyboard app can do whatever it wants still.

There are two places to apply the flag; one is on the omnibar `EditText` as that is a native component, and another is for keyboards spawned through the `WebView`.

The flag is only applicable for devices running Oreo and upwards.

**Discussion**
Do you think this needs to be a user-preference? It feels safe enough to me to _always_ have it enabled.


**Steps to test this PR**:
1. Launch the app
1. Click on the omnibar
1. If using standard Android GBoard, ensure you are in keyboard incognito mode. This can be verified by the very faint _spy_ watermark.
1. If using another keyboard, then it probably isn't respected anyway, so you're unlikely to notice any change.
1. Load a webpage, like our SERP, and start typing content *INSIDE* the `WebView` itself and ensure you see the same incognito watermark.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
