### PR TITLE
Cta new interfaces

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaTest.kt
@@ -76,12 +76,6 @@ class CtaTest {
     }
 
     @Test
-    fun whenCtaIsSurveyReturnNullDialogCta() {
-        val testee = HomePanelCta.Survey(Survey("abc", "http://example.com", 1, Survey.Status.SCHEDULED))
-        assertNull(testee.createDialogCta(mock(FragmentActivity::class.java)))
-    }
-
-    @Test
     fun whenCtaIsAddWidgetAutoReturnEmptyOkParameters() {
         val testee = HomePanelCta.AddWidgetAuto
         assertTrue(testee.pixelOkParameters().isEmpty())
@@ -99,11 +93,6 @@ class CtaTest {
         assertTrue(testee.pixelShownParameters().isEmpty())
     }
 
-    @Test
-    fun whenCtaIsAddWidgetAutoReturnNullDialogCta() {
-        val testee = HomePanelCta.AddWidgetAuto
-        assertNull(testee.createDialogCta(mock(FragmentActivity::class.java)))
-    }
 
     @Test
     fun whenCtaIsAddWidgetInstructionsReturnEmptyOkParameters() {
@@ -121,12 +110,6 @@ class CtaTest {
     fun whenCtaIsAddWidgetInstructionsReturnEmptyShownParameters() {
         val testee = HomePanelCta.AddWidgetInstructions
         assertTrue(testee.pixelShownParameters().isEmpty())
-    }
-
-    @Test
-    fun whenCtaIsAddWidgetInstructionsReturnNullDialogCta() {
-        val testee = HomePanelCta.AddWidgetInstructions
-        assertNull(testee.createDialogCta(mock(FragmentActivity::class.java)))
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1431,7 +1431,6 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 renderHomeCta()
             } else {
                 configuration.showCta(ctaContainer)
-                ctaContainer.show()
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1137,6 +1137,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         private var lastSeenGlobalViewState: GlobalLayoutViewState? = null
         private var lastSeenAutoCompleteViewState: AutoCompleteViewState? = null
         private var lastSeenCtaViewState: CtaViewState? = null
+        private var daxDialog: DaxDialog? = null
 
         fun renderAutocomplete(viewState: AutoCompleteViewState) {
             renderIfChanged(viewState, lastSeenAutoCompleteViewState) {
@@ -1372,7 +1373,8 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             hideDaxCta()
             val container = networksContainer
             activity?.let { activity ->
-                val daxDialog = configuration.createDialogCta(activity).apply {
+                daxDialog?.dismiss()
+                daxDialog = configuration.showCta(activity).apply {
                     setHideClickListener {
                         dismiss()
                         launchHideTipsDialog(activity, configuration)
@@ -1397,7 +1399,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                         }
                     }
                 }
-                daxDialog.show(activity.supportFragmentManager, DAX_DIALOG_DIALOG_TAG)
+                daxDialog?.show(activity.supportFragmentManager, DAX_DIALOG_DIALOG_TAG)
             }
         }
 
@@ -1418,20 +1420,19 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         }
 
         private fun showDaxCta(configuration: DaxBubbleCta) {
-            daxCtaContainer.alpha = 1f
-            daxCtaContainer.show()
             ddgLogo.hide()
             hideHomeCta()
-            configuration.apply(daxCtaContainer)
+            configuration.showCta(daxCtaContainer)
         }
 
         private fun showHomeCta(configuration: HomePanelCta) {
             hideDaxCta()
             if (ctaContainer.isEmpty()) {
                 renderHomeCta()
+            } else {
+                configuration.showCta(ctaContainer)
+                ctaContainer.show()
             }
-            configuration.apply(ctaContainer)
-            ctaContainer.show()
         }
 
         private fun hideDaxCta() {
@@ -1453,7 +1454,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             inflate(context, R.layout.include_cta, ctaContainer)
             logoHidingListener.callToActionView = ctaContainer
 
-            configuration.apply(ctaContainer)
+            configuration.showCta(ctaContainer)
             ctaContainer.ctaOkButton.setOnClickListener {
                 viewModel.onUserClickCtaOkButton()
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -332,6 +332,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     }
 
     override fun onPause() {
+        daxDialog = null
         logoHidingListener.onPause()
         super.onPause()
     }
@@ -983,7 +984,6 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     }
 
     override fun onDestroy() {
-        daxDialog = null
         supervisorJob.cancel()
         popupMenu.dismiss()
         destroyWebView()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -235,6 +235,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     private val logoHidingListener by lazy { LogoHidingLayoutChangeLifecycleListener(ddgLogo) }
 
     private var alertDialog: AlertDialog? = null
+    private var daxDialog: DaxDialog? = null
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -982,6 +983,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     }
 
     override fun onDestroy() {
+        daxDialog = null
         supervisorJob.cancel()
         popupMenu.dismiss()
         destroyWebView()
@@ -1137,7 +1139,6 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         private var lastSeenGlobalViewState: GlobalLayoutViewState? = null
         private var lastSeenAutoCompleteViewState: AutoCompleteViewState? = null
         private var lastSeenCtaViewState: CtaViewState? = null
-        private var daxDialog: DaxDialog? = null
 
         fun renderAutocomplete(viewState: AutoCompleteViewState) {
             renderIfChanged(viewState, lastSeenAutoCompleteViewState) {
@@ -1374,7 +1375,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             val container = networksContainer
             activity?.let { activity ->
                 daxDialog?.dismiss()
-                daxDialog = configuration.showCta(activity).apply {
+                daxDialog = configuration.createCta(activity).apply {
                     setHideClickListener {
                         dismiss()
                         launchHideTipsDialog(activity, configuration)
@@ -1398,8 +1399,8 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                             dismiss()
                         }
                     }
+                    show(activity.supportFragmentManager, DAX_DIALOG_DIALOG_TAG)
                 }
-                daxDialog?.show(activity.supportFragmentManager, DAX_DIALOG_DIALOG_TAG)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -41,6 +41,15 @@ import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.dialogTextCta
 import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.hiddenTextCta
 import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.primaryCta
 
+interface BrowserCta {
+    fun showCta(activity: FragmentActivity): DaxDialog
+}
+
+
+interface HomeCta {
+    fun showCta(view: View)
+}
+
 interface Cta {
     val ctaId: CtaId
     val shownPixel: Pixel.PixelName?
@@ -50,9 +59,6 @@ interface Cta {
     fun pixelShownParameters(): Map<String, String?>
     fun pixelCancelParameters(): Map<String, String?>
     fun pixelOkParameters(): Map<String, String?>
-
-    fun apply(view: View)
-    fun createDialogCta(activity: FragmentActivity): DaxDialog?
 }
 
 sealed class DaxDialogCta(
@@ -65,11 +71,9 @@ sealed class DaxDialogCta(
     var ctaPixelParam: String,
     val onboardingStore: OnboardingStore,
     val appInstallStore: AppInstallStore
-) : Cta {
+) : Cta, BrowserCta {
 
-    override fun apply(view: View) {}
-
-    override fun createDialogCta(activity: FragmentActivity) = DaxDialog(getDaxText(activity), activity.resources.getString(okButton))
+    override fun showCta(activity: FragmentActivity) = DaxDialog(getDaxText(activity), activity.resources.getString(okButton))
 
     override fun pixelCancelParameters(): Map<String, String?> = mapOf(Pixel.PixelParameter.CTA_SHOWN to ctaPixelParam)
 
@@ -120,7 +124,7 @@ sealed class DaxDialogCta(
             appInstallStore
         ) {
 
-        override fun createDialogCta(activity: FragmentActivity): DaxDialog =
+        override fun showCta(activity: FragmentActivity): DaxDialog =
             DaxDialog(getDaxText(activity), activity.resources.getString(okButton), false)
 
         override fun getDaxText(context: Context): String {
@@ -164,7 +168,7 @@ sealed class DaxDialogCta(
             }
         }
 
-        override fun createDialogCta(activity: FragmentActivity): DaxDialog {
+        override fun showCta(activity: FragmentActivity): DaxDialog {
             return DaxDialog(getDaxText(activity), activity.resources.getString(okButton)).apply {
                 val privacyGradeButton = activity.findViewById<View>(R.id.privacyGradeButton)
                 onAnimationFinishedListener {
@@ -204,7 +208,7 @@ sealed class DaxDialogCta(
         appInstallStore
     ) {
 
-        override fun createDialogCta(activity: FragmentActivity): DaxDialog {
+        override fun showCta(activity: FragmentActivity): DaxDialog {
             return DaxDialog(getDaxText(activity), activity.resources.getString(okButton)).apply {
                 val fireButton = activity.findViewById<View>(R.id.fire)
                 onAnimationFinishedListener {
@@ -232,9 +236,9 @@ sealed class DaxBubbleCta(
     val ctaPixelParam: String,
     val onboardingStore: OnboardingStore,
     val appInstallStore: AppInstallStore
-) : Cta {
+) : Cta, HomeCta {
 
-    override fun apply(view: View) {
+    override fun showCta(view: View) {
         val daxText = view.context.getString(description)
         view.show()
         view.alpha = 1f
@@ -242,8 +246,6 @@ sealed class DaxBubbleCta(
         view.primaryCta.hide()
         view.dialogTextCta.startTypingAnimation(daxText, true)
     }
-
-    override fun createDialogCta(activity: FragmentActivity): DaxDialog? = null
 
     override fun pixelCancelParameters(): Map<String, String?> = mapOf(Pixel.PixelParameter.CTA_SHOWN to ctaPixelParam)
 
@@ -295,17 +297,15 @@ sealed class HomePanelCta(
     override val shownPixel: Pixel.PixelName?,
     override val okPixel: Pixel.PixelName?,
     override val cancelPixel: Pixel.PixelName?
-) : Cta {
+) : Cta, HomeCta {
 
-    override fun apply(view: View) {
+    override fun showCta(view: View) {
         view.ctaIcon.setImageResource(image)
         view.ctaTitle.text = view.context.getString(title)
         view.ctaSubtitle.text = view.context.getString(description)
         view.ctaOkButton.text = view.context.getString(okButton)
         view.ctaDismissButton.text = view.context.getString(dismissButton)
     }
-
-    override fun createDialogCta(activity: FragmentActivity): DaxDialog? = null
 
     override fun pixelCancelParameters(): Map<String, String?> = emptyMap()
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -42,7 +42,7 @@ import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.hiddenTextCta
 import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.primaryCta
 
 interface DialogCta {
-    fun showCta(activity: FragmentActivity): DaxDialog
+    fun createCta(activity: FragmentActivity): DaxDialog
 }
 
 
@@ -73,7 +73,7 @@ sealed class DaxDialogCta(
     val appInstallStore: AppInstallStore
 ) : Cta, DialogCta {
 
-    override fun showCta(activity: FragmentActivity) = DaxDialog(getDaxText(activity), activity.resources.getString(okButton))
+    override fun createCta(activity: FragmentActivity) = DaxDialog(getDaxText(activity), activity.resources.getString(okButton))
 
     override fun pixelCancelParameters(): Map<String, String?> = mapOf(Pixel.PixelParameter.CTA_SHOWN to ctaPixelParam)
 
@@ -124,7 +124,7 @@ sealed class DaxDialogCta(
             appInstallStore
         ) {
 
-        override fun showCta(activity: FragmentActivity): DaxDialog =
+        override fun createCta(activity: FragmentActivity): DaxDialog =
             DaxDialog(getDaxText(activity), activity.resources.getString(okButton), false)
 
         override fun getDaxText(context: Context): String {
@@ -168,7 +168,7 @@ sealed class DaxDialogCta(
             }
         }
 
-        override fun showCta(activity: FragmentActivity): DaxDialog {
+        override fun createCta(activity: FragmentActivity): DaxDialog {
             return DaxDialog(getDaxText(activity), activity.resources.getString(okButton)).apply {
                 val privacyGradeButton = activity.findViewById<View>(R.id.privacyGradeButton)
                 onAnimationFinishedListener {
@@ -208,7 +208,7 @@ sealed class DaxDialogCta(
         appInstallStore
     ) {
 
-        override fun showCta(activity: FragmentActivity): DaxDialog {
+        override fun createCta(activity: FragmentActivity): DaxDialog {
             return DaxDialog(getDaxText(activity), activity.resources.getString(okButton)).apply {
                 val fireButton = activity.findViewById<View>(R.id.fire)
                 onAnimationFinishedListener {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -305,6 +305,7 @@ sealed class HomePanelCta(
         view.ctaSubtitle.text = view.context.getString(description)
         view.ctaOkButton.text = view.context.getString(okButton)
         view.ctaDismissButton.text = view.context.getString(dismissButton)
+        view.show()
     }
 
     override fun pixelCancelParameters(): Map<String, String?> = emptyMap()

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -41,12 +41,12 @@ import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.dialogTextCta
 import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.hiddenTextCta
 import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.primaryCta
 
-interface BrowserCta {
+interface DialogCta {
     fun showCta(activity: FragmentActivity): DaxDialog
 }
 
 
-interface HomeCta {
+interface ViewCta {
     fun showCta(view: View)
 }
 
@@ -71,7 +71,7 @@ sealed class DaxDialogCta(
     var ctaPixelParam: String,
     val onboardingStore: OnboardingStore,
     val appInstallStore: AppInstallStore
-) : Cta, BrowserCta {
+) : Cta, DialogCta {
 
     override fun showCta(activity: FragmentActivity) = DaxDialog(getDaxText(activity), activity.resources.getString(okButton))
 
@@ -236,7 +236,7 @@ sealed class DaxBubbleCta(
     val ctaPixelParam: String,
     val onboardingStore: OnboardingStore,
     val appInstallStore: AppInstallStore
-) : Cta, HomeCta {
+) : Cta, ViewCta {
 
     override fun showCta(view: View) {
         val daxText = view.context.getString(description)
@@ -297,7 +297,7 @@ sealed class HomePanelCta(
     override val shownPixel: Pixel.PixelName?,
     override val okPixel: Pixel.PixelName?,
     override val cancelPixel: Pixel.PixelName?
-) : Cta, HomeCta {
+) : Cta, ViewCta {
 
     override fun showCta(view: View) {
         view.ctaIcon.setImageResource(image)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1154748750174828 and https://app.asana.com/0/1125189844152671/1154586839765577
Tech Design URL: https://app.asana.com/0/1125189844152671/1158928566141337
CC: 

**Description**:
We used to have one Cta interface that dealt with the creation of a view cta and a dialog cta making it complicated to understand what method should be used for each of them plus they were very specific to a concrete type. This PR changes that to include two new interfaces depending on the cta type. 
It also fixes the issue when more than one dialog cta could be displayed at the same time.

**Steps to test this PR**:
**Concept test**
1. Using variant `me`
1. Launch the app and navigate to get the different CTAs

**Normal CTAs**
1. Using variant `mc`
1. Launch the app, you should see the default browser CTA and the widget CTA

**Double dialog showing**
1. Using variant `me`
1. Launch and API 21 emulator
1. Load google.com
1. Open privacy grade while it is still loading
1. Close privacy grade and see dialog
1. Tap in url to load cnn.com
1. Only one dialog is shown

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
