### PR TITLE
Add missing year and copyright owner to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -191,7 +191,7 @@ versions can be downloaded from https://duckduckgo.com/press.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2008 - Present, DuckDuckGO.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
Tech Design URL: 
CC: 

**Description**:
Thank you for the wonderful project! 

I just added missing year and the name to `LICENSE` in the same way as iOS.
(iOS commit: <https://github.com/duckduckgo/iOS/commit/db20e92ad22122c8d2ecebc3761f102ca1a8eef2#diff-9879d6db96fd29134fc802214163b95a>)

Note that "O" is an upper case like "DuckDuckGO" because I used the same way as iOS. Should I use lower case "o" like "DuckDuckGo"?

**Steps to test this PR**:
1. 
1. 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
