### PR TITLE
Programmatically disable omnibar scrolling on new tab page

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -63,6 +63,7 @@ import com.duckduckgo.app.browser.downloader.FileDownloader
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import com.duckduckgo.app.browser.filechooser.FileChooserIntentBuilder
 import com.duckduckgo.app.browser.omnibar.KeyboardAwareEditText
+import com.duckduckgo.app.browser.omnibar.OmnibarScrolling
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
 import com.duckduckgo.app.browser.useragent.UserAgentProvider
@@ -129,6 +130,9 @@ class BrowserTabFragment : Fragment(), FindListener {
 
     @Inject
     lateinit var ctaViewModel: CtaViewModel
+
+    @Inject
+    lateinit var omnibarScrolling: OmnibarScrolling
 
     val tabId get() = arguments!![TAB_ID_ARG] as String
 
@@ -943,9 +947,11 @@ class BrowserTabFragment : Fragment(), FindListener {
                 val browserShowing = viewState.browserShowing
                 if (browserShowing) {
                     webView?.show()
+                    omnibarScrolling.enableOmnibarScrolling(toolbarContainer)
                 } else {
                     logoHidingLayoutChangeListener.callToActionView = ctaContainer
                     webView?.hide()
+                    omnibarScrolling.disableOmnibarScrolling(toolbarContainer)
                 }
 
                 toggleDesktopSiteMode(viewState.isDesktopBrowsingMode)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarScrolling.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarScrolling.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.omnibar
+
+import android.view.View
+import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS
+import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
+import javax.inject.Inject
+
+
+class OmnibarScrolling @Inject constructor() {
+
+    fun enableOmnibarScrolling(toolbarContainer: View) {
+        updateScrollFlag(SCROLL_FLAG_SCROLL or SCROLL_FLAG_ENTER_ALWAYS, toolbarContainer)
+    }
+
+    fun disableOmnibarScrolling(toolbarContainer: View) {
+        updateScrollFlag(0, toolbarContainer)
+    }
+
+    private fun updateScrollFlag(flags: Int, toolbarContainer: View) {
+        val params = toolbarContainer.layoutParams as AppBarLayout.LayoutParams
+        params.scrollFlags = flags
+        toolbarContainer.layoutParams = params
+    }
+}

--- a/app/src/main/res/layout/include_omnibar_toolbar.xml
+++ b/app/src/main/res/layout/include_omnibar_toolbar.xml
@@ -32,6 +32,7 @@
         app:layout_scrollFlags="scroll|enterAlways">
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/toolbarContainer"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:layout_scrollFlags="scroll|enterAlways">


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1108456845546451
Tech Design URL: 
CC: 

**Description**:
Prevents the omnibar from scrolling when there is no `WebView` visible.

**Steps to test this PR**:
1. In blank tab view, swipe up on the omnibar; verify it doesn't scroll
1. Perform a search; verify you can now scroll the omnibar again
1. Scroll the search results; verify the omnibar scrolls in and out as expected
1. Return to blank tab view; verify the omnibar is visible and unscrollable



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
