### PR TITLE
Add webview renderer gone diagnositc pixel

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -18,14 +18,13 @@ package com.duckduckgo.app.browser
 
 import android.content.Context
 import android.webkit.HttpAuthHandler
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
 import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
+import com.duckduckgo.app.statistics.store.OfflinePixelDataStore
+import com.nhaarman.mockitokotlin2.*
 import org.junit.Before
 import org.junit.Test
 
@@ -38,6 +37,7 @@ class BrowserWebViewClientTest {
     private val specialUrlDetector: SpecialUrlDetector = mock()
     private val requestInterceptor: RequestInterceptor = mock()
     private val listener: WebViewClientListener = mock()
+    private val offlinePixelDataStore: OfflinePixelDataStore = mock()
 
     @UiThreadTest
     @Before
@@ -46,7 +46,8 @@ class BrowserWebViewClientTest {
         testee = BrowserWebViewClient(
             requestRewriter,
             specialUrlDetector,
-            requestInterceptor
+            requestInterceptor,
+            offlinePixelDataStore
         )
         testee.webViewClientListener = listener
     }
@@ -88,6 +89,22 @@ class BrowserWebViewClientTest {
         val authenticationRequest = BasicAuthenticationRequest(mockHandler, EXAMPLE_URL, EXAMPLE_URL, EXAMPLE_URL)
         testee.onReceivedHttpAuthRequest(webView, mockHandler, EXAMPLE_URL, EXAMPLE_URL)
         verify(listener).requiresAuthentication(authenticationRequest)
+    }
+
+    @Test
+    fun whenRenderProcessGoneDueToCrashThenCrashDataStoreEntryIsIncremented() {
+        val detail: RenderProcessGoneDetail = mock()
+        whenever(detail.didCrash()).thenReturn(true)
+        testee.onRenderProcessGone(webView, detail)
+        verify(offlinePixelDataStore, times(1)).webRendererGoneCrashCount = 1
+    }
+
+    @Test
+    fun whenRenderProcessGoneDueToNonCrashThenOtherDataStoreEntryIsIncremented() {
+        val detail: RenderProcessGoneDetail = mock()
+        whenever(detail.didCrash()).thenReturn(false)
+        testee.onRenderProcessGone(webView, detail)
+        verify(offlinePixelDataStore, times(1)).webRendererGoneOtherCount = 1
     }
 
     private class TestWebView(context: Context) : WebView(context)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser
 
 import android.content.Context
+import android.os.Build
 import android.webkit.HttpAuthHandler
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
@@ -93,18 +94,22 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenRenderProcessGoneDueToCrashThenCrashDataStoreEntryIsIncremented() {
-        val detail: RenderProcessGoneDetail = mock()
-        whenever(detail.didCrash()).thenReturn(true)
-        testee.onRenderProcessGone(webView, detail)
-        verify(offlinePixelDataStore, times(1)).webRendererGoneCrashCount = 1
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val detail: RenderProcessGoneDetail = mock()
+            whenever(detail.didCrash()).thenReturn(true)
+            testee.onRenderProcessGone(webView, detail)
+            verify(offlinePixelDataStore, times(1)).webRendererGoneCrashCount = 1
+        }
     }
 
     @Test
     fun whenRenderProcessGoneDueToNonCrashThenOtherDataStoreEntryIsIncremented() {
-        val detail: RenderProcessGoneDetail = mock()
-        whenever(detail.didCrash()).thenReturn(false)
-        testee.onRenderProcessGone(webView, detail)
-        verify(offlinePixelDataStore, times(1)).webRendererGoneOtherCount = 1
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val detail: RenderProcessGoneDetail = mock()
+            whenever(detail.didCrash()).thenReturn(false)
+            testee.onRenderProcessGone(webView, detail)
+            verify(offlinePixelDataStore, times(1)).webRendererGoneOtherCount = 1
+        }
     }
 
     private class TestWebView(context: Context) : WebView(context)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -22,6 +22,7 @@ import android.webkit.HttpAuthHandler
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
 import androidx.test.annotation.UiThreadTest
