### PR TITLE
Feature/tab switcher improvements

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -17,8 +17,6 @@
 package com.duckduckgo.app.browser
 
 import android.Manifest
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
 import android.animation.LayoutTransition.CHANGING
 import android.animation.LayoutTransition.DISAPPEARING
 import android.annotation.SuppressLint
@@ -44,7 +42,6 @@ import android.support.v4.content.pm.ShortcutManagerCompat
 import android.support.v7.app.AlertDialog
 import android.support.v7.widget.LinearLayoutManager
 import android.text.Editable
-import android.text.Layout
 import android.view.*
 import android.view.View.VISIBLE
 import android.view.inputmethod.EditorInfo
@@ -54,7 +51,6 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebView.FindListener
 import android.widget.EditText
-import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
@@ -385,6 +381,7 @@ class BrowserTabFragment : Fragment(), FindListener {
     }
 
     private fun openInNewBackgroundTab() {
+        appBarLayout.setExpanded(true, true)
         viewModel.tabs.removeObservers(this)
         val view = tabsButton?.actionView as TabSwitcherButton
         view.increment {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -25,7 +25,6 @@ import android.support.v7.widget.LinearLayoutManager
 import android.view.Menu
 import android.view.MenuItem
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.app.browser.WebDataManager
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
@@ -106,6 +105,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
         when (item.itemId) {
             R.id.fire -> onFire()
             R.id.newTab -> onNewTabRequested()
+            R.id.closeAllTabs -> closeAllTabs()
         }
         return super.onOptionsItemSelected(item)
     }
@@ -127,6 +127,12 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
 
     override fun onTabDeleted(tab: TabEntity) {
         viewModel.onTabDeleted(tab)
+    }
+
+    private fun closeAllTabs() {
+        viewModel.tabs.value?.forEach {
+            viewModel.onTabDeleted(it)
+        }
     }
 
     override fun finish() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -76,7 +76,6 @@ class TabSwitcherAdapter(private val context: Context, private val itemClickList
     fun updateData(data: List<TabEntity>?, selectedTab: TabEntity?) {
 
         data ?: return
-        selectedTab ?: return
 
         this.data = data
         this.selectedTab = selectedTab

--- a/app/src/main/res/menu/menu_tab_switcher_activity.xml
+++ b/app/src/main/res/menu/menu_tab_switcher_activity.xml
@@ -15,18 +15,25 @@
   -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="AlwaysShowAction">
 
     <item
         android:id="@+id/fire"
         android:icon="@drawable/ic_fire_gray_24dp"
         android:title="@string/fireMenu"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/newTab"
         android:icon="@drawable/ic_add_gray_30dp"
         android:title="@string/newTabMenuItem"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/closeAllTabs"
+        android:title="@string/closeAllTabsMenuItem"
+        app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="tapFireDirective">Tap </string>
     <string name="tapFireIconDescription">fire</string>
     <string name="tapFireExplanation"> to forget everything</string>
+    <string name="closeAllTabsMenuItem">Close All Tabs</string>
 
     <!-- Privacy Dashboard Activities -->
     <string name="privacyDashboardActivityTitle">Privacy Dashboard</string>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-rc01'
+        classpath 'com.android.tools.build:gradle:3.2.0-rc02'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Task/Issue URL: 

1. https://app.asana.com/0/488551667048375/795610899417598
1. https://app.asana.com/0/488551667048375/796714078222032
1. https://app.asana.com/0/488551667048375/795210608999753

**Description**:
Fixes a bug with the tab switcher where it sometimes fails to close the last remaining tab.

Additionally, adds the option to close all tabs (without 🔥all the data).

Finally, animates in the toolbar when you select to open a new tab in background if the toolbar is not already visible. This ensures the new BG tab animation is always seen by the user.

**Steps to test this PR**:

**Tab switcher bug**
1. Add non-background tab from SERP
1. Click the tab switcher
2. Close the first tab (not currently selected)
3. Attempt to close the remaining one; it should now be removed

**Close all tabs option**
1. Add multiple tabs
1. Click the tab switcher
1. Use the overflow menu to close all tabs; verify they all disappear

**Always show toolbar**
1. Load the SERP (or any scrollable webpage)
1. Scroll down so that the toolbar disappears
1. Long press a link and choose to open tab in background
1. Verify the toolbar appears and the new tab animation is visible

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
