### PR TITLE
Use stored specification rather than etag download check for https binary

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
@@ -59,13 +59,12 @@ class HttpsUpgradeDataDownloader @Inject constructor(
             Timber.d("Downloading https bloom filter binary")
 
             if (specification == httpsBloomSpecDao.get() && binaryDataStore.verifyCheckSum(HTTPS_BINARY_FILE, specification.sha256)) {
-                Timber.d("Https bloom filter binary already stored")
+                Timber.d("Https bloom data already stored for this spec")
                 return@fromAction
             }
 
             val call = service.httpsBloomFilter()
             val response = call.execute()
-
             if (!response.isSuccessful) {
                 throw IOException("Status: ${response.code()} - ${response.errorBody()?.string()}")
             }

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.httpsupgrade.api
 
 import com.duckduckgo.app.global.api.isCached
+import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.store.BinaryDataStore
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.httpsupgrade.db.HttpsBloomFilterSpecDao
@@ -34,7 +35,8 @@ class HttpsUpgradeDataDownloader @Inject constructor(
     private val httpsUpgrader: HttpsUpgrader,
     private val httpsBloomSpecDao: HttpsBloomFilterSpecDao,
     private val whitelistDao: HttpsWhitelistDao,
-    private val binaryDataStore: BinaryDataStore
+    private val binaryDataStore: BinaryDataStore,
+    private val appDatabase: AppDatabase
 ) {
 
     fun download(): Completable {
@@ -53,15 +55,16 @@ class HttpsUpgradeDataDownloader @Inject constructor(
 
     private fun downloadBloomFilter(specification: HttpsBloomFilterSpec): Completable {
         return fromAction {
-            Timber.d("Downloading https bloom filter binary")
-            val call = service.httpsBloomFilter()
-            val response = call.execute()
-            val fileName = HTTPS_BINARY_FILE
 
-            if (response.isCached && binaryDataStore.verifyCheckSum(fileName, specification.sha256)) {
-                Timber.d("Https bloom data already cached and stored for this spec")
+            Timber.d("Downloading https bloom filter binary")
+
+            if (specification == httpsBloomSpecDao.get() && binaryDataStore.verifyCheckSum(HTTPS_BINARY_FILE, specification.sha256)) {
+                Timber.d("Https bloom filter binary already stored")
                 return@fromAction
             }
+
+            val call = service.httpsBloomFilter()
+            val response = call.execute()
 
             if (!response.isSuccessful) {
                 throw IOException("Status: ${response.code()} - ${response.errorBody()?.string()}")
@@ -69,13 +72,15 @@ class HttpsUpgradeDataDownloader @Inject constructor(
 
             val bytes = response.body()!!.bytes()
             if (!binaryDataStore.verifyCheckSum(bytes, specification.sha256)) {
-                throw IOException("Https binary has incorrect checksum, throwisng away file")
+                throw IOException("Https binary has incorrect checksum, throwing away file")
             }
 
             Timber.d("Updating https bloom data store with new data")
-            httpsBloomSpecDao.insert(specification)
-            binaryDataStore.saveData(fileName, bytes)
-            httpsUpgrader.reloadData()
+            appDatabase.runInTransaction {
+                httpsBloomSpecDao.insert(specification)
+                binaryDataStore.saveData(HTTPS_BINARY_FILE, bytes)
+                httpsUpgrader.reloadData()
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/model/HttpsBloomFilterSpec.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/model/HttpsBloomFilterSpec.kt
@@ -21,7 +21,7 @@ import android.arch.persistence.room.PrimaryKey
 
 
 @Entity(tableName = "https_bloom_filter_spec")
-class HttpsBloomFilterSpec(
+data class HttpsBloomFilterSpec(
     @PrimaryKey val id: Int = 1,
     val errorRate: Double,
     val totalEntries: Int,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/721626625236432
Tech Design URL: N/A

**Description**:
I noticed the https binary being downloaded at times when it should have come from the cache. This PR replaces the bloom filter download cache check with a check against the stored bloom specification in the db. The bloom filter is a large download and we definitely do not want to duplicate it!

**Steps to test this PR**:
1. Run a new installation of the app and note "Updating https bloom data store with new data" in the logs when the initial app configuration run
1. Now kill and run the app again to trigger another download note that the logs now say "Https bloom data already stored for this spec"

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
