### PR TITLE
Feature/automatic data clearing home screen shortcut fix

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/InstantSchedulersRule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/InstantSchedulersRule.kt
@@ -40,6 +40,7 @@ class InstantSchedulersRule : TestRule {
                 RxJavaPlugins.setIoSchedulerHandler { Schedulers.trampoline() }
                 RxJavaPlugins.setComputationSchedulerHandler { Schedulers.trampoline() }
                 RxJavaPlugins.setNewThreadSchedulerHandler { Schedulers.trampoline() }
+                RxJavaPlugins.setSingleSchedulerHandler { Schedulers.trampoline() }
                 RxAndroidPlugins.setMainThreadSchedulerHandler { Schedulers.trampoline() }
 
                 base.evaluate()

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.nhaarman.mockitokotlin2.*
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -117,6 +118,11 @@ class BrowserViewModelTest {
         testee.onClearComplete()
         verify(mockCommandObserver).onChanged(commandCaptor.capture())
         assertEquals(DisplayMessage(R.string.fireDataCleared), commandCaptor.lastValue)
+    }
+
+    @Test
+    fun whenViewStateCreatedThenWebViewContentShouldBeHidden() {
+        assertTrue(testee.viewState.value!!.hideWebContent)
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -39,7 +39,7 @@ class BrowserViewModel(
 ) : ViewModel() {
 
     data class ViewState(
-        val hideWebContent: Boolean = false
+        val hideWebContent: Boolean = true
     )
 
     sealed class Command {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -81,6 +81,7 @@ class BrowserViewModel(
 
     fun onTabsUpdated(tabs: List<TabEntity>?) {
         if (tabs == null || tabs.isEmpty()) {
+            Timber.i("Tabs list is null or empty; adding default tab")
             tabRepository.add(isDefaultTab = true)
             return
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: Home screen shortcuts not launched correctly due to auto clearing
Tech Design URL: 
CC: 

**Description**:
With the introduction of auto clearing data (#405), we likely introduced (or at least exacerbated) a bug whereby sometimes we show a blank tab instead of the user's intended web page. 

This could present itself when launching the app from a home screen shortcut, or perhaps from a bookmark or sharing from another app.

**Problem**
The problem is concurrency-related, whereby we had multiple places a new tab could be created (and selected) and they would run on the `IO` scheduler (therefore, could be run on multiple threads concurrently).

**Solution**
The quickest fix for this is to stop using the `IO` scheduler for these tasks, and make use of a single-thread executor instead.

**Steps to test this PR**:
⚠️ As this is concurrency related, you might find your test device never (or rarely) shows the problem. Or conversely, always (or often) does, thus making testing it is fixed pretty tricky.

1. Enable data clearing option
1. Launch web page, add it to home screen shortcut
1. Navigate to another page
1. Background the app; wait for the allocated amount of time before data is cleared automatically
1. launch the app using the home screen shortcut
1. verify the app shows the intended home screen shortcut web page (and not the blank tab page)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
