### PR TITLE
Stop hiding newTabLayout on global state change

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -839,10 +839,8 @@ class BrowserTabFragment : Fragment(), FindListener {
                 lastSeenGlobalViewState = viewState
 
                 if (viewState.isNewTabState) {
-                    newTabLayout.show()
                     browserLayout.hide()
                 } else {
-                    newTabLayout.hide()
                     browserLayout.show()
                 }
             }

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -53,6 +53,8 @@
         tools:listitem="@layout/item_autocomplete_suggestion"
         tools:visibility="visible" />
 
+    <include layout="@layout/include_new_browser_tab" />
+
     <android.support.constraint.ConstraintLayout
         android:id="@+id/browserLayout"
         android:layout_width="match_parent"
@@ -84,7 +86,5 @@
             android:focusableInTouchMode="true" />
 
     </android.support.constraint.ConstraintLayout>
-
-    <include layout="@layout/include_new_browser_tab" />
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/757906361496519
Tech Design URL: 
CC: 

**Description**:
Previously we programmatically hid the view when it wasn't needed as the logo would otherwise have overlapped the WebView. However, that isn't needed if we re-order the view hierarchy to let the WebView sit on top of the logo anyway

**Steps to test this PR**:
1. Turn on developer settings to destroy activities immediately
1. From the new tab screen, hit the home button
1. Return to the app. Verify that the DDG logo is still visible.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
