### PR TITLE
Feature/ensure user settings retained on data clear

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
@@ -19,15 +19,14 @@ package com.duckduckgo.app.browser
 import android.content.Context
 import android.webkit.WebStorage
 import android.webkit.WebView
+import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
-import org.junit.Assert
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @Suppress("RemoveExplicitTypeArguments")
@@ -37,17 +36,15 @@ class WebViewDataManagerTest {
     private val mockStorage: WebStorage = mock()
     private val testee = WebViewDataManager(WebViewSessionInMemoryStorage(), mockCookieManager)
 
+    @UiThreadTest
     @Test
-    fun whenDataClearedThenCacheHistoryAndStorageDataCleared() = runBlocking<Unit> {
+    fun whenDataClearedThenCacheHistoryAndStorageDataCleared() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-
-        withContext(Dispatchers.Main) {
-            val webView = TestWebView(context)
-            testee.clearData(webView, mockStorage, context)
-            Assert.assertTrue(webView.historyCleared)
-            Assert.assertTrue(webView.cacheCleared)
-            verify(mockStorage).deleteAllData()
-        }
+        val webView = TestWebView(context)
+        testee.clearData(webView, mockStorage, context)
+        assertTrue(webView.historyCleared)
+        assertTrue(webView.cacheCleared)
+        verify(mockStorage).deleteAllData()
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
@@ -19,14 +19,15 @@ package com.duckduckgo.app.browser
 import android.content.Context
 import android.webkit.WebStorage
 import android.webkit.WebView
-import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertTrue
+import kotlinx.coroutines.withContext
+import org.junit.Assert
 import org.junit.Test
 
 @Suppress("RemoveExplicitTypeArguments")
@@ -36,15 +37,17 @@ class WebViewDataManagerTest {
     private val mockStorage: WebStorage = mock()
     private val testee = WebViewDataManager(WebViewSessionInMemoryStorage(), mockCookieManager)
 
-    @UiThreadTest
     @Test
-    fun whenDataClearedThenCacheHistoryAndStorageDataCleared() {
+    fun whenDataClearedThenCacheHistoryAndStorageDataCleared() = runBlocking<Unit> {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val webView = TestWebView(context)
-        testee.clearData(webView, mockStorage, context)
-        assertTrue(webView.historyCleared)
-        assertTrue(webView.cacheCleared)
-        verify(mockStorage).deleteAllData()
+
+        withContext(Dispatchers.Main) {
+            val webView = TestWebView(context)
+            testee.clearData(webView, mockStorage, context)
+            Assert.assertTrue(webView.historyCleared)
+            Assert.assertTrue(webView.cacheCleared)
+            verify(mockStorage).deleteAllData()
+        }
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
 
 interface WebDataManager {
     suspend fun clearExternalCookies()
-    suspend fun clearData(webView: WebView, webStorage: WebStorage, context: Context)
+    fun clearData(webView: WebView, webStorage: WebStorage, context: Context)
     fun clearWebViewSessions()
 }
 
@@ -37,7 +37,7 @@ class WebViewDataManager @Inject constructor(
     private val cookieManager: DuckDuckGoCookieManager
 ) : WebDataManager {
 
-    override suspend fun clearData(webView: WebView, webStorage: WebStorage, context: Context) {
+    override fun clearData(webView: WebView, webStorage: WebStorage, context: Context) {
         clearCache(webView)
         clearHistory(webView)
         clearWebStorage(webStorage)

--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -18,19 +18,17 @@ package com.duckduckgo.app.browser
 
 import android.content.Context
 import android.os.Build
-import android.util.Log
 import android.webkit.WebStorage
 import android.webkit.WebView
 import android.webkit.WebViewDatabase
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
 import com.duckduckgo.app.global.performance.measureExecution
-import java.io.File
 import javax.inject.Inject
 
 interface WebDataManager {
     suspend fun clearExternalCookies()
-    fun clearData(webView: WebView, webStorage: WebStorage, context: Context)
+    suspend fun clearData(webView: WebView, webStorage: WebStorage, context: Context)
     fun clearWebViewSessions()
 }
 
@@ -39,7 +37,7 @@ class WebViewDataManager @Inject constructor(
     private val cookieManager: DuckDuckGoCookieManager
 ) : WebDataManager {
 
-    override fun clearData(webView: WebView, webStorage: WebStorage, context: Context) {
+    override suspend fun clearData(webView: WebView, webStorage: WebStorage, context: Context) {
         clearCache(webView)
         clearHistory(webView)
         clearWebStorage(webStorage)
@@ -48,8 +46,6 @@ class WebViewDataManager @Inject constructor(
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             clearFormData(WebViewDatabase.getInstance(context))
         }
-
-        deleteWebViewDirectory(context)
     }
 
     private fun clearCache(webView: WebView) {
@@ -86,19 +82,6 @@ class WebViewDataManager @Inject constructor(
         }
     }
 
-    private fun deleteWebViewDirectory(context: Context) {
-        val webViewDirectory = File(context.applicationInfo.dataDir, WEBVIEW_STORAGE_DIRECTORY)
-        measureExecution("Deleted WebView directory ${webViewDirectory.name}") {
-            webViewDirectory.listFiles()?.forEach { deleteFile(it) }
-        }
-    }
-
-    private fun deleteFile(it: File) {
-        measureExecution("Deleted file: ${it.name}", Log.VERBOSE) {
-           it.deleteRecursively()
-        }
-    }
-
     override suspend fun clearExternalCookies() {
         measureExecution("Cleared cookies") {
             cookieManager.removeExternalCookies()
@@ -109,9 +92,5 @@ class WebViewDataManager @Inject constructor(
         measureExecution("Cleared web view sessions") {
             webViewSessionStorage.deleteAllSessions()
         }
-    }
-
-    companion object {
-        private const val WEBVIEW_STORAGE_DIRECTORY = "app_webview"
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1110354067585282
Tech Design URL: 
CC: 

**Description**:
Note, this is removing the extra clearing introduced in https://app.asana.com/0/0/942179575131652 due it to conflicting with the SERP user preferences.

We should revisit this when we have a better way of storing SERP user preferences (like region toggle, safe search etc..) that doesn't rely on cookies. Once we do that, we can kill all cookies and not have to worry about protecting the preference ones.

For now, though, let's just get the preferences retaining through a 🔥 again.


**Steps to test this PR**:
1. Perform a search
1. From the SERP, change some settings like the region toggle and safe search
1. Visit http://html-kit.com/tools/cookietester/ and set a cookie
1. Perform a data clear using 🔥 button
1. Perform another search; verify your region toggle and safe search settings were retained
1. Revisit http://html-kit.com/tools/cookietester/  and ensure cookies are **not retained**

As above, but use the automatic data clear settings - ensure you choose `Tabs and data` and ensure the DDG preferences are maintained but all other cookies are removed during the data clean



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
