### PR TITLE
Add CTA experiments

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -215,7 +215,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndConceptTestFeatureIsActiveThenReturnDaxIntroCta() = runBlockingTest {
+    fun whenRefreshCtaOnNewTabAndConceptTestFeatureActiveThenReturnDaxIntroCta() = runBlockingTest {
         setConceptTestFeature()
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = true)
@@ -223,7 +223,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndConceptTestFeatureIsActiveAndSiteIsNullThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaOnExistingTabAndConceptTestFeatureActiveAndSiteIsNullThenReturnNull() = runBlockingTest {
         setConceptTestFeature()
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = null)
@@ -231,7 +231,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndConceptTestFeatureIsActiveAndHideTipsIsTrueThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaOnExistingTabAndConceptTestFeatureActiveAndHideTipsIsTrueThenReturnNull() = runBlockingTest {
         setConceptTestFeature()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
@@ -241,7 +241,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndConceptTestFeatureIsActiveAndPrivacyOffThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaOnExistingTabAndConceptTestFeatureActiveAndPrivacyOffThenReturnNull() = runBlockingTest {
         setConceptTestFeature()
         whenever(mockPrivacySettingsStore.privacyOn).thenReturn(false)
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
@@ -333,7 +333,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndSuppressedWidgetCtaActiveThenReturnNullWhenTryngToShowWidgetCta() = runBlockingTest {
+    fun whenRefreshCtaOnNewTabAndSuppressWidgetCtaFeatureActiveThenReturnNullWhenTryngToShowWidgetCta() = runBlockingTest {
         setSuppressWidgetCtaFeature()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
@@ -345,7 +345,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnNewTabAndSuppressedWidgetCtaActiveThenReturnNullWhenTryngToShowWidgetInstructionsCta() = runBlockingTest {
+    fun whenRefreshCtaOnNewTabAndSuppressWidgetCtaFeatureActiveThenReturnNullWhenTryngToShowWidgetInstructionsCta() = runBlockingTest {
         setSuppressWidgetCtaFeature()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -377,7 +377,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenRefreshCtaOnExistingTabAndConceptTestFeatureActiveAndNoTrackersInformationThenReturnNoSerpCta() = runBlockingTest {
-        setConceptTestVariant()
+        setConceptTestFeature()
         val site = site(url = "http://www.cnn.com", trackerCount = 1)
         val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = site)
         assertTrue(value is DaxDialogCta.DaxNoSerpCta)

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -223,7 +223,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndAndConceptTestFeatureIsActiveAndSiteIsNullThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaOnExistingTabAndConceptTestFeatureIsActiveAndSiteIsNullThenReturnNull() = runBlockingTest {
         setConceptTestFeature()
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isNewTab = false, site = null)
@@ -231,7 +231,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndAndConceptTestFeatureIsActiveHideTipsIsTrueThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaOnExistingTabAndConceptTestFeatureIsActiveAndHideTipsIsTrueThenReturnNull() = runBlockingTest {
         setConceptTestFeature()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
@@ -241,7 +241,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnExistingTabAndAndConceptTestFeatureIsActivePrivacyOffThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaOnExistingTabAndConceptTestFeatureIsActiveAndPrivacyOffThenReturnNull() = runBlockingTest {
         setConceptTestFeature()
         whenever(mockPrivacySettingsStore.privacyOn).thenReturn(false)
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
@@ -72,8 +72,16 @@ class DefaultBrowserPageViewModelTest {
     }
 
     @Test
-    fun whenInitializeThenSendPixel() {
-        verify(mockPixel).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+    fun whenPageBecomesVisibleThenPixelSent() {
+        testee.pageBecameVisible()
+        verify(mockPixel, times(1)).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+    }
+
+    @Test
+    fun whenPageBecomesVisibleSubsequentTimeThenAdditionalPixelNotSent() {
+        testee.pageBecameVisible()
+        testee.pageBecameVisible()
+        verify(mockPixel, times(1)).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.statistics
 
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -25,57 +26,82 @@ class VariantManagerTest {
 
     private val variants = VariantManager.ACTIVE_VARIANTS
 
+    // SERP Experiment(s)
+
     @Test
-    fun serpAndSharedControlVariantActive() {
+    fun serpControlVariantIsInactiveAndHasNoFeatures() {
         val variant = variants.firstOrNull { it.key == "sc" }
         assertEqualsDouble(0.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
-    fun serpExperimentalVariantActive() {
+    fun serpExperimentalVariantIsInactiveAndHasNoFeatures() {
         val variant = variants.firstOrNull { it.key == "se" }
         assertEqualsDouble(0.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }
 
+    // Concept test experiment
+
     @Test
-    fun conceptTestControlGroupVariantActive() {
+    fun conceptTestControlVariantIsInactiveAndHasNoFeatures() {
         val variant = variants.firstOrNull { it.key == "mc" }
-        assertEqualsDouble(1.0, variant!!.weight)
+        assertEqualsDouble(0.0, variant!!.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
-    fun conceptTestControlGroupVariantHasNoExperimentFeatures() {
-        val variant = variants.firstOrNull { it.key == "mc" }
+    fun conceptTestNoCtaVariantIsInactiveAndHasSuppressCtaFeatures() {
+        val variant = variants.firstOrNull { it.key == "md" }
+        assertEqualsDouble(0.0, variant!!.weight)
+        assertEquals(2, variant!!.features.size)
+        assertTrue(variant.hasFeature(SuppressWidgetCta))
+        assertTrue(variant.hasFeature(SuppressDefaultBrowserCta))
+    }
+
+    @Test
+    fun conceptTestExperimentalVariantIsInactiveAndHasConceptTestAndSuppressCtaFeatures() {
+        val variant = variants.firstOrNull { it.key == "me" }
+        assertEqualsDouble(0.0, variant!!.weight)
+        assertEquals(3, variant!!.features.size)
+        assertTrue(variant.hasFeature(ConceptTest))
+        assertTrue(variant.hasFeature(SuppressWidgetCta))
+        assertTrue(variant.hasFeature(SuppressDefaultBrowserCta))
+    }
+
+    // CTA Validation experiments
+
+    @Test
+    fun ctaControlVariantIsActiveAndHasNoFeatures() {
+        val variant = variants.firstOrNull { it.key == "mq" }
+        assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(0, variant!!.features.size)
     }
 
     @Test
-    fun conceptTestExistingNoCtaExperimentVariantActive() {
-        val variant = variants.firstOrNull { it.key == "md" }
+    fun ctaSuppressDefaultBrowserVariantIsActiveAndHasSuppressDefaultBrowserFeature() {
+        val variant = variants.firstOrNull { it.key == "mr" }
         assertEqualsDouble(1.0, variant!!.weight)
-    }
-
-    @Test
-    fun conceptTestExistingNoCtaExperimentVariantHasExperimentalExistingNoCta() {
-        val variant = variants.firstOrNull { it.key == "md" }
         assertEquals(1, variant!!.features.size)
-        assertTrue(variant.hasFeature(VariantManager.VariantFeature.ExistingNoCta))
+        assertTrue(variant.hasFeature(SuppressDefaultBrowserCta))
     }
 
     @Test
-    fun conceptTestExperimentVariantActive() {
-        val variant = variants.firstOrNull { it.key == "me" }
+    fun ctaSuppressWidgetVariantIsActiveAndHasSuppressWidgetCtaFeature() {
+        val variant = variants.firstOrNull { it.key == "ms" }
         assertEqualsDouble(1.0, variant!!.weight)
+        assertEquals(1, variant!!.features.size)
+        assertTrue(variant.hasFeature(SuppressWidgetCta))
     }
 
     @Test
-    fun conceptTestExperimentVariantHasExperimentalExistingNoCta() {
-        val variant = variants.firstOrNull { it.key == "me" }
-        assertEquals(1, variant!!.features.size)
-        assertTrue(variant.hasFeature(VariantManager.VariantFeature.ConceptTest))
+    fun ctaSuppressAllVariantIsActiveAndHasSuppressCtaFeatures() {
+        val variant = variants.firstOrNull { it.key == "mt" }
+        assertEqualsDouble(1.0, variant!!.weight)
+        assertEquals(2, variant!!.features.size)
+        assertTrue(variant.hasFeature(SuppressDefaultBrowserCta))
+        assertTrue(variant.hasFeature(SuppressWidgetCta))
     }
 
     @Suppress("SameParameterValue")

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -327,9 +327,9 @@ sealed class HomePanelCta(
         R.string.addWidgetCtaDescription,
         R.string.addWidgetCtaAutoLaunchButton,
         R.string.addWidgetCtaDismissButton,
-        null,
-        null,
-        null
+        Pixel.PixelName.WIDGET_CTA_SHOWN,
+        Pixel.PixelName.WIDGET_CTA_LAUNCHED,
+        Pixel.PixelName.WIDGET_CTA_DISMISSED
     )
 
     object AddWidgetInstructions : HomePanelCta(
@@ -339,8 +339,8 @@ sealed class HomePanelCta(
         R.string.addWidgetCtaDescription,
         R.string.addWidgetCtaInstructionsLaunchButton,
         R.string.addWidgetCtaDismissButton,
-        null,
-        null,
-        null
+        Pixel.PixelName.WIDGET_LEGACY_CTA_SHOWN,
+        Pixel.PixelName.WIDGET_LEGACY_CTA_LAUNCHED,
+        Pixel.PixelName.WIDGET_LEGACY_CTA_DISMISSED
     )
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -28,7 +28,10 @@ import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.privacy.store.PrivacySettingsStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.ConceptTest
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.SuppressWidgetCta
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
@@ -143,8 +146,7 @@ class CtaViewModel @Inject constructor(
         return widgetCapabilities.supportsStandardWidgetAdd &&
                 !widgetCapabilities.hasInstalledWidgets &&
                 !dismissedCtaDao.exists(CtaId.ADD_WIDGET) &&
-                !isFromConceptTestVariant() &&
-                !isFromNoCtaVariant()
+                !variant().hasFeature(SuppressWidgetCta)
     }
 
     @WorkerThread
@@ -194,9 +196,9 @@ class CtaViewModel @Inject constructor(
 
     private fun hasPrivacySettingsOn(): Boolean = settingsPrivacySettingsStore.privacyOn
 
-    private fun isFromConceptTestVariant(): Boolean = variantManager.getVariant().hasFeature(VariantManager.VariantFeature.ConceptTest)
+    private fun variant(): Variant = variantManager.getVariant()
 
-    private fun isFromNoCtaVariant(): Boolean = variantManager.getVariant().hasFeature(VariantManager.VariantFeature.ExistingNoCta)
+    private fun isFromConceptTestVariant(): Boolean = variantManager.getVariant().hasFeature(ConceptTest)
 
     private fun daxDialogIntroShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_INTRO)
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.onboarding.ui.page.OnboardingPageFragment
 import com.duckduckgo.app.onboarding.ui.page.UnifiedSummaryPage
 import com.duckduckgo.app.onboarding.ui.page.WelcomePage
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.SuppressDefaultBrowserCta
 
 interface OnboardingPageManager {
     fun pageCount(): Int
@@ -84,8 +85,7 @@ class OnboardingPageManagerWithTrackerBlocking(
 
     private fun shouldShowDefaultBrowserPage(): Boolean {
         return defaultWebBrowserCapability.deviceSupportsDefaultBrowserConfiguration()
-                && !variantManager.getVariant().hasFeature(VariantManager.VariantFeature.ExistingNoCta)
-                && !variantManager.getVariant().hasFeature(VariantManager.VariantFeature.ConceptTest)
+                && !variantManager.getVariant().hasFeature(SuppressDefaultBrowserCta)
     }
 
     private fun isFinalPage(position: Int) = position == pageCount() - 1

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
@@ -63,6 +63,13 @@ class DefaultBrowserPage : OnboardingPageFragment() {
         super.onAttach(context)
     }
 
+    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
+        super.setUserVisibleHint(isVisibleToUser)
+        if (isVisibleToUser) {
+            viewModel.pageBecameVisible()
+        }
+    }
+
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         defaultCard = activity?.findViewById(R.id.defaultCard)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
@@ -52,12 +52,20 @@ class DefaultBrowserPageViewModel(
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
     var timesPressedJustOnce: Int = 0
 
+    private var viewHasShown: Boolean = false
+
     init {
         viewState.value = ViewState(
             showOnlyContinue = defaultBrowserDetector.isDefaultBrowser(),
             showSettingsUi = defaultBrowserDetector.hasDefaultBrowser()
         )
-        pixel.fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+    }
+
+    fun pageBecameVisible() {
+        if (!viewHasShown) {
+            viewHasShown = true
+            pixel.fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+        }
     }
 
     fun loadUI() {

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -50,8 +50,7 @@ interface VariantManager {
             Variant(key = "me", weight = 0.0, features = listOf(ConceptTest, SuppressWidgetCta, SuppressDefaultBrowserCta), filterBy = { isEnglishLocale() }),
             Variant(key = "md", weight = 0.0, features = listOf(SuppressWidgetCta, SuppressDefaultBrowserCta), filterBy = { isEnglishLocale() }),
 
-            // Validate CTA performance experiment
-
+            // Validate CTAs experiment
             Variant(key = "mq", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
             Variant(key = "mr", weight = 1.0, features = listOf(SuppressDefaultBrowserCta), filterBy = { noFilter() }),
             Variant(key = "ms", weight = 1.0, features = listOf(SuppressWidgetCta), filterBy = { noFilter() }),

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.statistics
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.VariantManager.Companion.referrerVariant
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.*
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import timber.log.Timber
 import java.util.*
@@ -26,11 +27,11 @@ import java.util.*
 @WorkerThread
 interface VariantManager {
 
+    // variant-dependant features listed here
     sealed class VariantFeature {
-        // variant-dependant features listed here
         object ConceptTest : VariantFeature()
-
-        object ExistingNoCta : VariantFeature()
+        object SuppressWidgetCta : VariantFeature()
+        object SuppressDefaultBrowserCta : VariantFeature()
     }
 
     companion object {
@@ -39,14 +40,22 @@ interface VariantManager {
         val DEFAULT_VARIANT = Variant(key = "", features = emptyList(), filterBy = { noFilter() })
 
         val ACTIVE_VARIANTS = listOf(
-
             // SERP variants. "sc" may also be used as a shared control for mobile experiments in
             // the future if we can filter by app version
             Variant(key = "sc", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
             Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "mc", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),
-            Variant(key = "me", weight = 1.0, features = listOf(VariantFeature.ConceptTest), filterBy = { isEnglishLocale() }),
-            Variant(key = "md", weight = 1.0, features = listOf(VariantFeature.ExistingNoCta), filterBy = { isEnglishLocale() })
+
+            // Concept test experiment
+            Variant(key = "mc", weight = 0.0, features = emptyList(), filterBy = { isEnglishLocale() }),
+            Variant(key = "me", weight = 0.0, features = listOf(ConceptTest, SuppressWidgetCta, SuppressDefaultBrowserCta), filterBy = { isEnglishLocale() }),
+            Variant(key = "md", weight = 0.0, features = listOf(SuppressWidgetCta, SuppressDefaultBrowserCta), filterBy = { isEnglishLocale() }),
+
+            // Validate CTA performance experiment
+
+            Variant(key = "mq", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "mr", weight = 1.0, features = listOf(SuppressDefaultBrowserCta), filterBy = { noFilter() }),
+            Variant(key = "ms", weight = 1.0, features = listOf(SuppressWidgetCta), filterBy = { noFilter() }),
+            Variant(key = "mt", weight = 1.0, features = listOf(SuppressWidgetCta, SuppressDefaultBrowserCta), filterBy = { noFilter() })
 
             // All groups in an experiment (control and variants) MUST use the same filters
         )

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -61,6 +61,7 @@ interface Pixel {
         ONBOARDING_DEFAULT_BROWSER_LAUNCHED("m_odb_l"),
         ONBOARDING_DEFAULT_BROWSER_SKIPPED("m_odb_s"),
         ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE("m_odb_jo"),
+
         ONBOARDING_DAX_CTA_SHOWN("m_odc_s"),
         ONBOARDING_DAX_ALL_CTA_HIDDEN("m_odc_h"),
         ONBOARDING_DAX_CTA_OK_BUTTON("m_odc_ok"),
@@ -85,6 +86,13 @@ interface Pixel {
         DEFAULT_BROWSER_SET("m_db_s"),
         DEFAULT_BROWSER_NOT_SET("m_db_ns"),
         DEFAULT_BROWSER_UNSET("m_db_u"),
+
+        WIDGET_CTA_SHOWN("m_wc_s"),
+        WIDGET_CTA_LAUNCHED("m_wc_l"),
+        WIDGET_CTA_DISMISSED("m_wc_d"),
+        WIDGET_LEGACY_CTA_SHOWN("m_wlc_s"),
+        WIDGET_LEGACY_CTA_LAUNCHED("m_wlc_l"),
+        WIDGET_LEGACY_CTA_DISMISSED("m_wlc_d"),
         WIDGETS_ADDED(pixelName = "m_w_a"),
         WIDGETS_DELETED(pixelName = "m_w_d"),
         WIDGET_LAUNCHED(pixelName = "m_w_l"),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1158110040574203
Tech Design URL: N/A

**Description**:
Adds CTA retention experiments to help up determine effectiveness of CTAa

**Steps to test this PR**:

**Check CTAs are shown for control:**
1. Open VariantManager.kt and comment out all variants other than `mq` control
1. Run a fresh installation of the app and launch it to the welcome screen
1. Ensure the `m_odb_v` pixel has NOT fired yet
1. Press `Continue`
1. Ensure the the `Make DuckDuckGo Your Default` onboarding is shown and the `m_odb_v` pixel now fires
1. Select `Maybe later` to get to the home screen
1. Ensure the widget CTA shows

**Check that only widget CTA is shown on high end device and triggers correct pixels when default browser CTA feature is suppressed:**
1. Open VariantManager.kt and comment out all variants other than `mr`
1. Launch the app on an API 26 above emulator or device that supports widget pinning
1. Run a fresh installation of the app and launch it to the welcome screen, press `Start Browsing`
1. Ensure the widget CTA shows and the `m_wc_s` pixel fires
1. Press `Add Widget` and ensure the `m_wc_l` pixel fires
1. Press `Add Automatically` and ensure the CTA is gone
--
7. Reset the app and run through the previous steps however this time select `Dismiss` at step 4
1. Ensure the `m_wc_d` pixel fires 
1. Ensure the Add widget CTA is now gone

**Check that only widget CTA is shown on low end device and triggers correct pixels when default browser CTA feature is suppressed:**
1. Open VariantManager.kt and comment out all variants other than `mr`
1. Launch the app on an API 22-25 emulator or device
1. Run a fresh installation of the app and launch it to the welcome screen, press `Start Browsing`
1. Ensure the widget CTA shows and the `m_wlc_s` pixel fires
1. Press `Show Me` and ensure the `m_wlc_l` pixel fires
1. Press `Go to home screen` and add the widget to the home screen
1. Relaunch the app, close the info screen and ensure the CTA is gone
--
7. Reset the app and run through previous steps 1-4 however this time select `Dismiss` at step 4
1. Ensure the `m_wlc_d` pixel fires 
1. Ensure the CTA is now gone

**Check only default browser CTA shown when widget CTA feature suppressed:**
1. Open VariantManager.kt and comment out all variants other than `ms`
1. Run a fresh installation of the app and launch it to the welcome screen
1. Ensure the `m_odb_v` pixel has NOT fired yet
1. Press `Continue`
1. Ensure the the `Make DuckDuckGo your default` onboarding is shown and the `m_odb_v` pixel now fires
1. Select `Maybe later` to get to the home screen
1. Ensure the widget CTA is not shown

**Check that no CTA shown when they are suppressed:**
1. Open VariantManager.kt and comment out all variants other than `mt`
1. Run a fresh installation of the app and launch it to the welcome screen and press  press `Start Browsing`
1. Note that no CTAs were displayed

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
