### PR TITLE
Ensure cookies are flushed and ddg cookies saved on clear

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser
 
 import android.content.Context
 import android.os.Build
+import android.webkit.CookieManager
 import android.webkit.HttpAuthHandler
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
@@ -39,6 +40,7 @@ class BrowserWebViewClientTest {
     private val specialUrlDetector: SpecialUrlDetector = mock()
     private val requestInterceptor: RequestInterceptor = mock()
     private val listener: WebViewClientListener = mock()
+    private val cookieManager: CookieManager = mock()
     private val offlinePixelCountDataStore: OfflinePixelCountDataStore = mock()
     private val uncaughtExceptionRepository: UncaughtExceptionRepository = mock()
     private val mainFrameUrlHandler: SpecialUrlHandler = mock()
@@ -54,7 +56,8 @@ class BrowserWebViewClientTest {
             offlinePixelCountDataStore,
             uncaughtExceptionRepository,
             mainFrameUrlHandler,
-            subFrameUrlHandler
+            subFrameUrlHandler,
+            cookieManager
         )
         testee.webViewClientListener = listener
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -46,7 +46,7 @@ class WebViewDataManager @Inject constructor(
         clearFormData(webView, webViewDatabase)
         clearAuthentication(webViewDatabase)
         clearExternalCookies()
-        clearWebViewDirectory(exclusions = WEBVIEW_FILES_EXCLUDED_FROM_DELETION)
+        clearWebViewDirectories(exclusions = WEBVIEW_FILES_EXCLUDED_FROM_DELETION)
     }
 
     private fun clearWebViewCache(webView: WebView) {
@@ -69,9 +69,10 @@ class WebViewDataManager @Inject constructor(
         }
     }
 
-    private suspend fun clearWebViewDirectory(exclusions: List<String>) {
-        val webViewDataDirectory = File(context.applicationInfo.dataDir, WEBVIEW_DATA_DIRECTORY_NAME)
-        fileDeleter.deleteContents(webViewDataDirectory, exclusions)
+    private suspend fun clearWebViewDirectories(exclusions: List<String>) {
+        val dataDir = context.applicationInfo.dataDir
+        fileDeleter.deleteContents(File(dataDir, WEBVIEW_DATA_DIRECTORY_NAME), exclusions)
+        fileDeleter.deleteContents(File(dataDir, WEBVIEW_DEFAULT_DIRECTORY_NAME), exclusions)
     }
 
     /**
@@ -96,8 +97,10 @@ class WebViewDataManager @Inject constructor(
 
     companion object {
         private const val WEBVIEW_DATA_DIRECTORY_NAME = "app_webview"
+        private const val WEBVIEW_DEFAULT_DIRECTORY_NAME = "app_webview/Default"
 
         private val WEBVIEW_FILES_EXCLUDED_FROM_DELETION = listOf(
+            "Default",
             "Cookies"
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -69,9 +69,17 @@ class WebViewDataManager @Inject constructor(
         }
     }
 
+    /**
+     * Deletes web view directory content. The Cookies file is kept as we clear cookies separately to avoid a crash and maintain ddg cookies.
+     * Cookies may appear in files:
+     *   app_webview/Cookies
+     *   app_webview/Default/Cookies
+     */
     private suspend fun clearWebViewDirectories(exclusions: List<String>) {
         val dataDir = context.applicationInfo.dataDir
         fileDeleter.deleteContents(File(dataDir, WEBVIEW_DATA_DIRECTORY_NAME), exclusions)
+
+        // We don't delete the Default dir as Cookies may be inside however we do clear any other content
         fileDeleter.deleteContents(File(dataDir, WEBVIEW_DEFAULT_DIRECTORY_NAME), exclusions)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -70,7 +70,8 @@ class BrowserModule {
         offlinePixelCountDataStore: OfflinePixelCountDataStore,
         uncaughtExceptionRepository: UncaughtExceptionRepository,
         @Named(SpecialUrlHandler.MAIN_FRAME_HANDLER) mainFrameUrlHandler: SpecialUrlHandler,
-        @Named(SpecialUrlHandler.SUB_FRAME_HANDLER) subFrameUrlHandler: SpecialUrlHandler
+        @Named(SpecialUrlHandler.SUB_FRAME_HANDLER) subFrameUrlHandler: SpecialUrlHandler,
+        cookieManager: CookieManager
     ): BrowserWebViewClient {
         return BrowserWebViewClient(
             specialUrlDetector,
@@ -78,7 +79,8 @@ class BrowserModule {
             offlinePixelCountDataStore,
             uncaughtExceptionRepository,
             mainFrameUrlHandler,
-            subFrameUrlHandler
+            subFrameUrlHandler,
+            cookieManager
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -29,7 +29,6 @@ class TabSwitcherViewModel(private val tabRepository: TabRepository, private val
 
     var tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
-    var selectedTab: LiveData<TabEntity> = tabRepository.liveSelectedTab
 
     sealed class Command {
         data class DisplayMessage(@StringRes val messageId: Int) : Command()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1147449930490345

**Description**:
Fixes issue where cookies are lost when app killed and ddg settings cookies are not maintained when fire pressed.

**Setup**
Get a device running the latest version of Chrome and confirm it is suffering the cookie loss issue:
1. From develop branch, visit duckduckgo.com and change the SERP theme to something different e.g Terminal
1. Press the fire button
1. Visit the SERP and note the theme is not persisted
1. Now switch to this branch ready to test

**Test DGG cookies maintained on app kill and after fire**
1. Visit the SERP and change the theme to something different e.g Terminal
1. Kill the app, launch it again
1. Visit the SERP and ensure the theme still persists
1. Press the fire button
1. Visit the SERP and ensure the theme still persists

**Test other cookies maintained on app kill and cleared after fire**
1. Visit a site that requires a login e.g facebook.com and login
1. Kill the app and launch it again
1. Ensure you are still logged in
1. Press the fire button
1. Visit the site again and ensure your are logged out.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
