### PR TITLE
347 — Parametrized queries are no longer detected as custom URIs 

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -127,4 +127,16 @@ class SpecialUrlDetectorImplTest {
         val type = testee.determineType("smsto:123-555-12323") as Sms
         assertEquals("123-555-12323", type.telephoneNumber)
     }
+
+    @Test
+    fun whenUrlIsCustomUriSchemeThenIntentTypeDetected() {
+        val type = testee.determineType("myapp:foo bar") as IntentType
+        assertEquals("myapp:foo bar", type.url)
+    }
+
+    @Test
+    fun whenUrlIsParametrizedQueryThenSearchQueryTypeDetected() {
+        val type = testee.determineType("foo site:duckduckgo.com") as SearchQuery
+        assertEquals("foo site:duckduckgo.com", type.query)
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -53,7 +53,7 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
             HTTP_SCHEME, HTTPS_SCHEME -> UrlType.Web(uriString)
             ABOUT_SCHEME -> UrlType.Unknown(uriString)
             null -> UrlType.SearchQuery(uriString)
-            else -> buildIntent(uriString)
+            else -> checkForIntent(uriString)
         }
     }
 
@@ -66,6 +66,15 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
     private fun buildSms(uriString: String) = UrlType.Sms(uriString.removePrefix("$SMS_SCHEME:"))
 
     private fun buildSmsTo(uriString: String) = UrlType.Sms(uriString.removePrefix("$SMSTO_SCHEME:"))
+
+    private fun checkForIntent(uriString: String): UrlType {
+        val validUriSchemeRegex = Regex("[a-z][a-zA-Z\\d+.-]+")
+        if (uriString.matches(validUriSchemeRegex)){
+            return buildIntent(uriString)
+        }
+
+        return UrlType.SearchQuery(uriString)
+    }
 
     private fun buildIntent(uriString: String): UrlType {
         return try {

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -53,7 +53,7 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
             HTTP_SCHEME, HTTPS_SCHEME -> UrlType.Web(uriString)
             ABOUT_SCHEME -> UrlType.Unknown(uriString)
             null -> UrlType.SearchQuery(uriString)
-            else -> checkForIntent(uriString)
+            else -> checkForIntent(scheme, uriString)
         }
     }
 
@@ -67,9 +67,9 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
 
     private fun buildSmsTo(uriString: String) = UrlType.Sms(uriString.removePrefix("$SMSTO_SCHEME:"))
 
-    private fun checkForIntent(uriString: String): UrlType {
+    private fun checkForIntent(scheme: String, uriString: String): UrlType {
         val validUriSchemeRegex = Regex("[a-z][a-zA-Z\\d+.-]+")
-        if (uriString.matches(validUriSchemeRegex)){
+        if (scheme.matches(validUriSchemeRegex)){
             return buildIntent(uriString)
         }
 


### PR DESCRIPTION
Task/Issue URL: [Issue 347](https://github.com/duckduckgo/Android/issues/347)
Tech Design URL: 
CC: 

**Description**:
Added `checkForIntent` method to `SpecialUrlDetector` to check if entered uri is a search query or a request to open another app. 
Added a couple of tests for added functionality.

**Steps to test this PR**:
_Custom search query_: 
1. Type "foo site:duckduckgo.com"
2. It opens search page with said query

_Custom search query_: 
1. Type "myapp:foobar"
2. It looks for an app waiting for such queries  

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
