### PR TITLE
Feature/pin to home screen

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.DownloadFile
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.OpenInNewTab
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserNotification
+import com.duckduckgo.app.browser.favicon.FaviconDownloader
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.global.db.AppConfigurationDao
@@ -114,6 +115,9 @@ class BrowserTabViewModelTest {
     @Mock
     private lateinit var webViewSessionStorage: WebViewSessionStorage
 
+    @Mock
+    private lateinit var mockFaviconDownloader: FaviconDownloader
+
     @Captor
     private lateinit var commandCaptor: ArgumentCaptor<Command>
 
@@ -148,7 +152,8 @@ class BrowserTabViewModelTest {
             defaultBrowserDetector = mockDefaultBrowserDetector,
             longPressHandler = mockLongPressHandler,
             appConfigurationDao = appConfigurationDao,
-            webViewSessionStorage = webViewSessionStorage
+            webViewSessionStorage = webViewSessionStorage,
+            faviconDownloader = mockFaviconDownloader
         )
 
         testee.loadData("abc", null)

--- a/app/src/androidTest/java/com/duckduckgo/app/di/TestAppComponent.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/TestAppComponent.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.TestApplication
 import com.duckduckgo.app.browser.autoComplete.BrowserAutoCompleteModule
 import com.duckduckgo.app.browser.di.BrowserModule
 import com.duckduckgo.app.browser.di.DefaultBrowserModule
+import com.duckduckgo.app.browser.favicon.FaviconModule
 import com.duckduckgo.app.httpsupgrade.di.HttpsUpgraderModule
 import com.duckduckgo.app.onboarding.di.OnboardingModule
 import com.duckduckgo.app.surrogates.di.ResourceSurrogateModule
@@ -56,7 +57,8 @@ import javax.inject.Singleton
     NotificationModule::class,
     DefaultBrowserModule::class,
     OnboardingModule::class,
-    VariantModule::class
+    VariantModule::class,
+    FaviconModule::class
 ])
 interface TestAppComponent : AndroidInjector<TestApplication> {
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
 
     <application
         android:name="com.duckduckgo.app.global.DuckDuckGoApplication"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -37,6 +37,7 @@ import android.support.annotation.StringRes
 import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
 import android.support.v4.content.ContextCompat
+import android.support.v4.content.pm.ShortcutManagerCompat
 import android.support.v7.widget.LinearLayoutManager
 import android.text.Editable
 import android.view.*
@@ -61,6 +62,7 @@ import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import com.duckduckgo.app.browser.filechooser.FileChooserIntentBuilder
 import com.duckduckgo.app.browser.omnibar.KeyboardAwareEditText
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
+import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
 import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.*
@@ -107,6 +109,9 @@ class BrowserTabFragment : Fragment(), FindListener {
 
     @Inject
     lateinit var webViewSessionStorage: WebViewSessionStorage
+
+    @Inject
+    lateinit var shortcutBuilder: ShortcutBuilder
 
     val tabId get() = arguments!![TAB_ID_ARG] as String
 
@@ -221,7 +226,18 @@ class BrowserTabFragment : Fragment(), FindListener {
                 )
             }
             onMenuItemClicked(view.sharePageMenuItem) { viewModel.userSharingLink(webView?.url) }
+            onMenuItemClicked(view.addToHome) {
+                context?.let {
+                    val url = webView?.url ?: return@let
+                    viewModel.userRequestedToPinPageToHome(url)
+                }
+            }
         }
+    }
+
+    private fun addHomeShortcut(homeShortcut: Command.AddHomeShortcut, context: Context) {
+        val shortcutInfo = shortcutBuilder.buildPinnedPageShortcut(context, homeShortcut)
+        ShortcutManagerCompat.requestPinShortcut(context, shortcutInfo, null)
     }
 
     private fun configureObservers() {
@@ -328,6 +344,11 @@ class BrowserTabFragment : Fragment(), FindListener {
             is Command.DisplayMessage -> showToast(it.messageId)
             is Command.ShowFileChooser -> {
                 launchFilePicker(it)
+            }
+            is Command.AddHomeShortcut -> {
+                context?.let { context ->
+                    addHomeShortcut(it, context)
+                }
             }
         }
     }
