### PR TITLE
Added pixels for content blocking

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -20,12 +20,16 @@ import android.content.Context
 import com.duckduckgo.app.browser.WebDataManager
 import com.duckduckgo.app.entities.EntityMapping
 import com.duckduckgo.app.fire.*
+import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
+import com.duckduckgo.app.privacy.HistoricTrackerBlockingObserver
 import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.model.PrivacyPracticesImpl
+import com.duckduckgo.app.privacy.store.PrivacySettingsStore
 import com.duckduckgo.app.privacy.store.TermsOfServiceStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabRepository
 import dagger.Module
 import dagger.Provides
@@ -65,4 +69,13 @@ class PrivacyModule {
     ): DataClearer {
         return AutomaticDataClearer(settingsDataStore, clearDataAction, dataClearerTimeKeeper)
     }
+
+    @Provides
+    @Singleton
+    fun historicTrackerBlockingObserver(
+        appInstallStore: AppInstallStore,
+        privacySettingsStore: PrivacySettingsStore,
+        pixel: Pixel
+    ): HistoricTrackerBlockingObserver =
+        HistoricTrackerBlockingObserver(appInstallStore, privacySettingsStore, pixel)
 }

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.job.AppConfigurationSyncer
 import com.duckduckgo.app.notification.NotificationRegistrar
 import com.duckduckgo.app.notification.NotificationScheduler
+import com.duckduckgo.app.privacy.HistoricTrackerBlockingObserver
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -88,6 +89,9 @@ open class DuckDuckGoApplication : HasActivityInjector, HasServiceInjector, HasS
 
     @Inject
     lateinit var defaultBrowserObserver: DefaultBrowserObserver
+
+    @Inject
+    lateinit var historicTrackerBlockingObserver: HistoricTrackerBlockingObserver
 
     @Inject
     lateinit var statisticsUpdater: StatisticsUpdater
@@ -157,6 +161,7 @@ open class DuckDuckGoApplication : HasActivityInjector, HasServiceInjector, HasS
             it.addObserver(dataClearer)
             it.addObserver(appDaysUsedRecorder)
             it.addObserver(defaultBrowserObserver)
+            it.addObserver(historicTrackerBlockingObserver)
             it.addObserver(appEnjoymentLifecycleObserver)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/privacy/HistoricTrackerBlockingObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/HistoricTrackerBlockingObserver.kt
