### PR TITLE
Improve tracker and entity lookup performance

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/entities/EntityMappingTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/entities/EntityMappingTest.kt
@@ -18,10 +18,7 @@ package com.duckduckgo.app.entities
 
 import com.duckduckgo.app.entities.db.EntityListDao
 import com.duckduckgo.app.entities.db.EntityListEntity
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -65,48 +62,19 @@ class EntityMappingTest {
     @Test
     fun whenUrlContainsOneUnmatchedSubDomainAndOneMatchingDomainThenValueIsReturned() {
         val url = "a.b.com"
-        whenever(mockDao.get(url)).thenReturn(anEntity())
+        val domains = listOf("a.b.com", "b.com")
+        whenever(mockDao.get(domains)).doReturn(anEntity())
         val entity = testee.entityForUrl("https://$url")
         assertNotNull(entity)
-        verify(mockDao).get("a.b.com")
+        verify(mockDao).get(domains)
     }
 
     @Test
     fun whenUrlContainsOneMultipartTldThenTldIsSearchedForInDb() {
         val url = "a.co.uk"
+        val domains = listOf("a.co.uk", "co.uk")
         testee.entityForUrl("https://$url")
-        verify(mockDao).get("a.co.uk")
-        verify(mockDao).get("co.uk")
-    }
-
-    @Test
-    fun whenUrlContainsManyUnmatchedSubdomainsThenAllIntermediateValuesAreSearchedFor() {
-        val url = "a.b.c.com"
-        whenever(mockDao.get("a.b.c.com")).thenReturn(null)
-        whenever(mockDao.get("b.c.com")).thenReturn(null)
-        whenever(mockDao.get("c.com")).thenReturn(null)
-
-        val entity = testee.entityForUrl("https://$url")
-        assertNull(entity)
-        verify(mockDao).get("a.b.c.com")
-        verify(mockDao).get("b.c.com")
-        verify(mockDao).get("b.c.com")
-        verify(mockDao).get("c.com")
-    }
-
-    @Test
-    fun whenUrlContainsManyMatchingSubdomainsThenSearchingStopsWhenValueFound() {
-        val url = "a.b.c.com"
-        whenever(mockDao.get("a.b.c.com")).thenReturn(null)
-        whenever(mockDao.get("b.c.com")).thenReturn(anEntity())
-        whenever(mockDao.get("c.com")).thenReturn(null)
-
-        val entity = testee.entityForUrl("https://$url")
-        assertNotNull(entity)
-
-        verify(mockDao).get("a.b.c.com")
-        verify(mockDao).get("b.c.com")
-        verify(mockDao, never()).get("c.com")
+        verify(mockDao).get(domains)
     }
 
     private fun anEntity() = EntityListEntity("", "")

--- a/app/src/main/java/com/duckduckgo/app/entities/db/EntityListDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/entities/db/EntityListDao.kt
@@ -30,6 +30,9 @@ abstract class EntityListDao {
     @Query("select * from entity_list where domainName=:domainName")
     abstract fun get(domainName: String): EntityListEntity?
 
+    @Query("select * from entity_list where domainName in (:domainNames)")
+    abstract fun get(domainNames: List<String>): EntityListEntity?
+
     @Query("delete from entity_list")
     abstract fun deleteAll()
 

--- a/app/src/main/java/com/duckduckgo/app/global/uri/UriSubdomainRemover.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/uri/UriSubdomainRemover.kt
@@ -17,7 +17,21 @@
 package com.duckduckgo.app.global.uri
 
 import android.net.Uri
+import androidx.core.net.toUri
 
+fun Uri?.extractAllSubdomainHostCombinations(parentHost: String): List<String> {
+    var nextUri = this
+    var nextHost = parentHost
+    val hosts = mutableListOf<String>()
+    while (nextHost.isNotEmpty()) {
+        hosts.add(nextHost)
+        val nextDomain = nextUri?.removeSubdomain()
+        nextUri = nextDomain?.toUri()
+        nextHost = nextUri?.host ?: ""
+    }
+
+    return hosts
+}
 
 fun Uri.removeSubdomain(): String? {
     val host = host ?: return null

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/db/TrackerDataDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/db/TrackerDataDao.kt
@@ -38,6 +38,8 @@ abstract class TrackerDataDao {
     @Query("select * from disconnect_tracker where url = :url")
     abstract fun get(url: String): DisconnectTracker?
 
+    @Query("select * from disconnect_tracker where url in (:urls)")
+    abstract fun get(urls: List<String>): DisconnectTracker?
 
     @Query("select count(*) from disconnect_tracker")
     abstract fun count(): Int


### PR DESCRIPTION
**Description**:
Whilst looking through the tracker detection code, I spotted an optimization that can be made when searching through both the entity and tracker databases. The current implementation searches the database with the parent host domain then recursively strips the subdomains off one by one. Each time a subdomain is stripped away, the result goes through a database search again.

Instead of doing a recursive search, we can generate the list of all domains to search immediately and have each entry in the database check against that list. This reduces it down to a single pass of the database entries no matter how many subdomains there are.

**Results**
I ran some tests with the existing code and the new code in order to compare the performance differences. I took 3 different sites, 1 with a low number of trackers (2), one with a medium number of trackers (15) and one with a high number of trackers (25). For each of these I measured the time it took to execute the `trackerDetector.evaluate` call in the `WebViewRequestInterceptor.shouldBlock` method. I ran each of these sites 7 times in a row and calculated a running average of the execution times. For the low number of trackers, I took the 10th result and for the other two I took the 100th result.

Low Trackers
Average time saved per execution = 2.58ms
Average % increase in performance = 4%
Total time saved per site load = 5.16ms

Medium Trackers
Average time saved per execution = 13.48ms
Average % increase in performance = 18.79%
Total time saved per site load = 202.14ms

High Trackers
Average time saved per execution = 17.89ms
Average % increase in performance = 28.37%
Total time saved per site load = 447.2ms

The results will vary even on sites with the same number of trackers. Things like varying average subdomain lengths of tracker urls and how deep the search has to go to find particular matches will impact times. But just from these results, the performance boost from making this change is pretty significant for sites with many trackers.

**Tests**
I didn't need to add any as existing tests already cover subdomain searching. In fact, I removed some tests that were specifically testing recursion that are no longer applicable.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
