### PR TITLE
Hotfix/5.3.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-kapt'
 apply from: '../versioning.gradle'
 
 ext {
-    VERSION_NAME = "5.3.0"
+    VERSION_NAME = "5.3.1"
     USE_ORCHESTRATOR = project.hasProperty('orchestrator') ? project.property('orchestrator') : false
 }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoWebViewTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoWebViewTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.annotation.UiThreadTest
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class DuckDuckGoWebViewTest {
+
+    private lateinit var testee: DuckDuckGoWebView
+
+    @UiThreadTest
+    @Test
+    fun whenWebViewInitialisedThenSafeBrowsingDisabled() {
+        testee = DuckDuckGoWebView(InstrumentationRegistry.getTargetContext())
+        assertFalse(testee.settings.safeBrowsingEnabled)
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,9 +16,14 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
+
         <meta-data
             android:name="android.webkit.WebView.MetricsOptOut"
             android:value="true" />
+
+        <meta-data
+            android:name="android.webkit.WebView.EnableSafeBrowsing"
+            android:value="false" />
 
         <activity
             android:name="com.duckduckgo.app.launch.LaunchActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,10 @@
             android:name="android.webkit.WebView.MetricsOptOut"
             android:value="true" />
 
+        <!--
+            To protect user privacy, disable SafeBrowsing which could send URLs to Google servers
+            https://developer.android.com/reference/android/webkit/WebView
+        -->
         <meta-data
             android:name="android.webkit.WebView.EnableSafeBrowsing"
             android:value="false" />


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/654220091942217

**Description**:
Explicitly disables Google SafeBrowsing which will be on by default from WebView versions 66 onwards.

**Steps to test this PR**:
1. Visit http://testsafebrowsing.appspot.com/ and click on the first link
1. The page should load
1. Compare the new `meta-data` tag with the documentation to ensure it matches the docs (https://developer.android.com/reference/android/webkit/WebView)

You can repeat the above test from `develop` and the page should fail to load (assuming you have v66 of Chrome on your device). Note, it won't fail in a nice way - it will just kinda stall as we haven't implemented the `SafeBrowsing` callbacks to show a nice UI.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
