### PR TITLE
Update omnibar to show controls when input is empty

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -384,14 +384,26 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOmnibarInputDoesNotHaveFocusThenFireButtonIsShown() {
+    fun whenOmnibarInputDoesNotHaveFocusAndHasQueryThenFireButtonIsShown() {
+        testee.onOmnibarInputStateChanged("query", false)
+        assertTrue(testee.viewState.value!!.showFireButton)
+    }
+
+    @Test
+    fun whenOmnibarInputDoesNotHaveFocusOrQueryThenFireButtonIsShown() {
         testee.onOmnibarInputStateChanged("", false)
         assertTrue(testee.viewState.value!!.showFireButton)
     }
 
     @Test
-    fun whenOmnibarInputHasFocusThenFireButtonIsHidden() {
+    fun whenOmnibarInputHasFocusAndNoQueryThenFireButtonIsShown() {
         testee.onOmnibarInputStateChanged("", true)
+        assertTrue(testee.viewState.value!!.showFireButton)
+    }
+
+    @Test
+    fun whenOmnibarInputHasFocusAndQueryThenFireButtonIsHidden() {
+        testee.onOmnibarInputStateChanged("query", true)
         assertFalse(testee.viewState.value!!.showFireButton)
     }
 
@@ -401,14 +413,26 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOmnibarInputDoesNotHaveFocusThenTabsButtonIsShown() {
+    fun whenOmnibarInputDoesNotHaveFocusOrQueryThenTabsButtonIsShown() {
         testee.onOmnibarInputStateChanged("", false)
         assertTrue(testee.viewState.value!!.showTabsButton)
     }
 
     @Test
-    fun whenOmnibarInputHasFocusThenTabsButtonIsNotShown() {
+    fun whenOmnibarInputDoesNotHaveFocusAndHasQueryThenTabsButtonIsShown() {
+        testee.onOmnibarInputStateChanged("query", false)
+        assertTrue(testee.viewState.value!!.showTabsButton)
+    }
+
+    @Test
+    fun whenOmnibarInputHasFocusAndNoQueryThenTabsButtonIsShown() {
         testee.onOmnibarInputStateChanged("", true)
+        assertTrue(testee.viewState.value!!.showTabsButton)
+    }
+
+    @Test
+    fun whenOmnibarInputHasFocusAndQueryThenTabsButtonIsHidden() {
+        testee.onOmnibarInputStateChanged("query", true)
         assertFalse(testee.viewState.value!!.showTabsButton)
     }
 
@@ -418,14 +442,26 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOmnibarInputDoesNotHaveFocusThenMenuButtonIsShown() {
+    fun whenOmnibarInputDoesNotHaveFocusOrQueryThenMenuButtonIsShown() {
         testee.onOmnibarInputStateChanged("", false)
         assertTrue(testee.viewState.value!!.showMenuButton)
     }
 
     @Test
-    fun whenOmnibarInputHasFocusThenMenuButtonIsNotShown() {
+    fun whenOmnibarInputDoesNotHaveFocusAndHasQueryThenMenuButtonIsShown() {
+        testee.onOmnibarInputStateChanged("query", false)
+        assertTrue(testee.viewState.value!!.showMenuButton)
+    }
+
+    @Test
+    fun whenOmnibarInputHasFocusAndNoQueryThenMenuButtonIsShown() {
         testee.onOmnibarInputStateChanged("", true)
+        assertTrue(testee.viewState.value!!.showMenuButton)
+    }
+
+    @Test
+    fun whenOmnibarInputHasFocusAndQueryThenMenuButtonIsHidden() {
+        testee.onOmnibarInputStateChanged("query", true)
         assertFalse(testee.viewState.value!!.showMenuButton)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -324,7 +324,6 @@ class BrowserTabViewModel(
     private fun currentViewState(): ViewState = viewState.value!!
 
     fun onOmnibarInputStateChanged(query: String, hasFocus: Boolean) {
-        val showClearButton = hasFocus && query.isNotEmpty()
 
         val currentViewState = currentViewState()
 
@@ -338,13 +337,15 @@ class BrowserTabViewModel(
         val hasQueryChanged = (currentViewState.omnibarText != query)
         val autoCompleteSuggestionsEnabled = appSettingsPreferencesStore.autoCompleteSuggestionsEnabled
         val showAutoCompleteSuggestions = hasFocus && query.isNotBlank() && hasQueryChanged && autoCompleteSuggestionsEnabled
+        val showClearButton = hasFocus && query.isNotBlank()
+        val showControls = !hasFocus || query.isBlank()
 
         viewState.value = currentViewState().copy(
             isEditing = hasFocus,
             showPrivacyGrade = appConfigurationDownloaded && currentViewState.browserShowing,
-            showTabsButton = !hasFocus,
-            showFireButton = !hasFocus,
-            showMenuButton = !hasFocus,
+            showTabsButton = showControls,
+            showFireButton = showControls,
+            showMenuButton = showControls,
             showClearButton = showClearButton,
             autoComplete = AutoCompleteViewState(showAutoCompleteSuggestions, autoCompleteSearchResults)
         )


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/board

**Description**:
Updates omnibar to show controls (fire, tabs, menu) when textfield is empty

**Steps to test this PR**:
1. Launch the app to the home screen
1. Ensure that the fire, tabs and menu buttons are visible
1. Start typing and ensure that the textfield expands to cover the buttons
1. Clear the text to show them again
Note: refer to images in https://app.asana.com/0/488551667048375/board

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
