### PR TITLE
Hotfix/5.10.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-kapt'
 apply from: '../versioning.gradle'
 
 ext {
-    VERSION_NAME = "5.10.5"
+    VERSION_NAME = "5.10.6"
     USE_ORCHESTRATOR = project.hasProperty('orchestrator') ? project.property('orchestrator') : false
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -31,7 +31,9 @@ import com.duckduckgo.app.global.simpleUrl
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.HTTPS_UPGRADE_SITE_ERROR
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.APP_VERSION
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.ERROR_CODE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.URL
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import timber.log.Timber
 import javax.inject.Inject
@@ -179,8 +181,9 @@ class BrowserWebViewClient @Inject constructor(
 
     private fun reportHttpsUpgradeSiteError(url: Uri, error: String?) {
         val params = mapOf(
-            PixelParameter.URL to url.simpleUrl,
-            PixelParameter.ERROR_CODE to error
+            APP_VERSION to "${BuildConfig.VERSION_NAME}",
+            URL to url.simpleUrl,
+            ERROR_CODE to error
         )
         pixel.fire(HTTPS_UPGRADE_SITE_ERROR, params)
     }

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.httpsupgrade.api
 
+import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.global.api.isCached
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.store.BinaryDataStore
@@ -25,6 +26,7 @@ import com.duckduckgo.app.httpsupgrade.db.HttpsWhitelistDao
 import com.duckduckgo.app.httpsupgrade.model.HttpsBloomFilterSpec
 import com.duckduckgo.app.httpsupgrade.model.HttpsBloomFilterSpec.Companion.HTTPS_BINARY_FILE
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.APP_VERSION
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FAILURE_COUNT
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.TOTAL_COUNT
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -120,6 +122,7 @@ class HttpsUpgradeDataDownloader @Inject constructor(
                 return@defer complete()
             }
             val params = mapOf(
+                APP_VERSION to "${BuildConfig.VERSION_NAME}",
                 TOTAL_COUNT to statisticsDataStore.httpsUpgradesTotal.toString(),
                 FAILURE_COUNT to statisticsDataStore.httpsUpgradesFailures.toString()
             )

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeService.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeService.kt
@@ -25,12 +25,12 @@ import retrofit2.http.GET
 
 interface HttpsUpgradeService {
 
-    @GET("https://staticcdn.duckduckgo.com/https/https-mobile-whitelist.json")
+    @GET("https://staticcdn.duckduckgo.com/https/https-mobile-whitelist.json?cache_version=1")
     fun whitelist(): Call<List<HttpsWhitelistedDomain>>
 
-    @GET("https://staticcdn.duckduckgo.com/https/https-mobile-bloom-spec.json")
+    @GET("https://staticcdn.duckduckgo.com/https/https-mobile-bloom-spec.json?cache_version=1")
     fun httpsBloomFilterSpec(): Observable<HttpsBloomFilterSpec>
 
-    @GET("https://staticcdn.duckduckgo.com/https/https-mobile-bloom.bin")
+    @GET("https://staticcdn.duckduckgo.com/https/https-mobile-bloom.bin?cache_version=1")
     fun httpsBloomFilter(): Call<ResponseBody>
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -58,6 +58,7 @@ interface Pixel {
         const val ERROR_CODE = "error_code"
         const val TOTAL_COUNT = "total"
         const val FAILURE_COUNT = "failures"
+        const val APP_VERSION = "app_version"
     }
 
     fun fire(pixel: PixelName, parameters: Map<String, String?> = emptyMap())


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/843748091381151
Tech Design URL: N/A
CC: 

**Description**:
There was an issue with expiry dates on the https backend requests. This has now been fixed however apps that pulled down this data will not update the it again until the expiry date in 2019.

In this PR we add a parameter to the https request urls to break the old cached record and force new data to be pulled down. We also add a new app_version parameter to `ehd` and `ehs` pixels to let us better separate old (and bad!) from new data.

**Steps to test this PR**:
TEST REQUESTS:
1. Run a new installation of the app and watch https requests in Charles, they should complete with a status 200
1. Run the app again, this time the status should be a 304

TEST PIXEL PARAM:
1. Remove the httpsUpgrader.shouldUpgrade check in the isHttpsUpgradeSite and visit https://badssl.com and ensure the pixel fires from there.
1. Ensure that the `ehd` pixel fires and contains an app_version param
1. Ensure that the `ehs` pixel fires and contains an app_version param

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
