### PR TITLE
Fix popup menu scroll when height is out of bounds

### DIFF
--- a/app/src/main/res/layout/popup_window_browser_menu.xml
+++ b/app/src/main/res/layout/popup_window_browser_menu.xml
@@ -68,6 +68,7 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/header">
 
         <LinearLayout


### PR DESCRIPTION
The last item from the popup menu can now be shown and clicked on small screens or landscape mode.

![solved_url](https://media.giphy.com/media/1oHpUDf892fDFG8jAl/giphy.gif)

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/241
Tech Design URL: 
CC: 

**Description**:
Fix popup menu scroll when height is out of bounds

**Steps to test this PR**:
- Open the app
- Click on the menu item on the toolbar in a small screen or in landscape mode

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
