### PR TITLE
Fix 449 - long pressing on an article link

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser
 
 import android.view.MenuItem
 import android.view.View
+import android.webkit.WebView
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
@@ -34,6 +35,7 @@ import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.DownloadFile
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.OpenInNewTab
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.favicon.FaviconDownloader
+import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.cta.db.DismissedCtaDao
@@ -695,11 +697,12 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenUserSelectsDownloadImageOptionFromContextMenuThenDownloadFileCommandIssued() {
-        whenever(mockLongPressHandler.userSelectedMenuItem(anyString(), any()))
+        whenever(mockLongPressHandler.userSelectedMenuItem(any(), any()))
             .thenReturn(DownloadFile("example.com"))
 
         val mockMenuItem: MenuItem = mock()
-        testee.userSelectedItemFromLongPressMenu("example.com", mockMenuItem)
+        val longPressTarget = LongPressTarget(url = "example.com", type = WebView.HitTestResult.SRC_ANCHOR_TYPE)
+        testee.userSelectedItemFromLongPressMenu(longPressTarget, mockMenuItem)
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertTrue(commandCaptor.lastValue is Command.DownloadImage)
 
@@ -781,7 +784,8 @@ class BrowserTabViewModelTest {
     fun whenUserSelectsOpenTabThenTabCommandSent() {
         whenever(mockLongPressHandler.userSelectedMenuItem(any(), any())).thenReturn(OpenInNewTab("http://example.com"))
         val mockMenItem: MenuItem = mock()
-        testee.userSelectedItemFromLongPressMenu("http://example.com", mockMenItem)
+        val longPressTarget = LongPressTarget(url = "http://example.com", type = WebView.HitTestResult.SRC_ANCHOR_TYPE)
+        testee.userSelectedItemFromLongPressMenu(longPressTarget, mockMenItem)
         val command = captureCommands().value as Command.OpenInNewTab
         assertEquals("http://example.com", command.query)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
@@ -20,6 +20,7 @@ import android.view.ContextMenu
 import android.view.MenuItem
 import android.webkit.WebView.HitTestResult
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.never
@@ -127,14 +128,16 @@ class WebViewLongPressHandlerTest {
     @Test
     fun whenUserSelectedDownloadImageOptionThenActionIsDownloadFileActionRequired() {
         whenever(mockMenuItem.itemId).thenReturn(WebViewLongPressHandler.CONTEXT_MENU_ID_DOWNLOAD_IMAGE)
-        val action = testee.userSelectedMenuItem("example.com", mockMenuItem)
+        val longPressTarget = LongPressTarget(url = "example.com", type = HitTestResult.SRC_ANCHOR_TYPE)
+        val action = testee.userSelectedMenuItem(longPressTarget, mockMenuItem)
         assertTrue(action is LongPressHandler.RequiredAction.DownloadFile)
     }
 
     @Test
     fun whenUserSelectedDownloadImageOptionThenDownloadFileWithCorrectUrlReturned() {
         whenever(mockMenuItem.itemId).thenReturn(WebViewLongPressHandler.CONTEXT_MENU_ID_DOWNLOAD_IMAGE)
-        val action = testee.userSelectedMenuItem("example.com", mockMenuItem) as LongPressHandler.RequiredAction.DownloadFile
+        val longPressTarget = LongPressTarget(url = "example.com", type = HitTestResult.SRC_ANCHOR_TYPE)
+        val action = testee.userSelectedMenuItem(longPressTarget, mockMenuItem) as LongPressHandler.RequiredAction.DownloadFile
         assertEquals("example.com", action.url)
     }
 
@@ -142,7 +145,8 @@ class WebViewLongPressHandlerTest {
     fun whenUserSelectedUnknownOptionThenNoActionRequiredReturned() {
         val unknownMenuId = 123
         whenever(mockMenuItem.itemId).thenReturn(unknownMenuId)
-        val action = testee.userSelectedMenuItem("example.com", mockMenuItem)
+        val longPressTarget = LongPressTarget(url = "example.com", type = HitTestResult.SRC_ANCHOR_TYPE)
+        val action = testee.userSelectedMenuItem(longPressTarget, mockMenuItem)
         assertTrue(action == LongPressHandler.RequiredAction.None)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.IntentType
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.favicon.FaviconDownloader
+import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.cta.ui.CtaConfiguration
@@ -504,12 +505,12 @@ class BrowserTabViewModel(
         autoCompleteViewState.value = AutoCompleteViewState(showSuggestions = false)
     }
 
-    fun userLongPressedInWebView(target: WebView.HitTestResult, menu: ContextMenu) {
-        Timber.i("Long pressed on ${target.type}, (extra=${target.extra})")
-        longPressHandler.handleLongPress(target.type, target.extra, menu)
+    fun userLongPressedInWebView(target: LongPressTarget, menu: ContextMenu, url: String? = null) {
+        Timber.i("Long pressed on ${target.type}, (url=${target.url})")
+        longPressHandler.handleLongPress(target.type, target.url, menu)
     }
 
-    fun userSelectedItemFromLongPressMenu(longPressTarget: String, item: MenuItem): Boolean {
+    fun userSelectedItemFromLongPressMenu(longPressTarget: LongPressTarget, item: MenuItem): Boolean {
 
         val requiredAction = longPressHandler.userSelectedMenuItem(longPressTarget, item)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -505,7 +505,7 @@ class BrowserTabViewModel(
         autoCompleteViewState.value = AutoCompleteViewState(showSuggestions = false)
     }
 
-    fun userLongPressedInWebView(target: LongPressTarget, menu: ContextMenu, url: String? = null) {
+    fun userLongPressedInWebView(target: LongPressTarget, menu: ContextMenu) {
         Timber.i("Long pressed on ${target.type}, (url=${target.url})")
         longPressHandler.handleLongPress(target.type, target.url, menu)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
@@ -23,6 +23,7 @@ import android.webkit.URLUtil
 import android.webkit.WebView
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.*
+import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 import timber.log.Timber
@@ -31,7 +32,7 @@ import javax.inject.Inject
 
 interface LongPressHandler {
     fun handleLongPress(longPressTargetType: Int, longPressTargetUrl: String?, menu: ContextMenu)
-    fun userSelectedMenuItem(longPressTarget: String, item: MenuItem): RequiredAction
+    fun userSelectedMenuItem(longPressTarget: LongPressTarget, item: MenuItem): RequiredAction
 
     sealed class RequiredAction {
         object None : RequiredAction()
@@ -91,27 +92,27 @@ class WebViewLongPressHandler @Inject constructor(private val context: Context, 
 
     private fun isLinkSupported(longPressTargetUrl: String?) = URLUtil.isNetworkUrl(longPressTargetUrl) || URLUtil.isDataUrl(longPressTargetUrl)
 
-    override fun userSelectedMenuItem(longPressTarget: String, item: MenuItem): RequiredAction {
+    override fun userSelectedMenuItem(longPressTarget: LongPressTarget, item: MenuItem): RequiredAction {
         return when (item.itemId) {
             CONTEXT_MENU_ID_OPEN_IN_NEW_TAB -> {
                 pixel.fire(LONG_PRESS_NEW_TAB)
-                return OpenInNewTab(longPressTarget)
+                return OpenInNewTab(longPressTarget.url)
             }
             CONTEXT_MENU_ID_OPEN_IN_NEW_BACKGROUND_TAB -> {
                 pixel.fire(LONG_PRESS_NEW_BACKGROUND_TAB)
-                return OpenInNewBackgroundTab(longPressTarget)
+                return OpenInNewBackgroundTab(longPressTarget.url)
             }
             CONTEXT_MENU_ID_DOWNLOAD_IMAGE -> {
                 pixel.fire(LONG_PRESS_DOWNLOAD_IMAGE)
-                return DownloadFile(longPressTarget)
+                return DownloadFile(longPressTarget.imageUrl ?: longPressTarget.url)
             }
             CONTEXT_MENU_ID_SHARE_LINK -> {
                 pixel.fire(LONG_PRESS_SHARE)
-                return ShareLink(longPressTarget)
+                return ShareLink(longPressTarget.url)
             }
             CONTEXT_MENU_ID_COPY -> {
                 pixel.fire(LONG_PRESS_COPY_URL)
-                return CopyLink(longPressTarget)
+                return CopyLink(longPressTarget.url)
             }
             else -> None
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/model/LongPressTarget.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/model/LongPressTarget.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.model
+
+data class LongPressTarget(val url: String, val type: Int, val imageUrl: String? = null)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: #449 
Tech Design URL: 
CC: 

**Description**:
When long pressing the page, depending on the mark up of the page, the `hitTestResult` can return the URL to an image that is embedded in the anchor tag and not the URL of the anchor tag itself.

The [Le Monde](https://www.lemonde.fr) which was mentioned in the issue (#449), has the following mark up for the article lists:

```
<a href="https://www.lemonde.fr/international/article/2019/03/21/donald-trump-pret-a-reconnaitre-de-la-souverainete-d-israel-sur-le-golan_5439399_3210.html"> 
  <div class="article__media-container">
    <picture class="article__media">
      <source data-srcset="...." media="(min-width: 576px)" srcset="...">
        <img data-src="https://img.lemde.fr/2019/03/13/0/0/3500/2333/576/0/60/0/4250828_FW1_USA-RIGHTS-ISRAEL_0313_1A.JPG" alt="..." class="initial loaded" src="https://img.lemde.fr/2019/03/13/0/0/3500/2333/576/0/60/0/4250828_FW1_USA-RIGHTS-ISRAEL_0313_1A.JPG" data-was-processed="true">
    </picture>
  </div>
  <p class="article__title">Donald Trump se dit prêt à reconnaître la souveraineté d’Israël sur le Golan</p>
  <p class="article__desc">....</p>
</a>

```
(Some markup removed for space)

When the anchor tag is long pressed the `hitTestResult.extra` is the _src_ for the image and not the _url_ of the tag.

In order to obtain the _url_ for the anchor tag the [requestFocusNodeHref](https://developer.android.com/reference/android/webkit/WebView.html#requestFocusNodeHref(android.os.Message)) method needs to be called.

An example of how to obtain the correct value was obtained from [WebKitHitTestTest.java](https://cs.chromium.org/chromium/src/android_webview/javatests/src/org/chromium/android_webview/test/WebKitHitTestTest.java?q=SRC_IMAGE_ANCHOR_TYPE&g=0&l=285). The code for the handler was taken from the test code used to verify the [hit target behaviour](https://cs.chromium.org/chromium/src/android_webview/javatests/src/org/chromium/android_webview/test/WebKitHitTestTest.java?q=SRC_IMAGE_ANCHOR_TYPE&g=0&l=129-136)


**Steps to test this PR**:
1. Navigate to `https://lemonde.fr`
1. Scroll down to see the articles list with images next to them
1. Long press on an article title.
1. Verify that _Open in New Tab_ and _Open in Background Tab_ open the article and not the image
1. Verify that _Download Image_ downloads the image.

![long-press](https://user-images.githubusercontent.com/4399627/54785330-ddc5c880-4c1d-11e9-8716-b66776d959ac.gif)

In order to encapsulate the image src and anchor tag url I created `LongPressTarget` model class and added a new `model` package to the `browse` package. I preferred using this and refactoring the parameter type from Sting to `LongPressTarget` for the functions called when handling a long press as opposed to adding a new parameter for the image src to all the functions.

The `LongPressTarget` data class is small enough that it may no warrant its own file & package, feedback on this is in order to better align with the project norms is welcome.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)