### PR TITLE
Fix issue where url can sometimes be out-of-date on broken url form

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -664,7 +664,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserOnSiteSelectsBrokenSiteThenBrokenSiteFeedbackCommandSentWithUrl() {
+    fun whenOnSiteAndBrokenSiteSelectedThenBrokenSiteFeedbackCommandSentWithUrl() {
         testee.urlChanged("foo.com")
         testee.onBrokenSiteSelected()
         val command = captureCommands().value as Command.BrokenSiteFeedback
@@ -672,10 +672,10 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserNotOnSiteSelectsBrokenSiteThenBrokenSiteFeedbackCommandSentWithNoUrl() {
+    fun whenNoSiteAndBrokenSiteSelectedThenBrokenSiteFeedbackCommandSentWithoutUrl() {
         testee.onBrokenSiteSelected()
         val command = captureCommands().value as Command.BrokenSiteFeedback
-        assertEquals(null, command.url)
+        assertNull(command.url)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -664,6 +664,21 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserOnSiteSelectsBrokenSiteThenBrokenSiteFeedbackCommandSentWithUrl() {
+        testee.urlChanged("foo.com")
+        testee.onBrokenSiteSelected()
+        val command = captureCommands().value as Command.BrokenSiteFeedback
+        assertEquals("foo.com", command.url)
+    }
+
+    @Test
+    fun whenUserNotOnSiteSelectsBrokenSiteThenBrokenSiteFeedbackCommandSentWithNoUrl() {
+        testee.onBrokenSiteSelected()
+        val command = captureCommands().value as Command.BrokenSiteFeedback
+        assertEquals(null, command.url)
+    }
+
+    @Test
     fun whenUserSelectsToShareLinkWithNullUrlThenShareLinkCommandNotSent() {
         testee.userSharingLink(null)
         verify(mockCommandObserver, never()).onChanged(any())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -202,7 +202,7 @@ class BrowserTabFragment : Fragment(), FindListener {
             onMenuItemClicked(view.bookmarksPopupMenuItem) { browserActivity?.launchBookmarks() }
             onMenuItemClicked(view.addBookmarksPopupMenuItem) { addBookmark() }
             onMenuItemClicked(view.findInPageMenuItem) { viewModel.userRequestingToFindInPage() }
-            onMenuItemClicked(view.brokenSitePopupMenuItem) { browserActivity?.launchBrokenSiteFeedback(viewModel.url.value) }
+            onMenuItemClicked(view.brokenSitePopupMenuItem) { viewModel.onBrokenSiteSelected() }
             onMenuItemClicked(view.settingsPopupMenuItem) { browserActivity?.launchSettings() }
             onMenuItemClicked(view.requestDesktopSiteCheckMenuItem) {
                 viewModel.desktopSiteModeToggled(
@@ -295,6 +295,9 @@ class BrowserTabFragment : Fragment(), FindListener {
             }
             Command.HideKeyboard -> {
                 hideKeyboard()
+            }
+            is Command.BrokenSiteFeedback -> {
+                browserActivity?.launchBrokenSiteFeedback(it.url)
             }
             is Command.ShowFullScreen -> {
                 webViewFullScreenContainer.addView(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -135,6 +135,7 @@ class BrowserTabViewModel(
         class DownloadImage(val url: String) : Command()
         class ShareLink(val url: String) : Command()
         class FindInPageCommand(val searchTerm: String) : Command()
+        class BrokenSiteFeedback(val url: String?) : Command()
         class DisplayMessage(@StringRes val messageId: Int) : Command()
         object DismissFindInPage : Command()
         class ShowFileChooser(val filePathCallback: ValueCallback<Array<Uri>>, val fileChooserParams: WebChromeClient.FileChooserParams) : Command()
@@ -429,6 +430,10 @@ class BrowserTabViewModel(
             bookmarksDao.insert(BookmarkEntity(title = title, url = url))
         }
         command.value = DisplayMessage(R.string.bookmarkAddedFeedback)
+    }
+
+    fun onBrokenSiteSelected() {
+        command.value = BrokenSiteFeedback(site?.url)
     }
 
     fun onUserSelectedToEditQuery(query: String) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/724933382879815

**Description**:
Use site model url (rather than live url which is designed to trigger a navigation) for broken site form

**Steps to test this PR**:
1. Visit a broken site e.g drudgereport.com
1. Select "Report broken site"
1. Ensure the correct url appears in the Url field

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
