### PR TITLE
Add action to launch app ready to perform a text search

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,16 +71,19 @@
             <!-- Allows apps to consume links and text shared from other apps e.g chrome -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
-
                 <category android:name="android.intent.category.DEFAULT" />
-
                 <data android:mimeType="text/plain" />
             </intent-filter>
 
             <!-- Allow app to be default assistant -->
             <intent-filter>
                 <action android:name="android.intent.action.ASSIST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
 
+            <!-- Required to allow the browser to be launched externally, ensuring it is ready to allow users to search immediately -->
+            <intent-filter>
+                <action android:name="com.duckduckgo.mobile.android.NEW_SEARCH"/>
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -253,7 +253,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
     }
 
     private fun launchNewSearch(intent: Intent): Boolean {
-        return intent.getBooleanExtra(NEW_SEARCH_EXTRA, false) || intent.action == Intent.ACTION_ASSIST
+        return intent.getBooleanExtra(NEW_SEARCH_EXTRA, false) || intent.action == Intent.ACTION_ASSIST || intent.action == NEW_SEARCH_ACTION
     }
 
     fun launchPrivacyDashboard() {
@@ -321,6 +321,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
             return intent
         }
 
+        const val NEW_SEARCH_ACTION = "com.duckduckgo.mobile.android.NEW_SEARCH"
         const val NEW_SEARCH_EXTRA = "NEW_SEARCH_EXTRA"
         const val WIDGET_SEARCH_EXTRA = "WIDGET_SEARCH_EXTRA"
         const val PERFORM_FIRE_ON_ENTRY_EXTRA = "PERFORM_FIRE_ON_ENTRY_EXTRA"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/608920331025313/1134626034285298/1134568220205427
Tech Design URL: 
CC: 

**Description**:
Allows the app to be launched from an external intent action `com.duckduckgo.mobile.android.NEW_SEARCH`

**Steps to test this PR**:
To test this PR, you'll need to use a third party app to launch an intent. It is important to test launching the app from outside our own app. The code to do this is:

    val intent = Intent("com.duckduckgo.mobile.android.NEW_SEARCH")
    startActivity(intent)

1. From a fresh install, **having never opened the app before**, run the code to launch the action; verify our app launches and displays the `BrowserActivity` and is ready to perform a search (and that the onboarding screen are **not shown**)
1. From a more usual setup, of having already opened the app normally and passed onboarding screens, run the code to launch the action; verify our app launches and displays `BrowserActivity` and is ready to perform a search
1. While the app is already running, perform the above. Verify the user is taken to our app and is ready to perform a new search


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
