### PR TITLE
Feature/pixels default browser onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/defaultBrowsing/DefaultBrowserSystemSettings.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultBrowsing/DefaultBrowserSystemSettings.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultBrowsing
+
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import android.support.annotation.RequiresApi
+
+
+class DefaultBrowserSystemSettings {
+
+    companion object {
+        @RequiresApi(Build.VERSION_CODES.N)
+        fun intent() = Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/di/AndroidBindingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AndroidBindingModule.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.fire.FireActivity
 import com.duckduckgo.app.job.AppConfigurationJobService
 import com.duckduckgo.app.launch.LaunchActivity
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
+import com.duckduckgo.app.onboarding.ui.OnboardingPageFragment
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity
 import com.duckduckgo.app.privacy.ui.PrivacyPracticesActivity
 import com.duckduckgo.app.privacy.ui.ScorecardActivity
@@ -101,6 +102,9 @@ abstract class AndroidBindingModule {
 
     @ContributesAndroidInjector
     abstract fun browserTabFragment(): BrowserTabFragment
+
+    @ContributesAndroidInjector
+    abstract fun onboardingDefaultBrowserFragment(): OnboardingPageFragment.DefaultBrowserPage
 
     /* Services */
 

--- a/app/src/main/java/com/duckduckgo/app/global/view/ActivityExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ActivityExtension.kt
@@ -20,12 +20,12 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.provider.Settings
 import android.support.annotation.RequiresApi
 import android.support.v4.app.FragmentActivity
 import android.view.View
 import android.widget.Toast
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.defaultBrowsing.DefaultBrowserSystemSettings
 import org.jetbrains.anko.toast
 import timber.log.Timber
 
@@ -40,7 +40,7 @@ fun FragmentActivity.launchExternalActivity(intent: Intent) {
 @RequiresApi(Build.VERSION_CODES.N)
 fun Context.launchDefaultAppActivity() {
     try {
-        val intent = Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+        val intent = DefaultBrowserSystemSettings.intent()
         startActivity(intent)
     } catch (e: ActivityNotFoundException) {
         val errorMessage = getString(R.string.cannotLaunchDefaultAppSettings)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -18,16 +18,13 @@ package com.duckduckgo.app.onboarding.ui
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.support.annotation.ColorInt
-import android.support.annotation.RequiresApi
 import android.support.v4.content.ContextCompat
 import android.view.View
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.ColorCombiner
-import com.duckduckgo.app.global.view.launchDefaultAppActivity
 import com.duckduckgo.app.onboarding.ui.ColorChangingPageListener.NewColorListener
 import kotlinx.android.synthetic.main.activity_onboarding.*
 import javax.inject.Inject
@@ -61,11 +58,6 @@ class OnboardingActivity : DuckDuckGoActivity() {
             viewModel.onOnboardingDone()
             finish()
         }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.N)
-    fun onLaunchDefaultBrowserSettingsClicked(view: View) {
-        launchDefaultAppActivity()
     }
 
     private fun configurePager() {

--- a/app/src/main/res/layout/content_onboarding_default_browser.xml
+++ b/app/src/main/res/layout/content_onboarding_default_browser.xml
@@ -65,7 +65,6 @@
     <Button
         android:id="@+id/launchSettingsButton"
         style="@style/OnboardingButtonDefaultBrowserLaunchSettings"
-        android:onClick="onLaunchDefaultBrowserSettingsClicked"
         android:text="@string/onboardingDefaultBrowserGoToSettingsAction"
         android:theme="@style/OnboardingButtonDefaultBrowserLaunchSettings"
         app:layout_constraintBottom_toTopOf="@+id/continueButton" />

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-rc03'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/831964787841923
Tech Design URL: 
CC: 

**Description**:
Add pixels to the onboarding _default browser_ page. These were previously available from `DefaultBrowserInfoActivity` interstitial but that is no longer used in the current setup, so copying the pixels from there into the onboarding page.

There will be a separate PR to remove `DefaultBrowserInfoActivity` altogether.

**Steps to test this PR**:

_Only applicable to Nougat or newer_
1. From fresh install; verify `mdb_v` does NOT fire yet.
1. Swipe/click along to next page; verify `mdb_v` does NOT fire yet.
1. Swipe/click along to see default browser screen; verify `mdb_v` fires when view is visible
1. Click the settings button and return without making a change; verify `mdb_n` is fired
1. Click the settings button and choose DDG as default, and return; verify `mdb_s` is fired


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
