### PR TITLE
Remove unused app referrer logic

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referral/QueryParamReferrerParserTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referral/QueryParamReferrerParserTest.kt
@@ -17,17 +17,13 @@
 package com.duckduckgo.app.referral
 
 import com.duckduckgo.app.referral.ParsedReferrerResult.ReferrerFound
-import com.duckduckgo.app.statistics.pixels.Pixel
-import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class QueryParamReferrerParserTest {
 
-    private val pixel: Pixel = mock()
-
-    private val testee: QueryParamReferrerParser = QueryParamReferrerParser(pixel)
+    private val testee: QueryParamReferrerParser = QueryParamReferrerParser()
 
     @Test
     fun whenReferrerDoesNotContainTargetThenNoReferrerFound() {
@@ -78,11 +74,6 @@ class QueryParamReferrerParserTest {
     @Test
     fun whenReferrerContainsTargetWithDifferentCaseThenNoReferrerFound() {
         verifyReferrerNotFound(testee.parse("ddgraAB"))
-    }
-
-    @Test
-    fun whenTypeAReferrerNotFoundButTypeBFoundThenReferrerFound() {
-        verifyReferrerFound("AB", testee.parse("key1=foo&key2=bar&key3=DDGRBAB"))
     }
 
     private fun verifyReferrerFound(expectedReferrer: String, result: ParsedReferrerResult) {

--- a/app/src/main/java/com/duckduckgo/app/di/PlayStoreReferralModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PlayStoreReferralModule.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import com.duckduckgo.app.referral.*
 import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.pixels.Pixel
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -33,8 +32,8 @@ class PlayStoreReferralModule {
     fun packageManager(context: Context) = context.packageManager
 
     @Provides
-    fun appInstallationReferrerParser(pixel: Pixel): AppInstallationReferrerParser {
-        return QueryParamReferrerParser(pixel)
+    fun appInstallationReferrerParser(): AppInstallationReferrerParser {
+        return QueryParamReferrerParser()
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -54,9 +54,6 @@ interface Pixel {
         WEB_RENDERER_GONE_KILLED("m_d_wrg_k"),
         BROKEN_SITE_REPORTED("m_bsr"),
 
-        APP_REFERRER_FOUND_TYPE_A("m_rfa"),
-        APP_REFERRER_FOUND_TYPE_B("m_rfb"),
-
         ONBOARDING_DEFAULT_BROWSER_VISUALIZED("m_odb_v"),
         ONBOARDING_DEFAULT_BROWSER_LAUNCHED("m_odb_l"),
         ONBOARDING_DEFAULT_BROWSER_SKIPPED("m_odb_s"),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/608920331025313/1154468535608530/1160451607351813
Tech Design URL: 
CC: 

**Description**:
Removes unused pixels and now redundant logic for capturing an app installation referrer type


**Steps to test this PR**:
### Referrer provided; ATB override test
1. Uninstall production app
1. Enable Play Store internal app sharing (more info: https://app.asana.com/0/414730916066338/1138191120120193)
1. Install app using [ATB Override](https://play.google.com/apps/test/RQl8L2Oq05Y/ahAAvZMmiYl6uhEW6GBQ885xne4f8IdOGBuJwU-Ur0q9hluCKfctwCtXB-1T3AsShS8VxAXYieOu80gsEkRyHGxT0w?&referrer=utm_source%3Dgoogle%26utm_medium%3Dcpc%26anid%3Dadmob%26utm_campaign%3DDDGRAXX)
1. Verify variant is set to `XX` (look for logcat message for variant)

### Referrer provided; No override test
1. Uninstall app
1. Install app using [No ATB override](https://play.google.com/apps/test/RQl8L2Oq05Y/ahAAvZMmiYl6uhEW6GBQ885xne4f8IdOGBuJwU-Ur0q9hluCKfctwCtXB-1T3AsShS8VxAXYieOu80gsEkRyHGxT0w?&referrer=utm_source%3Dgoogle%26utm_medium%3Dcpc%26anid%3Dadmob%26utm_campaign%3DDDGRBXX)
1. Verify variant **not set** to `XX`


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
