### PR TITLE
Allow DDG to handle links from certain external applications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,6 +72,10 @@
 
                 <data android:scheme="https" />
                 <data android:scheme="http" />
+
+                <data android:mimeType="text/html"/>
+                <data android:mimeType="text/plain"/>
+                <data android:mimeType="application/xhtml+xml"/>
             </intent-filter>
 
             <!-- Allows apps to consume links and text shared from other apps e.g chrome -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,9 +73,9 @@
                 <data android:scheme="https" />
                 <data android:scheme="http" />
 
-                <data android:mimeType="text/html"/>
-                <data android:mimeType="text/plain"/>
-                <data android:mimeType="application/xhtml+xml"/>
+                <data android:mimeType="text/html" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="application/xhtml+xml" />
             </intent-filter>
 
             <!-- Allows apps to consume links and text shared from other apps e.g chrome -->


### PR DESCRIPTION
**Problem:** DDG is not able to open certain links that use html redirects.

**Steps to test this PR:**
1. First, before pulling these changes, open the YouTube app.
2. Find a YouTube video with a link in the description, or in the comments (**or use the one I have provided below [which contains a link in its description] to save time)
3. Click on the link and verify that DDG browser is **NOT** listed as an app that is capable of opening the link, or that Chrome automatically handles the link if it is the only installed app with the appropriate intent filter.
4. Pull these changes and verify that DDG **IS** now able to open links from the the description of YouTube videos via the YouTube app.

** https://youtu.be/GnrwM7vFn_U (or search by title: "Thomas The Tank Engine Theme Song")

To be clear, the line that fixes the problem with apps like YouTube using html redirects is:
`<data android:mimeType="text/html"/>`

I added the other two lines since it seemed like it could prevent some headaches down the road.

Happy holidays :snowman::snowflake::santa::christmas_tree:

###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)