### PR TITLE
Feature/make app feedback dialogs cancellable

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/rating/db/AppEnjoymentDatabaseRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/rating/db/AppEnjoymentDatabaseRepositoryTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.rating.db
+
+import androidx.room.Room
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.app.global.rating.PromptCount
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@Suppress("RemoveExplicitTypeArguments")
+class AppEnjoymentDatabaseRepositoryTest {
+
+    private lateinit var testee: AppEnjoymentDatabaseRepository
+
+    private lateinit var database: AppDatabase
+    private lateinit var dao: AppEnjoymentDao
+
+
+    @Before
+    fun setup() {
+        database = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+
+        dao = database.appEnjoymentDao()
+        testee = AppEnjoymentDatabaseRepository(dao)
+    }
+
+    @Test
+    fun whenFirstCreatedThenPrompt1CanBeShown() = runBlocking<Unit> {
+        assertTrue(testee.canUserBeShownFirstPrompt())
+    }
+
+    @Test
+    fun whenUserGaveFeedbackForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+        testee.onUserSelectedToGiveFeedback(FIRST_PROMPT)
+        assertFalse(testee.canUserBeShownFirstPrompt())
+    }
+
+    @Test
+    fun whenUserDeclinedToGiveFeedbackForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+        testee.onUserDeclinedToGiveFeedback(FIRST_PROMPT)
+        assertFalse(testee.canUserBeShownFirstPrompt())
+    }
+
+    @Test
+    fun whenUserGaveRatingForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+        testee.onUserSelectedToRateApp(FIRST_PROMPT)
+        assertFalse(testee.canUserBeShownFirstPrompt())
+    }
+
+    @Test
+    fun whenUserDeclinedRatingForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+        testee.onUserDeclinedToRateApp(FIRST_PROMPT)
+        assertFalse(testee.canUserBeShownFirstPrompt())
+    }
+
+    @Test
+    fun whenUserDeclinedToSayWhetherEnjoyingForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+        testee.onUserDeclinedToSayIfEnjoyingApp(FIRST_PROMPT)
+        assertFalse(testee.canUserBeShownFirstPrompt())
+    }
+
+    @Test
+    fun whenUserGaveFeedbackForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+        testee.onUserSelectedToGiveFeedback(SECOND_PROMPT)
+        assertFalse(testee.canUserBeShownSecondPrompt())
+    }
+
+    @Test
+    fun whenUserDeclinedToGiveFeedbackForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+        testee.onUserDeclinedToGiveFeedback(SECOND_PROMPT)
+        assertFalse(testee.canUserBeShownSecondPrompt())
+    }
+
+    @Test
+    fun whenUserGaveRatingForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+        testee.onUserSelectedToRateApp(SECOND_PROMPT)
+        assertFalse(testee.canUserBeShownSecondPrompt())
+    }
+
+    @Test
+    fun whenUserDeclinedRatingForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+        testee.onUserDeclinedToRateApp(SECOND_PROMPT)
+        assertFalse(testee.canUserBeShownSecondPrompt())
+    }
+
+    @Test
+    fun whenUserDeclinedToSayWhetherEnjoyingForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+        testee.onUserDeclinedToSayIfEnjoyingApp(SECOND_PROMPT)
+        assertFalse(testee.canUserBeShownSecondPrompt())
+    }
+
+    companion object {
+        private val FIRST_PROMPT = PromptCount(1)
+        private val SECOND_PROMPT = PromptCount(2)
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/global/rating/InitialPromptDeciderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/rating/InitialPromptDeciderTest.kt
@@ -26,7 +26,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-@Suppress("RemoveExplicitTypeArguments")
+@Suppress("RemoveExplicitTypeArguments", "PrivatePropertyName")
 class InitialPromptDeciderTest {
 
     private lateinit var testee: InitialPromptDecider
@@ -46,42 +46,42 @@ class InitialPromptDeciderTest {
     @Test
     fun whenUserHasNotSeenPromptBeforeAndNotUsedTheAppEnoughThenShouldNotSeePrompt() = runBlocking<Unit> {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(NOT_ENOUGH_DAYS)
-        whenever(mockAppEnjoymentRepository.hasUserPreviouslySeenFirstPrompt()).thenReturn(false)
+        whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(true)
         assertFalse(testee.shouldShowPrompt())
     }
 
     @Test
     fun whenUserHasNotSeenPromptBeforeAndUsedTheAppExactEnoughDaysThenShouldSeePrompt() = runBlocking<Unit> {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(EXACT_NUMBER_OF_DAYS)
-        whenever(mockAppEnjoymentRepository.hasUserPreviouslySeenFirstPrompt()).thenReturn(false)
+        whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(true)
         assertTrue(testee.shouldShowPrompt())
     }
 
     @Test
     fun whenUserHasNotSeenPromptBeforeAndUsedTheAppMoreThanEnoughDaysThenShouldSeePrompt() = runBlocking<Unit> {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(MORE_THAN_ENOUGH_DAYS)
-        whenever(mockAppEnjoymentRepository.hasUserPreviouslySeenFirstPrompt()).thenReturn(false)
+        whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(true)
         assertTrue(testee.shouldShowPrompt())
     }
 
     @Test
     fun whenUserHasSeenPromptBeforeAndNotUsedTheAppEnoughThenShouldNotSeePrompt() = runBlocking<Unit> {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(NOT_ENOUGH_DAYS)
-        whenever(mockAppEnjoymentRepository.hasUserPreviouslySeenFirstPrompt()).thenReturn(true)
+        whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(false)
         assertFalse(testee.shouldShowPrompt())
     }
 
     @Test
     fun whenUserHasSeenPromptBeforeAndUsedTheAppExactEnoughDaysThenShouldNotSeePrompt() = runBlocking<Unit> {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(EXACT_NUMBER_OF_DAYS)
-        whenever(mockAppEnjoymentRepository.hasUserPreviouslySeenFirstPrompt()).thenReturn(true)
+        whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(false)
         assertFalse(testee.shouldShowPrompt())
     }
 
     @Test
     fun whenUserHasSeenPromptBeforeAndUsedTheAppMoreThanEnoughDaysThenShouldNotSeePrompt() = runBlocking<Unit> {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(MORE_THAN_ENOUGH_DAYS)
-        whenever(mockAppEnjoymentRepository.hasUserPreviouslySeenFirstPrompt()).thenReturn(true)
+        whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(false)
         assertFalse(testee.shouldShowPrompt())
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -37,7 +37,6 @@ import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.global.ApplicationClearDataState
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.intentText
-import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity
@@ -51,7 +50,7 @@ import org.jetbrains.anko.longToast
 import timber.log.Timber
 import javax.inject.Inject
 
-class BrowserActivity : DuckDuckGoActivity(), AppEnjoymentDialogFragment.Listener, RateAppDialogFragment.Listener, GiveFeedbackDialogFragment.Listener {
+class BrowserActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var clearPersonalDataAction: ClearPersonalDataAction
@@ -227,9 +226,9 @@ class BrowserActivity : DuckDuckGoActivity(), AppEnjoymentDialogFragment.Listene
             is Refresh -> currentTab?.refresh()
             is Command.DisplayMessage -> applicationContext?.longToast(command.messageId)
             is Command.LaunchPlayStore -> launchPlayStore()
-            is Command.ShowAppEnjoymentPrompt -> showAppEnjoymentPrompt(AppEnjoymentDialogFragment.create(command.promptCount))
-            is Command.ShowAppRatingPrompt -> showAppEnjoymentPrompt(RateAppDialogFragment.create(command.promptCount))
-            is Command.ShowAppFeedbackPrompt -> showAppEnjoymentPrompt(GiveFeedbackDialogFragment.create(command.promptCount))
+            is Command.ShowAppEnjoymentPrompt -> showAppEnjoymentPrompt(AppEnjoymentDialogFragment.create(command.promptCount, viewModel))
+            is Command.ShowAppRatingPrompt -> showAppEnjoymentPrompt(RateAppDialogFragment.create(command.promptCount, viewModel))
+            is Command.ShowAppFeedbackPrompt -> showAppEnjoymentPrompt(GiveFeedbackDialogFragment.create(command.promptCount, viewModel))
             is Command.LaunchFeedbackView -> startActivity(FeedbackActivity.intent(this, brokenSite = false))
         }
     }
@@ -358,30 +357,6 @@ class BrowserActivity : DuckDuckGoActivity(), AppEnjoymentDialogFragment.Listene
         Timber.d("Hiding web view content")
         removeObservers()
         clearingInProgressView.show()
-    }
-
-    override fun onUserSelectedAppIsEnjoyed(promptCount: PromptCount) {
-        viewModel.onUserSelectedAppIsEnjoyed(promptCount)
-    }
-
-    override fun onUserSelectedAppIsNotEnjoyed(promptCount: PromptCount) {
-        viewModel.onUserSelectedAppIsNotEnjoyed(promptCount)
-    }
-
-    override fun onUserSelectedToRateApp(promptCount: PromptCount) {
-        viewModel.onUserSelectedToRateApp(promptCount)
-    }
-
-    override fun onUserDeclinedToRateApp(promptCount: PromptCount) {
-        viewModel.onUserDeclinedToRateApp(promptCount)
-    }
-
-    override fun onUserSelectedToGiveFeedback(promptCount: PromptCount) {
-        viewModel.onUserSelectedToGiveFeedback(promptCount)
-    }
-
-    override fun onUserDeclinedToGiveFeedback(promptCount: PromptCount) {
-        viewModel.onUserDeclinedToGiveFeedback(promptCount)
     }
 
     private fun launchPlayStore() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -24,6 +24,9 @@ import androidx.lifecycle.ViewModel
 import com.duckduckgo.app.browser.BrowserViewModel.Command.DisplayMessage
 import com.duckduckgo.app.browser.BrowserViewModel.Command.Refresh
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
+import com.duckduckgo.app.browser.rating.ui.AppEnjoymentDialogFragment
+import com.duckduckgo.app.browser.rating.ui.GiveFeedbackDialogFragment
+import com.duckduckgo.app.browser.rating.ui.RateAppDialogFragment
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.global.ApplicationClearDataState
 import com.duckduckgo.app.global.SingleLiveEvent
@@ -46,7 +49,11 @@ class BrowserViewModel(
     private val dataClearer: DataClearer,
     private val appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
     private val appEnjoymentUserEventRecorder: AppEnjoymentUserEventRecorder
-) : ViewModel(), CoroutineScope {
+) : AppEnjoymentDialogFragment.Listener,
+    RateAppDialogFragment.Listener,
+    GiveFeedbackDialogFragment.Listener,
+    ViewModel(),
+    CoroutineScope {
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Main
@@ -152,31 +159,44 @@ class BrowserViewModel(
         appEnjoymentPromptEmitter.promptType.removeObserver(appEnjoymentObserver)
     }
 
-    fun onUserSelectedAppIsEnjoyed(promptCount: PromptCount) {
+    override fun onUserSelectedAppIsEnjoyed(promptCount: PromptCount) {
         appEnjoymentUserEventRecorder.onUserEnjoyingApp(promptCount)
     }
 
-    fun onUserSelectedAppIsNotEnjoyed(promptCount: PromptCount) {
+    override fun onUserSelectedAppIsNotEnjoyed(promptCount: PromptCount) {
         appEnjoymentUserEventRecorder.onUserNotEnjoyingApp(promptCount)
     }
 
-    fun onUserSelectedToRateApp(promptCount: PromptCount) {
+    override fun onUserSelectedToRateApp(promptCount: PromptCount) {
         command.value = Command.LaunchPlayStore
 
         launch { appEnjoymentUserEventRecorder.onUserSelectedToRateApp(promptCount) }
     }
 
-    fun onUserDeclinedToRateApp(promptCount: PromptCount) {
+    override fun onUserDeclinedToRateApp(promptCount: PromptCount) {
         launch { appEnjoymentUserEventRecorder.userDeclinedToRateApp(promptCount) }
     }
 
-    fun onUserSelectedToGiveFeedback(promptCount: PromptCount) {
+    override fun onUserSelectedToGiveFeedback(promptCount: PromptCount) {
         command.value = Command.LaunchFeedbackView
 
         launch { appEnjoymentUserEventRecorder.onUserSelectedToGiveFeedback(promptCount) }
     }
 
-    fun onUserDeclinedToGiveFeedback(promptCount: PromptCount) {
+    override fun onUserDeclinedToGiveFeedback(promptCount: PromptCount) {
         launch { appEnjoymentUserEventRecorder.onUserDeclinedToGiveFeedback(promptCount) }
     }
+
+    override fun onUserCancelledAppEnjoymentDialog(promptCount: PromptCount) {
+        launch { appEnjoymentUserEventRecorder.onUserDeclinedToSayIfEnjoyingApp(promptCount)}
+    }
+
+    override fun onUserCancelledRateAppDialog(promptCount: PromptCount) {
+        onUserDeclinedToRateApp(promptCount)
+    }
+
+    override fun onUserCancelledGiveFeedbackDialog(promptCount: PromptCount) {
+        onUserDeclinedToGiveFeedback(promptCount)
+    }
+
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/db/AppEnjoyment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/db/AppEnjoyment.kt
@@ -23,6 +23,7 @@ private const val TYPE_PROVIDED_RATING = 1
 private const val TYPE_DECLINED_RATING = 2
 private const val TYPE_PROVIDED_FEEDBACK = 3
 private const val TYPE_DECLINED_FEEDBACK = 4
+private const val TYPE_DECLINED_TO_PARTICIPATE = 5
 
 @Dao
 interface AppEnjoymentDao {
@@ -42,6 +43,9 @@ interface AppEnjoymentDao {
     @Query("SELECT * from app_enjoyment WHERE eventType = $TYPE_DECLINED_FEEDBACK AND promptCount = :promptCount")
     fun hasUserDeclinedFeedback(promptCount: Int): Boolean
 
+    @Query("SELECT * from app_enjoyment WHERE eventType = $TYPE_DECLINED_TO_PARTICIPATE AND promptCount = :promptCount")
+    fun hasUserDeclinedToSayWhetherEnjoying(promptCount: Int): Boolean
+
     @Query("SELECT timestamp FROM app_enjoyment WHERE eventType=$TYPE_DECLINED_RATING OR eventType=$TYPE_DECLINED_FEEDBACK ORDER BY timestamp DESC LIMIT 1")
     fun latestDateUserDeclinedRatingOrFeedback(): Long?
 
@@ -59,7 +63,8 @@ enum class AppEnjoymentEventType(val value: Int) {
     USER_PROVIDED_RATING(TYPE_PROVIDED_RATING),
     USER_DECLINED_RATING(TYPE_DECLINED_RATING),
     USER_PROVIDED_FEEDBACK(TYPE_PROVIDED_FEEDBACK),
-    USER_DECLINED_FEEDBACK(TYPE_DECLINED_FEEDBACK);
+    USER_DECLINED_FEEDBACK(TYPE_DECLINED_FEEDBACK),
+    USER_DECLINED_TO_SAY_WHETHER_ENJOYING(TYPE_DECLINED_TO_PARTICIPATE);
 
     companion object {
         private val map = AppEnjoymentEventType.values().associateBy(AppEnjoymentEventType::value)

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/db/AppEnjoyment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/db/AppEnjoyment.kt
@@ -46,7 +46,7 @@ interface AppEnjoymentDao {
     @Query("SELECT * from app_enjoyment WHERE eventType = $TYPE_DECLINED_TO_PARTICIPATE AND promptCount = :promptCount")
     fun hasUserDeclinedToSayWhetherEnjoying(promptCount: Int): Boolean
 
-    @Query("SELECT timestamp FROM app_enjoyment WHERE eventType=$TYPE_DECLINED_RATING OR eventType=$TYPE_DECLINED_FEEDBACK ORDER BY timestamp DESC LIMIT 1")
+    @Query("SELECT timestamp FROM app_enjoyment WHERE eventType=$TYPE_DECLINED_RATING OR eventType=$TYPE_DECLINED_FEEDBACK OR eventType=$TYPE_DECLINED_TO_PARTICIPATE ORDER BY timestamp DESC LIMIT 1")
     fun latestDateUserDeclinedRatingOrFeedback(): Long?
 
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/db/AppEnjoymentRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/db/AppEnjoymentRepository.kt
@@ -57,7 +57,7 @@ class AppEnjoymentDatabaseRepository(private val appEnjoymentDao: AppEnjoymentDa
     }
 
     override suspend fun onUserDeclinedToSayIfEnjoyingApp(promptCount: PromptCount) = withContext(singleThreadedDispatcher) {
-        appEnjoymentDao.insertEvent(AppEnjoymentEntity(AppEnjoymentEventType.USER_DECLINED_FEEDBACK, promptCount))
+        appEnjoymentDao.insertEvent(AppEnjoymentEntity(AppEnjoymentEventType.USER_DECLINED_TO_SAY_WHETHER_ENJOYING, promptCount))
     }
 
     override suspend fun canUserBeShownFirstPrompt(): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/AppEnjoymentDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/AppEnjoymentDialogFragment.kt
@@ -29,7 +29,10 @@ class AppEnjoymentDialogFragment : EnjoymentDialog() {
     interface Listener {
         fun onUserSelectedAppIsEnjoyed(promptCount: PromptCount)
         fun onUserSelectedAppIsNotEnjoyed(promptCount: PromptCount)
+        fun onUserCancelledAppEnjoymentDialog(promptCount: PromptCount)
     }
+
+    private lateinit var listener: Listener
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         firePixelWithPromptCount(APP_ENJOYMENT_DIALOG_SHOWN)
@@ -39,24 +42,26 @@ class AppEnjoymentDialogFragment : EnjoymentDialog() {
             .setMessage(R.string.appEnjoymentDialogMessage)
             .setPositiveButton(R.string.appEnjoymentDialogPositiveButton) { _, _ ->
                 firePixelWithPromptCount(APP_ENJOYMENT_DIALOG_USER_ENJOYING)
-                listener?.onUserSelectedAppIsEnjoyed(PromptCount(promptCount))
+                listener.onUserSelectedAppIsEnjoyed(promptCount)
             }
             .setNegativeButton(R.string.appEnjoymentDialogNegativeButton) { _, _ ->
                 firePixelWithPromptCount(APP_ENJOYMENT_DIALOG_USER_NOT_ENJOYING)
-                listener?.onUserSelectedAppIsNotEnjoyed(PromptCount(promptCount))
+                listener.onUserSelectedAppIsNotEnjoyed(promptCount)
             }
+            .setOnKeyListener(BackKeyListener {
+                firePixelWithPromptCount(APP_ENJOYMENT_DIALOG_USER_CANCELLED)
+                listener.onUserCancelledAppEnjoymentDialog(promptCount)
+            })
             .create()
     }
 
-    private val listener: Listener?
-        get() = activity as Listener
-
     companion object {
-        fun create(promptCount: PromptCount): AppEnjoymentDialogFragment {
+        fun create(promptCount: PromptCount, listener: Listener): AppEnjoymentDialogFragment {
             return AppEnjoymentDialogFragment().also { fragment ->
                 val bundle = Bundle()
                 bundle.putInt(PROMPT_COUNT_BUNDLE_KEY, promptCount.value)
                 fragment.arguments = bundle
+                fragment.listener = listener
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/EnjoymentDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/EnjoymentDialog.kt
@@ -17,8 +17,11 @@
 package com.duckduckgo.app.browser.rating.ui
 
 import android.content.Context
+import android.content.DialogInterface
 import android.os.Bundle
+import android.view.KeyEvent
 import androidx.fragment.app.DialogFragment
+import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.statistics.pixels.Pixel
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
@@ -29,8 +32,8 @@ abstract class EnjoymentDialog : DialogFragment() {
     @Inject
     lateinit var pixel: Pixel
 
-    val promptCount: Int
-        get() = arguments!![PROMPT_COUNT_BUNDLE_KEY] as Int
+    val promptCount: PromptCount
+        get() = PromptCount(arguments!![PROMPT_COUNT_BUNDLE_KEY] as Int)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,12 +46,28 @@ abstract class EnjoymentDialog : DialogFragment() {
     }
 
     fun firePixelWithPromptCount(name: Pixel.PixelName) {
-        val formattedPixelName = String.format(name.pixelName, promptCount)
+        val formattedPixelName = String.format(name.pixelName, promptCount.value)
         pixel.fire(formattedPixelName)
     }
 
     companion object {
         const val PROMPT_COUNT_BUNDLE_KEY = "PROMPT_COUNT"
+    }
+
+    inner class BackKeyListener(private val onBackPressed: () -> Unit) : DialogInterface.OnKeyListener {
+
+        override fun onKey(dialog: DialogInterface?, keyCode: Int, event: KeyEvent?): Boolean {
+            if (isBackKey(keyCode, event)) {
+                onBackPressed.invoke()
+                dialog?.dismiss()
+                return true
+            }
+            return false
+        }
+
+        private fun isBackKey(keyCode: Int, event: KeyEvent?): Boolean {
+            return (keyCode == KeyEvent.KEYCODE_BACK && event?.action == KeyEvent.ACTION_UP)
+        }
     }
 
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/GiveFeedbackDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/GiveFeedbackDialogFragment.kt
@@ -29,7 +29,10 @@ class GiveFeedbackDialogFragment : EnjoymentDialog() {
     interface Listener {
         fun onUserSelectedToGiveFeedback(promptCount: PromptCount)
         fun onUserDeclinedToGiveFeedback(promptCount: PromptCount)
+        fun onUserCancelledGiveFeedbackDialog(promptCount: PromptCount)
     }
+
+    private lateinit var listener: Listener
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         firePixelWithPromptCount(APP_FEEDBACK_DIALOG_SHOWN)
@@ -39,24 +42,26 @@ class GiveFeedbackDialogFragment : EnjoymentDialog() {
             .setMessage(R.string.giveFeedbackDialogMessage)
             .setPositiveButton(R.string.giveFeedbackDialogPositiveButton) { _, _ ->
                 firePixelWithPromptCount(APP_FEEDBACK_DIALOG_USER_GAVE_FEEDBACK)
-                listener?.onUserSelectedToGiveFeedback(PromptCount(promptCount))
+                listener.onUserSelectedToGiveFeedback(promptCount)
             }
             .setNegativeButton(R.string.giveFeedbackDialogNegativeButton) { _, _ ->
                 firePixelWithPromptCount(APP_FEEDBACK_DIALOG_USER_DECLINED_FEEDBACK)
-                listener?.onUserDeclinedToGiveFeedback(PromptCount(promptCount))
+                listener.onUserDeclinedToGiveFeedback(promptCount)
             }
+            .setOnKeyListener(BackKeyListener {
+                firePixelWithPromptCount(APP_FEEDBACK_DIALOG_USER_CANCELLED)
+                listener.onUserCancelledGiveFeedbackDialog(promptCount)
+            })
             .create()
     }
 
-    private val listener: Listener?
-        get() = activity as Listener
-
     companion object {
-        fun create(promptCount: PromptCount): GiveFeedbackDialogFragment {
+        fun create(promptCount: PromptCount, listener: Listener): GiveFeedbackDialogFragment {
             return GiveFeedbackDialogFragment().also { fragment ->
                 val bundle = Bundle()
                 bundle.putInt(PROMPT_COUNT_BUNDLE_KEY, promptCount.value)
                 fragment.arguments = bundle
+                fragment.listener = listener
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/RateAppDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/RateAppDialogFragment.kt
@@ -29,7 +29,10 @@ class RateAppDialogFragment : EnjoymentDialog() {
     interface Listener {
         fun onUserSelectedToRateApp(promptCount: PromptCount)
         fun onUserDeclinedToRateApp(promptCount: PromptCount)
+        fun onUserCancelledRateAppDialog(promptCount: PromptCount)
     }
+
+    private lateinit var listener: Listener
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         firePixelWithPromptCount(APP_RATING_DIALOG_SHOWN)
@@ -39,24 +42,26 @@ class RateAppDialogFragment : EnjoymentDialog() {
             .setMessage(R.string.rateAppDialogMessage)
             .setPositiveButton(R.string.rateAppDialogPositiveButton) { _, _ ->
                 firePixelWithPromptCount(APP_RATING_DIALOG_USER_GAVE_RATING)
-                listener?.onUserSelectedToRateApp(PromptCount(promptCount))
+                listener.onUserSelectedToRateApp(promptCount)
             }
             .setNegativeButton(R.string.rateAppDialogNegativeButton) { _, _ ->
                 firePixelWithPromptCount(APP_RATING_DIALOG_USER_DECLINED_RATING)
-                listener?.onUserDeclinedToRateApp(PromptCount(promptCount))
+                listener.onUserDeclinedToRateApp(promptCount)
             }
+            .setOnKeyListener(BackKeyListener {
+                firePixelWithPromptCount(APP_RATING_DIALOG_USER_CANCELLED)
+                listener.onUserCancelledRateAppDialog(promptCount)
+            })
             .create()
     }
 
-    private val listener: Listener?
-        get() = activity as Listener
-
     companion object {
-        fun create(promptCount: PromptCount): RateAppDialogFragment {
+        fun create(promptCount: PromptCount, listener: Listener): RateAppDialogFragment {
             return RateAppDialogFragment().also { fragment ->
                 val bundle = Bundle()
                 bundle.putInt(PROMPT_COUNT_BUNDLE_KEY, promptCount.value)
                 fragment.arguments = bundle
+                fragment.listener = listener
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentUserEventRecorder.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentUserEventRecorder.kt
@@ -28,6 +28,7 @@ interface AppEnjoymentUserEventRecorder {
     suspend fun userDeclinedToRateApp(promptCount: PromptCount)
     suspend fun onUserSelectedToGiveFeedback(promptCount: PromptCount)
     suspend fun onUserDeclinedToGiveFeedback(promptCount: PromptCount)
+    suspend fun onUserDeclinedToSayIfEnjoyingApp(promptCount: PromptCount)
 }
 
 class AppEnjoymentUserEventDatabaseRecorder(
@@ -75,6 +76,14 @@ class AppEnjoymentUserEventDatabaseRecorder(
         appEnjoymentRepository.onUserDeclinedToGiveFeedback(promptCount)
 
         Timber.i("Recorded that user declined to give feedback")
+    }
+
+    override suspend fun onUserDeclinedToSayIfEnjoyingApp(promptCount: PromptCount) {
+        hideAllPrompts()
+
+        appEnjoymentRepository.onUserDeclinedToSayIfEnjoyingApp(promptCount)
+
+        Timber.i("Recorded that user didn't want to participate in app enjoyment")
     }
 
     private fun hideAllPrompts() {

--- a/app/src/main/java/com/duckduckgo/app/global/rating/ShowInitialPromptDecider.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/ShowInitialPromptDecider.kt
@@ -36,7 +36,7 @@ class InitialPromptDecider(
             return false
         }
 
-        if (appEnjoymentRepository.hasUserPreviouslySeenFirstPrompt()) {
+        if (!appEnjoymentRepository.canUserBeShownFirstPrompt()) {
             Timber.i("User has seen first prompt already")
             return false
         }

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -95,14 +95,17 @@ interface Pixel {
         APP_ENJOYMENT_DIALOG_SHOWN("mrp_e_d%d_ds"),
         APP_ENJOYMENT_DIALOG_USER_ENJOYING("mrp_e_d%d_y"),
         APP_ENJOYMENT_DIALOG_USER_NOT_ENJOYING("mrp_e_d%d_n"),
+        APP_ENJOYMENT_DIALOG_USER_CANCELLED("mrp_e_d%d_c"),
 
         APP_RATING_DIALOG_SHOWN("mrp_r_d%d_ds"),
         APP_RATING_DIALOG_USER_GAVE_RATING("mrp_r_d%d_y"),
         APP_RATING_DIALOG_USER_DECLINED_RATING("mrp_r_d%d_n"),
+        APP_RATING_DIALOG_USER_CANCELLED("mrp_r_d%d_c"),
 
         APP_FEEDBACK_DIALOG_SHOWN("mrp_f_d%d_ds"),
         APP_FEEDBACK_DIALOG_USER_GAVE_FEEDBACK("mrp_f_d%d_y"),
         APP_FEEDBACK_DIALOG_USER_DECLINED_FEEDBACK("mrp_f_d%d_n"),
+        APP_FEEDBACK_DIALOG_USER_CANCELLED("mrp_f_d%d_c"),
     }
 
     object PixelParameter {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1110373019284746
Tech Design URL: 
CC: 

**Description**:
Allow dialogs to be cancelled with the back button. We received feedback that the forced answering of the modal dialog was too much so we want to let people cancel out if they want.

Note, they can't be cancelled by tapping around the dialog; only the back button.

### Behaviours

#### App Enjoyment Prompt
Functionally, pressing the back button on the first dialog (app enjoyment) is equivalent to the user having not given a rating or feedback. i.e., we'll ask them again after a few days for one final time.

#### App Rating Prompt
Pressing the back button on the app rating prompt is equivalent to the user tapping the "NO THANKS" button.

#### App Feedback Prompt
Pressing the back button on the app feedback prompt is equivalent to the user tapping the "NO THANKS" button.

**Steps to test this PR**:
ℹ️ I'd recommend setting all constants in `AppEnjoymentPromptCriteria` to `0` for easier testing. If you don't do this, you'll be required to mess with the phone's date and record app usage each day. The following steps assume you've done this for testing.

1. Launch the app; verify the app enjoyment dialog is shown
1. When presented with the first dialog; verify you can't touch outside of the dialog to cancel it
1. Tap the back button; verify the dialog disappears (and this creates a pixel `APP_ENJOYMENT_DIALOG_USER_CANCELLED`)
1. Background the app, and return it to foreground
1. Verify you see the second app enjoyment prompt
1. Hit the back button again; verify it disappears (and again with the pixel, but with `d2` as a value this time)
1. Verify the dialog is never shown again

App Rating Dialog tests
1. Clear app data
1. Repeat steps above for the app rating dialog (expecting `APP_RATING_DIALOG_USER_CANCELLED` pixel)

App Feedback Dialog tests
Another test
1. Clear app data
1. Repeat steps above for the feedback dialog (expecting `APP_FEEDBACK_DIALOG_USER_CANCELLED` pixel)
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
