### PR TITLE
Ensure bitmaps aren't generated on control group

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -55,7 +55,9 @@ import com.duckduckgo.app.privacy.db.NetworkLeaderboardDao
 import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.store.PrevalenceStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.db.SurveyDao
@@ -216,6 +218,7 @@ class BrowserTabViewModelTest {
         testee.command.observeForever(mockCommandObserver)
 
         whenever(mockOmnibarConverter.convertQueryToUrl(any())).thenReturn("duckduckgo.com")
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.DEFAULT_VARIANT)
     }
 
     @After
@@ -474,6 +477,23 @@ class BrowserTabViewModelTest {
         testee.progressChanged(10)
         assertEquals(0, loadingViewState().progress)
         assertEquals(false, loadingViewState().isLoading)
+    }
+
+    @Test
+    fun whenProgressChangesToFinishedAndImprovedTabUxVariantActiveThenUpdateWebViewPreview() {
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("mx", 1.0, listOf(VariantManager.VariantFeature.TabSwitcherGrid)))
+        updateUrl("https://example.com", "https://example.com", true)
+        testee.progressChanged(100)
+        val command = captureCommands().lastValue as Command.GenerateWebViewPreviewImage
+        assertFalse(command.forceImmediate)
+    }
+
+    @Test
+    fun whenProgressChangesToFinishedAndImprovedTabUxVariantNotActiveThenDoNotUpdateWebViewPreview() {
+        whenever(mockVariantManager.getVariant()).thenReturn(DEFAULT_VARIANT)
+        updateUrl("https://example.com", "https://example.com", true)
+        testee.progressChanged(100)
+        verify(mockCommandObserver, never()).onChanged(any<Command.GenerateWebViewPreviewImage>())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -480,7 +480,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenProgressChangesToFinishedAndImprovedTabUxVariantActiveThenUpdateWebViewPreview() {
+    fun whenProgressChangesToFinishedAndImprovedTabUxVariantActiveThenWebViewPreviewGenerated() {
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("mx", 1.0, listOf(VariantManager.VariantFeature.TabSwitcherGrid)))
         updateUrl("https://example.com", "https://example.com", true)
         testee.progressChanged(100)
@@ -489,7 +489,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenProgressChangesToFinishedAndImprovedTabUxVariantNotActiveThenDoNotUpdateWebViewPreview() {
+    fun whenProgressChangesToFinishedAndImprovedTabUxVariantNotActiveThenWebViewPreviewNotGenerated() {
         whenever(mockVariantManager.getVariant()).thenReturn(DEFAULT_VARIANT)
         updateUrl("https://example.com", "https://example.com", true)
         testee.progressChanged(100)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -502,7 +502,7 @@ class BrowserTabViewModel(
         val progress = currentLoadingViewState()
         loadingViewState.value = progress.copy(isLoading = isLoading, progress = newProgress)
 
-        if (variantManager.getVariant().hasFeature(TabSwitcherGrid) && !isLoading) {
+        if (!isLoading && variantManager.getVariant().hasFeature(TabSwitcherGrid)) {
             updateOrDeleteWebViewPreview(forceImmediate = false)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -502,7 +502,7 @@ class BrowserTabViewModel(
         val progress = currentLoadingViewState()
         loadingViewState.value = progress.copy(isLoading = isLoading, progress = newProgress)
 
-        if (!isLoading) {
+        if (variantManager.getVariant().hasFeature(TabSwitcherGrid) && !isLoading) {
             updateOrDeleteWebViewPreview(forceImmediate = false)
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1126768040926570/1137859260897020
Tech Design URL: 
CC: 

**Description**:
Was accidentally generating WebView previews on control variant, which is erroneous and wasteful. This PR ensures that WebView previews are only generated when you have the experimental variant.

**Steps to test this PR**:
1. Breakpoint `BrowserTabFragment.generateWebViewPreviewImage()`
1. Ensure it is never called during page loads on the control group variant


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
