### PR TITLE
Feature/https db write performance

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,7 @@ android {
 
 ext {
     supportLibrary = "27.1.1"
-    architectureComponents = "1.0.0"
+    architectureComponents = "1.1.0"
     architectureComponentsExtensions = "1.1.1"
     androidKtx = "0.3"
     dagger = "2.14.1"

--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDomainDAOTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDomainDAOTest.kt
@@ -51,44 +51,44 @@ class HttpsUpgradeDomainDaoTest {
 
     @Test
     fun whenExactMatchDomainAddedAndThenAllDeletedThenDoesNotContainExactMatchDomain() {
-        dao.insertAll(HttpsUpgradeDomain(exactMatchDomain))
+        dao.insertAll(listOf(HttpsUpgradeDomain(exactMatchDomain)))
         dao.deleteAll()
         assertFalse(dao.hasDomain(exactMatchDomain))
     }
 
     @Test
     fun whenWildcardDomainInsertedModelThenDoesNotContainParentOfWildcardDomain() {
-        dao.insertAll(HttpsUpgradeDomain(wildcardDomain))
+        dao.insertAll(listOf(HttpsUpgradeDomain(wildcardDomain)))
         assertFalse(dao.hasDomain(parentOfWildcardDomain))
     }
 
     @Test
     fun whenOtherWildcardDomainInsertedThenModelDoesNotContainExampleWildcardDomain() {
-        dao.insertAll(HttpsUpgradeDomain(otherWildcardDomain))
+        dao.insertAll(listOf(HttpsUpgradeDomain(otherWildcardDomain)))
         assertFalse(dao.hasDomain(exampleWildcardDomain))
     }
 
     @Test
     fun whenWildcardDomainInsertedThenModelDoesNotContainExactMatchDomain() {
-        dao.insertAll(HttpsUpgradeDomain(wildcardDomain))
+        dao.insertAll(listOf(HttpsUpgradeDomain(wildcardDomain)))
         assertFalse(dao.hasDomain(exactMatchDomain))
     }
 
     @Test
     fun whenWildcardDomainInsertedThenModelContainsExampleWildcardDomain() {
-        dao.insertAll(HttpsUpgradeDomain(wildcardDomain))
+        dao.insertAll(listOf(HttpsUpgradeDomain(wildcardDomain)))
         assertTrue(dao.hasDomain("*.$parentOfWildcardDomain"))
     }
 
     @Test
     fun whenExactMatchDomainInsertedThenModelDoesNotContainOtherDomain() {
-        dao.insertAll(HttpsUpgradeDomain(exactMatchDomain))
+        dao.insertAll(listOf(HttpsUpgradeDomain(exactMatchDomain)))
         assertFalse(dao.hasDomain(otherDomain))
     }
 
     @Test
     fun whenExactMatchDomainIsInsertedThenModelContainsExactMatchDomain() {
-        dao.insertAll(HttpsUpgradeDomain(exactMatchDomain))
+        dao.insertAll(listOf(HttpsUpgradeDomain(exactMatchDomain)))
         assertTrue(dao.hasDomain(exactMatchDomain))
     }
 
@@ -104,7 +104,7 @@ class HttpsUpgradeDomainDaoTest {
 
     @Test
     fun whenModelContainsTwoItemsThenCountIsTwo() {
-        dao.insertAll(HttpsUpgradeDomain(exactMatchDomain), HttpsUpgradeDomain(otherDomain))
+        dao.insertAll(listOf(HttpsUpgradeDomain(exactMatchDomain), HttpsUpgradeDomain(otherDomain)))
         assertEquals(2, dao.count())
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradePerformanceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradePerformanceTest.kt
@@ -101,7 +101,7 @@ class HttpsUpgraderPerformanceTest {
     private fun ingest(size: Int): Array<String> {
         val start = System.currentTimeMillis()
         for (i in 0 .. size) {
-            dao.insertAll(HttpsUpgradeDomain("domain$i.com"))
+            dao.insertAll(listOf(HttpsUpgradeDomain("domain$i.com")))
         }
 
         val testDomains = Array(size, {

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApi.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApi.kt
@@ -16,16 +16,12 @@
 
 package com.duckduckgo.app.autocomplete.api
 
-import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
 import com.duckduckgo.app.global.UriString
 import io.reactivex.Observable
 import javax.inject.Inject
 
 
-open class AutoCompleteApi @Inject constructor(
-        private val autoCompleteService: AutoCompleteService,
-        private val queryUrlConverter: QueryUrlConverter
-) {
+open class AutoCompleteApi @Inject constructor(private val autoCompleteService: AutoCompleteService) {
 
     fun autoComplete(query: String): Observable<AutoCompleteApi.AutoCompleteResult> {
 
@@ -34,16 +30,18 @@ open class AutoCompleteApi @Inject constructor(
         }
 
         return autoCompleteService.autoComplete(query)
-                .flatMapIterable { it -> it }
-                .map { AutoCompleteSuggestion(it.phrase, UriString.isWebUrl(it.phrase)) }
-                .toList()
-                .onErrorReturn { emptyList() }
-                .map { AutoCompleteResult(query = query, suggestions = it) }
-                .toObservable()
+            .flatMapIterable { it -> it }
+            .map { AutoCompleteSuggestion(it.phrase, UriString.isWebUrl(it.phrase)) }
+            .toList()
+            .onErrorReturn { emptyList() }
+            .map { AutoCompleteResult(query = query, suggestions = it) }
+            .toObservable()
     }
 
-    data class AutoCompleteResult(val query: String,
-                                  val suggestions: List<AutoCompleteSuggestion>)
+    data class AutoCompleteResult(
+        val query: String,
+        val suggestions: List<AutoCompleteSuggestion>
+    )
 
     data class AutoCompleteSuggestion(val phrase: String, val isUrl: Boolean)
 

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeListDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeListDownloader.kt
@@ -59,11 +59,7 @@ class HttpsUpgradeListDownloader @Inject constructor(
             if (response.isSuccessful) {
                 Timber.d("Updating HTTPS upgrade list from server")
 
-                val domains = response.body()
-                if (domains == null) {
-                    Timber.w("Failed to obtain HTTPS upgrade list")
-                    return@fromAction
-                }
+                val domains = response.body() ?: throw IllegalStateException("Failed to obtain HTTPS upgrade list")
 
                 val startTime = System.currentTimeMillis()
 

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeListDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeListDownloader.kt
@@ -30,7 +30,7 @@ class HttpsUpgradeListDownloader @Inject constructor(
     private val httpsUpgradeDao: HttpsUpgradeDomainDao
 ) {
 
-    fun downloadList(): Completable {
+    fun downloadList(chunkSize: Int = INSERTION_CHUNK_SIZE): Completable {
 
         Timber.d("Downloading HTTPS Upgrade data")
 
@@ -57,7 +57,7 @@ class HttpsUpgradeListDownloader @Inject constructor(
                 httpsUpgradeDao.deleteAll()
                 Timber.i("Took ${System.currentTimeMillis() - startTime}ms to delete existing records")
 
-                val chunks = domains.chunked(INSERTION_CHUNK_SIZE)
+                val chunks = domains.chunked(chunkSize)
                 Timber.i("Received ${domains.size} HTTPS domains; chunking by $INSERTION_CHUNK_SIZE into ${chunks.size} separate DB transactions")
 
                 chunks.forEach {

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeListDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeListDownloader.kt
@@ -51,7 +51,7 @@ class HttpsUpgradeListDownloader @Inject constructor(
 
             val call = service.https()
             val response = call.execute()
-            val eTag = response.headers().get("etag")
+            val eTag = response.headers().get(HEADER_ETAG)
 
             if (response.isCached && dbWriteStatusStore.isMatchingETag(eTag)) {
                 Timber.d("HTTPS data already cached and stored")
@@ -88,5 +88,6 @@ class HttpsUpgradeListDownloader @Inject constructor(
 
     companion object {
         private const val INSERTION_CHUNK_SIZE = 1_000
+        private const val HEADER_ETAG = "etag"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDbWriteStatusStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDbWriteStatusStore.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.httpsupgrade.db
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.support.annotation.VisibleForTesting
+import androidx.core.content.edit
+import javax.inject.Inject
+
+interface HttpsUpgradeDbWriteStatusStore {
+
+    fun updateStatus(writeComplete: Boolean)
+    fun hasWriteCompleted(): Boolean
+}
+
+class HttpsUpgradeDbWriteStatusSharedPreferences @Inject constructor(private val context: Context) : HttpsUpgradeDbWriteStatusStore {
+
+    override fun updateStatus(writeComplete: Boolean) {
+        preferences.edit { putBoolean(KEY_WRITE_COMPLETED, writeComplete) }
+    }
+
+    override fun hasWriteCompleted(): Boolean {
+        return preferences.getBoolean(KEY_WRITE_COMPLETED, false)
+    }
+
+    private val preferences: SharedPreferences
+        get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+
+    companion object {
+
+        @VisibleForTesting
+        const val FILENAME = "com.duckduckgo.app.httpsupgrade.db.HttpsUpgradeDbWriteStatus"
+        const val KEY_WRITE_COMPLETED = "KEY_WRITE_COMPLETED"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDbWriteStatusStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDbWriteStatusStore.kt
@@ -24,18 +24,19 @@ import javax.inject.Inject
 
 interface HttpsUpgradeDbWriteStatusStore {
 
-    fun updateStatus(writeComplete: Boolean)
-    fun hasWriteCompleted(): Boolean
+    fun saveETag(eTag: String?)
+    fun isMatchingETag(eTag: String?): Boolean
 }
 
 class HttpsUpgradeDbWriteStatusSharedPreferences @Inject constructor(private val context: Context) : HttpsUpgradeDbWriteStatusStore {
 
-    override fun updateStatus(writeComplete: Boolean) {
-        preferences.edit { putBoolean(KEY_WRITE_COMPLETED, writeComplete) }
+    override fun saveETag(eTag: String?) {
+        preferences.edit { putString(KEY_ETAG_OF_LAST_FULL_WRITE, eTag) }
     }
 
-    override fun hasWriteCompleted(): Boolean {
-        return preferences.getBoolean(KEY_WRITE_COMPLETED, false)
+    override fun isMatchingETag(eTag: String?): Boolean {
+        val existingETag = preferences.getString(KEY_ETAG_OF_LAST_FULL_WRITE, null)
+        return eTag == existingETag
     }
 
     private val preferences: SharedPreferences
@@ -45,6 +46,6 @@ class HttpsUpgradeDbWriteStatusSharedPreferences @Inject constructor(private val
 
         @VisibleForTesting
         const val FILENAME = "com.duckduckgo.app.httpsupgrade.db.HttpsUpgradeDbWriteStatus"
-        const val KEY_WRITE_COMPLETED = "KEY_WRITE_COMPLETED"
+        const val KEY_ETAG_OF_LAST_FULL_WRITE = "KEY_ETAG_OF_LAST_FULL_WRITE"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDomainDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDomainDao.kt
@@ -20,7 +20,6 @@ import android.arch.persistence.room.Dao
 import android.arch.persistence.room.Insert
 import android.arch.persistence.room.OnConflictStrategy
 import android.arch.persistence.room.Query
-import org.intellij.lang.annotations.Language
 
 @Dao
 interface HttpsUpgradeDomainDao {
@@ -28,7 +27,6 @@ interface HttpsUpgradeDomainDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAll(domains: List<HttpsUpgradeDomain>)
 
-    @Language("RoomSql")
     @Query("select count(1) > 0 from https_upgrade_domain where domain = :domain")
     fun hasDomain(domain: String) : Boolean
 

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDomainDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/db/HttpsUpgradeDomainDao.kt
@@ -26,7 +26,7 @@ import org.intellij.lang.annotations.Language
 interface HttpsUpgradeDomainDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertAll(vararg domains: HttpsUpgradeDomain)
+    fun insertAll(domains: List<HttpsUpgradeDomain>)
 
     @Language("RoomSql")
     @Query("select count(1) > 0 from https_upgrade_domain where domain = :domain")

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/di/HttpsUpgraderModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/di/HttpsUpgraderModule.kt
@@ -16,11 +16,15 @@
 
 package com.duckduckgo.app.httpsupgrade.di
 
+import android.content.Context
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.httpsupgrade.HttpsUpgraderImpl
+import com.duckduckgo.app.httpsupgrade.db.HttpsUpgradeDbWriteStatusSharedPreferences
+import com.duckduckgo.app.httpsupgrade.db.HttpsUpgradeDbWriteStatusStore
 import com.duckduckgo.app.httpsupgrade.db.HttpsUpgradeDomainDao
 import dagger.Module
 import dagger.Provides
+import javax.inject.Singleton
 
 @Module
 class HttpsUpgraderModule {
@@ -28,5 +32,11 @@ class HttpsUpgraderModule {
     @Provides
     fun httpsUpgrader(dao: HttpsUpgradeDomainDao): HttpsUpgrader {
         return HttpsUpgraderImpl(dao)
+    }
+
+    @Provides
+    @Singleton
+    fun httpsUpgradeDbWriteStatusStore(context: Context): HttpsUpgradeDbWriteStatusStore {
+        return HttpsUpgradeDbWriteStatusSharedPreferences(context)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.41'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/688772474867111
Tech Design URL: 
CC: 

**Description**:
Performance issue observed while large number of HTTPS upgrade rows were being written to DB. The number of rows is north of 200k and the time taken to write this data could span tens of seconds on some devices.

While the DB was being written to, other DB writes are blocked. If the HTTPS list is written at a bad time, the user might experience a delay in seeing the browser or launching a new tab (or potentially a whole host of other bad UX).

This PR stops writing the HTTPS list as a single transaction. Instead, it breaks the list down into many smaller transactions, which can support other app write taking place throughout. The result is that the total time to write all HTTPS rows will _increase_ but that because there are opportunities for other DB writes throughout, the overall UX is greatly increased and that initial delay in seeing the browser screen is eliminated.

**Benchmarking**
![screen shot 2018-06-01 at 14 43 19](https://user-images.githubusercontent.com/1336281/40918263-af88ec0e-67fd-11e8-9fe7-363f03652f03.png)

I performed some (unscientific) benchmarking comparing a few things; total write time and time granted between writing chunks. Compared this across two physical devices, using both `Room 1.0.0` and `Room 1.1.0`. Based on these numbers, I decided to chunk on inserting 1,000 rows at a time and decided to upgrade `Room` based on overall improved performance.

**Consideration**
A downside is that we can no longer rely on a single DB transaction to protect the integrity of our data. Instead, I've had to add an external guard which protects against the scenario whereby

1. Data downloaded
1. Data partially written to disk
1. Process crashes or exception thrown

In this scenario, it would be possible for us to detect that the data has been successfully stored already and not finish writing the missing data.

I've added a guard which is stored in `SharedPreferences` to counter this. See the full comment on `HttpsUpgradeListDownloader` class for more details.

**Steps to test this PR**:
1. Fresh install - watch the logs for a line like `I/HttpsUpgradeListDownloader$downloadList: Received 205621 HTTPS domains; chunking by 1000 into 206 separate DB transactions`
1. As soon as this is visible in the logs, hit the `Continue` button to end onboarding
1. Observe how long it takes to present browser. Browser should show before HTTPS data is fully written (which can be observed by watching logs for `Successfully wrote HTTPS data`)

Pay particular attention to this logic to make sure this makes sense:

    if (response.isCached && dbWriteStatusStore.hasWriteCompleted() && httpsUpgradeDao.count() != 0) {
                Timber.d("HTTPS data already cached and stored")
                return@fromAction
            }


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
