### PR TITLE
add serp variants and use equal normalised weighting across the board

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -23,12 +23,11 @@ import org.junit.Test
 class VariantManagerTest {
 
     private val variants = VariantManager.ACTIVE_VARIANTS
-    private val totalWeight = variants.sumByDouble { it.weight }
 
     @Test
     fun onboardingOnlyVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "ms" }
-        assertEqualsDouble( 0.20, variant!!.weight / totalWeight)
+        assertEqualsDouble( 1.0, variant!!.weight)
         assertTrue(variant.hasFeature(ShowInOnboarding))
         assertEquals(1, variant.features.size)
     }
@@ -36,7 +35,7 @@ class VariantManagerTest {
     @Test
     fun homeScreenCallToActionVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "mt" }
-        assertEqualsDouble( 0.20, variant!!.weight / totalWeight)
+        assertEqualsDouble( 1.0, variant!!.weight)
         assertTrue(variant.hasFeature(ShowHomeScreenCallToAction))
         assertEquals(1, variant.features.size)
     }
@@ -44,7 +43,7 @@ class VariantManagerTest {
     @Test
     fun showBannerVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "mu" }
-        assertEqualsDouble( 0.20, variant!!.weight / totalWeight)
+        assertEqualsDouble( 1.0, variant!!.weight)
         assertTrue(variant.hasFeature(ShowBanner))
         assertEquals(1, variant.features.size)
     }
@@ -52,7 +51,7 @@ class VariantManagerTest {
     @Test
     fun showBannerAndShowHomeScreenCallToActionVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "mv" }
-        assertEqualsDouble( 0.20, variant!!.weight / totalWeight)
+        assertEqualsDouble( 1.0, variant!!.weight)
         assertTrue(variant.hasFeature(ShowBanner))
         assertTrue(variant.hasFeature(ShowHomeScreenCallToAction))
         assertEquals(2, variant.features.size)
@@ -61,7 +60,21 @@ class VariantManagerTest {
     @Test
     fun controlVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "my" }
-        assertEqualsDouble( 0.2, variant!!.weight / totalWeight)
+        assertEqualsDouble( 1.0, variant!!.weight)
+        assertEquals(0, variant.features.size)
+    }
+
+    @Test
+    fun serpVariantAConfiguredCorrectly() {
+        val variant = variants.firstOrNull { it.key == "sa" }
+        assertEqualsDouble( 1.0, variant!!.weight)
+        assertEquals(0, variant.features.size)
+    }
+
+    @Test
+    fun serpVariantBConfiguredCorrectly() {
+        val variant = variants.firstOrNull { it.key == "sb" }
+        assertEqualsDouble( 1.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -27,7 +27,7 @@ class VariantManagerTest {
     @Test
     fun onboardingOnlyVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "ms" }
-        assertEqualsDouble( 1.0, variant!!.weight)
+        assertEqualsDouble(1.0, variant!!.weight)
         assertTrue(variant.hasFeature(ShowInOnboarding))
         assertEquals(1, variant.features.size)
     }
@@ -35,7 +35,7 @@ class VariantManagerTest {
     @Test
     fun homeScreenCallToActionVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "mt" }
-        assertEqualsDouble( 1.0, variant!!.weight)
+        assertEqualsDouble(1.0, variant!!.weight)
         assertTrue(variant.hasFeature(ShowHomeScreenCallToAction))
         assertEquals(1, variant.features.size)
     }
@@ -43,7 +43,7 @@ class VariantManagerTest {
     @Test
     fun showBannerVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "mu" }
-        assertEqualsDouble( 1.0, variant!!.weight)
+        assertEqualsDouble(1.0, variant!!.weight)
         assertTrue(variant.hasFeature(ShowBanner))
         assertEquals(1, variant.features.size)
     }
@@ -51,7 +51,7 @@ class VariantManagerTest {
     @Test
     fun showBannerAndShowHomeScreenCallToActionVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "mv" }
-        assertEqualsDouble( 1.0, variant!!.weight)
+        assertEqualsDouble(1.0, variant!!.weight)
         assertTrue(variant.hasFeature(ShowBanner))
         assertTrue(variant.hasFeature(ShowHomeScreenCallToAction))
         assertEquals(2, variant.features.size)
@@ -60,27 +60,27 @@ class VariantManagerTest {
     @Test
     fun controlVariantConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "my" }
-        assertEqualsDouble( 1.0, variant!!.weight)
+        assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
     fun serpVariantAConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "sa" }
-        assertEqualsDouble( 1.0, variant!!.weight)
+        assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
     fun serpVariantBConfiguredCorrectly() {
         val variant = variants.firstOrNull { it.key == "sb" }
-        assertEqualsDouble( 1.0, variant!!.weight)
+        assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }
 
     private fun assertEqualsDouble(expected: Double, actual: Double) {
         val comparison = expected.compareTo(actual)
-        if(comparison != 0) {
+        if (comparison != 0) {
             fail("Doubles are not equal. Expected $expected but was $actual")
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -41,13 +41,17 @@ interface VariantManager {
         val DEFAULT_VARIANT = Variant(key = "", features = emptyList())
 
         val ACTIVE_VARIANTS = listOf(
-            Variant(key = "ms", weight = 20.0, features = listOf(ShowInOnboarding)),
-            Variant(key = "mt", weight = 20.0, features = listOf(ShowHomeScreenCallToAction)),
-            Variant(key = "mu", weight = 20.0, features = listOf(ShowBanner)),
-            Variant(key = "mv", weight = 20.0, features = listOf(ShowBanner, ShowHomeScreenCallToAction)),
+            Variant(key = "ms", weight = 1.0, features = listOf(ShowInOnboarding)),
+            Variant(key = "mt", weight = 1.0, features = listOf(ShowHomeScreenCallToAction)),
+            Variant(key = "mu", weight = 1.0, features = listOf(ShowBanner)),
+            Variant(key = "mv", weight = 1.0, features = listOf(ShowBanner, ShowHomeScreenCallToAction)),
 
             // control group
-            Variant(key = "my", weight = 20.0, features = emptyList())
+            Variant(key = "my", weight = 1.0, features = emptyList()),
+
+            // SERP variants - do not remove
+            Variant(key = "sa", weight = 1.0, features = emptyList()),
+            Variant(key = "sb", weight = 1.0, features = emptyList())
         )
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/757819156125525
Tech Design URL: 
CC: 

**Description**:

Add `sa` and `sb` variants for use by the SERP.

**Steps to test this PR**:

1. Fresh install (or clear data) and ensure you get an `sa` and `sb` 
1. Ensure no regression on existing variants


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)