### PR TITLE
Add long click opens new tab functionality to tab switcher button

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -244,6 +244,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         configureAutoComplete()
         configureKeyboardAwareLogoAnimation()
         configureShowTabSwitcherListener()
+        configureLongClickOpensNewTabListener()
 
         if (savedInstanceState == null) {
             viewModel.onViewReady()
@@ -278,6 +279,13 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     private fun configureShowTabSwitcherListener() {
         tabsButton?.actionView?.setOnClickListener {
             launch { viewModel.userLaunchingTabSwitcher() }
+        }
+    }
+
+    private fun configureLongClickOpensNewTabListener() {
+        tabsButton?.actionView?.setOnLongClickListener {
+            launch { viewModel.userRequestedOpeningNewTab() }
+            return@setOnLongClickListener true
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/TabSwitcherButton.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/TabSwitcherButton.kt
@@ -44,6 +44,10 @@ class TabSwitcherButton(context: Context) : FrameLayout(context) {
         clickZone.setOnClickListener {
             super.callOnClick()
         }
+
+        clickZone.setOnLongClickListener {
+            super.performLongClick()
+        }
     }
 
     fun increment(callback: () -> Unit) {

--- a/app/src/main/res/layout/view_tab_switcher_button.xml
+++ b/app/src/main/res/layout/view_tab_switcher_button.xml
@@ -48,6 +48,7 @@
         android:layout_centerInParent="true"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:clickable="true"
+        android:longClickable="true"
         android:focusable="true" />
 
 </RelativeLayout>


### PR DESCRIPTION
Add "long click opens new tab" functionality to tab switcher button as per issue #607.

**Steps to test this PR**:
1. Verify that normal clicks on the tab switcher button work as intended.
2. Verify that long clicks open a new tab, with no unintended side effects.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
