### PR TITLE
Hide scanning view by default

### DIFF
--- a/app/src/main/res/layout/include_omnibar_toolbar.xml
+++ b/app/src/main/res/layout/include_omnibar_toolbar.xml
@@ -78,7 +78,7 @@
                         android:id="@+id/loadingText"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:alpha="1"
+                        android:alpha="0"
                         android:fontFamily="sans-serif-medium"
                         android:text="@string/trackersAnimationText"
                         android:textAlignment="textStart"


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL: 
CC: 

**Description**:
Hides the scanning view by default

**Other variants**:
1. Launch the app hardcoding the variant to `mc` and `md` and with no variant.
1. Notice how the scanning text doesn't show by default on the omnibar.

**Concept test variant**:
1. Launch the app hardcoding the variant to `me`.
1. Notice how the scanning text doesn't show by default on the omnibar but it shows as normally when the animations are triggered.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
