### PR TITLE
Ensure omnibar shows on reset

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -593,6 +593,7 @@ class BrowserTabFragment : Fragment(), FindListener {
         destroyWebView()
         configureWebView()
         showKeyboard()
+        appBarLayout.setExpanded(true)
     }
 
     fun onBackPressed(): Boolean {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/726263852905235/f

**Description**:
Fixes issues where omnibar could be hidden away and inaccessible

**Steps to test this PR**:
1. Go to a webpage
1. Scroll the page up to hide the bars
1. Press the back button to go home.
1. Observe that the bar is shown

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
