### PR TITLE
Update themes.xml

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -75,6 +75,7 @@
     <style name="AppTheme.Dark.Transparent">
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
     <!-- To create a new color theme, copy this light one and update the suffix as appropriate.


### PR DESCRIPTION
Right now on certain ROMs like OxygenOS the navigation bar is solid white which doesn't match the apps theme, this should make the navigation bar on these devices match the apps dark theme while keeping it the same on Pixel ROMs.