### PR TITLE
Stop allocating new list every time a tight inner loop is called

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/DisconnectClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/DisconnectClient.kt
@@ -24,10 +24,12 @@ class DisconnectClient(override val name: Client.ClientName, private val tracker
 
     override fun matches(url: String, documentUrl: String, resourceType: ResourceType): Boolean {
         return trackers
-            .filter { bannedCategories().contains(it.category) }
+            .filter { bannedCategories.contains(it.category) }
             .any { sameOrSubdomain(url, it.url) }
     }
 
-    private fun bannedCategories(): List<String> = listOf("Analytics", "Advertising", "Social")
+    companion object {
+        private val bannedCategories = listOf("Analytics", "Advertising", "Social")
+    }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1113514142528499
Tech Design URL: 
CC: 

**Description**:
When loading cnn.com, we generate ~160k instances of a `List<String>` where one instance would do.

**Steps to test this PR**:
1. Ensure this doesn't alter the functionality of the `DisconnectClient` to detect trackers


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
