### PR TITLE
For the global exception catcher, use `runBlocking` to preserve exception handling behavior

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
@@ -30,12 +30,15 @@ class AlertingUncaughtExceptionHandler(
 ) : Thread.UncaughtExceptionHandler {
 
     override fun uncaughtException(t: Thread?, originalException: Throwable?) {
+
+        // block until the exception has been fully processed
         runBlocking {
             withContext(Dispatchers.IO) {
                 uncaughtExceptionRepository.recordUncaughtException(originalException, UncaughtExceptionSource.GLOBAL)
                 offlinePixelCountDataStore.applicationCrashCount += 1
-                originalHandler.uncaughtException(t, originalException)
             }
         }
+        originalHandler.uncaughtException(t, originalException)
     }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1149245630738707
Tech Design URL: 
CC: 

**Description**:
With the use of `GlobalScope.launch`, we'd potentially be allowing some other code to run after this exception had been thrown, and before the uncaughtException function here had fully executed. Use of `runBlocking` to ensure execution waits for this function to complete makes more sense and it is likely to result in less unpredictable issues.

**Steps to test this PR**:
1. Trigger an exception that is otherwise uncaught, and ensure no execution continues on that thread after the exception has been thrown


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
