### PR TITLE
Remove duplicate call to finish() when clearing data from app shortcut

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -125,8 +125,6 @@ class BrowserActivity : DuckDuckGoActivity() {
         if (intent.getBooleanExtra(PERFORM_FIRE_ON_ENTRY_EXTRA, false)) {
             viewModel.onClearRequested()
             clearPersonalDataAction.clear()
-            Toast.makeText(applicationContext, R.string.fireDataCleared, Toast.LENGTH_LONG).show()
-            finish()
             return
         }
 
@@ -195,8 +193,8 @@ class BrowserActivity : DuckDuckGoActivity() {
 
     fun launchFire() {
         val dialog = FireDialog(context = this, pixel = pixel, clearPersonalDataAction = clearPersonalDataAction)
-        dialog.clearStarted = {viewModel.onClearRequested()}
-        dialog.clearComplete = { viewModel.onClearComplete()}
+        dialog.clearStarted = { viewModel.onClearRequested() }
+        dialog.clearComplete = { viewModel.onClearComplete() }
         dialog.show()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/794822164879962
Tech Design URL: 
CC: 

**Description**:
Small fix to remove duplicate call to `finish()` the Activity when clearing the data from an app shortcut.

**Steps to test this PR**:
1. Use the app shortcut to clear the data
1. Once the browser restarts, use the in-app fire button
1. Verify the app restarts and doesn't just disappear


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
