### PR TITLE
add bookmarks app shortcut

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -150,6 +150,7 @@
             android:label="@string/aboutActivityTitle"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
         <activity
+            android:parentActivityName=".BrowserActivity"
             android:name="com.duckduckgo.app.bookmarks.ui.BookmarksActivity"
             android:label="@string/bookmarksActivityTitle" />
         <activity

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -77,7 +77,7 @@ class AppShortcutCreator @Inject constructor() {
 
         return ShortcutInfoCompat.Builder(context, SHORTCUT_ID_SHOW_BOOKMARKS)
             .setShortLabel(context.getString(R.string.bookmarksActivityTitle))
-            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_overflow_bookmarks_24dp))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_bookmarks))
             .setIntents(stackBuilder.intents)
             .build().toShortcutInfo()
     }

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.global.shortcut
 
+import android.app.TaskStackBuilder
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ShortcutInfo
@@ -24,6 +25,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.graphics.drawable.IconCompat
+import com.duckduckgo.app.bookmarks.ui.BookmarksActivity
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import javax.inject.Inject
@@ -37,6 +39,7 @@ class AppShortcutCreator @Inject constructor() {
 
         shortcutList.add(buildNewTabShortcut(context))
         shortcutList.add(buildClearDataShortcut(context))
+        shortcutList.add(buildBookmarksShortcut(context))
 
         val shortcutManager = context.getSystemService(ShortcutManager::class.java)
         shortcutManager.dynamicShortcuts = shortcutList
@@ -66,9 +69,23 @@ class AppShortcutCreator @Inject constructor() {
             .build().toShortcutInfo()
     }
 
+    @RequiresApi(Build.VERSION_CODES.N_MR1)
+    private fun buildBookmarksShortcut(context: Context): ShortcutInfo {
+        val bookmarksActivity = BookmarksActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
+
+        val stackBuilder = TaskStackBuilder.create(context).addNextIntentWithParentStack(bookmarksActivity)
+
+        return ShortcutInfoCompat.Builder(context, SHORTCUT_ID_SHOW_BOOKMARKS)
+            .setShortLabel(context.getString(R.string.bookmarksActivityTitle))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_overflow_bookmarks_24dp))
+            .setIntents(stackBuilder.intents)
+            .build().toShortcutInfo()
+    }
+
     companion object {
         private const val SHORTCUT_ID_CLEAR_DATA = "clearData"
         private const val SHORTCUT_ID_NEW_TAB = "newTab"
+        private const val SHORTCUT_ID_SHOW_BOOKMARKS = "showBookmarks"
     }
 
 }

--- a/app/src/main/res/drawable/ic_app_shortcut_bookmarks.xml
+++ b/app/src/main/res/drawable/ic_app_shortcut_bookmarks.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2019 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+      android:fillColor="#F5F5F5"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M15.75,5.25h-7.5c-0.825,0 -1.5,0.675 -1.5,1.5v12L12,16.5l5.25,2.25v-12c0,-0.825 -0.675,-1.5 -1.5,-1.5z"
+      android:fillColor="#DE5833"
+      android:fillType="nonZero"/>
+</vector>

--- a/app/src/main/res/drawable/ic_app_shortcut_fire.xml
+++ b/app/src/main/res/drawable/ic_app_shortcut_fire.xml
@@ -1,30 +1,14 @@
-<!--
-  ~ Copyright (c) 2018 DuckDuckGo
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="48"
-    android:viewportHeight="48">
+    android:viewportWidth="24"
+    android:viewportHeight="24">
     <path
         android:fillColor="#F5F5F5"
         android:fillType="evenOdd"
-        android:pathData="M24,24m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0" />
+        android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0" />
     <path
         android:fillColor="#DE5833"
