### PR TITLE
Parse IP:PORT query as a URL

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
@@ -126,6 +126,22 @@ class UriExtensionTest {
     }
 
     @Test
+    fun whenIpWithPortUriThenHasIpHostIsTrue() {
+        assertTrue(Uri.parse("https://54.229.105.203:999/something").hasIpHost)
+        assertTrue(Uri.parse("54.229.105.203:999/something").hasIpHost)
+    }
+
+    @Test
+    fun whenIpWithPortUriThenPortNumberParsedSuccessfully() {
+        assertEquals(999, Uri.parse("https://54.229.105.203:999/something").port)
+    }
+
+    @Test
+    fun whenValidIpAddressWithPortParsedWithSchemeThenPortNumberParsedSuccessfully(){
+        assertEquals(999, Uri.parse("121.33.2.11:999").withScheme().port)
+    }
+
+    @Test
     fun whenStandardUriThenHasIpHostIsFalse() {
         assertFalse(Uri.parse("http://example.com").hasIpHost)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriStringTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriStringTest.kt
@@ -16,10 +16,10 @@
 
 package com.duckduckgo.app.global
 
+import android.net.Uri
 import com.duckduckgo.app.global.UriString.Companion.isWebUrl
 import com.duckduckgo.app.global.UriString.Companion.sameOrSubdomain
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Test
 
 class UriStringTest {
@@ -72,6 +72,11 @@ class UriStringTest {
     }
 
     @Test
+    fun whenHostIsValidIpAddressWithPortThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("121.33.2.11:999"))
+    }
+
+    @Test
     fun whenHostIsLocalhostThenIsWebUrlIsTrue() {
         assertTrue(isWebUrl("localhost"))
     }
@@ -104,6 +109,11 @@ class UriStringTest {
     @Test
     fun whenSchemeIsValidIpAddressThenIsWebUrlIsTrue() {
         assertTrue(isWebUrl("http://121.33.2.11"))
+    }
+
+    @Test
+    fun whenSchemeIsValidIpAddressWithPortThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://121.33.2.11:999"))
     }
 
     @Test
@@ -164,6 +174,11 @@ class UriStringTest {
     @Test
     fun whenPathIsValidIpAddressThenIsWebUrlIsTrue() {
         assertTrue(isWebUrl("http://121.33.2.11/path"))
+    }
+
+    @Test
+    fun whenPathIsValidIpAddressWithPortThenIsWebUrlIsTrue() {
+        assertTrue(isWebUrl("http://121.33.2.11:999/path"))
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -19,8 +19,13 @@ import android.net.Uri
 import android.net.Uri.parse
 import com.duckduckgo.app.global.UrlScheme.Companion.http
 
+val IP_REGEX = Regex("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:[0-9]+)?$")
+
 fun Uri.withScheme(): Uri {
-    if (scheme == null) {
+    // Uri.parse function falsely parses IP:PORT string.
+    // For example if input is "255.255.255.255:9999", it falsely flags 255.255.255.255 as the scheme.
+    // Therefore in the withScheme method, we need to parse it after manually inserting "http".
+    if (scheme == null || scheme!!.matches(IP_REGEX)) {
         return parse("$http://${toString()}")
     }
 
@@ -45,8 +50,7 @@ val Uri.toHttps: Uri
 
 val Uri.hasIpHost: Boolean
     get() {
-        val ipRegex = Regex("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
-        return baseHost?.matches(ipRegex) ?: false
+        return baseHost?.matches(IP_REGEX) ?: false
     }
 
 fun Uri.isHttpsVersionOfUri(other: Uri): Boolean {


### PR DESCRIPTION
**Description**:
When a query with `IP:PORT` format entered in omnibar, the app performs search, instead of going to that address.

**Steps to test this PR**:
1. Run the app and enter an ip with port in `IP:PORT` format.
2. Ensure that the browser did not interpret that IP and port as a search query.