### PR TITLE
Avoid sending null when dismissing FindInPage.

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -512,7 +512,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             }
             is Command.DownloadImage -> requestImageDownload(it.url)
             is Command.FindInPageCommand -> webView?.findAllAsync(it.searchTerm)
-            is Command.DismissFindInPage -> webView?.findAllAsync(null)
+            is Command.DismissFindInPage -> webView?.findAllAsync("")
             is Command.ShareLink -> launchSharePageChooser(it.url)
             is Command.CopyLink -> {
                 clipboardManager.primaryClip = ClipData.newPlainText(null, it.url)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1161045919778698/f
Tech Design URL: 
CC: 

**Description**:
Latest chromium release 80.0.3987.87 Feb 4 2020 introduced a null check inside AwContents.findAllAsync

https://chromium.googlesource.com/chromium/src.git/+/refs/tags/80.0.3987.87/android_webview/java/src/org/chromium/android_webview/AwContents.java#1627
vs
https://chromium.googlesource.com/chromium/src.git/+/refs/tags/79.0.3945.136/android_webview/java/src/org/chromium/android_webview/AwContents.java#1624

While analyzing a spike of crashes yesterday, I detected an error (that was also present in previous versions) reported with more frequency after the new chromium release.

The error is related to users dismissing findInPage feature.
```
java.lang.IllegalArgumentException:
(...)
com.duckduckgo.app.browser.BrowserTabViewModel.dismissFindInView
```

I decided to take a look at chromium sourcecode, previous links confirmed a breaking change in their side.

**Steps to test this PR**:
Use a device that has latest chromium update `80.0.3987.87`
1. Open browser
1. Navigate to any website
1. Click on "find in Page" from settings
1. Click on "x" to close it
1. Develop will crash, this branch avoids the crash.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
