### PR TITLE
Add variant key to the app version in settings

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -25,6 +25,8 @@ import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.settings.SettingsViewModel.Command
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.Variant
+import com.duckduckgo.app.statistics.VariantManager
 import com.nhaarman.mockito_kotlin.KArgumentCaptor
 import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.verify
@@ -55,6 +57,9 @@ class SettingsViewModelTest {
     @Mock
     private lateinit var mockDefaultBrowserDetector: DefaultBrowserDetector
 
+    @Mock
+    private lateinit var mockVariantManager: VariantManager
+
     private lateinit var commandCaptor: KArgumentCaptor<Command>
 
     @Before
@@ -64,9 +69,10 @@ class SettingsViewModelTest {
         context = InstrumentationRegistry.getTargetContext()
         commandCaptor = argumentCaptor()
 
-
-        testee = SettingsViewModel(mockAppSettingsDataStore, mockDefaultBrowserDetector)
+        testee = SettingsViewModel(mockAppSettingsDataStore, mockDefaultBrowserDetector, mockVariantManager)
         testee.command.observeForever(commandObserver)
+
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.DEFAULT_VARIANT)
     }
 
     @Test
@@ -92,7 +98,8 @@ class SettingsViewModelTest {
     fun whenStartCalledThenVersionSetCorrectly() {
         testee.start()
         val value = latestViewState()
-        assertEquals("${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})", value.version)
+        val expectedStartString = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+        assertTrue(value.version.startsWith(expectedStartString))
     }
 
     @Test
@@ -133,6 +140,20 @@ class SettingsViewModelTest {
         testee.start()
         assertTrue(latestViewState().showDefaultBrowserSetting)
     }
+
+    @Test
+    fun whenVariantIsEmptyThenEmptyVariantIncludedInSettings() {
+        testee.start()
+        assertTrue(latestViewState().version.contains("variant=()"))
+    }
+
+    @Test
+    fun whenVariantIsSetThenVariantKeyIncludedInSettings() {
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ab"))
+        testee.start()
+        assertTrue(latestViewState().version.contains("variant=(ab)"))
+    }
+
 
     private fun latestViewState() = testee.viewState.value!!
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -144,14 +144,16 @@ class SettingsViewModelTest {
     @Test
     fun whenVariantIsEmptyThenEmptyVariantIncludedInSettings() {
         testee.start()
-        assertTrue(latestViewState().version.contains("variant=()"))
+        val expectedStartString = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+        assertEquals(expectedStartString, latestViewState().version)
     }
 
     @Test
     fun whenVariantIsSetThenVariantKeyIncludedInSettings() {
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("ab"))
         testee.start()
-        assertTrue(latestViewState().version.contains("variant=(ab)"))
+        val expectedStartString = "${BuildConfig.VERSION_NAME} ab (${BuildConfig.VERSION_CODE})"
+        assertEquals(expectedStartString, latestViewState().version)
     }
 
 

--- a/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
@@ -93,7 +93,7 @@ class ViewModelFactory @Inject constructor(
                 isAssignableFrom(TrackerNetworksViewModel::class.java) -> TrackerNetworksViewModel()
                 isAssignableFrom(PrivacyPracticesViewModel::class.java) -> PrivacyPracticesViewModel()
                 isAssignableFrom(FeedbackViewModel::class.java) -> FeedbackViewModel(feedbackSender)
-                isAssignableFrom(SettingsViewModel::class.java) -> SettingsViewModel(appSettingsPreferencesStore, defaultBrowserDetector)
+                isAssignableFrom(SettingsViewModel::class.java) -> SettingsViewModel(appSettingsPreferencesStore, defaultBrowserDetector, variantManager)
                 isAssignableFrom(BookmarksViewModel::class.java) -> BookmarksViewModel(bookmarksDao)
                 else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -21,11 +21,15 @@ import android.arch.lifecycle.ViewModel
 import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.VariantManager
 import timber.log.Timber
 import javax.inject.Inject
 
-class SettingsViewModel @Inject constructor(private val settingsDataStore: SettingsDataStore,
-        private val defaultWebBrowserCapability: DefaultBrowserDetector) : ViewModel() {
+class SettingsViewModel @Inject constructor(
+    private val settingsDataStore: SettingsDataStore,
+    private val defaultWebBrowserCapability: DefaultBrowserDetector,
+    private val variantManager: VariantManager
+) : ViewModel() {
 
     data class ViewState(
             val loading: Boolean = true,
@@ -54,11 +58,13 @@ class SettingsViewModel @Inject constructor(private val settingsDataStore: Setti
         val defaultBrowserAlready = defaultWebBrowserCapability.isCurrentlyConfiguredAsDefaultBrowser()
         Timber.i("Is already default browser? $defaultBrowserAlready")
 
+        val variantKey = variantManager.getVariant().key
+
         viewState.value = currentViewState.copy(loading = false,
                 autoCompleteSuggestionsEnabled = autoCompleteEnabled,
                 isAppDefaultBrowser = defaultBrowserAlready,
                 showDefaultBrowserSetting = defaultWebBrowserCapability.deviceSupportsDefaultBrowserConfiguration(),
-                version = obtainVersion())
+                version = obtainVersion(variantKey))
     }
 
     fun userRequestedToSendFeedback() {
@@ -69,7 +75,8 @@ class SettingsViewModel @Inject constructor(private val settingsDataStore: Setti
         Timber.i("User changed autocomplete setting, is now enabled: $checked")
         settingsDataStore.autoCompleteSuggestionsEnabled = checked
     }
-    private fun obtainVersion(): String {
-        return "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+    private fun obtainVersion(variantKey: String): String {
+        val version = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+        return "$version variant=($variantKey)"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -75,8 +75,9 @@ class SettingsViewModel @Inject constructor(
         Timber.i("User changed autocomplete setting, is now enabled: $checked")
         settingsDataStore.autoCompleteSuggestionsEnabled = checked
     }
+
     private fun obtainVersion(variantKey: String): String {
-        val version = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
-        return "$version variant=($variantKey)"
+        val formattedVariantKey = if (variantKey.isBlank()) " " else " $variantKey "
+        return "${BuildConfig.VERSION_NAME}$formattedVariantKey(${BuildConfig.VERSION_CODE})"
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/763395487483363
Tech Design URL: 
CC: 

**Description**:
Adds the variant to the settings string in settings

**Steps to test this PR**:
1. Visit settings when you have a variant; verify the settings now ends `variant=(xx)` where `xx` is your variant key
1. Visit settings when you don't have a variant; verify the settings now ends `variant=()`


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