@@ -33,7 +33,7 @@ class HistoricTrackerBlockingObserver(
     @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
     fun onApplicationCreated() {
 
-        if (appInstallStore.daysInstalled() > 0 && !privacySettingsStore.historicTrackerOptionRecorded ) {
+        if (isHistoricUser() && !privacySettingsStore.historicTrackerOptionRecorded) {
             when (privacySettingsStore.privacyOn) {
                 true -> pixel.fire(Pixel.PixelName.TRACKER_BLOCKER_HISTORICAL_ON)
                 false -> pixel.fire(Pixel.PixelName.TRACKER_BLOCKER_HISTORICAL_OFF)
@@ -41,6 +41,9 @@ class HistoricTrackerBlockingObserver(
         }
 
         privacySettingsStore.historicTrackerOptionRecorded = true
+    }
 
+    private fun isHistoricUser() : Boolean {
+        return appInstallStore.hasInstallTimestampRecorded() && appInstallStore.daysInstalled() > 0
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/privacy/HistoricTrackerBlockingObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/HistoricTrackerBlockingObserver.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.privacy
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.global.install.daysInstalled
+import com.duckduckgo.app.privacy.store.PrivacySettingsStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+class HistoricTrackerBlockingObserver(
+    private val appInstallStore: AppInstallStore,
+    private val privacySettingsStore: PrivacySettingsStore,
+    private val pixel: Pixel
+) : LifecycleObserver {
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    fun onApplicationCreated() {
+
+        if (appInstallStore.daysInstalled() > 0 && !privacySettingsStore.historicTrackerOptionRecorded ) {
+            when (privacySettingsStore.privacyOn) {
+                true -> pixel.fire(Pixel.PixelName.TRACKER_BLOCKER_HISTORICAL_ON)
+                false -> pixel.fire(Pixel.PixelName.TRACKER_BLOCKER_HISTORICAL_OFF)
+            }
+        }
+
+        privacySettingsStore.historicTrackerOptionRecorded = true
+
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/privacy/store/PrivacySettingsSharedPreferences.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/store/PrivacySettingsSharedPreferences.kt
@@ -31,6 +31,14 @@ class PrivacySettingsSharedPreferences @Inject constructor(private val context: 
             editor.apply()
         }
 
+    override var historicTrackerOptionRecorded: Boolean
+        get() = preferences.getBoolean(KEY_PRIVACY_HISTORIC_TRACKING_OPTION_RECORDED, false)
+        set(recorded) {
+            val editor = preferences.edit()
+            editor.putBoolean(KEY_PRIVACY_HISTORIC_TRACKING_OPTION_RECORDED, recorded)
+            editor.apply()
+        }
+
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, MODE_PRIVATE)
 
@@ -38,5 +46,7 @@ class PrivacySettingsSharedPreferences @Inject constructor(private val context: 
     companion object {
         private const val FILENAME = "com.duckduckgo.app.privacymonitor.settings"
         private const val KEY_PRIVACY_ON = "com.duckduckgo.app.privacymonitor.privacyon"
+        private const val KEY_PRIVACY_HISTORIC_TRACKING_OPTION_RECORDED = "com.duckduckgo.app.privacymonitor.historictrackingoptionrecorded"
+
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/privacy/store/PrivacySettingsStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/store/PrivacySettingsStore.kt
@@ -18,4 +18,5 @@ package com.duckduckgo.app.privacy.store
 
 interface PrivacySettingsStore {
     var privacyOn: Boolean
+    var historicTrackerOptionRecorded: Boolean
 }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
@@ -30,12 +30,12 @@ import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.UNKNOWN
 import com.duckduckgo.app.privacy.store.PrivacySettingsStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.PRIVACY_DASHBOARD_OPENED
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 
 class PrivacyDashboardViewModel(
     private val settingsStore: PrivacySettingsStore,
     networkLeaderboardDao: NetworkLeaderboardDao,
-    pixel: Pixel
+    private val pixel: Pixel
 ) : ViewModel() {
 
     data class ViewState(
@@ -144,7 +144,11 @@ class PrivacyDashboardViewModel(
 
     fun onPrivacyToggled(enabled: Boolean) {
         if (enabled != viewState.value?.toggleEnabled) {
+
             settingsStore.privacyOn = enabled
+            val pixelName = if (enabled) TRACKER_BLOCKER_DASHBOARD_TURNED_ON else TRACKER_BLOCKER_DASHBOARD_TURNED_OFF
+            pixel.fire(pixelName)
+
             viewState.value = viewState.value?.copy(
                 toggleEnabled = enabled,
                 shouldReloadPage = shouldReloadPage

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -40,6 +40,11 @@ interface Pixel {
         PRIVACY_DASHBOARD_PRIVACY_PRACTICES("mp_p"),
         PRIVACY_DASHBOARD_NETWORKS("mp_n"),
 
+        TRACKER_BLOCKER_HISTORICAL_ON(pixelName = "m_tb_on_h"),
+        TRACKER_BLOCKER_HISTORICAL_OFF(pixelName = "m_tb_off_h"),
+        TRACKER_BLOCKER_DASHBOARD_TURNED_ON(pixelName = "m_tb_on_pd"),
+        TRACKER_BLOCKER_DASHBOARD_TURNED_OFF(pixelName = "m_tb_off_pd"),
+
         DEFAULT_BROWSER_SET("m_db_s"),
         DEFAULT_BROWSER_UNSET("m_db_u"),
         WIDGETS_ADDED(pixelName = "m_w_a"),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1122462911344278

**Description**:
Add pixels for content blocking on/off

**Steps to test this PR**:

TEST HISTORIC USERS CONTENT BLOCKING ON
1. Install this version over an installation that has been running for a few days with content blocking already on (you may need to hack this in!)
1. Run the app and watch for the pixel "m_tb_on_h" to indicate that content blocking is on
1. Run launch, resume etc the app again. This pixel should never fire again.

TEST HISTORIC USERS CONTENT BLOCKING OFF
1. Install this version over an installation that has been running for a few days with content blocking already off (you may need to hack this in!)
1. Run the app and watch for the pixel "m_tb_off_h" to indicate that content blocking is off
1. Run launch, resume etc the app again. This pixel should never fire again.

TEST NEW USERS
1. Run a CLEAN version of the app
1. Ensure that no "m_tb_on_pd" and "m_tb_off_pd" pixel fires

TEST CONTENT BLOCKING TOGGLE OFF
1. Run the app (clean or historic is fine)
1. Visit the dashboard and switch content blocking off
1. Ensure the "m_tb_off_pd" pixel fires

TEST CONTENT BLOCKING TOGGLE OFF
1. Run the app (clean or historic is fine)
1. Visit the dashboard and switch content blocking on
1. Ensure the "m_tb_on_pd" pixel fires

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
