### PR TITLE
Hotfix to reinstate old notification class

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
@@ -70,7 +70,11 @@ class NotificationScheduler @Inject constructor(
         WorkManager.getInstance().enqueue(request)
     }
 
-    class ClearDataNotificationWorker(context: Context, params: WorkerParameters) : SchedulableNotificationWorker(context, params)
+    // Legacy code. Unused class required for users who already have this notification scheduled from previous version. We can delete this in a
+    // couple of weeks once old notifications have cleared. We should also remove "open" access from ClearDataNotificationWorker.
+    class ShowClearDataNotification(context: Context, params: WorkerParameters): ClearDataNotificationWorker(context, params)
+
+    open class ClearDataNotificationWorker(context: Context, params: WorkerParameters) : SchedulableNotificationWorker(context, params)
     class PrivacyNotificationWorker(context: Context, params: WorkerParameters) : SchedulableNotificationWorker(context, params)
 
     open class SchedulableNotificationWorker(val context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {

--- a/app/version/release-notes
+++ b/app/version/release-notes
@@ -1,5 +1,5 @@
 ## What's new in this release?
-In this release, we tweaked our favicon service and added HTTP basic authentication to let you logon to websites that use this.
+In this release, we tweaked our favicon service, added HTTP basic authentication to let you logon to websites that use this and made some stability enhancements.
 
 ## Have feedback?
 You can always reach us at https://duckduckgo.com/feedback.

--- a/app/version/version.properties
+++ b/app/version/version.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-VERSION=5.21.1
+VERSION=5.21.2


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1118493496977133

**Description**:
Hotfix to reinstate old notification class, fixes java.lang.ClassNotFoundException.

@CDRussell I'm releasing this as an asap hotfix so I'm sending it to you for retrospective review. No rush to review though, it can wait until your return.

**Steps to test this PR**:
1. Run version 5.20.0 of the app, setting notification in NotificationScheduler time to 1 minute
1. Install (but do not run!) this version over the top
1. Wait a minute, notification should show. Same test with 5.21.1 leads to a background crash.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
