### PR TITLE
Make adding a bookmark a one-click operation (can edit from snackbar)

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -29,10 +29,11 @@ import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.autocomplete.api.AutoCompleteApi
+import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion
+import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.browser.BrowserTabViewModel.Command
-import com.duckduckgo.app.browser.BrowserTabViewModel.Command.DisplayMessage
 import com.duckduckgo.app.browser.BrowserTabViewModel.Command.Navigate
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.DownloadFile
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.OpenInNewTab
@@ -52,7 +53,6 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.privacy.db.NetworkLeaderboardDao
 import com.duckduckgo.app.privacy.model.PrivacyPractices
-import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion.*
 import com.duckduckgo.app.privacy.store.PrevalenceStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
@@ -295,11 +295,19 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenBookmarkAddedThenDaoIsUpdatedAndUserNotified() {
-        testee.onBookmarkSaved(null, "A title", "www.example.com")
+    fun whenBookmarkEditedThenDaoIsUpdated() = runBlocking<Unit> {
+        testee.editBookmark(0, "A title", "www.example.com")
+        verify(bookmarksDao).update(BookmarkEntity(title = "A title", url = "www.example.com"))
+    }
+
+    @Test
+    fun whenBookmarkAddedThenDaoIsUpdatedAndUserNotified() = runBlocking<Unit> {
+        loadUrl("www.example.com", "A title")
+
+        testee.onBookmarkAddRequested()
         verify(bookmarksDao).insert(BookmarkEntity(title = "A title", url = "www.example.com"))
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        assertTrue(commandCaptor.lastValue is DisplayMessage)
+        assertTrue(commandCaptor.lastValue is Command.ShowBookmarkAddedConfirmation)
     }
 
     @Test
@@ -895,22 +903,24 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenSiteLoadedAndUserSelectsToAddBookmarkThenAddBookmarkCommandSentWithUrlAndTitle() {
+    fun whenSiteLoadedAndUserSelectsToAddBookmarkThenAddBookmarkCommandSentWithUrlAndTitle() = runBlocking<Unit> {
         loadUrl("foo.com")
         testee.titleReceived("Foo Title")
-        testee.onAddBookmarkSelected()
-        val command = captureCommands().value as Command.AddBookmark
+        testee.onBookmarkAddRequested()
+        val command = captureCommands().value as Command.ShowBookmarkAddedConfirmation
         assertEquals("foo.com", command.url)
         assertEquals("Foo Title", command.title)
     }
 
     @Test
-    fun whenNoSiteAndUserSelectsToAddBookmarkThenAddBookmarkCommandSentWithBlankTitleAndUrl() {
-        testee.onAddBookmarkSelected()
-        val command = captureCommands().value as Command.AddBookmark
-        assertNotNull(command)
-        assertNull(command.url)
-        assertNull(command.title)
+    fun whenNoSiteAndUserSelectsToAddBookmarkThenBookmarkAddedWithBlankTitleAndUrl() = runBlocking<Unit> {
+        whenever(bookmarksDao.insert(any())).thenReturn(1)
+        testee.onBookmarkAddRequested()
+        verify(bookmarksDao).insert(BookmarkEntity(title = "", url = ""))
+        val command = captureCommands().value as Command.ShowBookmarkAddedConfirmation
+        assertEquals(1, command.bookmarkId)
+        assertEquals("", command.title)
+        assertEquals("", command.url)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/db/BookmarkEntity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/db/BookmarkEntity.kt
@@ -21,7 +21,7 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "bookmarks")
 data class BookmarkEntity(
-    @PrimaryKey(autoGenerate = true) var id: Int = 0,
+    @PrimaryKey(autoGenerate = true) var id: Long = 0,
     var title: String?,
     var url: String
 )

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/db/BookmarksDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/db/BookmarksDao.kt
@@ -24,7 +24,7 @@ import io.reactivex.Single
 interface BookmarksDao {
 
     @Insert
-    fun insert(bookmark: BookmarkEntity)
+    fun insert(bookmark: BookmarkEntity): Long
 
     @Query("select * from bookmarks")
     fun bookmarks(): LiveData<List<BookmarkEntity>>
@@ -32,7 +32,7 @@ interface BookmarksDao {
     @Delete
     fun delete(bookmark: BookmarkEntity)
 
-    @Update
+    @Update(onConflict = OnConflictStrategy.REPLACE)
     fun update(bookmarkEntity: BookmarkEntity)
 
     @Query("select * from bookmarks WHERE title LIKE :query OR url LIKE :query ")

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -91,7 +91,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
     }
 
     private fun showEditBookmarkDialog(bookmark: BookmarkEntity) {
-        val dialog = SaveBookmarkDialogFragment.createDialogEditingMode(bookmark)
+        val dialog = EditBookmarkDialogFragment.instance(bookmark.id.toLong(), bookmark.title, bookmark.url)
         dialog.show(supportFragmentManager, EDIT_BOOKMARK_FRAGMENT_TAG)
         dialog.listener = viewModel
     }

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -23,11 +23,11 @@ import androidx.lifecycle.ViewModel
 import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.bookmarks.ui.BookmarksViewModel.Command.*
-import com.duckduckgo.app.bookmarks.ui.SaveBookmarkDialogFragment.SaveBookmarkListener
+import com.duckduckgo.app.bookmarks.ui.EditBookmarkDialogFragment.EditBookmarkListener
 import com.duckduckgo.app.global.SingleLiveEvent
 import io.reactivex.schedulers.Schedulers
 
-class BookmarksViewModel(val dao: BookmarksDao) : SaveBookmarkListener, ViewModel() {
+class BookmarksViewModel(val dao: BookmarksDao) : EditBookmarkListener, ViewModel() {
 
     data class ViewState(
         val showBookmarks: Boolean = false,
@@ -58,9 +58,9 @@ class BookmarksViewModel(val dao: BookmarksDao) : SaveBookmarkListener, ViewMode
         bookmarks.removeObserver(bookmarksObserver)
     }
 
-    override fun onBookmarkSaved(id: Int?, title: String, url: String) {
-        id?.let {
-            editBookmark(it, title, url)
+    override fun onBookmarkEdited(id: Long, title: String, url: String) {
+        Schedulers.io().scheduleDirect {
+            dao.update(BookmarkEntity(id, title, url))
         }
     }
 
@@ -83,12 +83,6 @@ class BookmarksViewModel(val dao: BookmarksDao) : SaveBookmarkListener, ViewMode
     fun delete(bookmark: BookmarkEntity) {
         Schedulers.io().scheduleDirect {
             dao.delete(bookmark)
-        }
-    }
-
-    private fun editBookmark(id: Int, title: String, url: String) {
-        Schedulers.io().scheduleDirect {
-            dao.update(BookmarkEntity(id, title, url))
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -57,7 +57,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion
-import com.duckduckgo.app.bookmarks.ui.SaveBookmarkDialogFragment
+import com.duckduckgo.app.bookmarks.ui.EditBookmarkDialogFragment
 import com.duckduckgo.app.browser.BrowserTabViewModel.*
 import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.app.browser.downloader.FileDownloadNotificationManager
@@ -94,12 +94,7 @@ import kotlinx.android.synthetic.main.include_new_browser_tab.*
 import kotlinx.android.synthetic.main.include_omnibar_toolbar.*
 import kotlinx.android.synthetic.main.include_omnibar_toolbar.view.*
 import kotlinx.android.synthetic.main.popup_window_browser_menu.view.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import org.jetbrains.anko.longToast
 import org.jetbrains.anko.share
 import timber.log.Timber
@@ -263,7 +258,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             onMenuItemClicked(view.refreshPopupMenuItem) { refresh() }
             onMenuItemClicked(view.newTabPopupMenuItem) { browserActivity?.launchNewTab() }
             onMenuItemClicked(view.bookmarksPopupMenuItem) { browserActivity?.launchBookmarks() }
-            onMenuItemClicked(view.addBookmarksPopupMenuItem) { viewModel.onAddBookmarkSelected() }
+            onMenuItemClicked(view.addBookmarksPopupMenuItem) { launch { viewModel.onBookmarkAddRequested() }}
             onMenuItemClicked(view.findInPageMenuItem) { viewModel.onFindInPageSelected() }
             onMenuItemClicked(view.brokenSitePopupMenuItem) { viewModel.onBrokenSiteSelected() }
             onMenuItemClicked(view.settingsPopupMenuItem) { browserActivity?.launchSettings() }
@@ -362,9 +357,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             is Command.OpenInNewBackgroundTab -> {
                 openInNewBackgroundTab()
             }
-            is Command.AddBookmark -> {
-                addBookmark(it.title, it.url)
-            }
+            is Command.ShowBookmarkAddedConfirmation -> bookmarkAdded(it.bookmarkId, it.title, it.url)
             is Command.Navigate -> {
                 navigate(it.url)
             }
@@ -415,7 +408,6 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             is Command.CopyLink -> {
                 clipboardManager.primaryClip = ClipData.newPlainText(null, it.url)
             }
-            is Command.DisplayMessage -> showToast(it.messageId)
             is Command.ShowFileChooser -> {
                 launchFilePicker(it)
             }
@@ -746,10 +738,15 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         popupMenu.show(rootView, toolbar)
     }
 
-    private fun addBookmark(title: String?, url: String?) {
-        val addBookmarkDialog = SaveBookmarkDialogFragment.createDialogCreationMode(title, url)
-        addBookmarkDialog.show(childFragmentManager, ADD_BOOKMARK_FRAGMENT_TAG)
-        addBookmarkDialog.listener = viewModel
+    private fun bookmarkAdded(bookmarkId: Long, title: String?, url: String?) {
+
+        Snackbar.make(rootView, R.string.bookmarkEdited, Snackbar.LENGTH_LONG)
+            .setAction(R.string.edit) {
+                val addBookmarkDialog = EditBookmarkDialogFragment.instance(bookmarkId, title, url)
+                addBookmarkDialog.show(childFragmentManager, ADD_BOOKMARK_FRAGMENT_TAG)
+                addBookmarkDialog.listener = viewModel
+            }
+            .show()
     }
 
     private fun launchSharePageChooser(url: String) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -30,16 +30,14 @@ import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import androidx.lifecycle.*
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 import com.duckduckgo.app.autocomplete.api.AutoCompleteApi
 import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteResult
-import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
-import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion
+import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion
+import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
-import com.duckduckgo.app.bookmarks.ui.SaveBookmarkDialogFragment.SaveBookmarkListener
+import com.duckduckgo.app.bookmarks.ui.EditBookmarkDialogFragment.EditBookmarkListener
 import com.duckduckgo.app.browser.BrowserTabViewModel.Command.*
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.IntentType
@@ -65,6 +63,8 @@ import com.duckduckgo.app.privacy.model.PrivacyGrade
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -99,7 +99,7 @@ class BrowserTabViewModel(
     private val searchCountDao: SearchCountDao,
     private val pixel: Pixel,
     appConfigurationDao: AppConfigurationDao
-) : WebViewClientListener, SaveBookmarkListener, HttpAuthenticationListener, ViewModel() {
+) : WebViewClientListener, EditBookmarkListener, HttpAuthenticationListener, ViewModel() {
 
     private var buildingSiteFactoryJob: Job? = null
 
@@ -164,12 +164,11 @@ class BrowserTabViewModel(
         object HideKeyboard : Command()
         class ShowFullScreen(val view: View) : Command()
         class DownloadImage(val url: String) : Command()
-        class AddBookmark(val title: String?, val url: String?) : Command()
+        class ShowBookmarkAddedConfirmation(val bookmarkId: Long, val title: String?, val url: String?) : Command()
         class ShareLink(val url: String) : Command()
         class CopyLink(val url: String) : Command()
         class FindInPageCommand(val searchTerm: String) : Command()
         class BrokenSiteFeedback(val url: String?) : Command()
-        class DisplayMessage(@StringRes val messageId: Int) : Command()
         object DismissFindInPage : Command()
         class ShowFileChooser(val filePathCallback: ValueCallback<Array<Uri>>, val fileChooserParams: WebChromeClient.FileChooserParams) : Command()
         class HandleExternalAppLink(val appLink: IntentType) : Command()
@@ -595,11 +594,27 @@ class BrowserTabViewModel(
         }
     }
 
-    override fun onBookmarkSaved(id: Int?, title: String, url: String) {
-        Schedulers.io().scheduleDirect {
+    suspend fun onBookmarkAddRequested() {
+        val url = url ?: ""
+        val title = title ?: ""
+        val id = withContext(Dispatchers.IO) {
             bookmarksDao.insert(BookmarkEntity(title = title, url = url))
         }
-        command.value = DisplayMessage(R.string.bookmarkAddedFeedback)
+        withContext(Dispatchers.Main) {
+            command.value = ShowBookmarkAddedConfirmation(id, title, url)
+        }
+    }
+
+    override fun onBookmarkEdited(id: Long, title: String, url: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            editBookmark(id, title, url)
+        }
+    }
+
+    suspend fun editBookmark(id: Long, title: String, url: String) {
+        withContext(Dispatchers.IO) {
+            bookmarksDao.update(BookmarkEntity(id, title, url))
+        }
     }
 
     fun onBrokenSiteSelected() {
@@ -708,10 +723,6 @@ class BrowserTabViewModel(
         autoCompleteViewState.value = AutoCompleteViewState()
         omnibarViewState.value = OmnibarViewState()
         findInPageViewState.value = FindInPageViewState()
-    }
-
-    fun onAddBookmarkSelected() {
-        command.value = AddBookmark(title, url)
     }
 
     fun onShareSelected() {

--- a/app/src/main/res/layout/edit_bookmark.xml
+++ b/app/src/main/res/layout/edit_bookmark.xml
@@ -26,7 +26,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="20dp"
-        android:layout_marginEnd="20dp">
+        android:layout_marginEnd="20dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <EditText
             android:id="@+id/titleInput"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,7 +204,6 @@
     <string name="bookmarkUrlHint">Bookmark URL</string>
     <string name="bookmarkSave">Save</string>
     <string name="bookmarkTitleEdit">Edit Bookmark</string>
-    <string name="bookmarkTitleSave">Save Bookmark</string>
     <string name="noBookmarks">No bookmarks added yet</string>
     <string name="bookmarkOverflowContentDescription">More options for bookmark %s</string>
     <string name="delete">Delete</string>
@@ -363,5 +362,6 @@
     <string name="feedbackInitialDisambiguationSadButtonContentDescription">Negative feedback button</string>
     <string name="feedbackIsImportantToUs">Your anonymous feedback is important to us.</string>
 
+    <string name="bookmarkEdited">Bookmark added</string>
 
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/715106103902962/1134717259951641
Tech Design URL: 
CC: 

**Description**:
Removes the modal dialog presented to a user when they add a bookmark. Instead, the bookmark is added immediately and a `Snackbar` with an `Edit` action is shown. 

If the user does nothing, then the bookmark has already been added. If the user taps the `Edit` button, then they can choose to edit the title and/or URL.

**Steps to test this PR**:
1. Add a bookmark, and don't interact with the snackbar. 
    1. verify it disappears momentarily.
    1. verify the bookmark has been added
1. Add another bookmark, and this time swipe the snackbar away
    1. verify it disappears momentarily.
    1. verify the bookmark has been added
1. Add another bookmark, and this time hit the `edit` button
    1. Change the title and URL, and hit save
    1. Verify the bookmark was updated with your new values
1. Add another bookmark, and this time hit the `edit` button
    1. Cancel the dialog
    1. Verify the bookmark has still been added (the user cancelled the editing, but not the adding, of the bookmark


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
