### PR TITLE
Hackdays/more entry points into app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -93,6 +93,12 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+
+            <!-- Allow app to respond to "web search" requests from system -->
+            <intent-filter>
+                <action android:name="android.intent.action.WEB_SEARCH" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,6 +84,17 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
+        <activity android:name="com.duckduckgo.app.SelectedTextSearchActivity"
+            android:label="@string/systemTextSearchMessage"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name="com.duckduckgo.app.tabs.ui.TabSwitcherActivity"
             android:label="@string/tabActivityTitle" />

--- a/app/src/main/java/com/duckduckgo/app/SelectedTextSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/SelectedTextSearchActivity.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatActivity
+import com.duckduckgo.app.browser.BrowserActivity
+
+/**
+ * Exists purely to pull out the intent extra and launch the query in a new tab.
+ * This needs to be its own Activity so that we can customize the label that is user-facing, presented when the user selects some text.
+ */
+class SelectedTextSearchActivity : AppCompatActivity() {
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val query = intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT)
+        startActivity(BrowserActivity.intent(this, queryExtra = query))
+        finish()
+    }
+
+}

--- a/app/src/main/java/com/duckduckgo/app/SelectedTextSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/SelectedTextSearchActivity.kt
@@ -16,12 +16,14 @@
 
 package com.duckduckgo.app
 
+import android.app.SearchManager
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import com.duckduckgo.app.browser.BrowserActivity
+import timber.log.Timber
 
 /**
  * Exists purely to pull out the intent extra and launch the query in a new tab.
@@ -33,9 +35,23 @@ class SelectedTextSearchActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val query = intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT)
+        val query = extractQuery(intent)
         startActivity(BrowserActivity.intent(this, queryExtra = query))
         finish()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun extractQuery(intent: Intent?): String? {
+        if (intent == null) return null
+
+        val textSelectionQuery = intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT)
+        if (textSelectionQuery != null) return textSelectionQuery
+
+        val webSearchQuery = intent.getStringExtra(SearchManager.QUERY)
+        if (webSearchQuery != null) return webSearchQuery
+
+        Timber.w("SelectedTextSearchActivity launched with unexpected intent format")
+        return null
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,5 +296,7 @@
     <string name="authenticationDialogUsernameHint">Username</string>
     <string name="authenticationDialogPasswordHint">Password</string>
 
+    <!-- User-facing label for when a user selects text and might want to search for that text -->
+    <string name="systemTextSearchMessage">Duck it! (Private search)</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,6 +297,6 @@
     <string name="authenticationDialogPasswordHint">Password</string>
 
     <!-- User-facing label for when a user selects text and might want to search for that text -->
-    <string name="systemTextSearchMessage">Duck it! (Private search)</string>
+    <string name="systemTextSearchMessage">Search DuckDuckGo</string>
 
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1129700547188231
Tech Design URL: 
CC: 

**Description**:
Bringing in the work done during hack days to investigate new ways to allow users to quickly access our app.

This PR focusses on allowing users to select our app from the context menu that is shown when they long press on text in another app.

ℹ️Sometimes other apps will customise the long press text behaviour. They might disable the text from being selected, disable or customise the context menu. In these cases, our app might not show. But where a third-party app hasn't customised this, you should see the following behaviour.

**Steps to test this PR**:
1. From another app (e.g., Firefox Focus), long press on some text. If the other app isn't doing anything custom with the text (e.g., disabling long press, or customising the menu), you should see a context menu appear
1. Verify that "Search DuckDuckGo" appears as an option. Click this option and confirm it launches our app and performs the search for the selected text in a new tab.

On newer versions of Android, you should also see an option in the context menu to perform a `Web search` (I can't find out which OS version exactly). Verify you see the `Web search` option, and that clicking it results in opening that up as a new tab for that selected search term.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
