### PR TITLE
Ensure full screen webView container covers all other UI elements

### DIFF
--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -25,6 +25,18 @@
 
     <include layout="@layout/include_omnibar_toolbar" />
 
+    <FrameLayout
+        android:id="@+id/webViewFullScreenContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/windowBackground"
+        android:elevation="10dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <android.support.constraint.ConstraintLayout
         android:id="@+id/logoParent"
         android:layout_width="match_parent"
@@ -77,17 +89,6 @@
             tools:itemCount="3"
             tools:listitem="@layout/item_autocomplete_suggestion"
             tools:visibility="gone" />
-
-        <FrameLayout
-            android:id="@+id/webViewFullScreenContainer"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:background="@color/windowBackground"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
 
         <View
             android:id="@+id/focusDummy"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/701529969506244
Tech Design URL: 
CC: 

**Description**:
Changes the position and elevation of the fullscreen `View` used for when the `WebView` goes fullscreen.

**Steps to test this PR**:
1. Go to a site that supports going into full screen mode; such as youtube.com, vimeo.com etc...
1. Start watching a video, and click to enable full screen mode
1. Verify the omnibar (and all other UI elements) are hidden by the full screen video container
1. Exit full screen mode, and very everything looks as you'd expect


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
