### PR TITLE
Fix timing issue which can cause a crash when performing HTTPS upgrades

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
@@ -313,6 +313,7 @@ class WebViewRequestInterceptorTest {
 
     private fun configureShouldUpgrade() = runBlocking<Unit> {
         whenever(mockHttpsUpgrader.shouldUpgrade(any())).thenReturn(true)
+        whenever(mockHttpsUpgrader.upgrade(any())).thenReturn(validHttpsUri())
         whenever(mockRequest.url).thenReturn(validUri())
         whenever(mockRequest.isForMainFrame).thenReturn(true)
     }
@@ -325,6 +326,7 @@ class WebViewRequestInterceptorTest {
     }
 
     private fun validUri() = Uri.parse("example.com")
+    private fun validHttpsUri() = Uri.parse("https://example.com")
 
     private fun assertCancelledResponse(response: WebResourceResponse?) {
         assertNotNull(response)

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
@@ -27,6 +27,8 @@ import com.duckduckgo.app.privacy.model.TrustedSites
 import com.duckduckgo.app.surrogates.ResourceSurrogates
 import com.duckduckgo.app.trackerdetection.TrackerDetector
 import com.duckduckgo.app.trackerdetection.model.ResourceType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 interface RequestInterceptor {
@@ -69,7 +71,11 @@ class WebViewRequestInterceptor(
 
         if (shouldUpgrade(request)) {
             val newUri = httpsUpgrader.upgrade(url)
-            webView.post { webView.loadUrl(newUri.toString()) }
+
+            withContext(Dispatchers.Main) {
+                webView.loadUrl(newUri.toString())
+            }
+
             privacyProtectionCountDao.incrementUpgradeCount()
             return WebResourceResponse(null, null, null)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1134654612159126
Tech Design URL:
CC:

Description:
Change the way we load HTTPS versions of site during HTTPS-upgrades to avoid a WebView crash

Steps to test this PR:
The easiest way to test this out is to hack BrowserTabFragment.launchPopupMenu as follows

    private fun launchPopupMenu() {
        //popupMenu.show(rootView, toolbar)
        webView?.loadUrl("http://dealnews.com")
    }

Now, you can tap the overflow menu to attempt to load that site. Within a few taps of that (or certainly less than 10) on my Pixel 2, the app crashes.

Test the hack above against develop, and verify it crashes
Test the hack above against this branch, and verify it does not crash
Verify all the interceptor logic still works as before (still blocks trackers, still upgrades http sites etc...)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
