### PR TITLE
Issue/519 Tabs show home instead of webpage

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1046,8 +1046,15 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUrlNotPresentThenSetBrowserNotShowing() {
+    fun whenUrlNullThenSetBrowserNotShowing() {
         testee.loadData("id", null, false)
+        testee.determineShowBrowser()
+        assertEquals(false, testee.browserViewState.value?.browserShowing)
+    }
+
+    @Test
+    fun whenUrlBlankThenSetBrowserNotShowing() {
+        testee.loadData("id", "  ", false)
         testee.determineShowBrowser()
         assertEquals(false, testee.browserViewState.value?.browserShowing)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -51,7 +51,6 @@ import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.privacy.db.NetworkLeaderboardDao
-import com.duckduckgo.app.privacy.db.NetworkLeaderboardEntry
 import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.store.PrevalenceStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -1044,6 +1043,20 @@ class BrowserTabViewModelTest {
         whenever(webViewSessionStorage.restoreSession(anyOrNull(), anyString())).thenReturn(true)
         testee.restoreWebViewState(null, "")
         assertFalse(globalLayoutViewState().isNewTabState)
+    }
+
+    @Test
+    fun whenUrlNotPresentThenSetBrowserNotShowing() {
+        testee.loadData("id", null, false)
+        testee.determineShowBrowser()
+        assertEquals(false, testee.browserViewState.value?.browserShowing)
+    }
+
+    @Test
+    fun whenUrlPresentThenSetBrowserShowing() {
+        testee.loadData("id", "https://example.com", false)
+        testee.determineShowBrowser()
+        assertEquals(true, testee.browserViewState.value?.browserShowing)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -803,6 +803,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
     override fun onViewStateRestored(bundle: Bundle?) {
         viewModel.restoreWebViewState(webView, omnibarTextInput.text.toString())
+        viewModel.determineShowBrowser()
         super.onViewStateRestored(bundle)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -692,6 +692,10 @@ class BrowserTabViewModel(
         findInPageViewState.value = FindInPageViewState()
     }
 
+    fun determineShowBrowser() {
+        browserViewState.value = currentBrowserViewState().copy(browserShowing = !url.isNullOrBlank())
+    }
+
     fun userSharingLink(url: String?) {
         if (url != null) {
             command.value = ShareLink(removeAtbAndSourceParamsFromSearch(url))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/519
Tech Design URL: N/A

**Description**:
The root cause of the issue seemed to be not setting the 'browserShowing' view state when view gets restored. That led to home screen showing even for tabs with url as the default setting is false.
Added a trigger to set 'browserShowing' to true if there is an url after view restore.

**Steps to test this PR**:
1. Turn on the "Don't keep activities" in developer settings
1. Open a few webpages in separate tabs and switch between them


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
