### PR TITLE
Improve string translation settingLightTheme (croatian-hr)

### DIFF
--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -152,7 +152,7 @@
     <string name="settingsHeadingOther">Ostalo</string>
     <string name="settingsHeadingPrivacy">Zaštita privatnosti</string>
     <string name="settingsHeadingAutocomplete">Automatsko ispunjavanje</string>
-    <string name="settingsLightTheme">Tema svjetla</string>
+    <string name="settingsLightTheme">Svijetla tema</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGo</string>
     <string name="settingsVersion">Inačica</string>
     <string name="leaveFeedback">Ostavi povratne informacije</string>


### PR DESCRIPTION
Task/Issue URL: #559 
Tech Design URL: 
CC: 

**Description**:
Previous text **_Tema svjetla_** could be translated as Theme of light or Light's theme
where as **_Svijetla tema_** might be more in line with Light Theme.
Svjetlo - noun. the natural agent that stimulates sight and makes things visible.
Svijetlo - adjective. when something is full of light.

**Steps to test this PR**:
1. 
1. 