### PR TITLE
Ensure that pixel does fire if in upgrade list for https failures

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -161,7 +161,7 @@ class BrowserWebViewClient @Inject constructor(
     }
 
     private fun isHttpsUpgradeSite(url: Uri): Boolean {
-        return url.isHttps && httpsUpgrader.shouldUpgrade(url)
+        return url.isHttps && httpsUpgrader.isInUpgradeList(url)
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -120,6 +120,7 @@ class BrowserWebViewClient @Inject constructor(
         return webViewRequestInterceptor.shouldIntercept(request, webView, currentUrl, webViewClientListener)
     }
 
+    @UiThread
     @Suppress("OverridingDeprecatedMember")
     override fun onReceivedError(view: WebView, errorCode: Int, description: String, failingUrl: String) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
@@ -129,6 +130,7 @@ class BrowserWebViewClient @Inject constructor(
         super.onReceivedError(view, errorCode, description, failingUrl)
     }
 
+    @UiThread
     @TargetApi(Build.VERSION_CODES.M)
     override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
         if (request.isForMainFrame) {
@@ -137,6 +139,7 @@ class BrowserWebViewClient @Inject constructor(
         super.onReceivedError(view, request, error)
     }
 
+    @UiThread
     override fun onReceivedHttpError(view: WebView, request: WebResourceRequest, errorResponse: WebResourceResponse) {
         if (request.isForMainFrame) {
             reportHttpsErrorIfInUpgradeList(request.url, errorResponse.statusCode, error = null)

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -30,6 +30,9 @@ interface HttpsUpgrader {
     @WorkerThread
     fun shouldUpgrade(uri: Uri): Boolean
 
+    @WorkerThread
+    fun isInUpgradeList(uri: Uri): Boolean
+
     fun upgrade(uri: Uri): Uri {
         return uri.buildUpon().scheme(UrlScheme.https).build()
     }
@@ -52,6 +55,12 @@ class HttpsUpgraderImpl(
         if (uri.isHttps) {
             return false
         }
+
+        return isInUpgradeList(uri)
+    }
+
+    @WorkerThread
+    override fun isInUpgradeList(uri: Uri): Boolean {
 
         val host = uri.host ?: return false
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/832602107339144/f
Tech Design URL: N/A however spec was discussed in https://app.asana.com/0/56420494107937/832602107339145/f

**Description**:
Ensure that pixel _does_ fire if in upgrade list for https failures

**Steps to test this PR**:
1. Go to a broken https upgrade site ensure that the new ehd pixel is fired.
It may be easier to remove the `httpsUpgrader.shouldUpgrade` check in the `isHttpsUpgradeSite` and visit https://badssl.com and ensure the pixel fires from there.

1. Ensure that existing pixels fire as normal


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
