### PR TITLE
Add user agent to api calls

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
@@ -50,7 +50,7 @@ class DuckDuckGoRequestRewriterTest {
         testee.addCustomQueryParams(builder)
         val uri = builder.build()
         assertTrue(uri.queryParameterNames.contains(ParamKey.APP_VERSION))
-        assertEquals("android_${BuildConfig.VERSION_NAME.replace(".", "_")}", uri.getQueryParameter("tappv"))
+        assertEquals("android_${BuildConfig.VERSION_NAME}", uri.getQueryParameter("tappv"))
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -78,7 +78,6 @@ class QueryUrlConverterTest {
         assertEquals("ddg_android", uri.getQueryParameter("t"))
         assertTrue("Query string doesn't match. Expected `q=$query` somewhere in query ${uri.encodedQuery}", uri.encodedQuery.contains("q=$query"))
 
-        val version = BuildConfig.VERSION_NAME.replace(".", "_")
-        assertEquals("android_$version", uri.getQueryParameter("tappv"))
+        assertEquals("android_${BuildConfig.VERSION_NAME}", uri.getQueryParameter("tappv"))
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
@@ -46,8 +46,8 @@ class ApiRequestInterceptorTest {
 
     @Test
     fun whenAPIRequestIsMadeThenUserAgentIsAdded() {
-        whenever(mockChain.request()).thenReturn(stubRequest())
-        whenever(mockChain.proceed(any())).thenReturn(stubResponse())
+        whenever(mockChain.request()).thenReturn(request())
+        whenever(mockChain.proceed(any())).thenReturn(response())
 
         val captor = ArgumentCaptor.forClass(Request::class.java)
         testee.intercept(mockChain)
@@ -58,11 +58,11 @@ class ApiRequestInterceptorTest {
         assertTrue(result.matches(regex))
     }
 
-    private fun stubRequest(): Request {
+    private fun request(): Request {
         return Request.Builder().url("http://example.com").build()
     }
 
-    private fun stubResponse(): Response {
-        return Response.Builder().request(stubRequest()).protocol(Protocol.HTTP_2).code(200).message("").build()
+    private fun response(): Response {
+        return Response.Builder().request(request()).protocol(Protocol.HTTP_2).code(200).message("").build()
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import android.support.test.InstrumentationRegistry
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+
+class ApiRequestInterceptorTest {
+
+    private lateinit var testee: ApiRequestInterceptor
+
+    @Mock
+    private lateinit var mockChain: Interceptor.Chain
+
+    @Before
+    fun before() {
+        MockitoAnnotations.initMocks(this)
+        testee = ApiRequestInterceptor(InstrumentationRegistry.getContext())
+    }
+
+    @Test
+    fun whenAPIRequestIsMadeThenUserAgentIsAdded() {
+        whenever(mockChain.request()).thenReturn(stubRequest())
+        whenever(mockChain.proceed(any())).thenReturn(stubResponse())
+
+        val captor = ArgumentCaptor.forClass(Request::class.java)
+        testee.intercept(mockChain)
+        verify(mockChain).proceed(captor.capture())
+
+        val regex = "ddg_android/.*\\(com.duckduckgo.mobile.android.test; Android API .*\\)".toRegex()
+        val result = captor.value.header(Header.USER_AGENT)!!
+        assertTrue(result.matches(regex))
+    }
+
+    private fun stubRequest(): Request {
+        return Request.Builder().url("http://example.com").build()
+    }
+
+    private fun stubResponse(): Response {
+        return Response.Builder().request(stubRequest()).protocol(Protocol.HTTP_2).code(200).message("").build()
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
@@ -20,6 +20,7 @@ import android.app.job.JobScheduler
 import android.content.Context
 import com.duckduckgo.app.autocomplete.api.AutoCompleteService
 import com.duckduckgo.app.global.AppUrl.Url
+import com.duckduckgo.app.global.api.ApiRequestInterceptor
 import com.duckduckgo.app.global.job.JobBuilder
 import com.duckduckgo.app.httpsupgrade.api.HttpsUpgradeListService
 import com.duckduckgo.app.job.AppConfigurationSyncer
@@ -42,22 +43,28 @@ class NetworkModule {
 
     @Provides
     @Singleton
-    fun okHttpClient(context: Context): OkHttpClient {
+    fun okHttpClient(context: Context, apiRequestInterceptor: ApiRequestInterceptor): OkHttpClient {
         val cache = Cache(context.cacheDir, CACHE_SIZE)
         return OkHttpClient.Builder()
-                .cache(cache)
-                .build()
+            .addInterceptor(apiRequestInterceptor)
+            .cache(cache)
+            .build()
     }
 
     @Provides
     @Singleton
     fun retrofit(okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return Retrofit.Builder()
-                .baseUrl(Url.BASE)
-                .client(okHttpClient)
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
-                .addConverterFactory(MoshiConverterFactory.create(moshi))
-                .build()
+            .baseUrl(Url.API)
+            .client(okHttpClient)
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+    }
+
+    @Provides
+    fun apiRequestInterceptor(context: Context): ApiRequestInterceptor {
+        return ApiRequestInterceptor(context)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
@@ -41,7 +41,7 @@ class AppUrl {
         const val SOURCE = "ddg_android"
 
         val appVersion: String get() {
-            return String.format("android_%s", BuildConfig.VERSION_NAME.replace(".", "_"))
+            return String.format("android_%s", BuildConfig.VERSION_NAME)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
@@ -23,9 +23,9 @@ class AppUrl {
 
     object Url {
         const val HOST = "duckduckgo.com"
-        const val BASE = "https://$HOST"
-        const val HOME =  BASE
-        const val ABOUT = "$BASE/about"
+        const val API = "https://$HOST"
+        const val HOME =  "https://$HOST"
+        const val ABOUT = "https://$HOST/about"
         const val TOSDR = "https://tosdr.org"
     }
 
@@ -44,5 +44,4 @@ class AppUrl {
             return String.format("android_%s", BuildConfig.VERSION_NAME)
         }
     }
-
 }

--- a/app/src/main/java/com/duckduckgo/app/global/api/ApiRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/ApiRequestInterceptor.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import android.content.Context
+import com.duckduckgo.app.browser.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class ApiRequestInterceptor(context: Context) : Interceptor {
+
+    private val userAgent: String by lazy {
+        "DDG-Android/${BuildConfig.VERSION_NAME} (${context.applicationInfo.packageName}; Android API ${android.os.Build.VERSION.SDK_INT})"
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return chain.proceed(
+            chain.request()
+                .newBuilder()
+                .addHeader(Header.USER_AGENT, userAgent)
+                .build()
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/api/ApiRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/ApiRequestInterceptor.kt
@@ -28,11 +28,11 @@ class ApiRequestInterceptor(context: Context) : Interceptor {
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        return chain.proceed(
-            chain.request()
-                .newBuilder()
-                .addHeader(Header.USER_AGENT, userAgent)
-                .build()
-        )
+        val request = chain.request()
+            .newBuilder()
+            .addHeader(Header.USER_AGENT, userAgent)
+            .build()
+
+        return chain.proceed(request)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/api/ApiRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/ApiRequestInterceptor.kt
@@ -24,7 +24,7 @@ import okhttp3.Response
 class ApiRequestInterceptor(context: Context) : Interceptor {
 
     private val userAgent: String by lazy {
-        "DDG-Android/${BuildConfig.VERSION_NAME} (${context.applicationInfo.packageName}; Android API ${android.os.Build.VERSION.SDK_INT})"
+        "ddg_android/${BuildConfig.VERSION_NAME} (${context.applicationInfo.packageName}; Android API ${android.os.Build.VERSION.SDK_INT})"
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/app/src/main/java/com/duckduckgo/app/global/api/Header.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/Header.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+object Header {
+    val USER_AGENT = "User-Agent"
+}

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
@@ -34,9 +34,7 @@ class TrackerDataLoader @Inject constructor(
 
         Timber.d("Loading Tracker data")
 
-        // these are stored to disk, then fed to the C++ adblock module
-        loadAdblockData(Client.ClientName.EASYLIST)
-        loadAdblockData(Client.ClientName.EASYPRIVACY)
+        // this is stored to disk, then fed to the C++ adblock module
         loadAdblockData(Client.ClientName.TRACKERSWHITELIST)
 
         // stored in DB, then read into memory


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:  https://app.asana.com/0/193817002363848/661090964923373
CC: @nilnilnil 

**Description**:
Adds a networking interceptor to include a custom user agent to API requests. Also:
• Removes some dead code
• Updates the appversion to include dots rather than underscores

**Steps to test this PR**:
1. Run a fresh install of the app and watch traffic using a traffic sniffing tool e.g Charles
1. Ensure that api requests (e.g atb, exti, contentblocking.js?l=https2, contentblocking.js?l=disconnect, https2 etc) now contain a full user agent string e.g `ddg_android/5.2.0 (com.duckduckgo.mobile.android; Android API 22)` and not
` okhttp/3.10.0`
1. Run the app again and ensure that caching still works e.g contentblocking.js?l=disconnect should respond with a 304 now

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
