### PR TITLE
Add intent extras so that default browser system setting is highlighted

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserSystemSettings.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserSystemSettings.kt
@@ -20,12 +20,22 @@ import android.content.Intent
 import android.os.Build
 import android.provider.Settings
 import androidx.annotation.RequiresApi
+import androidx.core.os.bundleOf
 
 
 class DefaultBrowserSystemSettings {
 
     companion object {
         @RequiresApi(Build.VERSION_CODES.N)
-        fun intent() = Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+        fun intent(): Intent {
+            val intent = Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+            intent.putExtra(SETTINGS_SELECT_OPTION_KEY, DEFAULT_BROWSER_APP_OPTION)
+            intent.putExtra(SETTINGS_SHOW_FRAGMENT_ARGS, bundleOf(SETTINGS_SELECT_OPTION_KEY to DEFAULT_BROWSER_APP_OPTION))
+            return intent
+        }
+
+        private const val SETTINGS_SELECT_OPTION_KEY = ":settings:fragment_args_key"
+        private const val SETTINGS_SHOW_FRAGMENT_ARGS = ":settings:show_fragment_args"
+        private const val DEFAULT_BROWSER_APP_OPTION = "default_browser"
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/608920331025315/1125869815569488
Tech Design URL: 
CC: 

**Description**:
Highlights the default browser system setting after launching the default app system setting activity

**Steps to test this PR**:
1. Using our app's settings page, choose "Set as Default Browser" option
1. Verify that the "Browser app" (or equivalent if slightly different) is highlighted

It will be highlighted differently depending on the OS version (with older versions being a more subtle highlighting implementation) but testing that it works across a few different OS versions would be good.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
