### PR TITLE
Fix issue where page change not triggered when on SERP

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebNavigationStateTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebNavigationStateTest.kt
@@ -88,7 +88,7 @@ class WebNavigationStateComparisonTest {
     fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestContainsSameOriginalUrlAndDifferentCurrentUrlWithSameHostThenCompareReturnsUrlUpdated() {
         val previousState = buildState("http://same.com", "http://same.com/previous")
         val latestState = buildState("http://same.com", "http://same.com/latest")
-        assertEquals(UrlUpdated("http://subdomain.latest.com"), latestState.compare(previousState))
+        assertEquals(UrlUpdated("http://same.com/latest"), latestState.compare(previousState))
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebNavigationStateTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebNavigationStateTest.kt
@@ -24,91 +24,98 @@ class WebNavigationStateComparisonTest {
 
     @Test
     fun whenPreviousStateAndLatestStateSameThenCompareReturnsUnchanged() {
-        val state = buildState("foo.com", "subdomain.foo.com")
+        val state = buildState("http://foo.com", "http://subdomain.foo.com")
         assertEquals(Unchanged, state.compare(state))
     }
 
     @Test
     fun whenPreviousStateAndLatestStateEqualThenCompareReturnsUnchanged() {
-        val previousState = buildState("foo.com", "subdomain.foo.com")
-        val latestState = buildState("foo.com", "subdomain.foo.com")
+        val previousState = buildState("http://foo.com", "http://subdomain.foo.com")
+        val latestState = buildState("http://foo.com", "http://subdomain.foo.com")
         assertEquals(Unchanged, latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousStateIsNullAndLatestContainsAnOriginalUrlACurrentUrlAndTitleThenCompareReturnsNewPageWithTitle() {
         val previousState = null
-        val latestState = buildState("latest.com", "subdomain.latest.com", "Title")
-        assertEquals(NewPage("subdomain.latest.com", "Title"), latestState.compare(previousState))
+        val latestState = buildState("http://latest.com", "http://subdomain.latest.com", "Title")
+        assertEquals(NewPage("http://subdomain.latest.com", "Title"), latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousStateIsNullAndLatestContainsAnOriginalUrlACurrentUrlAndNoTitleThenCompareReturnsNewPageWithoutTitle() {
         val previousState = null
-        val latestState = buildState("latest.com", "subdomain.latest.com")
-        assertEquals(NewPage("subdomain.latest.com", null), latestState.compare(previousState))
+        val latestState = buildState("http://latest.com", "http://subdomain.latest.com")
+        assertEquals(NewPage("http://subdomain.latest.com", null), latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousContainsNoOriginalOrCurrentUrlAndLatestContainsAnOriginalAndCurrentUrlThenCompareReturnsNewPage() {
         val previousState = buildState(null, null)
-        val latestState = buildState("latest.com", "subdomain.latest.com")
-        assertEquals(NewPage("subdomain.latest.com", null), latestState.compare(previousState))
+        val latestState = buildState("http://latest.com", "http://subdomain.latest.com")
+        assertEquals(NewPage("http://subdomain.latest.com", null), latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousContainsNoOriginalUrlAndACurrentUrlAndLatestContainsAnOriginalAndCurrentUrlThenCompareReturnsNewPage() {
-        val previousState = buildState(null, "subdomain.previous.com")
-        val latestState = buildState("latest.com", "subdomain.latest.com")
-        assertEquals(NewPage("subdomain.latest.com", null), latestState.compare(previousState))
+        val previousState = buildState(null, "http://subdomain.previous.com")
+        val latestState = buildState("http://latest.com", "http://subdomain.latest.com")
+        assertEquals(NewPage("http://subdomain.latest.com", null), latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousContainsAnOriginalUrlAndNoCurrentUrlAndLatestContainsAnOriginalAndCurrentUrlThenCompareReturnsNewPage() {
-        val previousState = buildState("previous.com", null)
-        val latestState = buildState("latest.com", "subdomain.latest.com")
-        assertEquals(NewPage("subdomain.latest.com", null), latestState.compare(previousState))
+        val previousState = buildState("http://previous.com", null)
+        val latestState = buildState("http://latest.com", "http://subdomain.latest.com")
+        assertEquals(NewPage("http://subdomain.latest.com", null), latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestContainsADifferentOriginalUrlThenCompareReturnsNewPage() {
-        val previousState = buildState("previous.com", "subdomain.previous.com")
-        val latestState = buildState("latest.com", "subdomain.latest.com")
-        assertEquals(NewPage("subdomain.latest.com", null), latestState.compare(previousState))
+        val previousState = buildState("http://previous.com", "http://subdomain.previous.com")
+        val latestState = buildState("http://latest.com", "http://subdomain.latest.com")
+        assertEquals(NewPage("http://subdomain.latest.com", null), latestState.compare(previousState))
     }
 
     @Test
-    fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestContainsSameOriginalUrlAndDifferentCurrentUrlThenCompareReturnsUrlUpdated() {
-        val previousState = buildState("same.com", "subdomain.previous.com")
-        val latestState = buildState("same.com", "subdomain.latest.com")
-        assertEquals(UrlUpdated("subdomain.latest.com"), latestState.compare(previousState))
+    fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestContainsSameOriginalUrlAndDifferentCurrentUrlDomainThenCompareReturnsNewPage() {
+        val previousState = buildState("http://same.com", "http://subdomain.previous.com")
+        val latestState = buildState("http://same.com", "http://subdomain.latest.com")
+        assertEquals(NewPage("http://subdomain.latest.com", null), latestState.compare(previousState))
+    }
+
+    @Test
+    fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestContainsSameOriginalUrlAndDifferentCurrentUrlWithSameHostThenCompareReturnsUrlUpdated() {
+        val previousState = buildState("http://same.com", "http://same.com/previous")
+        val latestState = buildState("http://same.com", "http://same.com/latest")
+        assertEquals(UrlUpdated("http://subdomain.latest.com"), latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestContainsSameOriginalUrlAndNoCurrentUrlThenCompareReturnsOther() {
-        val previousState = buildState("same.com", "subdomain.previous.com")
-        val latestState = buildState("same.com", null)
+        val previousState = buildState("http://same.com", "http://subdomain.previous.com")
+        val latestState = buildState("http://same.com", null)
         assertEquals(Other, latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestStateContainsNoOriginalUrlAndNoCurrentUrlThenCompareReturnsPageCleared() {
-        val previousState = buildState("previous.com", "subdomain.previous.com")
+        val previousState = buildState("http://previous.com", "http://subdomain.previous.com")
         val latestState = buildState(null, null)
         assertEquals(PageCleared, latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestStateContainsNoOriginalUrlAndACurrentUrlThenCompareReturnsPageCleared() {
-        val previousState = buildState("previous.com", "subdomain.previous.com")
-        val latestState = buildState(null, "subdomain.latest.com")
+        val previousState = buildState("http://previous.com", "http://subdomain.previous.com")
+        val latestState = buildState(null, "http://subdomain.latest.com")
         assertEquals(PageCleared, latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestStateContainsDifferentOriginalUrlAndNoCurrentUrlThenCompareReturnsOther() {
-        val previousState = buildState("previous.com", "subdomain.previous.com")
-        val latestState = buildState("latest.com", null)
+        val previousState = buildState("http://previous.com", "http://subdomain.previous.com")
+        val latestState = buildState("http://latest.com", null)
         assertEquals(Other, latestState.compare(previousState))
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
@@ -57,8 +57,14 @@ fun WebNavigationState.compare(previous: WebNavigationState?): WebNavigationStat
         return NewPage(latestUrl, title)
     }
 
-    // The most up-to-date record of the url is the current one, this may change during a page load
+    // The most up-to-date record of the url is the current one, this may change many times during a page load
+    // If the host changes too, we class it as a new page load
     if (currentUrl != previous?.currentUrl) {
+
+        if (currentUrl?.toUri()?.host != previous?.currentUrl?.toUri()?.host) {
+            return NewPage(latestUrl, title)
+        }
+
         return UrlUpdated(latestUrl)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/361428290920650/1134826030433169/1135999501704081

**Description**:
Updates the url logic to also trigger a page change when the original url is unchanged but the current page has changed to a different domain

**Steps to test this PR**:

**Test privacy practices are updated**
1. Search for cnn on the SERP
1. Note that the logs log only one page change
```
Page changed: https://duckduckgo.com/?q=cnn&atb=v105-1se&t=ddg_android
2019-08-28 01:57:46.643 31240-31240/com.duckduckgo.mobile.android V/BrowserTabViewModel: Page url updated: https://duckduckgo.com/?q=cnn&atb=v105-1se&t=ddg_android&ia=web
``` 
3. Kill the app
4. Start the app again
5. Tap on the first SERP result for cnn
6. Open the privacy dash and ensure that privacy practices are correct.

**Test continued protection against spoofing**
1. Visit our register at https://app.asana.com/0/547792610048271/1126520042971108
1. Open the example links and ensure we are still protected

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
