### PR TITLE
Add broken site report pixel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -20,9 +20,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.app.brokensite.api.BrokenSiteSender
 import com.duckduckgo.app.global.SingleLiveEvent
+import com.duckduckgo.app.statistics.pixels.Pixel
 
 
-class BrokenSiteViewModel(private val brokenSiteSender: BrokenSiteSender) : ViewModel() {
+class BrokenSiteViewModel(private val pixel: Pixel, private val brokenSiteSender: BrokenSiteSender) : ViewModel() {
 
     data class ViewState(
         val url: String? = null,
@@ -87,6 +88,7 @@ class BrokenSiteViewModel(private val brokenSiteSender: BrokenSiteSender) : View
         val url = viewValue.url ?: return
 
         brokenSiteSender.submitBrokenSiteFeedback(message, url)
+        pixel.fire(Pixel.PixelName.BROKEN_SITE_REPORTED, mapOf(Pixel.PixelParameter.URL to url))
         command.value = Command.ConfirmAndFinish
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -26,7 +26,6 @@ import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import androidx.annotation.AnyThread
-import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import androidx.lifecycle.*

--- a/app/src/main/java/com/duckduckgo/app/di/AppConfigurationDownloadModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppConfigurationDownloadModule.kt
@@ -21,7 +21,6 @@ import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.httpsupgrade.api.HttpsUpgradeDataDownloader
 import com.duckduckgo.app.job.AppConfigurationDownloader
 import com.duckduckgo.app.job.ConfigurationDownloader
-import com.duckduckgo.app.statistics.api.OfflinePixelSender
 import com.duckduckgo.app.surrogates.api.ResourceSurrogateListDownloader
 import com.duckduckgo.app.survey.api.SurveyDownloader
 import com.duckduckgo.app.trackerdetection.api.TrackerDataDownloader

--- a/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
@@ -118,7 +118,7 @@ class ViewModelFactory @Inject constructor(
                 isAssignableFrom(TrackerNetworksViewModel::class.java) -> TrackerNetworksViewModel()
                 isAssignableFrom(PrivacyPracticesViewModel::class.java) -> PrivacyPracticesViewModel()
                 isAssignableFrom(FeedbackViewModel::class.java) -> FeedbackViewModel(playStoreUtils, feedbackSubmitter)
-                isAssignableFrom(BrokenSiteViewModel::class.java) -> BrokenSiteViewModel(brokenSiteSender)
+                isAssignableFrom(BrokenSiteViewModel::class.java) -> BrokenSiteViewModel(pixel, brokenSiteSender)
                 isAssignableFrom(SurveyViewModel::class.java) -> SurveyViewModel(surveyDao, statisticsStore, appInstallStore)
                 isAssignableFrom(AddWidgetInstructionsViewModel::class.java) -> AddWidgetInstructionsViewModel()
                 isAssignableFrom(SettingsViewModel::class.java) -> settingsViewModel()

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -37,6 +37,7 @@ interface Pixel {
         APPLICATION_CRASH("m_d_ac"),
         WEB_RENDERER_GONE_CRASH("m_d_wrg_c"),
         WEB_RENDERER_GONE_KILLED("m_d_wrg_k"),
+        BROKEN_SITE_REPORTED("m_bsr"),
 
         ONBOARDING_DEFAULT_BROWSER_SETTINGS_LAUNCHED("m_odb_l"),
         ONBOARDING_DEFAULT_BROWSER_SKIPPED("m_odb_s"),
@@ -119,6 +120,7 @@ interface Pixel {
 
     object PixelParameter {
         const val APP_VERSION = "appVersion"
+        const val URL = "url"
         const val COUNT = "count"
         const val BOOKMARK_CAPABLE = "bc"
         const val SHOWED_BOOKMARKS = "sb"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1137628760317279
Grafana: https://grafana.duckduckgo.com/d/sawhWhOWk/mobile-sre

**Description**:
Add a simple pixel to the broken site reports so we can visualize these in Grafana and add alerts should the numbers unexpectedly rise.

**Steps to test this PR**:
1. Run the app and browse to a site
1. Tap the browser settings button and select "Report Broken Site"
1. Enter "test.com" for the url and "TEST" in the comment section
1. Submit the report and ensure the "m_bsr" pixel fires, checking Kibana https://kibana.duckduckgo.com/goto/6bf29a6e1d9053c7395b9ddcf2338371

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
