### PR TITLE
Fire pixel on https upgrade failures

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-kapt'
 apply from: '../versioning.gradle'
 
 ext {
-    VERSION_NAME = "5.10.3"
+    VERSION_NAME = "5.10.4"
     USE_ORCHESTRATOR = project.hasProperty('orchestrator') ? project.property('orchestrator') : false
 }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
@@ -67,7 +67,7 @@ class WebViewLongPressHandlerTest {
     @Test
     fun whenLongPressedWithUnknownTypeThenPixelNotFired() {
         testee.handleLongPress(HitTestResult.UNKNOWN_TYPE, HTTPS_IMAGE_URL, mockMenu)
-        verify(mockPixel, never()).fire(any())
+        verify(mockPixel, never()).fire(Pixel.PixelName.LONG_PRESS)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
@@ -44,7 +44,7 @@ class StubStatisticsModule {
     @Provides
     fun stubPixel(): Pixel {
         return object : Pixel {
-            override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String?>?) {
+            override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String?>) {
             }
         }
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
@@ -44,7 +44,7 @@ class StubStatisticsModule {
     @Provides
     fun stubPixel(): Pixel {
         return object : Pixel {
-            override fun fire(pixel: Pixel.PixelName) {
+            override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String?>?) {
             }
         }
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
@@ -60,6 +60,36 @@ class UriExtensionTest {
     }
 
     @Test
+    fun whenUriContainsDomainThenSimpleUrlIsEqual() {
+        val url = "http://example.com"
+        assertEquals(url, Uri.parse(url).simpleUrl)
+    }
+
+    @Test
+    fun whenUriCotnainsSubdomainThenSimpleUrlIsEqual() {
+        val url = "http://subdomain.example.com"
+        assertEquals(url, Uri.parse(url).simpleUrl)
+    }
+
+    @Test
+    fun whenUriContainsPathThenSimpleUrlIsEqual() {
+        val url = "http://example.com/about"
+        assertEquals(url, Uri.parse(url).simpleUrl)
+    }
+
+    @Test
+    fun whenUriContainsUsernameThenSimpleUrlOmitsThis() {
+        val url = "http://user@example.com"
+        assertEquals("http://example.com", Uri.parse(url).simpleUrl)
+    }
+
+    @Test
+    fun whenUriContainsParametersThenSimpleUrlOmitsThese() {
+        val url = "http://example.com?search=54"
+        assertEquals("http://example.com", Uri.parse(url).simpleUrl)
+    }
+
+    @Test
     fun whenUriIsHttpIrrespectiveOfCaseThenIsHttpIsTrue() {
         assertTrue(Uri.parse("http://example.com").isHttp)
         assertTrue(Uri.parse("HTTP://example.com").isHttp)

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -23,10 +23,7 @@ import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.pixels.ApiBasedPixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockito_kotlin.*
 import io.reactivex.Completable
 import org.junit.Rule
 import org.junit.Test
@@ -52,7 +49,7 @@ class ApiBasedPixelTest {
 
     @Test
     fun whenPixelFiredThenPixelServiceCalledWithCorrectAtbAndVariant() {
-        whenever(mockPixelService.fire(any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockPixelService.fire(any(), any(), any(), anyOrNull())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
@@ -60,12 +57,12 @@ class ApiBasedPixelTest {
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(PRIVACY_DASHBOARD_OPENED)
 
-        verify(mockPixelService).fire("mp", "phone", "atbvariant")
+        verify(mockPixelService).fire("mp", "phone", "atbvariant", emptyMap())
     }
 
     @Test
     fun whenPixelFiredThenPixelServiceCalledWithCorrectAtb() {
-        whenever(mockPixelService.fire(any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.DEFAULT_VARIANT)
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
@@ -73,29 +70,54 @@ class ApiBasedPixelTest {
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(FORGET_ALL_EXECUTED)
 
-        verify(mockPixelService).fire("mf", "phone", "atb")
+        verify(mockPixelService).fire("mf", "phone", "atb", emptyMap())
     }
 
     @Test
     fun whenPixelFiredTabletFormFactorThenPixelServiceCalledWithTabletParameter() {
-        whenever(mockPixelService.fire(any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.TABLET)
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(APP_LAUNCH)
 
-        verify(mockPixelService).fire("ml", "tablet", "")
+        verify(mockPixelService).fire("ml", "tablet", "", emptyMap())
     }
 
     @Test
     fun whenPixelFiredWithNoAtbThenPixelServiceCalledWithCorrectPixelNameAndNoAtb() {
-        whenever(mockPixelService.fire(any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(APP_LAUNCH)
 
-        verify(mockPixelService).fire("ml", "phone", "")
+        verify(mockPixelService).fire("ml", "phone", "", emptyMap())
     }
 
+    @Test
+    fun whenPixelFiredWithAdditionalParametersThenPixelServiceCalledWithAdditionalParameters() {
+        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
+
+        val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
+        val params = mapOf("param1" to "value1", "param2" to "value2")
+        pixel.fire(PRIVACY_DASHBOARD_OPENED, params)
+        verify(mockPixelService).fire("mp", "phone", "atbvariant", params)
+    }
+
+    @Test
+    fun whenPixelFiredWithoutAdditionalParametersThenPixelServiceCalledWithNoParamaeters() {
+        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
+
+        val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
+        val params = emptyMap<String, String>()
+        pixel.fire(PRIVACY_DASHBOARD_OPENED)
+        verify(mockPixelService).fire("mp", "phone", "atbvariant", params)
+    }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -109,7 +109,7 @@ class ApiBasedPixelTest {
     }
 
     @Test
-    fun whenPixelFiredWithoutAdditionalParametersThenPixelServiceCalledWithNoParamaeters() {
+    fun whenPixelFiredWithoutAdditionalParametersThenPixelServiceCalledWithNoParameters() {
         whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -24,8 +24,8 @@ import android.os.Build
 import android.support.annotation.WorkerThread
 import android.webkit.*
 import androidx.core.net.toUri
-import com.duckduckgo.app.global.simpleUrl
 import com.duckduckgo.app.global.isHttps
+import com.duckduckgo.app.global.simpleUrl
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.HTTPS_UPGRADE_SITE_ERROR
@@ -119,9 +119,11 @@ class BrowserWebViewClient @Inject constructor(
 
     @Suppress("OverridingDeprecatedMember")
     override fun onReceivedError(view: WebView, errorCode: Int, description: String, failingUrl: String) {
-        val url = failingUrl.toUri()
-        if (isHttpsUpgradeSite(url)) {
-            reportHttpsUpgradeSiteError(url, statusCode = null, error = "WEB_RESOURCE_ERROR_$errorCode")
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            val url = failingUrl.toUri()
+            if (isHttpsUpgradeSite(url)) {
+                reportHttpsUpgradeSiteError(url, statusCode = null, error = "WEB_RESOURCE_ERROR_$errorCode")
+            }
         }
         super.onReceivedError(view, errorCode, description, failingUrl)
     }

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -41,9 +41,9 @@ val Uri.baseHost: String?
 val Uri.simpleUrl: String
     get() {
         var string = ""
-        scheme?.let { string += "$scheme://" }
-        host?.let { string += host }
-        path?.let { string += path }
+        if (scheme != null) { string = "$scheme://" }
+        if (host != null) { string += host }
+        if (path != null) { string += path }
         return string
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -43,7 +43,7 @@ val Uri.simpleUrl: String
         var string = ""
         scheme?.let { string += "$scheme://" }
         host?.let { string += host }
-        path?.let { string += "$path" }
+        path?.let { string += path }
         return string
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -34,6 +34,19 @@ fun Uri.withScheme(): Uri {
 val Uri.baseHost: String?
     get() = withScheme().host?.removePrefix("www.")
 
+/**
+ * Return a simple url with scheme, domain and path. Other elements such as username or
+ * query parameters are omitted
+ */
+val Uri.simpleUrl: String
+    get() {
+        var string = ""
+        scheme?.let { string += "$scheme://" }
+        host?.let { string += host }
+        path?.let { string += "$path" }
+        return string
+    }
+
 val Uri.isHttp: Boolean
     get() = scheme?.equals(UrlScheme.http, true) ?: false
 

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -53,11 +53,12 @@ class HttpsUpgraderImpl(
             return false
         }
 
+        val host = uri.host ?: return false
+
         waitForAnyReloadsToComplete()
 
-        val host = uri.host
         if (whitelistedDao.contains(host)) {
-            Timber.d("${host} is in whitelist and so not upgradable")
+            Timber.d("$host is in whitelist and so not upgradable")
             return false
         }
 
@@ -66,7 +67,7 @@ class HttpsUpgraderImpl(
             val initialTime = System.nanoTime()
             val shouldUpgrade = it.contains(host)
             val totalTime = System.nanoTime() - initialTime
-            Timber.d("${host} ${if (shouldUpgrade) "is" else "is not"} upgradable, lookup in ${totalTime / NANO_TO_MILLIS_DIVISOR}ms")
+            Timber.d("$host ${if (shouldUpgrade) "is" else "is not"} upgradable, lookup in ${totalTime / NANO_TO_MILLIS_DIVISOR}ms")
 
             return shouldUpgrade
         }

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
@@ -21,10 +21,15 @@ import io.reactivex.Completable
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.QueryMap
 
 interface PixelService {
 
     @GET("/t/{pixelName}_android_{formFactor}")
-    fun fire(@Path("pixelName") pixelName: String, @Path("formFactor") formFactor: String, @Query(AppUrl.ParamKey.ATB) atb: String): Completable
-
+    fun fire(
+        @Path("pixelName") pixelName: String,
+        @Path("formFactor") formFactor: String,
+        @Query(AppUrl.ParamKey.ATB) atb: String,
+        @QueryMap additionalQueryParams: Map<String, String?>? = null
+    ): Completable
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
@@ -30,6 +30,6 @@ interface PixelService {
         @Path("pixelName") pixelName: String,
         @Path("formFactor") formFactor: String,
         @Query(AppUrl.ParamKey.ATB) atb: String,
-        @QueryMap additionalQueryParams: Map<String, String?>? = null
+        @QueryMap additionalQueryParams: Map<String, String?> = emptyMap()
     ): Completable
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -46,10 +46,18 @@ interface Pixel {
         LONG_PRESS_DOWNLOAD_IMAGE("mlp_i"),
         LONG_PRESS_NEW_TAB("mlp_t"),
         LONG_PRESS_NEW_BACKGROUND_TAB("mlp_b"),
-        LONG_PRESS_SHARE("mlp_s")
+        LONG_PRESS_SHARE("mlp_s"),
+
+        HTTPS_UPGRADE_SITE_ERROR("ehd")
     }
 
-    fun fire(pixel: PixelName)
+    object PixelParameter {
+        const val URL = "url"
+        const val STATUS_CODE = "status_code"
+        const val ERROR_CODE = "error_code"
+    }
+
+    fun fire(pixel: PixelName, parameters: Map<String, String?> = emptyMap())
 
 }
 
@@ -60,18 +68,17 @@ class ApiBasedPixel @Inject constructor(
     private val deviceInfo: DeviceInfo
 ) : Pixel {
 
-    override fun fire(pixel: Pixel.PixelName) {
+    override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String?>) {
 
         val atb = statisticsDataStore.atb?.formatWithVariant(variantManager.getVariant()) ?: ""
 
-        api.fire(pixel.pixelName, deviceInfo.formFactor().description, atb)
+        api.fire(pixel.pixelName, deviceInfo.formFactor().description, atb, parameters)
             .subscribeOn(Schedulers.io())
             .subscribe({
                 Timber.v("Pixel sent: ${pixel.pixelName}")
             }, {
                 Timber.w("Pixel failed: ${pixel.pixelName}", it)
             })
-
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/832602107339144/f
Tech Design URL: N/A however spec was discussed in https://app.asana.com/0/56420494107937/832602107339145/f

**Description**:
Fire pixel on https upgrade failures to allow bad data to be removed from lists

**Steps to test this PR**:
1. Go to a broken https upgrade site ensure that the new ehd pixel is fired.
It may be easier to remove the `httpsUpgrader.shouldUpgrade` check in the `isHttpsUpgradeSite` and visit https://badssl.com and ensure the pixel fires from there.

1. Ensure that existing pixels fire as normal


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
