### PR TITLE
Fire pixels for data clearing settings only when new value selected

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -117,16 +117,21 @@ class SettingsViewModel @Inject constructor(
         return "${BuildConfig.VERSION_NAME}$formattedVariantKey(${BuildConfig.VERSION_CODE})"
     }
 
-    fun onAutomaticallyWhatOptionSelected(clearWhatSetting: ClearWhatOption) {
-        pixel.fire(clearWhatSetting.pixelEvent())
+    fun onAutomaticallyWhatOptionSelected(clearWhatNewSetting: ClearWhatOption) {
+        if (settingsDataStore.isCurrentlySelected(clearWhatNewSetting)) {
+            Timber.v("User selected same thing they already have set: $clearWhatNewSetting; no need to do anything else")
+            return
+        }
 
-        settingsDataStore.automaticallyClearWhatOption = clearWhatSetting
+        pixel.fire(clearWhatNewSetting.pixelEvent())
+
+        settingsDataStore.automaticallyClearWhatOption = clearWhatNewSetting
 
         viewState.value = currentViewState().copy(
             automaticallyClearData = AutomaticallyClearData(
-                clearWhatOption = clearWhatSetting,
+                clearWhatOption = clearWhatNewSetting,
                 clearWhenOption = settingsDataStore.automaticallyClearWhenOption,
-                clearWhenOptionEnabled = isAutomaticallyClearingDataWhenSettingEnabled(clearWhatSetting)
+                clearWhenOptionEnabled = isAutomaticallyClearingDataWhenSettingEnabled(clearWhatNewSetting)
             )
         )
     }
@@ -135,16 +140,21 @@ class SettingsViewModel @Inject constructor(
         return clearWhatOption != null && clearWhatOption != ClearWhatOption.CLEAR_NONE
     }
 
-    fun onAutomaticallyWhenOptionSelected(clearWhenSetting: ClearWhenOption) {
-        clearWhenSetting.pixelEvent()?.let {
+    fun onAutomaticallyWhenOptionSelected(clearWhenNewSetting: ClearWhenOption) {
+        if (settingsDataStore.isCurrentlySelected(clearWhenNewSetting)) {
+            Timber.v("User selected same thing they already have set: $clearWhenNewSetting; no need to do anything else")
+            return
+        }
+
+        clearWhenNewSetting.pixelEvent()?.let {
             pixel.fire(it)
         }
 
-        settingsDataStore.automaticallyClearWhenOption = clearWhenSetting
+        settingsDataStore.automaticallyClearWhenOption = clearWhenNewSetting
         viewState.value = currentViewState().copy(
             automaticallyClearData = AutomaticallyClearData(
                 settingsDataStore.automaticallyClearWhatOption,
-                clearWhenSetting
+                clearWhenNewSetting
             )
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
@@ -40,6 +40,8 @@ interface SettingsDataStore {
     var automaticallyClearWhenOption: ClearWhenOption
     var appBackgroundedTimestamp: Long
     var lastExecutedJobId: String?
+    fun isCurrentlySelected(clearWhatOption: ClearWhatOption): Boolean
+    fun isCurrentlySelected(clearWhenOption: ClearWhenOption): Boolean
     fun hasBackgroundTimestampRecorded(): Boolean
     fun clearAppBackgroundTimestamp()
 }
@@ -70,17 +72,11 @@ class SettingsSharedPreferences @Inject constructor(private val context: Context
         set(enabled) = preferences.edit(commit = true) { putBoolean(KEY_APP_USED_SINCE_LAST_CLEAR, enabled) }
 
     override var automaticallyClearWhatOption: ClearWhatOption
-        get() {
-            val savedValue = preferences.getString(KEY_AUTOMATICALLY_CLEAR_WHAT_OPTION, null) ?: ClearWhatOption.CLEAR_NONE.name
-            return ClearWhatOption.valueOf(savedValue)
-        }
+        get() = automaticallyClearWhatSavedValue() ?: ClearWhatOption.CLEAR_NONE
         set(value) = preferences.edit { putString(KEY_AUTOMATICALLY_CLEAR_WHAT_OPTION, value.name) }
 
     override var automaticallyClearWhenOption: ClearWhenOption
-        get() {
-            val savedValue = preferences.getString(KEY_AUTOMATICALLY_CLEAR_WHEN_OPTION, null) ?: ClearWhenOption.APP_EXIT_ONLY.name
-            return ClearWhenOption.valueOf(savedValue)
-        }
+        get() = automaticallyClearWhenSavedValue() ?: ClearWhenOption.APP_EXIT_ONLY
         set(value) = preferences.edit { putString(KEY_AUTOMATICALLY_CLEAR_WHEN_OPTION, value.name) }
 
     override var appBackgroundedTimestamp: Long
@@ -90,6 +86,25 @@ class SettingsSharedPreferences @Inject constructor(private val context: Context
     override fun hasBackgroundTimestampRecorded(): Boolean = preferences.contains(KEY_APP_BACKGROUNDED_TIMESTAMP)
     override fun clearAppBackgroundTimestamp() = preferences.edit { remove(KEY_APP_BACKGROUNDED_TIMESTAMP) }
 
+    override fun isCurrentlySelected(clearWhatOption: ClearWhatOption): Boolean {
+        val currentlySelected = automaticallyClearWhatSavedValue() ?: return false
+        return currentlySelected == clearWhatOption
+    }
+
+    override fun isCurrentlySelected(clearWhenOption: ClearWhenOption): Boolean {
+        val currentlySelected = automaticallyClearWhenSavedValue() ?: return false
+        return currentlySelected == clearWhenOption
+    }
+
+    private fun automaticallyClearWhatSavedValue(): ClearWhatOption? {
+        val savedValue = preferences.getString(KEY_AUTOMATICALLY_CLEAR_WHAT_OPTION, null) ?: return null
+        return ClearWhatOption.valueOf(savedValue)
+    }
+
+    private fun automaticallyClearWhenSavedValue(): ClearWhenOption? {
+        val savedValue = preferences.getString(KEY_AUTOMATICALLY_CLEAR_WHEN_OPTION, null) ?: return null
+        return ClearWhenOption.valueOf(savedValue)
+    }
 
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/193817002363848/984805359865213
Tech Design URL: 
CC: 

**Description**:
Previously we fired a pixel every time the user hit SAVE on a dialog for the automatic data clearing settings. 

Now, we only do it if they've actually changed the setting.

**Steps to test this PR**:
From a clean app state:
1. Go to app settings
1. Tap on the "Automatically clear..." setting so that the dialog appears
1. Hit "Save" (with `None` selected)
1. Verify a pixel is sent for this (even though `None` appears as default, it wasn't previously selected by the user)
1. Open the dialog again, and again, choose `None` and hit save button
1. Verify a pixel is NOT sent
1. Change the option again to something else; verify the pixel is sent

Repeat the above for the "Clear on..." settings too


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
