### PR TITLE
Release privacy notification on day one of inactivity to all users

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -25,16 +25,16 @@ class VariantManagerTest {
     private val variants = VariantManager.ACTIVE_VARIANTS
 
     @Test
-    fun serpAndSharedControlVariantSuppressed() {
+    fun serpAndSharedControlVariantActive() {
         val variant = variants.firstOrNull { it.key == "sc" }
-        assertEqualsDouble(0.0, variant!!.weight)
+        assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
-    fun serpExperimentalVariantSuppressed() {
+    fun serpExperimentalVariantActive() {
         val variant = variants.firstOrNull { it.key == "se" }
-        assertEqualsDouble(0.0, variant!!.weight)
+        assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -27,7 +27,6 @@ import com.duckduckgo.app.notification.model.ClearDataNotification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.app.statistics.VariantManager
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -74,12 +73,10 @@ class NotificationModule {
     @Provides
     @Singleton
     fun providesNotificationScheduler(
-        variantManager: VariantManager,
         clearDataNotification: ClearDataNotification,
         privacyProtectionNotification: PrivacyProtectionNotification
     ): NotificationScheduler {
         return NotificationScheduler(
-            variantManager,
             clearDataNotification,
             privacyProtectionNotification
         )

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.app.notification.model.Notification
 import com.duckduckgo.app.notification.model.NotificationSpec
 import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.*
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.NOTIFICATION_SHOWN
 import timber.log.Timber
@@ -47,13 +46,10 @@ class NotificationScheduler @Inject constructor(
         val variant = variantManager.getVariant()
 
         when {
-            variant.hasFeature(NotificationPrivacyDay1) && privacyNotification.canShow() -> {
+            privacyNotification.canShow() -> {
                 scheduleNotification(OneTimeWorkRequestBuilder<PrivacyNotificationWorker>(), 1, TimeUnit.DAYS)
             }
-            variant.hasFeature(NotificationClearDataDay1) && clearDataNotification.canShow() -> {
-                scheduleNotification(OneTimeWorkRequestBuilder<ClearDataNotificationWorker>(), 1, TimeUnit.DAYS)
-            }
-            !variant.hasFeature(NotificationSuppressClearDataDay3) && clearDataNotification.canShow() -> {
+            clearDataNotification.canShow() -> {
                 scheduleNotification(OneTimeWorkRequestBuilder<ClearDataNotificationWorker>(), 3, TimeUnit.DAYS)
             }
             else -> Timber.v("Notifications not enabled for this variant")
@@ -72,7 +68,7 @@ class NotificationScheduler @Inject constructor(
 
     // Legacy code. Unused class required for users who already have this notification scheduled from previous version. We can delete this in a
     // couple of weeks once old notifications have cleared. We should also remove "open" access from ClearDataNotificationWorker.
-    class ShowClearDataNotification(context: Context, params: WorkerParameters): ClearDataNotificationWorker(context, params)
+    class ShowClearDataNotification(context: Context, params: WorkerParameters) : ClearDataNotificationWorker(context, params)
 
     open class ClearDataNotificationWorker(context: Context, params: WorkerParameters) : SchedulableNotificationWorker(context, params)
     class PrivacyNotificationWorker(context: Context, params: WorkerParameters) : SchedulableNotificationWorker(context, params)

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
@@ -63,6 +63,10 @@ class NotificationScheduler @Inject constructor(
         WorkManager.getInstance().enqueue(request)
     }
 
+    // Legacy code. Unused class required for users who already have this notification scheduled from previous version. We will
+    // delete this as part of https://app.asana.com/0/414730916066338/1119619712088571
+    class ShowClearDataNotification(context: Context, params: WorkerParameters) : ClearDataNotificationWorker(context, params)
+
     open class ClearDataNotificationWorker(context: Context, params: WorkerParameters) : SchedulableNotificationWorker(context, params)
     class PrivacyNotificationWorker(context: Context, params: WorkerParameters) : SchedulableNotificationWorker(context, params)
 

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
@@ -28,7 +28,6 @@ import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.Notification
 import com.duckduckgo.app.notification.model.NotificationSpec
 import com.duckduckgo.app.notification.model.SchedulableNotification
-import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.NOTIFICATION_SHOWN
 import timber.log.Timber
@@ -36,14 +35,12 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 class NotificationScheduler @Inject constructor(
-    private val variantManager: VariantManager,
     private val clearDataNotification: SchedulableNotification,
     private val privacyNotification: SchedulableNotification
 ) {
     suspend fun scheduleNextNotification() {
 
         WorkManager.getInstance().cancelAllWorkByTag(WORK_REQUEST_TAG)
-        val variant = variantManager.getVariant()
 
         when {
             privacyNotification.canShow() -> {
@@ -65,10 +62,6 @@ class NotificationScheduler @Inject constructor(
 
         WorkManager.getInstance().enqueue(request)
     }
-
-    // Legacy code. Unused class required for users who already have this notification scheduled from previous version. We can delete this in a
-    // couple of weeks once old notifications have cleared. We should also remove "open" access from ClearDataNotificationWorker.
-    class ShowClearDataNotification(context: Context, params: WorkerParameters) : ClearDataNotificationWorker(context, params)
 
     open class ClearDataNotificationWorker(context: Context, params: WorkerParameters) : SchedulableNotificationWorker(context, params)
     class PrivacyNotificationWorker(context: Context, params: WorkerParameters) : SchedulableNotificationWorker(context, params)

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.app.statistics
 
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.*
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.TrackerBlockingOnboardingOptIn
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import timber.log.Timber
 
@@ -26,10 +26,6 @@ import timber.log.Timber
 interface VariantManager {
 
     sealed class VariantFeature {
-        object NotificationPrivacyDay1 : VariantFeature()
-        object NotificationClearDataDay1 : VariantFeature()
-        object NotificationSuppressClearDataDay3 : VariantFeature()
-
         object TrackerBlockingOnboardingOptIn : VariantFeature()
     }
 
@@ -40,17 +36,10 @@ interface VariantManager {
 
         val ACTIVE_VARIANTS = listOf(
 
-            // SERP variants. "sc" may be used as a shared control in the future if we can filter by app version
-            // Currently set to 0.0 to free up allocations for new projects
-            Variant(key = "sc", weight = 0.0, features = emptyList()),
-            Variant(key = "se", weight = 0.0, features = emptyList()),
-
-            // Notification variants
-            // Currently set to 0.0 to free up allocations for new projects
-            Variant(key = "me", weight = 0.0, features = listOf(NotificationPrivacyDay1, NotificationSuppressClearDataDay3)),
-            Variant(key = "mi", weight = 0.0, features = listOf(NotificationClearDataDay1, NotificationSuppressClearDataDay3)),
-            Variant(key = "mf", weight = 0.0, features = listOf(NotificationSuppressClearDataDay3)),
-            Variant(key = "mk", weight = 0.0, features = listOf(NotificationPrivacyDay1)),
+            // SERP variants. "sc" may also be used as a shared control for mobile experiments in
+            // the future if we can filter by app version
+            Variant(key = "sc", weight = 1.0, features = emptyList()),
+            Variant(key = "se", weight = 1.0, features = emptyList()),
 
             // tracker blocker opt in variants
             Variant(key = "mm", weight = 0.0, features = emptyList()),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
https://app.asana.com/0/361428290920652/1114172401555990
https://app.asana.com/0/361428290920652/1114174327194184

Tech Design URL: N/A

**Description**:
Removes various notification scenarios and releases **privacy stats** notification on day 1 of inactivity (also maintains existing **clear data**  notification on day 3).

**Steps to test this PR**:
Open the notification scheduler and change the privacy notification worker schedule from 1 day to 10 seconds:
```
scheduleNotification(OneTimeWorkRequestBuilder<PrivacyNotificationWorker>(), 10, TimeUnit.SECONDS)
```

And the clear data notification from 3 days to 30 seconds
```
scheduleNotification(OneTimeWorkRequestBuilder<ClearDataNotificationWorker>(), 30, TimeUnit.SECONDS)
```

1. Run a clean install of the app and background it
1. Ensure that the privacy notification appears after roughly 10 seconds (the scheduler isn't terribly precise)
1. Tap it to launch the app and then background it
1. Ensure that the clear data notification appears after roughly 30 seconds
1. Tap it to launch the app, then background the app again
1. No more notifications should appear
1. Kill and restart the app. Again no new notifications should appear

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
