### PR TITLE
Filter experimental variants

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -218,7 +218,7 @@ class BrowserTabViewModelTest {
         testee.command.observeForever(mockCommandObserver)
 
         whenever(mockOmnibarConverter.convertQueryToUrl(any())).thenReturn("duckduckgo.com")
-        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.DEFAULT_VARIANT)
+        whenever(mockVariantManager.getVariant()).thenReturn(DEFAULT_VARIANT)
     }
 
     @After
@@ -481,7 +481,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenProgressChangesToFinishedAndImprovedTabUxVariantActiveThenWebViewPreviewGenerated() {
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("mx", 1.0, listOf(VariantManager.VariantFeature.TabSwitcherGrid)))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("mx", 1.0, listOf(VariantManager.VariantFeature.TabSwitcherGrid), restrictToEnglish = false))
         updateUrl("https://example.com", "https://example.com", true)
         testee.progressChanged(100)
         val command = captureCommands().lastValue as Command.GenerateWebViewPreviewImage

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -481,7 +481,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenProgressChangesToFinishedAndImprovedTabUxVariantActiveThenWebViewPreviewGenerated() {
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("mx", 1.0, listOf(VariantManager.VariantFeature.TabSwitcherGrid), restrictToEnglish = false))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("mx", 1.0, listOf(VariantManager.VariantFeature.TabSwitcherGrid)))
         updateUrl("https://example.com", "https://example.com", true)
         testee.progressChanged(100)
         val command = captureCommands().lastValue as Command.GenerateWebViewPreviewImage

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -481,7 +481,9 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenProgressChangesToFinishedAndImprovedTabUxVariantActiveThenWebViewPreviewGenerated() {
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("mx", 1.0, listOf(VariantManager.VariantFeature.TabSwitcherGrid)))
+        whenever(mockVariantManager.getVariant()).thenReturn(
+            Variant("mx", 1.0, listOf(VariantManager.VariantFeature.TabSwitcherGrid), filterBy = { true })
+        )
         updateUrl("https://example.com", "https://example.com", true)
         testee.progressChanged(100)
         val command = captureCommands().lastValue as Command.GenerateWebViewPreviewImage

--- a/app/src/androidTest/java/com/duckduckgo/app/integration/AtbIntegrationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/integration/AtbIntegrationTest.kt
@@ -57,7 +57,7 @@ class AtbIntegrationTest {
         statisticsStore = StatisticsSharedPreferences(InstrumentationRegistry.getInstrumentation().targetContext)
         statisticsStore.clearAtb()
 
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0, restrictToEnglish = false))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
         service = getDaggerComponent().retrofit().create(StatisticsService::class.java)
         testee = StatisticsRequester(statisticsStore, service, mockVariantManager)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/integration/AtbIntegrationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/integration/AtbIntegrationTest.kt
@@ -57,7 +57,7 @@ class AtbIntegrationTest {
         statisticsStore = StatisticsSharedPreferences(InstrumentationRegistry.getInstrumentation().targetContext)
         statisticsStore.clearAtb()
 
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0, restrictToEnglish = false))
         service = getDaggerComponent().retrofit().create(StatisticsService::class.java)
         testee = StatisticsRequester(statisticsStore, service, mockVariantManager)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/integration/AtbIntegrationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/integration/AtbIntegrationTest.kt
