### PR TITLE
Feature/phishing url fix

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -112,23 +112,13 @@ class BrowserChromeClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnProgressChangedCalledWithNoUrlChangeThenListenerNotInstructedToUpdateUrlASecondTime() {
-        val url = "https://example.com"
-        webView.stubUrl = url
-        testee.onProgressChanged(webView, 10)
-        testee.onProgressChanged(webView, 20) // should NOT update url
-        verify(mockWebViewClientListener).urlChanged(url)
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenOnProgressChangedCalledAfterUrlChangeThenListenerInstructedToUpdateUrl() {
+    fun whenOnProgressChangedCalledAfterUrlChangeThenListenerInstructedToUpdateUrlEveryTime() {
         webView.stubUrl = "foo.com"
-        testee.onProgressChanged(webView, 10) // should update url
-        testee.onProgressChanged(webView, 20) // should NOT update url
+        testee.onProgressChanged(webView, 10)
+        testee.onProgressChanged(webView, 20)
         webView.stubUrl = "bar.com"
-        testee.onProgressChanged(webView, 30) // should update url
-        verify(mockWebViewClientListener, times(2)).urlChanged(any())
+        testee.onProgressChanged(webView, 30)
+        verify(mockWebViewClientListener, times(3)).urlChanged(any())
     }
 
     private class TestWebView(context: Context) : WebView(context) {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -16,9 +16,13 @@
 
 package com.duckduckgo.app.browser
 
+import android.content.Context
 import android.support.test.InstrumentationRegistry
+import android.support.test.annotation.UiThreadTest
 import android.view.View
 import android.webkit.WebChromeClient
+import android.webkit.WebView
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
@@ -28,14 +32,17 @@ import org.junit.Test
 class BrowserChromeClientTest {
 
     private lateinit var testee: BrowserChromeClient
+    private lateinit var webView: TestWebView
     private lateinit var mockWebViewClientListener: WebViewClientListener
     private val fakeView = View(InstrumentationRegistry.getTargetContext())
 
+    @UiThreadTest
     @Before
     fun setup() {
         testee = BrowserChromeClient()
         mockWebViewClientListener = mock()
         testee.webViewClientListener = mockWebViewClientListener
+        webView = TestWebView(InstrumentationRegistry.getTargetContext())
     }
 
     @Test
@@ -65,5 +72,70 @@ class BrowserChromeClientTest {
     fun whenHideCustomViewCalledThenListenerInstructedToExistFullScreen() {
         testee.onHideCustomView()
         verify(mockWebViewClientListener).exitFullScreen()
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnProgressChangedCalledThenListenerInstructedToUpdateProgress() {
+        testee.onProgressChanged(webView, 10)
+        verify(mockWebViewClientListener).progressChanged(10)
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnProgressChangedCalledButNoUrlChangeThenListenerInstructedToUpdateProgressASecondTime() {
+        webView.stubUrl = "foo.com"
+        testee.onProgressChanged(webView, 10)
+        testee.onProgressChanged(webView, 20)
+        verify(mockWebViewClientListener, times(2)).progressChanged(any())
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnProgressChangedCalledAfterUrlChangeThenListenerInstructedToUpdateProgressAgain() {
+        webView.stubUrl = "foo.com"
+        testee.onProgressChanged(webView, 10)
+        testee.onProgressChanged(webView, 20)
+        webView.stubUrl = "bar.com"
+        testee.onProgressChanged(webView, 30)
+        verify(mockWebViewClientListener, times(3)).progressChanged(any())
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnProgressChangedCalledThenListenerInstructedToUpdateUrl() {
+        val url = "https://example.com"
+        webView.stubUrl = url
+        testee.onProgressChanged(webView, 10)
+        verify(mockWebViewClientListener).urlChanged(url)
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnProgressChangedCalledWithNoUrlChangeThenListenerNotInstructedToUpdateUrlASecondTime() {
+        val url = "https://example.com"
+        webView.stubUrl = url
+        testee.onProgressChanged(webView, 10)
+        testee.onProgressChanged(webView, 20) // should NOT update url
+        verify(mockWebViewClientListener).urlChanged(url)
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnProgressChangedCalledAfterUrlChangeThenListenerInstructedToUpdateUrl() {
+        webView.stubUrl = "foo.com"
+        testee.onProgressChanged(webView, 10) // should update url
+        testee.onProgressChanged(webView, 20) // should NOT update url
+        webView.stubUrl = "bar.com"
+        testee.onProgressChanged(webView, 30) // should update url
+        verify(mockWebViewClientListener, times(2)).urlChanged(any())
+    }
+
+    private class TestWebView(context: Context) : WebView(context) {
+        var stubUrl: String = ""
+
+        override fun getUrl(): String {
+            return stubUrl
+        }
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -17,10 +17,8 @@
 package com.duckduckgo.app.browser
 
 import android.content.Context
-import android.os.Build
 import android.support.test.InstrumentationRegistry
 import android.support.test.annotation.UiThreadTest
-import android.support.test.filters.SdkSuppress
 import android.webkit.WebView
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -63,33 +61,9 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
-    fun whenOnPageStartedCalledOnNewerDevicesThenListenerNotInstructedToUpdateUrl() {
+    fun whenOnPageStartedCalledThenListenerNeverInstructedToUpdateUrl() {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         verify(listener, never()).urlChanged(any())
-    }
-
-    @UiThreadTest
-    @Test
-    @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.LOLLIPOP_MR1)
-    fun whenOnPageStartedCalledOnOlderDevicesThenListenerInstructedToUpdateUrl() {
-        testee.onPageStarted(webView, EXAMPLE_URL, null)
-        verify(listener).urlChanged(any())
-    }
-
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
-    @UiThreadTest
-    @Test
-    fun whenOnPageCommitVisibleCalledThenListenerInstructedToUpdateUrl() {
-        testee.onPageCommitVisible(webView, EXAMPLE_URL)
-        verify(listener).urlChanged(EXAMPLE_URL)
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenOnPageCommitVisibleCalledThenListenerInstructedToUpdateNavigationOptions() {
-        testee.onPageCommitVisible(webView, EXAMPLE_URL)
-        verify(listener).navigationOptionsChanged(any())
     }
 
     @UiThreadTest
@@ -104,6 +78,13 @@ class BrowserWebViewClientTest {
     fun whenOnPageFinishedCalledThenListenerInstructedToUpdateNavigationOptions() {
         testee.onPageFinished(webView, EXAMPLE_URL)
         verify(listener).navigationOptionsChanged(any())
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnPageFinishedCalledThenListenerInstructedToUpdateUrl() {
+        testee.onPageFinished(webView, EXAMPLE_URL)
+        verify(listener).urlChanged(EXAMPLE_URL)
     }
 
     private class TestWebView(context: Context) : WebView(context)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -30,9 +30,10 @@ class BrowserChromeClient @Inject constructor() : WebChromeClient() {
     var webViewClientListener: WebViewClientListener? = null
 
     private var customView: View? = null
+    private var currentUrl: String? = null
 
     override fun onShowCustomView(view: View, callback: CustomViewCallback?) {
-        Timber.i("on show custom view")
+        Timber.d("on show custom view")
 
         if (customView != null) {
             callback?.onCustomViewHidden()
@@ -44,14 +45,21 @@ class BrowserChromeClient @Inject constructor() : WebChromeClient() {
     }
 
     override fun onHideCustomView() {
-        Timber.i("hide custom view")
+        Timber.d("on hide custom view")
 
         webViewClientListener?.exitFullScreen()
         customView = null
     }
 
     override fun onProgressChanged(webView: WebView, newProgress: Int) {
+        Timber.d("onProgressChanged - $newProgress - ${webView.url}")
+
         webViewClientListener?.progressChanged(newProgress)
+
+        if (currentUrl != webView.url) {
+            currentUrl = webView.url
+            webViewClientListener?.urlChanged(currentUrl)
+        }
     }
 
     override fun onReceivedTitle(view: WebView, title: String) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -30,7 +30,6 @@ class BrowserChromeClient @Inject constructor() : WebChromeClient() {
     var webViewClientListener: WebViewClientListener? = null
 
     private var customView: View? = null
-    private var currentUrl: String? = null
 
     override fun onShowCustomView(view: View, callback: CustomViewCallback?) {
         Timber.d("on show custom view")
@@ -56,9 +55,10 @@ class BrowserChromeClient @Inject constructor() : WebChromeClient() {
 
         webViewClientListener?.progressChanged(newProgress)
 
+        val currentUrl = webViewClientListener?.currentUrl()
         if (currentUrl != webView.url) {
-            currentUrl = webView.url
-            webViewClientListener?.urlChanged(currentUrl)
+            Timber.i("Url has changed from $currentUrl to ${webView.url}")
+            webViewClientListener?.urlChanged(webView.url)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -370,8 +370,7 @@ class BrowserTabViewModel(
             statisticsUpdater.refreshRetentionAtb()
         }
 
-        val currentUrl = currentUrl()
-        if (currentUrl != url) {
+        if (currentUrl() != url) {
             site = siteFactory.build(url)
             onSiteChanged()
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -85,7 +85,6 @@ class BrowserTabViewModel(
     private val addToHomeCapabilityDetector: AddToHomeCapabilityDetector,
     appConfigurationDao: AppConfigurationDao
 ) : WebViewClientListener, SaveBookmarkListener, ViewModel() {
-
     data class GlobalLayoutViewState(
         val isNewTabState: Boolean = true
     )
@@ -343,7 +342,11 @@ class BrowserTabViewModel(
             findInPageViewState.value = FindInPageViewState(visible = false, canFindInPage = false)
 
             val currentBrowserViewState = currentBrowserViewState()
-            browserViewState.value = currentBrowserViewState.copy(canAddBookmarks = false, addToHomeEnabled = false, addToHomeVisible = addToHomeCapabilityDetector.isAddToHomeSupported())
+            browserViewState.value = currentBrowserViewState.copy(
+                canAddBookmarks = false,
+                addToHomeEnabled = false,
+                addToHomeVisible = addToHomeCapabilityDetector.isAddToHomeSupported()
+            )
 
             return
         }
@@ -367,8 +370,11 @@ class BrowserTabViewModel(
             statisticsUpdater.refreshRetentionAtb()
         }
 
-        site = siteFactory.build(url)
-        onSiteChanged()
+        val currentUrl = currentUrl()
+        if (currentUrl != url) {
+            site = siteFactory.build(url)
+            onSiteChanged()
+        }
     }
 
     private fun omnibarTextForUrl(url: String): String {
@@ -555,6 +561,10 @@ class BrowserTabViewModel(
         } else {
             command.value = Refresh
         }
+    }
+
+    override fun currentUrl(): String? {
+        return site?.url
     }
 
     fun resetView() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -107,14 +107,15 @@ class BrowserWebViewClient @Inject constructor(
     }
 
     override fun onPageStarted(webView: WebView, url: String?, favicon: Bitmap?) {
-        Timber.d("onPageStarted $url")
-
-        webViewClientListener?.loadingStarted()
+        Timber.d("\nonPageStarted {\nurl: $url\nwebView.url: ${webView.url}\n}\n")
 
         currentUrl = url
-        webViewClientListener?.navigationOptionsChanged(determineNavigationOptions(webView))
+        webViewClientListener?.let {
+            it.loadingStarted()
+            it.navigationOptionsChanged(determineNavigationOptions(webView))
+        }
 
-        val uri = if (url != null) Uri.parse(url) else null
+        val uri = if (currentUrl != null) Uri.parse(currentUrl) else null
         if (uri != null) {
             reportHttpsIfInUpgradeList(uri)
         }
@@ -124,7 +125,6 @@ class BrowserWebViewClient @Inject constructor(
         Timber.d("onPageFinished $url")
 
         currentUrl = url
-
         webViewClientListener?.let {
             it.loadingFinished(url)
             it.urlChanged(url)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -52,8 +52,6 @@ class BrowserWebViewClient @Inject constructor(
 
     private var currentUrl: String? = null
 
-    private val willGetNotifiedOfPageCommits = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-
     /**
      * This is the new method of url overriding available from API 24 onwards
      */
@@ -113,7 +111,8 @@ class BrowserWebViewClient @Inject constructor(
 
         webViewClientListener?.loadingStarted()
 
-        if (!willGetNotifiedOfPageCommits) onUrlChanged(url, webView)
+        currentUrl = url
+        webViewClientListener?.navigationOptionsChanged(determineNavigationOptions(webView))
 
         val uri = if (url != null) Uri.parse(url) else null
         if (uri != null) {
@@ -121,21 +120,14 @@ class BrowserWebViewClient @Inject constructor(
         }
     }
 
-    /**
-     * Note, this method is only called on APIs >= 23
-     * While this is the ideal time to indicate the URL has changed, on lower APIs we need to handle that instead in onPageStarted()
-     */
-    override fun onPageCommitVisible(webView: WebView, url: String?) {
-        Timber.d("onPageCommitVisible $url")
-
-        onUrlChanged(url, webView)
-    }
-
     override fun onPageFinished(webView: WebView, url: String?) {
         Timber.d("onPageFinished $url")
 
+        currentUrl = url
+
         webViewClientListener?.let {
             it.loadingFinished(url)
+            it.urlChanged(url)
             it.navigationOptionsChanged(determineNavigationOptions(webView))
         }
     }
@@ -220,14 +212,6 @@ class BrowserWebViewClient @Inject constructor(
         val canGoBack = webView.canGoBack()
         val canGoForward = webView.canGoForward()
         return BrowserNavigationOptions(canGoBack, canGoForward)
-    }
-
-    private fun onUrlChanged(url: String?, webView: WebView) {
-        currentUrl = url
-        webViewClientListener?.let {
-            it.urlChanged(url)
-            it.navigationOptionsChanged(determineNavigationOptions(webView))
-        }
     }
 
     data class BrowserNavigationOptions(val canGoBack: Boolean, val canGoForward: Boolean)

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -24,6 +24,8 @@ import com.duckduckgo.app.browser.BrowserWebViewClient.BrowserNavigationOptions
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 
 interface WebViewClientListener {
+    fun currentUrl(): String?
+
     fun loadingStarted()
     fun loadingFinished(url: String? = null)
     fun progressChanged(newProgress: Int)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/608920331025313/886417873773490/886557353517165
Tech Design URL: 
CC: 

**Description**:
The `5.12.1` hotfix restored basic functionality to Lollipop users, but removed protection from a niche phishing attack vector. This PR restores that protection again.

**Steps to test this PR**:
### Test 1
1. From a new tab, ensure the overflow menu options are suitably disabled
1. Perform a search, or open a webpage, ensure the menu options are available for use as expected (share, add bookmark etc...)

### Test 2
1. Visit https://geekboy.ninja/p0c/spoof-bar.html
1. Ensure the URL does NOT display `gmail` when it is loading

⚠️ Test both tests above on a Lollipop device, and a newer one.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
