### PR TITLE
Remove observers when clearing starts to avoid showing the keyboard

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -265,6 +265,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
     fun launchFire() {
         val dialog = FireDialog(context = this, clearPersonalDataAction = clearPersonalDataAction)
         dialog.clearStarted = {
+            removeObservers()
             clearingInProgressView.show()
         }
         dialog.clearComplete = { viewModel.onClearComplete() }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1134874424977664
Tech Design URL: 
CC: 

**Description**:
Stops the keyboard from showing during data clearing

**Steps to test this PR**:
1. With a webpage showing, use the 🔥button to clear the data
1. Verify the keyboard is shown once and only once, and is ready for the user to start typing


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
