### PR TITLE
Reduce boilerplate in each Activity in the way the ViewModel is obtained

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.bookmarks.ui
 
 import android.app.AlertDialog
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -35,7 +34,6 @@ import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.baseHost
 import com.duckduckgo.app.global.faviconLocation
 import com.duckduckgo.app.global.image.GlideApp
@@ -46,18 +44,13 @@ import kotlinx.android.synthetic.main.include_toolbar.*
 import kotlinx.android.synthetic.main.view_bookmark_entry.view.*
 import org.jetbrains.anko.alert
 import timber.log.Timber
-import javax.inject.Inject
 
 class BookmarksActivity : DuckDuckGoActivity() {
 
-    @Inject
-    lateinit var viewModelFactory: ViewModelFactory
     lateinit var adapter: BookmarksAdapter
     private var deleteDialog: AlertDialog? = null
 
-    private val viewModel: BookmarksViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(BookmarksViewModel::class.java)
-    }
+    private val viewModel: BookmarksViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.browser
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.EXTRA_TEXT
@@ -29,7 +28,6 @@ import com.duckduckgo.app.browser.BrowserViewModel.Command.Query
 import com.duckduckgo.app.browser.BrowserViewModel.Command.Refresh
 import com.duckduckgo.app.feedback.ui.FeedbackActivity
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.intentText
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
 import com.duckduckgo.app.global.view.FireDialog
@@ -47,9 +45,6 @@ import javax.inject.Inject
 class BrowserActivity : DuckDuckGoActivity() {
 
     @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-
-    @Inject
     lateinit var clearPersonalDataAction: ClearPersonalDataAction
 
     @Inject
@@ -57,9 +52,7 @@ class BrowserActivity : DuckDuckGoActivity() {
 
     private var currentTab: BrowserTabFragment? = null
 
-    private val viewModel: BrowserViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(BrowserViewModel::class.java)
-    }
+    private val viewModel: BrowserViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/FeedbackActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/FeedbackActivity.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.feedback.ui
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -28,21 +27,14 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.feedback.ui.FeedbackViewModel.Command
 import com.duckduckgo.app.feedback.ui.FeedbackViewModel.ViewState
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.TextChangedWatcher
 import kotlinx.android.synthetic.main.activity_feedback.*
 import org.jetbrains.anko.longToast
-import javax.inject.Inject
 
 
 class FeedbackActivity : DuckDuckGoActivity() {
 
-    @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-
-    private val viewModel: FeedbackViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(FeedbackViewModel::class.java)
-    }
+    private val viewModel: FeedbackViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/fire/FireActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/FireActivity.kt
@@ -21,7 +21,6 @@ import android.animation.AnimatorListenerAdapter
 import android.app.Activity
 import android.app.ActivityManager
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -30,9 +29,7 @@ import android.support.v4.app.ActivityOptionsCompat
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import kotlinx.android.synthetic.main.activity_fire.*
-import javax.inject.Inject
 
 /**
  * Activity which is responsible for killing the main process and restarting it. This Activity will automatically finish itself after a brief time.
@@ -49,12 +46,7 @@ import javax.inject.Inject
  */
 class FireActivity : DuckDuckGoActivity() {
 
-    @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-
-    private val viewModel: FireViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(FireViewModel::class.java)
-    }
+    private val viewModel: FireViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoActivity.kt
@@ -16,13 +16,19 @@
 
 package com.duckduckgo.app.global
 
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import dagger.android.AndroidInjection
+import javax.inject.Inject
 
 
 abstract class DuckDuckGoActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var viewModelFactory: ViewModelFactory
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
@@ -38,4 +44,6 @@ abstract class DuckDuckGoActivity : AppCompatActivity() {
         }
         return super.onOptionsItemSelected(item)
     }
+
+    protected inline fun <reified V : ViewModel> bindViewModel() = lazy { ViewModelProviders.of(this, viewModelFactory).get(V::class.java) }
 }

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchActivity.kt
@@ -17,24 +17,16 @@
 package com.duckduckgo.app.launch
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
-import javax.inject.Inject
 
 
 class LaunchActivity : DuckDuckGoActivity() {
 
-    @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-
-    private val viewModel: LaunchViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(LaunchViewModel::class.java)
-    }
+    private val viewModel: LaunchViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.onboarding.ui
 
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -27,7 +26,6 @@ import android.support.v4.content.ContextCompat
 import android.view.View
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.ColorCombiner
 import com.duckduckgo.app.global.view.launchDefaultAppActivity
 import com.duckduckgo.app.onboarding.ui.ColorChangingPageListener.NewColorListener
@@ -38,16 +36,11 @@ import javax.inject.Inject
 class OnboardingActivity : DuckDuckGoActivity() {
 
     @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-
-    @Inject
     lateinit var colorCombiner: ColorCombiner
 
     private lateinit var viewPageAdapter: PagerAdapter
 
-    private val viewModel: OnboardingViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(OnboardingViewModel::class.java)
-    }
+    private val viewModel: OnboardingViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.privacy.ui
 
 import android.app.Activity
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -26,7 +25,6 @@ import android.support.v4.content.ContextCompat
 import android.view.View
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.view.hide
 import com.duckduckgo.app.global.view.html
