### PR TITLE
Fix improper floating hint text color (Issue #605)

### DIFF
--- a/app/src/main/res/layout/content_feedback_negative_broken_site_feedback.xml
+++ b/app/src/main/res/layout/content_feedback_negative_broken_site_feedback.xml
@@ -63,7 +63,7 @@
             android:layout_marginTop="65dp"
             android:layout_marginEnd="20dp"
             android:hint="@string/whichBrokenSitesHint"
-            app:hintTextAppearance="@style/FeedbackInputHintStyle"
+            app:hintTextAppearance="@android:style/TextAppearance"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/subtitle">
@@ -87,7 +87,7 @@
             android:layout_marginTop="16dp"
             android:layout_marginEnd="20dp"
             android:hint="@string/openEndedInputHint"
-            app:hintTextAppearance="@style/FeedbackInputHintStyle"
+            app:hintTextAppearance="@android:style/TextAppearance"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/brokenSiteInputContainer">

--- a/app/src/main/res/layout/content_feedback_open_ended_feedback.xml
+++ b/app/src/main/res/layout/content_feedback_open_ended_feedback.xml
@@ -64,7 +64,7 @@
             android:layout_marginTop="@dimen/feedbackTitleMarginTop"
             android:layout_marginEnd="20dp"
             android:hint="@string/openEndedInputHint"
-            app:hintTextAppearance="@style/FeedbackInputHintStyle"
+            app:hintTextAppearance="@android:style/TextAppearance"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/subtitle">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -259,13 +259,9 @@
         <item name="android:layout_height">match_parent</item>
     </style>
 
-    <style name="FeedbackInputHintStyle" parent="@android:style/TextAppearance">
-        <item name="android:textColorHint">@color/cornflowerBlue</item>
-        <item name="android:textColor">@color/cornflowerBlue</item>
-    </style>
-
     <style name="FeedbackInputBoxStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="boxStrokeColor">@color/cornflowerBlue</item>
+        <item name="hintTextColor">@color/cornflowerBlue</item>
         <item name="android:textColorHint">?attr/feedbackEditTextHintColor</item>
         <item name="boxBackgroundColor">?attr/feedbackEditTextBackgroundColor</item>
     </style>


### PR DESCRIPTION
Fix issue #605.  It is my understanding that hint colors cannot be changed from a `TextInputLayout`directly (since `TextInputLayout` extends `LinearLayout` and not `EditText`) unless it is sub-classed further, which seems like an unnecessary hassle.

To test this PR, verify that everything appears as intended on Dark and Light theme.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
