### PR TITLE
Hotfix/fix failing tests

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoWebViewTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoWebViewTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.browser
 
+import android.os.Build
 import android.support.test.InstrumentationRegistry
 import android.support.test.annotation.UiThreadTest
 import org.junit.Assert.assertFalse
@@ -28,7 +29,9 @@ class DuckDuckGoWebViewTest {
     @UiThreadTest
     @Test
     fun whenWebViewInitialisedThenSafeBrowsingDisabled() {
-        testee = DuckDuckGoWebView(InstrumentationRegistry.getTargetContext())
-        assertFalse(testee.settings.safeBrowsingEnabled)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            testee = DuckDuckGoWebView(InstrumentationRegistry.getTargetContext())
+            assertFalse(testee.settings.safeBrowsingEnabled)
+        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/DataUriParser.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/DataUriParser.kt
@@ -42,6 +42,10 @@ class DataUriParser @Inject constructor() {
     }
 
     private fun determineSuffix(mimeType: String): String {
+
+        // MimeTypeMap returns the wrong value for "jpeg" types on Lollipop
+        if (mimeType == "image/jpeg") return "jpg"
+
         return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) ?: ""
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/656892186053109

**Description**:
Depending on the OS version used for the CI emulators, two tests can fail. This is currently causing `master` and `develop` to fail CI tests.

`SafeBrowsing` check on `WebView` is only available on `Oreo` or newer (the API is missing an annotation to denote such) so this PR adds an SDK check in the test itself - if the OS is too old, the test does nothing which is just a silent pass. If the OS is new enough, it confirms `SafeBrowsing` isn't enabled.

There is a test in the data uri parsing suite which pulls a filename suffix from a mime type. On Lollipop, the class it uses returns `jpeg` for `image/jpeg` whereas on newer OS versions it will always return `jpg`. This fix just adds a manual check for `image/jpeg` and returns `jpg` directly instead of relying on the differing OS implementations.

Additionally, there is one flakey test class `AppDatabaseTest` which will occasionally throw an `IllegalStateException`

**Steps to test this PR**:
1. Ensure CI passes
1. Run tests locally on a Lollipop emulator

All tests above should pass.

### Note on branches
This is a hotfix on `master` since `master` is currently failing. The plan is that after PR approval, I'll finish the hotfix and merge into both `master` and `develop` but *will not do a release/tag* since the fix is for tests only.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
