### PR TITLE
Make comment field mandatory

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/feedback/ui/FeedbackViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/feedback/ui/FeedbackViewModelTest.kt
@@ -55,15 +55,16 @@ class FeedbackViewModelTest {
 
     @Test
     fun whenBrokenUrlSwitchedOnWithUrlThenMessageFocused() {
-        testee.onBrokenSiteUrlChanged("http://example.com")
+        testee.onBrokenSiteUrlChanged(Constants.url)
         testee.onBrokenSiteChanged(true)
         verify(mockCommandObserver).onChanged(Command.FocusMessage)
     }
 
     @Test
-    fun whenBrokenUrlOnWithUrlThenCanSubmit() {
+    fun whenBrokenUrlOnWithUrlAndMessageThenCanSubmit() {
         testee.onBrokenSiteChanged(true)
-        testee.onBrokenSiteUrlChanged("http://example.com")
+        testee.onBrokenSiteUrlChanged(Constants.url)
+        testee.onFeedbackMessageChanged(Constants.message)
         assertTrue(viewState.submitAllowed)
     }
 
@@ -71,6 +72,15 @@ class FeedbackViewModelTest {
     fun whenBrokenUrlOnWithNullUrlThenCannotSubmit() {
         testee.onBrokenSiteChanged(true)
         testee.onBrokenSiteUrlChanged(null)
+        testee.onFeedbackMessageChanged(Constants.message)
+        assertFalse(viewState.submitAllowed)
+    }
+
+    @Test
+    fun whenBrokenUrlOnWithNullMessageThenCannotSubmit() {
+        testee.onBrokenSiteChanged(true)
+        testee.onBrokenSiteUrlChanged(Constants.url)
+        testee.onFeedbackMessageChanged(null)
         assertFalse(viewState.submitAllowed)
     }
 
@@ -78,13 +88,22 @@ class FeedbackViewModelTest {
     fun whenBrokenUrlOnWithBlankUrlThenCannotSubmit() {
         testee.onBrokenSiteChanged(true)
         testee.onBrokenSiteUrlChanged(" ")
+        testee.onFeedbackMessageChanged(Constants.message)
+        assertFalse(viewState.submitAllowed)
+    }
+
+    @Test
+    fun whenBrokenUrlOnWithBlankMessageThenCannotSubmit() {
+        testee.onBrokenSiteChanged(true)
+        testee.onBrokenSiteUrlChanged(Constants.url)
+        testee.onFeedbackMessageChanged(" ")
         assertFalse(viewState.submitAllowed)
     }
 
     @Test
     fun whenBrokenUrlOffWithMessageThenCanSubmit() {
         testee.onBrokenSiteChanged(false)
-        testee.onFeedbackMessageChanged("Feedback message")
+        testee.onFeedbackMessageChanged(Constants.message)
         assertTrue(viewState.submitAllowed)
     }
 
@@ -103,18 +122,18 @@ class FeedbackViewModelTest {
     }
 
     @Test
-    fun whenCanSubmitBrokenUrlAndSubmitPressedThenFeedbackSubmitted() {
-        val url = "http://example.com"
+    fun whenCanSubmitBrokenSiteAndSubmitPressedThenFeedbackSubmitted() {
         testee.onBrokenSiteChanged(true)
-        testee.onBrokenSiteUrlChanged(url)
+        testee.onBrokenSiteUrlChanged(Constants.url)
+        testee.onFeedbackMessageChanged(Constants.message)
         testee.onSubmitPressed()
 
-        verify(mockFeedbackSender).submitBrokenSiteFeedback(null, url)
+        verify(mockFeedbackSender).submitBrokenSiteFeedback(Constants.message, Constants.url)
         verify(mockCommandObserver).onChanged(Command.ConfirmAndFinish)
     }
 
     @Test
-    fun whenCannotSubmitBrokenUrlAndSubmitPressedThenFeedbackNotSubmitted() {
+    fun whenCannotSubmitBrokenSiteAndSubmitPressedThenFeedbackNotSubmitted() {
         testee.onBrokenSiteChanged(true)
         testee.onSubmitPressed()
         verify(mockFeedbackSender, never()).submitBrokenSiteFeedback(any(), any())
@@ -123,11 +142,10 @@ class FeedbackViewModelTest {
 
     @Test
     fun whenCanSubmitMessageAndSubmitPressedThenFeedbackSubmitted() {
-        val message = "Message"
         testee.onBrokenSiteChanged(false)
-        testee.onFeedbackMessageChanged(message)
+        testee.onFeedbackMessageChanged(Constants.message)
         testee.onSubmitPressed()
-        verify(mockFeedbackSender).submitGeneralFeedback(message)
+        verify(mockFeedbackSender).submitGeneralFeedback(Constants.message)
         verify(mockCommandObserver).onChanged(Command.ConfirmAndFinish)
     }
 
@@ -137,6 +155,11 @@ class FeedbackViewModelTest {
         testee.onSubmitPressed()
         verify(mockFeedbackSender, never()).submitGeneralFeedback(any())
         verify(mockCommandObserver, never()).onChanged(Command.ConfirmAndFinish)
+    }
+
+    companion object Constants {
+        private const val url = "http://example.com"
+        private const val message = "Feedback message"
     }
 
 }

--- a/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSender.kt
@@ -28,7 +28,7 @@ import timber.log.Timber
 
 interface FeedbackSender {
     fun submitGeneralFeedback(comment: String)
-    fun submitBrokenSiteFeedback(comment: String?, url: String)
+    fun submitBrokenSiteFeedback(comment: String, url: String)
 }
 
 class FeedbackSubmitter(
@@ -42,8 +42,8 @@ class FeedbackSubmitter(
         submitFeedback(Reason.GENERAL, comment, "")
     }
 
-    override fun submitBrokenSiteFeedback(comment: String?, url: String) {
-        submitFeedback(Reason.BROKEN_SITE, comment ?: "", url)
+    override fun submitBrokenSiteFeedback(comment: String, url: String) {
+        submitFeedback(Reason.BROKEN_SITE, comment, url)
     }
 
     private fun submitFeedback(type: String, comment: String, url: String) {

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/FeedbackActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/FeedbackActivity.kt
@@ -105,9 +105,11 @@ class FeedbackActivity : DuckDuckGoActivity() {
     }
 
     private fun render(viewState: ViewState) {
+        val messageHint = if (viewState.isBrokenSite) R.string.feedbackBrokenSiteHint else  R.string.feedbackMessageHint
         brokenSiteSwitch.isChecked = viewState.isBrokenSite
         brokenSiteUrl.isVisible = viewState.showUrl
         brokenSiteUrl.updateText(viewState.url ?: "")
+        feedbackMessage.setHint(messageHint)
         submitButton.isEnabled = viewState.submitAllowed
     }
 

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/FeedbackViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/FeedbackViewModel.kt
@@ -84,17 +84,27 @@ class FeedbackViewModel(private val feedbackSender: FeedbackSender) : ViewModel(
         )
     }
 
-
     private fun canSubmit(isBrokenSite: Boolean, url: String?, feedbackMessage: String?): Boolean {
-        return (isBrokenSite && !url.isNullOrBlank()) || (!isBrokenSite && !feedbackMessage.isNullOrBlank())
+
+        if (feedbackMessage.isNullOrBlank()) {
+            return false
+        }
+
+        if (isBrokenSite && url.isNullOrBlank()) {
+            return false
+        }
+
+        return true
     }
 
     fun onSubmitPressed() {
+
+        val message = viewValue.message ?: return
+
         if (viewValue.isBrokenSite) {
             val url = viewValue.url ?: return
-            feedbackSender.submitBrokenSiteFeedback(viewValue.message, url)
+            feedbackSender.submitBrokenSiteFeedback(message, url)
         } else {
-            val message = viewValue.message ?: return
             feedbackSender.submitGeneralFeedback(message)
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
     <string name="feedbackReportBrokenSite">Report a broken site</string>
     <string name="feedbackUrlHint">Enter URL</string>
     <string name="feedbackMessageHint">How can the app be improved? What do you love? What\'s breaking? Please be as specific as possible.</string>
+    <string name="feedbackBrokenSiteHint">Which website content or functionality is breaking? Please be as specific as possible.</string>
     <string name="feedbackSubmitButton">Submit Feedback</string>
     <string name="feedbackIsAnonymousLink">Your feedback is completely anonymous</string>
     <string name="feedbackSubmitted">Thank you! Feedback submitted</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,7 +169,6 @@
     <string name="feedbackHeading">Share Your Feedback</string>
     <string name="feedbackModalDescription">Anonymously share your feedback to help us improve the DuckDuckGo Privacy Browser</string>
     <string name="feedbackReportBrokenSite">Report a broken site</string>
-    <string name="feedbackDomainAdded">Domain Added to Feedback Report</string>
     <string name="feedbackUrlHint">Enter URL</string>
     <string name="feedbackMessageHint">How can the app be improved? What do you love? What\'s breaking? Please be as specific as possible.</string>
     <string name="feedbackSubmitButton">Submit Feedback</string>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha18'
+        classpath 'com.android.tools.build:gradle:3.2.0-beta01'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:  https://app.asana.com/0/361428290920652/724386484375024

**Description**:

- Makes the comment field mandatory on broken sites
- Adds broken site specific hint message

**Steps to test this PR**:

_TEST 1_
1. Open the "Report broken site" form
1. Enter a url and note that the submit button is NOT activated
1. Enter text in the comment field and note the button IS activated

_TEST 2_
1. Open the "Report broken site" form
1. Toggle the switch on and off and ensure that message hint text changes to "broken site" specific text when the switch is on

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