@@ -45,8 +43,6 @@ import javax.inject.Inject
 class PrivacyDashboardActivity : DuckDuckGoActivity() {
 
     @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-    @Inject
     lateinit var repository: TabRepository
     @Inject
     lateinit var pixel: Pixel
@@ -54,9 +50,7 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
     private val trackersRenderer = TrackersRenderer()
     private val upgradeRenderer = PrivacyUpgradeRenderer()
 
-    private val viewModel: PrivacyDashboardViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(PrivacyDashboardViewModel::class.java)
-    }
+    private val viewModel: PrivacyDashboardViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesActivity.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.privacy.ui
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -27,7 +26,6 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.AppUrl.Url
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.privacy.renderer.banner
 import com.duckduckgo.app.privacy.renderer.text
@@ -40,16 +38,11 @@ import javax.inject.Inject
 class PrivacyPracticesActivity : DuckDuckGoActivity() {
 
     @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-
-    @Inject
     lateinit var repository: TabRepository
 
     private val practicesAdapter = PrivacyPracticesAdapter()
 
-    private val viewModel: PrivacyPracticesViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(PrivacyPracticesViewModel::class.java)
-    }
+    private val viewModel: PrivacyPracticesViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardActivity.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.privacy.ui
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -26,9 +25,8 @@ import android.view.View
 import android.widget.TextView
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
-import com.duckduckgo.app.global.view.html
 import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.app.global.view.html
 import com.duckduckgo.app.privacy.renderer.*
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
@@ -39,14 +37,11 @@ import javax.inject.Inject
 
 class ScorecardActivity : DuckDuckGoActivity() {
 
-    @Inject lateinit var viewModelFactory: ViewModelFactory
     @Inject lateinit var repository: TabRepository
     private val trackersRenderer = TrackersRenderer()
     private val upgradeRenderer = PrivacyUpgradeRenderer()
 
-    private val viewModel: ScorecardViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(ScorecardViewModel::class.java)
-    }
+    private val viewModel: ScorecardViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksActivity.kt
@@ -17,14 +17,12 @@
 package com.duckduckgo.app.privacy.ui
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.privacy.renderer.TrackersRenderer
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -35,14 +33,11 @@ import javax.inject.Inject
 
 class TrackerNetworksActivity : DuckDuckGoActivity() {
 
-    @Inject lateinit var viewModelFactory: ViewModelFactory
     @Inject lateinit var repository: TabRepository
     private val trackersRenderer = TrackersRenderer()
     private val networksAdapter = TrackerNetworksAdapter()
 
-    private val viewModel: TrackerNetworksViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(TrackerNetworksViewModel::class.java)
-    }
+    private val viewModel: TrackerNetworksViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.settings
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -29,21 +28,14 @@ import com.duckduckgo.app.about.AboutDuckDuckGoActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.feedback.ui.FeedbackActivity
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.launchDefaultAppActivity
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 import kotlinx.android.synthetic.main.content_settings.*
 import kotlinx.android.synthetic.main.include_toolbar.*
-import javax.inject.Inject
 
 class SettingsActivity : DuckDuckGoActivity() {
 
-    @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-
-    private val viewModel: SettingsViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(SettingsViewModel::class.java)
-    }
+    private val viewModel: SettingsViewModel by bindViewModel()
 
     private val defaultBrowserChangeListener = OnCheckedChangeListener { _, _ -> launchDefaultAppScreen() }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.tabs.ui
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -26,7 +25,6 @@ import android.view.Menu
 import android.view.MenuItem
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
 import com.duckduckgo.app.global.view.FireDialog
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -42,17 +40,13 @@ import javax.inject.Inject
 class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitchedListener {
 
     @Inject
-    lateinit var viewModelFactory: ViewModelFactory
-
-    @Inject
     lateinit var clearPersonalDataAction: ClearPersonalDataAction
 
     @Inject
     lateinit var pixel: Pixel
 
-    private val viewModel: TabSwitcherViewModel by lazy {
-        ViewModelProviders.of(this, viewModelFactory).get(TabSwitcherViewModel::class.java)
-    }
+    private val viewModel: TabSwitcherViewModel by bindViewModel()
+    
     private val tabsAdapter = TabSwitcherAdapter(this, this)
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
**Description**:
No Asana issue for this one, as it's just a code tidy up.

Although I haven't functionally changed anything, this PR reduces the boilerplate needed in each `Activity` to obtain its `ViewModel`. We do this by moving the worst of the boilerplate to the parent `Activity` as a function.

The result now is that in each `Activity`, obtaining the `ViewModel` is as simple as 

**Now 👇**

    private val viewModel: BookmarksViewModel by bindViewModel()

**Before 👇**

    @Inject	
    lateinit var viewModelFactory: ViewModelFactory
    
    private val viewModel: BookmarksViewModel by lazy { 
        private val viewModel: BookmarksViewModel by bindViewModel()
        ViewModelProviders.of(this, viewModelFactory).get(BookmarksViewModel::class.java)	
    }

**Steps to test this PR**:
1. Just make sure the app is compiled and opens without crashing


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
