### PR TITLE
Feature/craig/close streams after writing

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewPersister.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewPersister.kt
@@ -90,10 +90,10 @@ class FileBasedWebViewPreviewPersister(val context: Context, private val fileDel
     }
 
     private fun writeBytesToFile(previewFile: File, bitmap: Bitmap) {
-        val outputStream = FileOutputStream(previewFile)
-        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
-        outputStream.flush()
-        outputStream.close()
+        val outputStream = FileOutputStream(previewFile).use { outputStream ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+            outputStream.flush()
+        }
     }
 
     private fun previewDestinationDirectory(): File {

--- a/app/src/main/java/com/duckduckgo/app/global/store/BinaryDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/store/BinaryDataStore.kt
@@ -28,7 +28,7 @@ class BinaryDataStore @Inject constructor(private val context: Context) {
         context.openFileInput(name).use { it.readBytes() }
 
     fun saveData(name: String, byteArray: ByteArray) {
-        context.openFileOutput(name, Context.MODE_PRIVATE).write(byteArray)
+        context.openFileOutput(name, Context.MODE_PRIVATE).use { it.write(byteArray) }
     }
 
     fun clearData(name: String) {

--- a/app/src/main/java/com/duckduckgo/app/surrogates/ResourceSurrogateLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/surrogates/ResourceSurrogateLoader.kt
@@ -46,13 +46,7 @@ class ResourceSurrogateLoader @Inject constructor(
 
     private fun parse(bytes: ByteArray): List<SurrogateResponse> {
         val surrogates = mutableListOf<SurrogateResponse>()
-
-        val reader = ByteArrayInputStream(bytes).bufferedReader()
-        val existingLines = reader.readLines().toMutableList()
-
-        if (existingLines.isNotEmpty() && existingLines.last().isNotBlank()) {
-            existingLines.add("")
-        }
+        val existingLines = readExistingLines(bytes)
 
         var nextLineIsNewRule = true
 
@@ -98,5 +92,16 @@ class ResourceSurrogateLoader @Inject constructor(
 
         Timber.d("Processed ${surrogates.size} surrogates")
         return surrogates
+    }
+
+    private fun readExistingLines(bytes: ByteArray): List<String> {
+        val existingLines = ByteArrayInputStream(bytes).bufferedReader().use { reader ->
+            reader.readLines().toMutableList()
+        }
+
+        if (existingLines.isNotEmpty() && existingLines.last().isNotBlank()) {
+            existingLines.add("")
+        }
+        return existingLines
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/surrogates/store/ResourceSurrogateDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/surrogates/store/ResourceSurrogateDataStore.kt
@@ -27,7 +27,7 @@ class ResourceSurrogateDataStore @Inject constructor(private val context: Contex
         context.openFileInput(FILENAME).use { it.readBytes() }
 
     fun saveData(byteArray: ByteArray) {
-        context.openFileOutput(FILENAME, Context.MODE_PRIVATE).write(byteArray)
+        context.openFileOutput(FILENAME, Context.MODE_PRIVATE).use { it.write(byteArray) }
     }
 
     fun clearData() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/608920331025315/1149977072638385
Tech Design URL: 
CC: 

**Description**:
Tidy up to ensure streams are always closed after they've been used

**Steps to test this PR**:
1. Run the app, and allow a sync to complete. Verify that `A resource failed to call close` **doesn't** appear in the logs. This appeared before this PR, as we were leaving a file output stream open.
1. Browse to any site, and switch to tab switcher. Verify the tab preview generates normally.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
