### PR TITLE
Catch Exception instead of RuntimeException for WebView preview

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -546,7 +546,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                     val fileName = previewPersister.save(preview, tabId)
                     viewModel.updateTabPreview(tabId, fileName)
                     Timber.d("Saved and updated tab preview")
-                } catch (e: RuntimeException) {
+                } catch (e: Exception) {
                     Timber.d(e, "Failed to generate WebView preview")
                 }
             }


### PR DESCRIPTION


<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/608920331025315/1157077742629569
Tech Design URL: 
CC: 

**Description**:
Catch Exception instead of RuntimeException for WebView preview. Crash reports show instances of FileNotFoundException which wouldn't be caught by the the RuntimeException catch block

**Steps to test this PR**:
1. You can force an `Exception` being thrown by hardcoding that into the `WebView` preview generator code, and verify there are no crashes as a result


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
