### PR TITLE
Add long press option to "open image in background tab"

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
@@ -128,17 +128,25 @@ class WebViewLongPressHandlerTest {
     @Test
     fun whenUserSelectedDownloadImageOptionThenActionIsDownloadFileActionRequired() {
         whenever(mockMenuItem.itemId).thenReturn(WebViewLongPressHandler.CONTEXT_MENU_ID_DOWNLOAD_IMAGE)
-        val longPressTarget = LongPressTarget(url = "example.com", type = HitTestResult.SRC_ANCHOR_TYPE)
+        val longPressTarget = LongPressTarget(url = "example.com", imageUrl = "example.com/foo.jpg", type = HitTestResult.SRC_ANCHOR_TYPE)
         val action = testee.userSelectedMenuItem(longPressTarget, mockMenuItem)
         assertTrue(action is LongPressHandler.RequiredAction.DownloadFile)
     }
 
     @Test
+    fun whenUserSelectedDownloadImageOptionButNoImageUrlAvailableThenNoActionRequired() {
+        whenever(mockMenuItem.itemId).thenReturn(WebViewLongPressHandler.CONTEXT_MENU_ID_DOWNLOAD_IMAGE)
+        val longPressTarget = LongPressTarget(url = "example.com", imageUrl = null, type = HitTestResult.SRC_ANCHOR_TYPE)
+        val action = testee.userSelectedMenuItem(longPressTarget, mockMenuItem)
+        assertTrue(action is LongPressHandler.RequiredAction.None)
+    }
+
+    @Test
     fun whenUserSelectedDownloadImageOptionThenDownloadFileWithCorrectUrlReturned() {
         whenever(mockMenuItem.itemId).thenReturn(WebViewLongPressHandler.CONTEXT_MENU_ID_DOWNLOAD_IMAGE)
-        val longPressTarget = LongPressTarget(url = "example.com", type = HitTestResult.SRC_ANCHOR_TYPE)
+        val longPressTarget = LongPressTarget(url = "example.com", imageUrl = "example.com/foo.jpg", type = HitTestResult.SRC_ANCHOR_TYPE)
         val action = testee.userSelectedMenuItem(longPressTarget, mockMenuItem) as LongPressHandler.RequiredAction.DownloadFile
-        assertEquals("example.com", action.url)
+        assertEquals("example.com/foo.jpg", action.url)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
@@ -60,73 +60,73 @@ class WebViewLongPressHandlerTest {
     }
 
     @Test
-    fun whenLongPressedWithImageTypeThenPixelFired() {
+    fun whenUserLongPressesWithImageTypeThenPixelFired() {
         testee.handleLongPress(HitTestResult.IMAGE_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verify(mockPixel).fire(Pixel.PixelName.LONG_PRESS)
     }
 
     @Test
-    fun whenLongPressedWithAnchorImageTypeThenPixelFired() {
+    fun whenUserLongPressesWithAnchorImageTypeThenPixelFired() {
         testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verify(mockPixel).fire(Pixel.PixelName.LONG_PRESS)
     }
 
     @Test
-    fun whenLongPressedWithUnknownTypeThenPixelNotFired() {
+    fun whenUserLongPressesWithUnknownTypeThenPixelNotFired() {
         testee.handleLongPress(HitTestResult.UNKNOWN_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verify(mockPixel, never()).fire(Pixel.PixelName.LONG_PRESS)
     }
 
     @Test
-    fun whenLongPressedWithImageTypeThenUrlHeaderAddedToMenu() {
+    fun whenUserLongPressesWithImageTypeThenUrlHeaderAddedToMenu() {
         testee.handleLongPress(HitTestResult.IMAGE_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verify(mockMenu).setHeaderTitle(HTTPS_IMAGE_URL)
     }
 
     @Test
-    fun whenLongPressedWithAnchorImageTypeThenUrlHeaderAddedToMenu() {
+    fun whenUserLongPressesWithAnchorImageTypeThenUrlHeaderAddedToMenu() {
         testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verify(mockMenu).setHeaderTitle(HTTPS_IMAGE_URL)
     }
 
     @Test
-    fun whenLongPressedWithAnchorImageTypeThenTabOptionsHeaderAddedToMenu() {
+    fun whenUserLongPressesWithAnchorImageTypeThenTabOptionsHeaderAddedToMenu() {
         testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verifyNewForegroundTabItemAdded()
     }
 
     @Test
-    fun whenLongPressedWithAnchorImageTypeThenBgTabOptionsHeaderAddedToMenu() {
+    fun whenUserLongPressesWithAnchorImageTypeThenBgTabOptionsHeaderAddedToMenu() {
         testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verifyNewBackgroundTabItemAdded()
     }
 
     @Test
-    fun whenLongPressedWithImageTypeThenDownloadImageMenuAdded() {
+    fun whenUserLongPressesWithImageTypeThenDownloadImageMenuAdded() {
         testee.handleLongPress(HitTestResult.IMAGE_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verifyDownloadImageItemAdded()
     }
 
     @Test
-    fun whenLongPressedWithAnchorImageTypeThenDownloadImageMenuAdded() {
+    fun whenUserLongPressesWithAnchorImageTypeThenDownloadImageMenuAdded() {
         testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verifyDownloadImageItemAdded()
     }
 
     @Test
-    fun whenLongPressedWithOtherImageTypeThenMenuNotAltered() {
+    fun whenUserLongPressesWithOtherImageTypeThenMenuNotAltered() {
         testee.handleLongPress(HitTestResult.UNKNOWN_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verifyMenuNotAltered()
     }
 
     @Test
-    fun whenLongPressedWithImageTypeWhichIsADataUriThenDownloadImageMenuAdded() {
+    fun whenUserLongPressesWithImageTypeWhichIsADataUriThenDownloadImageMenuAdded() {
         testee.handleLongPress(HitTestResult.IMAGE_TYPE, DATA_URI_IMAGE_URL, mockMenu)
         verifyDownloadImageItemAdded()
     }
 
     @Test
-    fun whenUserSelectedDownloadImageOptionThenActionIsDownloadFileActionRequired() {
+    fun whenUserSelectsDownloadImageOptionThenActionIsDownloadFileActionRequired() {
         whenever(mockMenuItem.itemId).thenReturn(WebViewLongPressHandler.CONTEXT_MENU_ID_DOWNLOAD_IMAGE)
         val longPressTarget = LongPressTarget(url = "example.com", imageUrl = "example.com/foo.jpg", type = HitTestResult.SRC_ANCHOR_TYPE)
         val action = testee.userSelectedMenuItem(longPressTarget, mockMenuItem)
@@ -134,7 +134,7 @@ class WebViewLongPressHandlerTest {
     }
 
     @Test
-    fun whenUserSelectedDownloadImageOptionButNoImageUrlAvailableThenNoActionRequired() {
+    fun whenUserSelectsDownloadImageOptionButNoImageUrlAvailableThenNoActionRequired() {
         whenever(mockMenuItem.itemId).thenReturn(WebViewLongPressHandler.CONTEXT_MENU_ID_DOWNLOAD_IMAGE)
         val longPressTarget = LongPressTarget(url = "example.com", imageUrl = null, type = HitTestResult.SRC_ANCHOR_TYPE)
         val action = testee.userSelectedMenuItem(longPressTarget, mockMenuItem)
@@ -142,7 +142,7 @@ class WebViewLongPressHandlerTest {
     }
 
     @Test
-    fun whenUserSelectedDownloadImageOptionThenDownloadFileWithCorrectUrlReturned() {
+    fun whenUserSelectsDownloadImageOptionThenDownloadFileWithCorrectUrlReturned() {
         whenever(mockMenuItem.itemId).thenReturn(WebViewLongPressHandler.CONTEXT_MENU_ID_DOWNLOAD_IMAGE)
         val longPressTarget = LongPressTarget(url = "example.com", imageUrl = "example.com/foo.jpg", type = HitTestResult.SRC_ANCHOR_TYPE)
         val action = testee.userSelectedMenuItem(longPressTarget, mockMenuItem) as LongPressHandler.RequiredAction.DownloadFile
@@ -150,7 +150,7 @@ class WebViewLongPressHandlerTest {
     }
 
     @Test
-    fun whenUserSelectedUnknownOptionThenNoActionRequiredReturned() {
+    fun whenUserSelectsUnknownOptionThenNoActionRequiredReturned() {
         val unknownMenuId = 123
         whenever(mockMenuItem.itemId).thenReturn(unknownMenuId)
         val longPressTarget = LongPressTarget(url = "example.com", type = HitTestResult.SRC_ANCHOR_TYPE)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -707,13 +707,20 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         return when {
             hitTestResult.extra == null -> null
             hitTestResult.type == UNKNOWN_TYPE -> null
-            hitTestResult.type == IMAGE_TYPE -> LongPressTarget(url = hitTestResult.extra, imageUrl = hitTestResult.extra, type = hitTestResult.type)
+            hitTestResult.type == IMAGE_TYPE -> LongPressTarget(
+                url = hitTestResult.extra,
+                imageUrl = hitTestResult.extra,
+                type = hitTestResult.type
+            )
             hitTestResult.type == SRC_IMAGE_ANCHOR_TYPE -> LongPressTarget(
                 url = getTargetUrlForImageSource(),
                 imageUrl = hitTestResult.extra,
                 type = hitTestResult.type
             )
-            else -> LongPressTarget(url = hitTestResult.extra, type = hitTestResult.type)
+            else -> LongPressTarget(
+                url = hitTestResult.extra,
+                type = hitTestResult.type
+            )
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -39,8 +39,7 @@ import android.view.inputmethod.EditorInfo
 import android.webkit.*
 import android.webkit.WebView.FindListener
 import android.webkit.WebView.HitTestResult
-import android.webkit.WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE
-import android.webkit.WebView.HitTestResult.UNKNOWN_TYPE
+import android.webkit.WebView.HitTestResult.*
 import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.AnyThread
@@ -696,15 +695,13 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         return when {
             hitTestResult.extra == null -> null
             hitTestResult.type == UNKNOWN_TYPE -> null
+            hitTestResult.type == IMAGE_TYPE -> LongPressTarget(url = hitTestResult.extra, imageUrl = hitTestResult.extra, type = hitTestResult.type)
             hitTestResult.type == SRC_IMAGE_ANCHOR_TYPE -> LongPressTarget(
-                url = getTargetUrlForImageSource() ?: hitTestResult.extra,
+                url = getTargetUrlForImageSource(),
                 imageUrl = hitTestResult.extra,
                 type = hitTestResult.type
             )
-            else -> LongPressTarget(
-                url = hitTestResult.extra,
-                type = hitTestResult.type
-            )
+            else -> LongPressTarget(url = hitTestResult.extra, type = hitTestResult.type)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -596,13 +596,14 @@ class BrowserTabViewModel(
     }
 
     fun userLongPressedInWebView(target: LongPressTarget, menu: ContextMenu) {
-        Timber.i("Long pressed on ${target.type}, (url=${target.url})")
+        Timber.i("Long pressed on ${target.type}, (url=${target.url}), (image url = ${target.imageUrl})")
         longPressHandler.handleLongPress(target.type, target.url, menu)
     }
 
     fun userSelectedItemFromLongPressMenu(longPressTarget: LongPressTarget, item: MenuItem): Boolean {
 
         val requiredAction = longPressHandler.userSelectedMenuItem(longPressTarget, item)
+        Timber.d("Required action from long press is $requiredAction")
 
         return when (requiredAction) {
             is RequiredAction.OpenInNewTab -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -42,15 +42,14 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
 
     override fun determineType(uri: Uri): UrlType {
         val uriString = uri.toString()
-        val scheme = uri.scheme
 
-        return when (scheme) {
+        return when (uri.scheme) {
             TEL_SCHEME -> buildTelephone(uriString)
             TELPROMPT_SCHEME -> buildTelephonePrompt(uriString)
             MAILTO_SCHEME -> buildEmail(uriString)
             SMS_SCHEME -> buildSms(uriString)
             SMSTO_SCHEME -> buildSmsTo(uriString)
-            HTTP_SCHEME, HTTPS_SCHEME -> UrlType.Web(uriString)
+            HTTP_SCHEME, HTTPS_SCHEME, DATA_SCHEME -> UrlType.Web(uriString)
             ABOUT_SCHEME -> UrlType.Unknown(uriString)
             null -> UrlType.SearchQuery(uriString)
             else -> buildIntent(uriString)
@@ -93,6 +92,7 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
         private const val HTTP_SCHEME = "http"
         private const val HTTPS_SCHEME = "https"
         private const val ABOUT_SCHEME = "about"
+        private const val DATA_SCHEME = "data"
 
         private const val EXTRA_FALLBACK_URL = "browser_fallback_url"
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
@@ -80,14 +80,15 @@ class WebViewLongPressHandler @Inject constructor(private val context: Context, 
     }
 
     private fun addImageMenuOptions(menu: ContextMenu) {
-        menu.add(0, CONTEXT_MENU_ID_DOWNLOAD_IMAGE, 0, R.string.downloadImage)
+        menu.add(0, CONTEXT_MENU_ID_DOWNLOAD_IMAGE, CONTEXT_MENU_ID_DOWNLOAD_IMAGE, R.string.downloadImage)
+        menu.add(0, CONTEXT_MENU_ID_OPEN_IMAGE_IN_NEW_BACKGROUND_TAB, CONTEXT_MENU_ID_OPEN_IMAGE_IN_NEW_BACKGROUND_TAB, R.string.openImageInNewTab)
     }
 
     private fun addLinkMenuOptions(menu: ContextMenu) {
-        menu.add(0, CONTEXT_MENU_ID_OPEN_IN_NEW_TAB, 1, R.string.openInNewTab)
-        menu.add(0, CONTEXT_MENU_ID_OPEN_IN_NEW_BACKGROUND_TAB, 2, R.string.openInNewBackgroundTab)
-        menu.add(0, CONTEXT_MENU_ID_COPY, 3, R.string.copyUrl)
-        menu.add(0, CONTEXT_MENU_ID_SHARE_LINK, 4, R.string.shareLink)
+        menu.add(0, CONTEXT_MENU_ID_OPEN_IN_NEW_TAB, CONTEXT_MENU_ID_OPEN_IN_NEW_TAB, R.string.openInNewTab)
+        menu.add(0, CONTEXT_MENU_ID_OPEN_IN_NEW_BACKGROUND_TAB, CONTEXT_MENU_ID_OPEN_IN_NEW_BACKGROUND_TAB, R.string.openInNewBackgroundTab)
+        menu.add(0, CONTEXT_MENU_ID_COPY, CONTEXT_MENU_ID_COPY, R.string.copyUrl)
+        menu.add(0, CONTEXT_MENU_ID_SHARE_LINK, CONTEXT_MENU_ID_SHARE_LINK, R.string.shareLink)
     }
 
     private fun isLinkSupported(longPressTargetUrl: String?) = URLUtil.isNetworkUrl(longPressTargetUrl) || URLUtil.isDataUrl(longPressTargetUrl)
@@ -96,23 +97,33 @@ class WebViewLongPressHandler @Inject constructor(private val context: Context, 
         return when (item.itemId) {
             CONTEXT_MENU_ID_OPEN_IN_NEW_TAB -> {
                 pixel.fire(LONG_PRESS_NEW_TAB)
-                return OpenInNewTab(longPressTarget.url)
+                val url = longPressTarget.url ?: return None
+                return OpenInNewTab(url)
             }
             CONTEXT_MENU_ID_OPEN_IN_NEW_BACKGROUND_TAB -> {
                 pixel.fire(LONG_PRESS_NEW_BACKGROUND_TAB)
-                return OpenInNewBackgroundTab(longPressTarget.url)
+                val url = longPressTarget.url ?: return None
+                return OpenInNewBackgroundTab(url)
             }
             CONTEXT_MENU_ID_DOWNLOAD_IMAGE -> {
                 pixel.fire(LONG_PRESS_DOWNLOAD_IMAGE)
-                return DownloadFile(longPressTarget.imageUrl ?: longPressTarget.url)
+                val url = longPressTarget.imageUrl ?: return None
+                return DownloadFile(url)
+            }
+            CONTEXT_MENU_ID_OPEN_IMAGE_IN_NEW_BACKGROUND_TAB -> {
+                pixel.fire(LONG_PRESS_OPEN_IMAGE_IN_BACKGROUND_TAB)
+                val url = longPressTarget.imageUrl ?: return None
+                return OpenInNewBackgroundTab(url)
             }
             CONTEXT_MENU_ID_SHARE_LINK -> {
                 pixel.fire(LONG_PRESS_SHARE)
-                return ShareLink(longPressTarget.url)
+                val url = longPressTarget.url ?: return None
+                return ShareLink(url)
             }
             CONTEXT_MENU_ID_COPY -> {
                 pixel.fire(LONG_PRESS_COPY_URL)
-                return CopyLink(longPressTarget.url)
+                val url = longPressTarget.url ?: return None
+                return CopyLink(url)
             }
             else -> None
         }
@@ -121,9 +132,10 @@ class WebViewLongPressHandler @Inject constructor(private val context: Context, 
 
     companion object {
         const val CONTEXT_MENU_ID_OPEN_IN_NEW_TAB = 1
-        const val CONTEXT_MENU_ID_DOWNLOAD_IMAGE = 2
-        const val CONTEXT_MENU_ID_SHARE_LINK = 3
-        const val CONTEXT_MENU_ID_OPEN_IN_NEW_BACKGROUND_TAB = 4
-        const val CONTEXT_MENU_ID_COPY = 5
+        const val CONTEXT_MENU_ID_OPEN_IN_NEW_BACKGROUND_TAB = 2
+        const val CONTEXT_MENU_ID_COPY = 3
+        const val CONTEXT_MENU_ID_SHARE_LINK = 4
+        const val CONTEXT_MENU_ID_DOWNLOAD_IMAGE = 5
+        const val CONTEXT_MENU_ID_OPEN_IMAGE_IN_NEW_BACKGROUND_TAB = 6
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/model/LongPressTarget.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/model/LongPressTarget.kt
@@ -16,4 +16,4 @@
 
 package com.duckduckgo.app.browser.model
 
-data class LongPressTarget(val url: String, val type: Int, val imageUrl: String? = null)
+data class LongPressTarget(val url: String?, val type: Int, val imageUrl: String? = null)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.omnibar
 
 import android.net.Uri
+import android.webkit.URLUtil
 import com.duckduckgo.app.browser.RequestRewriter
 import com.duckduckgo.app.global.AppUrl.Url
 import com.duckduckgo.app.global.UriString
@@ -29,6 +30,10 @@ class QueryUrlConverter @Inject constructor(private val requestRewriter: Request
     override fun convertQueryToUrl(searchQuery: String): String {
         if (UriString.isWebUrl(searchQuery)) {
             return convertUri(searchQuery)
+        }
+
+        if (URLUtil.isDataUrl(searchQuery)) {
+            return searchQuery
         }
 
         val uriBuilder = Uri.Builder()

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -67,6 +67,7 @@ interface Pixel {
         LONG_PRESS_NEW_BACKGROUND_TAB("mlp_b"),
         LONG_PRESS_SHARE("mlp_s"),
         LONG_PRESS_COPY_URL("mlp_c"),
+        LONG_PRESS_OPEN_IMAGE_IN_BACKGROUND_TAB("mlp_ibt"),
 
         SETTINGS_OPENED("ms"),
         SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="newTabMenuItem">New Tab</string>
     <string name="openInNewTab">Open in New Tab</string>
     <string name="openInNewBackgroundTab">Open In Background Tab</string>
+    <string name="openImageInNewTab">Open Image In Background Tab</string>
     <string name="faviconContentDescription">Favicon</string>
     <string name="closeContentDescription">Close</string>
     <string name="tapFireDirective">Tap </string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/186344451334986/1124956056611278
Tech Design URL: 
CC: 

**Description**:
Adds ability to "Open Image in Background Tab"

**Steps to test this PR**:
1. Browse to a site which contains images, such as bbc.co.uk and click through into an article. Long press on an image and verify you can open the image in a bg tab, and that existing functionality such as downloading the image still works.
1. Browse to a site which uses image anchor links, such as https://lemonde.fr or ebay.co.uk, and verify that long pressing works as expected for the new and existing menu options


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
