### PR TITLE
Update navigation options more frequently

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -78,9 +78,10 @@ class BrowserChromeClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnProgressChangedCalledThenListenerInstructedToUpdateProgress() {
+    fun whenOnProgressChangedCalledThenListenerInstructedToUpdateProgressAndNavigationOptions() {
         testee.onProgressChanged(webView, 10)
         verify(mockWebViewClientListener).progressChanged(webView.stubUrl, 10)
+        verify(mockWebViewClientListener).navigationOptionsChanged(any())
     }
 
     @UiThreadTest

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -21,6 +21,7 @@ import android.view.View
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import com.duckduckgo.app.browser.BrowserWebViewClient.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -61,6 +62,7 @@ class BrowserChromeClient @Inject constructor() : WebChromeClient(), CoroutineSc
     override fun onProgressChanged(webView: WebView, newProgress: Int) {
         Timber.d("onProgressChanged - $newProgress - ${webView.url}")
         webViewClientListener?.progressChanged(webView.url, newProgress)
+        webViewClientListener?.navigationOptionsChanged(WebViewNavigationOptions(webView.copyBackForwardList()))
     }
 
     override fun onReceivedTitle(view: WebView, title: String) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1125316196364807

**Description**:
The app relies on onPageStarted and onPageFinished to update its navigation stack. Some sites like reddit do not call these on subpages, which can cause navigation quirks like skipping two pages when pressing the back and forward buttons.

**Steps to test this PR**:
1. Go to reddit.com
1. Navigate to a subpage
1. Press back, this should go back to reddit.com
1. Press back, this should go home
1. Press forward, this should go to reddit.com
1. Press forward, this should go to subpage

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
