### PR TITLE
Fix issue 455

### DIFF
--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -20,6 +20,7 @@
     android:id="@+id/rootView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     app:layout_scrollFlags="scroll|enterAlways">
 
     <include layout="@layout/include_omnibar_toolbar" />

--- a/app/src/main/res/layout/include_omnibar_toolbar.xml
+++ b/app/src/main/res/layout/include_omnibar_toolbar.xml
@@ -27,7 +27,6 @@
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:fitsSystemWindows="true"
         android:theme="@style/AppTheme.Dark.AppBarOverlay"
         app:layout_scrollFlags="scroll|enterAlways">
 


### PR DESCRIPTION
Task/Issue URL:  #455

**Steps to test this PR**:
1. Launch a search query.
2. Scroll up and down such that the navigation bar is hidden and then revealed; verify that the navigation bar does not clip into the action bar.
3. Test other UI elements to make sure nothing else is broken.

Given the intermittent nature of this problem, I cannot say unequivocally that these changes will solve the problem.  What I can say, however, is that on my Pixel XL 9.0 I was always able to reproduce this bug within fifteen seconds, and after the changes I have been thoroughly abusing the app for days and have not seen any trace of this bug.

![1_4](https://user-images.githubusercontent.com/21976019/54659503-6f132e80-4aa8-11e9-94bd-415ef94eb301.gif)





---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
