### PR TITLE
Add new items to the Tab Switcher's overflow menu

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
 import com.duckduckgo.app.global.view.FireDialog
+import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
@@ -104,8 +105,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.fire -> onFire()
-            R.id.newTab -> onNewTabRequested()
+            R.id.newTab, R.id.newTabOverflow -> onNewTabRequested()
             R.id.closeAllTabs -> closeAllTabs()
+            R.id.settings -> showSettings()
         }
         return super.onOptionsItemSelected(item)
     }
@@ -133,6 +135,10 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
         viewModel.tabs.value?.forEach {
             viewModel.onTabDeleted(it)
         }
+    }
+
+    private fun showSettings() {
+        startActivity(SettingsActivity.intent(this))
     }
 
     override fun finish() {

--- a/app/src/main/res/menu/menu_tab_switcher_activity.xml
+++ b/app/src/main/res/menu/menu_tab_switcher_activity.xml
@@ -32,8 +32,18 @@
         app:showAsAction="always" />
 
     <item
+        android:id="@+id/newTabOverflow"
+        android:title="@string/newTabMenuItem"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/closeAllTabs"
         android:title="@string/closeAllTabsMenuItem"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/settings"
+        android:title="@string/settingsMenuItemTitle"
         app:showAsAction="never" />
 
 </menu>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/608920331025315/797446954126366
Tech Design URL: 
CC: 

**Description**:
When we added "close all tabs", it felt strange having an overflow with only one menu item in it. Furthermore, Chris M has expressed a desire to have a way to reach Settings from here too, and a look at some other browsers showed they were also duplicating the "new tab" option in their overflows too.

**Steps to test this PR**:
1. Visit tab switcher, and tap on the overflow
1. Ensure that "new tab" works identically to the existing `+` button
1. Ensure that "settings" takes you to settings 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
