### PR TITLE
Better handling of browser state to obtain a Cta

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/ValueCaptorObserver.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/ValueCaptorObserver.kt
@@ -22,6 +22,9 @@ import androidx.lifecycle.Observer
  * Concrete class of Observer<T> to validate if any value has been received when observing a LiveData
  *
  * @param skipFirst: skip first value emitted by LiveData stream.
+ * SkipFirst is usually:
+ * Set to False to observe a SingleLiveEvent or any LiveData that starts emitting after subscription.
+ * Set to True when observing any LiveData that emits its lastValue on subscription.
  */
 class ValueCaptorObserver<T>(private var skipFirst: Boolean = true) : Observer<T> {
     var hasReceivedValue = false

--- a/app/src/androidTest/java/com/duckduckgo/app/ValueCaptorObserver.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/ValueCaptorObserver.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app
+
+import androidx.lifecycle.Observer
+
+/**
+ * Concrete class of Observer<T> to validate if any value has been received when observing a LiveData
+ *
+ * @param skipFirst: skip first value emitted by LiveData stream.
+ */
+class ValueCaptorObserver<T>(private var skipFirst: Boolean = true) : Observer<T> {
+    var hasReceivedValue = false
+        private set
+
+    var lastValueReceived: T? = null
+        private set
+
+    override fun onChanged(t: T) {
+        if (skipFirst) {
+            skipFirst = false
+            return
+        }
+        lastValueReceived = t
+        hasReceivedValue = true
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -166,5 +166,4 @@ class BrowserViewModelTest {
     companion object {
         const val TAB_ID = "TAB_ID"
     }
-
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -218,215 +218,203 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabThenReturnDaxIntroCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabThenReturnDaxIntroCta() = runBlockingTest {
         setConceptTestVariant()
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
         assertTrue(value is DaxBubbleCta.DaxIntroCta)
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndSiteIsNullThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaWhileBrowsingAndSiteIsNullThenReturnNull() = runBlockingTest {
         setConceptTestVariant()
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = null)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = null)
         assertNull(value)
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndHideTipsIsTrueThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaWhileBrowsingAndHideTipsIsTrueThenReturnNull() = runBlockingTest {
         setConceptTestVariant()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
         assertNull(value)
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndPrivacyOffThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaWhileBrowsingAndPrivacyOffThenReturnNull() = runBlockingTest {
         setConceptTestVariant()
         whenever(mockPrivacySettingsStore.privacyOn).thenReturn(false)
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
         assertNull(value)
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndVariantIsNotConceptTestThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaWhileBrowsingAndVariantIsNotConceptTestThenReturnNull() = runBlockingTest {
         setDefaultVariant()
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
         assertNull(value)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabThenReturnDaxEndCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabThenReturnDaxEndCta() = runBlockingTest {
         setConceptTestVariant()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
         assertTrue(value is DaxBubbleCta.DaxEndCta)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndHideTipsIsTrueThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnNull() = runBlockingTest {
         setConceptTestVariant()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true)
         assertNull(value)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndVarianIstNotConceptTestThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndVarianIstNotConceptTestThenReturnNull() = runBlockingTest {
         setDefaultVariant()
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true)
         assertNull(value)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndVariantIsConceptTestThenDoNotShowWidgetAutoCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndVariantIsConceptTestThenDoNotShowWidgetAutoCta() = runBlockingTest {
         setConceptTestVariant()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true)
         assertTrue(value !is HomePanelCta.AddWidgetAuto)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndVariantIsConceptTestThenDoNotShowWidgetInstructionsCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndVariantIsConceptTestThenDoNotShowWidgetInstructionsCta() = runBlockingTest {
         setConceptTestVariant()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true)
         assertTrue(value !is HomePanelCta.AddWidgetInstructions)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndHideTipsIsTrueThenReturnWidgetAutoCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnWidgetAutoCta() = runBlockingTest {
         setDefaultVariant()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
         assertTrue(value is HomePanelCta.AddWidgetAuto)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndHideTipsIsTrueThenReturnWidgetInstructionsCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnWidgetInstructionsCta() = runBlockingTest {
         setDefaultVariant()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
         assertTrue(value is HomePanelCta.AddWidgetInstructions)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabVariantIsNoCtaReturnNullWhenTryngToShowWidgetCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabVariantIsNoCtaReturnNullWhenTryngToShowWidgetCta() = runBlockingTest {
         setNoCtaVariant()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true)
         assertNull(value)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabVariantIsNoCtaReturnNullWhenTryngToShowWidgetInstructionsCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabVariantIsNoCtaReturnNullWhenTryngToShowWidgetInstructionsCta() = runBlockingTest {
         setNoCtaVariant()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true)
         assertNull(value)
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabThenReturnNetworkCta() = runBlockingTest {
+    fun whenRefreshCtaWhileBrowsingThenReturnNetworkCta() = runBlockingTest {
         setConceptTestVariant()
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
 
         assertTrue(value is DaxDialogCta.DaxMainNetworkCta)
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabThenReturnTrackersBlockedCta() = runBlockingTest {
+    fun whenRefreshCtaWhileBrowsingThenReturnTrackersBlockedCta() = runBlockingTest {
         setConceptTestVariant()
         val site = site(url = "http://www.cnn.com", trackerCount = 1)
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
 
         assertTrue(value is DaxDialogCta.DaxTrackersBlockedCta)
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabThenReturnSerpCta() = runBlockingTest {
+    fun whenRefreshCtaWhileBrowsingThenReturnSerpCta() = runBlockingTest {
         setConceptTestVariant()
         val site = site(url = "http://www.duckduckgo.com")
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
 
         assertTrue(value is DaxDialogCta.DaxSerpCta)
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabThenReturnNoSerpCta() = runBlockingTest {
+    fun whenRefreshCtaWhileBrowsingThenReturnNoSerpCta() = runBlockingTest {
         setConceptTestVariant()
         val site = site(url = "http://www.wikipedia.com")
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
 
         assertTrue(value is DaxDialogCta.DaxNoSerpCta)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabThenValueReturnedIsNotDaxDialogCtaType() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabThenValueReturnedIsNotDaxDialogCtaType() = runBlockingTest {
         setConceptTestVariant()
         val site = site(url = "http://www.wikipedia.com")
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true, site = site)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, site = site)
 
         assertTrue(value !is DaxDialogCta)
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndJourneyCompletedAndSiteIsNotNullReturnNull() = runBlockingTest {
-        setConceptTestVariant()
-        val site = site(url = "http://www.wikipedia.com")
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
-
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true, site = site)
-        assertNull(value)
-    }
-
-    @Test
-    fun whenRefreshCtaOnNewTabEndCtaNotShownIfIntroCtaWasNotPreviouslyShown() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabEndCtaNotShownIfIntroCtaWasNotPreviouslyShown() = runBlockingTest {
         setConceptTestVariant()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(false)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true)
         assertTrue(value !is DaxBubbleCta.DaxEndCta)
     }
-
 
     private fun setConceptTestVariant() {
         whenever(mockVariantManager.getVariant()).thenReturn(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -323,8 +323,9 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         super.onResume()
         addTextChangedListeners()
         appBarLayout.setExpanded(true)
-        viewModel.onViewVisible()
+        viewModel.onViewResumed()
         logoHidingListener.onResume()
+        if(isVisible) { viewModel.onViewVisible() }
     }
 
     override fun onPause() {
@@ -954,7 +955,6 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             webView?.onPause()
         } else {
             webView?.onResume()
-            viewModel.onViewVisible()
         }
     }
 
@@ -1201,7 +1201,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         private fun createLoadedAnimation() {
             launch {
                 delay(TRACKERS_INI_DELAY)
-                viewModel.refreshCta(false)
+                viewModel.refreshCta()
                 delay(TRACKERS_SECONDARY_DELAY)
                 if (lastSeenOmnibarViewState?.isEditing != true) {
                     val site = viewModel.siteLiveData.value
@@ -1338,6 +1338,8 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         }
 
         fun renderCtaViewState(viewState: CtaViewState) {
+            if (!isVisible) return
+
             renderIfChanged(viewState, lastSeenCtaViewState) {
                 ddgLogo.show()
                 lastSeenCtaViewState = viewState

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -325,7 +325,9 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         appBarLayout.setExpanded(true)
         viewModel.onViewResumed()
         logoHidingListener.onResume()
-        if(isVisible) { viewModel.onViewVisible() }
+        if (isVisible) {
+            viewModel.onViewVisible()
+        }
     }
 
     override fun onPause() {
@@ -1181,7 +1183,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                     progress = viewState.progress
                 }
 
-                if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.ConceptTest) && privacySettingsStore.privacyOn ) {
+                if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.ConceptTest) && privacySettingsStore.privacyOn) {
 
                     if (lastSeenOmnibarViewState?.isEditing == true) {
                         cancelAllAnimations()
@@ -1236,7 +1238,8 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
         fun renderGlobalViewState(viewState: GlobalLayoutViewState) {
             if (lastSeenGlobalViewState is GlobalLayoutViewState.Invalidated &&
-                viewState is GlobalLayoutViewState.Browser) {
+                viewState is GlobalLayoutViewState.Browser
+            ) {
                 throw IllegalStateException("Invalid state transition")
             }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -300,7 +300,7 @@ class BrowserTabViewModel(
     }
 
     fun onViewVisible() {
-        //we expect refreshCta to be called when site is loaded if user is browsing to have trackers info.
+        //we expect refreshCta to be called when a site is fully loaded if browsingShowing -trackers data available-.
         if (!currentBrowserViewState().browserShowing) {
             refreshCta()
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -300,7 +300,10 @@ class BrowserTabViewModel(
     }
 
     fun onViewVisible() {
-        refreshCta()
+        //we expect refreshCta to be called when site is loaded if user is browsing to have trackers info.
+        if (!currentBrowserViewState().browserShowing) {
+            refreshCta()
+        }
     }
 
     fun onViewHidden() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -292,12 +292,15 @@ class BrowserTabViewModel(
         browserChromeClient.webViewClientListener = this
     }
 
-    fun onViewVisible() {
+    fun onViewResumed() {
         command.value = if (!currentBrowserViewState().browserShowing) ShowKeyboard else HideKeyboard
-        refreshCta(true)
         if (currentGlobalLayoutState() is Invalidated && currentBrowserViewState().browserShowing) {
             showErrorWithAction()
         }
+    }
+
+    fun onViewVisible() {
+        refreshCta()
     }
 
     fun onViewHidden() {
@@ -857,7 +860,7 @@ class BrowserTabViewModel(
     fun onSurveyChanged(survey: Survey?) {
         val activeSurvey = ctaViewModel.onSurveyChanged(survey)
         if (activeSurvey != null) {
-            refreshCta(true)
+            refreshCta()
         }
     }
 
@@ -870,12 +873,14 @@ class BrowserTabViewModel(
         ctaViewModel.onCtaShown(cta)
     }
 
-    fun refreshCta(isNewTab: Boolean) {
-        viewModelScope.launch {
-            val cta = withContext(dispatchers.io()) {
-                ctaViewModel.refreshCta(dispatchers.io(), isNewTab, siteLiveData.value)
+    fun refreshCta() {
+        if (currentGlobalLayoutState() is Browser) {
+            viewModelScope.launch {
+                val cta = withContext(dispatchers.io()) {
+                    ctaViewModel.refreshCta(dispatchers.io(), currentBrowserViewState().browserShowing, siteLiveData.value)
+                }
+                ctaViewState.value = currentCtaViewState().copy(cta = cta)
             }
-            ctaViewState.value = currentCtaViewState().copy(cta = cta)
         }
     }
 
@@ -900,7 +905,7 @@ class BrowserTabViewModel(
 
         ctaViewModel.onUserDismissedCta(cta)
         if (cta is HomePanelCta) {
-            refreshCta(true)
+            refreshCta()
         } else {
             ctaViewState.value = currentCtaViewState().copy(cta = null)
         }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -102,27 +102,41 @@ class CtaViewModel @Inject constructor(
         }
     }
 
-    suspend fun refreshCta(dispatcher: CoroutineContext, isNewTab: Boolean, site: Site? = null): Cta? {
+    suspend fun refreshCta(dispatcher: CoroutineContext, isBrowserShowing: Boolean, site: Site? = null): Cta? {
         surveyCta()?.let {
             return it
         }
 
         return withContext(dispatcher) {
-            when {
-                canShowDaxIntroCta() && isNewTab -> {
-                    DaxBubbleCta.DaxIntroCta(onboardingStore, appInstallStore)
-                }
-                canShowDaxCtaEndOfJourney(site) && isNewTab -> {
-                    DaxBubbleCta.DaxEndCta(onboardingStore, appInstallStore)
-                }
-                shouldShowDaxCta(site) != null && !isNewTab -> {
-                    shouldShowDaxCta(site)
-                }
-                canShowWidgetCta() && isNewTab -> {
-                    if (widgetCapabilities.supportsAutomaticWidgetAdd) AddWidgetAuto else AddWidgetInstructions
-                }
-                else -> null
+            if (isBrowserShowing) {
+                getBrowserCta(site)
+            } else {
+                getHomeCta()
             }
+        }
+    }
+
+    private fun getHomeCta(): Cta? {
+        return when {
+            canShowDaxIntroCta() -> {
+                DaxBubbleCta.DaxIntroCta(onboardingStore, appInstallStore)
+            }
+            canShowDaxCtaEndOfJourney() -> {
+                DaxBubbleCta.DaxEndCta(onboardingStore, appInstallStore)
+            }
+            canShowWidgetCta() -> {
+                if (widgetCapabilities.supportsAutomaticWidgetAdd) AddWidgetAuto else AddWidgetInstructions
+            }
+            else -> null
+        }
+    }
+
+    private fun getBrowserCta(site: Site?): Cta? {
+        return when {
+            canShowDaxDialogCta() -> {
+                getDaxDialogCta(site)
+            }
+            else -> null
         }
     }
 
@@ -151,20 +165,22 @@ class CtaViewModel @Inject constructor(
     private fun canShowDaxIntroCta(): Boolean = isFromConceptTestVariant() && !daxDialogIntroShown() && !settingsDataStore.hideTips
 
     @WorkerThread
-    private fun canShowDaxCtaEndOfJourney(site: Site?): Boolean = isFromConceptTestVariant() &&
+    private fun canShowDaxCtaEndOfJourney(): Boolean = isFromConceptTestVariant() &&
             hasPrivacySettingsOn() &&
             !daxDialogEndShown() &&
             daxDialogIntroShown() &&
             !settingsDataStore.hideTips &&
-            site == null &&
             (daxDialogNetworkShown() || daxDialogOtherShown() || daxDialogSerpShown() || daxDialogTrackersFoundShown())
 
-    @WorkerThread
-    private fun shouldShowDaxCta(site: Site?): Cta? {
+    private fun canShowDaxDialogCta(): Boolean {
         if (settingsDataStore.hideTips || !isFromConceptTestVariant() || !hasPrivacySettingsOn()) {
-            return null
+            return false
         }
+        return true
+    }
 
+    @WorkerThread
+    private fun getDaxDialogCta(site: Site?): Cta? {
         val nonNullSite = site ?: return null
 
         nonNullSite.let {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1154748750174826/f
Tech Design URL: https://app.asana.com/0/0/1157240085321108/f
CC: 

**Description**:
These changes allow us to rely on `browserShowing` property instead of using hardcoded boolean values and only call refresCta when a tab is visible to the user.

**Steps to test this PR**:
1. Keeps all the previous behavior described on how to test https://github.com/duckduckgo/Android/pull/651

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
