### PR TITLE
Move address bar text to start after loading page

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -341,13 +341,6 @@ class BrowserTabFragment : Fragment(), FindListener {
 
         if (shouldUpdateOmnibarTextInput(viewState, viewState.omnibarText)) {
             omnibarTextInput.setText(viewState.omnibarText)
-
-            // ensures caret sits at the end of the query
-            omnibarTextInput.post {
-                omnibarTextInput?.let {
-                    it.setSelection(it.text.length)
-                }
-            }
             appBarLayout.setExpanded(true, true)
         }
 


### PR DESCRIPTION
Task/Issue URL: #168 

**Description**:
After loading a webpage with a large address it wasn't easy to see the webpage domain name. This PR fixes this issue.

**Steps to test this PR**:
- Open the app and enter a large url 
- Click on a link that loads a large url

![solved_url](https://user-images.githubusercontent.com/12280517/40869973-864a80a4-65fb-11e8-8a0b-fd4b137aaf46.gif)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
