### PR TITLE
Use SystemClock.elapsedRealtime() for data clearing

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/fire/DataClearerTimeKeeperTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/DataClearerTimeKeeperTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.fire
 
+import android.os.SystemClock
 import com.duckduckgo.app.settings.clear.ClearWhenOption
 import com.duckduckgo.app.settings.clear.ClearWhenOption.*
 import org.junit.Assert.assertEquals
@@ -37,7 +38,7 @@ class DataClearerTimeKeeperTest(private val testCase: TestCase) {
         @Parameters(name = "Test case: {index} - {0}")
         fun testData(): Array<TestCase> {
 
-            val timeNow = System.currentTimeMillis()
+            val timeNow = SystemClock.elapsedRealtime()
 
             return arrayOf(
                 // APP_EXIT_ONLY shouldn't be passed to this method - always expected to return false regardless of other configuration/inputs
@@ -74,7 +75,7 @@ class DataClearerTimeKeeperTest(private val testCase: TestCase) {
         assertEquals(testCase.expected, testee.hasEnoughTimeElapsed(backgroundedTimestamp = timestamp, clearWhenOption = testCase.clearWhenOption))
     }
 
-    private fun getPastTimestamp(millisPreviously: Long, timeNow: Long = System.currentTimeMillis()): Long {
+    private fun getPastTimestamp(millisPreviously: Long, timeNow: Long = SystemClock.elapsedRealtime()): Long {
         return Calendar.getInstance().also {
             it.timeInMillis = timeNow
             it.add(Calendar.MILLISECOND, (-millisPreviously).toInt())

--- a/app/src/main/java/com/duckduckgo/app/fire/AutomaticDataClearer.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/AutomaticDataClearer.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.fire
 
 import android.os.Handler
+import android.os.SystemClock
 import androidx.annotation.UiThread
 import androidx.core.os.postDelayed
 import androidx.lifecycle.*
@@ -101,11 +102,12 @@ class AutomaticDataClearer(
     @UiThread
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun onAppBackgrounded() {
-        Timber.i("Recording when app backgrounded")
+        val timeNow = SystemClock.elapsedRealtime()
+        Timber.i("Recording when app backgrounded ($timeNow)")
 
         dataClearerState.value = INITIALIZING
 
-        settingsDataStore.appBackgroundedTimestamp = System.currentTimeMillis()
+        settingsDataStore.appBackgroundedTimestamp = timeNow
 
         val clearWhenOption = settingsDataStore.automaticallyClearWhenOption
         val clearWhatOption = settingsDataStore.automaticallyClearWhatOption

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearerTimeKeeper.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearerTimeKeeper.kt
@@ -16,11 +16,12 @@
 
 package com.duckduckgo.app.fire
 
+import android.os.SystemClock
 import com.duckduckgo.app.settings.clear.ClearWhenOption
 import timber.log.Timber
 
 interface BackgroundTimeKeeper {
-    fun hasEnoughTimeElapsed(timeNow: Long = System.currentTimeMillis(), backgroundedTimestamp: Long, clearWhenOption: ClearWhenOption): Boolean
+    fun hasEnoughTimeElapsed(timeNow: Long = SystemClock.elapsedRealtime(), backgroundedTimestamp: Long, clearWhenOption: ClearWhenOption): Boolean
 }
 
 class DataClearerTimeKeeper : BackgroundTimeKeeper {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/4665784270797/1154355783227569/f
Tech Design URL: 
CC: 

**Description**:
This offers more resiliency vs `System.currentTimeMillis()` against someone meddling with the device clock in an effort to delay data being cleared when expected.

`elapsedRealtime` will start again from 0 when the system is restarted, but in that scenario, we'd wipe the data anyway since it's a new process launch, so we don't have to worry about the recorded timestamp being smaller than the current one.


**Steps to test this PR**:
ℹ️You should temporarily disable the background data clearing worker from firing for this test. (comment out `scheduleBackgroundTimerToTriggerClear(clearWhenOption.durationMilliseconds())` from `DuckDuckGoApplication`)

1. Choose automatic data clearing with a timer
1. Open a tab
1. Leave the app (e.g, hit the home button)
1. Wait more than the time specified
1. Re-open the app
1. Verify the tabs/data is cleared

Again, but this time you're going to change the system clock part way through the test 🕰️
1. Choose automatic data clearing of 5 mins
1. Open a tab
1. Leave the app (e.g, hit the home button)
1. Wait more than 5 mins
1. Set device clock back an hour
1. Re-open the app
1. Verify the tabs/data is cleared

Again, but this time you're going to restart the device part way through the test 📴 
1. Choose automatic data clearing with a timer
1. Open a tab
1. Restart the device
1. Re-open the app
1. Verify the tabs/data is cleared
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
