### PR TITLE
Fix share failure

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.browser
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
 import android.arch.persistence.room.Room
-import android.net.Uri
 import android.support.test.InstrumentationRegistry
 import android.view.MenuItem
 import android.view.View
@@ -128,7 +127,7 @@ class BrowserTabViewModelTest {
                 queryUrlConverter = mockOmnibarConverter,
                 duckDuckGoUrlDetector = DuckDuckGoUrlDetector(),
                 siteFactory = siteFactory,
-                tabRepository = TabDataRepository(tabsDao),
+                tabRepository = TabDataRepository(tabsDao, siteFactory),
                 networkLeaderboardDao = mockNetworkLeaderboardDao,
                 autoCompleteApi = mockAutoCompleteApi,
                 appSettingsPreferencesStore = mockSettingsStore,
@@ -140,7 +139,7 @@ class BrowserTabViewModelTest {
         testee.url.observeForever(mockQueryObserver)
         testee.command.observeForever(mockCommandObserver)
 
-        whenever(mockOmnibarConverter.convertQueryToUri(any())).thenReturn(Uri.parse("duckduckgo.com"))
+        whenever(mockOmnibarConverter.convertQueryToUrl(any())).thenReturn("duckduckgo.com")
 
     }
 
@@ -171,7 +170,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenSubmittedQueryHasWhitespaceItIsTrimmed() {
         testee.onUserSubmittedQuery(" nytimes.com ")
-        verify(mockOmnibarConverter).isWebUrl("nytimes.com")
         assertEquals("nytimes.com", testee.viewState.value!!.omnibarText)
     }
 
@@ -621,7 +619,7 @@ class BrowserTabViewModelTest {
         whenever(mockLongPressHandler.userSelectedMenuItem(any(), any())).thenReturn(OpenInNewTab("http://example.com"))
         val mockMenItem: MenuItem = mock()
         testee.userSelectedItemFromLongPressMenu("http://example.com", mockMenItem)
-        val command = captureCommands().value as Command.NewTab
+        val command = captureCommands().value as Command.OpenInNewTab
         assertEquals("http://example.com", command.query)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -32,231 +32,9 @@ class QueryUrlConverterTest {
     private val testee: QueryUrlConverter = QueryUrlConverter(DuckDuckGoRequestRewriter(DuckDuckGoUrlDetector(), mockStatisticsStore))
 
     @Test
-    fun whenUserIsPresentThenIsWebUrlIsFalse() {
-        val input = "http://example.com@sample.com"
-        assertFalse(testee.isWebUrl(input))
-    }
-
-    @Test
-    fun whenGivenLongWellFormedUrlThenIsWebUrlIsTrue() {
-        val input = "http://www.veganchic.com/products/Camo-High-Top-Sneaker-by-The-Critical-Slide-Societ+80758-0180.html"
-        assertTrue(testee.isWebUrl(input))
-    }
-
-    @Test
-    fun whenHostIsValidThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("test.com"))
-    }
-
-    @Test
-    fun whenHostIsValidIpAddressThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("121.33.2.11"))
-    }
-
-    @Test
-    fun whenHostIsLocalhostThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("localhost"))
-    }
-
-    @Test
-    fun whenHostIsInvalidContainsSpaceThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("t est.com"))
-    }
-
-    @Test
-    fun whenHostIsInvalidContainsExclamationMarkThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("test!com.com"))
-    }
-
-    @Test
-    fun whenHostIsInvalidIpThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("121.33.33."))
-    }
-
-    @Test
-    fun whenHostIsInvalidMisspelledLocalhostContainsSpaceThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("localhostt"))
-    }
-
-    @Test
-    fun whenSchemeIsValidNormalUrlThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("http://test.com"))
-    }
-
-    @Test
-    fun whenSchemeIsValidIpAddressThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("http://121.33.2.11"))
-    }
-
-    @Test
-    fun whenSchemeIsValidLocalhostUrlThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("http://localhost"))
-    }
-
-    @Test
-    fun whenSchemeIsInvalidNormalUrlThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("asdas://test.com"))
-    }
-
-    @Test
-    fun whenSchemeIsInvalidIpAddressThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("asdas://121.33.2.11"))
-    }
-
-    @Test
-    fun whenSchemeIsInvalidLocalhostThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("asdas://localhost"))
-    }
-
-    @Test
-    fun whenTextIsIncompleteHttpSchemeLettersOnlyThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("http"))
-    }
-
-    @Test
-    fun whenTextIsIncompleteHttpSchemeMissingBothSlashesThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("http:"))
-    }
-
-    @Test
-    fun whenTextIsIncompleteHttpSchemeMissingOneSlashThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("http:/"))
-    }
-
-    @Test
-    fun whenTextIsIncompleteHttpsSchemeLettersOnlyThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("https"))
-    }
-
-    @Test
-    fun whenTextIsIncompleteHttpsSchemeMissingBothSlashesThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("https:"))
-    }
-
-    @Test
-    fun whenTextIsIncompleteHttpsSchemeMissingOneSlashThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("https:/"))
-    }
-
-    @Test
-    fun whenPathIsValidNormalUrlThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("http://test.com/path"))
-    }
-
-    @Test
-    fun whenPathIsValidIpAddressThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("http://121.33.2.11/path"))
-    }
-
-    @Test
-    fun whenPathIsValidLocalhostThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("http://localhost/path"))
-    }
-
-    @Test
-    fun whenPathIsValidMissingSchemeNormalUrlThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("test.com/path"))
-    }
-
-    @Test
-    fun whenPathIsValidMissingSchemeIpAddressThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("121.33.2.11/path"))
-    }
-
-    @Test
-    fun whenPathIsValidMissingSchemeLocalhostThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("localhost/path"))
-    }
-
-    @Test
-    fun whenPathIsInvalidContainsSpaceNormalUrlThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("http://test.com/pa th"))
-    }
-
-    @Test
-    fun whenPathIsInvalidContainsSpaceIpAddressThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("http://121.33.2.11/pa th"))
-    }
-
-    @Test
-    fun whenPathIsInvalidContainsSpaceLocalhostThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("http://localhost/pa th"))
-    }
-
-    @Test
-    fun whenPathIsInvalidContainsSpaceMissingSchemeNormalUrlThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("test.com/pa th"))
-    }
-
-    @Test
-    fun whenPathIsInvalidContainsSpaceMissingSchemeIpAddressThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("121.33.2.11/pa th"))
-    }
-
-    @Test
-    fun whenPathIsInvalidContainsSpaceMissingSchemeLocalhostThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("localhost/pa th"))
-    }
-
-    @Test
-    fun whenParamsAreValidNormalUrlThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("http://test.com?s=dafas&d=342"))
-    }
-
-    @Test
-    fun whenParamsAreValidIpAddressThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("http://121.33.2.11?s=dafas&d=342"))
-    }
-
-    @Test
-    fun whenParamsAreValidLocalhostThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("http://localhost?s=dafas&d=342"))
-    }
-
-    @Test
-    fun whenParamsAreValidNormalUrlMissingSchemeThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("test.com?s=dafas&d=342"))
-    }
-
-    @Test
-    fun whenParamsAreValidIpAddressMissingSchemeThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("121.33.2.11?s=dafas&d=342"))
-    }
-
-    @Test
-    fun whenParamsAreValidLocalhostMissingSchemeThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("localhost?s=dafas&d=342"))
-    }
-
-    @Test
-    fun whenParamsAreValidContainsEncodedUriThenIsWebUrlIsTrue() {
-        assertTrue(testee.isWebUrl("https://m.facebook.com/?refsrc=https%3A%2F%2Fwww.facebook.com%2F&_rdr"))
-    }
-
-    @Test
-    fun whenGivenSimpleStringThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("randomtext"))
-    }
-
-    @Test
-    fun whenGivenStringWithDotPrefixThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl(".randomtext"))
-    }
-
-    @Test
-    fun whenGivenStringWithDotSuffixThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("randomtext."))
-    }
-
-    @Test
-    fun whenGivenNumberThenIsWebUrlIsFalse() {
-        assertFalse(testee.isWebUrl("33"))
-    }
-
-    @Test
     fun whenSingleWordThenSearchQueryBuilt() {
         val input = "foo"
-        val result = testee.convertQueryToUri(input)
+        val result = testee.convertQueryToUrl(input)
         assertDuckDuckGoSearchQuery("foo", result)
     }
 
