### PR TITLE
Reduce sync frequency and remove https path from EHD pixel

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
@@ -60,36 +60,6 @@ class UriExtensionTest {
     }
 
     @Test
-    fun whenUriContainsDomainThenSimpleUrlIsEqual() {
-        val url = "http://example.com"
-        assertEquals(url, Uri.parse(url).simpleUrl)
-    }
-
-    @Test
-    fun whenUriCotnainsSubdomainThenSimpleUrlIsEqual() {
-        val url = "http://subdomain.example.com"
-        assertEquals(url, Uri.parse(url).simpleUrl)
-    }
-
-    @Test
-    fun whenUriContainsPathThenSimpleUrlIsEqual() {
-        val url = "http://example.com/about"
-        assertEquals(url, Uri.parse(url).simpleUrl)
-    }
-
-    @Test
-    fun whenUriContainsUsernameThenSimpleUrlOmitsThis() {
-        val url = "http://user@example.com"
-        assertEquals("http://example.com", Uri.parse(url).simpleUrl)
-    }
-
-    @Test
-    fun whenUriContainsParametersThenSimpleUrlOmitsThese() {
-        val url = "http://example.com?search=54"
-        assertEquals("http://example.com", Uri.parse(url).simpleUrl)
-    }
-
-    @Test
     fun whenUriIsHttpIrrespectiveOfCaseThenIsHttpIsTrue() {
         assertTrue(Uri.parse("http://example.com").isHttp)
         assertTrue(Uri.parse("HTTP://example.com").isHttp)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -179,9 +179,10 @@ class BrowserWebViewClient @Inject constructor(
     }
 
     private fun reportHttpsUpgradeSiteError(url: Uri, error: String?) {
+        val host = url.host ?: return
         val params = mapOf(
             APP_VERSION to BuildConfig.VERSION_NAME,
-            URL to "${url.scheme}://${url.host}",
+            URL to "https://$host",
             ERROR_CODE to error
         )
         pixel.fire(HTTPS_UPGRADE_SITE_ERROR, params)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -27,7 +27,6 @@ import android.support.annotation.WorkerThread
 import android.webkit.*
 import androidx.core.net.toUri
 import com.duckduckgo.app.global.isHttps
-import com.duckduckgo.app.global.simpleUrl
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.HTTPS_UPGRADE_SITE_ERROR
@@ -182,7 +181,7 @@ class BrowserWebViewClient @Inject constructor(
     private fun reportHttpsUpgradeSiteError(url: Uri, error: String?) {
         val params = mapOf(
             APP_VERSION to BuildConfig.VERSION_NAME,
-            URL to url.simpleUrl,
+            URL to "${url.scheme}://${url.host}",
             ERROR_CODE to error
         )
         pixel.fire(HTTPS_UPGRADE_SITE_ERROR, params)

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -34,19 +34,6 @@ fun Uri.withScheme(): Uri {
 val Uri.baseHost: String?
     get() = withScheme().host?.removePrefix("www.")
 
-/**
- * Return a simple url with scheme, domain and path. Other elements such as username or
- * query parameters are omitted
- */
-val Uri.simpleUrl: String
-    get() {
-        var string = ""
-        if (scheme != null) { string = "$scheme://" }
-        if (host != null) { string += host }
-        if (path != null) { string += path }
-        return string
-    }
-
 val Uri.isHttp: Boolean
     get() = scheme?.equals(UrlScheme.http, true) ?: false
 

--- a/app/src/main/java/com/duckduckgo/app/global/job/JobBuilder.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/job/JobBuilder.kt
@@ -31,9 +31,9 @@ class JobBuilder @Inject constructor() {
     fun appConfigurationJob(context: Context): JobInfo {
 
         return JobInfo.Builder(APP_CONFIGURATION_JOB_ID, ComponentName(context, AppConfigurationJobService::class.java))
-            .setPeriodic(TimeUnit.HOURS.toMillis(3))
+            .setPeriodic(TimeUnit.HOURS.toMillis(12))
             .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
-            .setBackoffCriteria(TimeUnit.MINUTES.toMillis(30), BACKOFF_POLICY_EXPONENTIAL)
+            .setBackoffCriteria(TimeUnit.MINUTES.toMillis(60), BACKOFF_POLICY_EXPONENTIAL)
             .setPersisted(true)
             .build()
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
https://app.asana.com/0/361428290920652/863340012156759
https://app.asana.com/0/361428290920652/863340012155762

**Description**:
* Removes the url path from EHD pixels.
* Increases app sync to 12 hours and failure backoff to 1 hour to reduce data usage and load on the backend
* Removes the simpleUrl extension method based on previous team conversations that it is not needed

**Steps to test this PR**:
**TEST PIXEL**
1. Turn on charles and watch app traffic
1. Visit https://badssl.com/abcd
1. Note the EHD pixel fires as https://badssl.com (without a path)

**CHECK SYNC LOGIC**
Check the code to ensure sync time has been updated to 12 hours.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
