### PR TITLE
Run all config on one scheduler

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
@@ -45,12 +45,12 @@ class AppConfigurationDownloader(
         val httpsUpgradeDownload = httpsUpgradeListDownloader.downloadList()
 
         return Completable.mergeDelayError(listOf(
-                easyListDownload.subscribeOn(Schedulers.io()),
-                easyPrivacyDownload.subscribeOn(Schedulers.io()),
-                trackersWhitelist.subscribeOn(Schedulers.io()),
-                disconnectDownload.subscribeOn(Schedulers.io()),
-                surrogatesDownload.subscribeOn(Schedulers.io()),
-                httpsUpgradeDownload.subscribeOn(Schedulers.io())
+                easyListDownload,
+                easyPrivacyDownload,
+                trackersWhitelist,
+                disconnectDownload,
+                surrogatesDownload,
+                httpsUpgradeDownload
         )).doOnComplete {
             Timber.i("Download task completed successfully")
             val appConfiguration = AppConfigurationEntity(appConfigurationDownloaded = true)

--- a/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.app.trackerdetection.api.TrackerDataDownloader
 import io.reactivex.Completable
 import timber.log.Timber
 
-interface ConfigurationDownloader{
+interface ConfigurationDownloader {
     fun downloadTask(): Completable
 }
 

--- a/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.app.surrogates.api.ResourceSurrogateListDownloader
 import com.duckduckgo.app.trackerdetection.Client.ClientName.*
 import com.duckduckgo.app.trackerdetection.api.TrackerDataDownloader
 import io.reactivex.Completable
-import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
 
 interface ConfigurationDownloader{


### PR DESCRIPTION
…ne grinds devices to a halt

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/592667188539745
Tech Design URL: 
CC: 

**Description**:
Moves scheduled jobs onto one scheduler as app is grinding to a halt when multiple are launched at once. This is a bandaid - we will improve the performance of this int he future

**Steps to test this PR**:
1. Launch fresh app
1. Note faster transition from onboarding to browser

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
