### PR TITLE
Clear form data on fire button

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebDataManagerTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.browser
 
+import android.support.test.InstrumentationRegistry
 import android.webkit.CookieManager
 import android.webkit.ValueCallback
 import android.webkit.WebStorage
@@ -36,10 +37,9 @@ class WebDataManagerTest {
 
     private val testee = WebDataManager(host)
 
-
     @Test
     fun whenDataClearedThenCacheHistoryAndStorageDataCleared() {
-        testee.clearData(mockWebView, mockStorage)
+        testee.clearData(mockWebView, mockStorage, InstrumentationRegistry.getTargetContext())
         verify(mockWebView).clearHistory()
         verify(mockWebView).clearCache(true)
         verify(mockStorage).deleteAllData()

--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -16,9 +16,11 @@
 
 package com.duckduckgo.app.browser
 
+import android.os.Build
 import android.webkit.CookieManager
 import android.webkit.WebStorage
 import android.webkit.WebView
+import android.webkit.WebViewDatabase
 
 class WebDataManager(private val host: String) {
 
@@ -26,6 +28,19 @@ class WebDataManager(private val host: String) {
         webView.clearCache(true)
         webView.clearHistory()
         webStorage.deleteAllData()
+        webView.clearFormData()
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            clearFormData(WebViewDatabase.getInstance(webView.context))
+        }
+    }
+
+    /**
+     * Deprecated and not needed on Oreo or later
+     */
+    @Suppress("DEPRECATION")
+    private fun clearFormData(webViewDatabase: WebViewDatabase) {
+        webViewDatabase.clearFormData()
     }
 
     fun clearExternalCookies(cookieManager: CookieManager, clearAllCallback: (() -> Unit)) {

--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.browser
 
+import android.content.Context
 import android.os.Build
 import android.webkit.CookieManager
 import android.webkit.WebStorage
@@ -24,14 +25,14 @@ import android.webkit.WebViewDatabase
 
 class WebDataManager(private val host: String) {
 
-    fun clearData(webView: WebView, webStorage: WebStorage) {
+    fun clearData(webView: WebView, webStorage: WebStorage, context: Context) {
         webView.clearCache(true)
         webView.clearHistory()
         webStorage.deleteAllData()
         webView.clearFormData()
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            clearFormData(WebViewDatabase.getInstance(webView.context))
+            clearFormData(WebViewDatabase.getInstance(context))
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -39,7 +39,7 @@ class FireDialog(context: Context, clearStarted: (() -> Unit), clearComplete: ((
 
         clearAllOption.setOnClickListener {
             clearStarted()
-            dataManager.clearData(WebView(context), WebStorage.getInstance())
+            dataManager.clearData(WebView(context), WebStorage.getInstance(), context)
             dataManager.clearExternalCookies(CookieManager.getInstance(), clearComplete)
             dismiss()
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/413877547933099/611090365191865
Tech Design URL: 
CC: 

**Description**:
This is only needed on pre-Oreo devices. From Oreo onwards, the auto-fill framework kicks instead of the WebView saved form data (as per https://codereview.chromium.org/2794113002)

**Steps to test this PR**:

On a pre-Oreo device;

1. Visit a site which has the autocomplete flag set in the HTML form element (e.g., https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_form_autocomplete)
1. Enter a value in `First Name` field (you can ignore email for quicker entry)
1. Hit submit
1. Refresh the webpage
1. Click on the `First name` field again - you **should** see the first name suggested for you.
1. 🔥 
1. Repeat
1. This time you **should not** see the value you entered in the `First name` field suggested to you.

On a Oreo or greater device;
Repeat the above. But you should never see the autocomplete suggestion unless it's coming from your password manager.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