+import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.statistics.store.OfflinePixelDataStore
@@ -93,23 +94,21 @@ class BrowserWebViewClientTest {
     }
 
     @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
     fun whenRenderProcessGoneDueToCrashThenCrashDataStoreEntryIsIncremented() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val detail: RenderProcessGoneDetail = mock()
-            whenever(detail.didCrash()).thenReturn(true)
-            testee.onRenderProcessGone(webView, detail)
-            verify(offlinePixelDataStore, times(1)).webRendererGoneCrashCount = 1
-        }
+        val detail: RenderProcessGoneDetail = mock()
+        whenever(detail.didCrash()).thenReturn(true)
+        testee.onRenderProcessGone(webView, detail)
+        verify(offlinePixelDataStore, times(1)).webRendererGoneCrashCount = 1
     }
 
     @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
     fun whenRenderProcessGoneDueToNonCrashThenOtherDataStoreEntryIsIncremented() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val detail: RenderProcessGoneDetail = mock()
-            whenever(detail.didCrash()).thenReturn(false)
-            testee.onRenderProcessGone(webView, detail)
-            verify(offlinePixelDataStore, times(1)).webRendererGoneOtherCount = 1
-        }
+        val detail: RenderProcessGoneDetail = mock()
+        whenever(detail.didCrash()).thenReturn(false)
+        testee.onRenderProcessGone(webView, detail)
+        verify(offlinePixelDataStore, times(1)).webRendererGoneOtherCount = 1
     }
 
     private class TestWebView(context: Context) : WebView(context)

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/store/OfflinePixelSharedPreferencesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/store/OfflinePixelSharedPreferencesTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.store
+
+import android.content.Context
+import androidx.core.content.edit
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class OfflinePixelSharedPreferencesTest {
+
+    private lateinit var testee: OfflinePixelSharedPreferences
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Before
+    fun setup() {
+        context.getSharedPreferences(OfflinePixelSharedPreferences.FILENAME, Context.MODE_PRIVATE).edit { clear() }
+        testee = OfflinePixelSharedPreferences(context)
+    }
+
+    @Test
+    fun whenInitializedThenWebRendererGoneCrashCountIsZero() {
+        assertEquals(0, testee.webRendererGoneCrashCount)
+    }
+
+    @Test
+    fun whenWebRendererGoneCrashCountIsSetThenUpdated() {
+        testee.webRendererGoneCrashCount = 2
+        assertEquals(2, testee.webRendererGoneCrashCount)
+    }
+
+    @Test
+    fun whenInitializedThenWebRendererGoneOtherCountIsZero() {
+        assertEquals(0, testee.webRendererGoneOtherCount)
+    }
+
+    @Test
+    fun whenWebRendererOtherCrashCountIsSetThenUpdated() {
+        testee.webRendererGoneOtherCount = 2
+        assertEquals(2, testee.webRendererGoneOtherCount)
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -123,9 +123,9 @@ class BrowserWebViewClient(
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {
         if (detail?.didCrash() == true) {
-            offlinePixelDataStore.webRendererGoneCrashCount  += 1
+            offlinePixelDataStore.webRendererGoneCrashCount += 1
         } else {
-            offlinePixelDataStore.webRendererGoneOtherCount  += 1
+            offlinePixelDataStore.webRendererGoneOtherCount += 1
         }
         return super.onRenderProcessGone(view, detail)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -20,9 +20,11 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.webkit.*
+import androidx.annotation.RequiresApi
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
+import com.duckduckgo.app.statistics.store.OfflinePixelDataStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -33,7 +35,8 @@ import java.net.URI
 class BrowserWebViewClient(
     private val requestRewriter: RequestRewriter,
     private val specialUrlDetector: SpecialUrlDetector,
-    private val requestInterceptor: RequestInterceptor
+    private val requestInterceptor: RequestInterceptor,
+    private val offlinePixelDataStore: OfflinePixelDataStore
 ) : WebViewClient() {
 
     var webViewClientListener: WebViewClientListener? = null
@@ -115,6 +118,16 @@ class BrowserWebViewClient(
             Timber.v("Intercepting resource ${request.url} on page $documentUrl")
             requestInterceptor.shouldIntercept(request, webView, documentUrl, webViewClientListener)
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {
+        if (detail?.didCrash() == true) {
+            offlinePixelDataStore.webRendererGoneCrashCount  += 1
+        } else {
+            offlinePixelDataStore.webRendererGoneOtherCount  += 1
+        }
+        return super.onRenderProcessGone(view, detail)
     }
 
     @UiThread

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.store.OfflinePixelDataStore
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.surrogates.ResourceSurrogates
 import com.duckduckgo.app.trackerdetection.TrackerDetector
@@ -59,9 +60,10 @@ class BrowserModule {
     fun browserWebViewClient(
         requestRewriter: RequestRewriter,
         specialUrlDetector: SpecialUrlDetector,
-        requestInterceptor: RequestInterceptor
+        requestInterceptor: RequestInterceptor,
+        offlinePixelDataStore: OfflinePixelDataStore
     ): BrowserWebViewClient {
-        return BrowserWebViewClient(requestRewriter, specialUrlDetector, requestInterceptor)
+        return BrowserWebViewClient(requestRewriter, specialUrlDetector, requestInterceptor, offlinePixelDataStore)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/di/AppConfigurationDownloadModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppConfigurationDownloadModule.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.httpsupgrade.api.HttpsUpgradeDataDownloader
 import com.duckduckgo.app.job.AppConfigurationDownloader
 import com.duckduckgo.app.job.ConfigurationDownloader
+import com.duckduckgo.app.statistics.api.OfflinePixelSender
 import com.duckduckgo.app.surrogates.api.ResourceSurrogateListDownloader
 import com.duckduckgo.app.survey.api.SurveyDownloader
 import com.duckduckgo.app.trackerdetection.api.TrackerDataDownloader
@@ -32,6 +33,7 @@ open class AppConfigurationDownloaderModule {
 
     @Provides
     open fun appConfigurationDownloader(
+        offlinePixelSender: OfflinePixelSender,
         trackerDataDownloader: TrackerDataDownloader,
         httpsUpgradeDataDownloader: HttpsUpgradeDataDownloader,
         resourceSurrogateDownloader: ResourceSurrogateListDownloader,
@@ -41,6 +43,7 @@ open class AppConfigurationDownloaderModule {
     ): ConfigurationDownloader {
 
         return AppConfigurationDownloader(
+            offlinePixelSender,
             trackerDataDownloader,
             httpsUpgradeDataDownloader,
             resourceSurrogateDownloader,
@@ -48,6 +51,5 @@ open class AppConfigurationDownloaderModule {
             surveyDownloader,
             appDatabase
         )
-
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
@@ -20,12 +20,10 @@ import android.content.Context
 import com.duckduckgo.app.global.device.ContextDeviceInfo
 import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.api.PixelService
-import com.duckduckgo.app.statistics.api.StatisticsRequester
-import com.duckduckgo.app.statistics.api.StatisticsService
-import com.duckduckgo.app.statistics.api.StatisticsUpdater
+import com.duckduckgo.app.statistics.api.*
 import com.duckduckgo.app.statistics.pixels.ApiBasedPixel
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.store.OfflinePixelDataStore
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import dagger.Module
 import dagger.Provides
@@ -53,10 +51,13 @@ class StatisticsModule {
     }
 
     @Provides
-    fun deviceInfo(context: Context): DeviceInfo = ContextDeviceInfo(context)
-
-    @Provides
     fun pixel(pixelService: PixelService, statisticsDataStore: StatisticsDataStore, variantManager: VariantManager, deviceInfo: DeviceInfo): Pixel =
         ApiBasedPixel(pixelService, statisticsDataStore, variantManager, deviceInfo)
+
+    @Provides
+    fun offlinePixelSender(offlinePixelDataStore: OfflinePixelDataStore, pixel: Pixel): OfflinePixelSender = OfflinePixelSender(offlinePixelDataStore, pixel )
+
+    @Provides
+    fun deviceInfo(context: Context): DeviceInfo = ContextDeviceInfo(context)
 
 }

--- a/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
@@ -23,6 +23,8 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingSharedPreferences
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.privacy.store.*
+import com.duckduckgo.app.statistics.store.OfflinePixelDataStore
+import com.duckduckgo.app.statistics.store.OfflinePixelSharedPreferences
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.statistics.store.StatisticsSharedPreferences
 import com.duckduckgo.app.tabs.model.TabDataRepository
@@ -53,6 +55,9 @@ abstract class StoreModule {
 
     @Binds
     abstract fun bindDataClearingStore(store: UnsentForgetAllPixelStoreSharedPreferences): UnsentForgetAllPixelStore
+
+    @Binds
+    abstract fun bindOfflinePixelDataStore(store: OfflinePixelSharedPreferences): OfflinePixelDataStore
 
     @Binds
     abstract fun bindPrevalenceStore(store: PrevalenceRawStore): PrevalenceStore

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.api
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.WEB_RENDERER_GONE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.WEB_RENDERER_GONE_CRASH
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.WEB_RENDERER_GONE_OTHER
+import com.duckduckgo.app.statistics.store.OfflinePixelDataStore
+import io.reactivex.Completable
+import io.reactivex.Completable.complete
+import io.reactivex.Completable.defer
+import timber.log.Timber
+import javax.inject.Inject
+
+
+/**
+ * Most pixels are "send and forget" however we sometimes need to guarantee that a pixel will be sent.
+ * In those cases we schedule them to happen as part of our app data sync.
+ */
+class OfflinePixelSender @Inject constructor(
+    private val dataStore: OfflinePixelDataStore,
+    private val pixel: Pixel
+) {
+
+    fun sendWebRendererGonePixel(): Completable {
+        return defer {
+
+            if (dataStore.webRendererGoneCrashCount == 0 && dataStore.webRendererGoneOtherCount == 0) {
+                return@defer complete()
+            }
+            val params = mapOf(
+                WEB_RENDERER_GONE_CRASH to dataStore.webRendererGoneCrashCount.toString(),
+                WEB_RENDERER_GONE_OTHER to dataStore.webRendererGoneOtherCount.toString()
+            )
+
+            pixel.fireCompletable(WEB_RENDERER_GONE.pixelName, params).andThen {
+                Timber.v("Offline pixel sent ${WEB_RENDERER_GONE.pixelName} crashes: ${dataStore.webRendererGoneCrashCount} other: ${dataStore.webRendererGoneOtherCount} ")
+                dataStore.webRendererGoneCrashCount = 0
+                dataStore.webRendererGoneOtherCount = 0
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
@@ -40,16 +40,18 @@ class OfflinePixelSender @Inject constructor(
     fun sendWebRendererGonePixel(): Completable {
         return defer {
 
-            if (dataStore.webRendererGoneCrashCount == 0 && dataStore.webRendererGoneOtherCount == 0) {
+            val goneCrashCount = dataStore.webRendererGoneCrashCount
+            val goneOtherCount = dataStore.webRendererGoneOtherCount
+            if (goneCrashCount == 0 && goneOtherCount == 0) {
                 return@defer complete()
             }
             val params = mapOf(
-                WEB_RENDERER_GONE_CRASH to dataStore.webRendererGoneCrashCount.toString(),
-                WEB_RENDERER_GONE_OTHER to dataStore.webRendererGoneOtherCount.toString()
+                WEB_RENDERER_GONE_CRASH to goneCrashCount.toString(),
+                WEB_RENDERER_GONE_OTHER to goneOtherCount.toString()
             )
 
             pixel.fireCompletable(WEB_RENDERER_GONE.pixelName, params).andThen {
-                Timber.v("Offline pixel sent ${WEB_RENDERER_GONE.pixelName} crashes: ${dataStore.webRendererGoneCrashCount} other: ${dataStore.webRendererGoneOtherCount} ")
+                Timber.v("Offline pixel sent ${WEB_RENDERER_GONE.pixelName} crashes: ${goneCrashCount} other: ${goneOtherCount} ")
                 dataStore.webRendererGoneCrashCount = 0
                 dataStore.webRendererGoneOtherCount = 0
             }

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -32,6 +32,7 @@ interface Pixel {
 
         APP_LAUNCH("ml"),
         FORGET_ALL_EXECUTED("mf"),
+        WEB_RENDERER_GONE("m_d_wrg"),
 
         ONBOARDING_DEFAULT_BROWSER_SETTINGS_LAUNCHED("m_odb_l"),
         ONBOARDING_DEFAULT_BROWSER_SKIPPED("m_odb_s"),
@@ -118,6 +119,8 @@ interface Pixel {
     object PixelParameter {
         const val BOOKMARK_CAPABLE = "bc"
         const val SHOWED_BOOKMARKS = "sb"
+        const val WEB_RENDERER_GONE_CRASH = "wrc"
+        const val WEB_RENDERER_GONE_OTHER = "wro"
     }
 
     fun fire(pixel: PixelName, parameters: Map<String, String?> = emptyMap(), includeLocale: Boolean = false)

--- a/app/src/main/java/com/duckduckgo/app/statistics/store/OfflinePixelDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/store/OfflinePixelDataStore.kt
@@ -37,7 +37,6 @@ class OfflinePixelSharedPreferences @Inject constructor(private val context: Con
         get() = preferences.getInt(KEY_WEB_RENDERER_GONE_OTHER_COUNT, 0)
         set(value) = preferences.edit(true) { putInt(KEY_WEB_RENDERER_GONE_OTHER_COUNT, value) }
 
-
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/store/OfflinePixelDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/store/OfflinePixelDataStore.kt
@@ -42,7 +42,7 @@ class OfflinePixelSharedPreferences @Inject constructor(private val context: Con
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
 
     companion object {
-        private const val FILENAME = "com.duckduckgo.app.statistics.offline.pixels"
+        const val FILENAME = "com.duckduckgo.app.statistics.offline.pixels"
         private const val KEY_WEB_RENDERER_GONE_CRASH_COUNT = "WEB_RENDERER_GONE_CRASH_COUNT"
         private const val KEY_WEB_RENDERER_GONE_OTHER_COUNT = "WEB_RENDERER_GONE_OTHER_COUNT"
     }

--- a/app/src/main/java/com/duckduckgo/app/statistics/store/OfflinePixelDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/store/OfflinePixelDataStore.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.store
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import javax.inject.Inject
+
+
+interface OfflinePixelDataStore {
+    var webRendererGoneCrashCount: Int
+    var webRendererGoneOtherCount: Int
+}
+
+class OfflinePixelSharedPreferences @Inject constructor(private val context: Context) : OfflinePixelDataStore {
+
+    override var webRendererGoneCrashCount: Int
+        get() = preferences.getInt(KEY_WEB_RENDERER_GONE_CRASH_COUNT, 0)
+        set(value) = preferences.edit(true) { putInt(KEY_WEB_RENDERER_GONE_CRASH_COUNT, value) }
+
+    override var webRendererGoneOtherCount: Int
+        get() = preferences.getInt(KEY_WEB_RENDERER_GONE_OTHER_COUNT, 0)
+        set(value) = preferences.edit(true) { putInt(KEY_WEB_RENDERER_GONE_OTHER_COUNT, value) }
+
+
+    private val preferences: SharedPreferences
+        get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+
+    companion object {
+        private const val FILENAME = "com.duckduckgo.app.statistics.offline.pixels"
+        private const val KEY_WEB_RENDERER_GONE_CRASH_COUNT = "WEB_RENDERER_GONE_CRASH_COUNT"
+        private const val KEY_WEB_RENDERER_GONE_OTHER_COUNT = "WEB_RENDERER_GONE_OTHER_COUNT"
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1135024870354624

**Description**:
Adds a diagnostic pixel when the webview renderer disappear so we can determine if this is caused by a crash or memory pressure

**Steps to test this PR**:
This is a little tricky to test however one path can be tested by causing a webview crash.

1. Open Charles to watch app traffic
1. Update `BrowserTabFragment.navigate(url: String)` method to load a crashing url when "crash" entered into the omnibar
```
if(url.contains("crash")) {
   webView?.loadUrl("chrome://crash")
} else {
   webView?.loadUrl(url)
}
```
3. Now open the app and type crash in the omnibar. The app will crash.
1. Launch the app to start a sync
1. Ensure the pixel is fired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
