### PR TITLE
Allow DDG to handle different MIME types

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,6 +74,21 @@
                 <data android:scheme="http" />
             </intent-filter>
 
+            <!-- Allows app to handle the specified MIME types that use the specified schemes, and to become the default handler for them -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+
+                <data android:mimeType="text/html" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="application/xhtml+xml" />
+            </intent-filter>
+
             <!-- Allows apps to consume links and text shared from other apps e.g chrome -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />


### PR DESCRIPTION
**Description**:
This is a continuation of PR #659.  The issue, as well as the original solution's shortcomings, are already well-documented there, so I will skip to the testing steps.

**Steps to test this PR**:
1. Install DDG and ensure that it asks to become default browser for variants that are not "me" or "md".
2. Set DDG as default browser.
3. Visit our good friend "Thomas The Tank Engine" once again via the YouTube app (https://youtu.be/GnrwM7vFn_U).  Any YouTube video with a link in the description/comments should be fine, but I'd be lying if I said I wasn't partial to Thomas :steam_locomotive: :smirk: 
4. Confirm that the link in the video description launches, by default, using DDG.

Also, I thought that there should be a comment above the new intent filter, so I added one.  I am, of course, happy to change or omit it upon request; it was more or less a "back-of-the-envelope" kind of thing as I wasn't too sure what should be noted.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
