### PR TITLE
Remove app version from requests

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
@@ -46,14 +46,6 @@ class DuckDuckGoRequestRewriterTest {
     }
 
     @Test
-    fun whenAddingCustomParamsAppVersionParameterIsAdded() {
-        testee.addCustomQueryParams(builder)
-        val uri = builder.build()
-        assertTrue(uri.queryParameterNames.contains(ParamKey.APP_VERSION))
-        assertEquals("android_${BuildConfig.VERSION_NAME}", uri.getQueryParameter("tappv"))
-    }
-
-    @Test
     fun whenAddingCustomParamsIfStoreContainsAtbIsAdded() {
         whenever(mockStatisticsStore.atb).thenReturn("v105-2ma")
         testee.addCustomQueryParams(builder)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -77,7 +77,5 @@ class QueryUrlConverterTest {
         assertEquals("", uri.path)
         assertEquals("ddg_android", uri.getQueryParameter("t"))
         assertTrue("Query string doesn't match. Expected `q=$query` somewhere in query ${uri.encodedQuery}", uri.encodedQuery.contains("q=$query"))
-
-        assertEquals("android_${BuildConfig.VERSION_NAME}", uri.getQueryParameter("tappv"))
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -45,17 +45,17 @@ class StatisticsRequesterTest {
     @Before
     fun before() {
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
-        whenever(mockService.atb(any())).thenReturn(Observable.just(Atb(ATB)))
-        whenever(mockService.updateAtb(any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
-        whenever(mockService.exti(any(), any())).thenReturn(Observable.just(mockResponseBody))
+        whenever(mockService.atb()).thenReturn(Observable.just(Atb(ATB)))
+        whenever(mockService.updateAtb(any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
+        whenever(mockService.exti(any())).thenReturn(Observable.just(mockResponseBody))
     }
 
     @Test
     fun whenNoStatisticsStoredThenInitializeAtbInvokesExti() {
         configureNoStoredStatistics()
         testee.initializeAtb()
-        verify(mockService).atb(any())
-        verify(mockService).exti(eq(ATB_WITH_VARIANT), any())
+        verify(mockService).atb()
+        verify(mockService).exti(eq(ATB_WITH_VARIANT))
         verify(mockStatisticsStore).saveAtb(ATB)
     }
 
@@ -63,22 +63,22 @@ class StatisticsRequesterTest {
     fun whenStatisticsStoredThenInitializeAtbDoesNothing() {
         configureStoredStatistics()
         testee.initializeAtb()
-        verify(mockService, never()).atb(any())
-        verify(mockService, never()).exti(eq(ATB), any())
+        verify(mockService, never()).atb()
+        verify(mockService, never()).exti(eq(ATB))
     }
 
     @Test
     fun whenNoStatisticsStoredThenRefreshRetrievesAtbAndInvokesExti() {
         configureNoStoredStatistics()
         testee.refreshRetentionAtb()
-        verify(mockService).atb(any())
-        verify(mockService).exti(eq(ATB_WITH_VARIANT), any())
+        verify(mockService).atb()
+        verify(mockService).exti(eq(ATB_WITH_VARIANT))
         verify(mockStatisticsStore).saveAtb(ATB)
     }
 
     @Test
     fun whenExitFailsThenAtbCleared() {
-        whenever(mockService.exti(any(), any())).thenReturn(Observable.error(Throwable()))
+        whenever(mockService.exti(any())).thenReturn(Observable.error(Throwable()))
         configureNoStoredStatistics()
         testee.initializeAtb()
         verify(mockStatisticsStore).saveAtb(ATB)
@@ -89,7 +89,7 @@ class StatisticsRequesterTest {
     fun whenStatisticsStoredThenRefreshUpdatesAtb() {
         configureStoredStatistics()
         testee.refreshRetentionAtb()
-        verify(mockService).updateAtb(eq(ATB_WITH_VARIANT), eq(ATB), any())
+        verify(mockService).updateAtb(eq(ATB_WITH_VARIANT), eq(ATB))
         verify(mockStatisticsStore).retentionAtb = NEW_ATB
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
@@ -39,7 +39,7 @@ class DuckDuckGoRequestRewriter(private val duckDuckGoUrlDetector: DuckDuckGoUrl
             .fragment(request.fragment)
 
         request.queryParameterNames
-            .filter { it != ParamKey.SOURCE && it != ParamKey.APP_VERSION && it != ParamKey.ATB }
+            .filter { it != ParamKey.SOURCE && it != ParamKey.ATB }
             .forEach { builder.appendQueryParameter(it, request.getQueryParameter(it)) }
 
         addCustomQueryParams(builder)
@@ -51,19 +51,18 @@ class DuckDuckGoRequestRewriter(private val duckDuckGoUrlDetector: DuckDuckGoUrl
 
     override fun shouldRewriteRequest(uri: Uri): Boolean {
         return duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(uri.toString()) &&
-                !uri.queryParameterNames.containsAll(arrayListOf(ParamKey.SOURCE, ParamKey.APP_VERSION, ParamKey.ATB))
+                !uri.queryParameterNames.containsAll(arrayListOf(ParamKey.SOURCE, ParamKey.ATB))
     }
 
     /**
-     * Applies cohort (atb) https://duck.co/help/privacy/atb, app version and
-     * and source (t) https://duck.co/help/privacy/t params to url
+     * Applies cohort (atb) https://duck.co/help/privacy/atb and
+     * source (t) https://duck.co/help/privacy/t params to url
      */
     override fun addCustomQueryParams(builder: Uri.Builder) {
         val atb = statisticsStore.atb
         if (atb != null) {
             builder.appendQueryParameter(ParamKey.ATB, atb)
         }
-        builder.appendQueryParameter(ParamKey.APP_VERSION, ParamValue.appVersion)
         builder.appendQueryParameter(ParamKey.SOURCE, ParamValue.SOURCE)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.app.global
 
-import com.duckduckgo.app.browser.BuildConfig
-
 
 class AppUrl {
 
@@ -33,16 +31,11 @@ class AppUrl {
     object ParamKey {
         const val QUERY = "q"
         const val SOURCE = "t"
-        const val APP_VERSION = "tappv"
         const val ATB = "atb"
         const val RETENTION_ATB = "set_atb"
     }
 
     object ParamValue {
         const val SOURCE = "ddg_android"
-
-        val appVersion: String get() {
-            return String.format("android_%s", BuildConfig.VERSION_NAME)
-        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.statistics.api
 
 import android.annotation.SuppressLint
-import com.duckduckgo.app.global.AppUrl.ParamValue
 import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -52,12 +51,12 @@ class StatisticsRequester(
             return
         }
 
-        service.atb(ParamValue.appVersion)
+        service.atb()
             .subscribeOn(Schedulers.io())
             .flatMap {
                 store.saveAtb(it.version)
                 val fullAtb = formatAtbWithVariant(it.version, variantManager.getVariant())
-                service.exti(fullAtb, ParamValue.appVersion)
+                service.exti(fullAtb)
             }
             .subscribe({
                 Timber.v("Atb initialization succeeded")
@@ -85,7 +84,7 @@ class StatisticsRequester(
 
         val fullAtb = formatAtbWithVariant(atb, variantManager.getVariant())
 
-        service.updateAtb(fullAtb, retentionAtb, ParamValue.appVersion)
+        service.updateAtb(fullAtb, retentionAtb)
             .subscribeOn(Schedulers.io())
             .subscribe({
                 Timber.v("Atb refresh succeeded")

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsService.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsService.kt
@@ -27,15 +27,14 @@ import retrofit2.http.Query
 interface StatisticsService {
 
     @GET("/exti/")
-    fun exti(@Query(ParamKey.ATB) atb: String, @Query(ParamKey.APP_VERSION) version: String): Observable<ResponseBody>
+    fun exti(@Query(ParamKey.ATB) atb: String): Observable<ResponseBody>
 
     @GET("/atb.js")
-    fun atb(@Query(ParamKey.APP_VERSION) version: String): Observable<Atb>
+    fun atb(): Observable<Atb>
 
     @GET("/atb.js")
     fun updateAtb(
         @Query(ParamKey.ATB) atb: String,
-        @Query(ParamKey.RETENTION_ATB) retentionAtb: String,
-        @Query(ParamKey.APP_VERSION) version: String
+        @Query(ParamKey.RETENTION_ATB) retentionAtb: String
     ): Observable<Atb>
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/361428290920652/649057775699177

**Description**:
Remove tappv parameter from app searches

**Steps to test this PR**:
1. Run a clean install of the app and watch network traffic
1. Submit a search
1. Ensure the tappv parameter is no longer in our atb, exti or search requests

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
