### PR TITLE
Add app version to backend stats calls

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -41,17 +41,17 @@ class StatisticsRequesterTest {
 
     @Before
     fun before() {
-        whenever(mockService.atb()).thenReturn(Observable.just(Atb(ATB)))
-        whenever(mockService.updateAtb(any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
-        whenever(mockService.exti(any())).thenReturn(Observable.just(mockResponseBody))
+        whenever(mockService.atb(any())).thenReturn(Observable.just(Atb(ATB)))
+        whenever(mockService.updateAtb(any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
+        whenever(mockService.exti(any(), any())).thenReturn(Observable.just(mockResponseBody))
     }
 
     @Test
     fun whenNoStatisticsStoredThenInitializeAtbRetrievesAtbAndInvokesExti() {
         configureNoStoredStatistics()
         testee.initializeAtb()
-        verify(mockService).atb()
-        verify(mockService).exti(ATB_WITH_VARIANT)
+        verify(mockService).atb(any())
+        verify(mockService).exti(eq(ATB_WITH_VARIANT), any())
         verify(mockStatisticsStore).atb = ATB_WITH_VARIANT
         verify(mockStatisticsStore).retentionAtb = ATB
     }
@@ -60,23 +60,23 @@ class StatisticsRequesterTest {
     fun whenStatisticsStoredThenInitializeAtbDoesNothing() {
         configureStoredStatistics()
         testee.initializeAtb()
-        verify(mockService, never()).atb()
-        verify(mockService, never()).exti(ATB)
+        verify(mockService, never()).atb(any())
+        verify(mockService, never()).exti(eq(ATB), any())
     }
 
     @Test
     fun whenNoStatisticsStoredThenRefreshRetrievesAtbAndInvokesExti() {
         configureNoStoredStatistics()
         testee.refreshRetentionAtb()
-        verify(mockService).atb()
-        verify(mockService).exti(ATB_WITH_VARIANT)
+        verify(mockService).atb(any())
+        verify(mockService).exti(eq(ATB_WITH_VARIANT), any())
         verify(mockStatisticsStore).atb = ATB_WITH_VARIANT
         verify(mockStatisticsStore).retentionAtb = ATB
     }
 
     @Test
     fun whenExitFailsThenAtbCleared() {
-        whenever(mockService.exti(any())).thenReturn(Observable.error(Throwable()))
+        whenever(mockService.exti(any(), any())).thenReturn(Observable.error(Throwable()))
         configureNoStoredStatistics()
         testee.initializeAtb()
         verify(mockStatisticsStore).atb = ATB_WITH_VARIANT
@@ -89,7 +89,7 @@ class StatisticsRequesterTest {
     fun whenStatisticsStoredThenRefreshUpdatesAtb() {
         configureStoredStatistics()
         testee.refreshRetentionAtb()
-        verify(mockService).updateAtb(ATB_WITH_VARIANT, ATB)
+        verify(mockService).updateAtb(eq(ATB_WITH_VARIANT), eq(ATB), any())
         verify(mockStatisticsStore).retentionAtb = NEW_ATB
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
@@ -63,11 +63,7 @@ class DuckDuckGoRequestRewriter(private val duckDuckGoUrlDetector: DuckDuckGoUrl
         if (atb != null) {
             builder.appendQueryParameter(ParamKey.ATB, atb)
         }
-        builder.appendQueryParameter(ParamKey.APP_VERSION, appVersion())
+        builder.appendQueryParameter(ParamKey.APP_VERSION, ParamValue.appVersion)
         builder.appendQueryParameter(ParamKey.SOURCE, ParamValue.SOURCE)
-    }
-
-    private fun appVersion(): String {
-        return String.format("android_%s", BuildConfig.VERSION_NAME.replace(".", "_"))
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.app.global
 
+import com.duckduckgo.app.browser.BuildConfig
+
 
 class AppUrl {
 
@@ -37,6 +39,10 @@ class AppUrl {
 
     object ParamValue {
         const val SOURCE = "ddg_android"
+
+        val appVersion: String get() {
+            return String.format("android_%s", BuildConfig.VERSION_NAME.replace(".", "_"))
+        }
     }
 
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.statistics.api
 
 import android.annotation.SuppressLint
+import com.duckduckgo.app.global.AppUrl.*
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
@@ -38,12 +39,12 @@ class StatisticsRequester(private val store: StatisticsDataStore, private val se
             return
         }
 
-        service.atb()
+        service.atb(ParamValue.appVersion)
             .subscribeOn(Schedulers.io())
             .flatMap {
                 store.atb = it.versionWithVariant
                 store.retentionAtb = it.version
-                service.exti(it.versionWithVariant)
+                service.exti(it.versionWithVariant, ParamValue.appVersion)
             }
             .subscribe({
                 Timber.v("Atb initalization succeeded")
@@ -65,7 +66,7 @@ class StatisticsRequester(private val store: StatisticsDataStore, private val se
             return
         }
 
-        service.updateAtb(atb, retentionAtb)
+        service.updateAtb(atb, retentionAtb, ParamValue.appVersion)
             .subscribeOn(Schedulers.io())
             .subscribe({
                 Timber.v("Atb refresh succeeded")

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsService.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsService.kt
@@ -27,11 +27,15 @@ import retrofit2.http.Query
 interface StatisticsService {
 
     @GET("/exti/")
-    fun exti(@Query(ParamKey.ATB) atb: String): Observable<ResponseBody>
+    fun exti(@Query(ParamKey.ATB) atb: String, @Query(ParamKey.APP_VERSION) version: String): Observable<ResponseBody>
 
     @GET("/atb.js")
-    fun atb(): Observable<Atb>
+    fun atb(@Query(ParamKey.APP_VERSION) version: String): Observable<Atb>
 
     @GET("/atb.js")
-    fun updateAtb(@Query(ParamKey.ATB) atb: String, @Query(ParamKey.RETENTION_ATB) retentionAtb: String): Observable<Atb>
+    fun updateAtb(
+        @Query(ParamKey.ATB) atb: String,
+        @Query(ParamKey.RETENTION_ATB) retentionAtb: String,
+        @Query(ParamKey.APP_VERSION) version: String
+    ): Observable<Atb>
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/649057775699176 

**Description**:
Temporarily adds the app version number (tappv) to exti and atb calls to help diagnose unexpected additional calls to exti

**Steps to test this PR**:
1. Run the app from a clean installation and watch traffic in charles
1. Note that the exti and atb calls contain the tappv parameter
1. Perform a search note the the atb call again contains the tappv parameter

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
