### PR TITLE
Feature/craig/map auction variant

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser
 
 import android.net.Uri
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
+import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.nhaarman.mockitokotlin2.mock
@@ -28,7 +29,8 @@ class QueryUrlConverterTest {
 
     private var mockStatisticsStore: StatisticsDataStore = mock()
     private val variantManager: VariantManager = mock()
-    private val requestRewriter = DuckDuckGoRequestRewriter(DuckDuckGoUrlDetector(), mockStatisticsStore, variantManager)
+    private val mockAppReferrerDataStore: AppReferrerDataStore = mock()
+    private val requestRewriter = DuckDuckGoRequestRewriter(DuckDuckGoUrlDetector(), mockStatisticsStore, variantManager, mockAppReferrerDataStore)
     private val testee: QueryUrlConverter = QueryUrlConverter(requestRewriter)
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
@@ -120,7 +120,7 @@ class LaunchViewModelTest {
         override suspend fun waitForReferrerCode(): ParsedReferrerResult {
             if (mockDelayMs > 0) delay(mockDelayMs)
 
-            return ParsedReferrerResult.ReferrerFound(referrer)
+            return ParsedReferrerResult.CampaignReferrerFound(referrer)
         }
 
         override fun initialiseReferralRetrieval() {

--- a/app/src/androidTest/java/com/duckduckgo/app/referral/QueryParamReferrerParserTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referral/QueryParamReferrerParserTest.kt
@@ -90,13 +90,13 @@ class QueryParamReferrerParserTest {
     }
 
     @Test
-    fun whenReferrerContainsEuAuctionKeyButNotMatchingValueThenNoReferrerFound() {
+    fun whenReferrerContainsInstallationSourceKeyButNotMatchingValueThenNoReferrerFound() {
         val result = testee.parse("$INSTALLATION_SOURCE_KEY=bar")
         verifyReferrerNotFound(result)
     }
 
     @Test
-    fun whenReferrerContainsEuAuctionKeyButNotMatchingValueAndCampaignReferrerDataThenCampaignReferrerFound() {
+    fun whenReferrerContainsInstallationSourceKeyAndNoEuAuctionValueButHasCampaignReferrerDataThenCampaignReferrerFound() {
         val result = testee.parse("key1=DDGRAAB&key2=foo&key3=bar&$INSTALLATION_SOURCE_KEY=bar")
         verifyCampaignReferrerFound("AB", result)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/referral/QueryParamReferrerParserTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referral/QueryParamReferrerParserTest.kt
@@ -18,8 +18,6 @@ package com.duckduckgo.app.referral
 
 import com.duckduckgo.app.referral.ParsedReferrerResult.CampaignReferrerFound
 import com.duckduckgo.app.referral.ParsedReferrerResult.EuAuctionReferrerFound
-import com.duckduckgo.app.referral.QueryParamReferrerParser.Companion.EU_AUCTION_KEY
-import com.duckduckgo.app.referral.QueryParamReferrerParser.Companion.EU_AUCTION_VALUE
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -81,25 +79,25 @@ class QueryParamReferrerParserTest {
 
     @Test
     fun whenReferrerContainsEuAuctionDataThenEuActionReferrerFound() {
-        val result = testee.parse("$EU_AUCTION_KEY=$EU_AUCTION_VALUE")
+        val result = testee.parse("$INSTALLATION_SOURCE_KEY=$INSTALLATION_SOURCE_EU_AUCTION_VALUE")
         assertTrue(result is EuAuctionReferrerFound)
     }
 
     @Test
     fun whenReferrerContainsBothEuAuctionAndCampaignReferrerDataThenEuActionReferrerFound() {
-        val result = testee.parse("key1=DDGRAAB&key2=foo&key3=bar&$EU_AUCTION_KEY=$EU_AUCTION_VALUE")
+        val result = testee.parse("key1=DDGRAAB&key2=foo&key3=bar&$INSTALLATION_SOURCE_KEY=$INSTALLATION_SOURCE_EU_AUCTION_VALUE")
         assertTrue(result is EuAuctionReferrerFound)
     }
 
     @Test
     fun whenReferrerContainsEuAuctionKeyButNotMatchingValueThenNoReferrerFound() {
-        val result = testee.parse("$EU_AUCTION_KEY=bar")
+        val result = testee.parse("$INSTALLATION_SOURCE_KEY=bar")
         verifyReferrerNotFound(result)
     }
 
     @Test
     fun whenReferrerContainsEuAuctionKeyButNotMatchingValueAndCampaignReferrerDataThenCampaignReferrerFound() {
-        val result = testee.parse("key1=DDGRAAB&key2=foo&key3=bar&$EU_AUCTION_KEY=bar")
+        val result = testee.parse("key1=DDGRAAB&key2=foo&key3=bar&$INSTALLATION_SOURCE_KEY=bar")
         verifyCampaignReferrerFound("AB", result)
     }
 
@@ -112,4 +110,10 @@ class QueryParamReferrerParserTest {
     private fun verifyReferrerNotFound(result: ParsedReferrerResult) {
         assertTrue(result is ParsedReferrerResult.ReferrerNotFound)
     }
+
+    companion object {
+        private const val INSTALLATION_SOURCE_KEY = "utm_source"
+        private const val INSTALLATION_SOURCE_EU_AUCTION_VALUE = "eea-search-choice"
+    }
+
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/AtbInitializerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/AtbInitializerTest.kt
@@ -88,6 +88,6 @@ class AtbInitializerTest {
 
     private suspend fun referrerAnswer(delayMs: Long): Answer<ParsedReferrerResult> {
         delay(delayMs)
-        return Answer { ParsedReferrerResult.ReferrerFound("") }
+        return Answer { ParsedReferrerResult.CampaignReferrerFound("") }
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -17,9 +17,7 @@
 package com.duckduckgo.app.statistics
 
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.*
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
+import org.junit.Assert.*
 import org.junit.Test
 
 class VariantManagerTest {
@@ -130,6 +128,17 @@ class VariantManagerTest {
         assertEquals(2, variant!!.features.size)
         assertTrue(variant.hasFeature(ConceptTest))
     }
+
+    @Test
+    fun verifyNoDuplicateVariantNames() {
+        val existingNames = mutableSetOf<String>()
+        variants.forEach {
+            if (!existingNames.add(it.key)) {
+                fail("Duplicate variant name found: ${it.key}")
+            }
+        }
+    }
+
 
     @Suppress("SameParameterValue")
     private fun assertEqualsDouble(expected: Double, actual: Double) {

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser
 import android.net.Uri
 import com.duckduckgo.app.global.AppUrl.ParamKey
 import com.duckduckgo.app.global.AppUrl.ParamValue
+import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import timber.log.Timber
@@ -32,7 +33,8 @@ interface RequestRewriter {
 class DuckDuckGoRequestRewriter(
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
     private val statisticsStore: StatisticsDataStore,
-    private val variantManager: VariantManager
+    private val variantManager: VariantManager,
+    private val appReferrerDataStore: AppReferrerDataStore
 ) : RequestRewriter {
 
     override fun rewriteRequestWithCustomQueryParams(request: Uri): Uri {
@@ -67,6 +69,8 @@ class DuckDuckGoRequestRewriter(
         if (atb != null) {
             builder.appendQueryParameter(ParamKey.ATB, atb.formatWithVariant(variantManager.getVariant()))
         }
-        builder.appendQueryParameter(ParamKey.SOURCE, ParamValue.SOURCE)
+
+        val sourceValue = if (appReferrerDataStore.installedFromEuAuction) ParamValue.SOURCE_EU_AUCTION else ParamValue.SOURCE
+        builder.appendQueryParameter(ParamKey.SOURCE, sourceValue)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.app.global.file.FileDeleter
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
+import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
@@ -57,9 +58,10 @@ class BrowserModule {
     fun duckDuckGoRequestRewriter(
         urlDetector: DuckDuckGoUrlDetector,
         statisticsStore: StatisticsDataStore,
-        variantManager: VariantManager
+        variantManager: VariantManager,
+        appReferrerDataStore: AppReferrerDataStore
     ): RequestRewriter {
-        return DuckDuckGoRequestRewriter(urlDetector, statisticsStore, variantManager)
+        return DuckDuckGoRequestRewriter(urlDetector, statisticsStore, variantManager, appReferrerDataStore)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
@@ -40,5 +40,6 @@ class AppUrl {
 
     object ParamValue {
         const val SOURCE = "ddg_android"
+        const val SOURCE_EU_AUCTION = "ddg_androideu"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerParser.kt
+++ b/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerParser.kt
@@ -45,7 +45,7 @@ class QueryParamReferrerParser : AppInstallationReferrerParser {
         for (part in referrerParts) {
 
             Timber.v("Analysing query param part: $part")
-            if (part.startsWith(EU_AUCTION_KEY) && part.endsWith(EU_AUCTION_VALUE)) {
+            if (part.startsWith(INSTALLATION_SOURCE_KEY) && part.endsWith(INSTALLATION_SOURCE_EU_AUCTION_VALUE)) {
                 Timber.i("App installed as a result of the EU auction")
                 return EuAuctionReferrerFound()
             }
@@ -94,8 +94,8 @@ class QueryParamReferrerParser : AppInstallationReferrerParser {
     companion object {
         private const val CAMPAIGN_NAME_PREFIX = "DDGRA"
 
-        const val EU_AUCTION_KEY = "utm_source"
-        const val EU_AUCTION_VALUE = "eea-search-choice"
+        private const val INSTALLATION_SOURCE_KEY = "utm_source"
+        private const val INSTALLATION_SOURCE_EU_AUCTION_VALUE = "eea-search-choice"
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerParser.kt
+++ b/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerParser.kt
@@ -44,7 +44,7 @@ class QueryParamReferrerParser : AppInstallationReferrerParser {
         Timber.d("Looking for Google EU Auction referrer data")
         for (part in referrerParts) {
 
-            Timber.d("Analysing query param part: $part")
+            Timber.v("Analysing query param part: $part")
             if (part.startsWith(EU_AUCTION_KEY) && part.endsWith(EU_AUCTION_VALUE)) {
                 Timber.i("App installed as a result of the EU auction")
                 return EuAuctionReferrerFound()
@@ -59,7 +59,7 @@ class QueryParamReferrerParser : AppInstallationReferrerParser {
         Timber.d("Looking for regular referrer data")
         for (part in referrerParts) {
 
-            Timber.d("Analysing query param part: $part")
+            Timber.v("Analysing query param part: $part")
             if (part.contains(CAMPAIGN_NAME_PREFIX)) {
                 return extractCampaignNameSuffix(part, CAMPAIGN_NAME_PREFIX)
             }

--- a/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerStateListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerStateListener.kt
@@ -167,7 +167,7 @@ class PlayStoreAppReferrerStateListener @Inject constructor(
                 appReferrerDataStore.campaignSuffix = result.campaignSuffix
             }
             is EuAuctionReferrerFound -> {
-                variantManager.updateAppReferrerVariant(VariantManager.EU_AUCTION_VARIANT)
+                variantManager.updateAppReferrerVariant(VariantManager.RESERVED_EU_AUCTION_VARIANT)
                 appReferrerDataStore.installedFromEuAcution = true
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerStateListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerStateListener.kt
@@ -64,8 +64,14 @@ class PlayStoreAppReferrerStateListener @Inject constructor(
             initialisationStartTime = System.currentTimeMillis()
 
             if (appReferrerDataStore.referrerCheckedPreviously) {
-                referralResult = loadPreviousReferrerData()
-                Timber.i("Already inspected this referrer data. Took ${System.currentTimeMillis() - initialisationStartTime}ms to load from disk")
+
+                referralResult = if (appReferrerDataStore.installedFromEuAcution) {
+                    EuAuctionReferrerFound(fromCache = true)
+                } else {
+                    loadPreviousReferrerData()
+                }
+
+                Timber.i("Already inspected this referrer data")
                 return
             }
 
@@ -87,7 +93,7 @@ class PlayStoreAppReferrerStateListener @Inject constructor(
             ReferrerNotFound(fromCache = true)
         } else {
             Timber.i("Already have referrer data from previous run - $suffix")
-            ReferrerFound(suffix, fromCache = true)
+            CampaignReferrerFound(suffix, fromCache = true)
         }
     }
 
@@ -155,11 +161,17 @@ class PlayStoreAppReferrerStateListener @Inject constructor(
     private fun referralResultReceived(result: ParsedReferrerResult) {
         referralResult = result
 
-        if (result is ReferrerFound) {
-            variantManager.updateAppReferrerVariant(result.campaignSuffix)
-            appReferrerDataStore.campaignSuffix = result.campaignSuffix
-
+        when (result) {
+            is CampaignReferrerFound -> {
+                variantManager.updateAppReferrerVariant(result.campaignSuffix)
+                appReferrerDataStore.campaignSuffix = result.campaignSuffix
+            }
+            is EuAuctionReferrerFound -> {
+                variantManager.updateAppReferrerVariant(VariantManager.EU_AUCTION_VARIANT)
+                appReferrerDataStore.installedFromEuAcution = true
+            }
         }
+
         appReferrerDataStore.referrerCheckedPreviously = true
     }
 

--- a/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerStateListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/referral/AppInstallationReferrerStateListener.kt
@@ -65,7 +65,7 @@ class PlayStoreAppReferrerStateListener @Inject constructor(
 
             if (appReferrerDataStore.referrerCheckedPreviously) {
 
-                referralResult = if (appReferrerDataStore.installedFromEuAcution) {
+                referralResult = if (appReferrerDataStore.installedFromEuAuction) {
                     EuAuctionReferrerFound(fromCache = true)
                 } else {
                     loadPreviousReferrerData()
@@ -168,7 +168,7 @@ class PlayStoreAppReferrerStateListener @Inject constructor(
             }
             is EuAuctionReferrerFound -> {
                 variantManager.updateAppReferrerVariant(VariantManager.RESERVED_EU_AUCTION_VARIANT)
-                appReferrerDataStore.installedFromEuAcution = true
+                appReferrerDataStore.installedFromEuAuction = true
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/referral/AppReferrerDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/referral/AppReferrerDataStore.kt
@@ -23,7 +23,7 @@ import androidx.core.content.edit
 interface AppReferrerDataStore {
     var referrerCheckedPreviously: Boolean
     var campaignSuffix: String?
-    var installedFromEuAcution: Boolean
+    var installedFromEuAuction: Boolean
 }
 
 class AppReferenceSharePreferences(private val context: Context) : AppReferrerDataStore {
@@ -35,7 +35,7 @@ class AppReferenceSharePreferences(private val context: Context) : AppReferrerDa
         get() = preferences.getBoolean(KEY_CHECKED_PREVIOUSLY, false)
         set(value) = preferences.edit(true) { putBoolean(KEY_CHECKED_PREVIOUSLY, value) }
 
-    override var installedFromEuAcution: Boolean
+    override var installedFromEuAuction: Boolean
         get() = preferences.getBoolean(KEY_INSTALLED_FROM_EU_AUCTION, false)
         set(value) = preferences.edit(true) { putBoolean(KEY_INSTALLED_FROM_EU_AUCTION, value) }
 

--- a/app/src/main/java/com/duckduckgo/app/referral/AppReferrerDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/referral/AppReferrerDataStore.kt
@@ -23,6 +23,7 @@ import androidx.core.content.edit
 interface AppReferrerDataStore {
     var referrerCheckedPreviously: Boolean
     var campaignSuffix: String?
+    var installedFromEuAcution: Boolean
 }
 
 class AppReferenceSharePreferences(private val context: Context) : AppReferrerDataStore {
@@ -34,6 +35,10 @@ class AppReferenceSharePreferences(private val context: Context) : AppReferrerDa
         get() = preferences.getBoolean(KEY_CHECKED_PREVIOUSLY, false)
         set(value) = preferences.edit(true) { putBoolean(KEY_CHECKED_PREVIOUSLY, value) }
 
+    override var installedFromEuAcution: Boolean
+        get() = preferences.getBoolean(KEY_INSTALLED_FROM_EU_AUCTION, false)
+        set(value) = preferences.edit(true) { putBoolean(KEY_INSTALLED_FROM_EU_AUCTION, value) }
+
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
 
@@ -41,5 +46,6 @@ class AppReferenceSharePreferences(private val context: Context) : AppReferrerDa
         const val FILENAME = "com.duckduckgo.app.referral"
         private const val KEY_CAMPAIGN_SUFFIX = "KEY_CAMPAIGN_SUFFIX"
         private const val KEY_CHECKED_PREVIOUSLY = "KEY_CHECKED_PREVIOUSLY"
+        private const val KEY_INSTALLED_FROM_EU_AUCTION = "KEY_INSTALLED_FROM_EU_AUCTION"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -37,7 +37,7 @@ interface VariantManager {
 
     companion object {
 
-        const val EU_AUCTION_VARIANT = "ml"
+        const val RESERVED_EU_AUCTION_VARIANT = "ml"
 
         // this will be returned when there are no other active experiments
         val DEFAULT_VARIANT = Variant(key = "", features = emptyList(), filterBy = { noFilter() })

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -37,6 +37,8 @@ interface VariantManager {
 
     companion object {
 
+        const val EU_AUCTION_VARIANT = "ml"
+
         // this will be returned when there are no other active experiments
         val DEFAULT_VARIANT = Variant(key = "", features = emptyList(), filterBy = { noFilter() })
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 

- https://app.asana.com/0/1134083878772872/1160666959362066
- https://app.asana.com/0/inbox/608920331025313/1161150028836612/1160844869366003

Tech Design URL: 
CC: 

**Description**:
Captures the eu auction referrer data and maps to a static variant `ml` if found

## Steps to test this PR:
Need to use Play Store ad-hoc app sharing for this. You can either upload your own APK and build your custom URLs to test, or here's some I made earlier! 😃

### Device setup
1. configure logcat to display regex `refer|var`
1. Charles interception will be required too.


### Scenarios
For each of the scenarios below:
1. uninstall the app first.
1. click on the link using your device which launch the ad-hoc Play Store installation screen
1. install and launch the app
1. verify if correct referrer identified

#### No referrer data at all
* https://play.google.com/apps/test/RQl8L2Oq05Y/ahAAvZMmgU1UTzrqZSY6imvdf6Lt0YRNKYXlHLncb943FFynluPOtfshW9hb7RyIj5Kjy5XMxe9wJCozok-mzan7VZ
* verify neither campaign referrer nor EU auction referrer identified
* verify variant allocation happens normally
* verify `/exti` call has correct variant
* perform a search; verify `t=ddg_android` is added to URL (as normal)

#### Campaign referrer
* https://play.google.com/apps/test/RQl8L2Oq05Y/ahAAvZMmgU1UTzrqZSY6imvdf6Lt0YRNKYXlHLncb943FFynluPOtfshW9hb7RyIj5Kjy5XMxe9wJCozok-mzan7VZ?&referrer=utm_source%3Dgoogle%26utm_medium%3Dcpc%26anid%3Dadmob%26utm_campaign%3DDDGRAXX
* verify campaign referrer `XX` found (logcat: Updating variant for app referer: XX)
* verify `/exti` call uses `XX`
* perform a search; verify `t=ddg_android` is added to URL (as normal)

#### EU auction referrer
* https://play.google.com/apps/test/RQl8L2Oq05Y/ahAAvZMmgU1UTzrqZSY6imvdf6Lt0YRNKYXlHLncb943FFynluPOtfshW9hb7RyIj5Kjy5XMxe9wJCozok-mzan7VZ?&referrer=utm_source%3Deea-search-choice%26utm_medium%3Dcpc%26anid%3Dadmob%26utm_campaign%3DFOO
* verify eu auction referrer found (logcat: Updating variant for app referer: ml)
* verify `/exti` call uses `ml`
* perform a search; verify `t=ddg_androideu` is added to URL (instead of normal t=ddg_android)

#### Both EU auction referrer and Campaign referrer (shouldn't happen, but if it does, EU auction takes precedence)
* https://play.google.com/apps/test/RQl8L2Oq05Y/ahAAvZMmgU1UTzrqZSY6imvdf6Lt0YRNKYXlHLncb943FFynluPOtfshW9hb7RyIj5Kjy5XMxe9wJCozok-mzan7VZ?&referrer=utm_source%3Deea-search-choice%26utm_medium%3Dcpc%26anid%3Dadmob%26utm_campaign%3DDDGRAXX
* verify eu auction referrer found (logcat: Updating variant for app referer: ml)
* verify `/exti` call uses `ml`
* perform a search; verify `t=ddg_androideu` is added to URL (instead of normal t=ddg_android)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
