### PR TITLE
add new pixels for dashboard and long press

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
@@ -19,10 +19,8 @@ package com.duckduckgo.app.browser
 import android.view.ContextMenu
 import android.view.MenuItem
 import android.webkit.WebView.HitTestResult
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.never
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.nhaarman.mockito_kotlin.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -45,10 +43,31 @@ class WebViewLongPressHandlerTest {
     @Mock
     private lateinit var mockMenuItem: MenuItem
 
+    @Mock
+    private lateinit var mockPixel: Pixel
+
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
-        testee = WebViewLongPressHandler()
+        testee = WebViewLongPressHandler(mockPixel)
+    }
+
+    @Test
+    fun whenLongPressedWithImageTypeThenPixelFired() {
+        testee.handleLongPress(HitTestResult.IMAGE_TYPE, HTTPS_IMAGE_URL, mockMenu)
+        verify(mockPixel).fire(Pixel.PixelName.LONG_PRESS)
+    }
+
+    @Test
+    fun whenLongPressedWithAnchorImageTypeThenPixelFired() {
+        testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, HTTPS_IMAGE_URL, mockMenu)
+        verify(mockPixel).fire(Pixel.PixelName.LONG_PRESS)
+    }
+
+    @Test
+    fun whenLongPressedWithUnknownTypeThenPixelNotFired() {
+        testee.handleLongPress(HitTestResult.UNKNOWN_TYPE, HTTPS_IMAGE_URL, mockMenu)
+        verify(mockPixel, never()).fire(any())
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
@@ -40,7 +40,7 @@ interface LongPressHandler {
     }
 }
 
