### PR TITLE
Add special handling for javascript URLs

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -139,4 +139,17 @@ class SpecialUrlDetectorImplTest {
         val type = testee.determineType("foo site:duckduckgo.com") as SearchQuery
         assertEquals("foo site:duckduckgo.com", type.query)
     }
+
+    @Test
+    fun whenUrlIsJavascriptSchemeThenWebSearchTypeDetected() {
+        val expected = SearchQuery::class
+        val actual = testee.determineType("javascript:alert(0)")
+        assertEquals(expected, actual::class)
+    }
+
+    @Test
+    fun whenUrlIsJavascriptSchemeThenFullQueryRetained() {
+        val type = testee.determineType("javascript:alert(0)") as SearchQuery
+        assertEquals("javascript:alert(0)", type.query)
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -42,9 +42,8 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
 
     override fun determineType(uri: Uri): UrlType {
         val uriString = uri.toString()
-        val scheme = uri.scheme
 
-        return when (scheme) {
+        return when (val scheme = uri.scheme) {
             TEL_SCHEME -> buildTelephone(uriString)
             TELPROMPT_SCHEME -> buildTelephonePrompt(uriString)
             MAILTO_SCHEME -> buildEmail(uriString)
@@ -52,6 +51,7 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
             SMSTO_SCHEME -> buildSmsTo(uriString)
             HTTP_SCHEME, HTTPS_SCHEME, DATA_SCHEME -> UrlType.Web(uriString)
             ABOUT_SCHEME -> UrlType.Unknown(uriString)
+            JAVASCRIPT_SCHEME -> UrlType.SearchQuery(uriString)
             null -> UrlType.SearchQuery(uriString)
             else -> checkForIntent(scheme, uriString)
         }
@@ -103,6 +103,7 @@ class SpecialUrlDetectorImpl : SpecialUrlDetector {
         private const val HTTPS_SCHEME = "https"
         private const val ABOUT_SCHEME = "about"
         private const val DATA_SCHEME = "data"
+        private const val JAVASCRIPT_SCHEME = "javascript"
 
         private const val EXTRA_FALLBACK_URL = "browser_fallback_url"
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:https://app.asana.com/0/414730916066338/1133861428497755 
Tech Design URL: 
CC: 

**Description**:
Adds special handling of `javascript:` URLs (e.g., `javascript:alert(0)`) so that they aren't treated as a reason to launch a 3rd party app. right now, the special URL is detected as being a URL that another app might want to handle, and offers it up to the system to show a launcher. This is unnecessary, and in the worst case, can result in a crash.

**Steps to test this PR**:
1. type `javascript:alert(0)` into the omnibar; verify a search is performed (and it isn't treated as invitation to launch a 3rd party app)
1. visit `http://one.vulnerableweb.site` and verify that the 3rd party app chooser is NOT shown


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)