### PR TITLE
Fix to allow for IPs with ports and schemes with no intent matches

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -393,7 +393,7 @@ class BrowserTabFragment : Fragment(), FindListener {
                     if (appLinkCommand.appLink.fallbackUrl != null) {
                         webView?.loadUrl(appLinkCommand.appLink.fallbackUrl)
                     } else {
-                        showToast(R.string.unableToOpenLink)
+                        submitQuery("search:${appLinkCommand.appLink.url}")
                     }
                     return
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -41,6 +41,8 @@ import com.duckduckgo.app.browser.BrowserTabViewModel.Command.*
 import com.duckduckgo.app.browser.BrowserWebViewClient.BrowserNavigationOptions
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.IntentType
+import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.SearchQuery
+import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.Web
 import com.duckduckgo.app.browser.addToHome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.favicon.FaviconDownloader
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
@@ -244,10 +246,12 @@ class BrowserTabViewModel(
         val trimmedInput = input.trim()
 
         val type = specialUrlDetector.determineType(trimmedInput)
-        if (type is IntentType) {
-            externalAppLinkClicked(type)
-        } else {
-            url.value = queryUrlConverter.convertQueryToUrl(trimmedInput)
+
+        when (type) {
+            is IntentType -> externalAppLinkClicked(type)
+            is SearchQuery -> url.value = queryUrlConverter.convertQueryToUrl(type.query)
+            is Web -> url.value = queryUrlConverter.convertQueryToUrl(type.webAddress)
+            else -> url.value = queryUrlConverter.convertQueryToUrl(trimmedInput)
         }
 
         globalLayoutState.value = GlobalLayoutViewState(isNewTabState = false)


### PR DESCRIPTION
Task/Issue URL: #347 

**Description**:
This is a proposal to fix certain URLs failing to load after app integration was added.
This works in two ways:
- By adding a new internally handled scheme of "search" which always runs a search. When an intent fails, it will re-submit the query with "search:" appended.
- By checking if the "scheme" is an IP address. This is more of a fault of the simplistic nature of the Android Uri parser which considers anything and everything before : to be a scheme. As such, ports become the path of a scheme of the IP.

**Alternate Approach**:
It may be better to replace the "search:" append with quotes, and update to always perform searches on quoted text. To the user, it would function exactly the same but would free up the scheme for use by the OS or installed apps.

**Steps to test this PR**:
1. Enter intent URLs such as market://details?id=com.duckduckgo.mobile.android
2. Enter IP addresses such as 192.168.0.1:8080
3. Enter things that may appear to be valid URLs but are intended to be searches such as define:duck
4. Enter a standard URL with and without scheme such as http://duckduckgo.com and duckduckgo.com

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
