### PR TITLE
Fix issue where launching from recents could create a duplicate tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -340,13 +340,16 @@ class BrowserActivity : DuckDuckGoActivity() {
                 return
             }
 
-            if (!processedOriginalIntent && instanceStateBundles?.originalInstanceState == null) {
+            if (!processedOriginalIntent && instanceStateBundles?.originalInstanceState == null && !intent.launchedFromRecents) {
                 Timber.i("Original instance state is null, so will inspect intent for actions to take. $intent")
                 launchNewSearchOrQuery(intent)
                 processedOriginalIntent = true
             }
         }
     }
+
+    private val Intent.launchedFromRecents: Boolean
+        get() = (flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
 
     private fun showAppEnjoymentPrompt(prompt: DialogFragment) {
         currentAppEnjoymentFragment?.dismiss()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1119368905666087
Tech Design URL: N/A

**Description**:
Fixes an issue where launching from recents could load an old share intent

**Steps to test this PR**:
1. Install the app and kill it
1. Share a ulr from another app to our app.
1. Open a new tab.
1. Now press, back (a few times!) to close our app
1. Go to recents to launch our app again
1. Note that the previously shared url is not loaded in the second tab

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
