### PR TITLE
When detecting mobile URLs, also includes "mobile."

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
@@ -108,6 +108,11 @@ class UriExtensionTest {
     }
 
     @Test
+    fun whenUrlStartsMobileDotThenIdentifiedAsMobileSite() {
+        assertTrue(Uri.parse("https://mobile.example.com").isMobileSite)
+    }
+
+    @Test
     fun whenUrlSubdomainEndsWithMThenNotIdentifiedAsMobileSite() {
         assertFalse(Uri.parse("https://adam.example.com").isMobileSite)
     }
@@ -118,8 +123,14 @@ class UriExtensionTest {
     }
 
     @Test
-    fun whenConvertingMobileSiteToDesktopSiteThenMobilePrefixStripped() {
+    fun whenConvertingMobileSiteToDesktopSiteThenShortMobilePrefixStripped() {
         val converted = Uri.parse("https://m.example.com").toDesktopUri()
+        assertEquals("https://example.com", converted.toString())
+    }
+
+    @Test
+    fun whenConvertingMobileSiteToDesktopSiteThenLongMobilePrefixStripped() {
+        val converted = Uri.parse("https://mobile.example.com").toDesktopUri()
         assertEquals("https://example.com", converted.toString())
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
@@ -135,6 +135,12 @@ class UriExtensionTest {
     }
 
     @Test
+    fun whenConvertingMobileSiteToDesktopSiteThenMultipleMobilePrefixesStripped() {
+        val converted = Uri.parse("https://mobile.m.example.com").toDesktopUri()
+        assertEquals("https://example.com", converted.toString())
+    }
+
+    @Test
     fun whenConvertingDesktopSiteToDesktopSiteThenUrlUnchanged() {
         val converted = Uri.parse("https://example.com").toDesktopUri()
         assertEquals("https://example.com", converted.toString())

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -46,27 +46,22 @@ val Uri.hasIpHost: Boolean
         return baseHost?.matches(ipRegex) ?: false
     }
 
-private const val MOBILE_URL_PREFIX_SHORT = "m."
-private const val MOBILE_URL_PREFIX_LONG = "mobile."
+private val MOBILE_URL_PREFIXES = listOf("m.", "mobile.")
 
 val Uri.isMobileSite: Boolean
     get() {
         val auth = authority ?: return false
-        return auth.startsWith(MOBILE_URL_PREFIX_SHORT) || auth.startsWith(MOBILE_URL_PREFIX_LONG)
+        return MOBILE_URL_PREFIXES.firstOrNull { auth.startsWith(it) } != null
     }
 
 fun Uri.toDesktopUri(): Uri {
-    return if (isMobileSite) {
-        val urlString = toString()
-        val newUrl = if (urlString.contains(MOBILE_URL_PREFIX_SHORT)) {
-            urlString.replaceFirst(MOBILE_URL_PREFIX_SHORT, "")
-        } else {
-            urlString.replaceFirst(MOBILE_URL_PREFIX_LONG, "")
-        }
-        return Uri.parse(newUrl)
-    } else {
-        this
+    if (!isMobileSite) return this
+
+    val newUrl = MOBILE_URL_PREFIXES.fold(toString()) { url, prefix ->
+        url.replaceFirst(prefix, "")
     }
+
+    return Uri.parse(newUrl)
 }
 
 private const val faviconBaseUrlFormat = "https://icons.duckduckgo.com/ip3/%s.ico"

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -46,12 +46,24 @@ val Uri.hasIpHost: Boolean
         return baseHost?.matches(ipRegex) ?: false
     }
 
+private const val MOBILE_URL_PREFIX_SHORT = "m."
+private const val MOBILE_URL_PREFIX_LONG = "mobile."
+
 val Uri.isMobileSite: Boolean
-    get() = authority.startsWith("m.")
+    get() {
+        val auth = authority ?: return false
+        return auth.startsWith(MOBILE_URL_PREFIX_SHORT) || auth.startsWith(MOBILE_URL_PREFIX_LONG)
+    }
 
 fun Uri.toDesktopUri(): Uri {
     return if (isMobileSite) {
-        Uri.parse(toString().replaceFirst("m.", ""))
+        val urlString = toString()
+        val newUrl = if (urlString.contains(MOBILE_URL_PREFIX_SHORT)) {
+            urlString.replaceFirst(MOBILE_URL_PREFIX_SHORT, "")
+        } else {
+            urlString.replaceFirst(MOBILE_URL_PREFIX_LONG, "")
+        }
+        return Uri.parse(newUrl)
     } else {
         this
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/608920331025313/945591783985791/945614451233295
Tech Design URL: 
CC: 

**Description**:
Adds "mobile." in as a recognised mobile-specific URL

**Steps to test this PR**:
1. Visit facebook.com - it'll redirect to the mobile site by default
1. Verify "request desktop site" takes you back to the main facebook.com page

Ideally, if you know a site which uses the "mobile." format for mobile pages, test that too. I don't know of one to hand though*

*Twitter does use mobile.twitter.com, but it also forcefully puts us back to that even if request desktop site is requested, so it's not a great test case.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
