### PR TITLE
Feature/restore partial network caching

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteService.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteService.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.autocomplete.api
 
+import com.duckduckgo.app.global.AppUrl
 import io.reactivex.Observable
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -23,7 +24,7 @@ import retrofit2.http.Query
 
 interface AutoCompleteService {
 
-    @GET("/ac/")
+    @GET("${AppUrl.Url.API}/ac/")
     fun autoComplete(@Query("q") query: String): Observable<List<AutoCompleteServiceRawResult>>
 }
 

--- a/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.feedback.api.FireAndForgetFeedbackSubmitter
 import com.duckduckgo.app.feedback.api.SubReasonApiMapper
 import com.duckduckgo.app.global.AppUrl.Url
 import com.duckduckgo.app.global.api.ApiRequestInterceptor
+import com.duckduckgo.app.global.api.NetworkApiCache
 import com.duckduckgo.app.global.job.JobBuilder
 import com.duckduckgo.app.httpsupgrade.api.HttpsUpgradeService
 import com.duckduckgo.app.job.AppConfigurationSyncer
@@ -47,6 +48,7 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.io.File
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -58,7 +60,8 @@ class NetworkModule {
     @Singleton
     @Named("api")
     fun apiOkHttpClient(context: Context, apiRequestInterceptor: ApiRequestInterceptor): OkHttpClient {
-        val cache = Cache(context.cacheDir, CACHE_SIZE)
+        val cacheLocation = File(context.cacheDir, NetworkApiCache.FILE_NAME)
+        val cache = Cache(cacheLocation, CACHE_SIZE)
         return OkHttpClient.Builder()
             .addInterceptor(apiRequestInterceptor)
             .cache(cache)

--- a/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
@@ -70,7 +70,7 @@ class NetworkModule {
 
     @Provides
     @Singleton
-    @Named("pixel")
+    @Named("nonCaching")
     fun pixelOkHttpClient(apiRequestInterceptor: ApiRequestInterceptor): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(apiRequestInterceptor)
@@ -92,12 +92,13 @@ class NetworkModule {
 
     @Provides
     @Singleton
-    @Named("pixel")
-    fun pixelRetrofit(@Named("pixel") okHttpClient: OkHttpClient): Retrofit {
+    @Named("nonCaching")
+    fun nonCachingRetrofit(@Named("nonCaching") okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(Url.PIXEL)
+            .baseUrl(Url.API)
             .client(okHttpClient)
             .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
             .build()
     }
 
@@ -115,7 +116,7 @@ class NetworkModule {
             retrofit.create(HttpsUpgradeService::class.java)
 
     @Provides
-    fun autoCompleteService(@Named("api") retrofit: Retrofit): AutoCompleteService =
+    fun autoCompleteService(@Named("nonCaching") retrofit: Retrofit): AutoCompleteService =
             retrofit.create(AutoCompleteService::class.java)
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import dagger.Module
 import dagger.Provides
-import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import javax.inject.Named
 
@@ -49,7 +48,7 @@ class StatisticsModule {
         StatisticsRequester(statisticsDataStore, statisticsService, variantManager)
 
     @Provides
-    fun pixelService(@Named("pixel") okHttpClient: OkHttpClient, @Named("pixel") retrofit: Retrofit): PixelService {
+    fun pixelService(@Named("nonCaching") retrofit: Retrofit): PixelService {
         return retrofit.create(PixelService::class.java)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/fire/AppCacheClearer.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/AppCacheClearer.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.fire
 
 import android.content.Context
+import com.duckduckgo.app.global.api.NetworkApiCache
 import com.duckduckgo.app.global.file.FileDeleter
 
 
@@ -34,13 +35,21 @@ class AndroidAppCacheClearer(private val context: Context, private val fileDelet
 
     companion object {
 
-        /* Exclude this WebView cache directory, based on warning from Firefox Focus:
+        /*
+         * Exclude this WebView cache directory, based on warning from Firefox Focus:
          *   "If the folder or its contents are deleted, WebView will stop using the disk cache entirely."
          */
         private const val WEBVIEW_CACHE_DIR = "org.chromium.android_webview"
 
+        /*
+         * Exclude the OkHttp networking cache from being deleted. This doesn't contain any sensitive information.
+         * Deleting this would just cause large amounts of non-sensitive data to have be downloaded again when app next launches.
+         */
+        private const val NETWORK_CACHE_DIR = NetworkApiCache.FILE_NAME
+
         private val FILENAMES_EXCLUDED_FROM_DELETION = listOf(
-            WEBVIEW_CACHE_DIR
+            WEBVIEW_CACHE_DIR,
+            NETWORK_CACHE_DIR
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/api/NetworkApiCache.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/NetworkApiCache.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+
+class NetworkApiCache {
+
+    companion object {
+        const val FILE_NAME = "okHttpCache"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
@@ -25,7 +25,7 @@ import retrofit2.http.QueryMap
 
 interface PixelService {
 
-    @GET("/t/{pixelName}_android_{formFactor}")
+    @GET("${AppUrl.Url.PIXEL}/t/{pixelName}_android_{formFactor}")
     fun fire(
         @Path("pixelName") pixelName: String,
         @Path("formFactor") formFactor: String,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1127752918556318
Tech Design URL: 
CC: 

**Description**:

1. Retains some network caching after data clearing; only non-sensitive data can be cached.
1. For sensitive data (like autocomplete results) we will disable caching entirely.
1. Moves the `okHttp` networking cache to a new location (still in `cache` dir, but now in a named directory)

As a result, when the data is cleared, we can delete the `cache` dir, but exclude the `okHttpCache` directory from this deletion. The result is that (non-sensitive) configuration data will be kept after clearing the app data.

**Steps to test this PR**:
1. From a clean install, verify the new `okHttpCache` directory is used
1. Start typing a search (to trigger a few autocomplete results); verify that this **does not** result in new cache files being created
1. Perform some browsing
1. Clear the app data 🔥 
1. Verify that the contents of the `okHttpCache` aren't modified / deleted etc...
1. Verify that the app didn't download full datasets again from the server after clearing the data (using a proxy)

In code, verify that 
1. the pixel service uses the non-caching `okHttp` client.
1. the autocomplete service uses the non-caching `okHttp` client

More generally, check the caching still works as expected, and that the data left on the device after clearing the data is expectedly minimal, and that it contains no sensitive data at all.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
