### PR TITLE
Issue/499 - Fix: Site-specific search doesn't work; attempts to open as a link instead and fails

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -127,4 +127,18 @@ class SpecialUrlDetectorImplTest {
         val type = testee.determineType("smsto:123-555-12323") as Sms
         assertEquals("123-555-12323", type.telephoneNumber)
     }
+
+    @Test
+    fun whenUrlIsSiteSearchThenSearchTypeDetected() {
+        val expected = SearchQuery::class
+        val actual = testee.determineType("site:duckduckgo.com about")
+        assertEquals(expected, actual::class)
+    }
+
+    @Test
+    fun whenUrlIsNormalSearchThenSearchTypeDetected() {
+        val expected = SearchQuery::class
+        val actual = testee.determineType("no scheme search")
+        assertEquals(expected, actual::class)
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -52,7 +52,7 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
             SMSTO_SCHEME -> buildSmsTo(uriString)
             HTTP_SCHEME, HTTPS_SCHEME -> UrlType.Web(uriString)
             ABOUT_SCHEME -> UrlType.Unknown(uriString)
-            null -> UrlType.SearchQuery(uriString)
+            SITE_SCHEME, null -> UrlType.SearchQuery(uriString)
             else -> buildIntent(uriString)
         }
     }
@@ -93,6 +93,7 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
         private const val HTTP_SCHEME = "http"
         private const val HTTPS_SCHEME = "https"
         private const val ABOUT_SCHEME = "about"
+        private const val SITE_SCHEME = "site"
 
         private const val EXTRA_FALLBACK_URL = "browser_fallback_url"
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/499 https://github.com/duckduckgo/Android/issues/347
Tech Design URL: N/A

**Description**:
1. Fixed bug of searches in address bar with `site:` scheme leading to a `Unable to open this type of link` toast message instead of showing the search results, by adding a new site scheme case in the `SpecialUrlDetector`. 
1. Added unit tests for new search cases

**Steps to test this PR**:
1. Go to top address bar and type a search like `site:duckduckgo.com about`
1. See search results displayed
1. Alternatively run new unit tests

![dgg-issue476](https://user-images.githubusercontent.com/8261416/59153354-42d7d000-8a4f-11e9-89a2-7df1c99a4af3.gif)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