@@ -882,6 +903,7 @@ class BrowserTabFragment : Fragment(), FindListener {
                 newTabPopupMenuItem.isEnabled = browserShowing
                 addBookmarksPopupMenuItem?.isEnabled = viewState.canAddBookmarks
                 sharePageMenuItem?.isEnabled = viewState.canSharePage
+                addToHome?.isEnabled = viewState.canAddToHome
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -40,9 +40,11 @@ import com.duckduckgo.app.browser.BrowserTabViewModel.Command.*
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserNotification
+import com.duckduckgo.app.browser.favicon.FaviconDownloader
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.global.SingleLiveEvent
+import com.duckduckgo.app.global.baseHost
 import com.duckduckgo.app.global.db.AppConfigurationDao
 import com.duckduckgo.app.global.db.AppConfigurationEntity
 import com.duckduckgo.app.global.isMobileSite
@@ -79,6 +81,7 @@ class BrowserTabViewModel(
     private val defaultBrowserNotification: DefaultBrowserNotification,
     private val longPressHandler: LongPressHandler,
     private val webViewSessionStorage: WebViewSessionStorage,
+    private val faviconDownloader: FaviconDownloader,
     appConfigurationDao: AppConfigurationDao
 ) : WebViewClientListener, SaveBookmarkListener, ViewModel() {
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -591,13 +591,11 @@ class BrowserTabViewModel(
     }
 
     fun userRequestedToPinPageToHome(currentPage: String) {
-
-        val title =
-            if (duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(currentPage)) {
-                duckDuckGoUrlDetector.extractQuery(currentPage) ?: currentPage
-            } else {
-                currentPage.toUri().baseHost ?: currentPage
-            }
+        val title = if (duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(currentPage)) {
+            duckDuckGoUrlDetector.extractQuery(currentPage) ?: currentPage
+        } else {
+            currentPage.toUri().baseHost ?: currentPage
+        }
 
         faviconDownloader.download(currentPage.toUri())
             .subscribeOn(Schedulers.io())
@@ -609,8 +607,6 @@ class BrowserTabViewModel(
                 Timber.w(throwable, "Failed to obtain favicon")
                 command.value = AddHomeShortcut(title, currentPage)
             })
-
-
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.favicon
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import com.bumptech.glide.Glide
+import com.duckduckgo.app.global.faviconLocation
+import com.duckduckgo.app.global.view.toPx
+import io.reactivex.Single
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+interface FaviconDownloader {
+
+    fun download(currentPageUrl: Uri): Single<Bitmap>
+}
+
+class GlideFaviconDownloader @Inject constructor(private val context: Context) : FaviconDownloader {
+
+    override fun download(currentPageUrl: Uri): Single<Bitmap> {
+
+        return Single.fromCallable {
+
+            val faviconUrl = currentPageUrl.faviconLocation() ?: throw IllegalArgumentException("Invalid favicon currentPageUrl")
+            val desiredImageSizePx = DESIRED_IMAGE_SIZE_DP.toPx()
+
+            Glide.with(context)
+                .asBitmap()
+                .load(faviconUrl)
+                .submit(desiredImageSizePx, desiredImageSizePx)
+                .get(TIMEOUT_PERIOD_SECONDS, TimeUnit.SECONDS)
+        }
+    }
+
+    companion object {
+        private const val DESIRED_IMAGE_SIZE_DP = 24
+        private const val TIMEOUT_PERIOD_SECONDS: Long = 3
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconModule.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.favicon
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+
+
+@Module
+class FaviconModule {
+
+    @Provides
+    fun faviconDownloader(context: Context): FaviconDownloader {
+        return GlideFaviconDownloader(context)
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutBuilder.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutBuilder.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.shortcut
+
+import android.content.Context
+import android.content.Intent
+import android.support.v4.content.pm.ShortcutInfoCompat
+import android.support.v4.graphics.drawable.IconCompat
+import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.browser.BrowserTabViewModel
+import com.duckduckgo.app.browser.R
+import java.util.*
+import javax.inject.Inject
+
+
+class ShortcutBuilder @Inject constructor() {
+
+    fun buildPinnedPageShortcut(context: Context, homeShortcut: BrowserTabViewModel.Command.AddHomeShortcut): ShortcutInfoCompat {
+        val intent = Intent(context, BrowserActivity::class.java)
+        intent.action = Intent.ACTION_VIEW
+        intent.putExtra(Intent.EXTRA_TEXT, homeShortcut.url)
+
+        val icon = if (homeShortcut.icon != null) {
+            IconCompat.createWithBitmap(homeShortcut.icon)
+        } else {
+            IconCompat.createWithResource(context, R.drawable.mini_logo)
+        }
+
+        return ShortcutInfoCompat.Builder(context, UUID.randomUUID().toString())
+            .setShortLabel(homeShortcut.title)
+            .setIntent(intent)
+            .setIcon(icon)
+            .build()
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
@@ -21,6 +21,7 @@ import android.app.Application
 import com.duckduckgo.app.browser.autoComplete.BrowserAutoCompleteModule
 import com.duckduckgo.app.browser.di.BrowserModule
 import com.duckduckgo.app.browser.di.DefaultBrowserModule
+import com.duckduckgo.app.browser.favicon.FaviconModule
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.httpsupgrade.di.HttpsUpgraderModule
 import com.duckduckgo.app.onboarding.di.OnboardingModule
@@ -53,7 +54,8 @@ import javax.inject.Singleton
     NotificationModule::class,
     DefaultBrowserModule::class,
     OnboardingModule::class,
-    VariantModule::class
+    VariantModule::class,
+    FaviconModule::class
 ])
 interface AppComponent : AndroidInjector<DuckDuckGoApplication> {
 

--- a/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.browser.LongPressHandler
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserNotification
+import com.duckduckgo.app.browser.favicon.FaviconDownloader
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.feedback.api.FeedbackSender
@@ -72,6 +73,7 @@ class ViewModelFactory @Inject constructor(
     private val variantManager: VariantManager,
     private val feedbackSender: FeedbackSender,
     private val webViewSessionStorage: WebViewSessionStorage,
+    private val faviconDownloader: FaviconDownloader,
     private val pixel: Pixel
 
 ) : ViewModelProvider.NewInstanceFactory() {
@@ -113,6 +115,7 @@ class ViewModelFactory @Inject constructor(
         appConfigurationDao = appConfigurationDao,
         longPressHandler = webViewLongPressHandler,
         webViewSessionStorage = webViewSessionStorage,
-        autoCompleteApi = autoCompleteApi
+        autoCompleteApi = autoCompleteApi,
+        faviconDownloader = faviconDownloader
     )
 }

--- a/app/src/main/res/layout/popup_window_browser_menu.xml
+++ b/app/src/main/res/layout/popup_window_browser_menu.xml
@@ -103,6 +103,11 @@
                 style="@style/BrowserTextMenuItem"
                 android:text="@string/findInPageMenuTitle" />
 
+            <TextView
+                android:id="@+id/addToHome"
+                style="@style/BrowserTextMenuItem"
+                android:text="@string/addToHome" />
+
             <CheckBox
                 android:id="@+id/requestDesktopSiteCheckMenuItem"
                 style="@style/BrowserTextMenuItem"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,4 +195,7 @@
     <!-- Widget -->
     <string name="searchWidgetTextHint">Search DuckDuckGo</string>
 
+    <!-- Home Screen Shortcuts -->
+    <string name="addToHome">Add to Home</string>
+
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/193817002363848/709872649224577
Tech Design URL: 
CC: 

**Description**:
Adds ability to pin pages to the home screen

This functionality is available for all OS versions but will differ slightly for Oreo and newer.

**Steps to test this PR**:

**Oreo**
1. Install on Oreo device
1. Ensure "add to home" popup menu item is disabled when looking at the new tab page
1. Load a page; verify "add to home" popup menu item is available to click
1. If the favicon can be retrieved for that site, verify it is used for the icon. choose to add to home
1. Visit the home page and verify the icon is visible. 
1. Click on it, and verify it launches our app and loads that page

**Nougat and older**
1. Install on Nougat or older
1. Repeat as above. Note you'll get a slightly different UX but the end result should be the same.

One additional test is to make the favicon retrieval step fail. Easiest way to do this is to enable ✈️ mode after page is loaded, but before choosing to "add to home". Verify a default DDG logo is used for the favicon.

<img width="709" alt="screen shot 2018-08-02 at 15 15 01" src="https://user-images.githubusercontent.com/1336281/43589542-de7883a2-9666-11e8-92c8-50db5ea0bb50.png">


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
