### PR TITLE
Fix crash when activity is null

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1189,14 +1189,19 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                     val site = viewModel.siteLiveData.value
                     val events = site?.trackingEvents
 
-                    animatorHelper.createLoadedAnimation(
-                        lastSeenCtaViewState?.cta,
-                        requireActivity(),
-                        networksContainer,
-                        loadingText,
-                        omnibarViews(),
-                        events
-                    )
+                    val act = activity
+                    if (act != null) {
+                        animatorHelper.createLoadedAnimation(
+                            lastSeenCtaViewState?.cta,
+                            act,
+                            networksContainer,
+                            loadingText,
+                            omnibarViews(),
+                            events
+                        )
+                    } else {
+                        cancelAllAnimations()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
@@ -45,7 +45,7 @@ class BrowserTrackersAnimatorHelper @Inject constructor() : CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = SupervisorJob() + Dispatchers.Main
 
-    var logosStayOnScreenDuration: Long = TRACKER_LOGOS_DELAY_ON_SCREEN
+    private var logosStayOnScreenDuration: Long = TRACKER_LOGOS_DELAY_ON_SCREEN
 
     private var loadingAnimation: AnimatorSet = AnimatorSet()
     private var trackersAnimation: AnimatorSet = AnimatorSet()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/inbox/1125189844075764/1154851166658734/1154795110641012
Tech Design URL: 
CC: 

**Description**:
In some cases using `requireActivity()` crashes the app, we didn't expect the activity to be null at the point where its called but it can happen.

**Steps to test this PR**:
1. Navigating in the with `me` variant should still have the omnibar animation working as expected.
1. You can simulate the crash by adding `throw IllegalStateException("Test Fragment $this not attached to an activity.")`before calling to `animatorHelper.createLoadedAnimation()` in the `BrowserTabFragment`



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
