### PR TITLE
Fix issue where onUrlChanged is called multiple times

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -78,7 +78,7 @@ class BrowserChromeClientTest {
     @Test
     fun whenOnProgressChangedCalledThenListenerInstructedToUpdateProgress() {
         testee.onProgressChanged(webView, 10)
-        verify(mockWebViewClientListener).progressChanged(10)
+        verify(mockWebViewClientListener).progressChanged(webView.stubUrl, 10)
     }
 
     @UiThreadTest
@@ -87,7 +87,7 @@ class BrowserChromeClientTest {
         webView.stubUrl = "foo.com"
         testee.onProgressChanged(webView, 10)
         testee.onProgressChanged(webView, 20)
-        verify(mockWebViewClientListener, times(2)).progressChanged(any())
+        verify(mockWebViewClientListener, times(2)).progressChanged(any(), any())
     }
 
     @UiThreadTest
@@ -98,27 +98,16 @@ class BrowserChromeClientTest {
         testee.onProgressChanged(webView, 20)
         webView.stubUrl = "bar.com"
         testee.onProgressChanged(webView, 30)
-        verify(mockWebViewClientListener, times(3)).progressChanged(any())
+        verify(mockWebViewClientListener, times(3)).progressChanged(any(), any())
     }
 
     @UiThreadTest
     @Test
-    fun whenOnProgressChangedCalledThenListenerInstructedToUpdateUrl() {
+    fun whenOnProgressChangedCalledThenPassedOnToWebClient() {
         val url = "https://example.com"
         webView.stubUrl = url
         testee.onProgressChanged(webView, 10)
-        verify(mockWebViewClientListener).urlChanged(url)
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenOnProgressChangedCalledAfterUrlChangeThenListenerInstructedToUpdateUrlEveryTime() {
-        webView.stubUrl = "foo.com"
-        testee.onProgressChanged(webView, 10)
-        testee.onProgressChanged(webView, 20)
-        webView.stubUrl = "bar.com"
-        testee.onProgressChanged(webView, 30)
-        verify(mockWebViewClientListener, times(3)).urlChanged(any())
+        verify(mockWebViewClientListener).progressChanged(url, 10)
     }
 
     private class TestWebView(context: Context) : WebView(context) {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -324,14 +324,27 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenLoadingFinishedThenUrUpdated() {
-        val url = "http://example.com/abc"
-        testee.loadingFinished(url)
-        assertEquals(url, testee.url)
+    fun whenLoadingFinishedAndInitialUrlNeverProgressedThenUrlUpdated() {
+        val initialUrl = "http://foo.com/abc"
+        val finalUrl = "http://bar.com/abc"
+        testee.loadingStarted(initialUrl)
+        testee.loadingFinished(finalUrl)
+        assertEquals(finalUrl, testee.url)
+    }
+
+    @Test
+    fun whenLoadingFinishedAndInitialUrlProgressedThenUrlNotUpdated() {
+        val initialUrl = "http://foo.com/abc"
+        val finalUrl = "http://foo.com/xyz"
+        testee.loadingStarted(initialUrl)
+        testee.progressChanged(initialUrl, 10)
+        testee.loadingFinished(finalUrl)
+        assertEquals(initialUrl, testee.url)
     }
 
     @Test
     fun whenLoadingFinishedWithUrlThenSiteVisitedEntryAddedToLeaderboardDao() {
+        testee.loadingStarted("http://example.com/abc")
         testee.loadingFinished("http://example.com/abc")
         verify(mockNetworkLeaderboardDao).insert(SiteVisitedEntity("example.com"))
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import org.junit.Before
 import org.junit.Test
@@ -56,14 +55,7 @@ class BrowserWebViewClientTest {
     @Test
     fun whenOnPageStartedCalledThenListenerNotified() {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
-        verify(listener).loadingStarted()
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenOnPageStartedCalledThenListenerNeverInstructedToUpdateUrl() {
-        testee.onPageStarted(webView, EXAMPLE_URL, null)
-        verify(listener, never()).urlChanged(any())
+        verify(listener).loadingStarted(EXAMPLE_URL)
     }
 
     @UiThreadTest
@@ -78,13 +70,6 @@ class BrowserWebViewClientTest {
     fun whenOnPageFinishedCalledThenListenerInstructedToUpdateNavigationOptions() {
         testee.onPageFinished(webView, EXAMPLE_URL)
         verify(listener).navigationOptionsChanged(any())
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenOnPageFinishedCalledThenListenerInstructedToUpdateUrl() {
-        testee.onPageFinished(webView, EXAMPLE_URL)
-        verify(listener).urlChanged(EXAMPLE_URL)
     }
 
     private class TestWebView(context: Context) : WebView(context)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -52,13 +52,7 @@ class BrowserChromeClient @Inject constructor() : WebChromeClient() {
 
     override fun onProgressChanged(webView: WebView, newProgress: Int) {
         Timber.d("onProgressChanged - $newProgress - ${webView.url}")
-
-        webViewClientListener?.progressChanged(newProgress)
-        val currentUrl = webViewClientListener?.url
-        if (currentUrl != webView.url) {
-            Timber.i("Url has changed from $currentUrl to ${webView.url}")
-            webViewClientListener?.urlChanged(webView.url)
-        }
+        webViewClientListener?.progressChanged(webView.url, newProgress)
     }
 
     override fun onReceivedTitle(view: WebView, title: String) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -54,8 +54,7 @@ class BrowserChromeClient @Inject constructor() : WebChromeClient() {
         Timber.d("onProgressChanged - $newProgress - ${webView.url}")
 
         webViewClientListener?.progressChanged(newProgress)
-
-        val currentUrl = webViewClientListener?.currentUrl()
+        val currentUrl = webViewClientListener?.url
         if (currentUrl != webView.url) {
             Timber.i("Url has changed from $currentUrl to ${webView.url}")
             webViewClientListener?.urlChanged(webView.url)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -289,10 +289,6 @@ class BrowserTabFragment : Fragment(), FindListener {
             it?.let { renderer.renderFindInPageState(it) }
         })
 
-        viewModel.url.observe(this, Observer {
-            it?.let { navigate(it) }
-        })
-
         viewModel.ctaViewState.observe(this, Observer {
             it?.let { renderer.renderCtaViewState(it) }
         })

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -96,9 +96,6 @@ class BrowserTabViewModel(
 
     private val job = SupervisorJob()
 
-    override val url: String?
-        get() = site?.url
-
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Main + job
 
@@ -195,6 +192,11 @@ class BrowserTabViewModel(
         }
     }
 
+    override val url: String?
+        get() = site?.url
+
+    private var nextUrl: String? = null
+
     private var appConfigurationDownloaded = false
     private val appConfigurationObservable = appConfigurationDao.appConfigurationStatus()
     private val autoCompletePublishSubject = PublishRelay.create<String>()
@@ -284,11 +286,15 @@ class BrowserTabViewModel(
         autoCompleteViewState.value = AutoCompleteViewState(false)
     }
 
-    override fun progressChanged(newProgress: Int) {
+    override fun progressChanged(progressedUrl: String?, newProgress: Int) {
         Timber.v("Loading in progress $newProgress")
-
         val progress = currentLoadingViewState()
         loadingViewState.value = progress.copy(progress = newProgress)
+
+        if (nextUrl == progressedUrl) {
+            Timber.i("Url has changed from ${this.url} to $nextUrl")
+            urlChanged(nextUrl)
+        }
     }
 
     override fun goFullScreen(view: View) {
@@ -303,10 +309,11 @@ class BrowserTabViewModel(
         browserViewState.value = currentState.copy(isFullScreen = false)
     }
 
-    override fun loadingStarted() {
+    override fun loadingStarted(url: String?) {
         Timber.v("Loading started")
         val progress = currentLoadingViewState()
         loadingViewState.value = progress.copy(isLoading = true)
+        nextUrl = url
         site = null
         onSiteChanged()
     }
@@ -320,6 +327,10 @@ class BrowserTabViewModel(
 
     override fun loadingFinished(url: String?) {
         Timber.v("Loading finished")
+
+        if (this.url != url) {
+            urlChanged(url)
+        }
 
         val currentOmnibarViewState = currentOmnibarViewState()
         val currentLoadingViewState = currentLoadingViewState()
@@ -359,7 +370,7 @@ class BrowserTabViewModel(
         command.postValue(SendSms(telephoneNumber))
     }
 
-    override fun urlChanged(url: String?) {
+    private fun urlChanged(url: String?) {
         Timber.v("Url changed: $url")
 
         if (url == null) {
@@ -393,6 +404,7 @@ class BrowserTabViewModel(
         if (duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)) {
             statisticsUpdater.refreshRetentionAtb()
         }
+        nextUrl = null
         site = siteFactory.build(url)
         onSiteChanged()
     }
@@ -583,6 +595,7 @@ class BrowserTabViewModel(
     }
 
     fun resetView() {
+        nextUrl = null
         site = null
         onSiteChanged()
         initializeViewStates()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -292,7 +292,6 @@ class BrowserTabViewModel(
         loadingViewState.value = progress.copy(progress = newProgress)
 
         if (nextUrl == progressedUrl) {
-            Timber.i("Url has changed from ${this.url} to $nextUrl")
             urlChanged(nextUrl)
         }
     }
@@ -328,7 +327,7 @@ class BrowserTabViewModel(
     override fun loadingFinished(url: String?) {
         Timber.v("Loading finished")
 
-        if (this.url != url) {
+        if (nextUrl != null) {
             urlChanged(url)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -108,10 +108,10 @@ class BrowserWebViewClient @Inject constructor(
 
     override fun onPageStarted(webView: WebView, url: String?, favicon: Bitmap?) {
         Timber.d("\nonPageStarted {\nurl: $url\nwebView.url: ${webView.url}\n}\n")
-
         currentUrl = url
+
         webViewClientListener?.let {
-            it.loadingStarted()
+            it.loadingStarted(url)
             it.navigationOptionsChanged(determineNavigationOptions(webView))
         }
 
@@ -127,7 +127,6 @@ class BrowserWebViewClient @Inject constructor(
         currentUrl = url
         webViewClientListener?.let {
             it.loadingFinished(url)
-            it.urlChanged(url)
             it.navigationOptionsChanged(determineNavigationOptions(webView))
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -24,7 +24,7 @@ import com.duckduckgo.app.browser.BrowserWebViewClient.BrowserNavigationOptions
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 
 interface WebViewClientListener {
-    fun currentUrl(): String?
+    val url: String?
 
     fun loadingStarted()
     fun loadingFinished(url: String? = null)

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -24,13 +24,12 @@ import com.duckduckgo.app.browser.BrowserWebViewClient.BrowserNavigationOptions
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 
 interface WebViewClientListener {
-    val url: String?
 
-    fun loadingStarted()
+    val url: String?
+    fun loadingStarted(url: String?)
+    fun progressChanged(progressedUrl: String?, newProgress: Int)
     fun loadingFinished(url: String? = null)
-    fun progressChanged(newProgress: Int)
     fun titleReceived(title: String)
-    fun urlChanged(url: String?)
     fun navigationOptionsChanged(navigationOptions: BrowserNavigationOptions)
     fun trackerDetected(event: TrackingEvent)
     fun pageHasHttpResources(page: String?)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
- https://app.asana.com/0/361428290920652/1111382543212308
- https://app.asana.com/0/414730916066338/728296763895517

**Description**:
- Fix issue where urlChanged was being called multiple times
- Remove url live data as we have the current url stored in a number of places and it was causing confusion when debugging this issue

**Steps to test this PR**:
1. Visit cnn.com and note that urlChanged is only called once, it was previously called twice.
1. Perform a search on the SERP and note that urlChanged is only called once
1. Visit https://geekboy.ninja/p0c/spoof-bar.html and ensure that changes made in https://github.com/duckduckgo/Android/pull/390 still apply, namely that gmail url cannot be spoofed.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
