### PR TITLE
Release JNI string chars after use

### DIFF
--- a/app/src/main/cpp/https-bloom-lib.cpp
+++ b/app/src/main/cpp/https-bloom-lib.cpp
@@ -24,6 +24,7 @@ Java_com_duckduckgo_app_httpsupgrade_BloomFilter_createBloomFilterFromFile(JNIEn
     const char *pathChars = env->GetStringUTFChars(path, &isElementCopy);
 
     BloomFilter* filter = new BloomFilter(pathChars, maxItems);
+    env->ReleaseStringUTFChars(path, pathChars);
     return (long) filter;
 }
 
@@ -50,6 +51,8 @@ Java_com_duckduckgo_app_httpsupgrade_BloomFilter_add(JNIEnv *env,
 
     BloomFilter *filter = (BloomFilter *) pointer;
     filter->add(elementChars);
+
+    env->ReleaseStringUTFChars(element, elementChars);
 }
 
 extern "C"
@@ -63,5 +66,7 @@ Java_com_duckduckgo_app_httpsupgrade_BloomFilter_contains(JNIEnv *env,
     const char *elementChars = env->GetStringUTFChars(element, &isElementCopy);
 
     BloomFilter *filter = (BloomFilter *) pointer;
-    return filter->contains(elementChars);
+    bool containsElement = filter->contains(elementChars);
+    env->ReleaseStringUTFChars(element, elementChars);
+    return containsElement;
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/721626625236432

**Description**:
JNI cleanup to release chars after use

**Steps to test this PR**:
1. Visit http://example.com and make sure it is upgraded to https
1. Visit a site from https://staticcdn.duckduckgo.com/https/https-mobile-whitelist.json e.g azara.org and make sure it is not upgraded to https

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
