### PR TITLE
Fix issue where last loaded url could show in omnibar when page fails

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -82,7 +82,7 @@ class BrowserWebViewClient @Inject constructor(
     }
 
     override fun onPageFinished(view: WebView?, url: String?) {
-        webViewClientListener?.loadingFinished(view?.url)
+        webViewClientListener?.loadingFinished(url)
     }
 
     @WorkerThread


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/361428290920650/726269452565961/726269452565964

**Description**:
Fixes issue where the webview rather than the onPageFinished callback url was used, showing an incorrect url on some devices on a failed page load

**Steps to test this PR**:
1. Visit a pages e.g bbc.com
1. Now enter nonsense.url in the omnibar and press enter
1. The page will fail to load
1. Ensure the omnibar shows the failed text 'nonsense.ulr` rather than the previously sucessful text

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
