### PR TITLE
remove atb and source from search urls when sharing

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -43,10 +43,8 @@ import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.privacy.db.NetworkLeaderboardDao
 import com.duckduckgo.app.privacy.db.NetworkLeaderboardEntry
 import com.duckduckgo.app.privacy.db.SiteVisitedEntity
-import com.duckduckgo.app.privacy.model.PrivacyGrade
 import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.store.PrevalenceStore
-import com.duckduckgo.app.privacy.store.TermsOfServiceStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -177,6 +175,27 @@ class BrowserTabViewModelTest {
         db.close()
         testee.url.removeObserver(mockQueryObserver)
         testee.command.removeObserver(mockCommandObserver)
+    }
+
+    @Test
+    fun whenSearchUrlSharedThenAtbAndSourceParametersAreRemoved() {
+        testee.userSharingLink("https://duckduckgo.com/?q=test&atb=v117-1&t=ddg_test")
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertTrue(commandCaptor.lastValue is Command.ShareLink)
+
+        val shareLink = commandCaptor.lastValue as Command.ShareLink
+        assertEquals("https://duckduckgo.com/?q=test", shareLink.url)
+    }
+
+    @Test
+    fun whenNonSearchUrlSharedThenUrlIsUnchanged() {
+        val url = "https://duckduckgo.com/about?atb=v117-1&t=ddg_test"
+        testee.userSharingLink(url)
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertTrue(commandCaptor.lastValue is Command.ShareLink)
+
+        val shareLink = commandCaptor.lastValue as Command.ShareLink
+        assertEquals(url, shareLink.url)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -45,14 +45,11 @@ import com.duckduckgo.app.browser.addToHome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.favicon.FaviconDownloader
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
-import com.duckduckgo.app.global.SingleLiveEvent
-import com.duckduckgo.app.global.baseHost
+import com.duckduckgo.app.global.*
 import com.duckduckgo.app.global.db.AppConfigurationDao
 import com.duckduckgo.app.global.db.AppConfigurationEntity
-import com.duckduckgo.app.global.isMobileSite
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.SiteFactory
-import com.duckduckgo.app.global.toDesktopUri
 import com.duckduckgo.app.privacy.db.NetworkLeaderboardDao
 import com.duckduckgo.app.privacy.db.NetworkLeaderboardEntry
 import com.duckduckgo.app.privacy.db.SiteVisitedEntity
@@ -584,8 +581,26 @@ class BrowserTabViewModel(
 
     fun userSharingLink(url: String?) {
         if (url != null) {
-            command.value = ShareLink(url)
+            command.value = ShareLink(removeAtbAndSourceParamsFromSearch(url))
         }
+    }
+
+    private fun removeAtbAndSourceParamsFromSearch(url: String): String {
+        if (!duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)) {
+            return url
+        }
+
+        val uri = Uri.parse(url)
+        val paramsToRemove = arrayOf(AppUrl.ParamKey.ATB, AppUrl.ParamKey.SOURCE)
+        val parameterNames = uri.queryParameterNames.filterNot { paramsToRemove.contains(it) }
+        val builder = uri.buildUpon()
+        builder.clearQuery()
+
+        for (paramName in parameterNames) {
+            builder.appendQueryParameter(paramName, uri.getQueryParameter(paramName))
+        }
+
+        return builder.build().toString()
     }
 
     fun saveWebViewState(webView: WebView?, tabId: String) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/898065300990903
Tech Design URL: 
CC: 

**Description**:

Remove ATB and source params from search URLs when sharing. 

**Steps to test this PR**:
1. Perform a search and use the browsing menu to share the URL.  Copy it and paste it in to Chrome - should be no ATB or source parameters.
1. Share other non-search links - URLs should be unaffected.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)