### PR TITLE
Don't try to go back if fragment not yet added

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -796,6 +796,7 @@ class BrowserTabFragment : Fragment(), FindListener {
     }
 
     fun onBackPressed(): Boolean {
+        if (!isAdded) return false
         return viewModel.onUserPressedBack()
     }
 

--- a/app/version/version.properties
+++ b/app/version/version.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-VERSION=5.22.0
+VERSION=5.22.1


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1120242182989787

**Description**:
Fix issue where back could be pressed before fragment dependency injection has occurred. Not reproduced however there are 3 reports in Play Store. @CDRussell I'm hotfixing this now as it has rolled out some users. Adding you for retrospective PR.

**Steps to test this PR**:
1. Run the app and navigate forward and back.
1. Make sure everything works as expected

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
