### PR TITLE
Feature/webview file deletion on data clear

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
@@ -24,6 +24,7 @@ import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
+import com.duckduckgo.app.global.file.FileDeleter
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.runBlocking
@@ -36,7 +37,8 @@ class WebViewDataManagerTest {
     private val mockCookieManager: DuckDuckGoCookieManager = mock()
     private val mockStorage: WebStorage = mock()
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val testee = WebViewDataManager(context, WebViewSessionInMemoryStorage(), mockCookieManager)
+    private val mockFileDeleter: FileDeleter = mock()
+    private val testee = WebViewDataManager(context, WebViewSessionInMemoryStorage(), mockCookieManager, mockFileDeleter)
 
     @UiThreadTest
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
@@ -35,7 +35,8 @@ class WebViewDataManagerTest {
 
     private val mockCookieManager: DuckDuckGoCookieManager = mock()
     private val mockStorage: WebStorage = mock()
-    private val testee = WebViewDataManager(WebViewSessionInMemoryStorage(), mockCookieManager)
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val testee = WebViewDataManager(context, WebViewSessionInMemoryStorage(), mockCookieManager)
 
     @UiThreadTest
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/di/TestAppComponent.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/TestAppComponent.kt
@@ -65,7 +65,8 @@ import javax.inject.Singleton
         PrivacyModule::class,
         WidgetModule::class,
         RatingModule::class,
-        AppUsageModule::class
+        AppUsageModule::class,
+        FileModule::class
     ]
 )
 interface TestAppComponent : AppComponent {

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/WebViewCookieManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/WebViewCookieManagerTest.kt
@@ -24,6 +24,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 @Suppress("RemoveExplicitTypeArguments")
 class WebViewCookieManagerTest {
@@ -33,8 +35,17 @@ class WebViewCookieManagerTest {
     private val cookieManager: CookieManager = CookieManager.getInstance()
 
     @Before
-    fun setup() {
+    fun setup() = runBlocking {
+        removeExistingCookies()
         testee = WebViewCookieManager(cookieManager, host)
+    }
+
+    private suspend fun removeExistingCookies() {
+        withContext(Dispatchers.Main) {
+            suspendCoroutine<Unit> { continuation ->
+                cookieManager.removeAllCookies { continuation.resume(Unit) }
+            }
+        }
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -23,6 +23,7 @@ import android.webkit.WebView
 import android.webkit.WebViewDatabase
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
+import com.duckduckgo.app.global.file.FileDeleter
 import java.io.File
 import javax.inject.Inject
 
@@ -36,7 +37,8 @@ interface WebDataManager {
 class WebViewDataManager @Inject constructor(
     private val context: Context,
     private val webViewSessionStorage: WebViewSessionStorage,
-    private val cookieManager: DuckDuckGoCookieManager
+    private val cookieManager: DuckDuckGoCookieManager,
+    private val fileDeleter: FileDeleter
 ) : WebDataManager {
 
     override fun clearData(webView: WebView, webStorage: WebStorage, webViewDatabase: WebViewDatabase) {
@@ -70,9 +72,7 @@ class WebViewDataManager @Inject constructor(
 
     override suspend fun deleteWebViewDirectory() {
         val webViewDataDirectory = File(context.applicationInfo.dataDir, WEBVIEW_DATA_DIRECTORY_NAME)
-        val files = webViewDataDirectory.listFiles() ?: return
-        val filesToDelete = files.filterNot { FILENAMES_EXCLUDED_FROM_DELETION.contains(it.name) }
-        filesToDelete.forEach { it.deleteRecursively() }
+        fileDeleter.deleteContents(webViewDataDirectory, FILENAMES_EXCLUDED_FROM_DELETION)
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
 import com.duckduckgo.app.fire.WebViewCookieManager
 import com.duckduckgo.app.global.AppUrl
+import com.duckduckgo.app.global.file.FileDeleter
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
@@ -91,8 +92,13 @@ class BrowserModule {
 
     @Singleton
     @Provides
-    fun webDataManager(context: Context, webViewSessionStorage: WebViewSessionStorage, cookieManager: DuckDuckGoCookieManager): WebDataManager =
-        WebViewDataManager(context, webViewSessionStorage, cookieManager)
+    fun webDataManager(
+        context: Context,
+        webViewSessionStorage: WebViewSessionStorage,
+        cookieManager: DuckDuckGoCookieManager,
+        fileDeleter: FileDeleter
+    ): WebDataManager =
+        WebViewDataManager(context, webViewSessionStorage, cookieManager, fileDeleter)
 
     @Provides
     fun clipboardManager(context: Context): ClipboardManager {

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -91,8 +91,8 @@ class BrowserModule {
 
     @Singleton
     @Provides
-    fun webDataManager(webViewSessionStorage: WebViewSessionStorage, cookieManager: DuckDuckGoCookieManager): WebDataManager =
-        WebViewDataManager(webViewSessionStorage, cookieManager)
+    fun webDataManager(context: Context, webViewSessionStorage: WebViewSessionStorage, cookieManager: DuckDuckGoCookieManager): WebDataManager =
+        WebViewDataManager(context, webViewSessionStorage, cookieManager)
 
     @Provides
     fun clipboardManager(context: Context): ClipboardManager {

--- a/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
@@ -63,7 +63,8 @@ import javax.inject.Singleton
         PrivacyModule::class,
         WidgetModule::class,
         RatingModule::class,
-        AppUsageModule::class
+        AppUsageModule::class,
+        FileModule::class
     ]
 )
 interface AppComponent : AndroidInjector<DuckDuckGoApplication> {

--- a/app/src/main/java/com/duckduckgo/app/di/FileModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/FileModule.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.di
+
+import com.duckduckgo.app.global.file.AndroidFileDeleter
+import com.duckduckgo.app.global.file.FileDeleter
+import dagger.Module
+import dagger.Provides
+
+
+@Module
+class FileModule {
+
+    @Provides
+    fun providesFileDeleter(): FileDeleter {
+        return AndroidFileDeleter()
+    }
+
+}

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import com.duckduckgo.app.browser.WebDataManager
 import com.duckduckgo.app.entities.EntityMapping
 import com.duckduckgo.app.fire.*
+import com.duckduckgo.app.global.file.FileDeleter
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
@@ -82,7 +83,7 @@ class PrivacyModule {
 
     @Provides
     @Singleton
-    fun appCacheCleaner(context: Context): AppCacheClearer {
-        return AndroidAppCacheClearer(context)
+    fun appCacheCleaner(context: Context, fileDeleter: FileDeleter): AppCacheClearer {
+        return AndroidAppCacheClearer(context, fileDeleter)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/fire/AppCacheClearer.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/AppCacheClearer.kt
@@ -17,8 +17,7 @@
 package com.duckduckgo.app.fire
 
 import android.content.Context
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import com.duckduckgo.app.global.file.FileDeleter
 
 
 interface AppCacheClearer {
@@ -27,12 +26,22 @@ interface AppCacheClearer {
 
 }
 
-class AndroidAppCacheClearer(private val context: Context) : AppCacheClearer {
+class AndroidAppCacheClearer(private val context: Context, private val fileDeleter: FileDeleter) : AppCacheClearer {
 
     override suspend fun clearCache() {
-        withContext(Dispatchers.IO) {
-            context.cacheDir.deleteRecursively()
-        }
+        fileDeleter.deleteContents(context.cacheDir, FILENAMES_EXCLUDED_FROM_DELETION)
+    }
+
+    companion object {
+
+        /* Exclude this WebView cache directory, based on warning from Firefox Focus:
+         *   "If the folder or its contents are deleted, WebView will stop using the disk cache entirely."
+         */
+        private const val WEBVIEW_CACHE_DIR = "org.chromium.android_webview"
+
+        private val FILENAMES_EXCLUDED_FROM_DELETION = listOf(
+            WEBVIEW_CACHE_DIR
+        )
     }
 
 }

--- a/app/src/main/java/com/duckduckgo/app/global/file/FileDeleter.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/file/FileDeleter.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.file
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+
+interface FileDeleter {
+
+    /**
+     * Delete the contents of the given directory, but don't delete the directory itself
+     *
+     * Optionally: specify an exclusion list. Files with names exactly matching will not be deleted.
+     * Note, the exclusion list only applies to the top-level directory. All files in subdirectories will be deleted, regardless of exclusion list.
+     */
+    suspend fun deleteContents(parentDirectory: File, excludedFiles: List<String> = emptyList())
+}
+
+class AndroidFileDeleter : FileDeleter {
+
+    override suspend fun deleteContents(parentDirectory: File, excludedFiles: List<String>) {
+        withContext(Dispatchers.IO) {
+            val files = parentDirectory.listFiles() ?: return@withContext
+            val filesToDelete = files.filterNot { excludedFiles.contains(it.name) }
+            filesToDelete.forEach { it.deleteRecursively() }
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -106,6 +106,7 @@ class ClearPersonalDataAction @Inject constructor(
 
         dataManager.clearData(createWebView(), createWebStorage(), WebViewDatabase.getInstance(context))
         dataManager.clearExternalCookies()
+        dataManager.deleteWebViewDirectory()
 
         appCacheClearer.clearCache()
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1126987722969423
Tech Design URL: 
CC: 

**Description**:
Performs cleanup on remaining files after the data has been cleared using the 🔥 button

**Steps to test this PR**:
ℹ️ Can only replicate the non-empty `Cookie-journal` file on `Marshmallow` and `Lollipop`, so ensure you use one of these emulators for your testing.

on **develop**, run these steps to ensure you can replicate the problem (to confirm the problem is definitely fixed):

1. Perform a clean install
1. Browse to a site which uses cookies (e.g., cnn.com, and accept cookies)
1. Delete the data using the 🔥 button
1. Pull the webview data directory 
    - `adb pull data/data/com.duckduckgo.mobile.android/app_webview`
1. Inspect the `Cookies-journal` file; verify you can see cnn.com cookies

now, checkout this branch, and repeat the steps above. this time, on the final step above, verify that the `Cookies-journal` no longer exists (it will be re-created when the `WebView` next accepts a cookie)

Additionally, check the general cookie handling works as you'd expect:
1. DDG SERP settings are not cleared when using the 🔥 functionality
1. Third party sites still have their cookies cleaned as expected


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
