### PR TITLE
Generate webview image when leaving BrowserActivity

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -55,7 +55,6 @@ import com.duckduckgo.app.privacy.db.NetworkLeaderboardDao
 import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.store.PrevalenceStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
@@ -477,25 +476,6 @@ class BrowserTabViewModelTest {
         testee.progressChanged(10)
         assertEquals(0, loadingViewState().progress)
         assertEquals(false, loadingViewState().isLoading)
-    }
-
-    @Test
-    fun whenProgressChangesToFinishedAndImprovedTabUxVariantActiveThenWebViewPreviewGenerated() {
-        whenever(mockVariantManager.getVariant()).thenReturn(
-            Variant("mx", 1.0, listOf(VariantManager.VariantFeature.TabSwitcherGrid), filterBy = { true })
-        )
-        updateUrl("https://example.com", "https://example.com", true)
-        testee.progressChanged(100)
-        val command = captureCommands().lastValue as Command.GenerateWebViewPreviewImage
-        assertFalse(command.forceImmediate)
-    }
-
-    @Test
-    fun whenProgressChangesToFinishedAndImprovedTabUxVariantNotActiveThenWebViewPreviewNotGenerated() {
-        whenever(mockVariantManager.getVariant()).thenReturn(DEFAULT_VARIANT)
-        updateUrl("https://example.com", "https://example.com", true)
-        testee.progressChanged(100)
-        verify(mockCommandObserver, never()).onChanged(any<Command.GenerateWebViewPreviewImage>())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1098,6 +1098,48 @@ class BrowserTabViewModelTest {
         assertFalse(omnibarViewState().shouldMoveCaretToEnd)
     }
 
+    @Test
+    fun whenUserRequestedToOpenNewTabThenGenerateWebViewPreviewImage() {
+        testee.userRequestedOpeningNewTab()
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val command = commandCaptor.firstValue
+        assertTrue(command is Command.GenerateWebViewPreviewImage)
+    }
+
+    @Test
+    fun whenUserRequestedToOpenNewTabThenNewTabCommandIssued() {
+        testee.userRequestedOpeningNewTab()
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val command = commandCaptor.lastValue
+        assertTrue(command is Command.LaunchNewTab)
+    }
+
+    @Test
+    fun whenUserPressesBackAndSkippingHomeThenWebViewPreviewGenerated() {
+        setupNavigation(isBrowsing = true, canGoBack = false, skipHome = true)
+        testee.onUserPressedBack()
+        verifyGenerateWebViewPreviewCommandIssued()
+    }
+
+    @Test
+    fun whenUserPressesBackAndNotSkippingHomeThenWebViewPreviewNotGenerated() {
+        setupNavigation(isBrowsing = true, canGoBack = false, skipHome = false)
+        testee.onUserPressedBack()
+        verifyGenerateWebViewPreviewCommandNotIssued()
+    }
+
+    private fun verifyGenerateWebViewPreviewCommandIssued() {
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val generatedPreviewCommand = commandCaptor.allValues.find { it is Command.GenerateWebViewPreviewImage }
+        assertNotNull(generatedPreviewCommand)
+    }
+
+    private fun verifyGenerateWebViewPreviewCommandNotIssued() {
+        verify(mockCommandObserver, atLeast(0)).onChanged(commandCaptor.capture())
+        val generatedPreviewCommand = commandCaptor.allValues.find { it is Command.GenerateWebViewPreviewImage }
+        assertNull(generatedPreviewCommand)
+    }
+
     private fun pixelParams(showedBookmarks: Boolean, bookmarkCapable: Boolean) = mapOf(
         Pixel.PixelParameter.SHOWED_BOOKMARKS to showedBookmarks.toString(),
         Pixel.PixelParameter.BOOKMARK_CAPABLE to bookmarkCapable.toString()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -53,8 +53,7 @@ import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.*
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.app.autocomplete.api.AutoCompleteApi.AutoCompleteSuggestion
 import com.duckduckgo.app.bookmarks.ui.EditBookmarkDialogFragment
@@ -82,6 +81,7 @@ import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.privacy.model.PrivacyGrade
 import com.duckduckgo.app.privacy.renderer.icon
+import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.ui.SurveyActivity
@@ -158,6 +158,9 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
     @Inject
     lateinit var previewPersister: WebViewPreviewPersister
+
+    @Inject
+    lateinit var variantManager: VariantManager
 
     val tabId get() = arguments!![TAB_ID_ARG] as String
 
@@ -244,6 +247,31 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
         if (savedInstanceState == null) {
             viewModel.onViewReady()
+        }
+
+        lifecycle.addObserver(object : LifecycleObserver {
+            @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+            fun onStop() {
+                if (isVisible) {
+                    userLeavingBrowserScreen()
+                }
+            }
+        })
+    }
+
+    fun userLeavingBrowserScreen() {
+        if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.TabSwitcherGrid)) {
+            updateOrDeleteWebViewPreview()
+        }
+    }
+
+    private fun updateOrDeleteWebViewPreview() {
+        val url = viewModel.url
+        Timber.d("Updating or deleting WebView preview for $url")
+        if (url == null) {
+            viewModel.deleteTabPreview(tabId)
+        } else {
+            generateWebViewPreviewImage()
         }
     }
 
