### PR TITLE
Feature/bug fix webview state too large

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebDataManagerTest.kt
@@ -23,6 +23,7 @@ import android.webkit.CookieManager
 import android.webkit.ValueCallback
 import android.webkit.WebStorage
 import android.webkit.WebView
+import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
 import com.nhaarman.mockito_kotlin.*
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -36,7 +37,7 @@ class WebDataManagerTest {
 
     private val mockStorage: WebStorage = mock()
 
-    private val testee = WebDataManager(host)
+    private val testee = WebDataManager(host, WebViewSessionInMemoryStorage())
 
     @UiThreadTest
     @Test
@@ -60,7 +61,7 @@ class WebDataManagerTest {
 
         whenever(mockCookieManager.getCookie(host)).thenReturn("da=abc; dz=zyx")
         whenever(mockCookieManager.getCookie(externalHost)).thenReturn("ea=abc; ez=zyx")
-        testee.clearExternalCookies(mockCookieManager, {})
+        testee.clearExternalCookies(mockCookieManager) {}
 
         val captor = argumentCaptor<ValueCallback<Boolean>>()
         verify(mockCookieManager).removeAllCookies(captor.capture())

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.tabs.ui
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.Observer
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
@@ -53,7 +54,7 @@ class TabSwitcherViewModelTest {
     fun before() {
         MockitoAnnotations.initMocks(this)
         whenever(mockTabRepository.add()).thenReturn("TAB_ID")
-        testee = TabSwitcherViewModel(mockTabRepository)
+        testee = TabSwitcherViewModel(mockTabRepository, WebViewSessionInMemoryStorage())
         testee.command.observeForever(mockCommandObserver)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -170,7 +170,8 @@ class BrowserActivity : DuckDuckGoActivity() {
     }
 
     fun launchFire() {
-        FireDialog(context = this, webDataManager = webDataManager,
+        FireDialog(context = this,
+            webDataManager = webDataManager,
             clearStarted = { viewModel.onClearRequested() },
             clearComplete = { viewModel.onClearComplete() }
         ).show()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -45,6 +45,9 @@ class BrowserActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
+    @Inject
+    lateinit var webDataManager: WebDataManager
+
     private var currentTab: BrowserTabFragment? = null
 
     private val viewModel: BrowserViewModel by lazy {
@@ -167,7 +170,7 @@ class BrowserActivity : DuckDuckGoActivity() {
     }
 
     fun launchFire() {
-        FireDialog(context = this,
+        FireDialog(context = this, webDataManager = webDataManager,
             clearStarted = { viewModel.onClearRequested() },
             clearComplete = { viewModel.onClearComplete() }
         ).show()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -827,6 +827,8 @@ class BrowserTabFragment : Fragment(), FindListener {
 
         fun renderGlobalViewState(viewState: GlobalLayoutViewState) {
             renderIfChanged(viewState, lastSeenGlobalViewState) {
+                lastSeenGlobalViewState = viewState
+
                 if (viewState.isNewTabState) {
                     newTabLayout.show()
                     browserLayout.hide()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -60,6 +60,7 @@ import com.duckduckgo.app.browser.downloader.FileDownloader
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import com.duckduckgo.app.browser.filechooser.FileChooserIntentBuilder
 import com.duckduckgo.app.browser.omnibar.KeyboardAwareEditText
+import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.*
@@ -103,6 +104,9 @@ class BrowserTabFragment : Fragment(), FindListener {
 
     @Inject
     lateinit var fileDownloadNotificationManager: FileDownloadNotificationManager
+
+    @Inject
+    lateinit var webViewSessionStorage: WebViewSessionStorage
 
     val tabId get() = arguments!![TAB_ID_ARG] as String
 
@@ -591,14 +595,19 @@ class BrowserTabFragment : Fragment(), FindListener {
         }
     }
 
+    /**
+     * Attempting to save the WebView's state can result in a TransactionTooLargeException being thrown.
+     * This will only happen if the bundle size is too large - but the exact size is undefined.
+     * Instead of saving using normal Android state mechanism - use our own implementation instead.
+     */
     override fun onSaveInstanceState(bundle: Bundle) {
-        webView?.saveState(bundle)
+        viewModel.saveWebViewState(webView, tabId)
         super.onSaveInstanceState(bundle)
     }
 
     override fun onViewStateRestored(bundle: Bundle?) {
+        viewModel.restoreWebViewState(webView, omnibarTextInput.text.toString())
         super.onViewStateRestored(bundle)
-        webView?.restoreState(bundle)
     }
 
     override fun onHiddenChanged(hidden: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -22,8 +22,9 @@ import android.webkit.CookieManager
 import android.webkit.WebStorage
 import android.webkit.WebView
 import android.webkit.WebViewDatabase
+import com.duckduckgo.app.browser.session.WebViewSessionStorage
 
-class WebDataManager(private val host: String) {
+class WebDataManager(private val host: String, private val webViewSessionStorage: WebViewSessionStorage) {
 
     fun clearData(webView: WebView, webStorage: WebStorage, context: Context) {
         webView.clearCache(true)
@@ -52,5 +53,9 @@ class WebDataManager(private val host: String) {
             ddgCookie?.forEach { cookieManager.setCookie(host, it.trim()) }
             clearAllCallback()
         }
+    }
+
+    fun clearWebViewSessions() {
+        webViewSessionStorage.deleteAllSessions()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -20,11 +20,15 @@ import android.content.Context
 import com.duckduckgo.app.browser.*
 import com.duckduckgo.app.browser.defaultBrowsing.AndroidDefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
+import com.duckduckgo.app.browser.session.WebViewSessionStorage
+import com.duckduckgo.app.global.AppUrl
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import dagger.Module
 import dagger.Provides
+import javax.inject.Singleton
 
 @Module
 class BrowserModule {
@@ -47,4 +51,12 @@ class BrowserModule {
     fun defaultWebBrowserCapability(context: Context, appInstallStore: AppInstallStore): DefaultBrowserDetector {
         return AndroidDefaultBrowserDetector(context, appInstallStore)
     }
+
+    @Singleton
+    @Provides
+    fun webViewSessionStorage(): WebViewSessionStorage = WebViewSessionInMemoryStorage()
+
+    @Singleton
+    @Provides
+    fun webDataManager(webViewSessionStorage: WebViewSessionStorage) = WebDataManager(AppUrl.Url.HOST, webViewSessionStorage)
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/session/WebViewSessionStorage.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/session/WebViewSessionStorage.kt
@@ -35,7 +35,7 @@ class WebViewSessionInMemoryStorage : WebViewSessionStorage {
     private val map = object: LruCache<String, Bundle>(CACHE_SIZE) {
 
         /**
-         * We can calculate this however we choose, but it should match up with the value we used for cache size.
+         * We can calculate this however we choose, but it should match up with the value we use for cache size.
          * i.e., if we specify max cache size in bytes, we should calculate an approximate size of the cache entry in bytes.
          */
         override fun sizeOf(key: String, bundle: Bundle) = bundle.sizeInBytes()

--- a/app/src/main/java/com/duckduckgo/app/browser/session/WebViewSessionStorage.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/session/WebViewSessionStorage.kt
@@ -35,8 +35,8 @@ class WebViewSessionInMemoryStorage : WebViewSessionStorage {
     private val cache = object : LruCache<String, Bundle>(CACHE_SIZE_BYTES) {
 
         /**
-         * We can calculate this however we choose, but it should match up with the value we use for cache size.
-         * i.e., we specify the max cache size in bytes, so we need to calculate an approximate size of the cache entry in bytes.
+         * Size (in bytes) of a single entry in the cache for the given key.
+         * We specify the max cache size in bytes, so we need to calculate an approximate size of the cache entry in bytes.
          */
         override fun sizeOf(key: String, bundle: Bundle) = bundle.sizeInBytes()
 

--- a/app/src/main/java/com/duckduckgo/app/browser/session/WebViewSessionStorage.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/session/WebViewSessionStorage.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.session
+
+import android.os.Bundle
+import android.os.Parcel
+import android.util.LruCache
+import android.webkit.WebView
+import timber.log.Timber
+
+
+interface WebViewSessionStorage {
+    fun saveSession(webView: WebView?, tabId: String)
+    fun restoreSession(webView: WebView?, tabId: String): Boolean
+    fun deleteSession(tabId: String)
+    fun deleteAllSessions()
+}
+
+class WebViewSessionInMemoryStorage : WebViewSessionStorage {
+
+    private val map = object: LruCache<String, Bundle>(CACHE_SIZE) {
+
+        /**
+         * We can calculate this however we choose, but it should match up with the value we used for cache size.
+         * i.e., if we specify max cache size in bytes, we should calculate an approximate size of the cache entry in bytes.
+         */
+        override fun sizeOf(key: String, bundle: Bundle) = bundle.sizeInBytes()
+
+        override fun entryRemoved(evicted: Boolean, key: String?, oldValue: Bundle?, newValue: Bundle?) {
+            if (evicted) {
+                Timber.v("Evicted $key from WebView session storage")
+            }
+        }
+    }
+
+    override fun saveSession(webView: WebView?, tabId: String) {
+        if (webView == null) {
+            Timber.w("WebView is null; cannot save session")
+            return
+        }
+
+        Timber.i("Saving WebView session for $tabId")
+
+        val webViewBundle = createWebViewBundle(webView)
+
+        val bundle = Bundle()
+        bundle.putBundle(CACHE_KEY_WEBVIEW, webViewBundle)
+        bundle.putInt(CACHE_KEY_SCROLL_POSITION, webView.scrollY)
+        map.put(tabId, bundle)
+
+        Timber.d("Stored ${bundle.sizeInBytes()} bytes for WebView $webView")
+        logCacheSize()
+    }
+
+    private fun createWebViewBundle(webView: WebView): Bundle {
+        return Bundle().also {
+            webView.saveState(it)
+        }
+    }
+
+    override fun restoreSession(webView: WebView?, tabId: String): Boolean {
+        if (webView == null) {
+            Timber.w("WebView is null; cannot restore session")
+            return false
+        }
+
+        Timber.i("Restoring WebView session for $tabId")
+
+        val bundle = map[tabId]
+        if (bundle == null) {
+            Timber.v("No saved bundle for tab $tabId")
+            return false
+        }
+
+        val webViewBundle = bundle.getBundle(CACHE_KEY_WEBVIEW)
+        webView.restoreState(webViewBundle)
+        webView.scrollY = bundle.getInt(CACHE_KEY_SCROLL_POSITION)
+        map.remove(tabId)
+
+        logCacheSize()
+
+        return true
+    }
+
+    override fun deleteSession(tabId: String) {
+        map.remove(tabId)
+        Timber.i("Deleted web session for $tabId")
+        logCacheSize()
+    }
+
+    override fun deleteAllSessions() = map.evictAll()
+
+    private fun logCacheSize() {
+        Timber.v("Cache size is now ~${map.size()} bytes out of a max size of ${map.maxSize()} bytes")
+    }
+
+    private fun Bundle.sizeInBytes(): Int {
+        val parcel = Parcel.obtain()
+        parcel.writeValue(this)
+
+        val bytes = parcel.marshall()
+        parcel.recycle()
+
+        return bytes.size
+    }
+
+    companion object {
+        private const val CACHE_SIZE = 10 * 1024 * 1024 // 10 MB
+
+        private const val CACHE_KEY_WEBVIEW = "webview"
+        private const val CACHE_KEY_SCROLL_POSITION = "scroll-position"
+
+    }
+
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/session/WebViewSessionStorage.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/session/WebViewSessionStorage.kt
@@ -32,11 +32,11 @@ interface WebViewSessionStorage {
 
 class WebViewSessionInMemoryStorage : WebViewSessionStorage {
 
-    private val map = object: LruCache<String, Bundle>(CACHE_SIZE) {
+    private val map = object : LruCache<String, Bundle>(CACHE_SIZE_BYTES) {
 
         /**
          * We can calculate this however we choose, but it should match up with the value we use for cache size.
-         * i.e., if we specify max cache size in bytes, we should calculate an approximate size of the cache entry in bytes.
+         * i.e., we specify the max cache size in bytes, so we need to calculate an approximate size of the cache entry in bytes.
          */
         override fun sizeOf(key: String, bundle: Bundle) = bundle.sizeInBytes()
 
@@ -119,7 +119,7 @@ class WebViewSessionInMemoryStorage : WebViewSessionStorage {
     }
 
     companion object {
-        private const val CACHE_SIZE = 10 * 1024 * 1024 // 10 MB
+        private const val CACHE_SIZE_BYTES = 10 * 1024 * 1024 // 10 MiB
 
         private const val CACHE_KEY_WEBVIEW = "webview"
         private const val CACHE_KEY_SCROLL_POSITION = "scroll-position"

--- a/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.browser.LongPressHandler
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserNotification
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
+import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.feedback.api.FeedbackSender
 import com.duckduckgo.app.feedback.ui.FeedbackViewModel
 import com.duckduckgo.app.global.db.AppConfigurationDao
@@ -68,7 +69,8 @@ class ViewModelFactory @Inject constructor(
     private val webViewLongPressHandler: LongPressHandler,
     private val defaultBrowserDetector: DefaultBrowserDetector,
     private val variantManager: VariantManager,
-    private val feedbackSender: FeedbackSender
+    private val feedbackSender: FeedbackSender,
+    private val webViewSessionStorage: WebViewSessionStorage
 
 ) : ViewModelProvider.NewInstanceFactory() {
 
@@ -79,7 +81,7 @@ class ViewModelFactory @Inject constructor(
                     isAssignableFrom(OnboardingViewModel::class.java) -> OnboardingViewModel(onboaringStore, defaultBrowserDetector, variantManager)
                     isAssignableFrom(BrowserViewModel::class.java) -> BrowserViewModel(tabRepository, queryUrlConverter)
                     isAssignableFrom(BrowserTabViewModel::class.java) -> browserTabViewModel()
-                    isAssignableFrom(TabSwitcherViewModel::class.java) -> TabSwitcherViewModel(tabRepository)
+                    isAssignableFrom(TabSwitcherViewModel::class.java) -> TabSwitcherViewModel(tabRepository, webViewSessionStorage)
                     isAssignableFrom(PrivacyDashboardViewModel::class.java) -> PrivacyDashboardViewModel(privacySettingsStore, networkLeaderboardDao)
                     isAssignableFrom(ScorecardViewModel::class.java) -> ScorecardViewModel(privacySettingsStore)
                     isAssignableFrom(TrackerNetworksViewModel::class.java) -> TrackerNetworksViewModel()
@@ -104,6 +106,7 @@ class ViewModelFactory @Inject constructor(
         defaultBrowserNotification = defaultBrowserNotification,
         appConfigurationDao = appConfigurationDao,
         longPressHandler = webViewLongPressHandler,
+        webViewSessionStorage = webViewSessionStorage,
         autoCompleteApi = autoCompleteApi
     )
 }

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -24,29 +24,28 @@ import android.webkit.WebStorage
 import android.webkit.WebView
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.WebDataManager
-import com.duckduckgo.app.global.AppUrl.Url
 import kotlinx.android.synthetic.main.sheet_fire_clear_data.*
 
-class FireDialog(context: Context, clearStarted: (() -> Unit), clearComplete: (() -> Unit)) :
-    BottomSheetDialog(context) {
+class FireDialog(
+    context: Context,
+    webDataManager: WebDataManager,
+    clearStarted: (() -> Unit),
+    clearComplete: (() -> Unit)
+) : BottomSheetDialog(context) {
 
     init {
-
-        val dataManager = WebDataManager(Url.HOST)
         val contentView = View.inflate(getContext(), R.layout.sheet_fire_clear_data, null)
-
         setContentView(contentView)
-
         clearAllOption.setOnClickListener {
             clearStarted()
-            dataManager.clearData(WebView(context), WebStorage.getInstance(), context)
-            dataManager.clearExternalCookies(CookieManager.getInstance(), clearComplete)
+            webDataManager.clearData(WebView(context), WebStorage.getInstance(), context)
+            webDataManager.clearExternalCookies(CookieManager.getInstance(), clearComplete)
+            webDataManager.clearWebViewSessions()
             dismiss()
         }
-
         cancelOption.setOnClickListener {
             dismiss()
         }
-
     }
+
 }

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -31,16 +31,16 @@ class FireDialog(
     webDataManager: WebDataManager,
     clearStarted: (() -> Unit),
     clearComplete: (() -> Unit)
-) : BottomSheetDialog(context) {
-
+) :
+    BottomSheetDialog(context) {
     init {
         val contentView = View.inflate(getContext(), R.layout.sheet_fire_clear_data, null)
         setContentView(contentView)
         clearAllOption.setOnClickListener {
             clearStarted()
             webDataManager.clearData(WebView(context), WebStorage.getInstance(), context)
-            webDataManager.clearExternalCookies(CookieManager.getInstance(), clearComplete)
             webDataManager.clearWebViewSessions()
+            webDataManager.clearExternalCookies(CookieManager.getInstance(), clearComplete)
             dismiss()
         }
         cancelOption.setOnClickListener {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -25,6 +25,7 @@ import android.support.v7.widget.LinearLayoutManager
 import android.view.Menu
 import android.view.MenuItem
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.WebDataManager
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.FireDialog
@@ -41,6 +42,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
 
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
+
+    @Inject
+    lateinit var webDataManager: WebDataManager
 
     private val viewModel: TabSwitcherViewModel by lazy {
         ViewModelProviders.of(this, viewModelFactory).get(TabSwitcherViewModel::class.java)
@@ -99,7 +103,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
     }
 
     private fun onFire() {
-        FireDialog(context = this,
+        FireDialog(context = this, webDataManager = webDataManager,
             clearStarted = { viewModel.onClearRequested() },
             clearComplete = { viewModel.onClearComplete() }
         ).show()

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -103,10 +103,11 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
     }
 
     private fun onFire() {
-        FireDialog(context = this, webDataManager = webDataManager,
+        FireDialog(
+            context = this,
+            webDataManager = webDataManager,
             clearStarted = { viewModel.onClearRequested() },
-            clearComplete = { viewModel.onClearComplete() }
-        ).show()
+            clearComplete = { viewModel.onClearComplete() }).show()
     }
 
     override fun onNewTabRequested() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -20,11 +20,12 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.ViewModel
 import android.support.annotation.StringRes
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.global.SingleLiveEvent
-import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabRepository
 
-class TabSwitcherViewModel(private val tabRepository: TabRepository) : ViewModel() {
+class TabSwitcherViewModel(private val tabRepository: TabRepository, private val webViewSessionStorage: WebViewSessionStorage) : ViewModel() {
 
     var tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
@@ -46,6 +47,7 @@ class TabSwitcherViewModel(private val tabRepository: TabRepository) : ViewModel
 
     fun onTabDeleted(tab: TabEntity) {
         tabRepository.delete(tab)
+        webViewSessionStorage.deleteSession(tab.tabId)
     }
 
     fun onClearRequested() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/533891143524678
Tech Design URL: 
CC: 

**Description**:
Attempting to save the `WebView`'s state using the usual Android state saving mechanism can fail with a `TransactionTooLargeException`. This will happen when the underlying `Bundle` exceeds a certain size. The size isn't well documented but can be anecdotally anywhere between 500KB and 1MB. This type of exception is dominating our crash reports.

This PR stops using the normal Android state saving mechanism, and reverts to an in-memory LRU cache instead. We have chosen 10MiB max cache size (after which `WebView` history for least recently used tabs will start becoming inaccessible).

**Steps to test this PR**:

_Testing - happy path_
1. Browse to a page, 
1. Browse to another. 
1. Hit the `HOME` button once loaded
1. Return to the app. Ensure the previous page is reloaded and the rough scroll position is restored.
1. Hit the `BACK` button. Verify the previous page is loaded (and that you don't just land on the new tab screen)
1. Add in multiple tabs and repeat the above - ensuring things work as expected while there is enough room in the cache.

_Testing - less happy path_
1. You might want to manually lower the cache size to test this PR out. See `WebViewSessionInMemoryStorage.CACHE_SIZE` for this value. Recommend setting it to around 5KB for testing (empirically, each visited site might add around 1KB to the size)
1. Additionally, you might want to get Android to throw out all `Activities` as soon you leave them from developer settings to force the state saving to kick in.
1. Monitor `logcat` for output given by `WebViewSessionInMemoryStorage` class - this will tell you what the size of the cache is and let you see how close you are to exhausting it.
1. Repeat the steps from the happy path, above. This time however, deliberately exhaust the cache.
1. When you bring the app to the foreground, verify that the previous page is loaded
1. This time, you should notice that you **can't** return to your previous pages in history. They are gone; we ran out of room in the cache to store the history. So we'll reload their previous page but they'll lose their browsing history.



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
