### PR TITLE
Hotfix to update WorkManger and resolve Exception

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ ext {
     constraintLayout = "2.0.0-beta1"
     lifecycle = "2.1.0-alpha04"
     room = "2.1.0"
-    workManager = "2.0.0"
+    workManager = "2.2.0"
     legacySupport = "1.0.0"
     espressoCore = "3.1.1"
     coreTesting = "2.0.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,9 @@ android {
             androidTest.resources.srcDirs += files("$projectDir/../submodules/".toString())
         }
     }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     signingConfigs {
         release
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/AutomaticDataClearerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/AutomaticDataClearerTest.kt
@@ -19,6 +19,7 @@
 package com.duckduckgo.app.fire
 
 import androidx.test.annotation.UiThreadTest
+import androidx.work.WorkManager
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.clear.ClearWhenOption
@@ -37,12 +38,13 @@ class AutomaticDataClearerTest {
     private val mockSettingsDataStore: SettingsDataStore = mock()
     private val mockClearAction: ClearDataAction = mock()
     private val mockTimeKeeper: BackgroundTimeKeeper = mock()
+    private val mockWorkManager: WorkManager = mock()
 
     @UiThreadTest
     @Before
     fun setup() {
         whenever(mockSettingsDataStore.hasBackgroundTimestampRecorded()).thenReturn(true)
-        testee = AutomaticDataClearer(mockSettingsDataStore, mockClearAction, mockTimeKeeper)
+        testee = AutomaticDataClearer(mockWorkManager, mockSettingsDataStore, mockClearAction, mockTimeKeeper)
     }
 
     private suspend fun simulateLifecycle(isFreshAppLaunch: Boolean) {

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationSchedulerTest.kt
@@ -19,6 +19,8 @@
 
 package com.duckduckgo.app.notification
 
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.work.Configuration
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.duckduckgo.app.notification.NotificationScheduler.ClearDataNotificationWorker
@@ -41,12 +43,15 @@ class NotificationSchedulerTest {
     private val clearNotification: SchedulableNotification = mock()
     private val privacyNotification: SchedulableNotification = mock()
 
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private var workManager = WorkManager.getInstance(context)
     private lateinit var testee: NotificationScheduler
 
     @Before
     fun before() {
         whenever(variantManager.getVariant(any())).thenReturn(DEFAULT_VARIANT)
         testee = NotificationScheduler(
+            workManager,
             clearNotification,
             privacyNotification
         )
@@ -93,8 +98,7 @@ class NotificationSchedulerTest {
     }
 
     private fun getScheduledWorkers(): List<WorkInfo> {
-        return WorkManager
-            .getInstance()
+        return workManager
             .getWorkInfosByTag(NotificationScheduler.WORK_REQUEST_TAG)
             .get()
             .filter { it.state == WorkInfo.State.ENQUEUED }

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -20,6 +20,7 @@ import android.app.NotificationManager
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.work.WorkManager
 import com.duckduckgo.app.notification.NotificationFactory
 import com.duckduckgo.app.notification.NotificationScheduler
 import com.duckduckgo.app.notification.db.NotificationDao
@@ -73,10 +74,12 @@ class NotificationModule {
     @Provides
     @Singleton
     fun providesNotificationScheduler(
+        workManager: WorkManager,
         clearDataNotification: ClearDataNotification,
         privacyProtectionNotification: PrivacyProtectionNotification
     ): NotificationScheduler {
         return NotificationScheduler(
+            workManager,
             clearDataNotification,
             privacyProtectionNotification
         )

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.di
 
 import android.content.Context
+import androidx.work.WorkManager
 import com.duckduckgo.app.browser.WebDataManager
 import com.duckduckgo.app.entities.EntityMapping
 import com.duckduckgo.app.fire.*
@@ -65,11 +66,12 @@ class PrivacyModule {
     @Provides
     @Singleton
     fun automaticDataClearer(
+        workManager: WorkManager,
         settingsDataStore: SettingsDataStore,
         clearDataAction: ClearDataAction,
         dataClearerTimeKeeper: BackgroundTimeKeeper
     ): DataClearer {
-        return AutomaticDataClearer(settingsDataStore, clearDataAction, dataClearerTimeKeeper)
+        return AutomaticDataClearer(workManager, settingsDataStore, clearDataAction, dataClearerTimeKeeper)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/di/WorkerModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/WorkerModule.kt
@@ -16,7 +16,10 @@
 
 package com.duckduckgo.app.di
 
+import android.content.Context
 import androidx.core.app.NotificationManagerCompat
+import androidx.work.Configuration
+import androidx.work.WorkManager
 import androidx.work.WorkerFactory
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.notification.NotificationFactory
@@ -32,6 +35,16 @@ import javax.inject.Singleton
 
 @Module
 class WorkerModule {
+
+    @Provides
+    @Singleton
+    fun workManager(context: Context, workerFactory: WorkerFactory): WorkManager {
+        val config = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+        WorkManager.initialize(context, config)
+        return WorkManager.getInstance(context)
+    }
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -25,8 +25,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.work.Configuration
-import androidx.work.WorkManager
 import androidx.work.WorkerFactory
 import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserObserver
@@ -47,7 +45,6 @@ import com.duckduckgo.app.notification.NotificationScheduler
 import com.duckduckgo.app.privacy.HistoricTrackerBlockingObserver
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.api.OfflinePixelScheduler
-import com.duckduckgo.app.statistics.api.OfflinePixelSender
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.APP_LAUNCH
@@ -164,8 +161,6 @@ open class DuckDuckGoApplication : HasActivityInjector, HasServiceInjector, HasS
 
         if (appIsRestarting()) return
 
-        configureWorkManager()
-
         ProcessLifecycleOwner.get().lifecycle.also {
             it.addObserver(this)
             it.addObserver(dataClearer)
@@ -196,14 +191,6 @@ open class DuckDuckGoApplication : HasActivityInjector, HasServiceInjector, HasS
     private fun configureUncaughtExceptionHandler() {
         val originalHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler(AlertingUncaughtExceptionHandler(originalHandler, offlinePixelDataStore))
-    }
-
-    private fun configureWorkManager() {
-        val config = Configuration.Builder()
-            .setWorkerFactory(workerFactory)
-            .build()
-
-        WorkManager.initialize(this, config)
     }
 
     private fun recordInstallationTimestamp() {

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationScheduler.kt
@@ -35,12 +35,14 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 class NotificationScheduler @Inject constructor(
+    private val workManager: WorkManager,
     private val clearDataNotification: SchedulableNotification,
     private val privacyNotification: SchedulableNotification
 ) {
+
     suspend fun scheduleNextNotification() {
 
-        WorkManager.getInstance().cancelAllWorkByTag(WORK_REQUEST_TAG)
+        workManager.cancelAllWorkByTag(WORK_REQUEST_TAG)
 
         when {
             privacyNotification.canShow() -> {
@@ -60,7 +62,7 @@ class NotificationScheduler @Inject constructor(
             .setInitialDelay(duration, unit)
             .build()
 
-        WorkManager.getInstance().enqueue(request)
+        workManager.enqueue(request)
     }
 
     // Legacy code. Unused class required for users who already have this notification scheduled from previous version. We will

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
@@ -22,12 +22,11 @@ import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-class OfflinePixelScheduler @Inject constructor() {
+class OfflinePixelScheduler @Inject constructor(private val workManager: WorkManager) {
 
     fun scheduleOfflinePixels() {
 
         Timber.v("Scheduling offline pixels to be sent")
-        val workManager = WorkManager.getInstance()
         workManager.cancelAllWorkByTag(WORK_REQUEST_TAG)
 
         val constraints = Constraints.Builder()

--- a/app/version/version.properties
+++ b/app/version/version.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-VERSION=5.32.0
+VERSION=5.32.1


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1135925618579905
Tech Design URL: 
CC: 

**Description**:
Hotfix to update WorkManger and resolve RejectedExecutionException bug on APIs 21 and 22. Do not merge, hotfix will be merges as part of release.

**Steps to test this PR**:

**Setup**
Update `BrowserTabFragment.navigate(url: String)` method to crash after a url is loaded
```
webView?.loadUrl(url)
throw Exception("")
```
Test the following scenarios on API 21 AND a recent API

**Test work manager schedules immediate task**
1. Open the app and type in a search term e.g "test" in the omnibar. The app will crash.
1. Launch the app to start an immediate sync
1. Ensure the `m_d_ac` pixel is fired

**Test work manager schedules in background**
1. Set:
```
private const val SERVICE_INTERVAL = 30L
private val SERVICE_TIME_UNIT = TimeUnit.SECONDS
```
2. Run the app, and as before, type in a search term e.g "test" in the omnibar. The app will crash.
1. Wait a while for the service to kick in and ensure the `m_d_ac` pixel is fired

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
