### PR TITLE
Delete unused surveys when syncing

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/feedback/api/SurveyDownloaderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/feedback/api/SurveyDownloaderTest.kt
@@ -39,39 +39,39 @@ class SurveyDownloaderTest {
     val schedulers = InstantSchedulersRule()
 
     @Test
-    fun whenNewSurveyAllocatedThenSavedAsScheduledAndOldSurveysCancelled() {
+    fun whenNewSurveyAllocatedThenSavedAsScheduledAndUnusedSurveysDeleted() {
         whenever(mockCall.execute()).thenReturn(Response.success(surveyWithAllocation("abc")))
         whenever(mockService.survey()).thenReturn(mockCall)
         testee.download().blockingAwait()
         verify(mockDao).insert(Survey("abc", SURVEY_URL, 7, SCHEDULED))
-        verify(mockDao).cancelScheduledSurveys()
+        verify(mockDao).deleteUnusedSurveys()
     }
 
     @Test
-    fun whenNewSurveyNotAllocatedThenSavedAsUnallocatedAndOldSurveysCancelled() {
+    fun whenNewSurveyNotAllocatedThenSavedAsUnallocatedAndUnusedSurveysDeleted() {
         whenever(mockCall.execute()).thenReturn(Response.success(surveyNoAllocation("abc")))
         whenever(mockService.survey()).thenReturn(mockCall)
         testee.download().blockingAwait()
         verify(mockDao).insert(Survey("abc", null, null, NOT_ALLOCATED))
-        verify(mockDao).cancelScheduledSurveys()
+        verify(mockDao).deleteUnusedSurveys()
     }
 
     @Test
-    fun whenSurveyAlreadyExistsThenNotSavedAndOldSurveysNotCancelled() {
+    fun whenSurveyAlreadyExistsThenNotSavedAndUnusedSurveysNotDeleted() {
         whenever(mockDao.exists(any())).thenReturn(true)
         whenever(mockCall.execute()).thenReturn(Response.success(surveyWithAllocation("abc")))
         whenever(mockService.survey()).thenReturn(mockCall)
         testee.download().blockingAwait()
         verify(mockDao, never()).insert(any())
-        verify(mockDao, never()).cancelScheduledSurveys()
+        verify(mockDao, never()).deleteUnusedSurveys()
     }
 
     @Test
-    fun whenSuccessfulRequestReturnsNoSurveysThenOldSurveysCancelled() {
+    fun whenSuccessfulRequestReturnsNoSurveysThenUnusedSurveysDeleted() {
         whenever(mockCall.execute()).thenReturn(Response.success(null))
         whenever(mockService.survey()).thenReturn(mockCall)
         testee.download().blockingAwait()
-        verify(mockDao).cancelScheduledSurveys()
+        verify(mockDao).deleteUnusedSurveys()
     }
 
     @Test(expected = RuntimeException::class)

--- a/app/src/androidTest/java/com/duckduckgo/app/feedback/db/SurveyDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/feedback/db/SurveyDaoTest.kt
@@ -56,14 +56,6 @@ class SurveyDaoTest {
     }
 
     @Test
-    fun whenSurveyDeletedThenItDoesNotExist() {
-        val survey = Survey("1", "", null, SCHEDULED)
-        dao.insert(survey)
-        dao.delete(survey)
-        assertFalse(dao.exists("1"))
-    }
-
-    @Test
     fun whenSurveyUpdatedThenRecordIsUpdated() {
         val original = Survey("1", "https://abc.com", null, SCHEDULED)
         val updated = Survey("1", "https://xyz.com", null, CANCELLED)

--- a/app/src/androidTest/java/com/duckduckgo/app/feedback/db/SurveyDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/feedback/db/SurveyDaoTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.feedback.db
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.duckduckgo.app.feedback.model.Survey
+import com.duckduckgo.app.feedback.model.Survey.Status.*
 import com.duckduckgo.app.global.db.AppDatabase
 import org.junit.After
 import org.junit.Assert.*
@@ -48,16 +49,24 @@ class SurveyDaoTest {
 
     @Test
     fun whenSurveyInsertedThenItExists() {
-        val survey = Survey("1", "", null, Survey.Status.SCHEDULED)
+        val survey = Survey("1", "", null, SCHEDULED)
         dao.insert(survey)
         assertTrue(dao.exists("1"))
         assertEquals(survey, dao.get("1"))
     }
 
     @Test
+    fun whenSurveyDeletedThenItDoesNotExist() {
+        val survey = Survey("1", "", null, SCHEDULED)
+        dao.insert(survey)
+        dao.delete(survey)
+        assertFalse(dao.exists("1"))
+    }
+
+    @Test
     fun whenSurveyUpdatedThenRecordIsUpdated() {
-        val original = Survey("1", "https://abc.com", null, Survey.Status.SCHEDULED)
-        val updated = Survey("1", "https://xyz.com", null, Survey.Status.CANCELLED)
+        val original = Survey("1", "https://abc.com", null, SCHEDULED)
+        val updated = Survey("1", "https://xyz.com", null, CANCELLED)
 
         dao.insert(original)
         dao.update(updated)
@@ -73,18 +82,30 @@ class SurveyDaoTest {
 
     @Test
     fun whenScheduledSurveysExistThenGetScheduledContainsThem() {
-        dao.insert(Survey("1", "", null, Survey.Status.SCHEDULED))
-        dao.insert(Survey("2", "", null, Survey.Status.SCHEDULED))
-        dao.insert(Survey("3", "", null, Survey.Status.DONE))
-        dao.insert(Survey("4", "", null, Survey.Status.CANCELLED))
+        dao.insert(Survey("1", "", null, SCHEDULED))
+        dao.insert(Survey("2", "", null, SCHEDULED))
+        dao.insert(Survey("3", "", null, DONE))
+        dao.insert(Survey("4", "", null, CANCELLED))
         assertEquals(2, dao.getScheduled().size)
     }
 
     @Test
-    fun whenScheduledSurveysAreCanceledThenGetScheduledIsEmpty() {
-        dao.insert(Survey("1", "", null, Survey.Status.SCHEDULED))
-        dao.insert(Survey("2", "", null, Survey.Status.SCHEDULED))
+    fun whenScheduledSurveysAreCancelledTheirStatusIsUpdatedAndGetScheduledIsEmpty() {
+        dao.insert(Survey("1", "", null, SCHEDULED))
+        dao.insert(Survey("2", "", null, SCHEDULED))
         dao.cancelScheduledSurveys()
-        assertEquals(0, dao.getScheduled().size)
+        assertEquals(CANCELLED, dao.get("1")?.status)
+        assertEquals(CANCELLED, dao.get("2")?.status)
+        assertTrue(dao.getScheduled().isEmpty())
+    }
+
+    @Test
+    fun whenUnusedSurveysAreDeletedThenTheyNoLongerExistAndGetScheduledIsEmpty() {
+        dao.insert(Survey("1", "", null, SCHEDULED))
+        dao.insert(Survey("2", "", null, NOT_ALLOCATED))
+        dao.deleteUnusedSurveys()
+        assertFalse(dao.exists("1"))
+        assertFalse(dao.exists("2"))
+        assertTrue(dao.getScheduled().isEmpty())
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/feedback/api/SurveyDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/api/SurveyDownloader.kt
@@ -49,8 +49,8 @@ class SurveyDownloader @Inject constructor(
 
             val surveyGroup = response.body()
             if (surveyGroup?.id == null) {
-                Timber.d("No survey received, canceling any old scheduled surveys")
-                surveyDao.cancelScheduledSurveys()
+                Timber.d("No survey received, deleting old unused surveys")
+                surveyDao.deleteUnusedSurveys()
                 return@fromAction
             }
 
@@ -59,8 +59,8 @@ class SurveyDownloader @Inject constructor(
                 return@fromAction
             }
 
-            Timber.d("New survey received replaces any previous scheduled surveys")
-            surveyDao.cancelScheduledSurveys()
+            Timber.d("New survey received. Unused surveys cleared and new survey saved")
+            surveyDao.deleteUnusedSurveys()
             val surveyOption = determineOption(surveyGroup.surveyOptions)
             val newSurvey = when {
                 surveyOption != null -> Survey(surveyGroup.id, surveyOption.url, surveyOption.installationDay, SCHEDULED)

--- a/app/src/main/java/com/duckduckgo/app/feedback/db/SurveyDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/db/SurveyDao.kt
@@ -26,6 +26,9 @@ abstract class SurveyDao {
     @Insert
     abstract fun insert(survey: Survey)
 
+    @Delete
+    abstract fun delete(survey: Survey)
+
     @Update(onConflict = OnConflictStrategy.REPLACE)
     abstract fun update(survey: Survey)
 
@@ -41,11 +44,21 @@ abstract class SurveyDao {
     @Query("""select * from survey where status = "SCHEDULED"""")
     abstract fun getScheduled(): List<Survey>
 
+    @Query("""select * from survey where status = "SCHEDULED" or status = "NOT_ALLOCATED"""")
+    abstract fun getUnused(): List<Survey>
+
     @Transaction
     open fun cancelScheduledSurveys() {
         getScheduled().forEach {
             it.status = Survey.Status.CANCELLED
             update(it)
+        }
+    }
+
+    @Transaction
+    open fun deleteUnusedSurveys() {
+        getUnused().forEach {
+            delete(it)
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/feedback/db/SurveyDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/db/SurveyDao.kt
@@ -26,9 +26,6 @@ abstract class SurveyDao {
     @Insert
     abstract fun insert(survey: Survey)
 
-    @Delete
-    abstract fun delete(survey: Survey)
-
     @Update(onConflict = OnConflictStrategy.REPLACE)
     abstract fun update(survey: Survey)
 
@@ -44,21 +41,14 @@ abstract class SurveyDao {
     @Query("""select * from survey where status = "SCHEDULED"""")
     abstract fun getScheduled(): List<Survey>
 
-    @Query("""select * from survey where status = "SCHEDULED" or status = "NOT_ALLOCATED"""")
-    abstract fun getUnused(): List<Survey>
+    @Query("""delete from survey where status = "SCHEDULED" or status = "NOT_ALLOCATED"""")
+    abstract fun deleteUnusedSurveys()
 
     @Transaction
     open fun cancelScheduledSurveys() {
         getScheduled().forEach {
             it.status = Survey.Status.CANCELLED
             update(it)
-        }
-    }
-
-    @Transaction
-    open fun deleteUnusedSurveys() {
-        getUnused().forEach {
-            delete(it)
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/945831998597279

**Description**:
There are cases when we want to switch a survey off on the backend to make changes and then switch it back on again, however doing so sets the survey to a cancelled status so existing users will never see it (new users will).

When syncing, delete old surveys that the user has not interacted with. This data is irrelevant (we only care about surveys they have dismissed or submitted) and clearing it allows us to reschedule easily.

**Steps to test this PR**:
**TEST 1: Undismissed survey appears again after a sync**
- Install a fresh version of the app
- Using a tool such as Charles intercept the survey request to https://staticcdn.duckduckgo.com/survey/survey-mobile.json and replace with
```
{
  "id": "509c0d52-f4a8-4409-a9b1-d858af42fa01",
  "surveyOptions": [
    {
      "url": "https://www.surveymonkey.com/r/9JTMFGJ",
      "installationDay": 0,
      "ratioOfUsersToShow": 1
    }
  ]
}
```
- Ensure that the survey CTA box appears
- Now run the app again this time responding with an empty response
```
{}
```
- Ensure the CTA is gone
- Run it again with the original payload
```
{
  "id": "509c0d52-f4a8-4409-a9b1-d858af42fa01",
  "surveyOptions": [
    {
      "url": "https://www.surveymonkey.com/r/9JTMFGJ",
      "installationDay": 0,
      "ratioOfUsersToShow": 1
    }
  ]
}
```
- The CTA should appear again

**TEST 2: Dismissed survey does not appears again after a sync**
- Install a fresh version of the app
- Intercept the survey request and replace with
```
{
  "id": "509c0d52-f4a8-4409-a9b1-d858af42fa01",
  "surveyOptions": [
    {
      "url": "https://www.surveymonkey.com/r/9JTMFGJ",
      "installationDay": 0,
      "ratioOfUsersToShow": 1
    }
  ]
}
```
- Ensure that the survey CTA box appears
- Dismiss the survey and note it is gone
- Now run the app again this time responding with an empty response

```
{}
```
- The CTA should still be gone
- Run it again with the original payload
```
{
  "id": "509c0d52-f4a8-4409-a9b1-d858af42fa01",
  "surveyOptions": [
    {
      "url": "https://www.surveymonkey.com/r/9JTMFGJ",
      "installationDay": 0,
      "ratioOfUsersToShow": 1
    }
  ]
}
```
- The CTA should still be gone (the user dismissed it, we don't want to bbombard them!)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
