### PR TITLE
Delete app cache when clearing data using fire button

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.global.view
 
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.WebDataManager
+import com.duckduckgo.app.fire.AppCacheClearer
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -40,6 +41,7 @@ class ClearPersonalDataActionTest {
     private val mockTabRepository: TabRepository = mock()
     private val mockSettingsDataStore: SettingsDataStore = mock()
     private val mockCookieManager: DuckDuckGoCookieManager = mock()
+    private val mockAppCacheClearer: AppCacheClearer = mock()
 
     @Before
     fun setup() {
@@ -49,7 +51,8 @@ class ClearPersonalDataActionTest {
             mockClearingUnsentForgetAllPixelStore,
             mockTabRepository,
             mockSettingsDataStore,
-            mockCookieManager
+            mockCookieManager,
+            mockAppCacheClearer
         )
     }
 
@@ -81,6 +84,12 @@ class ClearPersonalDataActionTest {
     fun whenClearCalledThenDataManagerClearsCookies() = runBlocking<Unit> {
         testee.clearTabsAndAllDataAsync(false, false)
         verify(mockDataManager).clearExternalCookies()
+    }
+
+    @Test
+    fun whenClearCalledThenAppCacheClearerClearsCache() = runBlocking<Unit> {
+        testee.clearTabsAndAllDataAsync(false, false)
+        verify(mockAppCacheClearer).clearCache()
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -50,9 +50,10 @@ class PrivacyModule {
         clearingStore: UnsentForgetAllPixelStore,
         tabRepository: TabRepository,
         settingsDataStore: SettingsDataStore,
-        cookieManager: DuckDuckGoCookieManager
+        cookieManager: DuckDuckGoCookieManager,
+        appCacheClearer: AppCacheClearer
     ): ClearDataAction {
-        return ClearPersonalDataAction(context, dataManager, clearingStore, tabRepository, settingsDataStore, cookieManager)
+        return ClearPersonalDataAction(context, dataManager, clearingStore, tabRepository, settingsDataStore, cookieManager, appCacheClearer)
     }
 
     @Provides
@@ -78,4 +79,10 @@ class PrivacyModule {
         pixel: Pixel
     ): HistoricTrackerBlockingObserver =
         HistoricTrackerBlockingObserver(appInstallStore, privacySettingsStore, pixel)
+
+    @Provides
+    @Singleton
+    fun appCacheCleaner(context: Context): AppCacheClearer {
+        return AndroidAppCacheClearer(context)
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/fire/AppCacheClearer.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/AppCacheClearer.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fire
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+
+interface AppCacheClearer {
+
+    suspend fun clearCache()
+
+}
+
+class AndroidAppCacheClearer(private val context: Context) : AppCacheClearer {
+
+    override suspend fun clearCache() {
+        withContext(Dispatchers.IO) {
+            context.cacheDir.deleteRecursively()
+        }
+    }
+
+}

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -23,6 +23,7 @@ import android.webkit.WebViewDatabase
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.browser.WebDataManager
+import com.duckduckgo.app.fire.AppCacheClearer
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
 import com.duckduckgo.app.fire.FireActivity
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
@@ -53,7 +54,8 @@ class ClearPersonalDataAction @Inject constructor(
     private val clearingStore: UnsentForgetAllPixelStore,
     private val tabRepository: TabRepository,
     private val settingsDataStore: SettingsDataStore,
-    private val cookieManager: DuckDuckGoCookieManager
+    private val cookieManager: DuckDuckGoCookieManager,
+    private val appCacheClearer: AppCacheClearer
 ) : ClearDataAction, CoroutineScope {
 
     private val clearJob: Job = Job()
@@ -104,6 +106,8 @@ class ClearPersonalDataAction @Inject constructor(
 
         dataManager.clearData(createWebView(), createWebStorage(), WebViewDatabase.getInstance(context))
         dataManager.clearExternalCookies()
+
+        appCacheClearer.clearCache()
 
         Timber.i("Finished clearing data")
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1127121283487017
Tech Design URL: 
CC: 

**Description**:
Clears the app cache when the fire button is invoked.

**Steps to test this PR**:
1. Ensure you can verify app data (e.g., use an emulator / rooted device)
1. Do a DDG search
1. Clear the data using the fire button
1. Examine the `data/data/com.duckduckgo.mobile.android/cache` directory and verify there are no remnants of the previous search.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
