### PR TITLE
Make fire notification available to all

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ExperimentationVariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ExperimentationVariantManagerTest.kt
@@ -38,7 +38,7 @@ class ExperimentationVariantManagerTest {
         // mock randomizer always returns the first active variant
         whenever(mockRandomizer.random(any())).thenReturn(0)
 
-        testee = ExperimentationVariantManager(mockStore, mockWidgetCapabilities, mockRandomizer)
+        testee = ExperimentationVariantManager(mockStore, mockRandomizer)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -25,15 +25,8 @@ class VariantManagerTest {
     private val variants = VariantManager.ACTIVE_VARIANTS
 
     @Test
-    fun serpVariantAConfiguredCorrectly() {
-        val variant = variants.firstOrNull { it.key == "sa" }
-        assertEqualsDouble(1.0, variant!!.weight)
-        assertEquals(0, variant.features.size)
-    }
-
-    @Test
-    fun serpVariantBConfiguredCorrectly() {
-        val variant = variants.firstOrNull { it.key == "sb" }
+    fun sharedControlVariantConfiguredCorrectly() {
+        val variant = variants.firstOrNull { it.key == "sc" }
         assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -55,10 +55,9 @@ class NotificationModule {
     fun providesNotificationScheduler(
         notificationDao: NotificationDao,
         notificationManager: NotificationManagerCompat,
-        settingsDataStore: SettingsDataStore,
-        variantManager: VariantManager
+        settingsDataStore: SettingsDataStore
     ): NotificationScheduler {
-        return NotificationScheduler(notificationDao, notificationManager, settingsDataStore, variantManager)
+        return NotificationScheduler(notificationDao, notificationManager, settingsDataStore)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/di/VariantModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/VariantModule.kt
@@ -20,7 +20,6 @@ import com.duckduckgo.app.statistics.ExperimentationVariantManager
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.WeightedRandomizer
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
-import com.duckduckgo.app.widget.ui.AppWidgetCapabilities
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -31,8 +30,8 @@ class VariantModule {
 
     @Provides
     @Singleton
-    fun variantManager(statisticsDataStore: StatisticsDataStore, widgetCapabilities: AppWidgetCapabilities, weightedRandomizer: WeightedRandomizer): VariantManager =
-        ExperimentationVariantManager(statisticsDataStore, widgetCapabilities, weightedRandomizer)
+    fun variantManager(statisticsDataStore: StatisticsDataStore, weightedRandomizer: WeightedRandomizer): VariantManager =
+        ExperimentationVariantManager(statisticsDataStore, weightedRandomizer)
 
     @Provides
     fun weightedRandomizer() = WeightedRandomizer()

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
@@ -32,9 +32,6 @@ import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.Notification
 import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NotificationDayOne
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NotificationDayThree
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.NOTIFICATIONS_SHOWN
 import kotlinx.coroutines.CoroutineScope
@@ -48,8 +45,7 @@ import javax.inject.Inject
 class NotificationScheduler @Inject constructor(
     val dao: NotificationDao,
     val manager: NotificationManagerCompat,
-    val settingsDataStore: SettingsDataStore,
-    val variantManager: VariantManager
+    val settingsDataStore: SettingsDataStore
 ) {
 
     data class NotificationSpec(
@@ -76,16 +72,7 @@ class NotificationScheduler @Inject constructor(
 
     fun scheduleNextNotification(scope: CoroutineScope = GlobalScope) {
         WorkManager.getInstance().cancelAllWorkByTag(WORK_REQUEST_TAG)
-
-        val duration = when {
-            variantManager.getVariant().hasFeature(NotificationDayOne) -> 1
-            variantManager.getVariant().hasFeature(NotificationDayThree) -> 3
-            else -> {
-                Timber.v("Notifications not enabled for this variant")
-                return
-            }
-        }
-        scheduleClearDataNotification(duration.toLong(), TimeUnit.DAYS, scope)
+        scheduleClearDataNotification(SCHEDULE_AFTER_INACTIVE_DAYS, TimeUnit.DAYS, scope)
     }
 
     private fun scheduleClearDataNotification(duration: Long, unit: TimeUnit, scope: CoroutineScope) {
@@ -145,5 +132,6 @@ class NotificationScheduler @Inject constructor(
 
     companion object {
         const val WORK_REQUEST_TAG = "com.duckduckgo.notification.schedule"
+        const val SCHEDULE_AFTER_INACTIVE_DAYS = 3L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -33,9 +33,9 @@ interface VariantManager {
         val DEFAULT_VARIANT = Variant(key = "", features = emptyList())
 
         val ACTIVE_VARIANTS = listOf(
-            // Shared control. Use this control only if you want the general population
-            // in your experiment. If your experiment is on a subgroup of users e.g a
-            // device API or specific language then create an experiment specific control group
+
+            // Shared control. You can use this as your control unless you are experimenting on
+            // a subgroup e.g a device API or specific language
             Variant(key = "sc", weight = 1.0, features = emptyList())
         )
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1111526030478043
Tech Design URL: N/A

**Description**:
Makes the fire notification available to all

**Steps to test this PR**:
**TEST ONE**
1. Updated the `NotificationScheduler` to scheduleClearDataNotification after seconds not days:
```scheduleClearDataNotification(SCHEDULE_AFTER_INACTIVE_DAYS , TimeUnit.DAYS, scope)```
becomes 
```scheduleClearDataNotification(SCHEDULE_AFTER_INACTIVE_DAYS, TimeUnit.SECONDS, scope)```
1. Freshly install the app
1. Launch and make sure that the notification does not show
1. Wait a few seconds to ensure the notification shows

**TEST TWO**
1. Freshly install the app
1. Run the app
1. Go to settings add an auto clear option
1. Make sure that the notification does not show

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
