### PR TITLE
when updateVersion is present store it

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
@@ -73,6 +73,22 @@ class StatisticsRequesterJsonTest {
     }
 
     @Test
+    fun whenAlreadyInitializedRefreshSearchRetentionCallWithUpdateVersionResponseUpdatesAtb() {
+        statisticsStore.saveAtb(Atb("100-1"))
+        queueResponseFromFile(VALID_UPDATE_RESPONSE_JSON)
+        testee.refreshSearchRetentionAtb()
+        assertEquals("v99-1", statisticsStore.atb?.version)
+    }
+
+    @Test
+    fun whenAlreadyInitializedRefreshAppRetentionCallWithUpdateVersionResponseUpdatesAtb() {
+        statisticsStore.saveAtb(Atb("100-1"))
+        queueResponseFromFile(VALID_UPDATE_RESPONSE_JSON)
+        testee.refreshAppRetentionAtb()
+        assertEquals("v99-1", statisticsStore.atb?.version)
+    }
+
+    @Test
     fun whenNotYetInitializedAtbInitializationStoresAtbResponse() {
         queueResponseFromFile(VALID_JSON)
         queueResponseFromString(responseBody = "", responseCode = 200)
@@ -332,6 +348,7 @@ class StatisticsRequesterJsonTest {
     companion object {
         private const val VALID_JSON = "atb_response_valid.json"
         private const val VALID_REFRESH_RESPONSE_JSON = "atb_refresh_response_valid.json"
+        private const val VALID_UPDATE_RESPONSE_JSON = "atb_update_response_valid.json"
         private const val INVALID_JSON_MISSING_VERSION = "atb_response_invalid_missing_version.json"
         private const val INVALID_JSON_CORRUPT_JSON = "atb_response_invalid_malformed_json.json"
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -51,6 +51,22 @@ class StatisticsRequesterTest {
     }
 
     @Test
+    fun whenUpdateVersionPresentDuringRefreshSearchRetentionThenPreviousAtbIsReplacedWithUpdateVersion() {
+        configureStoredStatistics()
+        whenever(mockService.updateSearchAtb(any(), any(), any())).thenReturn(Observable.just(UPDATE_ATB))
+        testee.refreshSearchRetentionAtb()
+        verify(mockStatisticsStore).atb = Atb(UPDATE_ATB.updateVersion!!)
+    }
+
+    @Test
+    fun whenUpdateVersionPresentDuringRefreshAppRetentionThenPreviousAtbIsReplacedWithUpdateVersion() {
+        configureStoredStatistics()
+        whenever(mockService.updateAppAtb(any(), any(), any())).thenReturn(Observable.just(UPDATE_ATB))
+        testee.refreshAppRetentionAtb()
+        verify(mockStatisticsStore).atb = Atb(UPDATE_ATB.updateVersion!!)
+    }
+
+    @Test
     fun whenNoStatisticsStoredThenInitializeAtbInvokesExti() {
         configureNoStoredStatistics()
         testee.initializeAtb()
@@ -68,9 +84,18 @@ class StatisticsRequesterTest {
     }
 
     @Test
-    fun whenNoStatisticsStoredThenRefreshRetrievesAtbAndInvokesExti() {
+    fun whenNoStatisticsStoredThenRefreshSearchRetentionRetrievesAtbAndInvokesExti() {
         configureNoStoredStatistics()
         testee.refreshSearchRetentionAtb()
+        verify(mockService).atb(any())
+        verify(mockService).exti(eq(ATB_WITH_VARIANT), any())
+        verify(mockStatisticsStore).saveAtb(ATB)
+    }
+
+    @Test
+    fun whenNoStatisticsStoredThenRefreshAppRetentionRetrievesAtbAndInvokesExti() {
+        configureNoStoredStatistics()
+        testee.refreshAppRetentionAtb()
         verify(mockService).atb(any())
         verify(mockService).exti(eq(ATB_WITH_VARIANT), any())
         verify(mockStatisticsStore).saveAtb(ATB)
@@ -125,6 +150,7 @@ class StatisticsRequesterTest {
 
     companion object {
         private val ATB = Atb("v105-2")
+        private val UPDATE_ATB = Atb("v105-2", updateVersion = "v99-1")
         private const val ATB_WITH_VARIANT = "v105-2ma"
         private const val NEW_ATB = "v105-4"
     }

--- a/app/src/androidTest/resources/json/atb_update_response_valid.json
+++ b/app/src/androidTest/resources/json/atb_update_response_valid.json
@@ -1,0 +1,7 @@
+{
+  "for_more_info": "https://duck.co/help/privacy/atb",
+  "minorVersion": 3,
+  "majorVersion": 105,
+  "version": "v107-7",
+  "updateVersion": "v99-1"
+}

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
@@ -119,7 +119,7 @@ class StatisticsRequester(
 
     private fun storeUpdateVersionIfPresent(retrievedAtb: Atb) {
         if (retrievedAtb.updateVersion != null) {
-            store.atb = Atb(retrievedAtb.updateVersion!!)
+            store.atb = Atb(retrievedAtb.updateVersion)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
@@ -87,6 +87,7 @@ class StatisticsRequester(
             .subscribe({
                 Timber.v("Search atb refresh succeeded, latest atb is ${it.version}")
                 store.searchRetentionAtb = it.version
+                storeUpdateVersionIfPresent(it)
             }, {
                 Timber.v("Search atb refresh failed with error ${it.localizedMessage}")
             })
@@ -94,7 +95,6 @@ class StatisticsRequester(
 
     @SuppressLint("CheckResult")
     override fun refreshAppRetentionAtb() {
-
         val atb = store.atb
 
         if (atb == null) {
@@ -110,9 +110,17 @@ class StatisticsRequester(
             .subscribe({
                 Timber.v("App atb refresh succeeded, latest atb is ${it.version}")
                 store.appRetentionAtb = it.version
+                storeUpdateVersionIfPresent(it)
             }, {
                 Timber.v("App atb refresh failed with error ${it.localizedMessage}")
             })
+
+    }
+
+    private fun storeUpdateVersionIfPresent(retrievedAtb: Atb) {
+        if (retrievedAtb.updateVersion != null) {
+            store.atb = Atb(retrievedAtb.updateVersion!!)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/statistics/model/Atb.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/model/Atb.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.app.statistics.model
 
 import com.duckduckgo.app.statistics.Variant
 
-data class Atb(val version: String) {
+data class Atb(val version: String, val updateVersion: String? = null) {
 
     fun formatWithVariant(variant: Variant): String {
         return version + variant.key


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1114152243888973
Tech Design URL: 
CC: 

**Description**:

When the `udpateVersion` property is available in the atb.js response then it is stored as the main atb version.

**Steps to test this PR**:

With Charles proxy running and a breakpoint for atb.js
1. clean install
1. edit the `atb.js` response to set the atb version to something old
1. perform a search, observe the `updateVersion` in the response
1. subsequent `set_atb` calls should use the new cohort for the atb

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