@@ -452,23 +480,19 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             is Command.LaunchLegacyAddWidget -> launchLegacyAddWidget()
             is Command.RequiresAuthentication -> showAuthenticationDialog(it.request)
             is Command.SaveCredentials -> saveBasicAuthCredentials(it.request, it.credentials)
-            is Command.GenerateWebViewPreviewImage -> generateWebViewPreviewImage(it.forceImmediate)
+            is Command.GenerateWebViewPreviewImage -> generateWebViewPreviewImage()
             is Command.LaunchTabSwitcher -> launchTabSwitcher()
             is Command.LaunchTabSwitcherLegacy -> launchTabSwitcherLegacy()
         }
     }
 
-    private fun generateWebViewPreviewImage(forceImmediate: Boolean) {
+    private fun generateWebViewPreviewImage() {
         webView?.let { webView ->
 
             // if there's an existing job for generating a preview, cancel that in favor of the new request
             bitmapGeneratorJob?.cancel()
 
             bitmapGeneratorJob = launch {
-                if (!forceImmediate) {
-                    delay(WEBVIEW_PREVIEW_GENERATOR_DEBOUNCE_TIME_MS)
-                }
-
                 Timber.d("Generating WebView preview")
                 try {
                     val preview = previewGenerator.generatePreview(webView)
@@ -1021,8 +1045,6 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         private const val URL_BUNDLE_KEY = "url"
 
         private const val AUTHENTICATION_DIALOG_TAG = "AUTH_DIALOG_TAG"
-
-        private const val WEBVIEW_PREVIEW_GENERATOR_DEBOUNCE_TIME_MS = 1_000L
 
         fun newInstance(tabId: String, query: String? = null, skipHome: Boolean): BrowserTabFragment {
             val fragment = BrowserTabFragment()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -890,7 +890,6 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
         if (hidden) {
-            generateWebViewPreviewImage()
             viewModel.onViewHidden()
             webView?.onPause()
         } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -312,7 +312,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             onMenuItemClicked(view.forwardPopupMenuItem) { viewModel.onUserPressedForward() }
             onMenuItemClicked(view.backPopupMenuItem) { activity?.onBackPressed() }
             onMenuItemClicked(view.refreshPopupMenuItem) { refresh() }
-            onMenuItemClicked(view.newTabPopupMenuItem) { browserActivity?.launchNewTab() }
+            onMenuItemClicked(view.newTabPopupMenuItem) { viewModel.userRequestedOpeningNewTab() }
             onMenuItemClicked(view.bookmarksPopupMenuItem) { browserActivity?.launchBookmarks() }
             onMenuItemClicked(view.addBookmarksPopupMenuItem) { launch { viewModel.onBookmarkAddRequested() } }
             onMenuItemClicked(view.findInPageMenuItem) { viewModel.onFindInPageSelected() }
@@ -413,6 +413,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             is Command.OpenInNewBackgroundTab -> {
                 openInNewBackgroundTab()
             }
+            is Command.LaunchNewTab -> browserActivity?.launchNewTab()
             is Command.ShowBookmarkAddedConfirmation -> bookmarkAdded(it.bookmarkId, it.title, it.url)
             is Command.Navigate -> {
                 navigate(it.url)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -890,6 +890,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
         if (hidden) {
+            generateWebViewPreviewImage()
             viewModel.onViewHidden()
             webView?.onPause()
         } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -500,7 +500,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                     viewModel.updateTabPreview(tabId, fileName)
                     Timber.d("Saved and updated tab preview")
                 } catch (e: RuntimeException) {
-                    Timber.w(e, "Failed to generate WebView preview")
+                    Timber.d(e, "Failed to generate WebView preview")
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -158,6 +158,7 @@ class BrowserTabViewModel(
         object NavigateForward : Command()
         class OpenInNewTab(val query: String) : Command()
         class OpenInNewBackgroundTab(val query: String) : Command()
+        object LaunchNewTab : Command()
         object ResetHistory : Command()
         class DialNumber(val telephoneNumber: String) : Command()
         class SendSms(val telephoneNumber: String) : Command()
@@ -803,6 +804,11 @@ class BrowserTabViewModel(
                 Timber.w(throwable, "Failed to obtain favicon")
                 command.value = AddHomeShortcut(title, currentPage)
             })
+    }
+
+    fun userRequestedOpeningNewTab() {
+        command.value = GenerateWebViewPreviewImage
+        command.value = LaunchNewTab
     }
 
     fun onSurveyChanged(survey: Survey?) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -180,7 +180,7 @@ class BrowserTabViewModel(
         object LaunchLegacyAddWidget : Command()
         class RequiresAuthentication(val request: BasicAuthenticationRequest) : Command()
         class SaveCredentials(val request: BasicAuthenticationRequest, val credentials: BasicAuthenticationCredentials) : Command()
-        class GenerateWebViewPreviewImage() : Command()
+        object GenerateWebViewPreviewImage : Command()
         object LaunchTabSwitcher : Command()
         object LaunchTabSwitcherLegacy : Command()
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -180,7 +180,7 @@ class BrowserTabViewModel(
         object LaunchLegacyAddWidget : Command()
         class RequiresAuthentication(val request: BasicAuthenticationRequest) : Command()
         class SaveCredentials(val request: BasicAuthenticationRequest, val credentials: BasicAuthenticationCredentials) : Command()
-        class GenerateWebViewPreviewImage(val forceImmediate: Boolean) : Command()
+        class GenerateWebViewPreviewImage() : Command()
         object LaunchTabSwitcher : Command()
         object LaunchTabSwitcherLegacy : Command()
     }
@@ -501,10 +501,6 @@ class BrowserTabViewModel(
         val isLoading = newProgress < 100
         val progress = currentLoadingViewState()
         loadingViewState.value = progress.copy(isLoading = isLoading, progress = newProgress)
-
-        if (!isLoading && variantManager.getVariant().hasFeature(TabSwitcherGrid)) {
-            updateOrDeleteWebViewPreview(forceImmediate = false)
-        }
     }
 
     private fun registerSiteVisit() {
@@ -825,7 +821,7 @@ class BrowserTabViewModel(
         tabRepository.updateTabPreviewImage(tabId, fileName)
     }
 
-    private fun deleteTabPreview(tabId: String) {
+    fun deleteTabPreview(tabId: String) {
         tabRepository.updateTabPreviewImage(tabId, null)
     }
 
@@ -848,21 +844,9 @@ class BrowserTabViewModel(
 
     fun userLaunchingTabSwitcher() {
         if (variantManager.getVariant().hasFeature(TabSwitcherGrid)) {
-            updateOrDeleteWebViewPreview(forceImmediate = true)
-
             command.value = LaunchTabSwitcher
         } else {
             command.value = LaunchTabSwitcherLegacy
-        }
-    }
-
-    private fun updateOrDeleteWebViewPreview(forceImmediate: Boolean) {
-        val url = site?.url
-        Timber.d("Updating or deleting WebView preview for $url")
-        if (url == null) {
-            deleteTabPreview(tabId)
-        } else {
-            command.value = GenerateWebViewPreviewImage(forceImmediate)
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -379,6 +379,8 @@ class BrowserTabViewModel(
             return true
         }
 
+        Timber.d("User pressed back and tab is set to skip home; need to generate WebView preview now")
+        command.value = GenerateWebViewPreviewImage
         return false
     }
 
@@ -646,10 +648,12 @@ class BrowserTabViewModel(
 
         return when (requiredAction) {
             is RequiredAction.OpenInNewTab -> {
+                command.value = GenerateWebViewPreviewImage
                 command.value = OpenInNewTab(requiredAction.url)
                 true
             }
             is RequiredAction.OpenInNewBackgroundTab -> {
+                command.value = GenerateWebViewPreviewImage
                 viewModelScope.launch { openInNewBackgroundTab(requiredAction.url) }
                 true
             }

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -21,7 +21,7 @@ import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import timber.log.Timber
-import java.util.Locale
+import java.util.*
 
 @WorkerThread
 interface VariantManager {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1126768040926570/1140520481588209
Tech Design URL: 
CC: 

**Description**:
This fixes an issue whereby a page might be loaded in a tab (TAB A) but the callback for page loaded is fired before anything is visible, producing a blank WebView preview. This would normally be fine if the user hit the tab switcher button. But if they instead leave the app, then they might return to the app later launching another tab (TAB B). From TAB B, they could launch the tab switcher. TAB B preview would be re-generated, but TAB A would remain white.

This PR ensures the preview is generated when the user is leaving the screen altogether, and this removes the need to generate a bitmap every time the page loads.


**Steps to test this PR**:
1. Launch a tab, and browse to a site; **do not** hit the tab switcher
1. Hit the home button
1. Launch the app into a new tab (e.g, use the widget, long press the app for the new tab shortcut etc...)
1. Hit the tab switcher button
1. Verify the original tab preview is populated
1. Generally browse around, open new tabs, and verify the webview preview logic holds


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
