### PR TITLE
Make privacy grade thread safe by using copy over mutating map

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/privacy/model/Grade.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/model/Grade.kt
@@ -33,7 +33,6 @@ class Grade {
         D,
         @Json(name = "D-")
         D_MINUS
-
     }
 
 
@@ -56,8 +55,8 @@ class Grade {
 
     val scores: Grade.Scores get() = calculate()
 
-    private var entitiesNotBlocked: MutableMap<String, Double> = mutableMapOf()
-    private var entitiesBlocked: MutableMap<String, Double> = mutableMapOf()
+    private var entitiesNotBlocked: Map<String, Double> = mapOf()
+    private var entitiesBlocked: Map<String, Double> = mapOf()
 
     private fun calculate(): Grade.Scores {
 
@@ -155,19 +154,17 @@ class Grade {
 
     fun addEntityNotBlocked(entity: String, prevalence: Double?) {
         prevalence ?: return
-        entitiesNotBlocked[entity] = prevalence
+        entitiesNotBlocked = entitiesNotBlocked + Pair(entity, prevalence)
     }
 
     fun addEntityBlocked(entity: String, prevalence: Double?) {
         prevalence ?: return
-        entitiesBlocked[entity] = prevalence
+        entitiesBlocked = entitiesBlocked + Pair(entity, prevalence)
     }
 
     companion object {
-
         const val UNKNOWN_PRIVACY_SCORE = 2
         const val MAX_PRIVACY_SCORE = 10
-
     }
 
 }

--- a/app/src/main/java/com/duckduckgo/app/privacy/model/Grade.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/model/Grade.kt
@@ -154,12 +154,12 @@ class Grade {
 
     fun addEntityNotBlocked(entity: String, prevalence: Double?) {
         prevalence ?: return
-        entitiesNotBlocked = entitiesNotBlocked + Pair(entity, prevalence)
+        entitiesNotBlocked = entitiesNotBlocked.plus(Pair(entity, prevalence))
     }
 
     fun addEntityBlocked(entity: String, prevalence: Double?) {
         prevalence ?: return
-        entitiesBlocked = entitiesBlocked + Pair(entity, prevalence)
+        entitiesBlocked = entitiesBlocked.plus(Pair(entity, prevalence))
     }
 
     companion object {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/361428290920650/1114937051540633/1115009060889228
Tech Design URL: N/A

**Description**:
Remove mutable map (which is not thread safe) from privacy grade calculation to fix ConcurrentModificationException. Note this map generally only holds a small number of items so there is no performance issue with recreating the map when it changes.

**Steps to test this PR**:
1. Run the app and ensure that loading urls still works as expected

Note I couln't generale ConcurrentModificationException naturally however it was clear where this was coming from and I can force it to happen by spawning more threads in the `addEntityBlocked` method and then visiting a site with many trackers such as cnn.com:
```
for(i in 1..100) {
  Schedulers.newThread().scheduleDirect {
       entitiesNotBlocked[entity+i] = prevalence
  }
}
```

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
