### PR TITLE
Set JobScheduler backoff policy to 30 minutes exponential back-off

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/job/JobBuilder.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/job/JobBuilder.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.global.job
 
 import android.app.job.JobInfo
+import android.app.job.JobInfo.BACKOFF_POLICY_EXPONENTIAL
 import android.content.ComponentName
 import android.content.Context
 import com.duckduckgo.app.job.AppConfigurationJobService
@@ -32,6 +33,7 @@ class JobBuilder @Inject constructor(){
         return JobInfo.Builder(APP_CONFIGURATION_JOB_ID, ComponentName(context, AppConfigurationJobService::class.java))
                 .setPeriodic(TimeUnit.HOURS.toMillis(3))
                 .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                .setBackoffCriteria(TimeUnit.MINUTES.toMillis(30), BACKOFF_POLICY_EXPONENTIAL)
                 .setPersisted(true)
                 .build()
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/622674467677606
Tech Design URL: 
CC: 

**Description**:
This is only used when there has been a failure in the job. The default is 30 seconds so we're making the retries less aggressive.

**Steps to test this PR**:
1. Just checking the code is probably fine
1. But if you want to really test it, you could go make the job fail and see if it retries 30 seconds later or 30 minutes later.
1. But checking the code is probably fine 😄 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
