### PR TITLE
Fix query bug

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -245,6 +245,13 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenLoadingFinishedWithQueryOmnibarTextUpdatedToShowQuery() {
+        val queryUrl = "http://duckduckgo.com?q=test"
+        testee.loadingFinished(queryUrl)
+        assertEquals("test", viewState().omnibarText)
+    }
+
+    @Test
     fun whenLoadingFinishedWithNoUrlOmnibarTextUpdatedToMatch() {
         val exampleUrl = "http://example.com/abc"
         testee.urlChanged(exampleUrl)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -245,7 +245,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenLoadingFinishedWithQueryOmnibarTextUpdatedToShowQuery() {
+    fun whenLoadingFinishedWithQueryUrlOmnibarTextUpdatedToShowQuery() {
         val queryUrl = "http://duckduckgo.com?q=test"
         testee.loadingFinished(queryUrl)
         assertEquals("test", viewState().omnibarText)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -238,21 +238,21 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenLoadingFinishedWithUrlOmnibarTextUpdatedToMatch() {
+    fun whenLoadingFinishedWithUrlThenOmnibarTextUpdatedToMatch() {
         val exampleUrl = "http://example.com/abc"
         testee.loadingFinished(exampleUrl)
         assertEquals(exampleUrl, viewState().omnibarText)
     }
 
     @Test
-    fun whenLoadingFinishedWithQueryUrlOmnibarTextUpdatedToShowQuery() {
+    fun whenLoadingFinishedWithQueryUrlThenOmnibarTextUpdatedToShowQuery() {
         val queryUrl = "http://duckduckgo.com?q=test"
         testee.loadingFinished(queryUrl)
         assertEquals("test", viewState().omnibarText)
     }
 
     @Test
-    fun whenLoadingFinishedWithNoUrlOmnibarTextUpdatedToMatch() {
+    fun whenLoadingFinishedWithNoUrlThenOmnibarTextUpdatedToMatch() {
         val exampleUrl = "http://example.com/abc"
         testee.urlChanged(exampleUrl)
         testee.loadingFinished(null)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/675239971772914

**Description**:
Fixes issue where queries e.g http://duckduckgo.com?q=test display full url rather than just "test" query part in the omnibar.

**Steps to test this PR**:
*TEST 1:*
1. Submit a query e.g "test" in the app
2. Ensure that only test appears in the omnibar

*TEST 2:*
1. Enter a full (non ddg) url e.g http://www.bbc.co.uk
2. Ensure the full url is displayed in the omnibar

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
