### PR TITLE
Verify bloom checksum before load

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/BloomFilterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/BloomFilterTest.kt
@@ -59,7 +59,7 @@ class BloomFilterTest {
             }
         }
 
-        val errorRate = falsePositives / testData.size
+        val errorRate = falsePositives.toDouble() / testData.size.toDouble()
         assertEquals(0, falseNegatives)
         assertEquals(bloomData.size, truePositives)
         assertTrue(trueNegatives <= testData.size - bloomData.size)
@@ -73,9 +73,9 @@ class BloomFilterTest {
     }
 
     companion object {
-        const val FILTER_ELEMENT_COUNT = 1000
-        const val ADDITIONAL_TEST_DATA_ELEMENT_COUNT = 9000
+        const val FILTER_ELEMENT_COUNT = 5000
+        const val ADDITIONAL_TEST_DATA_ELEMENT_COUNT = 5000
         const val TARGET_ERROR_RATE = 0.001
-        const val ACCEPTABLE_ERROR_RATE = TARGET_ERROR_RATE * 1.1
+        const val ACCEPTABLE_ERROR_RATE = TARGET_ERROR_RATE * 2
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsBloomFilterFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsBloomFilterFactory.kt
@@ -43,6 +43,12 @@ class HttpsBloomFilterFactoryImpl @Inject constructor(private val dao: HttpsBloo
             return null
         }
 
+        if (!binaryDataStore.verifyCheckSum(HTTPS_BINARY_FILE, specification.sha256)) {
+            Timber.d("Https update data failed checksum, clearing")
+            binaryDataStore.clearData(HTTPS_BINARY_FILE)
+            return null
+        }
+
         val initialTimestamp = System.currentTimeMillis()
         Timber.d("Found https data at $dataPath, building filter")
         var bloomFilter = BloomFilter(dataPath, specification.totalEntries)

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
@@ -79,7 +79,7 @@ class HttpsUpgradeDataDownloader @Inject constructor(
 
             val bytes = response.body()!!.bytes()
             if (!binaryDataStore.verifyCheckSum(bytes, specification.sha256)) {
-                throw IOException("Https binary has incorrect checksum, throwing away file")
+                throw IOException("Https binary has incorrect sha, throwing away file")
             }
 
             Timber.d("Updating https bloom data store with new data")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/850930018552054

**Description**:
Fixes issue where bad bloom data could cause the app to crash. Also performed some tidy up.

**Steps to test this PR**:
1. Run the app on an emulator
1. Once a sync has finished delete the file at /data/data/com.duckduckgo.mobile.android/files/HTTPS_BINARY_FILE
1. Run the app again, note that the app does not crash and the file is downloaded again during the next sync

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
