### PR TITLE
Allow users to recover from WebView renderer failures

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1122,7 +1122,9 @@ class BrowserTabViewModelTest {
 
         showErrorWithAction.action()
 
-        assertCommandIssued<Command.OpenInNewTab>()
+        assertCommandIssued<Command.OpenInNewTab> {
+            assertEquals("https://example.com", query)
+        }
     }
 
     @Test
@@ -1278,10 +1280,11 @@ class BrowserTabViewModelTest {
         verify(mockCommandObserver, never()).onChanged(commandCaptor.capture())
     }
 
-    private inline fun <reified T : Command> assertCommandIssued() {
+    private inline fun <reified T : Command> assertCommandIssued(instanceAssertions: T.() -> Unit = {}) {
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         val issuedCommand = commandCaptor.allValues.find { it is T }
         assertNotNull(issuedCommand)
+        (issuedCommand as T).apply { instanceAssertions() }
     }
 
     private fun pixelParams(showedBookmarks: Boolean, bookmarkCapable: Boolean) = mapOf(

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -298,7 +298,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenInvalidatedGlobalLayoutRestoredAndVisibleThenErrorIsShown() {
+    fun whenInvalidatedGlobalLayoutRestoredThenErrorIsShown() {
         givenInvalidatedGlobalLayout()
         testee.onViewVisible()
         assertCommandIssued<Command.ShowErrorWithAction>()

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -300,6 +300,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenInvalidatedGlobalLayoutRestoredThenErrorIsShown() {
         givenInvalidatedGlobalLayout()
+        setBrowserShowing(true)
         testee.onViewVisible()
         assertCommandIssued<Command.ShowErrorWithAction>()
     }
@@ -834,6 +835,15 @@ class BrowserTabViewModelTest {
         assertTrue(browserViewState().canGoForward)
     }
 
+    @Test
+    fun whenHomeShowingByPressingBackOnInvalidatedBrowserThenForwardButtonInactive() {
+        setupNavigation(isBrowsing = true)
+        givenInvalidatedGlobalLayout()
+        testee.onUserPressedBack()
+        assertFalse(browserViewState().browserShowing)
+        assertFalse(browserViewState().canGoForward)
+    }
+    
     @Test
     fun whenBrowserShowingAndCanGoForwardThenForwardButtonActive() {
         setupNavigation(isBrowsing = true, canGoForward = true)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -117,6 +117,15 @@ class BrowserWebViewClientTest {
         verify(offlinePixelCountDataStore, times(1)).webRendererGoneKilledCount = 1
     }
 
+    @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
+    fun whenRenderProcessGoneThenEmitEventIntoListener() {
+        val detail: RenderProcessGoneDetail = mock()
+        whenever(detail.didCrash()).thenReturn(true)
+        testee.onRenderProcessGone(webView, detail)
+        verify(listener, times(1)).recoverFromRenderProcessGone()
+    }
+
     private class TestWebView(context: Context) : WebView(context)
 
     companion object {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/EmptyNavigationStateTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/EmptyNavigationStateTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class EmptyNavigationStateTest {
+
+    @Test
+    fun whenEmptyNavigationStateFromNavigationStateThenBrowserPropertiesAreTheSame() {
+        val previousState = buildState("originalUrl", "currentUrl", "titlle")
+        val emptyNavigationState = EmptyNavigationState(previousState)
+
+        assertEquals(emptyNavigationState.currentUrl, previousState.currentUrl)
+        assertEquals(emptyNavigationState.originalUrl, previousState.originalUrl)
+        assertEquals(emptyNavigationState.title, previousState.title)
+    }
+
+    @Test
+    fun whenEmptyNavigationStateFromNavigationStateThenNavigationPropertiesAreCleared() {
+        val emptyNavigationState = EmptyNavigationState(buildState("originalUrl", "currentUrl", "titlle"))
+
+        assertEquals(emptyNavigationState.stepsToPreviousPage, 0)
+        assertFalse(emptyNavigationState.canGoBack)
+        assertFalse(emptyNavigationState.canGoForward)
+        assertFalse(emptyNavigationState.hasNavigationHistory)
+    }
+
+    private fun buildState(originalUrl: String?, currentUrl: String?, title: String? = null): WebNavigationState {
+        return TestNavigationState(
+            originalUrl = originalUrl,
+            currentUrl = currentUrl,
+            title = title,
+            stepsToPreviousPage = 1,
+            canGoBack = true,
+            canGoForward = true,
+            hasNavigationHistory = true
+        )
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/TestNavigationState.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/TestNavigationState.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+data class TestNavigationState(
+    override val originalUrl: String?,
+    override val currentUrl: String?,
+    override val title: String?,
+    override val stepsToPreviousPage: Int,
+    override val canGoBack: Boolean,
+    override val canGoForward: Boolean,
+    override val hasNavigationHistory: Boolean
+) : WebNavigationState

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebNavigationStateTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebNavigationStateTest.kt
@@ -92,13 +92,6 @@ class WebNavigationStateComparisonTest {
     }
 
     @Test
-    fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestContainsSameOriginalUrlAndNoCurrentUrlThenCompareReturnsOther() {
-        val previousState = buildState("http://same.com", "http://subdomain.previous.com")
-        val latestState = buildState("http://same.com", null)
-        assertEquals(Other, latestState.compare(previousState))
-    }
-
-    @Test
     fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestStateContainsNoOriginalUrlAndNoCurrentUrlThenCompareReturnsPageCleared() {
         val previousState = buildState("http://previous.com", "http://subdomain.previous.com")
         val latestState = buildState(null, null)
@@ -110,6 +103,20 @@ class WebNavigationStateComparisonTest {
         val previousState = buildState("http://previous.com", "http://subdomain.previous.com")
         val latestState = buildState(null, "http://subdomain.latest.com")
         assertEquals(PageCleared, latestState.compare(previousState))
+    }
+
+    @Test
+    fun whenLatestStateIsEmptyNavigationCompareReturnsPageNavigationCleared() {
+        val previousState = buildState("http://previous.com", "http://subdomain.previous.com")
+        val latestState = EmptyNavigationState(previousState)
+        assertEquals(PageNavigationCleared, latestState.compare(previousState))
+    }
+
+    @Test
+    fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestContainsSameOriginalUrlAndNoCurrentUrlThenCompareReturnsOther() {
+        val previousState = buildState("http://same.com", "http://subdomain.previous.com")
+        val latestState = buildState("http://same.com", null)
+        assertEquals(Other, latestState.compare(previousState))
     }
 
     @Test
@@ -131,13 +138,3 @@ class WebNavigationStateComparisonTest {
         )
     }
 }
-
-data class TestNavigationState(
-    override val originalUrl: String?,
-    override val currentUrl: String?,
-    override val title: String?,
-    override val stepsToPreviousPage: Int,
-    override val canGoBack: Boolean,
-    override val canGoForward: Boolean,
-    override val hasNavigationHistory: Boolean
-) : WebNavigationState

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -244,7 +244,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
         Timber.i("Processing command: $command")
         when (command) {
             is Query -> currentTab?.submitQuery(command.query)
-            is Refresh -> currentTab?.refresh()
+            is Refresh -> currentTab?.onRefreshRequested()
             is Command.DisplayMessage -> applicationContext?.longToast(command.messageId)
             is Command.LaunchPlayStore -> launchPlayStore()
             is Command.ShowAppEnjoymentPrompt -> showAppEnjoymentPrompt(AppEnjoymentDialogFragment.create(command.promptCount, viewModel))

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -379,6 +379,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     }
 
     private fun showHome() {
+        errorSnackbar.dismiss()
         newTabLayout.show()
         showKeyboardImmediately()
         appBarLayout.setExpanded(true)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1202,6 +1202,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 addBookmarksPopupMenuItem?.isEnabled = viewState.canAddBookmarks
                 sharePageMenuItem?.isEnabled = viewState.canSharePage
                 brokenSitePopupMenuItem?.isEnabled = viewState.canReportSite
+                requestDesktopSiteCheckMenuItem?.isEnabled = viewState.canChangeBrowsingMode
 
                 addToHome?.let {
                     it.visibility = if (viewState.addToHomeVisible) VISIBLE else GONE

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -204,7 +204,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     private var webView: WebView? = null
 
     private val errorSnackbar: Snackbar by lazy {
-        Snackbar.make(rootView, "The webpage could not be displayed.", Snackbar.LENGTH_INDEFINITE)
+        Snackbar.make(rootView, R.string.crashedWebViewErrorMessage, Snackbar.LENGTH_INDEFINITE)
             .setBehavior(NonDismissibleBehavior())
     }
 
@@ -495,8 +495,9 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     }
 
     private fun showErrorSnackbar(command: Command.ShowErrorWithAction) {
-        if (!errorSnackbar.view.isAttachedToWindow) {
-            errorSnackbar.setAction("Reload") { command.action() }.show()
+        //Snackbar is global and it should appear only the foreground fragment
+        if (!errorSnackbar.view.isAttachedToWindow && isVisible) {
+            errorSnackbar.setAction(R.string.crashedWebViewErrorAction) { command.action() }.show()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -413,7 +413,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
     private fun processCommand(it: Command?) {
         when (it) {
-            Command.Refresh -> refresh()
+            is Command.Refresh -> refresh()
             is Command.OpenInNewTab -> {
                 browserActivity?.openInNewTab(it.query)
             }
@@ -428,10 +428,10 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             is Command.NavigateBack -> {
                 webView?.goBackOrForward(-it.steps)
             }
-            Command.NavigateForward -> {
+            is Command.NavigateForward -> {
                 webView?.goForward()
             }
-            Command.ResetHistory -> {
+            is Command.ResetHistory -> {
                 resetWebView()
             }
             is Command.DialNumber -> {
@@ -448,10 +448,10 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 val intent = Intent(Intent.ACTION_SENDTO, Uri.parse("smsto:${it.telephoneNumber}"))
                 openExternalDialog(intent)
             }
-            Command.ShowKeyboard -> {
+            is Command.ShowKeyboard -> {
                 showKeyboard()
             }
-            Command.HideKeyboard -> {
+            is Command.HideKeyboard -> {
                 hideKeyboard()
             }
             is Command.BrokenSiteFeedback -> {
@@ -467,7 +467,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             }
             is Command.DownloadImage -> requestImageDownload(it.url)
             is Command.FindInPageCommand -> webView?.findAllAsync(it.searchTerm)
-            Command.DismissFindInPage -> webView?.findAllAsync(null)
+            is Command.DismissFindInPage -> webView?.findAllAsync(null)
             is Command.ShareLink -> launchSharePageChooser(it.url)
             is Command.CopyLink -> {
                 clipboardManager.primaryClip = ClipData.newPlainText(null, it.url)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -204,7 +204,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     private var webView: WebView? = null
 
     private val errorSnackbar: Snackbar by lazy {
-        Snackbar.make(rootView, R.string.crashedWebViewErrorMessage, Snackbar.LENGTH_INDEFINITE)
+        Snackbar.make(browserLayout, R.string.crashedWebViewErrorMessage, Snackbar.LENGTH_INDEFINITE)
             .setBehavior(NonDismissibleBehavior())
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -379,6 +379,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     }
 
     private fun showHome() {
+        newTabLayout.show()
         showKeyboardImmediately()
         appBarLayout.setExpanded(true)
         webView?.onPause()
@@ -388,6 +389,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     }
 
     private fun showBrowser() {
+        newTabLayout.gone()
         webView?.show()
         webView?.onResume()
         omnibarScrolling.enableOmnibarScrolling(toolbarContainer)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -314,7 +314,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         popupMenu.apply {
             onMenuItemClicked(view.forwardPopupMenuItem) { viewModel.onUserPressedForward() }
             onMenuItemClicked(view.backPopupMenuItem) { activity?.onBackPressed() }
-            onMenuItemClicked(view.refreshPopupMenuItem) { refresh() }
+            onMenuItemClicked(view.refreshPopupMenuItem) { viewModel.onRefreshRequested() }
             onMenuItemClicked(view.newTabPopupMenuItem) { viewModel.userRequestedOpeningNewTab() }
             onMenuItemClicked(view.bookmarksPopupMenuItem) { browserActivity?.launchBookmarks() }
             onMenuItemClicked(view.addBookmarksPopupMenuItem) { launch { viewModel.onBookmarkAddRequested() } }
@@ -401,6 +401,10 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         hideKeyboard()
         renderer.hideFindInPage()
         webView?.loadUrl(url)
+    }
+
+    fun onRefreshRequested() {
+        viewModel.onRefreshRequested()
     }
 
     fun refresh() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1196,6 +1196,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 newTabPopupMenuItem.isEnabled = browserShowing
                 addBookmarksPopupMenuItem?.isEnabled = viewState.canAddBookmarks
                 sharePageMenuItem?.isEnabled = viewState.canSharePage
+                brokenSitePopupMenuItem?.isEnabled = viewState.canReportSite
 
                 addToHome?.let {
                     it.visibility = if (viewState.addToHomeVisible) VISIBLE else GONE

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -299,7 +299,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         super.onResume()
         addTextChangedListeners()
         appBarLayout.setExpanded(true)
-        viewModel.onViewVisible(isVisible)
+        viewModel.onViewVisible()
         logoHidingListener.onResume()
     }
 
@@ -920,7 +920,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             webView?.onPause()
         } else {
             webView?.onResume()
-            viewModel.onViewVisible(true)
+            viewModel.onViewVisible()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -422,7 +422,7 @@ class BrowserTabViewModel(
         browserViewState.value = currentBrowserViewState().copy(
             browserShowing = false,
             canGoBack = false,
-            canGoForward = true
+            canGoForward = currentGlobalLayoutState() !is Invalidated
         )
         omnibarViewState.value = currentOmnibarViewState().copy(omnibarText = "", shouldMoveCaretToEnd = false)
         loadingViewState.value = currentLoadingViewState().copy(isLoading = false)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -115,6 +115,7 @@ class BrowserTabViewModel(
         val browserShowing: Boolean = false,
         val isFullScreen: Boolean = false,
         val isDesktopBrowsingMode: Boolean = false,
+        val canChangeBrowsingMode: Boolean = true,
         val showPrivacyGrade: Boolean = false,
         val showClearButton: Boolean = false,
         val showTabsButton: Boolean = true,
@@ -903,7 +904,8 @@ class BrowserTabViewModel(
         browserViewState.value = currentBrowserViewState().copy(
             canGoBack = false,
             canGoForward = false,
-            canReportSite = false
+            canReportSite = false,
+            canChangeBrowsingMode = false
         )
         loadingViewState.value = LoadingViewState()
         findInPageViewState.value = FindInPageViewState()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -300,7 +300,9 @@ class BrowserTabViewModel(
     fun onViewVisible() {
         command.value = if (!currentBrowserViewState().browserShowing) ShowKeyboard else HideKeyboard
         ctaViewModel.refreshCta()
-        if (currentGlobalLayoutState() is Invalidated) showErrorWithAction()
+        if (currentGlobalLayoutState() is Invalidated && currentBrowserViewState().browserShowing) {
+            showErrorWithAction()
+        }
     }
 
     fun onViewHidden() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -334,6 +334,12 @@ class BrowserTabViewModel(
             return
         }
 
+        if (currentGlobalLayoutState() is Invalidated) {
+            viewModelScope.launch { closeCurrentTab() }
+            command.value = OpenInNewTab(input)
+            return
+        }
+
         command.value = HideKeyboard
         val trimmedInput = input.trim()
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -126,6 +126,7 @@ class BrowserTabViewModel(
         val canAddBookmarks: Boolean = false,
         val canGoBack: Boolean = false,
         val canGoForward: Boolean = false,
+        val canReportSite: Boolean = true,
         val addToHomeEnabled: Boolean = false,
         val addToHomeVisible: Boolean = false
     )
@@ -901,7 +902,8 @@ class BrowserTabViewModel(
         globalLayoutState.value = Invalidated()
         browserViewState.value = currentBrowserViewState().copy(
             canGoBack = false,
-            canGoForward = false
+            canGoForward = false,
+            canReportSite = false
         )
         loadingViewState.value = LoadingViewState()
         findInPageViewState.value = FindInPageViewState()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -457,6 +457,7 @@ class BrowserTabViewModel(
             is NewPage -> pageChanged(stateChange.url, stateChange.title)
             is PageCleared -> pageCleared()
             is UrlUpdated -> urlUpdated(stateChange.url)
+            is PageNavigationCleared -> disableUserNavigation()
         }
     }
 
@@ -878,7 +879,10 @@ class BrowserTabViewModel(
     }
 
     override fun recoverFromRenderProcessGone() {
-        invalidateUserNavigation()
+        webNavigationState?.let {
+            navigationStateChanged(EmptyNavigationState(it))
+        }
+        invalidateBrowsingActions()
         showErrorWithAction()
     }
 
@@ -899,16 +903,19 @@ class BrowserTabViewModel(
         command.value = LaunchTabSwitcher
     }
 
-    private fun invalidateUserNavigation() {
-        globalLayoutState.value = Invalidated()
+    private fun invalidateBrowsingActions() {
+        globalLayoutState.value = Invalidated
+        loadingViewState.value = LoadingViewState()
+        findInPageViewState.value = FindInPageViewState()
+    }
+
+    private fun disableUserNavigation() {
         browserViewState.value = currentBrowserViewState().copy(
             canGoBack = false,
             canGoForward = false,
             canReportSite = false,
             canChangeBrowsingMode = false
         )
-        loadingViewState.value = LoadingViewState()
-        findInPageViewState.value = FindInPageViewState()
     }
 
     private fun showErrorWithAction() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -175,7 +175,9 @@ class BrowserWebViewClient(
         } else {
             offlinePixelCountDataStore.webRendererGoneKilledCount += 1
         }
-        return super.onRenderProcessGone(view, detail)
+
+        webViewClientListener?.recoverFromRenderProcessGone()
+        return true
     }
 
     @UiThread

--- a/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
@@ -37,10 +37,14 @@ sealed class WebNavigationStateChange {
     data class UrlUpdated(val url: String) : WebNavigationStateChange()
     object PageCleared : WebNavigationStateChange()
     object Unchanged : WebNavigationStateChange()
+    object PageNavigationCleared : WebNavigationStateChange()
     object Other : WebNavigationStateChange()
 }
 
 fun WebNavigationState.compare(previous: WebNavigationState?): WebNavigationStateChange {
+
+    if (this is EmptyNavigationState)
+        return PageNavigationCleared
 
     if (this == previous) {
         return Unchanged
@@ -120,6 +124,30 @@ data class WebViewNavigationState(private val stack: WebBackForwardList) : WebNa
         result = 31 * result + hasNavigationHistory.hashCode()
         return result
     }
+}
+
+@Suppress("DataClassPrivateConstructor")
+data class EmptyNavigationState private constructor(override val originalUrl: String?,
+                                                    override val currentUrl: String?,
+                                                    override val title: String?) : WebNavigationState {
+    companion object {
+        operator fun invoke(webNavigationState: WebNavigationState): EmptyNavigationState {
+            return EmptyNavigationState(
+                webNavigationState.originalUrl,
+                webNavigationState.currentUrl,
+                webNavigationState.title
+            )
+        }
+    }
+
+    override val stepsToPreviousPage: Int
+        get() = 0
+    override val canGoBack: Boolean
+        get() = false
+    override val canGoForward: Boolean
+        get() = false
+    override val hasNavigationHistory: Boolean
+        get() = false
 }
 
 private val WebBackForwardList.originalUrl: String?

--- a/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
@@ -42,13 +42,12 @@ sealed class WebNavigationStateChange {
 }
 
 fun WebNavigationState.compare(previous: WebNavigationState?): WebNavigationStateChange {
-
-    if (this is EmptyNavigationState)
-        return PageNavigationCleared
-
     if (this == previous) {
         return Unchanged
     }
+
+    if (this is EmptyNavigationState)
+        return PageNavigationCleared
 
     if (originalUrl == null && previous?.originalUrl != null) {
         return PageCleared
@@ -140,14 +139,10 @@ data class EmptyNavigationState private constructor(override val originalUrl: St
         }
     }
 
-    override val stepsToPreviousPage: Int
-        get() = 0
-    override val canGoBack: Boolean
-        get() = false
-    override val canGoForward: Boolean
-        get() = false
-    override val hasNavigationHistory: Boolean
-        get() = false
+    override val stepsToPreviousPage: Int = 0
+    override val canGoBack: Boolean = false
+    override val canGoForward: Boolean = false
+    override val hasNavigationHistory: Boolean = false
 }
 
 private val WebBackForwardList.originalUrl: String?

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -40,6 +40,7 @@ interface WebViewClientListener {
     fun exitFullScreen()
     fun showFileChooser(filePathCallback: ValueCallback<Array<Uri>>, fileChooserParams: WebChromeClient.FileChooserParams)
     fun externalAppLinkClicked(appLink: SpecialUrlDetector.UrlType.IntentType)
+    fun recoverFromRenderProcessGone()
 
     fun requiresAuthentication(request: BasicAuthenticationRequest)
 }

--- a/app/src/main/java/com/duckduckgo/app/global/view/NonDismissibleBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/NonDismissibleBehavior.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.view
+
+import android.view.View
+import com.google.android.material.snackbar.BaseTransientBottomBar
+
+class NonDismissibleBehavior : BaseTransientBottomBar.Behavior() {
+    override fun canSwipeDismissView(child: View) = false
+}

--- a/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
@@ -101,8 +101,8 @@ class SurveyActivity : DuckDuckGoActivity() {
 
     private fun showError() {
         progress.gone()
-        webView.gone()
         errorView.show()
+        destroyWebView()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -126,6 +126,13 @@ class SurveyActivity : DuckDuckGoActivity() {
     private fun onSurveyDismissed() {
         pixel.fire(SURVEY_SURVEY_DISMISSED)
         viewModel.onSurveyDismissed()
+    }
+
+    private fun destroyWebView() {
+        webView.gone()
+        surveyActivityContainerViewGroup.removeView(webView)
+        webView.destroy()
+        webView.webViewClient = null
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
@@ -165,5 +165,10 @@ class SurveyActivity : DuckDuckGoActivity() {
                 viewModel.onSurveyFailedToLoad()
             }
         }
+
+        override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {
+            viewModel.onSurveyFailedToLoad()
+            return true
+        }
     }
 }

--- a/app/src/main/res/layout/activity_user_survey.xml
+++ b/app/src/main/res/layout/activity_user_survey.xml
@@ -24,6 +24,7 @@
     tools:context="com.duckduckgo.app.feedback.ui.common.FeedbackActivity">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/surveyActivityContainerViewGroup"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/survey_background">

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2019 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<resources>
-    <string name="crashedWebViewErrorMessage" translatable="false">"The webpage could not be displayed."</string>
-    <string name="crashedWebViewErrorAction" translatable="false">"Reload"</string>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="crashedWebViewErrorMessage">"The webpage could not be displayed."</string>
+    <string name="crashedWebViewErrorAction">"Reload"</string>
 </resources>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2019 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="crashedWebViewErrorMessage" translatable="false">"The webpage could not be displayed."</string>
+    <string name="crashedWebViewErrorAction" translatable="false">"Reload"</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,8 @@
     <string name="refresh">Refresh</string>
     <string name="back">Back</string>
     <string name="forward">Forward</string>
+    <string name="crashedWebViewErrorMessage" translatable="false">"The webpage could not be displayed."</string>
+    <string name="crashedWebViewErrorAction" translatable="false">"Reload"</string>
 
     <string name="omnibarInputHint">Search or type URL</string>
     <string name="clearButtonContentDescription">Clear search input</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,8 +39,6 @@
     <string name="refresh">Refresh</string>
     <string name="back">Back</string>
     <string name="forward">Forward</string>
-    <string name="crashedWebViewErrorMessage" translatable="false">"The webpage could not be displayed."</string>
-    <string name="crashedWebViewErrorAction" translatable="false">"Reload"</string>
 
     <string name="omnibarInputHint">Search or type URL</string>
     <string name="clearButtonContentDescription">Clear search input</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1152512237237203/f
Tech Design URL: https://app.asana.com/0/0/1151307893053517/f
CC: 

### **Description**:
Introducing gracefully handling WebView crash errors into our Browser.
A WebView render process can be gone due to a rendering crash or memory pressure situations. When we receive such event from WebViewClient we will avoid crashing, and instead, we will show a snackbar to inform about what happened and the possibility to reload the current URL. Also, application will still be usable so users will be able to perform other actions as closing the tab or navigate to a new URL.

### **Steps to test this PR**:
As we can't reproduce easily memory pressure situations or crashes, we will need to change our source code a bit in order to manually produce a crash.
Easiest way is to call `recoverFromRenderProcessGone()` when user clicks in a menu option, example will be inside `onBrokenSiteSelected()`.

### **Scenarios to test**
***Scenario to test***:
- Open app
- submit an URL
- crash the app (with hardcoded code)
- Verify user can't navigate back/forward/find a page/report a site

***Scenario to test***:
- Open app
- submit an URL
- crash the app (with hardcoded code)
- Verify snackbar appears
- Reload from snackbar
- Verify current tab is closed and a new one is opened with same URL

**Scenario to test**:
- Open app
- submit an URL
- crash the app (with hardcoded code)
- Verify snackbar appears
- Reload from option menu
- Verify current tab is closed and a new one is opened with same URL

**Scenario to test**:
- Open app
- submit an URL
- Navigate to produce some history navigation
- crash the app (with hardcoded code)
- Verify snackbar appears
- press back
- Verify home is shown
- press back
- Verify exits the app

**Scenario to test**:
- Open app
- submit an URL
- crash the app (with hardcoded code)
- Verify snackbar appears
- Submit current or a new URL
- Verify current tab is closed and a new one is opened with expected URL

**Scenario to test**:
- Open app
- submit an URL
- crash the app (with hardcoded code)
- Verify snackbar appears
- Open privacy settings and disable or enable toogle
- Go back to the tab
- Verify current tab is closed and a new one is opened with same URL

**Scenario to test**:
- Open app
- submit an URL
- crash the app (with hardcoded code)
- Open a new tab
- submit an URL
- crash the app (with hardcoded code)
- Change between tabs, snackbar should appear

**Scenario to test**:
- Open app
- submit an URL
- crash the app (with hardcoded code)
- Open a new tab
- submit an URL
- crash the app (with hardcoded code)
- Send app to background
- Bring back to foreground the app
- Snakbar should appear

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
