### PR TITLE
Fix fragment reference and small tidy ups

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -78,10 +78,9 @@ class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private fun openNewTab(tabId: String, userQuery: String? = null) {
-        val previousFragment = supportFragmentManager.findFragmentById(R.id.fragmentContainer) as? BrowserTabFragment
         val fragment = BrowserTabFragment.newInstance(tabId, userQuery)
         val transaction = supportFragmentManager.beginTransaction()
-        if (previousFragment == null) {
+        if (currentTab == null) {
             transaction.replace(R.id.fragmentContainer, fragment, tabId)
         } else {
             transaction.hide(currentTab)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -280,7 +280,11 @@ class BrowserTabFragment : Fragment(), FindListener {
             omnibarTextInput.setText(viewState.omnibarText)
 
             // ensures caret sits at the end of the query
-            omnibarTextInput.post { omnibarTextInput?.setSelection(omnibarTextInput.text.length) }
+            omnibarTextInput.post {
+                omnibarTextInput?.let {
+                    it.setSelection(it.text.length)
+                }
+            }
             appBarLayout.setExpanded(true, true)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -571,7 +571,7 @@ class BrowserTabFragment : Fragment(), FindListener {
     private fun hideKeyboardImmediately() {
         if (!isHidden) {
             Timber.v("Keyboard now hiding")
-            omnibarTextInput?.hideKeyboard()
+            omnibarTextInput.hideKeyboard()
             focusDummy.requestFocus()
         }
     }
@@ -605,8 +605,7 @@ class BrowserTabFragment : Fragment(), FindListener {
         super.onHiddenChanged(hidden)
         if (hidden) {
             webView?.onPause()
-        }
-        else {
+        } else {
             webView?.onResume()
             viewModel.onViewVisible()
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -595,7 +595,11 @@ class BrowserTabFragment : Fragment(), FindListener {
 
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
-        if (!hidden) {
+        if (hidden) {
+            webView?.onPause()
+        }
+        else {
+            webView?.onResume()
             viewModel.onViewVisible()
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -410,7 +410,7 @@ class BrowserTabFragment : Fragment(), FindListener {
                     return@setOnMenuItemClickListener true
                 }
                 R.id.browserPopup -> {
-                    hideKeyboard()
+                    hideKeyboardImmediately()
                     launchPopupMenu()
                     return@setOnMenuItemClickListener true
                 }
@@ -566,6 +566,14 @@ class BrowserTabFragment : Fragment(), FindListener {
     private fun EditText.replaceTextChangedListener(textWatcher: TextChangedWatcher) {
         removeTextChangedListener(textWatcher)
         addTextChangedListener(textWatcher)
+    }
+
+    private fun hideKeyboardImmediately() {
+        if (!isHidden) {
+            Timber.v("Keyboard now hiding")
+            omnibarTextInput?.hideKeyboard()
+            focusDummy.requestFocus()
+        }
     }
 
     private fun hideKeyboard() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/596538433213756
Tech Design URL: N/A

**Description**:
Fixes issues:
• Where a fragment could be null
• Where keyboard might not be dismissed when opening popover menu
• Youtube video could keep playing when opening new tab via assist

**Steps to test this PR**:
Check that the above are fixed

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
