### PR TITLE
Add https upgrades summary pixel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-kapt'
 apply from: '../versioning.gradle'
 
 ext {
-    VERSION_NAME = "5.10.4"
+    VERSION_NAME = "5.10.5"
     USE_ORCHESTRATOR = project.hasProperty('orchestrator') ? project.property('orchestrator') : false
 }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import dagger.Module
 import dagger.Provides
+import io.reactivex.Completable
 import retrofit2.Retrofit
 
 @Module
@@ -44,8 +45,14 @@ class StubStatisticsModule {
     @Provides
     fun stubPixel(): Pixel {
         return object : Pixel {
+
             override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String?>) {
             }
+
+            override fun fireCompletable(pixel: Pixel.PixelName, parameters: Map<String, String?>): Completable {
+                return Completable.fromAction {}
+            }
+
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -147,14 +147,6 @@ class BrowserWebViewClient @Inject constructor(
     }
 
     @UiThread
-    override fun onReceivedHttpError(view: WebView, request: WebResourceRequest, errorResponse: WebResourceResponse) {
-        if (request.isForMainFrame) {
-            reportHttpsErrorIfInUpgradeList(request.url, "HTTP_STATUS_${errorResponse.statusCode}")
-        }
-        super.onReceivedHttpError(view, request, errorResponse)
-    }
-
-    @UiThread
     override fun onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {
         val uri = error.url.toUri()
         val isMainFrameRequest = currentUrl == uri.toString()

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
@@ -29,7 +29,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FAILURE_COUNT
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.TOTAL_COUNT
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import io.reactivex.Completable
-import io.reactivex.Completable.fromAction
+import io.reactivex.Completable.*
 import timber.log.Timber
 import java.io.IOException
 import javax.inject.Inject
@@ -114,20 +114,21 @@ class HttpsUpgradeDataDownloader @Inject constructor(
     }
 
     fun reportUpgradeStatistics(): Completable {
-        return fromAction {
+        return defer {
 
             if (statisticsDataStore.httpsUpgradesTotal == 0) {
-                return@fromAction
+                return@defer complete()
             }
             val params = mapOf(
                 TOTAL_COUNT to statisticsDataStore.httpsUpgradesTotal.toString(),
                 FAILURE_COUNT to statisticsDataStore.httpsUpgradesFailures.toString()
             )
 
-            pixel.fireCompletable(Pixel.PixelName.HTTPS_UPGRADE_SITE_SUMMARY, params).blockingGet()
-            Timber.v("Sent https statistics")
-            statisticsDataStore.httpsUpgradesTotal = 0
-            statisticsDataStore.httpsUpgradesFailures = 0
+            pixel.fireCompletable(Pixel.PixelName.HTTPS_UPGRADE_SITE_SUMMARY, params).andThen {
+                Timber.v("Sent https statistics")
+                statisticsDataStore.httpsUpgradesTotal = 0
+                statisticsDataStore.httpsUpgradesFailures = 0
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
@@ -89,24 +89,6 @@ class HttpsUpgradeDataDownloader @Inject constructor(
         }
     }
 
-    fun reportUpgradeStatistics(): Completable {
-        return fromAction {
-
-            if (statisticsDataStore.httpsUpgradesTotal == 0) {
-                return@fromAction
-            }
-            val params = mapOf(
-                TOTAL_COUNT to statisticsDataStore.httpsUpgradesTotal.toString(),
-                FAILURE_COUNT to statisticsDataStore.httpsUpgradesFailures.toString()
-            )
-
-            pixel.fireCompletable(Pixel.PixelName.HTTPS_UPGRADE_SITE_SUMMARY, params).blockingGet()
-            Timber.v("Sent https statistics")
-            statisticsDataStore.httpsUpgradesTotal = 0
-            statisticsDataStore.httpsUpgradesFailures = 0
-        }
-    }
-
     private fun downloadWhitelist(): Completable {
 
         Timber.d("Downloading HTTPS whitelist")
@@ -129,6 +111,24 @@ class HttpsUpgradeDataDownloader @Inject constructor(
             }
         }
 
+    }
+
+    fun reportUpgradeStatistics(): Completable {
+        return fromAction {
+
+            if (statisticsDataStore.httpsUpgradesTotal == 0) {
+                return@fromAction
+            }
+            val params = mapOf(
+                TOTAL_COUNT to statisticsDataStore.httpsUpgradesTotal.toString(),
+                FAILURE_COUNT to statisticsDataStore.httpsUpgradesFailures.toString()
+            )
+
+            pixel.fireCompletable(Pixel.PixelName.HTTPS_UPGRADE_SITE_SUMMARY, params).blockingGet()
+            Timber.v("Sent https statistics")
+            statisticsDataStore.httpsUpgradesTotal = 0
+            statisticsDataStore.httpsUpgradesFailures = 0
+        }
     }
 
 }

--- a/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
@@ -43,6 +43,7 @@ class AppConfigurationDownloader(
         val disconnectDownload = trackerDataDownloader.downloadList(DISCONNECT)
         val surrogatesDownload = resourceSurrogateDownloader.downloadList()
         val httpsUpgradeDownload = httpsUpgradeDataDownloader.download()
+        val httpStatisticsReport = httpsUpgradeDataDownloader.reportUpgradeStatistics()
 
         return Completable.mergeDelayError(
             listOf(
@@ -51,7 +52,8 @@ class AppConfigurationDownloader(
                 trackersWhitelist,
                 disconnectDownload,
                 surrogatesDownload,
-                httpsUpgradeDownload
+                httpsUpgradeDownload,
+                httpStatisticsReport
             )
         ).doOnComplete {
             Timber.i("Download task completed successfully")
@@ -59,4 +61,6 @@ class AppConfigurationDownloader(
             appDatabase.appConfigurationDao().configurationDownloadSuccessful(appConfiguration)
         }
     }
+
+
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -53,7 +53,6 @@ interface Pixel {
 
     object PixelParameter {
         const val URL = "url"
-        const val STATUS_CODE = "status_code"
         const val ERROR_CODE = "error_code"
     }
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsDataStore.kt
@@ -23,9 +23,11 @@ interface StatisticsDataStore {
     val hasInstallationStatistics: Boolean
 
     var atb: Atb?
-
     var retentionAtb: String?
     var variant: String?
+
+    var httpsUpgradesTotal: Int
+    var httpsUpgradesFailures: Int
 
     fun saveAtb(atb: Atb)
     fun clearAtb()

--- a/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsSharedPreferences.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsSharedPreferences.kt
@@ -43,6 +43,14 @@ class StatisticsSharedPreferences @Inject constructor(private val context: Conte
         get() = preferences.getString(KEY_RETENTION_ATB, null)
         set(value) = preferences.edit { putString(KEY_RETENTION_ATB, value) }
 
+    override var httpsUpgradesTotal: Int
+        get() = preferences.getInt(KEY_HTTPS_UPGRADES_TOTAL, 0)
+        set(value) = preferences.edit { putInt(KEY_HTTPS_UPGRADES_TOTAL, value) }
+
+    override var httpsUpgradesFailures: Int
+        get() = preferences.getInt(KEY_HTTPS_UPGRADES_FAILURES, 0)
+        set(value) = preferences.edit { putInt(KEY_HTTPS_UPGRADES_FAILURES, value) }
+
     override fun saveAtb(atb: Atb) {
         preferences.edit {
             putString(KEY_ATB, atb.version)
@@ -65,5 +73,7 @@ class StatisticsSharedPreferences @Inject constructor(private val context: Conte
         private const val KEY_ATB = "com.duckduckgo.app.statistics.atb"
         private const val KEY_RETENTION_ATB = "com.duckduckgo.app.statistics.retentionatb"
         private const val KEY_VARIANT = "com.duckduckgo.app.statistics.variant"
+        private const val KEY_HTTPS_UPGRADES_TOTAL = "com.duckduckgo.app.statistics.httpsupgradestotal"
+        private const val KEY_HTTPS_UPGRADES_FAILURES = "com.duckduckgo.app.statistics.httpsupgradesfailures"
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/839627367764303
Tech Design URL: N/A however spec was discussed in https://app.asana.com/0/361428290920652/832602107339150

**Description**:
- Add a summary `ehs` pixel to determine https failures versus successes
- Remove status error from `ehd` pixel. Status errors are generally connectivity (we never see them in kibana as the `ehd` pixel fails too) but they could skew summary counts
- Restrict errors to main frame

**Steps to test this PR**:
1. Go to a broken https upgrade site ensure that the failure `ehd` pixel is still fired.
It may be easier to remove the `httpsUpgrader.shouldUpgrade` check in the `isHttpsUpgradeSite` and visit https://badssl.com and ensure the pixel fires from there.
1. Navigate to a few sites successfully
1. Stop and relaunch the app ensure that the `ehs` summary pixel is fired on sync showing the count of failed versus total https sites in our upgrade list
1. Ensure that other app pixels continue to fire as normal

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
