### PR TITLE
Exti Hotfix/5.21.1

### DIFF
--- a/app/version/version.properties
+++ b/app/version/version.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-VERSION=5.21.0
+VERSION=5.21.1


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1118061167779455

**Description**:
Patches race condition where exti can be called twice on first launch (once when initializing stats and again when sending app retention)

**Steps to test this PR**:
1. Open Charles and throttle the connection to 256 kbps
1. Run a fresh install of the app
1. Note that exti is only called once (same test on develop will call it twice)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
