### PR TITLE
Hotfix/5.12.1

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.app.browser
 
 import android.content.Context
+import android.os.Build
 import android.support.test.InstrumentationRegistry
 import android.support.test.annotation.UiThreadTest
+import android.support.test.filters.SdkSuppress
 import android.webkit.WebView
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -61,11 +63,21 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenListenerNotInstructedToUpdateUrl() {
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
+    fun whenOnPageStartedCalledOnNewerDevicesThenListenerNotInstructedToUpdateUrl() {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         verify(listener, never()).urlChanged(any())
     }
 
+    @UiThreadTest
+    @Test
+    @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.LOLLIPOP_MR1)
+    fun whenOnPageStartedCalledOnOlderDevicesThenListenerInstructedToUpdateUrl() {
+        testee.onPageStarted(webView, EXAMPLE_URL, null)
+        verify(listener).urlChanged(any())
+    }
+
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
     @UiThreadTest
     @Test
     fun whenOnPageCommitVisibleCalledThenListenerInstructedToUpdateUrl() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -52,6 +52,8 @@ class BrowserWebViewClient @Inject constructor(
 
     private var currentUrl: String? = null
 
+    private val willGetNotifiedOfPageCommits = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+
     /**
      * This is the new method of url overriding available from API 24 onwards
      */
@@ -111,7 +113,7 @@ class BrowserWebViewClient @Inject constructor(
 
         webViewClientListener?.loadingStarted()
 
-        if (!willGetNotifiedOfPageCommits()) onUrlChanged(url, webView)
+        if (!willGetNotifiedOfPageCommits) onUrlChanged(url, webView)
 
         val uri = if (url != null) Uri.parse(url) else null
         if (uri != null) {
@@ -218,10 +220,6 @@ class BrowserWebViewClient @Inject constructor(
         val canGoBack = webView.canGoBack()
         val canGoForward = webView.canGoForward()
         return BrowserNavigationOptions(canGoBack, canGoForward)
-    }
-
-    private fun willGetNotifiedOfPageCommits(): Boolean {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
     }
 
     private fun onUrlChanged(url: String?, webView: WebView) {

--- a/app/version/version.properties
+++ b/app/version/version.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-VERSION=5.12.0
+VERSION=5.12.1


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/885011869511894
Tech Design URL: 
CC: 

**Description**:
We made a change in `5.12.0` to mitigate a potential phishing attack, but sadly the callback used was only ever invoked in API 23 and newer. As such, we created a bug for Lollipop users where the app got into bad state (not able to add bookmarks, share pages, open new tabs).

This solution effectively reverts the phishing protection, but only for Lollipop users; those users will have the same functionality as before the fix went in. But newer devices will continue to be protected from that phishing attack. This seems like a good all-round compromise.

**Steps to test this PR**:
1. Test this on a Lollipop device - open a page/perform a search and ensure bookmarks/tabs/sharing works as expected
1. Test this out on a newer and ensure the above is all working well
1. Additionally, on a Marshmallow or newer device, test out to ensure the phishing attack still mitigated, as detailed in https://app.asana.com/0/0/865896277649322


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
