### PR TITLE
Add devMode parameter onto PixelService requests

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/ApiBasedPixelTest.kt
@@ -49,7 +49,7 @@ class ApiBasedPixelTest {
 
     @Test
     fun whenPixelFiredThenPixelServiceCalledWithCorrectAtbAndVariant() {
-        whenever(mockPixelService.fire(any(), any(), any(), anyOrNull())).thenReturn(Completable.complete())
+        configurePixelFireIsSuccessful()
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", filterBy = { true }))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
@@ -57,12 +57,12 @@ class ApiBasedPixelTest {
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(PRIVACY_DASHBOARD_OPENED)
 
-        verify(mockPixelService).fire(eq("mp"), eq("phone"), eq("atbvariant"), any())
+        verify(mockPixelService).fire(eq("mp"), eq("phone"), eq("atbvariant"), any(), any())
     }
 
     @Test
     fun whenPixelFiredThenPixelServiceCalledWithCorrectAtb() {
-        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockPixelService.fire(any(), any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.DEFAULT_VARIANT)
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
@@ -70,34 +70,34 @@ class ApiBasedPixelTest {
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(FORGET_ALL_EXECUTED)
 
-        verify(mockPixelService).fire(eq("mf"), eq("phone"), eq("atb"), any())
+        verify(mockPixelService).fire(eq("mf"), eq("phone"), eq("atb"), any(), any())
     }
 
     @Test
     fun whenPixelFiredTabletFormFactorThenPixelServiceCalledWithTabletParameter() {
-        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockPixelService.fire(any(), any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.TABLET)
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(APP_LAUNCH)
 
-        verify(mockPixelService).fire(eq("ml"), eq("tablet"), eq(""), any())
+        verify(mockPixelService).fire(eq("ml"), eq("tablet"), eq(""), any(), any())
     }
 
     @Test
     fun whenPixelFiredWithNoAtbThenPixelServiceCalledWithCorrectPixelNameAndNoAtb() {
-        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockPixelService.fire(any(), any(), any(), any(), any())).thenReturn(Completable.complete())
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
 
         val pixel = ApiBasedPixel(mockPixelService, mockStatisticsDataStore, mockVariantManager, mockDeviceInfo)
         pixel.fire(APP_LAUNCH)
 
-        verify(mockPixelService).fire(eq("ml"), eq("phone"), eq(""), any())
+        verify(mockPixelService).fire(eq("ml"), eq("phone"), eq(""), any(), any())
     }
 
     @Test
     fun whenPixelFiredWithAdditionalParametersThenPixelServiceCalledWithDefaultAndAdditionalParameters() {
-        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
+        configurePixelFireIsSuccessful()
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", filterBy = { true }))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
@@ -113,7 +113,7 @@ class ApiBasedPixelTest {
 
     @Test
     fun whenPixelFiredWithoutAdditionalParametersThenPixelServiceCalledWithOnlyDefaultParameters() {
-        whenever(mockPixelService.fire(any(), any(), any(), any())).thenReturn(Completable.complete())
+        configurePixelFireIsSuccessful()
         whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", filterBy = { true }))
         whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
@@ -124,5 +124,9 @@ class ApiBasedPixelTest {
         pixel.fire(PRIVACY_DASHBOARD_OPENED)
         val expectedParams = mapOf("appVersion" to "1.0.0")
         verify(mockPixelService).fire("mp", "phone", "atbvariant", expectedParams)
+    }
+
+    private fun configurePixelFireIsSuccessful() {
+        whenever(mockPixelService.fire(any(), any(), any(), anyOrNull(), any())).thenReturn(Completable.complete())
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.statistics.api
 
+import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.global.AppUrl
 import io.reactivex.Completable
 import retrofit2.http.GET
@@ -30,6 +31,7 @@ interface PixelService {
         @Path("pixelName") pixelName: String,
         @Path("formFactor") formFactor: String,
         @Query(AppUrl.ParamKey.ATB) atb: String,
-        @QueryMap additionalQueryParams: Map<String, String?> = emptyMap()
+        @QueryMap additionalQueryParams: Map<String, String?> = emptyMap(),
+        @Query(AppUrl.ParamKey.DEV_MODE) devMode: Int? = if (BuildConfig.DEBUG) 1 else null
     ): Completable
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/608920331025313/1148562571541097/1148555304057513
Tech Design URL: 
CC: 

**Description**:
Adds `test=1` as query parameter to pixels

**Steps to test this PR**:
1. Send a pixel in `DEBUG` mode; verify `test=1` flag is added to request


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