@@ -57,7 +57,7 @@ class AtbIntegrationTest {
         statisticsStore = StatisticsSharedPreferences(InstrumentationRegistry.getInstrumentation().targetContext)
         statisticsStore.clearAtb()
 
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0, filterBy = { true }))
         service = getDaggerComponent().retrofit().create(StatisticsService::class.java)
         testee = StatisticsRequester(statisticsStore, service, mockVariantManager)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -206,7 +206,7 @@ class SettingsViewModelTest {
 
     @Test
     fun whenVariantIsSetThenVariantKeyIncludedInSettings() {
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ab"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ab", filterBy = { true }))
         testee.start()
         val expectedStartString = "${BuildConfig.VERSION_NAME} ab (${BuildConfig.VERSION_CODE})"
         assertEquals(expectedStartString, latestViewState().version)

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -206,7 +206,7 @@ class SettingsViewModelTest {
 
     @Test
     fun whenVariantIsSetThenVariantKeyIncludedInSettings() {
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ab", restrictToEnglish = false))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ab"))
         testee.start()
         val expectedStartString = "${BuildConfig.VERSION_NAME} ab (${BuildConfig.VERSION_CODE})"
         assertEquals(expectedStartString, latestViewState().version)

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -206,7 +206,7 @@ class SettingsViewModelTest {
 
     @Test
     fun whenVariantIsSetThenVariantKeyIncludedInSettings() {
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ab"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ab", restrictToEnglish = false))
         testee.start()
         val expectedStartString = "${BuildConfig.VERSION_NAME} ab (${BuildConfig.VERSION_CODE})"
         assertEquals(expectedStartString, latestViewState().version)

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -51,7 +51,7 @@ class ApiBasedPixelTest {
     fun whenPixelFiredThenPixelServiceCalledWithCorrectAtbAndVariant() {
         whenever(mockPixelService.fire(any(), any(), any(), anyOrNull())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", filterBy = { true }))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
@@ -99,7 +99,7 @@ class ApiBasedPixelTest {
     fun whenPixelFiredWithAdditionalParametersThenPixelServiceCalledWithDefaultAndAdditionalParameters() {
         whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", filterBy = { true }))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
         whenever(mockDeviceInfo.appVersion).thenReturn("1.0.0")
 
@@ -115,7 +115,7 @@ class ApiBasedPixelTest {
     fun whenPixelFiredWithoutAdditionalParametersThenPixelServiceCalledWithOnlyDefaultParameters() {
         whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", filterBy = { true }))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
         whenever(mockDeviceInfo.appVersion).thenReturn("1.0.0")
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -51,7 +51,7 @@ class ApiBasedPixelTest {
     fun whenPixelFiredThenPixelServiceCalledWithCorrectAtbAndVariant() {
         whenever(mockPixelService.fire(any(), any(), any(), anyOrNull())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", restrictToEnglish = false))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
@@ -99,7 +99,7 @@ class ApiBasedPixelTest {
     fun whenPixelFiredWithAdditionalParametersThenPixelServiceCalledWithDefaultAndAdditionalParameters() {
         whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", restrictToEnglish = false))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
         whenever(mockDeviceInfo.appVersion).thenReturn("1.0.0")
 
@@ -115,7 +115,7 @@ class ApiBasedPixelTest {
     fun whenPixelFiredWithoutAdditionalParametersThenPixelServiceCalledWithOnlyDefaultParameters() {
         whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", restrictToEnglish = false))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
         whenever(mockDeviceInfo.appVersion).thenReturn("1.0.0")
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -51,7 +51,7 @@ class ApiBasedPixelTest {
     fun whenPixelFiredThenPixelServiceCalledWithCorrectAtbAndVariant() {
         whenever(mockPixelService.fire(any(), any(), any(), anyOrNull())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", restrictToEnglish = false))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
@@ -99,7 +99,7 @@ class ApiBasedPixelTest {
     fun whenPixelFiredWithAdditionalParametersThenPixelServiceCalledWithDefaultAndAdditionalParameters() {
         whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", restrictToEnglish = false))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
         whenever(mockDeviceInfo.appVersion).thenReturn("1.0.0")
 
@@ -115,7 +115,7 @@ class ApiBasedPixelTest {
     fun whenPixelFiredWithoutAdditionalParametersThenPixelServiceCalledWithOnlyDefaultParameters() {
         whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", restrictToEnglish = false))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
         whenever(mockDeviceInfo.appVersion).thenReturn("1.0.0")
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ExperimentationVariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ExperimentationVariantManagerTest.kt
@@ -43,7 +43,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantAlreadyPersistedThenVariantReturned() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
         whenever(mockStore.variant).thenReturn("foo")
 
         assertEquals("foo", testee.getVariant(activeVariants).key)
@@ -51,7 +51,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantAlreadyPersistedThenVariantAllocatorNeverInvoked() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
         whenever(mockStore.variant).thenReturn("foo")
 
         testee.getVariant(activeVariants)
@@ -77,7 +77,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantPersistedIsNotFoundInActiveVariantListThenRestoredToDefaultVariant() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
         whenever(mockStore.variant).thenReturn("bar")
 
         assertEquals(VariantManager.DEFAULT_VARIANT, testee.getVariant(activeVariants))
@@ -85,7 +85,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantPersistedIsNotFoundInActiveVariantListThenNewVariantIsPersisted() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
 
         whenever(mockStore.variant).thenReturn("bar")
         testee.getVariant(activeVariants)
@@ -96,7 +96,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenNoVariantPersistedThenNewVariantAllocated() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
 
         testee.getVariant(activeVariants)
 
@@ -105,7 +105,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenNoVariantPersistedThenNewVariantKeyIsAllocatedAndPersisted() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
 
         testee.getVariant(activeVariants)
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ExperimentationVariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ExperimentationVariantManagerTest.kt
@@ -43,7 +43,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantAlreadyPersistedThenVariantReturned() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, filterBy = { true }))
         whenever(mockStore.variant).thenReturn("foo")
 
         assertEquals("foo", testee.getVariant(activeVariants).key)
@@ -51,7 +51,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantAlreadyPersistedThenVariantAllocatorNeverInvoked() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, filterBy = { true }))
         whenever(mockStore.variant).thenReturn("foo")
 
         testee.getVariant(activeVariants)
@@ -77,7 +77,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantPersistedIsNotFoundInActiveVariantListThenRestoredToDefaultVariant() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, filterBy = { true }))
         whenever(mockStore.variant).thenReturn("bar")
 
         assertEquals(VariantManager.DEFAULT_VARIANT, testee.getVariant(activeVariants))
@@ -85,7 +85,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantPersistedIsNotFoundInActiveVariantListThenNewVariantIsPersisted() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, filterBy = { true }))
 
         whenever(mockStore.variant).thenReturn("bar")
         testee.getVariant(activeVariants)
@@ -96,7 +96,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenNoVariantPersistedThenNewVariantAllocated() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, filterBy = { true }))
 
         testee.getVariant(activeVariants)
 
@@ -105,7 +105,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenNoVariantPersistedThenNewVariantKeyIsAllocatedAndPersisted() {
-        activeVariants.add(Variant("foo", 100.0))
+        activeVariants.add(Variant("foo", 100.0, filterBy = { true }))
 
         testee.getVariant(activeVariants)
 
@@ -124,15 +124,6 @@ class ExperimentationVariantManagerTest {
     @Test
     fun whenVariantDoesComplyWithFiltersThenNewVariantKeyIsAllocatedAndPersisted() {
         activeVariants.add(Variant("foo", 100.0, filterBy = { true }))
-
-        testee.getVariant(activeVariants)
-
-        verify(mockStore).variant = "foo"
-    }
-
-    @Test
-    fun whenVariantDoesNotHaveFiltersThenNewVariantKeyIsAllocatedAndPersisted() {
-        activeVariants.add(Variant("foo", 100.0))
 
         testee.getVariant(activeVariants)
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ExperimentationVariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ExperimentationVariantManagerTest.kt
@@ -43,7 +43,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantAlreadyPersistedThenVariantReturned() {
-        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
+        activeVariants.add(Variant("foo", 100.0))
         whenever(mockStore.variant).thenReturn("foo")
 
         assertEquals("foo", testee.getVariant(activeVariants).key)
@@ -51,7 +51,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantAlreadyPersistedThenVariantAllocatorNeverInvoked() {
-        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
+        activeVariants.add(Variant("foo", 100.0))
         whenever(mockStore.variant).thenReturn("foo")
 
         testee.getVariant(activeVariants)
@@ -77,7 +77,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantPersistedIsNotFoundInActiveVariantListThenRestoredToDefaultVariant() {
-        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
+        activeVariants.add(Variant("foo", 100.0))
         whenever(mockStore.variant).thenReturn("bar")
 
         assertEquals(VariantManager.DEFAULT_VARIANT, testee.getVariant(activeVariants))
@@ -85,7 +85,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenVariantPersistedIsNotFoundInActiveVariantListThenNewVariantIsPersisted() {
-        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
+        activeVariants.add(Variant("foo", 100.0))
 
         whenever(mockStore.variant).thenReturn("bar")
         testee.getVariant(activeVariants)
@@ -96,7 +96,7 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenNoVariantPersistedThenNewVariantAllocated() {
-        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
+        activeVariants.add(Variant("foo", 100.0))
 
         testee.getVariant(activeVariants)
 
@@ -105,7 +105,34 @@ class ExperimentationVariantManagerTest {
 
     @Test
     fun whenNoVariantPersistedThenNewVariantKeyIsAllocatedAndPersisted() {
-        activeVariants.add(Variant("foo", 100.0, restrictToEnglish = false))
+        activeVariants.add(Variant("foo", 100.0))
+
+        testee.getVariant(activeVariants)
+
+        verify(mockStore).variant = "foo"
+    }
+
+    @Test
+    fun whenVariantDoesNotComplyWithFiltersThenDefaultVariantIsPersisted() {
+        activeVariants.add(Variant("foo", 100.0, filterBy = { false }))
+
+        testee.getVariant(activeVariants)
+
+        verify(mockStore).variant = VariantManager.DEFAULT_VARIANT.key
+    }
+
+    @Test
+    fun whenVariantDoesComplyWithFiltersThenNewVariantKeyIsAllocatedAndPersisted() {
+        activeVariants.add(Variant("foo", 100.0, filterBy = { true }))
+
+        testee.getVariant(activeVariants)
+
+        verify(mockStore).variant = "foo"
+    }
+
+    @Test
+    fun whenVariantDoesNotHaveFiltersThenNewVariantKeyIsAllocatedAndPersisted() {
+        activeVariants.add(Variant("foo", 100.0))
 
         testee.getVariant(activeVariants)
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
@@ -70,7 +70,7 @@ class StatisticsRequesterJsonTest {
         statisticsStore.clearAtb()
 
         testee = StatisticsRequester(statisticsStore, statisticsService, mockVariantManager)
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0, restrictToEnglish = false))
     }
 
     @After

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
@@ -70,7 +70,7 @@ class StatisticsRequesterJsonTest {
         statisticsStore.clearAtb()
 
         testee = StatisticsRequester(statisticsStore, statisticsService, mockVariantManager)
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0, filterBy = { true }))
     }
 
     @After

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
@@ -70,7 +70,7 @@ class StatisticsRequesterJsonTest {
         statisticsStore.clearAtb()
 
         testee = StatisticsRequester(statisticsStore, statisticsService, mockVariantManager)
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0, restrictToEnglish = false))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
     }
 
     @After

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -44,7 +44,7 @@ class StatisticsRequesterTest {
 
     @Before
     fun before() {
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0, restrictToEnglish = false))
         whenever(mockService.atb(any())).thenReturn(Observable.just(ATB))
         whenever(mockService.updateSearchAtb(any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
         whenever(mockService.exti(any(), any())).thenReturn(Observable.just(mockResponseBody))

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -44,7 +44,7 @@ class StatisticsRequesterTest {
 
     @Before
     fun before() {
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0, filterBy = { true }))
         whenever(mockService.atb(any())).thenReturn(Observable.just(ATB))
         whenever(mockService.updateSearchAtb(any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
         whenever(mockService.exti(any(), any())).thenReturn(Observable.just(mockResponseBody))

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -44,7 +44,7 @@ class StatisticsRequesterTest {
 
     @Before
     fun before() {
-        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0, restrictToEnglish = false))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("ma", 100.0))
         whenever(mockService.atb(any())).thenReturn(Observable.just(ATB))
         whenever(mockService.updateSearchAtb(any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
         whenever(mockService.exti(any(), any())).thenReturn(Observable.just(mockResponseBody))

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -42,6 +42,7 @@ interface VariantManager {
             Variant(key = "sc", weight = 0.0, features = emptyList()),
             Variant(key = "se", weight = 0.0, features = emptyList()),
 
+            // All groups in an experiment (control and variants) MUST use the same filters
             Variant(key = "mw", weight = 1.0, features = emptyList()),
             Variant(key = "mx", weight = 1.0, features = listOf(VariantFeature.TabSwitcherGrid))
         )

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -16,10 +16,12 @@
 
 package com.duckduckgo.app.statistics
 
+import android.os.Build
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import timber.log.Timber
+import java.util.Locale
 
 @WorkerThread
 interface VariantManager {
@@ -32,17 +34,17 @@ interface VariantManager {
     companion object {
 
         // this will be returned when there are no other active experiments
-        val DEFAULT_VARIANT = Variant(key = "", features = emptyList())
+        val DEFAULT_VARIANT = Variant(key = "", features = emptyList(), restrictToEnglish = false)
 
         val ACTIVE_VARIANTS = listOf(
 
             // SERP variants. "sc" may also be used as a shared control for mobile experiments in
             // the future if we can filter by app version
-            Variant(key = "sc", weight = 0.0, features = emptyList()),
-            Variant(key = "se", weight = 0.0, features = emptyList()),
+            Variant(key = "sc", weight = 0.0, features = emptyList(), restrictToEnglish = false),
+            Variant(key = "se", weight = 0.0, features = emptyList(), restrictToEnglish = false),
 
-            Variant(key = "mw", weight = 1.0, features = emptyList()),
-            Variant(key = "mx", weight = 1.0, features = listOf(VariantFeature.TabSwitcherGrid))
+            Variant(key = "mw", weight = 1.0, features = emptyList(), restrictToEnglish = false),
+            Variant(key = "mx", weight = 1.0, features = listOf(VariantFeature.TabSwitcherGrid), restrictToEnglish = false)
         )
     }
 
@@ -90,13 +92,23 @@ class ExperimentationVariantManager(
     }
 
     private fun generateVariant(activeVariants: List<Variant>): Variant {
-        val weightSum = activeVariants.sumByDouble { it.weight }
+        val weightSum = filterByEnglishLocale(filterByApi(activeVariants)).sumByDouble { it.weight }
         if (weightSum == 0.0) {
             Timber.v("No variants active; allocating default")
             return DEFAULT_VARIANT
         }
         val randomizedIndex = indexRandomizer.random(activeVariants)
         return activeVariants[randomizedIndex]
+    }
+
+    private fun filterByApi(activeVariants: List<Variant>) = activeVariants.filter { it.minApi == null || it.minApi <= Build.VERSION.SDK_INT }
+
+    private fun filterByEnglishLocale(activeVariants: List<Variant>): List<Variant> =
+        activeVariants.filter { (it.restrictToEnglish && isEnglishLocale() || !it.restrictToEnglish) }
+
+    private fun isEnglishLocale(): Boolean {
+        val locale = Locale.getDefault()
+        return locale != null && locale.language == "en"
     }
 }
 
@@ -108,7 +120,9 @@ class ExperimentationVariantManager(
 data class Variant(
     val key: String,
     override val weight: Double = 0.0,
-    val features: List<VariantManager.VariantFeature> = emptyList()
+    val features: List<VariantManager.VariantFeature> = emptyList(),
+    val restrictToEnglish: Boolean,
+    val minApi: Int? = null
 ) : Probabilistic {
 
     fun hasFeature(feature: VariantManager.VariantFeature) = features.contains(feature)

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -33,18 +33,18 @@ interface VariantManager {
     companion object {
 
         // this will be returned when there are no other active experiments
-        val DEFAULT_VARIANT = Variant(key = "", features = emptyList())
+        val DEFAULT_VARIANT = Variant(key = "", features = emptyList(), filterBy = { true })
 
         val ACTIVE_VARIANTS = listOf(
 
             // SERP variants. "sc" may also be used as a shared control for mobile experiments in
             // the future if we can filter by app version
-            Variant(key = "sc", weight = 0.0, features = emptyList()),
-            Variant(key = "se", weight = 0.0, features = emptyList()),
+            Variant(key = "sc", weight = 0.0, features = emptyList(), filterBy = { true }),
+            Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { true }),
 
             // All groups in an experiment (control and variants) MUST use the same filters
-            Variant(key = "mw", weight = 1.0, features = emptyList()),
-            Variant(key = "mx", weight = 1.0, features = listOf(VariantFeature.TabSwitcherGrid))
+            Variant(key = "mw", weight = 1.0, features = emptyList(), filterBy = { true }),
+            Variant(key = "mx", weight = 1.0, features = listOf(VariantFeature.TabSwitcherGrid), filterBy = { true })
         )
 
         private fun isEnglishLocale(): Boolean {
@@ -121,7 +121,7 @@ data class Variant(
     val key: String,
     override val weight: Double = 0.0,
     val features: List<VariantManager.VariantFeature> = emptyList(),
-    val filterBy: () -> Boolean = { true }
+    val filterBy: () -> Boolean
 ) : Probabilistic {
 
     fun hasFeature(feature: VariantManager.VariantFeature) = features.contains(feature)

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -33,19 +33,21 @@ interface VariantManager {
     companion object {
 
         // this will be returned when there are no other active experiments
-        val DEFAULT_VARIANT = Variant(key = "", features = emptyList(), filterBy = { true })
+        val DEFAULT_VARIANT = Variant(key = "", features = emptyList(), filterBy = { noFilter() })
 
         val ACTIVE_VARIANTS = listOf(
 
             // SERP variants. "sc" may also be used as a shared control for mobile experiments in
             // the future if we can filter by app version
-            Variant(key = "sc", weight = 0.0, features = emptyList(), filterBy = { true }),
-            Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { true }),
+            Variant(key = "sc", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
 
             // All groups in an experiment (control and variants) MUST use the same filters
-            Variant(key = "mw", weight = 1.0, features = emptyList(), filterBy = { true }),
-            Variant(key = "mx", weight = 1.0, features = listOf(VariantFeature.TabSwitcherGrid), filterBy = { true })
+            Variant(key = "mw", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "mx", weight = 1.0, features = listOf(VariantFeature.TabSwitcherGrid), filterBy = { noFilter() })
         )
+
+        private fun noFilter(): Boolean = true
 
         private fun isEnglishLocale(): Boolean {
             val locale = Locale.getDefault()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1138059002087732

Tech Design: https://app.asana.com/0/481882893211075/1139758288255945

**Description**:

Adds a new filterBy lambda parameter to Variant so each of them can specify conditions for them to be allocated or not.

**Steps to test this PR**:
**Doesn't filter when filter returning true added**
1. Add a variant using `filterBy = { true }`
1. Install the app notice how that variant does not get filtered out after being allocated.

**Doesn't filter when no filter added**
1. Add a variant without creating a filter
1. Install the app notice how that variant does not get filtered out after being allocated.

**Filters correctly when filter returning false added**
1. Add a variant using `filterBy = { false }`
1. Install the app notice how that variant gets filtered out after being allocated and is replaced by the default variant instead.
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
