### PR TITLE
Update instructions to remove references to old translations branch

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -28,18 +28,13 @@ If you know any of the following languages and would like to help us improve the
 
 ## How to help
 
-There is a branch containing the current translations, called [`feature/app_translations`](https://github.com/duckduckgo/Android/tree/feature/app_translations/app/src/main/res).
-1. Each language has a `values` directory containing the language code, and the `strings.xml` file contains the translations. Examples:
-    - Italian translation files are located within `values-it/strings.xml`  
-    - Spanish translation files are located within `values-es/strings.xml`
-1. If you notice anything which could be improved, you should create a PR containing the improved language suggestions and those changes will be merged into that branch if accepted.
-    1. Fork the project, and clone your forked project to your machine. [Instructions](https://help.github.com/en/articles/fork-a-repo)
-    1. Checkout the translations branch `git checkout --track origin/feature/app_translations`
-    1. Make the changes to the relevant `strings.xml` file, and commit
+1. Each language has a [`values`](https://github.com/duckduckgo/Android/tree/develop/app/src/main/res) directory containing the language code, and the `strings.xml` file contains the translations. Examples:
+    - Italian translation files are located within `app/src/main/res/values-it/strings.xml`  
+    - Spanish translation files are located within `app/src/main/res/values-es/strings.xml`
+1. If you notice anything which could be improved, you should create a PR containing the improved language suggestions.
+    1. Make the changes to the relevant `strings.xml` file
     1. Test the app in the language you've improved, and ensure the changed strings look good
-    1. Push the changes to your fork `git push origin`
-    1. Create a Pull Request for your changes. [Instructions](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork)
-        - Ensure the base branch in your PR is `feature/app_translations`
-      
+    1. Create a PR. As well as the changes themselves, explaining _why_ the changes are an improvement helps a lot.
+             
 
 ℹ️ Please note we are not looking for help with other languages at this time; only the languages listed above. We may open up requests in future for additional languages.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1139003998368552/f
Tech Design URL: 
CC: 

**Description**:
Updates the community translation docs now that we don't use the intermediate app translations branch any longer

**Steps to test this PR**:
1. Check the documentation makes sense and renders correctly

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
