### PR TITLE
New onboarding tweaks and bug fixes

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaTest.kt
@@ -53,8 +53,8 @@ class CtaTest {
         MockitoAnnotations.initMocks(this)
 
         whenever(mockActivity.resources).thenReturn(mockResources)
-        whenever(mockResources.getString(any(), any())).thenReturn("withZero")
-        whenever(mockResources.getQuantityString(any(), any(), any(), any())).thenReturn("withMultiple")
+        whenever(mockResources.getString(any())).thenReturn("withZero")
+        whenever(mockResources.getQuantityString(any(), any(), any())).thenReturn("withMultiple")
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.model.Survey.Status.SCHEDULED
 import com.duckduckgo.app.trackerdetection.model.Entity
+import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
@@ -373,10 +374,20 @@ class CtaViewModelTest {
     @Test
     fun whenRefreshCtaOnExistingTabThenReturnTrackersBlockedCta() = runBlockingTest {
         setConceptTestVariant()
-        val site = site(url = "http://www.cnn.com", trackerCount = 1)
+        val trackingEvent = TrackingEvent("test.com", "test.com", null, TestEntity("test", "test", 9.0), true)
+        val site = site(url = "http://www.cnn.com", trackerCount = 1, events = listOf(trackingEvent))
         val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
 
         assertTrue(value is DaxDialogCta.DaxTrackersBlockedCta)
+    }
+
+    @Test
+    fun whenRefreshCtaOnExistingTabButNoTrackersInformationThenReturnNoSerpCta() = runBlockingTest {
+        setConceptTestVariant()
+        val site = site(url = "http://www.cnn.com", trackerCount = 1)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
+
+        assertTrue(value is DaxDialogCta.DaxNoSerpCta)
     }
 
     @Test
@@ -455,6 +466,7 @@ class CtaViewModelTest {
         uri: Uri? = Uri.parse(url),
         https: HttpsStatus = HttpsStatus.SECURE,
         trackerCount: Int = 0,
+        events: List<TrackingEvent> = emptyList(),
         majorNetworkCount: Int = 0,
         allTrackersBlocked: Boolean = true,
         privacyPractices: PrivacyPractices.Practices = PrivacyPractices.UNKNOWN,
@@ -467,6 +479,7 @@ class CtaViewModelTest {
         whenever(site.uri).thenReturn(uri)
         whenever(site.https).thenReturn(https)
         whenever(site.entity).thenReturn(entity)
+        whenever(site.trackingEvents).thenReturn(events)
         whenever(site.trackerCount).thenReturn(trackerCount)
         whenever(site.majorNetworkCount).thenReturn(majorNetworkCount)
         whenever(site.allTrackersBlocked).thenReturn(allTrackersBlocked)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.cta.ui
 
+import android.content.Context
 import android.net.Uri
 import android.view.View
 import androidx.annotation.AnyRes
@@ -87,7 +88,7 @@ sealed class DaxDialogCta(
         )
     }
 
-    open fun getDaxText(activity: FragmentActivity): String = activity.getString(description)
+    open fun getDaxText(context: Context): String = context.getString(description)
 
     class DaxSerpCta(onboardingStore: OnboardingStore, appInstallStore: AppInstallStore) : DaxDialogCta(
         CtaId.DAX_DIALOG_SERP,
@@ -101,7 +102,12 @@ sealed class DaxDialogCta(
         appInstallStore
     )
 
-    class DaxTrackersBlockedCta(onboardingStore: OnboardingStore, appInstallStore: AppInstallStore, val trackers: List<TrackingEvent>, val host: String) :
+    class DaxTrackersBlockedCta(
+        onboardingStore: OnboardingStore,
+        appInstallStore: AppInstallStore,
+        val trackers: List<TrackingEvent>,
+        val host: String
+    ) :
         DaxDialogCta(
             CtaId.DAX_DIALOG_TRACKERS_FOUND,
             R.plurals.daxTrackersBlockedCtaText,
@@ -117,7 +123,7 @@ sealed class DaxDialogCta(
         override fun createDialogCta(activity: FragmentActivity): DaxDialog =
             DaxDialog(getDaxText(activity), activity.resources.getString(okButton), false)
 
-        override fun getDaxText(activity: FragmentActivity): String {
+        override fun getDaxText(context: Context): String {
             val trackersFiltered = trackers.asSequence()
                 .filter { it.entity?.isMajor == true }
                 .map { it.entity?.displayName }
@@ -130,9 +136,9 @@ sealed class DaxDialogCta(
             val size = trackers.size - trackersFiltered.size
             val quantityString =
                 if (size == 0) {
-                    activity.resources.getString(R.string.daxTrackersBlockedCtaZeroText)
+                    context.resources.getString(R.string.daxTrackersBlockedCtaZeroText)
                 } else {
-                    activity.resources.getQuantityString(description, size, size)
+                    context.resources.getQuantityString(description, size, size)
                 }
             return "<b>$trackersText</b>$quantityString"
         }
@@ -150,11 +156,11 @@ sealed class DaxDialogCta(
         appInstallStore
     ) {
 
-        override fun getDaxText(activity: FragmentActivity): String {
+        override fun getDaxText(context: Context): String {
             return if (isFromSameNetworkDomain()) {
-                activity.resources.getString(R.string.daxMainNetworkStep1CtaText, network)
+                context.resources.getString(R.string.daxMainNetworkStep1CtaText, network)
             } else {
-                activity.resources.getString(R.string.daxMainNetworkStep1OwnedCtaText, Uri.parse(host).baseHost?.removePrefix("m."), network)
+                context.resources.getString(R.string.daxMainNetworkStep1OwnedCtaText, Uri.parse(host).baseHost?.removePrefix("m."), network)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -128,12 +128,11 @@ sealed class DaxDialogCta(
 
             val trackersText = trackersFiltered.joinToString(", ")
             val size = trackers.size - trackersFiltered.size
-            val url = Uri.parse(host).baseHost?.removePrefix("m.")
             val quantityString =
                 if (size == 0) {
-                    activity.resources.getString(R.string.daxTrackersBlockedCtaZeroText, url)
+                    activity.resources.getString(R.string.daxTrackersBlockedCtaZeroText)
                 } else {
-                    activity.resources.getQuantityString(description, size, size, url)
+                    activity.resources.getQuantityString(description, size, size)
                 }
             return "<b>$trackersText</b>$quantityString"
         }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -193,16 +193,13 @@ class CtaViewModel @Inject constructor(
         }
     }
 
-    private fun hasTrackersInformation(events: List<TrackingEvent>): Boolean {
-        if (events.isNullOrEmpty()) return false
-
-        return events.asSequence()
+    private fun hasTrackersInformation(events: List<TrackingEvent>): Boolean =
+        events.asSequence()
             .filter { it.entity?.isMajor == true }
             .map { it.entity?.displayName }
             .filterNotNull()
             .distinct()
             .toList().isNotEmpty()
-    }
 
     private fun hasPrivacySettingsOn(): Boolean = settingsPrivacySettingsStore.privacyOn
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -198,8 +198,7 @@ class CtaViewModel @Inject constructor(
             .filter { it.entity?.isMajor == true }
             .map { it.entity?.displayName }
             .filterNotNull()
-            .distinct()
-            .toList().isNotEmpty()
+            .any()
 
     private fun hasPrivacySettingsOn(): Boolean = settingsPrivacySettingsStore.privacyOn
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
+import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.withContext
@@ -182,7 +183,7 @@ class CtaViewModel @Inject constructor(
                 return DaxDialogCta.DaxSerpCta(onboardingStore, appInstallStore)
             }
             // Trackers blocked
-            return if (!daxDialogTrackersFoundShown() && !isSerpUrl(it.url) && it.trackerCount > 0 && host != null) {
+            return if (!daxDialogTrackersFoundShown() && !isSerpUrl(it.url) && hasTrackersInformation(it.trackingEvents) && host != null) {
                 DaxDialogCta.DaxTrackersBlockedCta(onboardingStore, appInstallStore, it.trackingEvents, host)
             } else if (!isSerpUrl(it.url) && !daxDialogOtherShown() && !daxDialogTrackersFoundShown() && !daxDialogNetworkShown()) {
                 DaxDialogCta.DaxNoSerpCta(onboardingStore, appInstallStore)
@@ -190,6 +191,17 @@ class CtaViewModel @Inject constructor(
                 null
             }
         }
+    }
+
+    private fun hasTrackersInformation(events: List<TrackingEvent>): Boolean {
+        if (events.isNullOrEmpty()) return false
+
+        return events.asSequence()
+            .filter { it.entity?.isMajor == true }
+            .map { it.entity?.displayName }
+            .filterNotNull()
+            .distinct()
+            .toList().isNotEmpty()
     }
 
     private fun hasPrivacySettingsOn(): Boolean = settingsPrivacySettingsStore.privacyOn

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -101,6 +101,6 @@ class WelcomePage : OnboardingPageFragment() {
         private const val MIN_ALPHA = 0f
         private const val MAX_ALPHA = 1f
         private const val ANIMATION_DURATION = 400L
-        private const val ANIMATION_DELAY = 1000L
+        private const val ANIMATION_DELAY = 1400L
     }
 }

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -37,10 +37,10 @@
     <string name="daxMainNetworkStep2CtaText">%sI\'ll block these trackers when you\'re browsing non-%s sites.</string>
 
     <plurals name="daxTrackersBlockedCtaText">
-        <item quantity="one"><![CDATA[&#160;and <b>%d other</b> were trying to track you here. <br/><br/>I blocked them!<br/><br/> Tap the privacy grade to learn more about your privacy on %s.]]></item>
-        <item quantity="other"><![CDATA[&#160;and <b>%d others</b> were trying to track you here. <br/><br/>I blocked them!<br/><br/> Tap the privacy grade to learn more about your privacy on %s.]]></item>
+        <item quantity="one"><![CDATA[&#160;and <b>%d other</b> were trying to track you here. <br/><br/>I blocked them!<br/><br/> ☝️You can check the URL bar to see who is trying to track you when you visit a new site.️]]></item>
+        <item quantity="other"><![CDATA[&#160;and <b>%d others</b> were trying to track you here. <br/><br/>I blocked them!<br/><br/> ☝️You can check the URL bar to see who is trying to track you when you visit a new site.️]]></item>
     </plurals>
-    <string name="daxTrackersBlockedCtaZeroText"><![CDATA[&#160;was trying to track you here. <br/><br/>I blocked it!<br/><br/> Tap the privacy grade to learn more about your privacy on %s.]]></string>
+    <string name="daxTrackersBlockedCtaZeroText"><![CDATA[&#160;was trying to track you here. <br/><br/>I blocked it!<br/><br/> ☝️You can check the URL bar to see who is trying to track you when you visit a new site.️]]></string>
 
     <!-- Dax Dialog -->
     <string name="daxDialogHideButton">HIDE</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1157213430036874
Tech Design URL: 
CC: 

**Description**:
Minor bugs and amends to the new onboarding experience.

**Steps to test this PR**:
Use the `me` variant.

**Longer delay to welcome message**
https://app.asana.com/0/1125189844152671/1157012774769366
1. After a clean install launch the app.
1. Notice how the "Welcome to DuckDuckGo" message stays longer than before.

**Trackers blocked copy changed**
https://app.asana.com/0/1125189844152671/1157012774769367
1. After a clean install launch the app.
1. Navigate to cnn.com
1. Notice how the trackers blocked copy has changed to the one in https://app.asana.com/0/1125189844152671/1157012774769367

**Trackers blocked bug**
https://app.asana.com/0/1125189844152671/1157012774769368
1. After a clean install launch the app.
1. Navigate to twitch.tv
1. Notice how rather than showing the trackers blocked CTA we now show the No Trackers CTA instead. This is due to not having enough information about the trackers blocked.
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
