### PR TITLE
Fix: cancel coroutine when activity gets destroyed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -103,8 +103,12 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
         viewModel.awaitClearDataFinishedNotification()
     }
 
-    override fun onDestroy() {
+    override fun onStop() {
         job.cancel()
+        super.onStop()
+    }
+
+    override fun onDestroy() {
         currentTab = null
         super.onDestroy()
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -56,7 +56,7 @@ import kotlin.coroutines.CoroutineContext
 class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext
-        get() = SupervisorJob() + Dispatchers.Main
+        get() = job + Dispatchers.Main
 
     @Inject
     lateinit var clearPersonalDataAction: ClearPersonalDataAction
@@ -69,6 +69,8 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
 
     @Inject
     lateinit var playStoreUtils: PlayStoreUtils
+
+    private val job = SupervisorJob()
 
     private var currentTab: BrowserTabFragment? = null
 
@@ -99,6 +101,11 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
             renderer.renderBrowserViewState(it)
         })
         viewModel.awaitClearDataFinishedNotification()
+    }
+
+    override fun onDestroy() {
+        job.cancel()
+        super.onDestroy()
     }
 
     override fun onNewIntent(intent: Intent?) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -105,6 +105,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope {
 
     override fun onDestroy() {
         job.cancel()
+        currentTab = null
         super.onDestroy()
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1159930185369809/f

**Description**:
This fixes some crashes when trying to commit a Fragment transaction when the activity is destroyed.
Additionally, I'm removing also a reference to the `currentFragment` when activity is destroyed as this is causing a leak.

**Steps to test this PR**:

**How to reproduce the crash**
In order to reproduce the crash, we need to hardcode a `delay` in our code and enable activities being killed. Also, we need to use current `develop` branch.

- Developer settings -> enable don't keep activities
- In code ->
```
    fun openMessageInNewTab(message: Message) {
        launch {
            val tabId = viewModel.onNewTabRequested()
delay(5000)
            val fragment = openNewTab(tabId, null, false)
            fragment.messageFromPreviousTab = message
        }
    }
```

1. Visit https://www.w3schools.com/code/tryit.asp?filename=G8SKXWB6508R
1. Press "Run"
1. Tap the "click on me" button or link
1. Navigate to tab switcher screen

**How to test this fix**
Checkout this branch.
Follow the same steps as in the previous description.
Crash should be gone.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