@@ -264,7 +42,7 @@ class QueryUrlConverterTest {
     fun whenWebUrlCalledWithInvalidURLThenEncodedSearchQueryBuilt() {
         val input = "http://test .com"
         val expected = "http%3A%2F%2Ftest%20.com"
-        val result = testee.convertQueryToUri(input)
+        val result = testee.convertQueryToUrl(input)
         assertDuckDuckGoSearchQuery(expected, result)
     }
 
@@ -272,7 +50,7 @@ class QueryUrlConverterTest {
     fun whenEncodingQueryWithSymbolsThenQueryProperlyEncoded() {
         val input = "test \"%-.<>\\^_`{|~"
         val expected = "test%20%22%25-.%3C%3E%5C%5E_%60%7B%7C~"
-        val result = testee.convertQueryToUri(input)
+        val result = testee.convertQueryToUrl(input)
         assertDuckDuckGoSearchQuery(expected, result)
     }
 
@@ -280,7 +58,7 @@ class QueryUrlConverterTest {
     fun whenParamHasInvalidCharactersThenAddingParamAppendsEncodedVersion() {
         val input = "43 + 5"
         val expected = "43%20%2B%205"
-        val result = testee.convertQueryToUri(input)
+        val result = testee.convertQueryToUrl(input)
         assertDuckDuckGoSearchQuery(expected, result)
     }
 
@@ -288,11 +66,12 @@ class QueryUrlConverterTest {
     fun whenIsWebUrlMissingSchemeThenHttpWillBeAddedUponConversion() {
         val input = "example.com"
         val expected = "http://$input"
-        val result = testee.convertUri(input)
+        val result = testee.convertQueryToUrl(input)
         assertEquals(expected, result)
     }
 
-    private fun assertDuckDuckGoSearchQuery(query: String, uri: Uri) {
+    private fun assertDuckDuckGoSearchQuery(query: String, url: String) {
+        val uri = Uri.parse(url)
         assertEquals("duckduckgo.com", uri.host)
         assertEquals("https", uri.scheme)
         assertEquals("", uri.path)

--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriStringTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriStringTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.global
 
+import com.duckduckgo.app.global.UriString.Companion.isWebUrl
 import com.duckduckgo.app.global.UriString.Companion.sameOrSubdomain
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -46,6 +47,228 @@ class UriStringTest {
     @Test
     fun whenParentUrlIsMalformedThenSameOrSubdomainIsFalse() {
         assertFalse(sameOrSubdomain("http://example.com/index.html", "??.example.com/home.html"))
+    }
+
+    @Test
+    fun whenUserIsPresentThenIsWebUrlIsFalse() {
+        val input = "http://example.com@sample.com"
+        assertFalse(isWebUrl(input))
+    }
+
+    @Test
+    fun whenGivenLongWellFormedUrlThenIsWebUrlIsTrue() {
+        val input = "http://www.veganchic.com/products/Camo-High-Top-Sneaker-by-The-Critical-Slide-Societ+80758-0180.html"
+        assertTrue(isWebUrl(input))
+    }
+
+    @Test
+    fun whenHostIsValidThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("test.com"))
+    }
+
+    @Test
+    fun whenHostIsValidIpAddressThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("121.33.2.11"))
+    }
+
+    @Test
+    fun whenHostIsLocalhostThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("localhost"))
+    }
+
+    @Test
+    fun whenHostIsInvalidContainsSpaceThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("t est.com"))
+    }
+
+    @Test
+    fun whenHostIsInvalidContainsExclamationMarkThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("test!com.com"))
+    }
+
+    @Test
+    fun whenHostIsInvalidIpThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("121.33.33."))
+    }
+
+    @Test
+    fun whenHostIsInvalidMisspelledLocalhostContainsSpaceThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("localhostt"))
+    }
+
+    @Test
+    fun whenSchemeIsValidNormalUrlThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://test.com"))
+    }
+
+    @Test
+    fun whenSchemeIsValidIpAddressThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://121.33.2.11"))
+    }
+
+    @Test
+    fun whenSchemeIsValidLocalhostUrlThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://localhost"))
+    }
+
+    @Test
+    fun whenSchemeIsInvalidNormalUrlThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("asdas://test.com"))
+    }
+
+    @Test
+    fun whenSchemeIsInvalidIpAddressThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("asdas://121.33.2.11"))
+    }
+
+    @Test
+    fun whenSchemeIsInvalidLocalhostThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("asdas://localhost"))
+    }
+
+    @Test
+    fun whenTextIsIncompleteHttpSchemeLettersOnlyThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("http"))
+    }
+
+    @Test
+    fun whenTextIsIncompleteHttpSchemeMissingBothSlashesThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("http:"))
+    }
+
+    @Test
+    fun whenTextIsIncompleteHttpSchemeMissingOneSlashThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("http:/"))
+    }
+
+    @Test
+    fun whenTextIsIncompleteHttpsSchemeLettersOnlyThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("https"))
+    }
+
+    @Test
+    fun whenTextIsIncompleteHttpsSchemeMissingBothSlashesThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("https:"))
+    }
+
+    @Test
+    fun whenTextIsIncompleteHttpsSchemeMissingOneSlashThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("https:/"))
+    }
+
+    @Test
+    fun whenPathIsValidNormalUrlThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://test.com/path"))
+    }
+
+    @Test
+    fun whenPathIsValidIpAddressThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://121.33.2.11/path"))
+    }
+
+    @Test
+    fun whenPathIsValidLocalhostThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://localhost/path"))
+    }
+
+    @Test
+    fun whenPathIsValidMissingSchemeNormalUrlThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("test.com/path"))
+    }
+
+    @Test
+    fun whenPathIsValidMissingSchemeIpAddressThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("121.33.2.11/path"))
+    }
+
+    @Test
+    fun whenPathIsValidMissingSchemeLocalhostThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("localhost/path"))
+    }
+
+    @Test
+    fun whenPathIsInvalidContainsSpaceNormalUrlThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("http://test.com/pa th"))
+    }
+
+    @Test
+    fun whenPathIsInvalidContainsSpaceIpAddressThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("http://121.33.2.11/pa th"))
+    }
+
+    @Test
+    fun whenPathIsInvalidContainsSpaceLocalhostThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("http://localhost/pa th"))
+    }
+
+    @Test
+    fun whenPathIsInvalidContainsSpaceMissingSchemeNormalUrlThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("test.com/pa th"))
+    }
+
+    @Test
+    fun whenPathIsInvalidContainsSpaceMissingSchemeIpAddressThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("121.33.2.11/pa th"))
+    }
+
+    @Test
+    fun whenPathIsInvalidContainsSpaceMissingSchemeLocalhostThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("localhost/pa th"))
+    }
+
+    @Test
+    fun whenParamsAreValidNormalUrlThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://test.com?s=dafas&d=342"))
+    }
+
+    @Test
+    fun whenParamsAreValidIpAddressThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://121.33.2.11?s=dafas&d=342"))
+    }
+
+    @Test
+    fun whenParamsAreValidLocalhostThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://localhost?s=dafas&d=342"))
+    }
+
+    @Test
+    fun whenParamsAreValidNormalUrlMissingSchemeThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("test.com?s=dafas&d=342"))
+    }
+
+    @Test
+    fun whenParamsAreValidIpAddressMissingSchemeThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("121.33.2.11?s=dafas&d=342"))
+    }
+
+    @Test
+    fun whenParamsAreValidLocalhostMissingSchemeThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("localhost?s=dafas&d=342"))
+    }
+
+    @Test
+    fun whenParamsAreValidContainsEncodedUriThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("https://m.facebook.com/?refsrc=https%3A%2F%2Fwww.facebook.com%2F&_rdr"))
+    }
+
+    @Test
+    fun whenGivenSimpleStringThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("randomtext"))
+    }
+
+    @Test
+    fun whenGivenStringWithDotPrefixThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl(".randomtext"))
+    }
+
+    @Test
+    fun whenGivenStringWithDotSuffixThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("randomtext."))
+    }
+
+    @Test
+    fun whenGivenNumberThenIsWebUrlIsFalse() {
+        assertFalse(isWebUrl("33"))
     }
 
 }

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApi.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApi.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.autocomplete.api
 
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
+import com.duckduckgo.app.global.UriString
 import io.reactivex.Observable
 import javax.inject.Inject
 
