### PR TITLE
Fix for autocomplete suggestions sometimes not showing

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -365,13 +365,13 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenViewModelNotifiedThatUrlGotFocusThenViewStateIsUpdated() {
-        testee.onOmnibarInputStateChanged("", true)
+        testee.onOmnibarInputStateChanged("", true, hasQueryChanged = false)
         assertTrue(omnibarViewState().isEditing)
     }
 
     @Test
     fun whenViewModelNotifiedThatUrlLostFocusThenViewStateIsUpdated() {
-        testee.onOmnibarInputStateChanged("", false)
+        testee.onOmnibarInputStateChanged("", false, hasQueryChanged = false)
         assertFalse(omnibarViewState().isEditing)
     }
 
@@ -468,27 +468,27 @@ class BrowserTabViewModelTest {
     fun whenOmnibarInputDoesNotHaveFocusAndAppConfigDownloadedAndBrowserShownThenPrivacyGradeIsShown() {
         testee.onUserSubmittedQuery("foo")
         testee.appConfigurationObserver.onChanged(AppConfigurationEntity(appConfigurationDownloaded = true))
-        testee.onOmnibarInputStateChanged(query = "", hasFocus = false)
+        testee.onOmnibarInputStateChanged(query = "", hasFocus = false, hasQueryChanged = false)
         assertTrue(browserViewState().showPrivacyGrade)
     }
 
     @Test
     fun whenOmnibarInputDoesNotHaveFocusAndAppConfigDownloadedButBrowserNotShownThenPrivacyGradeIsHidden() {
         testee.appConfigurationObserver.onChanged(AppConfigurationEntity(appConfigurationDownloaded = true))
-        testee.onOmnibarInputStateChanged(query = "", hasFocus = false)
+        testee.onOmnibarInputStateChanged(query = "", hasFocus = false, hasQueryChanged = false)
         assertFalse(browserViewState().showPrivacyGrade)
     }
 
     @Test
     fun whenOmnibarInputDoesNotHaveFocusAndAppConfigNotDownloadedThenPrivacyGradeIsNotShown() {
         testee.appConfigurationObserver.onChanged(AppConfigurationEntity(appConfigurationDownloaded = false))
-        testee.onOmnibarInputStateChanged("", false)
+        testee.onOmnibarInputStateChanged("", false, hasQueryChanged = false)
         assertFalse(browserViewState().showPrivacyGrade)
     }
 
     @Test
     fun whenOmnibarInputHasFocusThenPrivacyGradeIsNotShown() {
-        testee.onOmnibarInputStateChanged("", true)
+        testee.onOmnibarInputStateChanged("", true, hasQueryChanged = false)
         assertFalse(browserViewState().showPrivacyGrade)
     }
 
@@ -499,25 +499,25 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenOmnibarInputDoesNotHaveFocusAndHasQueryThenFireButtonIsShown() {
-        testee.onOmnibarInputStateChanged("query", false)
+        testee.onOmnibarInputStateChanged("query", false, hasQueryChanged = false)
         assertTrue(browserViewState().showFireButton)
     }
 
     @Test
     fun whenOmnibarInputDoesNotHaveFocusOrQueryThenFireButtonIsShown() {
-        testee.onOmnibarInputStateChanged("", false)
+        testee.onOmnibarInputStateChanged("", false, hasQueryChanged = false)
         assertTrue(browserViewState().showFireButton)
     }
 
     @Test
     fun whenOmnibarInputHasFocusAndNoQueryThenFireButtonIsShown() {
-        testee.onOmnibarInputStateChanged("", true)
+        testee.onOmnibarInputStateChanged("", true, hasQueryChanged = false)
         assertTrue(browserViewState().showFireButton)
     }
 
     @Test
     fun whenOmnibarInputHasFocusAndQueryThenFireButtonIsHidden() {
-        testee.onOmnibarInputStateChanged("query", true)
+        testee.onOmnibarInputStateChanged("query", true, hasQueryChanged = false)
         assertFalse(browserViewState().showFireButton)
     }
 
@@ -528,25 +528,25 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenOmnibarInputDoesNotHaveFocusOrQueryThenTabsButtonIsShown() {
-        testee.onOmnibarInputStateChanged("", false)
+        testee.onOmnibarInputStateChanged("", false, hasQueryChanged = false)
         assertTrue(browserViewState().showTabsButton)
     }
 
     @Test
     fun whenOmnibarInputDoesNotHaveFocusAndHasQueryThenTabsButtonIsShown() {
-        testee.onOmnibarInputStateChanged("query", false)
+        testee.onOmnibarInputStateChanged("query", false, hasQueryChanged = false)
         assertTrue(browserViewState().showTabsButton)
     }
 
     @Test
     fun whenOmnibarInputHasFocusAndNoQueryThenTabsButtonIsShown() {
-        testee.onOmnibarInputStateChanged("", true)
+        testee.onOmnibarInputStateChanged("", true, hasQueryChanged = false)
         assertTrue(browserViewState().showTabsButton)
     }
 
     @Test
     fun whenOmnibarInputHasFocusAndQueryThenTabsButtonIsHidden() {
-        testee.onOmnibarInputStateChanged("query", true)
+        testee.onOmnibarInputStateChanged("query", true, hasQueryChanged = false)
         assertFalse(browserViewState().showTabsButton)
     }
 
@@ -557,53 +557,60 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenOmnibarInputDoesNotHaveFocusOrQueryThenMenuButtonIsShown() {
-        testee.onOmnibarInputStateChanged("", false)
+        testee.onOmnibarInputStateChanged("", false, hasQueryChanged = false)
         assertTrue(browserViewState().showMenuButton)
     }
 
     @Test
     fun whenOmnibarInputDoesNotHaveFocusAndHasQueryThenMenuButtonIsShown() {
-        testee.onOmnibarInputStateChanged("query", false)
+        testee.onOmnibarInputStateChanged("query", false, hasQueryChanged = false)
         assertTrue(browserViewState().showMenuButton)
     }
 
     @Test
     fun whenOmnibarInputHasFocusAndNoQueryThenMenuButtonIsShown() {
-        testee.onOmnibarInputStateChanged("", true)
+        testee.onOmnibarInputStateChanged("", true, hasQueryChanged = false)
         assertTrue(browserViewState().showMenuButton)
     }
 
     @Test
     fun whenOmnibarInputHasFocusAndQueryThenMenuButtonIsHidden() {
-        testee.onOmnibarInputStateChanged("query", true)
+        testee.onOmnibarInputStateChanged("query", true, hasQueryChanged = false)
         assertFalse(browserViewState().showMenuButton)
     }
 
     @Test
     fun whenEnteringQueryWithAutoCompleteEnabledThenAutoCompleteSuggestionsShown() {
         doReturn(true).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
-        testee.onOmnibarInputStateChanged("foo", true)
+        testee.onOmnibarInputStateChanged("foo", true, hasQueryChanged = true)
         assertTrue(autoCompleteViewState().showSuggestions)
+    }
+
+    @Test
+    fun whenOmnibarInputStateChangedWithAutoCompleteEnabledButNoQueryChangeThenAutoCompleteSuggestionsNotShown() {
+        doReturn(true).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
+        testee.onOmnibarInputStateChanged("foo", true, hasQueryChanged = false)
+        assertFalse(autoCompleteViewState().showSuggestions)
     }
 
     @Test
     fun whenEnteringQueryWithAutoCompleteDisabledThenAutoCompleteSuggestionsNotShown() {
         doReturn(false).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
-        testee.onOmnibarInputStateChanged("foo", true)
+        testee.onOmnibarInputStateChanged("foo", true, hasQueryChanged = true)
         assertFalse(autoCompleteViewState().showSuggestions)
     }
 
     @Test
     fun whenEnteringEmptyQueryWithAutoCompleteEnabledThenAutoCompleteSuggestionsNotShown() {
         doReturn(true).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
-        testee.onOmnibarInputStateChanged("", true)
+        testee.onOmnibarInputStateChanged("", true, hasQueryChanged = true)
         assertFalse(autoCompleteViewState().showSuggestions)
     }
 
     @Test
     fun whenEnteringEmptyQueryWithAutoCompleteDisabledThenAutoCompleteSuggestionsNotShown() {
         doReturn(false).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
-        testee.onOmnibarInputStateChanged("", true)
+        testee.onOmnibarInputStateChanged("", true, hasQueryChanged = true)
         assertFalse(autoCompleteViewState().showSuggestions)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -175,10 +175,7 @@ class BrowserTabFragment : Fragment(), FindListener {
 
     private val omnibarInputTextWatcher = object : TextChangedWatcher() {
         override fun afterTextChanged(editable: Editable) {
-            viewModel.onOmnibarInputStateChanged(
-                omnibarTextInput.text.toString(),
-                omnibarTextInput.hasFocus()
-            )
+            viewModel.onOmnibarInputStateChanged(omnibarTextInput.text.toString(), omnibarTextInput.hasFocus(), true)
         }
     }
 
@@ -526,7 +523,7 @@ class BrowserTabFragment : Fragment(), FindListener {
     private fun configureOmnibarTextInput() {
         omnibarTextInput.onFocusChangeListener =
                 View.OnFocusChangeListener { _, hasFocus: Boolean ->
-                    viewModel.onOmnibarInputStateChanged(omnibarTextInput.text.toString(), hasFocus)
+                    viewModel.onOmnibarInputStateChanged(omnibarTextInput.text.toString(), hasFocus, false)
                 }
 
         omnibarTextInput.onBackKeyListener = object : KeyboardAwareEditText.OnBackKeyListener {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -214,7 +214,6 @@ class BrowserTabViewModel(
     private fun configureAutoComplete() {
         autoCompletePublishSubject
             .debounce(300, TimeUnit.MILLISECONDS)
-            .distinctUntilChanged()
             .switchMap { autoCompleteApi.autoComplete(it) }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
@@ -428,7 +427,7 @@ class BrowserTabViewModel(
     private fun currentOmnibarViewState(): OmnibarViewState = omnibarViewState.value!!
     private fun currentLoadingViewState(): LoadingViewState = loadingViewState.value!!
 
-    fun onOmnibarInputStateChanged(query: String, hasFocus: Boolean) {
+    fun onOmnibarInputStateChanged(query: String, hasFocus: Boolean, hasQueryChanged: Boolean) {
 
         // determine if empty list to be shown, or existing search results
         val autoCompleteSearchResults = if (query.isBlank()) {
@@ -438,7 +437,6 @@ class BrowserTabViewModel(
         }
 
         val currentOmnibarViewState = currentOmnibarViewState()
-        val hasQueryChanged = (currentOmnibarViewState.omnibarText != query)
         val autoCompleteSuggestionsEnabled = appSettingsPreferencesStore.autoCompleteSuggestionsEnabled
         val showAutoCompleteSuggestions = hasFocus && query.isNotBlank() && hasQueryChanged && autoCompleteSuggestionsEnabled
         val showClearButton = hasFocus && query.isNotBlank()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Fixes https://github.com/duckduckgo/Android/issues/431
Task/Issue URL: https://app.asana.com/0/488551667048375/1108574295820133
Tech Design URL: 
CC: 

**Description**:
In certain conditions, the autocomplete suggestions weren't showing, as reported and discussed in #431 

The fix for this was actually two separate fixes:

1. Improve the check for if the query has changed
1. Remove the optimisation to filter distinct results from the Rx chain

Fix 1 improved the original case described, whereby if you had a single character query, deleted it, and then repeated that query you wouldn't see the suggestions.

Fix 2 improved a related case where if you had a single character query, deleted it and **quickly** typed the same character again, you wouldn't see the suggestions.

**Steps to test this PR**:
1. Type a character; verify suggestions are shown
1. Delete it; verify suggestions are not shown
1. Type same character again; verify suggestions are shown

As above, but make sure steps 2 and 3 and performed rapidly (within 300ms)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
