### PR TITLE
Remove legacy https pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -22,9 +22,6 @@ import android.webkit.WebView
 import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
-import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
-import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -40,9 +37,6 @@ class BrowserWebViewClientTest {
     private val requestRewriter: RequestRewriter = mock()
     private val specialUrlDetector: SpecialUrlDetector = mock()
     private val requestInterceptor: RequestInterceptor = mock()
-    private val httpsUpgrader: HttpsUpgrader = mock()
-    private val statisticsDataStore: StatisticsDataStore = mock()
-    private val pixel: Pixel = mock()
     private val listener: WebViewClientListener = mock()
 
     @UiThreadTest
@@ -52,10 +46,7 @@ class BrowserWebViewClientTest {
         testee = BrowserWebViewClient(
             requestRewriter,
             specialUrlDetector,
-            requestInterceptor,
-            httpsUpgrader,
-            statisticsDataStore,
-            pixel
+            requestInterceptor
         )
         testee.webViewClientListener = listener
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -59,12 +59,9 @@ class BrowserModule {
     fun browserWebViewClient(
         requestRewriter: RequestRewriter,
         specialUrlDetector: SpecialUrlDetector,
-        requestInterceptor: RequestInterceptor,
-        httpsUpgrader: HttpsUpgrader,
-        statisticsDataStore: StatisticsDataStore,
-        pixel: Pixel
+        requestInterceptor: RequestInterceptor
     ): BrowserWebViewClient {
-        return BrowserWebViewClient(requestRewriter, specialUrlDetector, requestInterceptor, httpsUpgrader, statisticsDataStore, pixel)
+        return BrowserWebViewClient(requestRewriter, specialUrlDetector, requestInterceptor)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/api/HttpsUpgradeDataDownloader.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.httpsupgrade.api
 
-import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.global.api.isCached
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.store.BinaryDataStore
@@ -25,11 +24,6 @@ import com.duckduckgo.app.httpsupgrade.db.HttpsBloomFilterSpecDao
 import com.duckduckgo.app.httpsupgrade.db.HttpsWhitelistDao
 import com.duckduckgo.app.httpsupgrade.model.HttpsBloomFilterSpec
 import com.duckduckgo.app.httpsupgrade.model.HttpsBloomFilterSpec.Companion.HTTPS_BINARY_FILE
-import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.APP_VERSION
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FAILURE_COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.TOTAL_COUNT
-import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import io.reactivex.Completable
 import io.reactivex.Completable.*
 import timber.log.Timber
@@ -42,9 +36,7 @@ class HttpsUpgradeDataDownloader @Inject constructor(
     private val httpsBloomSpecDao: HttpsBloomFilterSpecDao,
     private val whitelistDao: HttpsWhitelistDao,
     private val binaryDataStore: BinaryDataStore,
-    private val appDatabase: AppDatabase,
-    private val statisticsDataStore: StatisticsDataStore,
-    private val pixel: Pixel
+    private val appDatabase: AppDatabase
 ) {
 
     fun download(): Completable {
@@ -114,25 +106,4 @@ class HttpsUpgradeDataDownloader @Inject constructor(
         }
 
     }
-
-    fun reportUpgradeStatistics(): Completable {
-        return defer {
-
-            if (statisticsDataStore.httpsUpgradesTotal == 0) {
-                return@defer complete()
-            }
-            val params = mapOf(
-                APP_VERSION to BuildConfig.VERSION_NAME,
-                TOTAL_COUNT to statisticsDataStore.httpsUpgradesTotal.toString(),
-                FAILURE_COUNT to statisticsDataStore.httpsUpgradesFailures.toString()
-            )
-
-            pixel.fireCompletable(Pixel.PixelName.HTTPS_UPGRADE_SITE_SUMMARY.pixelName, params).andThen {
-                Timber.v("Sent https statistics")
-                statisticsDataStore.httpsUpgradesTotal = 0
-                statisticsDataStore.httpsUpgradesFailures = 0
-            }
-        }
-    }
-
 }

--- a/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
@@ -48,7 +48,6 @@ class AppConfigurationDownloader(
         val entityListDownload = entityListDownloader.download()
         val surrogatesDownload = resourceSurrogateDownloader.downloadList()
         val httpsUpgradeDownload = httpsUpgradeDataDownloader.download()
-        val httpStatisticsReport = httpsUpgradeDataDownloader.reportUpgradeStatistics()
         val surveyDownload = surveyDownloader.download()
 
         return Completable.mergeDelayError(
@@ -60,7 +59,6 @@ class AppConfigurationDownloader(
                 entityListDownload,
                 surrogatesDownload,
                 httpsUpgradeDownload,
-                httpStatisticsReport,
                 surveyDownload
             )
         ).doOnComplete {

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -116,11 +116,6 @@ interface Pixel {
         FEEDBACK_NEGATIVE_SUBMISSION("mfbs_%s_%s_%s")
     }
 
-    object PixelParameter {
-        const val URL = "url"
-        const val APP_VERSION = "app_version"
-    }
-
     fun fire(pixel: PixelName, parameters: Map<String, String?> = emptyMap(), includeLocale: Boolean = false)
     fun fire(pixelName: String, parameters: Map<String, String?> = emptyMap(), includeLocale: Boolean = false)
     fun fireCompletable(pixelName: String, parameters: Map<String, String?>): Completable

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -73,9 +73,6 @@ interface Pixel {
         SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),
         SETTINGS_THEME_TOGGLED_DARK("ms_td"),
 
-        HTTPS_UPGRADE_SITE_ERROR("ehd"),
-        HTTPS_UPGRADE_SITE_SUMMARY("ehs"),
-
         SURVEY_CTA_SHOWN(pixelName = "mus_cs"),
         SURVEY_CTA_DISMISSED(pixelName = "mus_cd"),
         SURVEY_CTA_LAUNCHED(pixelName = "mus_cl"),
@@ -121,9 +118,6 @@ interface Pixel {
 
     object PixelParameter {
         const val URL = "url"
-        const val ERROR_CODE = "error_code"
-        const val TOTAL_COUNT = "total"
-        const val FAILURE_COUNT = "failures"
         const val APP_VERSION = "app_version"
     }
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsDataStore.kt
@@ -27,9 +27,6 @@ interface StatisticsDataStore {
     var searchRetentionAtb: String?
     var variant: String?
 
-    var httpsUpgradesTotal: Int
-    var httpsUpgradesFailures: Int
-
     fun saveAtb(atb: Atb)
     fun clearAtb()
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsSharedPreferences.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/store/StatisticsSharedPreferences.kt
@@ -47,19 +47,12 @@ class StatisticsSharedPreferences @Inject constructor(private val context: Conte
         get() = preferences.getString(KEY_APP_RETENTION_ATB, null)
         set(value) = preferences.edit { putString(KEY_APP_RETENTION_ATB, value) }
 
-    override var httpsUpgradesTotal: Int
-        get() = preferences.getInt(KEY_HTTPS_UPGRADES_TOTAL, 0)
-        set(value) = preferences.edit { putInt(KEY_HTTPS_UPGRADES_TOTAL, value) }
-
-    override var httpsUpgradesFailures: Int
-        get() = preferences.getInt(KEY_HTTPS_UPGRADES_FAILURES, 0)
-        set(value) = preferences.edit { putInt(KEY_HTTPS_UPGRADES_FAILURES, value) }
-
     override fun saveAtb(atb: Atb) {
         preferences.edit {
             putString(KEY_ATB, atb.version)
         }
     }
+
     override fun clearAtb() {
         preferences.edit {
             putString(KEY_ATB, null)
@@ -75,7 +68,5 @@ class StatisticsSharedPreferences @Inject constructor(private val context: Conte
         private const val KEY_SEARCH_RETENTION_ATB = "com.duckduckgo.app.statistics.retentionatb"
         private const val KEY_APP_RETENTION_ATB = "com.duckduckgo.app.statistics.appretentionatb"
         private const val KEY_VARIANT = "com.duckduckgo.app.statistics.variant"
-        private const val KEY_HTTPS_UPGRADES_TOTAL = "com.duckduckgo.app.statistics.httpsupgradestotal"
-        private const val KEY_HTTPS_UPGRADES_FAILURES = "com.duckduckgo.app.statistics.httpsupgradesfailures"
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1127961676181366

**Description**:
Remove unused https pixels.

**Steps to test this PR**:
1. Run the app and watch traffic with Charles proxy on
1. Navigate to a few pages and then kill and restart the app
1. Note that a `ehs` pixel **does not** fire on startup sync (it previously did)
1. Using Charles proxy, blacklist duckduckgo.com
1. Navigate to http://duckduckgo.com (which will fail) and note that an `ehd` pixel does **not** fire (it previously did)
1. Remove Charles blacklist ;-)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
