### PR TITLE
Fix privacy grade

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -253,13 +253,13 @@ class BrowserTabViewModel(
 
         site = siteFactory.buildSite(url, title)
         onSiteChanged()
-        buildingSiteFactoryJob = viewModelScope.launch(Dispatchers.IO) {
+        buildingSiteFactoryJob = viewModelScope.launch {
             site?.let {
-                siteFactory.loadFullSiteDetails(it)
+                withContext(Dispatchers.IO) {
+                    siteFactory.loadFullSiteDetails(it)
+                }
+                onSiteChanged()
             }
-        }
-        site?.let {
-            onSiteChanged()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1145265836949881

**Description**:
https://github.com/duckduckgo/Android/pull/602 introduce a bug where the privacy grade was updated before being calculated in some instances.

**Steps to test this PR**:
1. Navigate using the browser and notice how the `?` symbol is not permanently displayed once a site has been loaded.
1. Make sure tests are not flakey and CI passes several times (usually 2 or 3 times is enough)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
