### PR TITLE
Update to target Android Pie 🥧

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,11 +11,11 @@ ext {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.duckduckgo.mobile.android"
         minSdkVersion 21
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode buildVersionCode()
         versionName VERSION_NAME
         testInstrumentationRunner "com.duckduckgo.app.TestRunner"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -22,4 +22,8 @@
             <certificates src="user" />
         </trust-anchors>
     </debug-overrides>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">duckduckgo.com</domain>
+    </domain-config>
+    <base-config cleartextTrafficPermitted="true" />
 </network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -22,8 +22,5 @@
             <certificates src="user" />
         </trust-anchors>
     </debug-overrides>
-    <domain-config cleartextTrafficPermitted="false">
-        <domain includeSubdomains="true">duckduckgo.com</domain>
-    </domain-config>
     <base-config cleartextTrafficPermitted="true" />
 </network-security-config>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/615543272514906
Tech Design URL: 
CC: 

**Description**:
Apps targeting Android Pie have cleartext comms disabled by default. That doesn't really work for a browser. So we enable cleartext comms but disable cleartext comms for *duckduckgo.com sites to enforce secure comms with our server.

**Steps to test this PR**:
Repeat these steps for both an Android Pie device and a pre-Pie device.

1. Verify the https/tracker lists are successfully downloaded from duckduckgo.com servers upon app installation
1. Visit an insecure site (e.g., http://stealmylogin.com). Verify the site loads as expected
1. Visit a secure site, such as https://bbc.co.uk and verify that loads correctly.

⚠️ Since we're updating the `targetSdk`, there are additional compatibilities which could kick in. So give the whole app a smoke test.



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
