### PR TITLE
Change from "done" to "go" button.

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -490,7 +490,7 @@ class BrowserTabFragment : Fragment(), FindListener {
         }
 
         omnibarTextInput.setOnEditorActionListener(TextView.OnEditorActionListener { _, actionId, keyEvent ->
-            if (actionId == EditorInfo.IME_ACTION_DONE || keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER) {
+            if (actionId == EditorInfo.IME_ACTION_GO || keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER) {
                 userEnteredQuery(omnibarTextInput.text.toString())
                 return@OnEditorActionListener true
             }

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -90,7 +90,7 @@
                             android:elevation="4dp"
                             android:fontFamily="sans-serif-medium"
                             android:hint="@string/omnibarInputHint"
-                            android:imeOptions="flagNoExtractUi|actionDone|flagNoPersonalizedLearning"
+                            android:imeOptions="flagNoExtractUi|actionGo|flagNoPersonalizedLearning"
                             android:inputType="textUri|textNoSuggestions"
                             android:maxLines="1"
                             android:paddingBottom="4dp"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/547792610048271/542801398504155
Tech Design URL: 
CC: 

**Description**:
Requests the keyboard displays a "GO" button instead of a "DONE" button. But this is IME specific; don't expect all keyboards to honor it. (Google's own GBoard displays it as an -> arrow now)

**Steps to test this PR**:
1. Tap on the omnibar bar to show the keyboard
1. Check the action button's text or icon. Respected on Samsung and SwiftKey.
1. Check that tapping the button actually submits the query ❗️ 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
