### PR TITLE
Feature/494 - Feature Request: Centre on current tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/NestedScrollViewExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/NestedScrollViewExtension.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.global.view
 import androidx.core.view.get
 import androidx.core.widget.NestedScrollView
 import androidx.recyclerview.widget.RecyclerView
-import kotlin.math.max
 import kotlin.math.min
 
 /**
@@ -30,7 +29,7 @@ import kotlin.math.min
 fun NestedScrollView.smoothScrollTo(position: Int, recyclerView: RecyclerView) {
     post {
         if (recyclerView.childCount > 0) {
-            val currentItemY = recyclerView[min(position, max(recyclerView.childCount - 1, 0))].y.toInt()
+            val currentItemY = recyclerView[min(position, recyclerView.childCount - 1)].y.toInt()
             smoothScrollTo(0, currentItemY)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/global/view/NestedScrollViewExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/NestedScrollViewExtension.kt
@@ -29,8 +29,8 @@ import kotlin.math.min
 fun NestedScrollView.smoothScrollTo(position: Int, recyclerView: RecyclerView) {
     post {
         if (recyclerView.childCount > 0 && position < recyclerView.childCount) {
-            val currentItemY = recyclerView[min(position, recyclerView.childCount - 1)].y.toInt()
-            smoothScrollTo(0, currentItemY)
+            val currentItem = recyclerView[min(position, recyclerView.childCount - 1)]
+            smoothScrollTo(0, currentItem.y.toInt() - currentItem.height * 4/3 )
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/view/NestedScrollViewExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/NestedScrollViewExtension.kt
@@ -28,7 +28,7 @@ import kotlin.math.min
  */
 fun NestedScrollView.smoothScrollTo(position: Int, recyclerView: RecyclerView) {
     post {
-        if (recyclerView.childCount > 0) {
+        if (recyclerView.childCount > 0 && position < recyclerView.childCount) {
             val currentItemY = recyclerView[min(position, recyclerView.childCount - 1)].y.toInt()
             smoothScrollTo(0, currentItemY)
         }

--- a/app/src/main/java/com/duckduckgo/app/global/view/NestedScrollViewExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/NestedScrollViewExtension.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.view
+
+import androidx.core.view.get
+import androidx.core.widget.NestedScrollView
+import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Scroll to a [RecyclerView] item position if the recycler view is nested in a [NestedScrollView]
+ * @param position Int of the recycler view item index
+ * @param recyclerView RecyclerView inside this nested scroll view
+ */
+fun NestedScrollView.smoothScrollTo(position: Int, recyclerView: RecyclerView) {
+    post {
+        if (recyclerView.childCount > 0) {
+            val currentItemY = recyclerView[min(position, max(recyclerView.childCount - 1, 0))].y.toInt()
+            smoothScrollTo(0, currentItemY)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.core.view.get
+import androidx.core.widget.NestedScrollView
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.app.browser.R
@@ -67,12 +68,13 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
 
     override fun onResume() {
         super.onResume()
-        tabScrollView.post {
+        tabScrollView.smoothScrollTo(tabsAdapter.selectedTabPosition)
+    }
+
+    private fun NestedScrollView.smoothScrollTo(position: Int) {
+        post {
             if (tabsRecycler.childCount > 0) {
-                val currentItemY = tabsRecycler[min(
-                    tabsAdapter.selectedTabPosition,
-                    max(tabsRecycler.childCount - 1, 0)
-                )].y.toInt()
+                val currentItemY = tabsRecycler[min(position, max(tabsRecycler.childCount - 1, 0))].y.toInt()
                 tabScrollView.smoothScrollTo(0, currentItemY)
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.launch
 import org.jetbrains.anko.longToast
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
+import kotlin.math.max
 import kotlin.math.min
 
 class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitchedListener, CoroutineScope {
@@ -66,9 +67,12 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
 
     override fun onResume() {
         super.onResume()
-        tabsAdapter.selectedTab?.let { selectedTab ->
-            tabScrollView.post {
-                val currentItemY = tabsRecycler[min(selectedTab.position, tabsRecycler.childCount-1)].y.toInt()
+        tabScrollView.post {
+            if (tabsRecycler.childCount > 0) {
+                val currentItemY = tabsRecycler[min(
+                    tabsAdapter.selectedTabPosition,
+                    max(tabsRecycler.childCount - 1, 0)
+                )].y.toInt()
                 tabScrollView.smoothScrollTo(0, currentItemY)
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -21,14 +21,13 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import androidx.core.view.get
-import androidx.core.widget.NestedScrollView
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
 import com.duckduckgo.app.global.view.FireDialog
+import com.duckduckgo.app.global.view.smoothScrollTo
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
@@ -43,8 +42,6 @@ import kotlinx.coroutines.launch
 import org.jetbrains.anko.longToast
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
-import kotlin.math.max
-import kotlin.math.min
 
 class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitchedListener, CoroutineScope {
 
@@ -68,16 +65,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
 
     override fun onResume() {
         super.onResume()
-        tabScrollView.smoothScrollTo(tabsAdapter.selectedTabPosition)
-    }
-
-    private fun NestedScrollView.smoothScrollTo(position: Int) {
-        post {
-            if (tabsRecycler.childCount > 0) {
-                val currentItemY = tabsRecycler[min(position, max(tabsRecycler.childCount - 1, 0))].y.toInt()
-                tabScrollView.smoothScrollTo(0, currentItemY)
-            }
-        }
+        tabScrollView.smoothScrollTo(tabsAdapter.selectedTabPosition, tabsRecycler)
     }
 
     private fun configureToolbar() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import androidx.core.view.get
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.app.browser.R
@@ -41,6 +42,7 @@ import kotlinx.coroutines.launch
 import org.jetbrains.anko.longToast
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
+import kotlin.math.min
 
 class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitchedListener, CoroutineScope {
 
@@ -60,6 +62,16 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
         configureToolbar()
         configureRecycler()
         configureObservers()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        tabsAdapter.selectedTab?.let { selectedTab ->
+            tabScrollView.post {
+                val currentItemY = tabsRecycler[min(selectedTab.position, tabsRecycler.childCount-1)].y.toInt()
+                tabScrollView.smoothScrollTo(0, currentItemY)
+            }
+        }
     }
 
     private fun configureToolbar() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -34,7 +34,9 @@ import kotlinx.android.synthetic.main.item_tab.view.*
 class TabSwitcherAdapter(private val context: Context, private val itemClickListener: TabSwitchedListener) : Adapter<TabViewHolder>() {
 
     private var data: List<TabEntity> = ArrayList()
-    var selectedTab: TabEntity? = null
+    private var selectedTab: TabEntity? = null
+    val selectedTabPosition: Int
+        get() = selectedTab?.position ?: 0
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TabViewHolder {
         val inflater = LayoutInflater.from(parent.context)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -34,7 +34,7 @@ import kotlinx.android.synthetic.main.item_tab.view.*
 class TabSwitcherAdapter(private val context: Context, private val itemClickListener: TabSwitchedListener) : Adapter<TabViewHolder>() {
 
     private var data: List<TabEntity> = ArrayList()
-    private var selectedTab: TabEntity? = null
+    var selectedTab: TabEntity? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TabViewHolder {
         val inflater = LayoutInflater.from(parent.context)

--- a/app/src/main/res/layout/content_tab_switcher.xml
+++ b/app/src/main/res/layout/content_tab_switcher.xml
@@ -13,9 +13,11 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tabScrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_marginBottom="10dp"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/494
Tech Design URL: N/A

**Description**:
On resume of `TabSwitcherActivity` scroll the nested scroll view to the selected Tab. Just calling scrollTo.. methods of the `RecyclerView` class wouldn't work since the tabs recycler view was inside of a nested scrollview with `wrap_content` height. So the solution was to just scroll the nested scrollview to the Y position of the selected recyler view item. An alternative solution would have been to get rid of the nested scrollview altogether and just use a recyclerview with footer instead.
This doesn't add a setting to enable scrolling to selected tab yet, but that could be done in a different PR if really wanted.

**Steps to test this PR**:
1. Go to tabs overview screen with about 10+ open tabs
1. Scroll down ad click one of the last tabs
1. Go back to tabs overview screen and see the tabs list scrolled to the last selected Tab


![ddg-feature494](https://user-images.githubusercontent.com/8261416/59159772-730e8580-8ac6-11e9-9813-bad087735e6b.gif)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
