### PR TITLE
Add pixel for when automatic clear settings dialogs are shown

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -36,12 +36,18 @@ import com.duckduckgo.app.settings.SettingsViewModel.AutomaticallyClearData
 import com.duckduckgo.app.settings.SettingsViewModel.Command
 import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.clear.ClearWhenOption
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 import kotlinx.android.synthetic.main.content_settings_general.*
 import kotlinx.android.synthetic.main.content_settings_other.*
 import kotlinx.android.synthetic.main.content_settings_privacy.*
 import kotlinx.android.synthetic.main.include_toolbar.*
+import javax.inject.Inject
 
 class SettingsActivity : DuckDuckGoActivity(), SettingsAutomaticallyClearWhatFragment.Listener, SettingsAutomaticallyClearWhenFragment.Listener {
+
+    @Inject
+    lateinit var pixel: Pixel
 
     private val viewModel: SettingsViewModel by bindViewModel()
 
@@ -111,11 +117,13 @@ class SettingsActivity : DuckDuckGoActivity(), SettingsAutomaticallyClearWhatFra
     private fun launchAutomaticallyClearWhatDialog() {
         val dialog = SettingsAutomaticallyClearWhatFragment.create(viewModel.viewState.value?.automaticallyClearData?.clearWhatOption)
         dialog.show(supportFragmentManager, CLEAR_WHAT_DIALOG_TAG)
+        pixel.fire(PixelName.AUTOMATIC_CLEAR_DATA_WHAT_SHOWN)
     }
 
     private fun launchAutomaticallyClearWhenDialog() {
         val dialog = SettingsAutomaticallyClearWhenFragment.create(viewModel.viewState.value?.automaticallyClearData?.clearWhenOption)
         dialog.show(supportFragmentManager, CLEAR_WHEN_DIALOG_TAG)
+        pixel.fire(PixelName.AUTOMATIC_CLEAR_DATA_WHEN_SHOWN)
     }
 
     private fun processCommand(it: Command?) {

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -62,10 +62,12 @@ interface Pixel {
         SURVEY_CTA_LAUNCHED_SURVEY(pixelName = "mus_cl"),
         SURVEY_SURVEY_DISMISSED(pixelName = "mus_sd"),
 
+        AUTOMATIC_CLEAR_DATA_WHAT_SHOWN("macwhat_s"),
         AUTOMATIC_CLEAR_DATA_WHAT_OPTION_NONE("macwhat_n"),
         AUTOMATIC_CLEAR_DATA_WHAT_OPTION_TABS("macwhat_t"),
         AUTOMATIC_CLEAR_DATA_WHAT_OPTION_TABS_AND_DATA("macwhat_d"),
 
+        AUTOMATIC_CLEAR_DATA_WHEN_SHOWN("macwhen_s"),
         AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_ONLY("macwhen_x"),
         AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_5_MINS("macwhen_5"),
         AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_15_MINS("macwhen_15"),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/193817002363848/948421103947412
Tech Design URL: 
CC: 

**Description**:
Adds pixels for when the what/when settings dialogs are shown

**Steps to test this PR**:
1. Enable proxy
1. Click on the "Automatically clear..." _what_ option; verify the **macwhat_s** pixel is created
1. Click on the "Clear on..." _when_ option; verify the **macwhen_s** pixel is created


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