-class WebViewLongPressHandler @Inject constructor(val pixel: Pixel) : LongPressHandler {
+class WebViewLongPressHandler @Inject constructor(private val pixel: Pixel) : LongPressHandler {
 
     override fun handleLongPress(longPressTargetType: Int, longPressTargetUrl: String?, menu: ContextMenu) {
         var menuShown = true

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
@@ -22,6 +22,8 @@ import android.webkit.URLUtil
 import android.webkit.WebView
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.*
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -38,9 +40,10 @@ interface LongPressHandler {
     }
 }
 
-class WebViewLongPressHandler @Inject constructor() : LongPressHandler {
+class WebViewLongPressHandler @Inject constructor(val pixel: Pixel) : LongPressHandler {
 
     override fun handleLongPress(longPressTargetType: Int, longPressTargetUrl: String?, menu: ContextMenu) {
+        var menuShown = true
         when (longPressTargetType) {
             WebView.HitTestResult.IMAGE_TYPE,
             WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE -> {
@@ -54,19 +57,30 @@ class WebViewLongPressHandler @Inject constructor() : LongPressHandler {
                 menu.add(0, CONTEXT_MENU_ID_OPEN_IN_NEW_TAB, 1, R.string.openInNewTab)
                 menu.add(0, CONTEXT_MENU_ID_SHARE_LINK, 2, R.string.shareLink)
             }
-            else -> Timber.v("App does not yet handle target type: $longPressTargetType")
+            else -> {
+                Timber.v("App does not yet handle target type: $longPressTargetType")
+                menuShown = false
+            }
         }
+
+        if (menuShown) {
+            pixel.fire(LONG_PRESS)
+        }
+
     }
 
     override fun userSelectedMenuItem(longPressTarget: String, item: MenuItem): RequiredAction {
         return when (item.itemId) {
             CONTEXT_MENU_ID_OPEN_IN_NEW_TAB -> {
+                pixel.fire(LONG_PRESS_NEW_TAB)
                 return OpenInNewTab(longPressTarget)
             }
             CONTEXT_MENU_ID_DOWNLOAD_IMAGE -> {
+                pixel.fire(LONG_PRESS_DOWNLOAD_IMAGE)
                 return DownloadFile(longPressTarget)
             }
             CONTEXT_MENU_ID_SHARE_LINK -> {
+                pixel.fire(LONG_PRESS_SHARE)
                 return ShareLink(longPressTarget)
             }
             else -> None

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.global.AppUrl
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import dagger.Module
 import dagger.Provides
@@ -43,8 +44,8 @@ class BrowserModule {
     }
 
     @Provides
-    fun webViewLongPressHandler(): LongPressHandler {
-        return WebViewLongPressHandler()
+    fun webViewLongPressHandler(pixel: Pixel): LongPressHandler {
+        return WebViewLongPressHandler(pixel)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
@@ -33,6 +33,8 @@ import com.duckduckgo.app.global.view.html
 import com.duckduckgo.app.global.view.show
 import com.duckduckgo.app.privacy.renderer.*
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.ViewState
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
 import kotlinx.android.synthetic.main.content_privacy_dashboard.*
@@ -46,6 +48,9 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
     lateinit var viewModelFactory: ViewModelFactory
     @Inject
     lateinit var repository: TabRepository
+    @Inject
+    lateinit var pixel: Pixel
+
     private val trackersRenderer = TrackersRenderer()
     private val upgradeRenderer = PrivacyUpgradeRenderer()
 
@@ -134,15 +139,26 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
     }
 
     fun onScorecardClicked() {
+        pixel.fire(PRIVACY_DASHBOARD_SCORECARD)
         startActivity(ScorecardActivity.intent(this, intent.tabId!!))
     }
 
+    fun onEncryptionClicked(@Suppress("UNUSED_PARAMETER") view: View) {
+        pixel.fire(PRIVACY_DASHBOARD_ENCRYPTION)
+    }
+
     fun onNetworksClicked(@Suppress("UNUSED_PARAMETER") view: View) {
+        pixel.fire(PRIVACY_DASHBOARD_NETWORKS)
         startActivity(TrackerNetworksActivity.intent(this, intent.tabId!!))
     }
 
     fun onPracticesClicked(@Suppress("UNUSED_PARAMETER") view: View) {
+        pixel.fire(PRIVACY_DASHBOARD_PRIVACY_PRACTICES)
         startActivity(PrivacyPracticesActivity.intent(this, intent.tabId!!))
+    }
+
+    fun onLeaderboardClick(@Suppress("UNUSED_PARAMETER") view: View) {
+        pixel.fire(PRIVACY_DASHBOARD_GLOBAL_STATS)
     }
 
     private fun updateActivityResult(shouldReload: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
@@ -149,7 +149,7 @@ class PrivacyDashboardViewModel(
 
     private companion object {
         private const val LEADERBOARD_MIN_NETWORKS = 3
-        private const val LEADERNOARD_MIN_DOMAINS_EXCLUSIVE = 30
+        private const val LEADERNOARD_MIN_DOMAINS_EXCLUSIVE = 5
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
@@ -149,7 +149,7 @@ class PrivacyDashboardViewModel(
 
     private companion object {
         private const val LEADERBOARD_MIN_NETWORKS = 3
-        private const val LEADERNOARD_MIN_DOMAINS_EXCLUSIVE = 5
+        private const val LEADERNOARD_MIN_DOMAINS_EXCLUSIVE = 30
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -30,11 +30,22 @@ interface Pixel {
 
         APP_LAUNCH("ml"),
         FORGET_ALL_EXECUTED("mf"),
+
         PRIVACY_DASHBOARD_OPENED("mp"),
+        PRIVACY_DASHBOARD_SCORECARD("mp_c"),
+        PRIVACY_DASHBOARD_ENCRYPTION("mp_e"),
+        PRIVACY_DASHBOARD_GLOBAL_STATS("mp_s"),
+        PRIVACY_DASHBOARD_PRIVACY_PRACTICES("mp_p"),
+        PRIVACY_DASHBOARD_NETWORKS("mp_n"),
 
         DEFAULT_BROWSER_INFO_VIEWED("mdb_v"),
         DEFAULT_BROWSER_SET("mdb_s"),
-        DEFAULT_BROWSER_NOT_SET("mdb_n")
+        DEFAULT_BROWSER_NOT_SET("mdb_n"),
+
+        LONG_PRESS("mlp"),
+        LONG_PRESS_DOWNLOAD_IMAGE("mlp_i"),
+        LONG_PRESS_NEW_TAB("mlp_t"),
+        LONG_PRESS_SHARE("mlp_s")
     }
 
     fun fire(pixel: PixelName)

--- a/app/src/main/res/layout/content_privacy_dashboard.xml
+++ b/app/src/main/res/layout/content_privacy_dashboard.xml
@@ -46,7 +46,8 @@
             <LinearLayout
                 android:id="@+id/httpsContainer"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:onClick="onEncryptionClicked">
 
                 <ImageView
                     android:id="@+id/httpsIcon"
@@ -144,6 +145,7 @@
             android:layout_height="108dp"
             android:paddingEnd="20dp"
             android:paddingStart="20dp"
+            android:onClick="onLeaderboardClick"
             app:layout_constraintTop_toBottomOf="@id/privacyToggleContainer">
 
             <TextView


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/772541567088307
Tech Design URL: 
CC: 

**Description**:

Adds new pixels for the Privacy Dashboard and Long Press Menu.

Note, is subject to pixels.json changes being approved but currently has no conflicts.

**Steps to test this PR**:

Check each pixel is fired under the specified circumstances.  Can be verified by monitoring Kibana with specified query or using network proxy to sniff traffic.

Privacy Protection dashboard:

Kibana `ddg_app:pixel AND pixel_id:mp AND url:/\/t\/mp_._(.?+)_(.?+)/`

1. Tap on grade to view score card, fires `mp_c`
1. Tap on encryption type, fires `mp_e`
1. Tap on Tracker Networks found/blocked, fires `mp_n`
1. Tap on Privacy Practices, fires `mp_p`
1. Tap on Global Stats, fires `mp_s`

Long press menu:

Kibana `ddg_app:pixel AND pixel_id:mlp AND url:/\/t\/mlp.?+/`

1. Long press menu opened, fires `mlp`
1. Open Image selected, fires `mlp_i`
1. New Tab selected, fires `mlp_t`
1. Share selected, fires `mlp_s`

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)