### PR TITLE
Replace mocked WebView with test implementation

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebDataManagerTest.kt
@@ -16,12 +16,15 @@
 
 package com.duckduckgo.app.browser
 
+import android.content.Context
 import android.support.test.InstrumentationRegistry
+import android.support.test.annotation.UiThreadTest
 import android.webkit.CookieManager
 import android.webkit.ValueCallback
 import android.webkit.WebStorage
 import android.webkit.WebView
 import com.nhaarman.mockito_kotlin.*
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.ArgumentCaptor
 
@@ -31,17 +34,18 @@ class WebDataManagerTest {
 
     private val mockCookieManager: CookieManager = mock()
 
-    private val mockWebView: WebView = mock()
-
     private val mockStorage: WebStorage = mock()
 
     private val testee = WebDataManager(host)
 
+    @UiThreadTest
     @Test
     fun whenDataClearedThenCacheHistoryAndStorageDataCleared() {
-        testee.clearData(mockWebView, mockStorage, InstrumentationRegistry.getTargetContext())
-        verify(mockWebView).clearHistory()
-        verify(mockWebView).clearCache(true)
+        val context = InstrumentationRegistry.getTargetContext()
+        val webView = TestWebView(context)
+        testee.clearData(webView, mockStorage, context)
+        assertTrue(webView.historyCleared)
+        assertTrue(webView.cacheCleared)
         verify(mockStorage).deleteAllData()
     }
 
@@ -79,6 +83,27 @@ class WebDataManagerTest {
         verify(mockCookieManager, never()).setCookie(host, "ea=abc")
         verify(mockCookieManager, never()).setCookie(host, "ez=zyx")
     }
+
+    private class TestWebView(context: Context) : WebView(context) {
+
+        var historyCleared: Boolean = false
+        var cacheCleared: Boolean = false
+
+        override fun clearHistory() {
+            super.clearHistory()
+
+            historyCleared = true
+        }
+
+        override fun clearCache(includeDiskFiles: Boolean) {
+            super.clearCache(includeDiskFiles)
+
+            if(includeDiskFiles) {
+                cacheCleared = true
+            }
+        }
+    }
+
 
     companion object {
         private const val host = "duckduckgo.com"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

**Description**:
This avoids the large slow-down we were seeing in the test execution. `SpecialUrlDetectorTest` was never to blame; it was just the class that ran immediately before `WebDataManagerTest` was trying to startup. 

`WebDataMangerTest` was always the problem. Attempting to mock a `WebView` is too heavyweight of an operation: you'd see logs like this during the stalled period:

    Compiler allocated 17MB to compile net.bytebuddy.description.type.TypeDescription net.bytebuddy.dynamic.scaffold.InstrumentedType$Default.validated()

The alternative is to implement a test-specific subclass of `WebView` and just track whether the history and cache clearing methods were called or not with booleans.

**Steps to test this PR**:
1. Run the unit tests; observe that the execution doesn't stall while seemingly trying to execute `SpecialUrlDetectorTest` tests.
1. Observe the overall time to execute tests is significantly reduced. For me, it now executes about 3x faster! 🚀


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
