### PR TITLE
Append DuckDuckGo to user agent

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
@@ -23,18 +23,18 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-private const val CHROME_UA_MOBILE =
+private const val CHROME_MOBILE_UA =
     "Mozilla/5.0 (Linux; Android 8.1.0; Nexus 6P Build/OPM3.171019.014) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36"
 
 // Some values will be dynamic based on OS/Architecture/Software versions, so use Regex to match around dynamic values
-private val UA_DESKTOP_REGEX = Regex(
+private val DESKTOP_UA_REGEX = Regex(
     "Mozilla/5.0 \\(X11; Linux .*?\\) AppleWebKit/[.0-9]+ \\(KHTML, like Gecko\\) Chrome/[.0-9]+ Safari/[.0-9]+ DuckDuckGo/5"
 )
-private val UA_MOBILE_REGEX = Regex(
+private val MOBILE_UA_REGEX = Regex(
     "Mozilla/5.0 \\(Linux; Android .*?\\) AppleWebKit/[.0-9]+ \\(KHTML, like Gecko\\) Chrome/[.0-9]+ Mobile Safari/[.0-9]+ DuckDuckGo/5"
 )
 
-private val CHROME_UA_MOBILE_REGEX_MISSING_APPLE_WEBKIT_DETAILS = Regex(
+private val MOBILE_UA_REGEX_MISSING_APPLE_WEBKIT_DETAILS = Regex(
     "Mozilla/5.0 \\(Linux; Android .*?\\) DuckDuckGo/5"
 )
 
@@ -51,16 +51,16 @@ class UserAgentProviderTest {
 
     @Test
     fun whenMobileUaRetrievedThenDeviceStrippedAndDuckDuckGoSuffixAddedToUA() {
-        testee = UserAgentProvider(CHROME_UA_MOBILE, deviceInfo)
+        testee = UserAgentProvider(CHROME_MOBILE_UA, deviceInfo)
         val actual = testee.getUserAgent(desktopSiteRequested = false)
-        assertTrue(UA_MOBILE_REGEX.matches(actual))
+        assertTrue(MOBILE_UA_REGEX.matches(actual))
     }
 
     @Test
     fun whenDesktopUaRetrievedThenDeviceStrippedAndDuckDuckGoSuffixAddedToUA() {
-        testee = UserAgentProvider(CHROME_UA_MOBILE, deviceInfo)
+        testee = UserAgentProvider(CHROME_MOBILE_UA, deviceInfo)
         val actual = testee.getUserAgent(desktopSiteRequested = true)
-        assertTrue(UA_DESKTOP_REGEX.matches(actual))
+        assertTrue(DESKTOP_UA_REGEX.matches(actual))
     }
 
     @Test
@@ -68,6 +68,6 @@ class UserAgentProviderTest {
         val missingAppleWebKitPart = "Mozilla/5.0 (Linux; Android 8.1.0; Nexus 6P Build/OPM3.171019.014) Chrome/64.0.3282.137 Mobile Safari/537.36"
         testee = UserAgentProvider(missingAppleWebKitPart, deviceInfo)
         val actual = testee.getUserAgent(desktopSiteRequested = false)
-        assertTrue(CHROME_UA_MOBILE_REGEX_MISSING_APPLE_WEBKIT_DETAILS.matches(actual))
+        assertTrue(MOBILE_UA_REGEX_MISSING_APPLE_WEBKIT_DETAILS.matches(actual))
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
@@ -16,46 +16,57 @@
 
 package com.duckduckgo.app.browser.useragent
 
+import com.duckduckgo.app.global.device.DeviceInfo
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 private const val CHROME_UA_MOBILE =
     "Mozilla/5.0 (Linux; Android 8.1.0; Nexus 6P Build/OPM3.171019.014) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36"
 
 // Some values will be dynamic based on OS/Architecture/Software versions, so use Regex to match around dynamic values
-private val CHROME_UA_DESKTOP_REGEX = Regex(
-    "Mozilla/5.0 \\(X11; Linux .*?\\) AppleWebKit/[.0-9]+ \\(KHTML, like Gecko\\) Chrome/[.0-9]+ Safari/[.0-9]+"
+private val UA_DESKTOP_REGEX = Regex(
+    "Mozilla/5.0 \\(X11; Linux .*?\\) AppleWebKit/[.0-9]+ \\(KHTML, like Gecko\\) Chrome/[.0-9]+ Safari/[.0-9]+ DuckDuckGo/5"
 )
-private val CHROME_UA_MOBILE_REGEX = Regex(
-    "Mozilla/5.0 \\(Linux; Android .*?\\) AppleWebKit/[.0-9]+ \\(KHTML, like Gecko\\) Chrome/[.0-9]+ Mobile Safari/[.0-9]+"
+private val UA_MOBILE_REGEX = Regex(
+    "Mozilla/5.0 \\(Linux; Android .*?\\) AppleWebKit/[.0-9]+ \\(KHTML, like Gecko\\) Chrome/[.0-9]+ Mobile Safari/[.0-9]+ DuckDuckGo/5"
 )
 
 private val CHROME_UA_MOBILE_REGEX_MISSING_APPLE_WEBKIT_DETAILS = Regex(
-    "Mozilla/5.0 \\(Linux; Android .*?\\)"
+    "Mozilla/5.0 \\(Linux; Android .*?\\) DuckDuckGo/5"
 )
 
 class UserAgentProviderTest {
 
     private lateinit var testee: UserAgentProvider
 
+    private var deviceInfo: DeviceInfo = mock()
+
+    @Before
+    fun before() {
+        whenever (deviceInfo.majorAppVersion).thenReturn("5")
+    }
+
     @Test
-    fun whenMobileUaRetrievedThenDeviceStrippedFromReturnedUa() {
-        testee = UserAgentProvider(CHROME_UA_MOBILE)
+    fun whenMobileUaRetrievedThenDeviceStrippedAndDuckDuckGoSuffixAddedToUA() {
+        testee = UserAgentProvider(CHROME_UA_MOBILE, deviceInfo)
         val actual = testee.getUserAgent(desktopSiteRequested = false)
-        assertTrue(CHROME_UA_MOBILE_REGEX.matches(actual))
+        assertTrue(UA_MOBILE_REGEX.matches(actual))
     }
 
     @Test
-    fun whenDesktopUaRetrievedThenDeviceStrippedFromReturnedUa() {
-        testee = UserAgentProvider(CHROME_UA_MOBILE)
+    fun whenDesktopUaRetrievedThenDeviceStrippedAndDuckDuckGoSuffixAddedToUA() {
+        testee = UserAgentProvider(CHROME_UA_MOBILE, deviceInfo)
         val actual = testee.getUserAgent(desktopSiteRequested = true)
-        assertTrue(CHROME_UA_DESKTOP_REGEX.matches(actual))
+        assertTrue(UA_DESKTOP_REGEX.matches(actual))
     }
 
     @Test
-    fun whenMissingAppleWebKitStringThenSimplyReturnsNothing() {
+    fun whenMissingAppleWebKitStringThenUAContainsOnlyMozillaAndDuckDuckGoProducts() {
         val missingAppleWebKitPart = "Mozilla/5.0 (Linux; Android 8.1.0; Nexus 6P Build/OPM3.171019.014) Chrome/64.0.3282.137 Mobile Safari/537.36"
-        testee = UserAgentProvider(missingAppleWebKitPart)
+        testee = UserAgentProvider(missingAppleWebKitPart, deviceInfo)
         val actual = testee.getUserAgent(desktopSiteRequested = false)
         assertTrue(CHROME_UA_MOBILE_REGEX_MISSING_APPLE_WEBKIT_DETAILS.matches(actual))
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.app.di
 
+import android.content.Context
+import com.duckduckgo.app.global.device.ContextDeviceInfo
+import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.app.statistics.api.StatisticsService
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -63,4 +66,7 @@ class StubStatisticsModule {
             }
         }
     }
+
+    @Provides
+    fun deviceInfo(context: Context): DeviceInfo = ContextDeviceInfo(context)
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -76,6 +76,7 @@ import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.cta.ui.CtaConfiguration
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.global.ViewModelFactory
+import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.privacy.model.PrivacyGrade
 import com.duckduckgo.app.privacy.renderer.icon
@@ -117,6 +118,9 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
+
+    @Inject
+    lateinit var deviceInfo: DeviceInfo
 
     @Inject
     lateinit var fileChooserIntentBuilder: FileChooserIntentBuilder
@@ -632,7 +636,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             true
         ).findViewById(R.id.browserWebView) as WebView
         webView?.let {
-            userAgentProvider = UserAgentProvider(it.settings.userAgentString)
+            userAgentProvider = UserAgentProvider(it.settings.userAgentString, deviceInfo)
 
             it.webViewClient = webViewClient
             it.webChromeClient = webChromeClient

--- a/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.useragent
 
 import android.os.Build
+import com.duckduckgo.app.global.device.DeviceInfo
 
 
 /**
@@ -26,7 +27,7 @@ import android.os.Build
  * Example Default Desktop User Agent (From Chrome):
  * Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
  */
-class UserAgentProvider constructor(private val defaultUserAgent: String) {
+class UserAgentProvider constructor(private val defaultUserAgent: String, private val device: DeviceInfo) {
 
     /**
      * Returns a modified UA string which omits the user's device make and model
@@ -38,7 +39,7 @@ class UserAgentProvider constructor(private val defaultUserAgent: String) {
     fun getUserAgent(desktopSiteRequested: Boolean = false): String {
 
         val platform = if (desktopSiteRequested) desktopUaPrefix() else mobileUaPrefix()
-        val userAgentStringSuffix = getWebKitVersionOnwards(desktopSiteRequested)
+        val userAgentStringSuffix = "${getWebKitVersionOnwards(desktopSiteRequested)} ${getApplicationSuffix()}"
 
         return "$MOZILLA_PREFIX ($platform)$userAgentStringSuffix"
     }
@@ -54,6 +55,10 @@ class UserAgentProvider constructor(private val defaultUserAgent: String) {
             result = result.replace(" Mobile ", " ")
         }
         return " $result"
+    }
+
+    private fun getApplicationSuffix(): String {
+        return "DuckDuckGo/${device.majorAppVersion}"
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/device/Device.kt
@@ -32,6 +32,8 @@ interface DeviceInfo {
 
     val appVersion: String
 
+    val majorAppVersion: String
+
     val language: String
 
     val country: String
@@ -42,6 +44,8 @@ interface DeviceInfo {
 class ContextDeviceInfo @Inject constructor(private val context: Context) : DeviceInfo {
 
     override val appVersion = "${BuildConfig.VERSION_NAME}"
+
+    override val majorAppVersion = appVersion.split(".").first()
 
     override val language: String by lazy {
         Locale.getDefault().language


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1136878908228409
Tech Design URL: N/A

**Description**:
Append application to user agent following RFC and the format of other browsers.

**Steps to test this PR**:
1. Run the app
1. Search for "what is my user agent"
1. Note the Instant Answer displaying our UA shows the suffix as "DuckDuckGo/5"
1. Visit https://github.com/duckduckgo/Android and note that the mobile version of the site is showing
1. From the menu select, "Desktop Site" and note the desktop site is loaded
1. Now  search for "what is my user agent" again
1. Note that the desktop UA suffix also shows as "DuckDuckGo/5"

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
