### PR TITLE
Add light theme pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
@@ -95,7 +95,8 @@ class ViewModelFactory @Inject constructor(
                 isAssignableFrom(SettingsViewModel::class.java) -> SettingsViewModel(
                     appSettingsPreferencesStore,
                     defaultBrowserDetector,
-                    variantManager
+                    variantManager,
+                    pixel
                 )
                 isAssignableFrom(BookmarksViewModel::class.java) -> BookmarksViewModel(bookmarksDao)
                 isAssignableFrom(FireViewModel::class.java) -> FireViewModel()

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -25,13 +25,16 @@ import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.ThemeFeature.ThemeToggle
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 import timber.log.Timber
 import javax.inject.Inject
 
 class SettingsViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val defaultWebBrowserCapability: DefaultBrowserDetector,
-    private val variantManager: VariantManager
+    private val variantManager: VariantManager,
+    private val pixel: Pixel
 ) : ViewModel() {
 
     data class ViewState(
@@ -58,6 +61,10 @@ class SettingsViewModel @Inject constructor(
 
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
+    init {
+        pixel.fire(SETTINGS_OPENED)
+    }
+
     fun start() {
 
         val defaultBrowserAlready = defaultWebBrowserCapability.isCurrentlyConfiguredAsDefaultBrowser()
@@ -83,6 +90,9 @@ class SettingsViewModel @Inject constructor(
         Timber.i("User toggled light theme, is now enabled: $enabled")
         settingsDataStore.theme = if (enabled) DuckDuckGoTheme.LIGHT else DuckDuckGoTheme.DARK
         command.value = Command.UpdateTheme
+
+        val pixelName = if (enabled) SETTINGS_THEME_TOGGLED_LIGHT else SETTINGS_THEME_TOGGLED_DARK
+        pixel.fire(pixelName)
     }
 
     fun onAutocompleteSettingChanged(enabled: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -50,6 +50,10 @@ interface Pixel {
         LONG_PRESS_SHARE("mlp_s"),
         LONG_PRESS_COPY_URL("mlp_c"),
 
+        SETTINGS_OPENED("ms"),
+        SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),
+        SETTINGS_THEME_TOGGLED_DARK("ms_td"),
+
         HTTPS_UPGRADE_SITE_ERROR("ehd"),
         HTTPS_UPGRADE_SITE_SUMMARY("ehs")
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/816426578517930
Tech Design URL: https://app.asana.com/0/361428290920652/814618797160182

**Description**:
Adds pixel for settings and switching between light and dark theme

**Steps to test this PR**:
1. Comment out all variants other than `mh` and `mj` in `VariantManager`
1. Install the app
1. Open Settings note that the mp pixel fires
1. Toggle the theme a few times and note that the mp_tl (light theme) and mp td (dark theme) fire as appropriate

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
