### PR TITLE
Enable WebView debugging during BuildConfig.DEBUG builds

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -660,7 +660,9 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             it.setFindListener(this)
         }
 
-        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
+        if (BuildConfig.DEBUG) {
+            WebView.setWebContentsDebuggingEnabled(true)
+        }
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -659,6 +659,8 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
             it.setFindListener(this)
         }
+
+        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
     }
 
     /**


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1124956056611274
Tech Design URL: 
CC: 

**Description**:
Allows `WebView`s to be remotely debugged when the app is running in `BuildConfig.DEBUG` mode only.

**Steps to test this PR**:
1. From a `DEBUG` build, using Chrome on the desktop, visit `chrome://inspect` and verify the `WebView` shows and can be inspected
1. Repeat the above on a `RELEASE` build and ensure it cannot be inspected


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
