### PR TITLE
When activity is found to be null, don't attempt further UI calls

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1189,18 +1189,15 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                     val site = viewModel.siteLiveData.value
                     val events = site?.trackingEvents
 
-                    val act = activity
-                    if (act != null) {
+                    activity?.let { activity ->
                         animatorHelper.createLoadedAnimation(
                             lastSeenCtaViewState?.cta,
-                            act,
+                            activity,
                             networksContainer,
                             loadingText,
                             omnibarViews(),
                             events
                         )
-                    } else {
-                        cancelAllAnimations()
                     }
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1095,7 +1095,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         private const val MIN_PROGRESS = 10
         private const val MAX_PROGRESS = 100
         private const val TRACKERS_INI_DELAY = 700L
-        private const val TRACKERS_SECONDARY_DELAY = 7000L
+        private const val TRACKERS_SECONDARY_DELAY = 300L
 
         fun newInstance(tabId: String, query: String? = null, skipHome: Boolean): BrowserTabFragment {
             val fragment = BrowserTabFragment()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.browser
 
 import android.Manifest
-import android.animation.AnimatorSet
 import android.animation.LayoutTransition.CHANGING
 import android.animation.LayoutTransition.DISAPPEARING
 import android.annotation.SuppressLint
@@ -116,8 +115,10 @@ import kotlin.coroutines.CoroutineContext
 
 class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
+    private val supervisorJob = SupervisorJob()
+
     override val coroutineContext: CoroutineContext
-        get() = SupervisorJob() + Dispatchers.Main
+        get() = supervisorJob + Dispatchers.Main
 
     @Inject
     lateinit var webViewClient: BrowserWebViewClient
@@ -963,6 +964,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     }
 
     override fun onDestroy() {
+        supervisorJob.cancel()
         popupMenu.dismiss()
         destroyWebView()
         super.onDestroy()
@@ -1093,7 +1095,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         private const val MIN_PROGRESS = 10
         private const val MAX_PROGRESS = 100
         private const val TRACKERS_INI_DELAY = 700L
-        private const val TRACKERS_SECONDARY_DELAY = 300L
+        private const val TRACKERS_SECONDARY_DELAY = 7000L
 
         fun newInstance(tabId: String, query: String? = null, skipHome: Boolean): BrowserTabFragment {
             val fragment = BrowserTabFragment()

--- a/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
@@ -77,7 +77,7 @@ class DaxDialog(
     }
 
     override fun onDismiss(dialog: DialogInterface) {
-        dialogText.cancelAnimation()
+        dialogText?.cancelAnimation()
         dismissListener()
         super.onDismiss(dialog)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1154851166658740/1154845361621030
Tech Design URL: 
CC: 

**Description**:
I _think_ attempting to cancel the animations after detecting the `activity` is null is bad, and can actually be a cause of new `IllegalStateExceptions` being triggered.

**Steps to test this PR**:
1. Increase `TRACKERS_SECONDARY_DELAY` to a large value (~ 7_000L)
1. Load a webpage (e.g., cnn.com)
1. Wait for "scanning" text to appear
1. Press `back` a few times, until you have exited back to home screen
1. Wait for remainder of `TRACKERS_SECONDARY_DELAY` time to finish
1. Verify no exception thrown (in logcat)

If you try the above on `develop`, you should be able to see an `IllegalStateException` being thrown


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
