### PR TITLE
Check savedInstanceState before calling consumeSharedText()

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -165,7 +165,10 @@ class BrowserTabFragment : Fragment(), FindListener {
         configureFindInPage()
         configureAutoComplete()
         configureKeyboardAwareLogoAnimation()
-        consumeSharedText()
+
+        if (savedInstanceState == null) {
+            consumeSharedText()
+        }
     }
 
     private fun consumeSharedText() {


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/633172962296836
Tech Design URL: 
CC: 

**Description**:
If savedInstanceState is not null, we'll already have consumed the shared text

**Steps to test this PR**:
1. Enable "don't keep activities"
1. Select a pre-existing tab
1. Navigate to a few different pages to build up some page history
1. Hit the Home button
1. Return to the app
1. Ensure it reloads the latest page you were viewing; and not the page it first loaded when you selected the tab initially


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