@@ -34,7 +35,7 @@ open class AutoCompleteApi @Inject constructor(
 
         return autoCompleteService.autoComplete(query)
                 .flatMapIterable { it -> it }
-                .map { AutoCompleteSuggestion(it.phrase, queryUrlConverter.isWebUrl(it.phrase)) }
+                .map { AutoCompleteSuggestion(it.phrase, UriString.isWebUrl(it.phrase)) }
                 .toList()
                 .onErrorReturn { emptyList() }
                 .map { AutoCompleteResult(query = query, suggestions = it) }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -108,13 +108,13 @@ class BrowserActivity : DuckDuckGoActivity() {
         }
 
         if (launchNewSearch(intent)) {
-            viewModel.onNewSearchRequested()
+            viewModel.onNewTabRequested()
             return
         }
 
         val sharedText = intent.intentText
         if (sharedText != null) {
-            viewModel.onSharedTextReceived(sharedText)
+            viewModel.onOpenInNewTabRequested(sharedText)
         }
     }
 
@@ -148,7 +148,6 @@ class BrowserActivity : DuckDuckGoActivity() {
     private fun processCommand(command: Command?) {
         Timber.i("Processing command: $command")
         when (command) {
-            is NewTab -> openNewTab(command.tabId, command.query)
             is Query -> currentTab?.submitQuery(command.query)
             is Refresh -> currentTab?.refresh()
             is Command.DisplayMessage -> applicationContext?.longToast(command.messageId)
@@ -176,8 +175,12 @@ class BrowserActivity : DuckDuckGoActivity() {
         startActivity(TabSwitcherActivity.intent(this))
     }
 
-    fun launchNewTab(query: String? = null) {
-        viewModel.onNewTabRequested(query)
+    fun launchNewTab() {
+        viewModel.onNewTabRequested()
+    }
+
+    fun openInNewTab(query: String) {
+        viewModel.onOpenInNewTabRequested(query)
     }
 
     fun launchSettings() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -128,7 +128,6 @@ class BrowserTabFragment : Fragment(), FindListener {
     private val menuButton: MenuItem?
         get() = toolbar.menu.findItem(R.id.browserPopup)
 
-
     private var webView: WebView? = null
 
     private val findInPageTextWatcher = object : TextChangedWatcher() {
@@ -240,8 +239,8 @@ class BrowserTabFragment : Fragment(), FindListener {
     private fun processCommand(it: Command?) {
         when (it) {
             Command.Refresh -> refresh()
-            is Command.NewTab -> {
-                browserActivity?.launchNewTab(it.query)
+            is Command.OpenInNewTab -> {
+                browserActivity?.openInNewTab(it.query)
             }
             is Command.Navigate -> {
                 navigate(it.url)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -98,8 +98,8 @@ class BrowserTabViewModel(
     sealed class Command {
         object LandingPage : Command()
         object Refresh : Command()
-        class NewTab(val query: String) : Command()
         class Navigate(val url: String) : Command()
+        class OpenInNewTab(val query: String) : Command()
         class DialNumber(val telephoneNumber: String) : Command()
         class SendSms(val telephoneNumber: String) : Command()
         class SendEmail(val emailAddress: String) : Command()
@@ -189,7 +189,7 @@ class BrowserTabViewModel(
 
         command.value = HideKeyboard
         val trimmedInput = input.trim()
-        url.value = buildUrl(trimmedInput)
+        url.value = queryUrlConverter.convertQueryToUrl(trimmedInput)
 
         viewState.value = currentViewState().copy(
             findInPage = FindInPage(visible = false, canFindInPage = true),
@@ -198,13 +198,6 @@ class BrowserTabViewModel(
             browserShowing = true,
             autoComplete = AutoCompleteViewState(false)
         )
-    }
-
-    private fun buildUrl(input: String): String {
-        if (queryUrlConverter.isWebUrl(input)) {
-            return queryUrlConverter.convertUri(input)
-        }
-        return queryUrlConverter.convertQueryToUri(input).toString()
     }
 
     override fun progressChanged(newProgress: Int) {
@@ -381,7 +374,7 @@ class BrowserTabViewModel(
 
         return when (requiredAction) {
             is RequiredAction.OpenInNewTab -> {
-                command.value = NewTab(requiredAction.url)
+                command.value = OpenInNewTab(requiredAction.url)
                 true
             }
             is RequiredAction.DownloadFile -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarEntryConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarEntryConverter.kt
@@ -16,12 +16,7 @@
 
 package com.duckduckgo.app.browser.omnibar
 
-import android.net.Uri
-
-
 interface OmnibarEntryConverter {
 
-    fun isWebUrl(inputQuery: String): Boolean
-    fun convertQueryToUri(inputQuery: String): Uri
-    fun convertUri(input: String): String
+    fun convertQueryToUrl(searchQuery: String): String
 }

--- a/app/src/main/java/com/duckduckgo/app/global/UriString.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriString.kt
@@ -17,13 +17,38 @@
 package com.duckduckgo.app.global
 
 import android.net.Uri
+import android.support.v4.util.PatternsCompat
 
 class UriString {
+
     companion object {
+
+        private const val localhost = "localhost"
+        private const val space = " "
+        private val webUrlRegex = PatternsCompat.WEB_URL.toRegex()
+
         fun sameOrSubdomain(child: String, parent: String): Boolean {
             val childHost = Uri.parse(child)?.baseHost ?: return false
             val parentHost = Uri.parse(parent)?.baseHost ?: return false
             return parentHost == childHost || childHost.endsWith(".$parentHost")
+        }
+
+        fun isWebUrl(inputQuery: String): Boolean {
+            val uri = Uri.parse(inputQuery).withScheme()
+            if (uri.scheme != UrlScheme.http && uri.scheme != UrlScheme.https) return false
+            if (uri.userInfo != null) return false
+            if (uri.host == null) return false
+            if (uri.path.contains(space)) return false
+            return isValidHost(uri.host)
+        }
+
+        private fun isValidHost(host: String): Boolean {
+            if (host == localhost) return true
+            if (host.contains(space)) return false
+            if (host.contains("!")) return false
+
+            if (webUrlRegex.containsMatchIn(host)) return true
+            return false
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
@@ -68,7 +68,7 @@ class ViewModelFactory @Inject constructor(
                 when {
                     isAssignableFrom(LaunchViewModel::class.java) -> LaunchViewModel(onboaringStore)
                     isAssignableFrom(OnboardingViewModel::class.java) -> OnboardingViewModel(onboaringStore)
-                    isAssignableFrom(BrowserViewModel::class.java) -> BrowserViewModel(tabRepository)
+                    isAssignableFrom(BrowserViewModel::class.java) -> BrowserViewModel(tabRepository, queryUrlConverter)
                     isAssignableFrom(BrowserTabViewModel::class.java) -> browserTabViewModel()
                     isAssignableFrom(TabSwitcherViewModel::class.java) -> TabSwitcherViewModel(tabRepository)
                     isAssignableFrom(PrivacyDashboardViewModel::class.java) -> PrivacyDashboardViewModel(privacySettingsStore, networkLeaderboardDao)

--- a/app/src/main/java/com/duckduckgo/app/migration/LegacyMigration.kt
+++ b/app/src/main/java/com/duckduckgo/app/migration/LegacyMigration.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.migration
 
 import android.content.Context
 import android.support.annotation.WorkerThread
-import android.webkit.URLUtil
 import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
@@ -75,7 +74,7 @@ class LegacyMigration @Inject constructor(
                 val title = it.getString(titleColumn)
                 val query = it.getString(queryColumn)
 
-                val url = if (URLUtil.isNetworkUrl(query)) query else queryUrlConverter.convertQueryToUri(query).toString()
+                val url = queryUrlConverter.convertQueryToUrl(query)
 
                 bookmarksDao.insert(BookmarkEntity(title = title, url = url))
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -20,6 +20,7 @@ package com.duckduckgo.app.tabs.model
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.tabs.db.TabsDao
 import io.reactivex.schedulers.Schedulers
 import java.util.*
@@ -27,7 +28,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class TabDataRepository @Inject constructor(private val tabsDao: TabsDao) : TabRepository {
+class TabDataRepository @Inject constructor(private val tabsDao: TabsDao, private val siteFactory: SiteFactory) : TabRepository {
 
     override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs()
 
@@ -35,10 +36,19 @@ class TabDataRepository @Inject constructor(private val tabsDao: TabsDao) : TabR
 
     private val siteData: LinkedHashMap<String, MutableLiveData<Site>> = LinkedHashMap()
 
-    override fun add(): String {
+    override fun add(url: String?): String {
         val tabId = UUID.randomUUID().toString()
-        add(tabId, MutableLiveData())
+        add(tabId, buildSiteData(url))
         return tabId
+    }
+
+    private fun buildSiteData(url: String?): MutableLiveData<Site> {
+        val data = MutableLiveData<Site>()
+        url?.let {
+            val siteMonitor = siteFactory.build(it)
+            data.value = siteMonitor
+        }
+        return data
     }
 
     override fun add(tabId: String, data: MutableLiveData<Site>) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabEntitiy.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabEntitiy.kt
@@ -32,3 +32,6 @@ data class TabEntity(
     var url: String? = null,
     var title: String? = null
 )
+
+val TabEntity.isBlank: Boolean
+    get() = title == null && url == null

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -29,7 +29,7 @@ interface TabRepository {
     /**
      * @return tabId of new record
      */
-    fun add(): String
+    fun add(url: String? = null): String
 
     fun add(tabId: String, data: MutableLiveData<Site>)
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabRendererExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabRendererExtension.kt
@@ -22,9 +22,8 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.AppUrl
 import com.duckduckgo.app.global.faviconLocation
 import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.isBlank
 
-val TabEntity.isBlank: Boolean
-    get() = title == null && url == null
 
 fun TabEntity.displayTitle(context: Context): String {
     if (isBlank) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/611385370877136
Tech Design URL: N/A

**Description**:
Removes the manual launching of share intents into tabs allowing live data updates to trigger them. This fixes an issue where sharing from an external app such as Chrome sometimes failed, resulting in a blank tab.

**Steps to test this PR**:
1. With the app open, share a url from chrome to our app and ensure the shared url displays
1. With the app closes, share a url from chrome to our app and ensure the shared url displays
1. Now repeat the above steps with developer settings set to "Don't keep activities" on and "Background process limit" set to one
1. Reset the settings changed in the previous step back to defaults

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
