### PR TITLE
Fix network caching bug

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/api/ResponseExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/ResponseExtension.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.global.api
 
 import retrofit2.Response
+import java.net.HttpURLConnection.HTTP_NOT_MODIFIED
 
 val <T> Response<T>.isCached: Boolean
-    get() = raw().cacheResponse() != null
-
+    get() = raw().cacheResponse() != null && raw().networkResponse()?.code() == HTTP_NOT_MODIFIED


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/646509999202748

**Description**:
Fix issue where we consider a network response to come from the cache even when caching is off or there is new data

**Steps to test this PR**:
TEST ONE
1. Run the app and watch network data in charles
1. Allow the app to sync and download everything
1. In Charles, right click the https://duckduckgo.com/contentblocking.js?l=easylist request and select the "No caching" option
1. Start the app again and logs should show an entry of "Updating EASYLIST data store with new data"

TEST TWO
1. In Charles, right click the https://duckduckgo.com/contentblocking.js?l=easylist request and *deselect* the "No caching" option from the previous test
1. Kill and launch the app again let it sync (do this twice)
1. Logs should now only show "EASYLIST data already cached and stored"
1. Logs should not show "Updating EASYLIST data store with new data"

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
