### PR TITLE
Add new pixels for android instrumentation

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -174,21 +174,21 @@ class CtaViewModelTest {
     fun whenCtaShownPixelIsFired() {
         testee.onSurveyChanged(Survey("abc", "http://example.com", 1, SCHEDULED))
         testee.onCtaShown()
-        verify(mockPixel).fire(eq(SURVEY_CTA_SHOWN), any())
+        verify(mockPixel).fire(eq(SURVEY_CTA_SHOWN), any(), eq(false))
     }
 
     @Test
     fun whenCtaLaunchedPixelIsFired() {
         testee.onSurveyChanged(Survey("abc", "http://example.com", 1, SCHEDULED))
         testee.onCtaLaunched()
-        verify(mockPixel).fire(eq(SURVEY_CTA_LAUNCHED), any())
+        verify(mockPixel).fire(eq(SURVEY_CTA_LAUNCHED), any(), eq(false))
     }
 
     @Test
     fun whenCtaDismissedPixelIsFired() {
         testee.onSurveyChanged(Survey("abc", "http://example.com", 1, SCHEDULED))
         testee.onCtaDismissed()
-        verify(mockPixel).fire(eq(SURVEY_CTA_DISMISSED), any())
+        verify(mockPixel).fire(eq(SURVEY_CTA_DISMISSED), any(), eq(false))
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
@@ -51,10 +51,10 @@ class StubStatisticsModule {
     fun stubPixel(): Pixel {
         return object : Pixel {
 
-            override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String?>) {
+            override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String?>, includeLocale: Boolean) {
             }
 
-            override fun fire(pixelName: String, parameters: Map<String, String?>) {
+            override fun fire(pixelName: String, parameters: Map<String, String?>, includeLocale: Boolean) {
 
             }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationHandlerServiceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationHandlerServiceTest.kt
@@ -50,7 +50,7 @@ class NotificationHandlerServiceTest {
         intent.type = CLEAR_DATA_LAUNCH
         intent.putExtra(PIXEL_SUFFIX_EXTRA, "abc")
         testee.onHandleIntent(intent)
-        verify(mockPixel).fire(eq("mnot_l_abc"), any())
+        verify(mockPixel).fire(eq("mnot_l_abc"), any(), eq(false))
     }
 
     @Test
@@ -59,6 +59,6 @@ class NotificationHandlerServiceTest {
         intent.type = CANCEL
         intent.putExtra(PIXEL_SUFFIX_EXTRA, "abc")
         testee.onHandleIntent(intent)
-        verify(mockPixel).fire(eq("mnot_c_abc"), any())
+        verify(mockPixel).fire(eq("mnot_c_abc"), any(), eq(false))
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationHandlerServiceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationHandlerServiceTest.kt
@@ -50,7 +50,7 @@ class NotificationHandlerServiceTest {
         intent.type = CLEAR_DATA_LAUNCH
         intent.putExtra(PIXEL_SUFFIX_EXTRA, "abc")
         testee.onHandleIntent(intent)
-        verify(mockPixel).fire(eq("mnot_l_abc"), any(), eq(false))
+        verify(mockPixel).fire(eq("mnot_l_abc"), any(), any())
     }
 
     @Test
@@ -59,6 +59,6 @@ class NotificationHandlerServiceTest {
         intent.type = CANCEL
         intent.putExtra(PIXEL_SUFFIX_EXTRA, "abc")
         testee.onHandleIntent(intent)
-        verify(mockPixel).fire(eq("mnot_c_abc"), any(), eq(false))
+        verify(mockPixel).fire(eq("mnot_c_abc"), any(), any())
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
@@ -56,7 +56,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOffAndNowOnThenPixelIsFiredAndSettingsUpdated() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(false)
         testee.updateStatus(true)
-        verify(mockPixel).fire(eq(Pixel.PixelName.NOTIFICATIONS_ENABLED), any())
+        verify(mockPixel).fire(eq(Pixel.PixelName.NOTIFICATIONS_ENABLED), any(), eq(false))
         verify(mockSettingsDataStore).appNotificationsEnabled = true
     }
 
@@ -64,7 +64,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOffAndStillOffThenNoPixelIsFiredAndSettingsUnchanged() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(false)
         testee.updateStatus(false)
-        verify(mockPixel, never()).fire(any<Pixel.PixelName>(), any())
+        verify(mockPixel, never()).fire(any<Pixel.PixelName>(), any(), eq(false))
         verify(mockSettingsDataStore, never()).appNotificationsEnabled = true
     }
 
@@ -72,7 +72,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOnAndStillOnThenNoPixelIsFiredAndSettingsUnchanged() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(true)
         testee.updateStatus(true)
-        verify(mockPixel, never()).fire(any<Pixel.PixelName>(), any())
+        verify(mockPixel, never()).fire(any<Pixel.PixelName>(), any(), eq(false))
         verify(mockSettingsDataStore, never()).appNotificationsEnabled = false
     }
 
@@ -80,7 +80,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOnAndNowOffPixelIsFiredAndSettingsUpdated() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(true)
         testee.updateStatus(false)
-        verify(mockPixel).fire(eq(Pixel.PixelName.NOTIFICATIONS_DISABLED), any())
+        verify(mockPixel).fire(eq(Pixel.PixelName.NOTIFICATIONS_DISABLED), any(), eq(false))
         verify(mockSettingsDataStore).appNotificationsEnabled = false
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -169,7 +169,7 @@ class SettingsViewModelTest {
 
     @Test
     fun whenDefaultBrowserAppAlreadySetToOursThenIsDefaultBrowserFlagIsTrue() {
-        whenever(mockDefaultBrowserDetector.isCurrentlyConfiguredAsDefaultBrowser()).thenReturn(true)
+        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
         testee.start()
         val viewState = latestViewState()
         assertTrue(viewState.isAppDefaultBrowser)
@@ -177,7 +177,7 @@ class SettingsViewModelTest {
 
     @Test
     fun whenDefaultBrowserAppNotSetToOursThenIsDefaultBrowserFlagIsFalse() {
-        whenever(mockDefaultBrowserDetector.isCurrentlyConfiguredAsDefaultBrowser()).thenReturn(false)
+        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
         testee.start()
         val viewState = latestViewState()
         assertFalse(viewState.isAppDefaultBrowser)

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -133,7 +133,7 @@ class ApiBasedPixelTest {
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         val params = mapOf("param1" to "value1")
         val localeParams = mapOf("lg" to "es", "co" to "us")
-        pixel.fire(PRIVACY_DASHBOARD_OPENED, params, addLocale = true)
+        pixel.fire(PRIVACY_DASHBOARD_OPENED, params, includeLocale = true)
         verify(mockPixelService).fire("mp", "phone", "atbvariant", params.plus(localeParams))
     }
 
@@ -148,7 +148,7 @@ class ApiBasedPixelTest {
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         val localeParams = mapOf("lg" to "es", "co" to "us")
-        pixel.fire(PRIVACY_DASHBOARD_OPENED, addLocale = true)
+        pixel.fire(PRIVACY_DASHBOARD_OPENED, includeLocale = true)
         verify(mockPixelService).fire("mp", "phone", "atbvariant", localeParams)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -120,4 +120,35 @@ class ApiBasedPixelTest {
         pixel.fire(PRIVACY_DASHBOARD_OPENED)
         verify(mockPixelService).fire("mp", "phone", "atbvariant", params)
     }
+
+    @Test
+    fun whenPixelFiredWithAdditionalParametersAndLocaleThenPixelServiceCalledWithBothSetsOfParameters() {
+        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
+        whenever(mockDeviceInfo.country).thenReturn("us")
+        whenever(mockDeviceInfo.language).thenReturn("es")
+
+        val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
+        val params = mapOf("param1" to "value1")
+        val localeParams = mapOf("lg" to "es", "co" to "us")
+        pixel.fire(PRIVACY_DASHBOARD_OPENED, params, addLocale = true)
+        verify(mockPixelService).fire("mp", "phone", "atbvariant", params.plus(localeParams))
+    }
+
+    @Test
+    fun whenPixelFiredWithLocaleAndNoAdditionalParametersThenPixelServiceCalledWithLocaleParameters() {
+        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
+        whenever(mockDeviceInfo.country).thenReturn("us")
+        whenever(mockDeviceInfo.language).thenReturn("es")
+
+        val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
+        val localeParams = mapOf("lg" to "es", "co" to "us")
+        pixel.fire(PRIVACY_DASHBOARD_OPENED, addLocale = true)
+        verify(mockPixelService).fire("mp", "phone", "atbvariant", localeParams)
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -179,7 +179,7 @@ class BrowserActivity : DuckDuckGoActivity() {
 
         if (launchedFromWidget(intent)) {
             Timber.w("new tab requested from widget")
-            pixel.fire(Pixel.PixelName.WIDGET_LAUNCHED, includeLocal = true)
+            pixel.fire(Pixel.PixelName.WIDGET_LAUNCHED, includeLocale = true)
             viewModel.onNewTabRequested()
             return
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -179,7 +179,7 @@ class BrowserActivity : DuckDuckGoActivity() {
 
         if (launchedFromWidget(intent)) {
             Timber.w("new tab requested from widget")
-            pixel.fire(Pixel.PixelName.WIDGET_LAUNCHED)
+            pixel.fire(Pixel.PixelName.WIDGET_LAUNCHED, includeLocal = true)
             viewModel.onNewTabRequested()
             return
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -42,6 +42,7 @@ import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity
 import com.duckduckgo.app.settings.SettingsActivity
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.TabSwitcherActivity
 import kotlinx.android.synthetic.main.activity_browser.*
@@ -58,6 +59,9 @@ class BrowserActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var dataClearer: DataClearer
+
+    @Inject
+    lateinit var pixel: Pixel
 
     @Inject
     lateinit var playStoreUtils: PlayStoreUtils
@@ -173,6 +177,13 @@ class BrowserActivity : DuckDuckGoActivity() {
             Toast.makeText(applicationContext, R.string.fireDataCleared, Toast.LENGTH_LONG).show()
         }
 
+        if (launchedFromWidget(intent)) {
+            Timber.w("new tab requested from widget")
+            pixel.fire(Pixel.PixelName.WIDGET_LAUNCHED)
+            viewModel.onNewTabRequested()
+            return
+        }
+
         if (launchNewSearch(intent)) {
             Timber.w("new tab requested")
             viewModel.onNewTabRequested()
@@ -232,6 +243,10 @@ class BrowserActivity : DuckDuckGoActivity() {
             is Command.ShowAppFeedbackPrompt -> showAppEnjoymentPrompt(GiveFeedbackDialogFragment.create(command.promptCount, viewModel))
             is Command.LaunchFeedbackView -> startActivity(FeedbackActivity.intent(this))
         }
+    }
+
+    private fun launchedFromWidget(intent: Intent): Boolean {
+        return intent.getBooleanExtra(WIDGET_SEARCH_EXTRA, false)
     }
 
     private fun launchNewSearch(intent: Intent): Boolean {
@@ -294,15 +309,17 @@ class BrowserActivity : DuckDuckGoActivity() {
 
     companion object {
 
-        fun intent(context: Context, queryExtra: String? = null, newSearch: Boolean = false, launchedFromFireAction: Boolean = false): Intent {
+        fun intent(context: Context, queryExtra: String? = null, newSearch: Boolean = false, widgetSearch: Boolean = false, launchedFromFireAction: Boolean = false): Intent {
             val intent = Intent(context, BrowserActivity::class.java)
             intent.putExtra(EXTRA_TEXT, queryExtra)
             intent.putExtra(NEW_SEARCH_EXTRA, newSearch)
+            intent.putExtra(WIDGET_SEARCH_EXTRA, widgetSearch)
             intent.putExtra(LAUNCHED_FROM_FIRE_EXTRA, launchedFromFireAction)
             return intent
         }
 
         const val NEW_SEARCH_EXTRA = "NEW_SEARCH_EXTRA"
+        const val WIDGET_SEARCH_EXTRA = "WIDGET_SEARCH_EXTRA"
         const val PERFORM_FIRE_ON_ENTRY_EXTRA = "PERFORM_FIRE_ON_ENTRY_EXTRA"
         const val LAUNCHED_FROM_FIRE_EXTRA = "LAUNCHED_FROM_FIRE_EXTRA"
 

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserDetector.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
 
 interface DefaultBrowserDetector {
     fun deviceSupportsDefaultBrowserConfiguration(): Boolean
-    fun isCurrentlyConfiguredAsDefaultBrowser(): Boolean
+    fun isDefaultBrowser(): Boolean
 }
 
 class AndroidDefaultBrowserDetector @Inject constructor(private val context: Context) : DefaultBrowserDetector {
@@ -38,7 +38,7 @@ class AndroidDefaultBrowserDetector @Inject constructor(private val context: Con
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
     }
 
-    override fun isCurrentlyConfiguredAsDefaultBrowser(): Boolean {
+    override fun isDefaultBrowser(): Boolean {
         val intent = Intent(ACTION_VIEW, Uri.parse("https://"))
         val resolutionInfo: ResolveInfo? = context.packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
         val defaultAlready = resolutionInfo?.activityInfo?.packageName == BuildConfig.APPLICATION_ID

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserInfoActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserInfoActivity.kt
@@ -73,7 +73,7 @@ class DefaultBrowserInfoActivity : DuckDuckGoActivity() {
         when (requestCode) {
             DEFAULT_BROWSER_REQUEST_CODE -> {
                 val wasSet = if (defaultBrowserDetector.isDefaultBrowser()) "was" else "was not"
-                Timber.i("User returned from default settings; DDG ${wasSet} set as the default")
+                Timber.i("User returned from default settings; DDG $wasSet set as the default")
             }
             else -> super.onActivityResult(requestCode, resultCode, data)
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserInfoActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserInfoActivity.kt
@@ -23,12 +23,10 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
-import androidx.annotation.RequiresApi
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 import kotlinx.android.synthetic.main.activity_default_browser_info.*
 import timber.log.Timber
 import javax.inject.Inject
@@ -38,17 +36,10 @@ class DefaultBrowserInfoActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var defaultBrowserDetector: DefaultBrowserDetector
 
-    @Inject
-    lateinit var pixel: Pixel
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_default_browser_info)
         configureUiEventHandlers()
-
-        if (savedInstanceState == null) {
-            pixel.fire(DEFAULT_BROWSER_INFO_VIEWED)
-        }
     }
 
     @TargetApi(Build.VERSION_CODES.N)
@@ -73,7 +64,7 @@ class DefaultBrowserInfoActivity : DuckDuckGoActivity() {
     override fun onResume() {
         super.onResume()
 
-        if (defaultBrowserDetector.isCurrentlyConfiguredAsDefaultBrowser()) {
+        if (defaultBrowserDetector.isDefaultBrowser()) {
             finish()
         }
     }
@@ -81,19 +72,10 @@ class DefaultBrowserInfoActivity : DuckDuckGoActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         when (requestCode) {
             DEFAULT_BROWSER_REQUEST_CODE -> {
-                fireDefaultBrowserPixel()
+                val wasSet = if (defaultBrowserDetector.isDefaultBrowser()) "was" else "was not"
+                Timber.i("User returned from default settings; DDG ${wasSet} set as the default")
             }
             else -> super.onActivityResult(requestCode, resultCode, data)
-        }
-    }
-
-    private fun fireDefaultBrowserPixel() {
-        if (defaultBrowserDetector.isCurrentlyConfiguredAsDefaultBrowser()) {
-            Timber.i("User returned from default settings; DDG is now the default")
-            pixel.fire(DEFAULT_BROWSER_SET)
-        } else {
-            Timber.i("User returned from default settings; DDG was not set default")
-            pixel.fire(DEFAULT_BROWSER_NOT_SET)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
@@ -34,8 +34,8 @@ class DefaultBrowserObserver(
         if (appInstallStore.defaultBrowser != isDefaultBrowser) {
             appInstallStore.defaultBrowser = isDefaultBrowser
             when {
-                isDefaultBrowser -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_SET)
-                else -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_UNSET)
+                isDefaultBrowser -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_SET, includeLocal = true)
+                else -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_UNSET, includeLocal = true)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+class DefaultBrowserObserver(
+    private val defaultBrowserDetector: DefaultBrowserDetector,
+    private val appInstallStore: AppInstallStore,
+    private val pixel: Pixel
+) : LifecycleObserver {
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    fun onApplicationResumed() {
+        val isDefaultBrowser = defaultBrowserDetector.isDefaultBrowser()
+        if (appInstallStore.defaultBrowser != isDefaultBrowser) {
+            appInstallStore.defaultBrowser = isDefaultBrowser
+            when {
+                isDefaultBrowser -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_SET)
+                else -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_UNSET)
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
@@ -34,8 +34,8 @@ class DefaultBrowserObserver(
         if (appInstallStore.defaultBrowser != isDefaultBrowser) {
             appInstallStore.defaultBrowser = isDefaultBrowser
             when {
-                isDefaultBrowser -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_SET, includeLocal = true)
-                else -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_UNSET, includeLocal = true)
+                isDefaultBrowser -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_SET, includeLocale = true)
+                else -> pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_UNSET, includeLocale = true)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -22,6 +22,7 @@ import android.webkit.CookieManager
 import com.duckduckgo.app.browser.*
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.addtohome.AddToHomeSystemCapabilityDetector
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserObserver
 import com.duckduckgo.app.browser.defaultbrowsing.AndroidDefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
@@ -29,6 +30,7 @@ import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
 import com.duckduckgo.app.fire.WebViewCookieManager
 import com.duckduckgo.app.global.AppUrl
+import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.statistics.VariantManager
@@ -60,6 +62,15 @@ class BrowserModule {
     @Provides
     fun defaultWebBrowserCapability(context: Context): DefaultBrowserDetector {
         return AndroidDefaultBrowserDetector(context)
+    }
+
+    @Provides
+    fun defaultBrowserObserver(
+        defaultBrowserDetector: DefaultBrowserDetector,
+        appInstallStore: AppInstallStore,
+        pixel: Pixel
+    ): DefaultBrowserObserver {
+        return DefaultBrowserObserver(defaultBrowserDetector, appInstallStore, pixel)
     }
 
     @Singleton

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -106,13 +106,16 @@ class CtaViewModel @Inject constructor(
     }
 
     fun onCtaShown() {
-        val cta = currentViewState.cta ?: return
-        pixel.fire(cta.shownPixel)
+        currentViewState.cta?.shownPixel?.let {
+            pixel.fire(it)
+        }
     }
 
     fun onCtaDismissed() {
         val cta = currentViewState.cta ?: return
-        pixel.fire(cta.cancelPixel)
+        cta.cancelPixel?.let {
+            pixel.fire(it)
+        }
 
         Schedulers.io().scheduleDirect {
             when (cta) {
@@ -130,8 +133,9 @@ class CtaViewModel @Inject constructor(
     }
 
     fun onCtaLaunched() {
-        val cta = currentViewState.cta ?: return
-        pixel.fire(cta.okPixel)
+        currentViewState.cta?.okPixel?.let {
+            pixel.fire(it)
+        }
     }
 }
 
@@ -142,9 +146,9 @@ sealed class CtaConfiguration(
     @StringRes open val description: Int,
     @StringRes open val okButton: Int,
     @StringRes open val dismissButton: Int,
-    open val shownPixel: Pixel.PixelName,
-    open val okPixel: Pixel.PixelName,
-    open val cancelPixel: Pixel.PixelName
+    open val shownPixel: Pixel.PixelName?,
+    open val okPixel: Pixel.PixelName?,
+    open val cancelPixel: Pixel.PixelName?
 ) {
 
     data class Survey(val survey: com.duckduckgo.app.survey.model.Survey) : CtaConfiguration(
@@ -166,9 +170,9 @@ sealed class CtaConfiguration(
         R.string.addWidgetCtaDescription,
         R.string.addWidgetCtaAutoLaunchButton,
         R.string.addWidgetCtaDismissButton,
-        ADD_WIDGET_AUTO_CTA_SHOWN,
-        ADD_WIDGET_AUTO_CTA_LAUNCHED,
-        ADD_WIDGET_AUTO_CTA_DISMISSED
+        null,
+        null,
+        null
     )
 
     object AddWidgetInstructions : CtaConfiguration(
@@ -178,9 +182,9 @@ sealed class CtaConfiguration(
         R.string.addWidgetCtaDescription,
         R.string.addWidgetCtaInstructionsLaunchButton,
         R.string.addWidgetCtaDismissButton,
-        ADD_WIDGET_INSTRUCTIONS_CTA_SHOWN,
-        ADD_WIDGET_INSTRUCTIONS_CTA_LAUNCHED,
-        ADD_WIDGET_INSTRUCTIONS_CTA_DISMISSED
+        null,
+        null,
+        null
     )
 
     fun apply(view: View) {

--- a/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.onboarding.di.OnboardingModule
 import com.duckduckgo.app.surrogates.di.ResourceSurrogateModule
 import com.duckduckgo.app.trackerdetection.di.TrackerDetectionModule
 import com.duckduckgo.app.usage.di.AppUsageModule
+import com.duckduckgo.widget.SearchWidget
 import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjector
@@ -75,4 +76,6 @@ interface AppComponent : AndroidInjector<DuckDuckGoApplication> {
 
         fun build(): AppComponent
     }
+
+    fun inject(searchWidget: SearchWidget)
 }

--- a/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
@@ -34,7 +34,8 @@ class AppUrl {
         const val ATB = "atb"
         const val RETENTION_ATB = "set_atb"
         const val DEV_MODE = "test"
-        const val FORM_FACTOR = "f"
+        const val LANGUAGE = "lg"
+        const val COUNTRY = "co"
     }
 
     object ParamValue {

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -29,6 +29,7 @@ import androidx.work.Configuration
 import androidx.work.WorkManager
 import androidx.work.WorkerFactory
 import com.duckduckgo.app.browser.BuildConfig
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserObserver
 import com.duckduckgo.app.di.AppComponent
 import com.duckduckgo.app.di.DaggerAppComponent
 import com.duckduckgo.app.fire.DataClearer
@@ -83,6 +84,9 @@ open class DuckDuckGoApplication : HasActivityInjector, HasServiceInjector, HasS
 
     @Inject
     lateinit var appConfigurationSyncer: AppConfigurationSyncer
+
+    @Inject
+    lateinit var defaultBrowserObserver: DefaultBrowserObserver
 
     @Inject
     lateinit var statisticsUpdater: StatisticsUpdater
@@ -148,6 +152,7 @@ open class DuckDuckGoApplication : HasActivityInjector, HasServiceInjector, HasS
             it.addObserver(this)
             it.addObserver(dataClearer)
             it.addObserver(appDaysUsedRecorder)
+            it.addObserver(defaultBrowserObserver)
             it.addObserver(appEnjoymentLifecycleObserver)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
@@ -48,5 +48,5 @@ class ContextDeviceInfo @Inject constructor(private val context: Context) : Devi
         get() = Locale.getDefault().country
 
     override val language: String
-        get() = Locale.getDefault().isO3Language
+        get() = Locale.getDefault().language
 }

--- a/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
@@ -29,11 +29,11 @@ interface DeviceInfo {
         TABLET("tablet")
     }
 
-    fun formFactor(): FormFactor
-
     val language: String
 
     val country: String
+
+    fun formFactor(): FormFactor
 }
 
 class ContextDeviceInfo @Inject constructor(private val context: Context) : DeviceInfo {

--- a/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
@@ -42,11 +42,11 @@ class ContextDeviceInfo @Inject constructor(private val context: Context) : Devi
         context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
     }
 
-    override val language by lazy {
+    override val language: String by lazy {
         Locale.getDefault().language
     }
 
-    override val country by lazy {
+    override val country: String by lazy {
         val telephonyCountry = telephonyManager.networkCountryIso
         val deviceCountry = if (telephonyCountry.isNotBlank()) telephonyCountry else Locale.getDefault().country
         deviceCountry.toLowerCase()

--- a/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
@@ -18,20 +18,21 @@ package com.duckduckgo.app.global.device
 
 import android.content.Context
 import android.util.TypedValue
+import java.util.*
 import javax.inject.Inject
-
 
 interface DeviceInfo {
 
     enum class FormFactor(val description: String) {
-
         PHONE("phone"),
         TABLET("tablet")
-
     }
 
     fun formFactor(): FormFactor
 
+    val country: String
+
+    val language: String
 }
 
 class ContextDeviceInfo @Inject constructor(private val context: Context) : DeviceInfo {
@@ -43,4 +44,9 @@ class ContextDeviceInfo @Inject constructor(private val context: Context) : Devi
         return if (smallestSize >= tabletSize) DeviceInfo.FormFactor.TABLET else DeviceInfo.FormFactor.PHONE
     }
 
+    override val country: String
+        get() = Locale.getDefault().country
+
+    override val language: String
+        get() = Locale.getDefault().isO3Language
 }

--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
@@ -27,6 +27,10 @@ import javax.inject.Inject
 interface AppInstallStore {
     var installTimestamp: Long
 
+    var widgetInstalled: Boolean
+
+    var defaultBrowser: Boolean
+
     fun hasInstallTimestampRecorded(): Boolean
 }
 
@@ -39,16 +43,25 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
         get() = preferences.getLong(KEY_TIMESTAMP_UTC, 0L)
         set(timestamp) = preferences.edit { putLong(KEY_TIMESTAMP_UTC, timestamp) }
 
+    override var widgetInstalled: Boolean
+        get() = preferences.getBoolean(KEY_WIDGET_INSTALLED, false)
+        set(widgetInstalled) = preferences.edit { putBoolean(KEY_WIDGET_INSTALLED, widgetInstalled) }
+
+    override var defaultBrowser: Boolean
+        get() = preferences.getBoolean(KEY_DEFAULT_BROWSER, false)
+        set(widgetInstalled) = preferences.edit { putBoolean(KEY_DEFAULT_BROWSER, widgetInstalled) }
+
     override fun hasInstallTimestampRecorded(): Boolean = preferences.contains(KEY_TIMESTAMP_UTC)
 
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
 
     companion object {
-
         @VisibleForTesting
         const val FILENAME = "com.duckduckgo.app.install.settings"
         const val KEY_TIMESTAMP_UTC = "INSTALL_TIMESTAMP_UTC"
+        const val KEY_WIDGET_INSTALLED = "KEY_WIDGET_INSTALLED"
+        const val KEY_DEFAULT_BROWSER = "KEY_DEFAULT_BROWSER"
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
@@ -49,7 +49,7 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
 
     override var defaultBrowser: Boolean
         get() = preferences.getBoolean(KEY_DEFAULT_BROWSER, false)
-        set(widgetInstalled) = preferences.edit { putBoolean(KEY_DEFAULT_BROWSER, widgetInstalled) }
+        set(defaultBrowser) = preferences.edit { putBoolean(KEY_DEFAULT_BROWSER, defaultBrowser) }
 
     override fun hasInstallTimestampRecorded(): Boolean = preferences.contains(KEY_TIMESTAMP_UTC)
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageFragment.kt
@@ -111,7 +111,7 @@ sealed class OnboardingPageFragment : Fragment() {
 
             if (isDefault) {
                 installStore.defaultBrowser = true
-                pixel.fire(DEFAULT_BROWSER_SET)
+                pixel.fire(DEFAULT_BROWSER_SET, includeLocal = true)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageFragment.kt
@@ -46,8 +46,6 @@ sealed class OnboardingPageFragment : Fragment() {
     @LayoutRes
     abstract fun layoutResource(): Int
 
-    lateinit var installStore: AppInstallStore
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -70,6 +68,9 @@ sealed class OnboardingPageFragment : Fragment() {
 
         @Inject
         lateinit var pixel: Pixel
+
+        @Inject
+        lateinit var installStore: AppInstallStore
 
         @Inject
         lateinit var defaultBrowserDetector: DefaultBrowserDetector

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageFragment.kt
@@ -111,7 +111,7 @@ sealed class OnboardingPageFragment : Fragment() {
 
             if (isDefault) {
                 installStore.defaultBrowser = true
-                pixel.fire(DEFAULT_BROWSER_SET, includeLocal = true)
+                pixel.fire(DEFAULT_BROWSER_SET, includeLocale = true)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageFragment.kt
@@ -30,6 +30,7 @@ import androidx.fragment.app.Fragment
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserSystemSettings
+import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 import dagger.android.support.AndroidSupportInjection
@@ -44,6 +45,8 @@ sealed class OnboardingPageFragment : Fragment() {
 
     @LayoutRes
     abstract fun layoutResource(): Int
+
+    lateinit var installStore: AppInstallStore
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -81,13 +84,6 @@ sealed class OnboardingPageFragment : Fragment() {
             launchSettingsButton.setOnClickListener { onLaunchDefaultBrowserSettingsClicked() }
         }
 
-        override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-            super.setUserVisibleHint(isVisibleToUser)
-            if (isVisibleToUser) {
-                pixel.fire(DEFAULT_BROWSER_INFO_VIEWED)
-            }
-        }
-
         private fun onLaunchDefaultBrowserSettingsClicked() {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 val intent = DefaultBrowserSystemSettings.intent()
@@ -102,19 +98,20 @@ sealed class OnboardingPageFragment : Fragment() {
         override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
             when (requestCode) {
                 DEFAULT_BROWSER_REQUEST_CODE -> {
-                    fireDefaultBrowserPixel()
+                    handleDefaultBrowserResult()
                 }
                 else -> super.onActivityResult(requestCode, resultCode, data)
             }
         }
 
-        private fun fireDefaultBrowserPixel() {
-            if (defaultBrowserDetector.isCurrentlyConfiguredAsDefaultBrowser()) {
-                Timber.i("User returned from default settings; DDG is now the default")
+        private fun handleDefaultBrowserResult() {
+            val isDefault = defaultBrowserDetector.isDefaultBrowser()
+            val setText = if (isDefault) "was" else "was not"
+            Timber.i("User returned from default settings; DDG $setText set as default")
+
+            if (isDefault) {
+                installStore.defaultBrowser = true
                 pixel.fire(DEFAULT_BROWSER_SET)
-            } else {
-                Timber.i("User returned from default settings; DDG was not set default")
-                pixel.fire(DEFAULT_BROWSER_NOT_SET)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -73,7 +73,7 @@ class SettingsViewModel @Inject constructor(
 
     fun start() {
 
-        val defaultBrowserAlready = defaultWebBrowserCapability.isCurrentlyConfiguredAsDefaultBrowser()
+        val defaultBrowserAlready = defaultWebBrowserCapability.isDefaultBrowser()
         val variant = variantManager.getVariant()
         val isLightTheme = settingsDataStore.theme == DuckDuckGoTheme.LIGHT
         val automaticallyClearWhat = settingsDataStore.automaticallyClearWhatOption

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -40,8 +40,8 @@ interface Pixel {
         PRIVACY_DASHBOARD_PRIVACY_PRACTICES("mp_p"),
         PRIVACY_DASHBOARD_NETWORKS("mp_n"),
 
-        DEFAULT_BROWSER_SET("m_b_s"),
-        DEFAULT_BROWSER_UNSET("m_b_u"),
+        DEFAULT_BROWSER_SET("m_db_s"),
+        DEFAULT_BROWSER_UNSET("m_db_u"),
         WIDGETS_ADDED(pixelName = "m_w_a"),
         WIDGETS_DELETED(pixelName = "m_w_d"),
         WIDGET_LAUNCHED(pixelName = "m_w_l"),
@@ -111,8 +111,8 @@ interface Pixel {
         const val APP_VERSION = "app_version"
     }
 
-    fun fire(pixel: PixelName, parameters: Map<String, String?> = emptyMap(), includeLocal: Boolean = false)
-    fun fire(pixelName: String, parameters: Map<String, String?> = emptyMap(), includeLocal: Boolean = false)
+    fun fire(pixel: PixelName, parameters: Map<String, String?> = emptyMap(), includeLocale: Boolean = false)
+    fun fire(pixelName: String, parameters: Map<String, String?> = emptyMap(), includeLocale: Boolean = false)
     fun fireCompletable(pixelName: String, parameters: Map<String, String?>): Completable
 
 }
@@ -124,12 +124,12 @@ class ApiBasedPixel @Inject constructor(
     private val deviceInfo: DeviceInfo
 ) : Pixel {
 
-    override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String?>, addLocale: Boolean) {
-        fire(pixel.pixelName, parameters, addLocale)
+    override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String?>, includeLocale: Boolean) {
+        fire(pixel.pixelName, parameters, includeLocale)
     }
 
-    override fun fire(pixelName: String, parameters: Map<String, String?>, addLocale: Boolean) {
-        val locale = if (addLocale) localeMap else emptyMap()
+    override fun fire(pixelName: String, parameters: Map<String, String?>, includeLocale: Boolean) {
+        val locale = if (includeLocale) localeMap else emptyMap()
 
         fireCompletable(pixelName, parameters.plus(locale))
             .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -42,6 +42,8 @@ interface Pixel {
         DEFAULT_BROWSER_INFO_VIEWED("mdb_v"),
         DEFAULT_BROWSER_SET("mdb_s"),
         DEFAULT_BROWSER_NOT_SET("mdb_n"),
+        WIDGET_ADDED(pixelName = "maw_a"),
+        WIDGET_DELETED(pixelName = "maw_d"),
 
         LONG_PRESS("mlp"),
         LONG_PRESS_DOWNLOAD_IMAGE("mlp_i"),
@@ -61,18 +63,6 @@ interface Pixel {
         SURVEY_CTA_DISMISSED(pixelName = "mus_cd"),
         SURVEY_CTA_LAUNCHED(pixelName = "mus_cl"),
         SURVEY_SURVEY_DISMISSED(pixelName = "mus_sd"),
-
-        ADD_WIDGET_AUTO_CTA_SHOWN(pixelName = "maw_acs"),
-        ADD_WIDGET_AUTO_CTA_DISMISSED(pixelName = "maw_acd"),
-        ADD_WIDGET_AUTO_CTA_LAUNCHED(pixelName = "maw_acl"),
-        ADD_WIDGET_AUTO_ADDED(pixelName = "maw_aa"),
-        ADD_WIDGET_AUTO_DELETED(pixelName = "maw_ad"),
-
-        ADD_WIDGET_INSTRUCTIONS_CTA_SHOWN(pixelName = "maw_ics"),
-        ADD_WIDGET_INSTRUCTIONS_CTA_DISMISSED(pixelName = "maw_icd"),
-        ADD_WIDGET_INSTRUCTIONS_CTA_LAUNCHED(pixelName = "maw_icl"),
-        ADD_WIDGET_INSTRUCTIONS_ADDED(pixelName = "maw_ia"),
-        ADD_WIDGET_INSTRUCTIONS_DELETED(pixelName = "maw_id"),
 
         NOTIFICATION_SHOWN("mnot_s"),
         NOTIFICATION_LAUNCHED("mnot_l"),

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -39,11 +39,11 @@ interface Pixel {
         PRIVACY_DASHBOARD_PRIVACY_PRACTICES("mp_p"),
         PRIVACY_DASHBOARD_NETWORKS("mp_n"),
 
-        DEFAULT_BROWSER_INFO_VIEWED("mdb_v"),
-        DEFAULT_BROWSER_SET("mdb_s"),
-        DEFAULT_BROWSER_NOT_SET("mdb_n"),
-        WIDGET_ADDED(pixelName = "maw_a"),
-        WIDGET_DELETED(pixelName = "maw_d"),
+        DEFAULT_BROWSER_SET("m_b_s"),
+        DEFAULT_BROWSER_UNSET("m_b_u"),
+        WIDGET_ADDED(pixelName = "m_w_a"),
+        WIDGET_DELETED(pixelName = "m_w_d"),
+        WIDGET_LAUNCHED(pixelName = "m_w_l"),
 
         LONG_PRESS("mlp"),
         LONG_PRESS_DOWNLOAD_IMAGE("mlp_i"),

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -41,8 +41,8 @@ interface Pixel {
 
         DEFAULT_BROWSER_SET("m_b_s"),
         DEFAULT_BROWSER_UNSET("m_b_u"),
-        WIDGET_ADDED(pixelName = "m_w_a"),
-        WIDGET_DELETED(pixelName = "m_w_d"),
+        WIDGETS_ADDED(pixelName = "m_w_a"),
+        WIDGETS_DELETED(pixelName = "m_w_d"),
         WIDGET_LAUNCHED(pixelName = "m_w_l"),
 
         LONG_PRESS("mlp"),

--- a/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
@@ -27,8 +27,8 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.WIDGET_ADDED
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.WIDGET_DELETED
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.WIDGETS_ADDED
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.WIDGETS_DELETED
 import com.duckduckgo.app.widget.ui.AppWidgetCapabilities
 import javax.inject.Inject
 
@@ -59,7 +59,7 @@ open class SearchWidget(val layoutId: Int = R.layout.search_widget) : AppWidgetP
     override fun onEnabled(context: Context) {
         if (!appInstallStore.widgetInstalled) {
             appInstallStore.widgetInstalled = true
-            pixel.fire(WIDGET_ADDED)
+            pixel.fire(WIDGETS_ADDED)
         }
     }
 
@@ -84,7 +84,7 @@ open class SearchWidget(val layoutId: Int = R.layout.search_widget) : AppWidgetP
     override fun onDeleted(context: Context, appWidgetIds: IntArray?) {
         if (appInstallStore.widgetInstalled && !widgetCapabilities.hasInstalledWidgets) {
             appInstallStore.widgetInstalled = false
-            pixel.fire(WIDGET_DELETED)
+            pixel.fire(WIDGETS_DELETED)
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
@@ -59,7 +59,7 @@ open class SearchWidget(val layoutId: Int = R.layout.search_widget) : AppWidgetP
     override fun onEnabled(context: Context) {
         if (!appInstallStore.widgetInstalled) {
             appInstallStore.widgetInstalled = true
-            pixel.fire(WIDGETS_ADDED, includeLocal = true)
+            pixel.fire(WIDGETS_ADDED, includeLocale = true)
         }
     }
 
@@ -84,7 +84,7 @@ open class SearchWidget(val layoutId: Int = R.layout.search_widget) : AppWidgetP
     override fun onDeleted(context: Context, appWidgetIds: IntArray?) {
         if (appInstallStore.widgetInstalled && !widgetCapabilities.hasInstalledWidgets) {
             appInstallStore.widgetInstalled = false
-            pixel.fire(WIDGETS_DELETED, includeLocal = true)
+            pixel.fire(WIDGETS_DELETED, includeLocale = true)
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
@@ -59,7 +59,7 @@ open class SearchWidget(val layoutId: Int = R.layout.search_widget) : AppWidgetP
     override fun onEnabled(context: Context) {
         if (!appInstallStore.widgetInstalled) {
             appInstallStore.widgetInstalled = true
-            pixel.fire(WIDGETS_ADDED)
+            pixel.fire(WIDGETS_ADDED, includeLocal = true)
         }
     }
 
@@ -84,7 +84,7 @@ open class SearchWidget(val layoutId: Int = R.layout.search_widget) : AppWidgetP
     override fun onDeleted(context: Context, appWidgetIds: IntArray?) {
         if (appInstallStore.widgetInstalled && !widgetCapabilities.hasInstalledWidgets) {
             appInstallStore.widgetInstalled = false
-            pixel.fire(WIDGETS_DELETED)
+            pixel.fire(WIDGETS_DELETED, includeLocal = true)
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
-import com.duckduckgo.app.widget.ui.supportsAutomaticWidgetAdd
 
 
 class SearchWidgetLight : SearchWidget(R.layout.search_widget_light)
@@ -34,8 +33,7 @@ open class SearchWidget(val layoutId: Int = R.layout.search_widget) : AppWidgetP
 
     override fun onEnabled(context: Context) {
         val application = context.applicationContext as? DuckDuckGoApplication
-        val pixelType = if (context.supportsAutomaticWidgetAdd) ADD_WIDGET_AUTO_ADDED else ADD_WIDGET_INSTRUCTIONS_ADDED
-        application?.pixel?.fire(pixelType)
+        application?.pixel?.fire(WIDGET_ADDED)
         super.onEnabled(context)
     }
 
@@ -59,7 +57,6 @@ open class SearchWidget(val layoutId: Int = R.layout.search_widget) : AppWidgetP
 
     override fun onDeleted(context: Context, appWidgetIds: IntArray?) {
         val application = context.applicationContext as? DuckDuckGoApplication
-        val pixelType = if (context.supportsAutomaticWidgetAdd) ADD_WIDGET_AUTO_DELETED else ADD_WIDGET_INSTRUCTIONS_DELETED
-        application?.pixel?.fire(pixelType)
+        application?.pixel?.fire(WIDGET_DELETED)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1119886581463189
Tech Design URL: 

**Description**:
TIdy up pixels to for better widgets and default browser counts. Also add pixel to detect widget engagement.

**Steps to test this PR**:

**TEST 1: Add / Remove widget Test**
1. Run the app add a bunch of widgets
1. Note the add widget pixel "m_w_a" is fired with lang and country only once
1. Launch the app from the widget and check that the "m_w_l" pixel launches with lang and country
1. Delete all the widgets
1. Note the delete widget pixel "m_w_d" is fired once when the last widget is removed
1. Check that other pixels do not contain lang and country

**TEST 2: Set / Unset default browser** 
1. From settings, set the app as the default browser
1. Launch the app
1. Note the default browser pixel "m_db_s" is fired with lang and country
1. From settings, choose a different app to be the default browser
1. Note the unset pixel "m_db_u" is fired with lang and country
1. Check that other pixels do not contain lang and country

**TEST 3: Device Restart**
1. Restart device
1. Ensure pixels are not resent unless newly triggered 

**TEST 4: Onboarding**
1. Freshly install the app
1. When onboarding select option to set as default browser
1. Ensure pixel sent

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
