### PR TITLE
Add code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+#These people are listed as being the code owners for this project. As such, they will be automatically added as a reviewer when a PR is created.
+#For more details on how this is configured, see https://help.github.com/articles/about-code-owners/
+
+* @CDRussell @subsymbolic @brindy

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 #These people are listed as being the code owners for this project. As such, they will be automatically added as a reviewer when a PR is created.
 #For more details on how this is configured, see https://help.github.com/articles/about-code-owners/
 
-* @CDRussell @subsymbolic @brindy
+*       @CDRussell @subsymbolic @brindy


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1107339920546026/1108412157345253
Tech Design URL: 
CC: 

**Description**:
Automatically add the relevant people as reviewers when creating a PR. Annoyingly, I don't think this will take effect until the `CODEOWNERS` file is in `develop`; i.e., after this is merged.

**Steps to test this PR**:
1. Wait until this merged to `develop`, then check the _next_ PR after that 🙃 
1. Check the syntax looks correct, according to [the docs](https://help.github.com/articles/about-code-owners/)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
