### PR TITLE
Removes incorrect strlen(input) call

### DIFF
--- a/app/src/main/cpp/third-party/ad-block/ad_block_client.cc
+++ b/app/src/main/cpp/third-party/ad-block/ad_block_client.cc
@@ -269,7 +269,7 @@ void parseFilter(const char *input, const char *end, Filter *f,
           }
           break;
         case '/': {
-          const size_t inputLen = strlen(input);
+          const size_t inputLen = end - input;
           if (parseState == FPStart || parseState == FPPastWhitespace) {
             if (input[inputLen - 1] == '/' && inputLen > 1) {
               // Just copy out the whole regex and return early


### PR DESCRIPTION
**Description**:
The function takes input and end, which implies that input is not a
C-string, and isn't a valid argument to strlen().

I'm getting crashes when running duckduckgo on android virtual devices (cuttlefish)
with address sanitizer and this changes gets it running again.

**Steps to test this PR**:
1. I don't know of public instructions on reproducing the crash, I'd need to get back to you on this if its necessary to demonstrate that this is actually fixing something