### PR TITLE
Lint layout tidy-up

### DIFF
--- a/app/src/main/res/drawable/icon_fire_glyph_24dp.xml
+++ b/app/src/main/res/drawable/icon_fire_glyph_24dp.xml
@@ -19,7 +19,7 @@
         android:gravity="center"
         android:left="3.5dp"
         android:right="3.5dp">
-        <bitmap xmlns:android="http://schemas.android.com/apk/res/android"
+        <bitmap
             android:scaleType="fitXY"
             android:src="@drawable/icon_fire_glyph" />
     </item>

--- a/app/src/main/res/layout/content_bookmarks.xml
+++ b/app/src/main/res/layout/content_bookmarks.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -41,4 +41,4 @@
         android:textColor="?attr/bookmarkTitleTextColor"
         android:textSize="16sp" />
 
-</FrameLayout>
+</merge>


### PR DESCRIPTION
- Replace `FrameLayout` with `merge` which is more faster.

- Remove Redundant `namespace`