-        android:fillType="evenOdd"
-        android:pathData="M20.96,36.71c-1.43,-0.836 -2.451,-2.31 -2.512,-4.044 -0.088,-3.235 2.19,-4.824 3.534,-6.99 1.93,-3.12 1.403,-5.056 1.403,-5.056s1.606,0.896 2.541,4.219c0.292,0.981 0.35,1.964 0.261,2.888 -0.145,2.34 -1.167,4.448 -1.167,4.448s1.781,-0.375 2.278,-3.58c0.818,0.836 1.578,2.05 1.665,3.321 0.147,2.195 -1.169,4.217 -3.155,5.084 3.447,-0.78 5.9,-3.668 6.748,-5.778 1.08,-2.657 0.788,-5.026 0.613,-7.077 -0.233,-2.803 0.76,-4.883 0.76,-4.883s-1.9,0.549 -3.3,2.832c-0.643,1.04 -0.908,2.57 -0.908,2.57s0.148,-1.356 -0.76,-3.843c-0.904,-2.425 -1.722,-3.292 -2.22,-5.083 -0.641,-2.397 0.791,-4.738 0.791,-4.738s-5.666,1.04 -8.237,5.922c-2.279,4.333 -1.344,6.933 -1.344,6.933s-0.964,-0.896 -1.46,-2.136c-0.496,-1.244 -0.38,-2.37 -0.38,-2.37s-4.032,4.392 -2.075,9.91c1.316,3.87 3.859,6.412 6.924,7.452z" />
+        android:fillType="nonZero"
+        android:pathData="M10.076,19.593c-1.95,-0.645 -3.566,-2.219 -4.402,-4.616C4.43,11.559 6.993,8.839 6.993,8.839s-0.074,0.697 0.241,1.467c0.316,0.769 0.929,1.324 0.929,1.324s-0.594,-1.61 0.854,-4.295c1.634,-3.024 5.236,-3.668 5.236,-3.668s-0.91,1.45 -0.502,2.934c0.316,1.11 0.835,1.647 1.411,3.15 0.576,1.54 0.483,2.38 0.483,2.38s0.168,-0.948 0.576,-1.592c0.892,-1.414 2.098,-1.754 2.098,-1.754s-0.63,1.288 -0.482,3.024c0.111,1.27 0.297,2.738 -0.39,4.384 -0.539,1.307 -2.098,3.096 -4.29,3.579 1.263,-0.537 2.099,-1.79 2.006,-3.15 -0.056,-0.786 -0.538,-1.538 -1.058,-2.057 -0.316,1.986 -1.449,2.219 -1.449,2.219s0.65,-1.306 0.743,-2.756a4.581,4.581 0,0 0,-0.167 -1.79c-0.594,-2.057 -1.615,-2.612 -1.615,-2.612s0.334,1.198 -0.891,3.131c-0.855,1.342 -2.303,2.327 -2.247,4.33 0.037,1.074 0.687,1.987 1.597,2.506z" />
 </vector>

--- a/app/src/main/res/drawable/ic_app_shortcut_new_tab.xml
+++ b/app/src/main/res/drawable/ic_app_shortcut_new_tab.xml
@@ -1,34 +1,14 @@
-<!--
-  ~ Copyright (c) 2018 DuckDuckGo
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="48"
-    android:viewportHeight="48">
+    android:viewportWidth="24"
+    android:viewportHeight="24">
     <path
         android:fillColor="#F5F5F5"
         android:fillType="evenOdd"
-        android:pathData="M24,24m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0" />
+        android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0" />
     <path
         android:fillColor="#DE5833"
         android:fillType="nonZero"
-        android:pathData="M18,14v16h16L34,14L18,14zM20.25,12h13.5A2.25,2.25 0,0 1,36 14.25v13.5A2.25,2.25 0,0 1,33.75 30h-13.5A2.25,2.25 0,0 1,18 27.75v-13.5A2.25,2.25 0,0 1,20.25 12z" />
-    <path
-        android:fillColor="#DE5833"
-        android:fillType="nonZero"
-        android:pathData="M24,24v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zM16,16h14a2,2 0,0 1,2 2v14a2,2 0,0 1,-2 2L16,34a2,2 0,0 1,-2 -2L14,18a2,2 0,0 1,2 -2z" />
+        android:pathData="M5.7,7.8c-0.385,0 -0.7,0.315 -0.7,0.7v9.1c0,0.77 0.63,1.4 1.4,1.4h9.1c0.385,0 0.7,-0.315 0.7,-0.7 0,-0.385 -0.315,-0.7 -0.7,-0.7L7.1,17.6a0.702,0.702 0,0 1,-0.7 -0.7L6.4,8.5c0,-0.385 -0.315,-0.7 -0.7,-0.7zM17.6,5L9.2,5c-0.77,0 -1.4,0.63 -1.4,1.4v8.4c0,0.77 0.63,1.4 1.4,1.4h8.4c0.77,0 1.4,-0.63 1.4,-1.4L19,6.4c0,-0.77 -0.63,-1.4 -1.4,-1.4zM16.2,11.3h-2.1v2.1c0,0.385 -0.315,0.7 -0.7,0.7a0.702,0.702 0,0 1,-0.7 -0.7v-2.1h-2.1a0.702,0.702 0,0 1,-0.7 -0.7c0,-0.385 0.315,-0.7 0.7,-0.7h2.1L12.7,7.8c0,-0.385 0.315,-0.7 0.7,-0.7 0.385,0 0.7,0.315 0.7,0.7v2.1h2.1c0.385,0 0.7,0.315 0.7,0.7 0,0.385 -0.315,0.7 -0.7,0.7z" />
 </vector>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1132517241064881
Tech Design URL: 
CC: 

**Description**:
Adds an additional app shortcut for accessing bookmarks. This can be accessed by long pressing the app icon.

**Steps to test this PR**:
1. Long press the app icon, and verify you see bookmarks as an option
1. Verify that pressing on the bookmarks shortcut launches bookmarks
1. Choose a bookmark; verify it loads correctly
1. Long press again to see bookmarks
1. Hit the back button; verify back button takes you back to the browser activity
1. Kill the process
1. Long press again to see bookmarks
1. Hit the back button; verify back button takes you back to the browser activity (ie, checking the activity stack is created correctly)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
