### PR TITLE
Update crash pixels and add work scheduler to send these offline

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -108,7 +108,7 @@ class BrowserWebViewClientTest {
         val detail: RenderProcessGoneDetail = mock()
         whenever(detail.didCrash()).thenReturn(false)
         testee.onRenderProcessGone(webView, detail)
-        verify(offlinePixelDataStore, times(1)).webRendererGoneOtherCount = 1
+        verify(offlinePixelDataStore, times(1)).webRendererGoneKilledCount = 1
     }
 
     private class TestWebView(context: Context) : WebView(context)

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -104,9 +104,11 @@ class ApiBasedPixelTest {
         whenever(mockDeviceInfo.appVersion).thenReturn("1.0.0")
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
-        val params = mapOf("param1" to "value1", "param2" to "value2", "version" to "1.0.0")
+        val params = mapOf("param1" to "value1", "param2" to "value2")
+        val expectedParams = mapOf("param1" to "value1", "param2" to "value2", "appVersion" to "1.0.0")
+
         pixel.fire(PRIVACY_DASHBOARD_OPENED, params)
-        verify(mockPixelService).fire("mp", "phone", "atbvariant", params)
+        verify(mockPixelService).fire("mp", "phone", "atbvariant", expectedParams)
     }
 
     @Test
@@ -119,8 +121,8 @@ class ApiBasedPixelTest {
 
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
-        val params = mapOf("version" to "1.0.0")
         pixel.fire(PRIVACY_DASHBOARD_OPENED)
-        verify(mockPixelService).fire("mp", "phone", "atbvariant", params)
+        val expectedParams = mapOf("appVersion" to "1.0.0")
+        verify(mockPixelService).fire("mp", "phone", "atbvariant", expectedParams)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -57,7 +57,7 @@ class ApiBasedPixelTest {
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(PRIVACY_DASHBOARD_OPENED)
 
-        verify(mockPixelService).fire("mp", "phone", "atbvariant", emptyMap())
+        verify(mockPixelService).fire(eq("mp"), eq("phone"), eq("atbvariant"), any())
     }
 
     @Test
@@ -70,7 +70,7 @@ class ApiBasedPixelTest {
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(FORGET_ALL_EXECUTED)
 
-        verify(mockPixelService).fire("mf", "phone", "atb", emptyMap())
+        verify(mockPixelService).fire(eq("mf"), eq("phone"), eq("atb"), any())
     }
 
     @Test
@@ -81,7 +81,7 @@ class ApiBasedPixelTest {
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(APP_LAUNCH)
 
-        verify(mockPixelService).fire("ml", "tablet", "", emptyMap())
+        verify(mockPixelService).fire(eq("ml"), eq("tablet"), eq(""), any())
     }
 
     @Test
@@ -92,31 +92,34 @@ class ApiBasedPixelTest {
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(APP_LAUNCH)
 
-        verify(mockPixelService).fire("ml", "phone", "", emptyMap())
+        verify(mockPixelService).fire(eq("ml"), eq("phone"), eq(""), any())
     }
 
     @Test
-    fun whenPixelFiredWithAdditionalParametersThenPixelServiceCalledWithAdditionalParameters() {
+    fun whenPixelFiredWithAdditionalParametersThenPixelServiceCalledWithDefaultAndAdditionalParameters() {
         whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
+        whenever(mockDeviceInfo.appVersion).thenReturn("1.0.0")
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
-        val params = mapOf("param1" to "value1", "param2" to "value2")
+        val params = mapOf("param1" to "value1", "param2" to "value2", "version" to "1.0.0")
         pixel.fire(PRIVACY_DASHBOARD_OPENED, params)
         verify(mockPixelService).fire("mp", "phone", "atbvariant", params)
     }
 
     @Test
-    fun whenPixelFiredWithoutAdditionalParametersThenPixelServiceCalledWithNoParameters() {
+    fun whenPixelFiredWithoutAdditionalParametersThenPixelServiceCalledWithOnlyDefaultParameters() {
         whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
+        whenever(mockDeviceInfo.appVersion).thenReturn("1.0.0")
+
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
-        val params = emptyMap<String, String>()
+        val params = mapOf("version" to "1.0.0")
         pixel.fire(PRIVACY_DASHBOARD_OPENED)
         verify(mockPixelService).fire("mp", "phone", "atbvariant", params)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/store/OfflinePixelSharedPreferencesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/store/OfflinePixelSharedPreferencesTest.kt
@@ -36,6 +36,17 @@ class OfflinePixelSharedPreferencesTest {
     }
 
     @Test
+    fun whenInitializedThenApplicartionCountIsZero() {
+        assertEquals(0, testee.applicationCrashCount)
+    }
+
+    @Test
+    fun whenApplicationCrashCountIsSetThenUpdated() {
+        testee.applicationCrashCount = 2
+        assertEquals(2, testee.applicationCrashCount)
+    }
+
+    @Test
     fun whenInitializedThenWebRendererGoneCrashCountIsZero() {
         assertEquals(0, testee.webRendererGoneCrashCount)
     }
@@ -47,13 +58,13 @@ class OfflinePixelSharedPreferencesTest {
     }
 
     @Test
-    fun whenInitializedThenWebRendererGoneOtherCountIsZero() {
-        assertEquals(0, testee.webRendererGoneOtherCount)
+    fun whenInitializedThenWebRendererGoneKilledCountIsZero() {
+        assertEquals(0, testee.webRendererGoneKilledCount)
     }
 
     @Test
-    fun whenWebRendererOtherCrashCountIsSetThenUpdated() {
-        testee.webRendererGoneOtherCount = 2
-        assertEquals(2, testee.webRendererGoneOtherCount)
+    fun whenWebRendererKilledCrashCountIsSetThenUpdated() {
+        testee.webRendererGoneKilledCount = 2
+        assertEquals(2, testee.webRendererGoneKilledCount)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/store/OfflinePixelSharedPreferencesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/store/OfflinePixelSharedPreferencesTest.kt
@@ -36,7 +36,7 @@ class OfflinePixelSharedPreferencesTest {
     }
 
     @Test
-    fun whenInitializedThenApplicartionCountIsZero() {
+    fun whenInitializedThenApplicationCountIsZero() {
         assertEquals(0, testee.applicationCrashCount)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -658,7 +658,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 setSupportZoom(true)
             }
 
-            it.setDownloadListener { url, userAgent, contentDisposition, mimeType, contentLength ->
+            it.setDownloadListener { url, _, contentDisposition, mimeType, _ ->
                 requestFileDownload(url, contentDisposition, mimeType)
             }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -125,7 +125,7 @@ class BrowserWebViewClient(
         if (detail?.didCrash() == true) {
             offlinePixelDataStore.webRendererGoneCrashCount += 1
         } else {
-            offlinePixelDataStore.webRendererGoneOtherCount += 1
+            offlinePixelDataStore.webRendererGoneKilledCount += 1
         }
         return super.onRenderProcessGone(view, detail)
     }

--- a/app/src/main/java/com/duckduckgo/app/di/AppConfigurationDownloadModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppConfigurationDownloadModule.kt
@@ -33,7 +33,6 @@ open class AppConfigurationDownloaderModule {
 
     @Provides
     open fun appConfigurationDownloader(
-        offlinePixelSender: OfflinePixelSender,
         trackerDataDownloader: TrackerDataDownloader,
         httpsUpgradeDataDownloader: HttpsUpgradeDataDownloader,
         resourceSurrogateDownloader: ResourceSurrogateListDownloader,
@@ -43,7 +42,6 @@ open class AppConfigurationDownloaderModule {
     ): ConfigurationDownloader {
 
         return AppConfigurationDownloader(
-            offlinePixelSender,
             trackerDataDownloader,
             httpsUpgradeDataDownloader,
             resourceSurrogateDownloader,

--- a/app/src/main/java/com/duckduckgo/app/di/DaggerWorkerFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DaggerWorkerFactory.kt
@@ -30,10 +30,13 @@ import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.ClearDataNotification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.api.OfflinePixelScheduler
+import com.duckduckgo.app.statistics.api.OfflinePixelSender
 import com.duckduckgo.app.statistics.pixels.Pixel
 import timber.log.Timber
 
 class DaggerWorkerFactory(
+    private val offlinePixelSender: OfflinePixelSender,
     private val settingsDataStore: SettingsDataStore,
     private val clearDataAction: ClearDataAction,
     private val notificationManager: NotificationManagerCompat,
@@ -51,6 +54,7 @@ class DaggerWorkerFactory(
         val instance = constructor.newInstance(appContext, workerParameters)
 
         when (instance) {
+            is OfflinePixelScheduler.OfflinePixelWorker -> injectOfflinePixelWorker(instance)
             is DataClearingWorker -> injectDataClearWorker(instance)
             is ClearDataNotificationWorker -> injectClearDataNotificationWorker(instance)
             is PrivacyNotificationWorker -> injectPrivacyNotificationWorker(instance)
@@ -58,6 +62,10 @@ class DaggerWorkerFactory(
         }
 
         return instance
+    }
+
+    private fun injectOfflinePixelWorker(worker: OfflinePixelScheduler.OfflinePixelWorker) {
+        worker.offlinePixelSender = offlinePixelSender
     }
 
     private fun injectDataClearWorker(worker: DataClearingWorker) {

--- a/app/src/main/java/com/duckduckgo/app/di/WorkerModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/WorkerModule.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.ClearDataNotification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.api.OfflinePixelSender
 import com.duckduckgo.app.statistics.pixels.Pixel
 import dagger.Module
 import dagger.Provides
@@ -35,6 +36,7 @@ class WorkerModule {
     @Provides
     @Singleton
     fun workerFactory(
+        offlinePixelSender: OfflinePixelSender,
         settingsDataStore: SettingsDataStore,
         clearDataAction: ClearDataAction,
         notficationManager: NotificationManagerCompat,
@@ -45,6 +47,7 @@ class WorkerModule {
         pixel: Pixel
     ): WorkerFactory {
         return DaggerWorkerFactory(
+            offlinePixelSender,
             settingsDataStore,
             clearDataAction,
             notficationManager,

--- a/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global
+
+import com.duckduckgo.app.statistics.store.OfflinePixelDataStore
+
+class AlertingUncaughtExceptionHandler(
+    private val originalHandler: Thread.UncaughtExceptionHandler,
+    private val offlinePixelDataStore: OfflinePixelDataStore
+) : Thread.UncaughtExceptionHandler {
+
+    override fun uncaughtException(t: Thread?, e: Throwable?) {
+        offlinePixelDataStore.applicationCrashCount += 1
+        originalHandler.uncaughtException(t, e);
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
@@ -25,6 +25,6 @@ class AlertingUncaughtExceptionHandler(
 
     override fun uncaughtException(t: Thread?, e: Throwable?) {
         offlinePixelDataStore.applicationCrashCount += 1
-        originalHandler.uncaughtException(t, e);
+        originalHandler.uncaughtException(t, e)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.global.device
 import android.content.Context
 import android.telephony.TelephonyManager
 import android.util.TypedValue
+import com.duckduckgo.app.browser.BuildConfig
 import java.util.*
 import javax.inject.Inject
 
@@ -29,6 +30,8 @@ interface DeviceInfo {
         TABLET("tablet")
     }
 
+    val appVersion: String
+
     val language: String
 
     val country: String
@@ -38,9 +41,7 @@ interface DeviceInfo {
 
 class ContextDeviceInfo @Inject constructor(private val context: Context) : DeviceInfo {
 
-    private val telephonyManager by lazy {
-        context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
-    }
+    override val appVersion = "${BuildConfig.VERSION_NAME}"
 
     override val language: String by lazy {
         Locale.getDefault().language
@@ -50,6 +51,10 @@ class ContextDeviceInfo @Inject constructor(private val context: Context) : Devi
         val telephonyCountry = telephonyManager.networkCountryIso
         val deviceCountry = if (telephonyCountry.isNotBlank()) telephonyCountry else Locale.getDefault().country
         deviceCountry.toLowerCase()
+    }
+
+    private val telephonyManager by lazy {
+        context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
     }
 
     override fun formFactor(): DeviceInfo.FormFactor {

--- a/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/AppConfigurationDownloader.kt
@@ -17,12 +17,11 @@
 package com.duckduckgo.app.job
 
 import com.duckduckgo.app.entities.api.EntityListDownloader
-import com.duckduckgo.app.survey.api.SurveyDownloader
 import com.duckduckgo.app.global.db.AppConfigurationEntity
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.httpsupgrade.api.HttpsUpgradeDataDownloader
-import com.duckduckgo.app.statistics.api.OfflinePixelSender
 import com.duckduckgo.app.surrogates.api.ResourceSurrogateListDownloader
+import com.duckduckgo.app.survey.api.SurveyDownloader
 import com.duckduckgo.app.trackerdetection.Client.ClientName.*
 import com.duckduckgo.app.trackerdetection.api.TrackerDataDownloader
 import io.reactivex.Completable
@@ -33,7 +32,6 @@ interface ConfigurationDownloader {
 }
 
 class AppConfigurationDownloader(
-    private val offlinePixelSender: OfflinePixelSender,
     private val trackerDataDownloader: TrackerDataDownloader,
     private val httpsUpgradeDataDownloader: HttpsUpgradeDataDownloader,
     private val resourceSurrogateDownloader: ResourceSurrogateListDownloader,
@@ -43,7 +41,6 @@ class AppConfigurationDownloader(
 ) : ConfigurationDownloader {
 
     override fun downloadTask(): Completable {
-        val sendWebPixel = offlinePixelSender.sendWebRendererGonePixel()
         val easyListDownload = trackerDataDownloader.downloadList(EASYLIST)
         val easyPrivacyDownload = trackerDataDownloader.downloadList(EASYPRIVACY)
         val trackersWhitelist = trackerDataDownloader.downloadList(TRACKERSWHITELIST)
@@ -55,7 +52,6 @@ class AppConfigurationDownloader(
 
         return Completable.mergeDelayError(
             listOf(
-                sendWebPixel,
                 easyListDownload,
                 easyPrivacyDownload,
                 trackersWhitelist,

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
@@ -30,8 +30,13 @@ class OfflinePixelScheduler @Inject constructor() {
         val workManager = WorkManager.getInstance()
         workManager.cancelAllWorkByTag(WORK_REQUEST_TAG)
 
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
         val request = PeriodicWorkRequestBuilder<OfflinePixelWorker>(SERVICE_INTERVAL, SERVICE_TIME_UNIT)
             .addTag(WORK_REQUEST_TAG)
+            .setConstraints(constraints)
             .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_INTERVAL, BACKOFF_TIME_UNIT)
             .build()
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.api
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+class OfflinePixelScheduler @Inject constructor() {
+
+    fun scheduleOfflinePixels() {
+
+        Timber.v("Scheduling offline pixels to be sent")
+        val workManager = WorkManager.getInstance()
+        workManager.cancelAllWorkByTag(WORK_REQUEST_TAG)
+
+        val request = PeriodicWorkRequestBuilder<OfflinePixelWorker>(HOURLY_INTERVAL, TimeUnit.HOURS)
+            .addTag(WORK_REQUEST_TAG)
+            .build()
+
+        workManager.enqueue(request)
+    }
+
+    open class OfflinePixelWorker(val context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
+
+        lateinit var offlinePixelSender: OfflinePixelSender
+
+        override suspend fun doWork(): Result {
+            try {
+                offlinePixelSender
+                    .sendOfflinePixels()
+                    .blockingGet()
+                return Result.success()
+            } catch (e: Exception) {
+                return Result.failure()
+            }
+        }
+    }
+
+    companion object {
+        private const val WORK_REQUEST_TAG = "com.duckduckgo.statistics.offlinepixels.schedule"
+        private const val HOURLY_INTERVAL = 3L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
@@ -48,7 +48,7 @@ class OfflinePixelScheduler @Inject constructor() {
             try {
                 offlinePixelSender
                     .sendOfflinePixels()
-                    .blockingGet()
+                    .blockingAwait()
                 return Result.success()
             } catch (e: Exception) {
                 return Result.failure()

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
@@ -40,7 +40,7 @@ class OfflinePixelSender @Inject constructor(
         return Completable.mergeDelayError(
             listOf(
                 sendApplicationKilledPixel(),
-                sendWebRendererCrashPixel(),
+                sendWebRendererCrashedPixel(),
                 sendWebRendererKilledPixel()
             )
         )
@@ -60,7 +60,7 @@ class OfflinePixelSender @Inject constructor(
         }
     }
 
-    private fun sendWebRendererCrashPixel(): Completable {
+    private fun sendWebRendererCrashedPixel(): Completable {
         return defer {
             val count = dataStore.webRendererGoneCrashCount
             if (count == 0) {

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
@@ -37,9 +37,13 @@ class OfflinePixelSender @Inject constructor(
 ) {
 
     fun sendOfflinePixels(): Completable {
-        return sendApplicationKilledPixel()
-            .andThen(sendWebRendererCrashPixel())
-            .andThen(sendWebRendererKilledPixel())
+        return Completable.mergeDelayError(
+            listOf(
+                sendApplicationKilledPixel(),
+                sendWebRendererCrashPixel(),
+                sendWebRendererKilledPixel()
+            )
+        )
     }
 
     private fun sendApplicationKilledPixel(): Completable {

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
@@ -54,7 +54,7 @@ class OfflinePixelSender @Inject constructor(
             }
             val params = mapOf(COUNT to count.toString())
             pixel.fireCompletable(APPLICATION_CRASH.pixelName, params).andThen {
-                Timber.v("Offline pixel sent ${APPLICATION_CRASH.pixelName} count: ${count}")
+                Timber.v("Offline pixel sent ${APPLICATION_CRASH.pixelName} count: $count")
                 dataStore.applicationCrashCount = 0
             }
         }
@@ -68,7 +68,7 @@ class OfflinePixelSender @Inject constructor(
             }
             val params = mapOf(COUNT to count.toString())
             pixel.fireCompletable(WEB_RENDERER_GONE_CRASH.pixelName, params).andThen {
-                Timber.v("Offline pixel sent ${WEB_RENDERER_GONE_CRASH.pixelName} count: ${count}")
+                Timber.v("Offline pixel sent ${WEB_RENDERER_GONE_CRASH.pixelName} count: $count")
                 dataStore.webRendererGoneCrashCount = 0
             }
         }
@@ -82,7 +82,7 @@ class OfflinePixelSender @Inject constructor(
             }
             val params = mapOf(COUNT to count.toString())
             pixel.fireCompletable(WEB_RENDERER_GONE_KILLED.pixelName, params).andThen {
-                Timber.v("Offline pixel sent ${WEB_RENDERER_GONE_KILLED.pixelName} count: ${count}")
+                Timber.v("Offline pixel sent ${WEB_RENDERER_GONE_KILLED.pixelName} count: $count")
                 dataStore.webRendererGoneKilledCount = 0
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -122,7 +122,7 @@ interface Pixel {
     }
 
     object PixelParameter {
-        const val APP_VERSION = "version"
+        const val APP_VERSION = "appVersion"
         const val COUNT = "count"
         const val BOOKMARK_CAPABLE = "bc"
         const val SHOWED_BOOKMARKS = "sb"

--- a/app/src/main/java/com/duckduckgo/app/statistics/store/OfflinePixelDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/store/OfflinePixelDataStore.kt
@@ -23,26 +23,32 @@ import javax.inject.Inject
 
 
 interface OfflinePixelDataStore {
+    var applicationCrashCount: Int
     var webRendererGoneCrashCount: Int
-    var webRendererGoneOtherCount: Int
+    var webRendererGoneKilledCount: Int
 }
 
 class OfflinePixelSharedPreferences @Inject constructor(private val context: Context) : OfflinePixelDataStore {
+
+    override var applicationCrashCount: Int
+        get() = preferences.getInt(KEY_APPLICATION_CRASH_COUNT, 0)
+        set(value) = preferences.edit(true) { putInt(KEY_APPLICATION_CRASH_COUNT, value) }
 
     override var webRendererGoneCrashCount: Int
         get() = preferences.getInt(KEY_WEB_RENDERER_GONE_CRASH_COUNT, 0)
         set(value) = preferences.edit(true) { putInt(KEY_WEB_RENDERER_GONE_CRASH_COUNT, value) }
 
-    override var webRendererGoneOtherCount: Int
-        get() = preferences.getInt(KEY_WEB_RENDERER_GONE_OTHER_COUNT, 0)
-        set(value) = preferences.edit(true) { putInt(KEY_WEB_RENDERER_GONE_OTHER_COUNT, value) }
+    override var webRendererGoneKilledCount: Int
+        get() = preferences.getInt(KEY_WEB_RENDERER_GONE_KILLED_COUNT, 0)
+        set(value) = preferences.edit(true) { putInt(KEY_WEB_RENDERER_GONE_KILLED_COUNT, value) }
 
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
 
     companion object {
         const val FILENAME = "com.duckduckgo.app.statistics.offline.pixels"
+        private const val KEY_APPLICATION_CRASH_COUNT = "APPLICATION_CRASH_COUNT"
         private const val KEY_WEB_RENDERER_GONE_CRASH_COUNT = "WEB_RENDERER_GONE_CRASH_COUNT"
-        private const val KEY_WEB_RENDERER_GONE_OTHER_COUNT = "WEB_RENDERER_GONE_OTHER_COUNT"
+        private const val KEY_WEB_RENDERER_GONE_KILLED_COUNT = "WEB_RENDERER_GONE_KILLED_COUNT"
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1135707350642503

**Description**:
- Add a high level crash pixel to allow us to monitor overall crash numbers
- Send pixels via regular scheduled job, to protect against case where app is too unstable to run.
- Include app version globally in pixels.
- Update existing web render pixels to be separate entities to allow us to use standard Grafana dashboards (ClickHouse is too slow)

**Steps to test this PR**:

**Setup**
Open Charles to watch app traffic

**Test web pixel sent**
1. Update `BrowserTabFragment.navigate(url: String)` method to load a crashing url when "crash" entered into the omnibar
```
if(url.contains("crash")) {
   webView?.loadUrl("chrome://crash")
} else {
   webView?.loadUrl(url)
}
```
2. Open the app and type "crash" in the omnibar. The app will crash.
1. Launch the app to start an immediate sync
1. Ensure the `m_d_wrg` pixel is fired, check that it includes the app version as a param

**Test app crash pixel sent**
1. Revert previous changes and update `BrowserTabFragment.navigate(url: String)` method to crash after a url is loaded
```
webView?.loadUrl(url)
throw Exception("")
```
1. Open the app and type in a search term e.g "test" in the omnibar. The app will crash.
1. Launch the app to start an immediate sync
1. Ensure the `m_d_ac` pixel is fired, check that it includes the app version as a param

**Test pixels still sent in background**
1. Set:
```
private const val SERVICE_INTERVAL = 30L
private val SERVICE_TIME_UNIT = TimeUnit.SECONDS
```
2. Run the app, and as before, type in a search term e.g "test" in the omnibar. The app will crash.
1. Wait a while for the service to kick in and ensure the `m_d_ac` pixel is fired, check that it includes the app version as a param

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
