### PR TITLE
Add safer null handling around WebView copyBackForwardList calls

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/navigation/WebViewBackForwardListSafeExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/navigation/WebViewBackForwardListSafeExtractorTest.kt
@@ -21,30 +21,26 @@ import android.webkit.WebBackForwardList
 import android.webkit.WebView
 import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 class WebViewBackForwardListSafeExtractorTest {
 
-    @UiThreadTest
-    @Test(expected = NullPointerException::class)
-    fun whenCopyBackForwardListCalledTestWebViewThrowsException() {
-        val testWebView = TestWebViewThrowsNullPointerException(getInstrumentation().targetContext)
-        testWebView.copyBackForwardList()
-    }
+    private val context = getInstrumentation().targetContext
 
     @UiThreadTest
     @Test
     fun whenCopyBackForwardListCalledAndExceptionThrownThenNavigationListIsNull() {
-        val testWebView = TestWebViewThrowsNullPointerException(getInstrumentation().targetContext)
+        val testWebView = TestWebViewThrowsNullPointerException(context)
         assertNull(testWebView.safeCopyBackForwardList())
     }
 
     @UiThreadTest
     @Test
     fun whenCopyBackForwardListCalledAndNoExceptionThrownThenNavigationListIsNotNull() {
-        val testWebView = TestWebViewThrowsNullPointerException(getInstrumentation().targetContext)
-        assertNull(testWebView.safeCopyBackForwardList())
+        val testWebView = WebView(context)
+        assertNotNull(testWebView.safeCopyBackForwardList())
     }
 }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/navigation/WebViewBackForwardListSafeExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/navigation/WebViewBackForwardListSafeExtractorTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.navigation
+
+import android.content.Context
+import android.webkit.WebBackForwardList
+import android.webkit.WebView
+import androidx.test.annotation.UiThreadTest
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WebViewBackForwardListSafeExtractorTest {
+
+    @UiThreadTest
+    @Test(expected = NullPointerException::class)
+    fun whenCopyBackForwardListCalledTestWebViewThrowsException() {
+        val testWebView = TestWebViewThrowsNullPointerException(getInstrumentation().targetContext)
+        testWebView.copyBackForwardList()
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenCopyBackForwardListCalledAndExceptionThrownThenNavigationListIsNull() {
+        val testWebView = TestWebViewThrowsNullPointerException(getInstrumentation().targetContext)
+        assertNull(testWebView.safeCopyBackForwardList())
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenCopyBackForwardListCalledAndNoExceptionThrownThenNavigationListIsNotNull() {
+        val testWebView = TestWebViewThrowsNullPointerException(getInstrumentation().targetContext)
+        assertNull(testWebView.safeCopyBackForwardList())
+    }
+}
+
+class TestWebViewThrowsNullPointerException(context: Context) : WebView(context) {
+
+    override fun copyBackForwardList(): WebBackForwardList {
+        throw NullPointerException("Deliberate")
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -21,6 +21,7 @@ import android.view.View
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource.*
 import kotlinx.coroutines.*
@@ -75,7 +76,7 @@ class BrowserChromeClient @Inject constructor(private val uncaughtExceptionRepos
     override fun onProgressChanged(webView: WebView, newProgress: Int) {
         try {
             Timber.d("onProgressChanged ${webView.url}, $newProgress")
-            val navigationList = webView.copyBackForwardList()
+            val navigationList = webView.safeCopyBackForwardList() ?: return
             webViewClientListener?.navigationStateChanged(WebViewNavigationState(navigationList))
             webViewClientListener?.progressChanged(newProgress)
         } catch (e: Throwable) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -627,7 +627,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         }
 
         viewModel.privacyGrade.observe(this, Observer<PrivacyGrade> {
-            Timber.i("Observed grade: $it")
+            Timber.d("Observed grade: $it")
             it?.let { privacyGrade ->
                 val drawable = context?.getDrawable(privacyGrade.icon()) ?: return@let
                 privacyGradeButton?.setImageDrawable(drawable)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -26,6 +26,7 @@ import androidx.annotation.WorkerThread
 import com.duckduckgo.app.browser.BrowserWebViewClient.RequestOrigin.MainFrame
 import com.duckduckgo.app.browser.BrowserWebViewClient.RequestOrigin.SubFrame
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
+import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource.*
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
@@ -88,7 +89,8 @@ class BrowserWebViewClient(
     @UiThread
     override fun onPageStarted(webView: WebView, url: String?, favicon: Bitmap?) {
         try {
-            webViewClientListener?.navigationStateChanged(WebViewNavigationState(webView.copyBackForwardList()))
+            val navigationList = webView.safeCopyBackForwardList() ?: return
+            webViewClientListener?.navigationStateChanged(WebViewNavigationState(navigationList))
             if (url != null && url == lastPageStarted) {
                 webViewClientListener?.pageRefreshed(url)
             }
@@ -104,7 +106,8 @@ class BrowserWebViewClient(
     @UiThread
     override fun onPageFinished(webView: WebView, url: String?) {
         try {
-            webViewClientListener?.navigationStateChanged(WebViewNavigationState(webView.copyBackForwardList()))
+            val navigationList = webView.safeCopyBackForwardList() ?: return
+            webViewClientListener?.navigationStateChanged(WebViewNavigationState(navigationList))
         } catch (e: Throwable) {
             GlobalScope.launch {
                 uncaughtExceptionRepository.recordUncaughtException(e, ON_PAGE_FINISHED)

--- a/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
@@ -132,6 +132,6 @@ private val WebBackForwardList.isHttpsUpgrade: Boolean
     get() {
         if (currentIndex < 1) return false
         val current = originalUrl?.toUri() ?: return false
-        val previous = getItemAtIndex(currentIndex - 1).originalUrl?.toUri() ?: return false
+        val previous = getItemAtIndex(currentIndex - 1)?.originalUrl?.toUri() ?: return false
         return current.isHttpsVersionOfUri(previous)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/WebViewBackForwardListSafeExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/WebViewBackForwardListSafeExtractor.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.navigation
+
+import android.webkit.WebBackForwardList
+import android.webkit.WebView
+import timber.log.Timber
+
+/**
+ * There is a bug in WebView whereby `webView.copyBackForwardList()` can internally throw a NPE
+ *
+ * This extension function can be used as a direct replacement of `copyBackForwardList()`
+ * It will catch the NullPointerException and return `null` when it happens.
+ *
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=498796
+ */
+fun WebView.safeCopyBackForwardList(): WebBackForwardList? {
+    return try {
+        copyBackForwardList()
+    } catch (e: NullPointerException) {
+
+        Timber.e(e, "Failed to extract WebView back forward list")
+        null
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/WebViewBackForwardListSafeExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/WebViewBackForwardListSafeExtractor.kt
@@ -32,7 +32,6 @@ fun WebView.safeCopyBackForwardList(): WebBackForwardList? {
     return try {
         copyBackForwardList()
     } catch (e: NullPointerException) {
-
         Timber.e(e, "Failed to extract WebView back forward list")
         null
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
 - https://app.asana.com/0/0/1148502601574098
 - https://app.asana.com/0/0/1148504523095289

Tech Design URL: 
CC: 

**Description**:
Adds safer handling around access to `WebView`'s `copyBackForwardList` calls

**Steps to test this PR**:
1. With no easy way to replicate this for real, you might want to hack a line into `WebViewBackForwardListSafeExtractor` which randomly throws a `NullPointerException`, and check the app handles that happening. This should be a fair test 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
