### PR TITLE
Hotfix to ensure that http requests cannot sneak through when app is starting up

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-kapt'
 apply from: '../versioning.gradle'
 
 ext {
-    VERSION_NAME = "5.9.0"
+    VERSION_NAME = "5.9.1"
     USE_ORCHESTRATOR = project.hasProperty('orchestrator') ? project.property('orchestrator') : false
 }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
@@ -16,9 +16,7 @@
 
 package com.duckduckgo.app.httpsupgrade
 
-import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.net.Uri
-import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.httpsupgrade.api.HttpsBloomFilterFactory
 import com.duckduckgo.app.httpsupgrade.db.HttpsWhitelistDao
 import com.nhaarman.mockito_kotlin.mock
@@ -26,18 +24,9 @@ import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
 class HttpsUpgraderTest {
-
-    @get:Rule
-    @Suppress("unused")
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
-
-    @get:Rule
-    @Suppress("unused")
-    val schedulers = InstantSchedulersRule()
 
     lateinit var testee: HttpsUpgrader
 
@@ -49,6 +38,7 @@ class HttpsUpgraderTest {
     fun before() {
         whenever(mockHttpsBloomFilterFactory.create()).thenReturn(bloomFilter)
         testee = HttpsUpgraderImpl(mockWhitelistDao, mockHttpsBloomFilterFactory)
+        testee.reloadData()
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.app.global.UrlScheme
 import com.duckduckgo.app.global.isHttps
 import com.duckduckgo.app.httpsupgrade.api.HttpsBloomFilterFactory
 import com.duckduckgo.app.httpsupgrade.db.HttpsWhitelistDao
-import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
 
 interface HttpsUpgrader {
@@ -43,16 +42,18 @@ class HttpsUpgraderImpl(
 ) : HttpsUpgrader {
 
     private var httpsBloomFilter: BloomFilter? = null
+    private var dataLoaded = false
 
-    init {
-        reloadData()
-    }
 
     @WorkerThread
     override fun shouldUpgrade(uri: Uri): Boolean {
 
         if (uri.isHttps) {
             return false
+        }
+
+        if (!dataLoaded) {
+            reloadData()
         }
 
         val host = uri.host
@@ -75,9 +76,8 @@ class HttpsUpgraderImpl(
     }
 
     override fun reloadData() {
-        Schedulers.io().scheduleDirect {
-            httpsBloomFilter = bloomFactory.create()
-        }
+        dataLoaded = true
+        httpsBloomFilter = bloomFactory.create()
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -44,7 +44,7 @@ class HttpsUpgraderImpl(
 ) : HttpsUpgrader {
 
     private var httpsBloomFilter: BloomFilter? = null
-    private val reloadLock = ReentrantLock()
+    private val dataReloadLock = ReentrantLock()
 
     init {
         thread {
@@ -82,16 +82,16 @@ class HttpsUpgraderImpl(
 
     private fun waitForAnyReloadsToComplete() {
         // wait for lock (by locking and unlocking) before continuing
-        if (reloadLock.isLocked) {
-            reloadLock.lock()
-            reloadLock.unlock()
+        if (dataReloadLock.isLocked) {
+            dataReloadLock.lock()
+            dataReloadLock.unlock()
         }
     }
 
     override fun reloadData() {
-        reloadLock.lock()
+        dataReloadLock.lock()
         httpsBloomFilter = bloomFactory.create()
-        reloadLock.unlock()
+        dataReloadLock.unlock()
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -88,6 +88,7 @@ class HttpsUpgraderImpl(
         }
     }
 
+    @WorkerThread
     override fun reloadData() {
         dataReloadLock.lock()
         httpsBloomFilter = bloomFactory.create()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/782471025741719

**Description**:
Fix an issue where if data is not loaded then a http request can sneak through without being updated.

**Steps to test this PR**:
1. Install the app complete onboarding and allow config to be downloaded etc. 
1. Kill the app
1. Open Chrome and visit http://example.com
1. Share this url with duckduckgo
1. Note the url is updated to https (there will be a small loading delay this won't happen unless the url being loaded is http and the data hasn't already loaded)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
