### PR TITLE
Fix back navigation on that report same url onPageFinished

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
@@ -87,6 +87,34 @@ class UriExtensionTest {
     }
 
     @Test
+    fun whenUriIsHttpsAndOtherIsHttpButOtherwiseIdenticalThenIsHttpsVersionOfOtherIsTrue() {
+        val uri = Uri.parse("https://example.com")
+        val other = Uri.parse("http://example.com")
+        assertTrue(uri.isHttpsVersionOfUri(other))
+    }
+
+    @Test
+    fun whenUriIsHttpsAndOtherIsHttpButNotOtherwiseIdenticalThenIsHttpsVersionOfOtherIsFalse() {
+        val uri = Uri.parse("https://example.com")
+        val other = Uri.parse("http://example.com/path")
+        assertFalse(uri.isHttpsVersionOfUri(other))
+    }
+
+    @Test
+    fun whenUriIsHttpThenIsHttpsVersionOfOtherIsFalse() {
+        val uri = Uri.parse("http://example.com")
+        val other = Uri.parse("http://example.com")
+        assertFalse(uri.isHttpsVersionOfUri(other))
+    }
+
+    @Test
+    fun whenUriIsHttpsAndOtherIsHttpsThenIsHttpsVersionOfOtherIsFalse() {
+        val uri = Uri.parse("https://example.com")
+        val other = Uri.parse("https://example.com")
+        assertFalse(uri.isHttpsVersionOfUri(other))
+    }
+
+    @Test
     fun whenUriIsMalformedThenIsHtpsIsFalse() {
         assertFalse(Uri.parse("[example com]").isHttps)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -286,7 +286,7 @@ class BrowserWebViewClient @Inject constructor(
         private val WebBackForwardList.isHttpsUpgrade: Boolean
             get() {
                 if (currentIndex < 1) return false
-                val current = currentItem.originalUrl?.toUri() ?: return false
+                val current = currentItem?.originalUrl?.toUri() ?: return false
                 val previous = getItemAtIndex(currentIndex - 1).originalUrl?.toUri() ?: return false
                 return current.isHttpsVersionOfUri(previous)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -28,7 +28,7 @@ import androidx.annotation.WorkerThread
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.global.isHttps
-import com.duckduckgo.app.global.toHttpsString
+import com.duckduckgo.app.global.isHttpsVersionOfUri
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.HTTPS_UPGRADE_SITE_ERROR
@@ -286,9 +286,9 @@ class BrowserWebViewClient @Inject constructor(
         private val WebBackForwardList.isHttpsUpgrade: Boolean
             get() {
                 if (currentIndex < 1) return false
-                val current = currentItem.originalUrl ?: return false
-                val previous = getItemAtIndex(currentIndex - 1).originalUrl
-                return current == previous.toUri().toHttpsString
+                val current = currentItem.originalUrl?.toUri() ?: return false
+                val previous = getItemAtIndex(currentIndex - 1).originalUrl?.toUri() ?: return false
+                return current.isHttpsVersionOfUri(previous)
             }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -43,14 +43,15 @@ val Uri.isHttps: Boolean
 val Uri.toHttps: Uri
     get() = buildUpon().scheme(UrlScheme.https).build()
 
-val Uri.toHttpsString
-    get() = toHttps.toString()
-
 val Uri.hasIpHost: Boolean
     get() {
         val ipRegex = Regex("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
         return baseHost?.matches(ipRegex) ?: false
     }
+
+fun Uri.isHttpsVersionOfUri(other: Uri): Boolean {
+    return isHttps && other.isHttp && other.toHttps == this
+}
 
 private val MOBILE_URL_PREFIXES = listOf("m.", "mobile.")
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/361428290920650/1120790452461796/1120758001420790

**Description**:
Fix back navigation on sites like reddit that report same url onPageFinished as previous page.

**Steps to test this PR**:
1. Open a webpage e.g facebook.com
1. Now go to reddit.com
1. Select a subcategory e.g movies
1. Press back
1. You should still be on reddit.com

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
