### PR TITLE
Make call to `onSiteChanged` safe for any thread to call

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/CoroutineTestRule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/CoroutineTestRule.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.app
 
+import com.duckduckgo.app.global.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -25,9 +27,15 @@ import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
-class CoroutineTestRule(
-    private val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
-) : TestWatcher() {
+class CoroutineTestRule(val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()) : TestWatcher() {
+
+    val testDispatcherProvider = object : DispatcherProvider {
+        override fun default(): CoroutineDispatcher = testDispatcher
+        override fun io(): CoroutineDispatcher = testDispatcher
+        override fun main(): CoroutineDispatcher = testDispatcher
+        override fun unconfined(): CoroutineDispatcher = testDispatcher
+
+    }
 
     override fun starting(description: Description?) {
         super.starting(description)

--- a/app/src/main/java/com/duckduckgo/app/global/DispatcherProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DispatcherProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+
+interface DispatcherProvider {
+
+    fun main(): CoroutineDispatcher = Dispatchers.Main
+    fun default(): CoroutineDispatcher = Dispatchers.Default
+    fun io(): CoroutineDispatcher = Dispatchers.IO
+    fun unconfined(): CoroutineDispatcher = Dispatchers.Unconfined
+
+}
+
+class DefaultDispatcherProvider : DispatcherProvider


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/276630244458377/1147610969828114
Tech Design URL: 
CC: 

**Description**:
Ensures `onSiteChanged()` (which contains an expensive operation) is safe to call on the main thread (or any thread).

We might want to consider making this function a `suspend` function later, but that would result in a much larger change footprint. For now, it uses `coroutines` under the hood, and introduces some changes to the way in which we make coroutine-using code more testable

- Injects dispatchers into view model instead of having them be hardcoded
- Introduces a `DispatcherProvider` interface, which is used to grab a dispatcher (or uses the `TestCoroutineDispatcher` during tests)
- Makes use of the new `runBlockingTest` from the coroutines test library
(as per advice from here: https://www.youtube.com/watch?v=KMb0Fs8rCRs)

**Steps to test this PR**:
1. Run the tests, repeatedly, on a few different devices. Previously, fixes were made around this code to eliminate flakey tests, so we want to be sure I haven't re-introduced any instability in this area
1. Ensure the privacy grade and site information is updated correctly when browsing the web. Ensure the `?` always resolves to be a letter.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
