### PR TITLE
Issue/510 - Feature request: delete tab by swipe

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -19,6 +19,7 @@
 package com.duckduckgo.app.tabs.ui
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
@@ -58,6 +59,8 @@ class TabSwitcherViewModelTest {
         MockitoAnnotations.initMocks(this)
         runBlocking {
             whenever(mockTabRepository.add()).thenReturn("TAB_ID")
+            whenever(mockTabRepository.liveTabs).thenReturn(
+                MutableLiveData<List<TabEntity>>(listOf(TabEntity("id", position = 0))))
             testee = TabSwitcherViewModel(mockTabRepository, WebViewSessionInMemoryStorage())
             testee.command.observeForever(mockCommandObserver)
         }
@@ -92,6 +95,13 @@ class TabSwitcherViewModelTest {
         verify(mockCommandObserver, times(2)).onChanged(commandCaptor.capture())
         assertEquals(Command.DisplayMessage(R.string.fireDataCleared), commandCaptor.allValues[0])
         assertEquals(Command.Close, commandCaptor.allValues[1])
+    }
+
+    @Test
+    fun whenDeleteTabThenThenVerifyDeleteTabCommandWithCorrectTab() {
+        testee.deleteTab(0)
+        verify(mockCommandObserver).onChanged(commandCaptor.capture())
+        assertEquals(Command.DeleteTab(testee.tabs.value!![0]), commandCaptor.value)
     }
 
 }

--- a/app/src/main/java/com/duckduckgo/app/global/view/JustSwipeCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/JustSwipeCallback.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.view
+
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
+
+abstract class JustSwipeCallback(swipeDirs: Int) : ItemTouchHelper.SimpleCallback(0, swipeDirs) {
+
+    override fun onMove(
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        target: RecyclerView.ViewHolder
+    ): Boolean = false
+
+    abstract override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int)
+}

--- a/app/src/main/java/com/duckduckgo/app/global/view/RecyclerViewExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/RecyclerViewExtension.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.view
+
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
+
+fun RecyclerView.attachItemTouchHelper(simpleCallback: ItemTouchHelper.SimpleCallback) =
+        ItemTouchHelper(simpleCallback).attachToRecyclerView(this)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
 import com.duckduckgo.app.global.view.FireDialog
+import com.duckduckgo.app.global.view.JustSwipeCallback
 import com.duckduckgo.app.global.view.attachItemTouchHelper
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -74,15 +75,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
         tabsRecycler.layoutManager = LinearLayoutManager(this)
         tabsRecycler.adapter = tabsAdapter
         tabsRecycler.attachItemTouchHelper(
-            object :
-                ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
-
-                override fun onMove(
-                    recyclerView: RecyclerView,
-                    viewHolder: RecyclerView.ViewHolder,
-                    target: RecyclerView.ViewHolder
-                ): Boolean = false
-
+            object : JustSwipeCallback(swipeDirs = ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
                 override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
                     viewModel.deleteTab(viewHolder.adapterPosition)
                 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -22,7 +22,9 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
@@ -70,6 +72,25 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
     private fun configureRecycler() {
         tabsRecycler.layoutManager = LinearLayoutManager(this)
         tabsRecycler.adapter = tabsAdapter
+
+        ItemTouchHelper(
+            object : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
+                override fun onMove(
+                    recyclerView: RecyclerView,
+                    viewHolder: RecyclerView.ViewHolder,
+                    target: RecyclerView.ViewHolder
+                ): Boolean = false
+
+                override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+                    val position = viewHolder.adapterPosition
+                    viewModel.tabs.value?.takeIf { it.count() > position }?.let { tabList ->
+                        val swipedTab = tabList[position]
+                        onTabDeleted(swipedTab)
+                    }
+                }
+
+            }
+        ).attachToRecyclerView(tabsRecycler)
     }
 
     private fun configureObservers() {
@@ -155,3 +176,4 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
         }
     }
 }
+

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -84,11 +84,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
                 ): Boolean = false
 
                 override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-                    val position = viewHolder.adapterPosition
-                    viewModel.tabs.value?.takeIf { it.count() > position }?.let { tabList ->
-                        val swipedTab = tabList[position]
-                        onTabDeleted(swipedTab)
-                    }
+                    viewModel.deleteTab(viewHolder.adapterPosition)
                 }
             }
         )
@@ -113,6 +109,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
     private fun processCommand(command: Command?) {
         when (command) {
             is DisplayMessage -> applicationContext?.longToast(command.messageId)
+            is Command.DeleteTab -> onTabDeleted(command.tab)
             is Close -> finish()
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
 import com.duckduckgo.app.global.view.FireDialog
+import com.duckduckgo.app.global.view.attachItemTouchHelper
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
@@ -72,9 +73,10 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
     private fun configureRecycler() {
         tabsRecycler.layoutManager = LinearLayoutManager(this)
         tabsRecycler.adapter = tabsAdapter
+        tabsRecycler.attachItemTouchHelper(
+            object :
+                ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
 
-        ItemTouchHelper(
-            object : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
                 override fun onMove(
                     recyclerView: RecyclerView,
                     viewHolder: RecyclerView.ViewHolder,
@@ -88,9 +90,8 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherAdapter.TabSwitched
                         onTabDeleted(swipedTab)
                     }
                 }
-
             }
-        ).attachToRecyclerView(tabsRecycler)
+        )
     }
 
     private fun configureObservers() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -33,6 +33,7 @@ class TabSwitcherViewModel(private val tabRepository: TabRepository, private val
 
     sealed class Command {
         data class DisplayMessage(@StringRes val messageId: Int) : Command()
+        data class DeleteTab(val tab: TabEntity) : Command()
         object Close : Command()
     }
 
@@ -49,6 +50,12 @@ class TabSwitcherViewModel(private val tabRepository: TabRepository, private val
     suspend fun onTabDeleted(tab: TabEntity) {
         tabRepository.delete(tab)
         webViewSessionStorage.deleteSession(tab.tabId)
+    }
+
+    fun deleteTab(position: Int) {
+        tabs.value?.takeIf { it.count() > position }?.let { tabList ->
+            command.value = Command.DeleteTab(tabList[position])
+        }
     }
 
     fun onClearComplete() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/510
Tech Design URL: N/A

**Description**:
In tabs screen the tabs can get deleted by swipe left and right now. Implemented ItemTouchHelper for the tabs recyclerview to achieve this. Added unit test for tabs deletion

**Steps to test this PR**:
1. Go to tabs screen with multiple open tabs
1. Swipe right or left to delete that tab

![ddg-issue510](https://user-images.githubusercontent.com/8261416/59966750-9f8bbe00-9518-11e9-8413-292fa1397206.gif)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
