### PR TITLE
add pixel for fire button pressed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -269,7 +269,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
     }
 
     fun launchFire() {
-        pixel.fire(Pixel.PixelName.FORGET_ALL_PRESSED)
+        pixel.fire(Pixel.PixelName.FORGET_ALL_PRESSED_BROWSING)
         val dialog = FireDialog(context = this, clearPersonalDataAction = clearPersonalDataAction)
         dialog.clearStarted = {
             removeObservers()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -269,6 +269,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
     }
 
     fun launchFire() {
+        pixel.fire(Pixel.PixelName.FORGET_ALL_PRESSED)
         val dialog = FireDialog(context = this, clearPersonalDataAction = clearPersonalDataAction)
         dialog.clearStarted = {
             removeObservers()

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -32,6 +32,8 @@ interface Pixel {
     enum class PixelName(val pixelName: String) {
 
         APP_LAUNCH("ml"),
+
+        FORGET_ALL_PRESSED("mf_p"),
         FORGET_ALL_EXECUTED("mf"),
 
         APPLICATION_CRASH("m_d_ac"),

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -33,7 +33,8 @@ interface Pixel {
 
         APP_LAUNCH("ml"),
 
-        FORGET_ALL_PRESSED("mf_p"),
+        FORGET_ALL_PRESSED_BROWSING("mf_bp"),
+        FORGET_ALL_PRESSED_TABSWITCHING("mf_tp"),
         FORGET_ALL_EXECUTED("mf"),
 
         APPLICATION_CRASH("m_d_ac"),

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.global.view.ClearPersonalDataAction
 import com.duckduckgo.app.global.view.FireDialog
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.Close
@@ -62,6 +63,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     @Inject
     lateinit var webViewPreviewPersister: WebViewPreviewPersister
+
+    @Inject
+    lateinit var pixel: Pixel
 
     private val viewModel: TabSwitcherViewModel by bindViewModel()
 
@@ -165,6 +169,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun onFire() {
+        pixel.fire(Pixel.PixelName.FORGET_ALL_PRESSED_TABSWITCHING)
         val dialog = FireDialog(context = this, clearPersonalDataAction = clearPersonalDataAction)
         dialog.clearComplete = { viewModel.onClearComplete() }
         dialog.show()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1147336208469615
Tech Design URL: 
CC: 

**Description**:

Adds a pixel for when the fire button is pressed so we can see what level of conversion there is.

**Steps to test this PR**:
1. From the browser/home screen press the fire button, check Kibana for the `mf.bp` pixel.
1. From the tab switcher press the fire button, check Kibana for the `mf.tp` pixel.
1. Check Grafana


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
