### PR TITLE
Add missing updates to view state

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -98,6 +98,7 @@ class SettingsViewModel @Inject constructor(
     fun onLightThemeToggled(enabled: Boolean) {
         Timber.i("User toggled light theme, is now enabled: $enabled")
         settingsDataStore.theme = if (enabled) DuckDuckGoTheme.LIGHT else DuckDuckGoTheme.DARK
+        viewState.value = currentViewState().copy(lightThemeEnabled = enabled)
         command.value = Command.UpdateTheme
 
         val pixelName = if (enabled) SETTINGS_THEME_TOGGLED_LIGHT else SETTINGS_THEME_TOGGLED_DARK
@@ -107,6 +108,8 @@ class SettingsViewModel @Inject constructor(
     fun onAutocompleteSettingChanged(enabled: Boolean) {
         Timber.i("User changed autocomplete setting, is now enabled: $enabled")
         settingsDataStore.autoCompleteSuggestionsEnabled = enabled
+
+        viewState.value = currentViewState().copy(autoCompleteSuggestionsEnabled = enabled)
     }
 
     private fun obtainVersion(variantKey: String): String {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/193817002363848/948558473017839
Tech Design URL: 
CC: 

**Description**:
The `SettingsViewModel` wasn't correctly updating the `ViewState` to reflect new values of autocomplete and light theme.

This was always the case, but before the changes for automatic data clearing, it wasn't important as the view state was never changed beyond initial creation. Now it does change.

**Steps to test this PR**:
1. Visit settings
1. Change settings for "Automatically clear..."; verify the autocomplete/light theme radio buttons don't change
1. Toggle autocomplete radio button
1. Change settings for "Automatically clear..."; verify the autocomplete/light theme radio buttons don't change
1. Toggle light theme radio button
1. Change settings for "Automatically clear..."; verify the autocomplete/light theme radio buttons don't change


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
