### PR TITLE
Explicitly disables WebSQL.

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -576,6 +576,9 @@ class BrowserTabFragment : Fragment(), FindListener {
                 useWideViewPort = true
                 builtInZoomControls = true
                 displayZoomControls = false
+
+                // explicitly disable database to try protect against Magellan WebSQL/SQLite vulnerability
+                databaseEnabled = false
                 mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                 setSupportZoom(true)
             }


### PR DESCRIPTION
this should be disabled already, as the docs state it is disabled by default. but given the recent Magellan, i figure it's best to be explicit so it doesn't accidentally get enabled in future.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/949984894756229
Tech Design URL: 
CC: 

**Description**:
Explicitly disables WebSQL. This should be the default, but making this explicit (along with the rationale) should help ensure we don't accidentally enable it in future (without careful consideration)

**Steps to test this PR**:
1. Visit https://andrew.hedges.name/html5/sql.html in the app
1. Verify that it reports that `WebSQL` **is not** enabled


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
