### PR TITLE
Improve android back navigation

### DIFF
--- a/app/schemas/com.duckduckgo.app.global.db.AppDatabase/12.json
+++ b/app/schemas/com.duckduckgo.app.global.db.AppDatabase/12.json
@@ -1,0 +1,541 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "8d414cd582c69593832208fcdb860fd7",
+    "entities": [
+      {
+        "tableName": "disconnect_tracker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `category` TEXT NOT NULL, `networkName` TEXT NOT NULL, `networkUrl` TEXT NOT NULL, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkName",
+            "columnName": "networkName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkUrl",
+            "columnName": "networkUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "url"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "https_bloom_filter_spec",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `errorRate` REAL NOT NULL, `totalEntries` INTEGER NOT NULL, `sha256` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorRate",
+            "columnName": "errorRate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalEntries",
+            "columnName": "totalEntries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "https_whitelisted_domain",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "network_leaderboard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkName` TEXT NOT NULL, `domainVisited` TEXT NOT NULL, PRIMARY KEY(`networkName`, `domainVisited`))",
+        "fields": [
+          {
+            "fieldPath": "networkName",
+            "columnName": "networkName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainVisited",
+            "columnName": "domainVisited",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "networkName",
+            "domainVisited"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "site_visited",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "app_configuration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `appConfigurationDownloaded` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appConfigurationDownloaded",
+            "columnName": "appConfigurationDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tabs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tabId` TEXT NOT NULL, `url` TEXT, `title` TEXT, `skipHome` INTEGER NOT NULL, `viewed` INTEGER NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`tabId`))",
+        "fields": [
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "skipHome",
+            "columnName": "skipHome",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewed",
+            "columnName": "viewed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "tabId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_tabs_tabId",
+            "unique": false,
+            "columnNames": [
+              "tabId"
+            ],
+            "createSql": "CREATE  INDEX `index_tabs_tabId` ON `${TABLE_NAME}` (`tabId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tab_selection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `tabId` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`tabId`) REFERENCES `tabs`(`tabId`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_tab_selection_tabId",
+            "unique": false,
+            "columnNames": [
+              "tabId"
+            ],
+            "createSql": "CREATE  INDEX `index_tab_selection_tabId` ON `${TABLE_NAME}` (`tabId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tabs",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tabId"
+            ],
+            "referencedColumns": [
+              "tabId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "entity_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domainName` TEXT NOT NULL, `entityName` TEXT NOT NULL, PRIMARY KEY(`domainName`))",
+        "fields": [
+          {
+            "fieldPath": "domainName",
+            "columnName": "domainName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityName",
+            "columnName": "entityName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domainName"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "survey",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surveyId` TEXT NOT NULL, `url` TEXT, `daysInstalled` INTEGER, `status` TEXT NOT NULL, PRIMARY KEY(`surveyId`))",
+        "fields": [
+          {
+            "fieldPath": "surveyId",
+            "columnName": "surveyId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "daysInstalled",
+            "columnName": "daysInstalled",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "surveyId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "dismissed_cta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ctaId` TEXT NOT NULL, PRIMARY KEY(`ctaId`))",
+        "fields": [
+          {
+            "fieldPath": "ctaId",
+            "columnName": "ctaId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "ctaId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "search_count",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "app_days_used",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "date"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "app_enjoyment",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventType` INTEGER NOT NULL, `promptCount` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `primaryKey` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptCount",
+            "columnName": "promptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryKey",
+            "columnName": "primaryKey",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "primaryKey"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "notification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`notificationId` TEXT NOT NULL, PRIMARY KEY(`notificationId`))",
+        "fields": [
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notificationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "notificationId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "privacy_protection_count",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `blocked_tracker_count` INTEGER NOT NULL, `upgrade_count` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockedTrackerCount",
+            "columnName": "blocked_tracker_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "upgradeCount",
+            "columnName": "upgrade_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"8d414cd582c69593832208fcdb860fd7\")"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -250,6 +250,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenViewBecomesVisibleWithActiveSiteThenKeyboardHidden() {
+        isBrowsing(true)
         changeUrl("http://exmaple.com")
         testee.onViewVisible()
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
@@ -271,13 +272,22 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUrlPresentThenAddBookmarkButtonEnabled() {
+    fun whenBrowsingAndUrlPresentThenAddBookmarkButtonEnabled() {
+        isBrowsing(true)
         changeUrl("www.example.com")
         assertTrue(browserViewState().canAddBookmarks)
     }
 
     @Test
+    fun whenNotBrowsingAndUrlPresentThenAddBookmarkButtonDisabled() {
+        isBrowsing(false)
+        changeUrl("www.example.com")
+        assertFalse(browserViewState().canAddBookmarks)
+    }
+
+    @Test
     fun whenNoUrlThenAddBookmarkButtonDisabled() {
+        isBrowsing(true)
         changeUrl(null)
         assertFalse(browserViewState().canAddBookmarks)
     }
@@ -318,6 +328,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenViewModelNotifiedThatWebViewIsLoadingThenViewStateIsUpdated() {
+        isBrowsing(true)
         testee.loadingStarted("http://example.com")
         assertTrue(loadingViewState().isLoading)
     }
@@ -332,6 +343,7 @@ class BrowserTabViewModelTest {
     fun whenLoadingFinishedAndInitialUrlNeverProgressedThenUrlUpdated() {
         val initialUrl = "http://foo.com/abc"
         val finalUrl = "http://bar.com/abc"
+        isBrowsing(true)
         testee.loadingStarted(initialUrl)
         testee.loadingFinished(finalUrl)
         assertEquals(finalUrl, testee.url)
@@ -341,6 +353,7 @@ class BrowserTabViewModelTest {
     fun whenLoadingFinishedAndInitialUrlProgressedThenUrlNotUpdated() {
         val initialUrl = "http://foo.com/abc"
         val finalUrl = "http://foo.com/xyz"
+        isBrowsing(true)
         testee.loadingStarted(initialUrl)
         testee.progressChanged(initialUrl, 10)
         testee.loadingFinished(finalUrl)
@@ -349,6 +362,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenLoadingFinishedWithUrlThenSiteVisitedEntryAddedToLeaderboardDao() {
+        isBrowsing(true)
         testee.loadingStarted("http://example.com/abc")
         testee.loadingFinished("http://example.com/abc")
         verify(mockNetworkLeaderboardDao).insert(SiteVisitedEntity("example.com"))
@@ -357,6 +371,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenLoadingFinishedWithUrlThenOmnibarTextUpdatedToMatch() {
         val exampleUrl = "http://example.com/abc"
+        isBrowsing(true)
         testee.loadingFinished(exampleUrl)
         assertEquals(exampleUrl, omnibarViewState().omnibarText)
     }
@@ -364,6 +379,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenLoadingFinishedWithQueryUrlThenOmnibarTextUpdatedToShowQuery() {
         val queryUrl = "http://duckduckgo.com?q=test"
+        isBrowsing(true)
         testee.loadingFinished(queryUrl)
         assertEquals("test", omnibarViewState().omnibarText)
     }
@@ -371,6 +387,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenLoadingFinishedWithNoUrlThenOmnibarTextUpdatedToMatch() {
         val exampleUrl = "http://example.com/abc"
+        isBrowsing(true)
         changeUrl(exampleUrl)
         testee.loadingFinished(null)
         assertEquals(exampleUrl, omnibarViewState().omnibarText)
@@ -408,6 +425,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenUrlStartsLoadingWithProgressChangeThenUrlUpdated() {
         val url = "foo.com"
+        isBrowsing(true)
         testee.loadingStarted(url)
         testee.progressChanged(url, 10)
         assertEquals(url, testee.url)
@@ -426,37 +444,51 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUrlChangedThenViewStateIsUpdated() {
+    fun whenBrowsingAndUrlChangedThenViewStateIsUpdated() {
+        isBrowsing(true)
         changeUrl("duckduckgo.com")
         assertEquals("duckduckgo.com", omnibarViewState().omnibarText)
     }
 
     @Test
+    fun whenNotBrowsingAndUrlChangedThenUrlIsNotUpdated() {
+        isBrowsing(false)
+        changeUrl("duckduckgo.com")
+        assertEquals("", omnibarViewState().omnibarText)
+    }
+
+    @Test
     fun whenUrlChangedWithDuckDuckGoUrlContainingQueryThenUrlRewrittenToContainQuery() {
+        isBrowsing(true)
         changeUrl("http://duckduckgo.com?q=test")
         assertEquals("test", omnibarViewState().omnibarText)
     }
 
     @Test
     fun whenUrlChangedWithDuckDuckGoUrlContainingQueryThenAtbRefreshed() {
+        isBrowsing(true)
         changeUrl("http://duckduckgo.com?q=test")
         verify(mockStatisticsUpdater).refreshSearchRetentionAtb()
     }
 
     @Test
     fun whenUrlChangedWithDuckDuckGoUrlNotContainingQueryThenFullUrlShown() {
+        isBrowsing(true)
         changeUrl("http://duckduckgo.com")
         assertEquals("http://duckduckgo.com", omnibarViewState().omnibarText)
     }
 
     @Test
     fun whenUrlChangedWithNonDuckDuckGoUrlThenFullUrlShown() {
+        isBrowsing(true)
         changeUrl("http://example.com")
         assertEquals("http://example.com", omnibarViewState().omnibarText)
     }
 
     @Test
-    fun whenViewModelGetsProgressUpdateThenViewStateIsUpdated() {
+    fun whenBrowserShowingAndViewModelGetsProgressUpdateThenViewStateIsUpdated() {
+        isBrowsing(true)
+
         testee.progressChanged("", 0)
         assertEquals(0, loadingViewState().progress)
 
@@ -476,6 +508,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenUrlChangedThenPrivacyGradeIsReset() {
         val grade = testee.privacyGrade.value
+        isBrowsing(true)
         changeUrl("https://example.com")
         assertNotEquals(grade, testee.privacyGrade.value)
     }
@@ -483,6 +516,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenEnoughTrackersDetectedThenPrivacyGradeIsUpdated() {
         val grade = testee.privacyGrade.value
+        isBrowsing(true)
         changeUrl("https://example.com")
         for (i in 1..10) {
             testee.trackerDetected(TrackingEvent("https://example.com", "", null, false))
@@ -498,6 +532,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenUrlUpdatedAfterConfigDownloadThenPrivacyGradeIsShown() {
         testee.appConfigurationObserver.onChanged(AppConfigurationEntity(appConfigurationDownloaded = true))
+        isBrowsing(true)
         changeUrl("")
         assertTrue(browserViewState().showPrivacyGrade)
     }
@@ -802,6 +837,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenOnSiteAndBrokenSiteSelectedThenBrokenSiteFeedbackCommandSentWithUrl() {
+        isBrowsing(true)
         changeUrl("foo.com")
         testee.onBrokenSiteSelected()
         val command = captureCommands().value as Command.BrokenSiteFeedback
@@ -883,6 +919,10 @@ class BrowserTabViewModelTest {
         testee.handleAuthentication(request = authenticationRequest, credentials = credentials)
 
         verify(mockHandler, atLeastOnce()).proceed(username, password)
+    }
+
+    private fun isBrowsing(isBrowsing: Boolean) {
+        testee.browserViewState.value = browserViewState().copy(browserShowing = isBrowsing)
     }
 
     private fun changeUrl(url: String?) {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -257,6 +257,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenViewBecomesVisibleWithoutActiveSiteThenKeyboardShown() {
+        changeUrl(null)
         testee.onViewVisible()
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertTrue(commandCaptor.allValues.contains(Command.ShowKeyboard))
@@ -530,7 +531,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenBrowserShowingAndViewModelGetsProgressUpdateThenViewStateIsUpdated() {
+    fun whenBrowsingAndViewModelGetsProgressUpdateThenViewStateIsUpdated() {
         isBrowsing(true)
 
         testee.progressChanged("", 0)
@@ -541,6 +542,14 @@ class BrowserTabViewModelTest {
 
         testee.progressChanged("", 100)
         assertEquals(100, loadingViewState().progress)
+    }
+
+
+    @Test
+    fun whenNotBrowserAndViewModelGetsProgressUpdateThenViewStateIsNotUpdated() {
+        isBrowsing(false)
+        testee.progressChanged("", 10)
+        assertEquals(0, loadingViewState().progress)
     }
 
     @Test
@@ -854,7 +863,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenHomeShowingThenBackButtonInactiveIrrespectiveOfWhetherBrowserCanGoBack() {
+    fun whenHomeShowingThenBackButtonInactiveEvenIfBrowserCanGoBack() {
         setupNavigation(isBrowsing = false, canGoBack = false)
         assertFalse(browserViewState().canGoBack)
 
@@ -896,11 +905,9 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserBrowsingPressesBackAndBrowserCanGoBackThenNavigatesBackStepsToPreviousPageAndHandledTrue() {
+    fun whenUserBrowsingPressesBackAndBrowserCanGoBackThenNavigatesToPreviousPageAndHandledTrue() {
         setupNavigation(isBrowsing = true, canGoBack = true, stepsToPreviousPage = 2)
-
-        val handled = testee.onUserPressedBack()
-        assertTrue(handled)
+        assertTrue(testee.onUserPressedBack())
 
         val backCommand = captureCommands().lastValue as Command.NavigateBack
         assertNotNull(backCommand)
@@ -910,9 +917,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenUserBrowsingPressesBackAndBrowserCannotGoBackAndHomeNotSkippedThenHomeShownAndHandledTrue() {
         setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
-
-        val handled = testee.onUserPressedBack()
-        assertTrue(handled)
+        assertTrue(testee.onUserPressedBack())
         assertFalse(browserViewState().browserShowing)
         assertEquals("", omnibarViewState().omnibarText)
     }
@@ -920,16 +925,13 @@ class BrowserTabViewModelTest {
     @Test
     fun whenUserBrowsingPressesBackAndBrowserCannotGoBackAndHomeIsSkippedThenHandledFalse() {
         setupNavigation(skipHome = true, isBrowsing = false, canGoBack = false)
-
-        val handled = testee.onUserPressedBack()
-        assertFalse(handled)
+        assertFalse(testee.onUserPressedBack())
     }
 
     @Test
     fun whenUserOnHomePressesBackThenReturnsHandledFalse() {
         isBrowsing(false)
-        val handled = testee.onUserPressedBack()
-        assertFalse(handled)
+        assertFalse(testee.onUserPressedBack())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -202,7 +202,7 @@ class BrowserTabViewModelTest {
             searchCountDao = mockSearchCountDao
         )
 
-        testee.loadData("abc", null)
+        testee.loadData("abc", null, false)
         testee.command.observeForever(mockCommandObserver)
 
         whenever(mockOmnibarConverter.convertQueryToUrl(any())).thenReturn("duckduckgo.com")

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -111,12 +111,12 @@ class BrowserViewModelTest {
     @Test
     fun whenTabsUpdatedAndNoTabsThenNewTabAddedToRepository() {
         testee.onTabsUpdated(ArrayList())
-        verify(mockTabRepository).add(null, true)
+        verify(mockTabRepository).add(null, false, true)
     }
 
     @Test
     fun whenTabsUpdatedWithTabsThenNewTabNotLaunched() {
-        testee.onTabsUpdated(asList(TabEntity(TAB_ID, "", "", true, 0)))
+        testee.onTabsUpdated(asList(TabEntity(TAB_ID, "", "", false, true, 0)))
         verify(mockCommandObserver, never()).onChanged(any())
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/global/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/db/AppDatabaseTest.kt
@@ -24,8 +24,7 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.duckduckgo.app.blockingObserve
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 
@@ -80,11 +79,9 @@ class AppDatabaseTest {
 
     @Test
     fun whenMigratingFromVersion4To5ThenTabsAreConsideredViewed() {
-
         testHelper.createDatabase(TEST_DB_NAME, 4).use {
             it.execSQL("INSERT INTO `tabs` values ('tabid1', 'url', 'title') ")
         }
-
         assertTrue(database().tabsDao().tabs()[0].viewed)
     }
 
@@ -116,6 +113,19 @@ class AppDatabaseTest {
     @Test
     fun whenMigratingFromVersion10To11ThenValidationSucceeds() {
         createDatabaseAndMigrate(10, 11, AppDatabase.MIGRATION_10_TO_11)
+    }
+
+    @Test
+    fun whenMigratingFromVersion11To12ThenValidationSucceeds() {
+        createDatabaseAndMigrate(11, 12, AppDatabase.MIGRATION_11_TO_12)
+    }
+
+    @Test
+    fun whenMigratingFromVersion11To12ThenTabsDoNotSkipHome() {
+        testHelper.createDatabase(TEST_DB_NAME, 11).use {
+            it.execSQL("INSERT INTO `tabs` values ('tabid1', 'url', 'title', 1, 0) ")
+        }
+        assertFalse(database().tabsDao().tabs()[0].skipHome)
     }
 
     private fun createDatabase(version: Int) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -74,8 +74,6 @@ class BrowserActivity : DuckDuckGoActivity() {
 
     private lateinit var renderer: BrowserStateRenderer
 
-    private var skipHome = false
-
     @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.daggerInject()
@@ -108,9 +106,9 @@ class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun openNewTab(tabId: String, url: String? = null) {
+    private fun openNewTab(tabId: String, url: String? = null, skipHome: Boolean) {
         Timber.i("Opening new tab, url: $url, tabId: $tabId")
-        val fragment = BrowserTabFragment.newInstance(tabId, skipHome, url)
+        val fragment = BrowserTabFragment.newInstance(tabId, url, skipHome)
         val transaction = supportFragmentManager.beginTransaction()
         val tab = currentTab
         if (tab == null) {
@@ -121,7 +119,6 @@ class BrowserActivity : DuckDuckGoActivity() {
         }
         transaction.commit()
         currentTab = fragment
-        skipHome = false
     }
 
     private fun selectTab(tab: TabEntity?) {
@@ -133,12 +130,11 @@ class BrowserActivity : DuckDuckGoActivity() {
 
         val fragment = supportFragmentManager.findFragmentByTag(tab.tabId) as? BrowserTabFragment
         if (fragment == null) {
-            openNewTab(tab.tabId, tab.url)
+            openNewTab(tab.tabId, tab.url, tab.skipHome)
             return
         }
         val transaction = supportFragmentManager.beginTransaction()
         currentTab?.let {
-            it.resetHome()
             transaction.hide(it)
         }
         transaction.show(fragment)
@@ -186,8 +182,7 @@ class BrowserActivity : DuckDuckGoActivity() {
         val sharedText = intent.intentText
         if (sharedText != null) {
             Timber.w("opening in new tab requested for $sharedText")
-            skipHome = true
-            viewModel.onOpenInNewTabRequested(sharedText)
+            viewModel.onOpenInNewTabRequested(sharedText, true)
             return
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -74,6 +74,8 @@ class BrowserActivity : DuckDuckGoActivity() {
 
     private lateinit var renderer: BrowserStateRenderer
 
+    private var skipHome = false
+
     @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.daggerInject()
@@ -108,7 +110,7 @@ class BrowserActivity : DuckDuckGoActivity() {
 
     private fun openNewTab(tabId: String, url: String? = null) {
         Timber.i("Opening new tab, url: $url, tabId: $tabId")
-        val fragment = BrowserTabFragment.newInstance(tabId, url)
+        val fragment = BrowserTabFragment.newInstance(tabId, skipHome, url)
         val transaction = supportFragmentManager.beginTransaction()
         val tab = currentTab
         if (tab == null) {
@@ -119,6 +121,7 @@ class BrowserActivity : DuckDuckGoActivity() {
         }
         transaction.commit()
         currentTab = fragment
+        skipHome = false
     }
 
     private fun selectTab(tab: TabEntity?) {
@@ -182,6 +185,7 @@ class BrowserActivity : DuckDuckGoActivity() {
         val sharedText = intent.intentText
         if (sharedText != null) {
             Timber.w("opening in new tab requested for $sharedText")
+            skipHome = true
             viewModel.onOpenInNewTabRequested(sharedText)
             return
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -138,6 +138,7 @@ class BrowserActivity : DuckDuckGoActivity() {
         }
         val transaction = supportFragmentManager.beginTransaction()
         currentTab?.let {
+            it.resetHome()
             transaction.hide(it)
         }
         transaction.show(fragment)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -243,7 +243,7 @@ class BrowserTabFragment : Fragment(), FindListener {
         val view = popupMenu.contentView
         popupMenu.apply {
             onMenuItemClicked(view.forwardPopupMenuItem) { viewModel.onUserPressedForward() }
-            onMenuItemClicked(view.backPopupMenuItem) { if (!viewModel.onUserPressedBack()) onBackPressed() }
+            onMenuItemClicked(view.backPopupMenuItem) { activity?.onBackPressed() }
             onMenuItemClicked(view.refreshPopupMenuItem) { refresh() }
             onMenuItemClicked(view.newTabPopupMenuItem) { browserActivity?.launchNewTab() }
             onMenuItemClicked(view.bookmarksPopupMenuItem) { browserActivity?.launchBookmarks() }
@@ -913,6 +913,10 @@ class BrowserTabFragment : Fragment(), FindListener {
         startActivity(AddWidgetInstructionsActivity.intent(context), options)
     }
 
+    fun resetHome() {
+        viewModel.skipHome = false
+    }
+
     companion object {
 
         private const val TAB_ID_ARG = "TAB_ID_ARG"
@@ -1006,7 +1010,6 @@ class BrowserTabFragment : Fragment(), FindListener {
             }
         }
 
-        // TODO move this out into model
         fun renderBrowserViewState(viewState: BrowserViewState) {
             renderIfChanged(viewState, lastSeenBrowserViewState) {
                 val browserShowing = viewState.browserShowing

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -342,7 +342,6 @@ class BrowserTabFragment : Fragment(), FindListener {
             is Command.Navigate -> {
                 navigate(it.url)
             }
-            Command.LandingPage -> resetTabState()
             is Command.DialNumber -> {
                 val intent = Intent(Intent.ACTION_DIAL)
                 intent.data = Uri.parse("tel:${it.telephoneNumber}")

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -776,6 +776,7 @@ class BrowserTabFragment : Fragment(), FindListener {
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
         if (hidden) {
+            viewModel.onViewHidden()
             webView?.onPause()
         } else {
             webView?.onResume()
@@ -913,10 +914,6 @@ class BrowserTabFragment : Fragment(), FindListener {
         startActivity(AddWidgetInstructionsActivity.intent(context), options)
     }
 
-    fun resetHome() {
-        viewModel.skipHome = false
-    }
-
     companion object {
 
         private const val TAB_ID_ARG = "TAB_ID_ARG"
@@ -933,7 +930,7 @@ class BrowserTabFragment : Fragment(), FindListener {
 
         private const val AUTHENTICATION_DIALOG_TAG = "AUTH_DIALOG_TAG"
 
-        fun newInstance(tabId: String, skipHome: Boolean, query: String? = null): BrowserTabFragment {
+        fun newInstance(tabId: String, query: String? = null, skipHome: Boolean): BrowserTabFragment {
             val fragment = BrowserTabFragment()
             val args = Bundle()
             args.putString(TAB_ID_ARG, tabId)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -318,10 +318,16 @@ class BrowserTabViewModel(
         }
     }
 
+    /**
+     * Handles back navigation. Returns false if navigation could not be
+     * handled at this level, giving system an opportunity to handle it
+     *
+     * @return true if navigation handled, otherwise false
+     */
     fun onUserPressedBack(): Boolean {
-        val navigation = navigationOptions
+        val navigation = navigationOptions ?: return false
 
-        if (!currentBrowserViewState().browserShowing || navigation == null) {
+        if (!currentBrowserViewState().browserShowing) {
             return false
         }
 
@@ -341,13 +347,13 @@ class BrowserTabViewModel(
         site = null
         onSiteChanged()
 
-        omnibarViewState.value = currentOmnibarViewState().copy(omnibarText = "")
-        loadingViewState.value = currentLoadingViewState().copy(isLoading = false)
         browserViewState.value = currentBrowserViewState().copy(
             browserShowing = false,
             canGoBack = false,
             canGoForward = true
         )
+        omnibarViewState.value = currentOmnibarViewState().copy(omnibarText = "")
+        loadingViewState.value = currentLoadingViewState().copy(isLoading = false)
     }
 
     override fun progressChanged(progressedUrl: String?, newProgress: Int) {
@@ -393,7 +399,7 @@ class BrowserTabViewModel(
         if (!currentBrowserViewState().browserShowing) return
 
         browserViewState.value = currentBrowserViewState().copy(
-            canGoBack = true,
+            canGoBack = navigation.canGoBack || !skipHome,
             canGoForward = navigation.canGoForward
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -526,7 +526,7 @@ class BrowserTabViewModel(
     }
 
     override fun showFileChooser(filePathCallback: ValueCallback<Array<Uri>>, fileChooserParams: WebChromeClient.FileChooserParams) {
-        command.value = Command.ShowFileChooser(filePathCallback, fileChooserParams)
+        command.value = ShowFileChooser(filePathCallback, fileChooserParams)
     }
 
     private fun currentAutoCompleteViewState(): AutoCompleteViewState = autoCompleteViewState.value!!

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -149,7 +149,6 @@ class BrowserTabViewModel(
     )
 
     sealed class Command {
-        object LandingPage : Command()
         object Refresh : Command()
         class Navigate(val url: String) : Command()
         class OpenInNewTab(val query: String) : Command()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -267,8 +267,12 @@ class BrowserTabViewModel(
     }
 
     fun onViewVisible() {
-        command.value = if (url == null) ShowKeyboard else Command.HideKeyboard
+        command.value = if (url == null) ShowKeyboard else HideKeyboard
         ctaViewModel.refreshCta()
+    }
+
+    fun onViewHidden() {
+        skipHome = false
     }
 
     fun onUserSubmittedQuery(input: String) {
@@ -329,7 +333,6 @@ class BrowserTabViewModel(
             return true
         }
 
-        skipHome = false
         return false
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -326,7 +326,7 @@ class BrowserTabViewModel(
 
     override fun navigationOptionsChanged(navigationOptions: BrowserNavigationOptions) {
         browserViewState.value = currentBrowserViewState().copy(
-            canGoBack = navigationOptions.canGoBack,
+            canGoBack = true,
             canGoForward = navigationOptions.canGoForward
         )
     }
@@ -600,11 +600,14 @@ class BrowserTabViewModel(
         }
     }
 
-    fun resetView() {
+    fun goHome() {
         pendingUrl = null
         site = null
         onSiteChanged()
-        initializeViewStates()
+        browserViewState.value = currentBrowserViewState().copy(
+            canGoBack = false,
+            canGoForward = true
+        )
     }
 
     private fun initializeViewStates() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -188,7 +188,7 @@ class BrowserViewModel(
     }
 
     override fun onUserCancelledAppEnjoymentDialog(promptCount: PromptCount) {
-        launch { appEnjoymentUserEventRecorder.onUserDeclinedToSayIfEnjoyingApp(promptCount)}
+        launch { appEnjoymentUserEventRecorder.onUserDeclinedToSayIfEnjoyingApp(promptCount) }
     }
 
     override fun onUserCancelledRateAppDialog(promptCount: PromptCount) {
@@ -198,5 +198,4 @@ class BrowserViewModel(
     override fun onUserCancelledGiveFeedbackDialog(promptCount: PromptCount) {
         onUserDeclinedToGiveFeedback(promptCount)
     }
-
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -124,8 +124,8 @@ class BrowserViewModel(
         tabRepository.add(isDefaultTab = isDefaultTab)
     }
 
-    fun onOpenInNewTabRequested(query: String) {
-        tabRepository.add(queryUrlConverter.convertQueryToUrl(query), isDefaultTab = false)
+    fun onOpenInNewTabRequested(query: String, skipHome: Boolean = false) {
+        tabRepository.add(queryUrlConverter.convertQueryToUrl(query), skipHome, isDefaultTab = false)
     }
 
     fun onTabsUpdated(tabs: List<TabEntity>?) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -28,6 +28,7 @@ import androidx.annotation.WorkerThread
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.global.isHttps
+import com.duckduckgo.app.global.toHttpsString
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.HTTPS_UPGRADE_SITE_ERROR
@@ -114,7 +115,7 @@ class BrowserWebViewClient @Inject constructor(
 
         webViewClientListener?.let {
             it.loadingStarted(url)
-            it.navigationOptionsChanged(determineNavigationOptions(webView))
+            it.navigationOptionsChanged(BrowserNavigationOptions(webView.copyBackForwardList()))
         }
 
         val uri = if (currentUrl != null) Uri.parse(currentUrl) else null
@@ -129,7 +130,7 @@ class BrowserWebViewClient @Inject constructor(
         currentUrl = url
         webViewClientListener?.let {
             it.loadingFinished(url)
-            it.navigationOptionsChanged(determineNavigationOptions(webView))
+            it.navigationOptionsChanged(BrowserNavigationOptions(webView.copyBackForwardList()))
         }
     }
 
@@ -268,12 +269,19 @@ class BrowserWebViewClient @Inject constructor(
         return true
     }
 
-    private fun determineNavigationOptions(webView: WebView): BrowserNavigationOptions {
-        val canGoBack = webView.canGoBack()
-        val canGoForward = webView.canGoForward()
-        return BrowserNavigationOptions(canGoBack, canGoForward)
+    data class BrowserNavigationOptions(val stack: WebBackForwardList) {
+
+        val stepsToPreviousPage: Int = if (stack.isHttpsUpgrade) 2 else 1
+        val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage
+        val canGoForward: Boolean = stack.currentIndex + 1 < stack.size
+        val hasNavigationHistory = stack.size != 0
+
+        private val WebBackForwardList.isHttpsUpgrade: Boolean
+            get() {
+                if (currentIndex < 1) return false
+                val current = currentItem.originalUrl
+                val previous = getItemAtIndex(currentIndex - 1).originalUrl
+                return current == previous.toUri().toHttpsString
+            }
     }
-
-    data class BrowserNavigationOptions(val canGoBack: Boolean, val canGoForward: Boolean)
-
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -115,7 +115,7 @@ class BrowserWebViewClient @Inject constructor(
 
         webViewClientListener?.let {
             it.loadingStarted(url)
-            it.navigationOptionsChanged(BrowserNavigationOptions(webView.copyBackForwardList()))
+            it.navigationOptionsChanged(WebViewNavigationOptions(webView.copyBackForwardList()))
         }
 
         val uri = if (currentUrl != null) Uri.parse(currentUrl) else null
@@ -130,7 +130,7 @@ class BrowserWebViewClient @Inject constructor(
         currentUrl = url
         webViewClientListener?.let {
             it.loadingFinished(url)
-            it.navigationOptionsChanged(BrowserNavigationOptions(webView.copyBackForwardList()))
+            it.navigationOptionsChanged(WebViewNavigationOptions(webView.copyBackForwardList()))
         }
     }
 
@@ -269,12 +269,19 @@ class BrowserWebViewClient @Inject constructor(
         return true
     }
 
-    data class BrowserNavigationOptions(val stack: WebBackForwardList) {
+    interface BrowserNavigationOptions {
+        val stepsToPreviousPage: Int
+        val canGoBack: Boolean
+        val canGoForward: Boolean
+        val hasNavigationHistory: Boolean
+    }
 
-        val stepsToPreviousPage: Int = if (stack.isHttpsUpgrade) 2 else 1
-        val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage
-        val canGoForward: Boolean = stack.currentIndex + 1 < stack.size
-        val hasNavigationHistory = stack.size != 0
+    data class WebViewNavigationOptions(val stack: WebBackForwardList): BrowserNavigationOptions {
+
+        override val stepsToPreviousPage: Int = if (stack.isHttpsUpgrade) 2 else 1
+        override val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage
+        override val canGoForward: Boolean = stack.currentIndex + 1 < stack.size
+        override val hasNavigationHistory = stack.size != 0
 
         private val WebBackForwardList.isHttpsUpgrade: Boolean
             get() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -276,7 +276,7 @@ class BrowserWebViewClient @Inject constructor(
         val hasNavigationHistory: Boolean
     }
 
-    data class WebViewNavigationOptions(val stack: WebBackForwardList): BrowserNavigationOptions {
+    data class WebViewNavigationOptions(val stack: WebBackForwardList) : BrowserNavigationOptions {
 
         override val stepsToPreviousPage: Int = if (stack.isHttpsUpgrade) 2 else 1
         override val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage
@@ -286,7 +286,7 @@ class BrowserWebViewClient @Inject constructor(
         private val WebBackForwardList.isHttpsUpgrade: Boolean
             get() {
                 if (currentIndex < 1) return false
-                val current = currentItem.originalUrl
+                val current = currentItem.originalUrl ?: return false
                 val previous = getItemAtIndex(currentIndex - 1).originalUrl
                 return current == previous.toUri().toHttpsString
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -31,7 +31,7 @@ interface WebViewClientListener {
     fun progressChanged(progressedUrl: String?, newProgress: Int)
     fun loadingFinished(url: String? = null)
     fun titleReceived(title: String)
-    fun navigationOptionsChanged(navigationOptions: BrowserNavigationOptions)
+    fun navigationOptionsChanged(navigation: BrowserNavigationOptions)
     fun trackerDetected(event: TrackingEvent)
     fun pageHasHttpResources(page: String?)
 

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -35,12 +35,12 @@ val Uri.baseHost: String?
     get() = withScheme().host?.removePrefix("www.")
 
 val Uri.isHttp: Boolean
-    get() = scheme?.equals(UrlScheme.http, true) ?: false
+    get() = scheme?.equals(http, true) ?: false
 
 val Uri.isHttps: Boolean
     get() = scheme?.equals(UrlScheme.https, true) ?: false
 
-val Uri.toHttps
+val Uri.toHttps: Uri
     get() = buildUpon().scheme(UrlScheme.https).build()
 
 val Uri.toHttpsString
@@ -67,7 +67,7 @@ fun Uri.toDesktopUri(): Uri {
         url.replaceFirst(prefix, "")
     }
 
-    return Uri.parse(newUrl)
+    return parse(newUrl)
 }
 
 private const val faviconBaseUrlFormat = "https://proxy.duckduckgo.com/ip3/%s.ico"
@@ -75,5 +75,5 @@ private const val faviconBaseUrlFormat = "https://proxy.duckduckgo.com/ip3/%s.ic
 fun Uri?.faviconLocation(): Uri? {
     val host = this?.host
     if (host.isNullOrBlank()) return null
-    return Uri.parse(String.format(faviconBaseUrlFormat, host))
+    return parse(String.format(faviconBaseUrlFormat, host))
 }

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -40,6 +40,12 @@ val Uri.isHttp: Boolean
 val Uri.isHttps: Boolean
     get() = scheme?.equals(UrlScheme.https, true) ?: false
 
+val Uri.toHttps
+    get() = buildUpon().scheme(UrlScheme.https).build()
+
+val Uri.toHttpsString
+    get() = toHttps.toString()
+
 val Uri.hasIpHost: Boolean
     get() {
         val ipRegex = Regex("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -55,7 +55,7 @@ import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.app.usage.search.SearchCountEntity
 
 @Database(
-    exportSchema = true, version = 11, entities = [
+    exportSchema = true, version = 12, entities = [
         DisconnectTracker::class,
         HttpsBloomFilterSpec::class,
         HttpsWhitelistedDomain::class,
@@ -182,6 +182,12 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_11_TO_12: Migration = object : Migration(11, 12) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `tabs` ADD COLUMN `skipHome` INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
         val ALL_MIGRATIONS: List<Migration>
             get() = listOf(
                 MIGRATION_1_TO_2,
@@ -193,7 +199,8 @@ abstract class AppDatabase : RoomDatabase() {
                 MIGRATION_7_TO_8,
                 MIGRATION_8_TO_9,
                 MIGRATION_9_TO_10,
-                MIGRATION_10_TO_11
+                MIGRATION_10_TO_11,
+                MIGRATION_11_TO_12
             )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.httpsupgrade
 
 import android.net.Uri
 import androidx.annotation.WorkerThread
-import com.duckduckgo.app.global.UrlScheme
 import com.duckduckgo.app.global.isHttps
 import com.duckduckgo.app.global.toHttps
 import com.duckduckgo.app.httpsupgrade.api.HttpsBloomFilterFactory

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -20,6 +20,7 @@ import android.net.Uri
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.global.UrlScheme
 import com.duckduckgo.app.global.isHttps
+import com.duckduckgo.app.global.toHttps
 import com.duckduckgo.app.httpsupgrade.api.HttpsBloomFilterFactory
 import com.duckduckgo.app.httpsupgrade.db.HttpsWhitelistDao
 import timber.log.Timber
@@ -34,7 +35,7 @@ interface HttpsUpgrader {
     fun isInUpgradeList(uri: Uri): Boolean
 
     fun upgrade(uri: Uri): Uri {
-        return uri.buildUpon().scheme(UrlScheme.https).build()
+        return uri.toHttps
     }
 
     @WorkerThread

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabEntitiy.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabEntitiy.kt
@@ -31,6 +31,7 @@ data class TabEntity(
     @PrimaryKey var tabId: String,
     var url: String? = null,
     var title: String? = null,
+    var skipHome: Boolean = false,
     var viewed: Boolean = true,
     var position: Int
 )

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -29,11 +29,11 @@ interface TabRepository {
     /**
      * @return tabId of new record
      */
-    fun add(url: String? = null, isDefaultTab: Boolean = false): String
+    fun add(url: String? = null, skipHome: Boolean = false, isDefaultTab: Boolean = false): String
 
     fun addNewTabAfterExistingTab(url: String? = null, tabId: String)
 
-    fun add(tabId: String, data: MutableLiveData<Site>, isDefaultTab: Boolean = false)
+    fun add(tabId: String, data: MutableLiveData<Site>, skipHome: Boolean = false, isDefaultTab: Boolean = false)
 
     fun update(tabId: String, site: Site?)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1117886846776279
Tech Design URL: https://app.asana.com/0/361428290920652/1118398381563523 and https://app.asana.com/0/361428290920652/1118398381563522

**Description**:
Improves three aspects of android back navigation:
- Pressing back after launching from another app takes user back to the previous application (rather than via home screen)
- When pressing back to get to the home screen, users can now press forward again to return to webpage they were viewing
- Pressing back on a https-upgraded site navigates two steps to avoid sending user back to the http site which just upgrades again

**Steps to test this PR**:
MIGRATION TEST
1. Install the develop version of the app.
1. Open some tabs
1. Install this version and make sure nothing goes "boom"

FORWARD TEST
1. Go to a webpage
1. Press the back button to go back to the home page
1. Press the forward button to go back to the webpage

SHARE TEST
1. Share a link from twitter to our app
1. Now from our app, press back
1. This should return you to twitter (without going via the home screen)

HTTPS Test
1. Navigate to http://duckduckgo.com
1. Now navigate to http://facebook.com
1. Press back, this should take you to https://duckduckgo.com
1. Press back again, this should take you to the native home screen
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
