### PR TITLE
Remove "Local Storage" from the deletion exclusion list

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -99,8 +99,7 @@ class WebViewDataManager @Inject constructor(
         private const val WEBVIEW_DATA_DIRECTORY_NAME = "app_webview"
 
         private val FILENAMES_EXCLUDED_FROM_DELETION = listOf(
-            "Cookies",
-            "Local Storage"
+            "Cookies"
         )
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1127922529954338
Tech Design URL: 
CC: 

**Description**:
Despite the `WebView` API claiming it will delete the data, it doesn't appear to remove "Local Storage" when using their APIs. As a result, past site remnants can continue to be present in this directory.

This PR manually ensures the "Local Storage" directory is deleted, by removing it from our excluded list.

**Steps to test this PR**:
1. Test this change removes sensitive data
1. Test this changes doesn't limit the `Local Storage` abilities to perform after clearing


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
