### PR TITLE
Dax dialog with two buttons

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -174,6 +174,14 @@ class CtaViewModelTest {
     }
 
     @Test
+    fun whenCtaSecondaryButonClickedPixelIsFired() {
+        val secondaryButtonCta = mock<SecondaryButtonCta>()
+        whenever(secondaryButtonCta.secondaryButtonPixel).thenReturn(ONBOARDING_DAX_ALL_CTA_HIDDEN)
+        testee.onUserClickCtaSecondaryButton(secondaryButtonCta)
+        verify(mockPixel).fire(eq(ONBOARDING_DAX_ALL_CTA_HIDDEN), any())
+    }
+
+    @Test
     fun whenCtaDismissedPixelIsFired() {
         testee.onUserDismissedCta(HomePanelCta.Survey(Survey("abc", "http://example.com", 1, SCHEDULED)))
         verify(mockPixel).fire(eq(SURVEY_CTA_DISMISSED), any())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -49,6 +49,7 @@ import androidx.core.view.isEmpty
 import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.*
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -76,6 +77,7 @@ import com.duckduckgo.app.cta.ui.HomePanelCta
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.cta.ui.DaxBubbleCta
 import com.duckduckgo.app.cta.ui.DaxDialogCta
+import com.duckduckgo.app.cta.ui.SecondaryButtonCta
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.app.global.view.*
@@ -235,7 +237,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     private val logoHidingListener by lazy { LogoHidingLayoutChangeLifecycleListener(ddgLogo) }
 
     private var alertDialog: AlertDialog? = null
-    private var daxDialog: DaxDialog? = null
+    private var daxDialog: DialogFragment? = null
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -1388,7 +1390,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 daxDialog?.dismiss()
                 daxDialog = configuration.createCta(activity).apply {
                     setHideClickListener {
-                        dismiss()
+                        getDaxDialog().dismiss()
                         launchHideTipsDialog(activity, configuration)
                     }
                     setDismissListener {
@@ -1402,16 +1404,22 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                         if (configuration is DaxDialogCta.DaxMainNetworkCta) {
                             setPrimaryCtaClickListener {
                                 viewModel.onUserClickCtaOkButton()
-                                dismiss()
+                                getDaxDialog().dismiss()
                             }
                             configuration.setSecondDialog(this, activity)
                             viewModel.onManualCtaShown(configuration)
                         } else {
-                            dismiss()
+                            getDaxDialog().dismiss()
                         }
                     }
-                    show(activity.supportFragmentManager, DAX_DIALOG_DIALOG_TAG)
-                }
+                    if (configuration is SecondaryButtonCta) {
+                        setSecondaryCtaClickListener {
+                            viewModel.onUserClickCtaSecondaryButton(configuration)
+                            getDaxDialog().dismiss()
+                        }
+                    }
+                    getDaxDialog().show(activity.supportFragmentManager, DAX_DIALOG_DIALOG_TAG)
+                }.getDaxDialog()
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -55,6 +55,7 @@ import com.duckduckgo.app.browser.ui.HttpAuthenticationDialogFragment.HttpAuthen
 import com.duckduckgo.app.cta.ui.Cta
 import com.duckduckgo.app.cta.ui.HomePanelCta
 import com.duckduckgo.app.cta.ui.CtaViewModel
+import com.duckduckgo.app.cta.ui.SecondaryButtonCta
 import com.duckduckgo.app.global.*
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.SiteFactory
@@ -901,6 +902,10 @@ class BrowserTabViewModel(
             is HomePanelCta.AddWidgetInstructions -> LaunchLegacyAddWidget
             else -> return
         }
+    }
+
+    fun onUserClickCtaSecondaryButton(cta: SecondaryButtonCta) {
+        ctaViewModel.onUserClickCtaSecondaryButton(cta)
     }
 
     fun onUserDismissedCta() {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -30,6 +30,8 @@ import com.duckduckgo.app.global.baseHost
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.install.daysInstalled
 import com.duckduckgo.app.global.view.DaxDialog
+import com.duckduckgo.app.global.view.DaxDialogHighlightView
+import com.duckduckgo.app.global.view.TypewriterDaxDialog
 import com.duckduckgo.app.global.view.hide
 import com.duckduckgo.app.global.view.html
 import com.duckduckgo.app.global.view.show
@@ -38,9 +40,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import kotlinx.android.synthetic.main.include_cta_buttons.view.*
 import kotlinx.android.synthetic.main.include_cta_content.view.*
-import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.dialogTextCta
-import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.hiddenTextCta
-import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.primaryCta
+import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.*
 
 interface DialogCta {
     fun createCta(activity: FragmentActivity): DaxDialog
@@ -89,7 +89,7 @@ sealed class DaxDialogCta(
     override val appInstallStore: AppInstallStore
 ) : Cta, DialogCta, DaxCta {
 
-    override fun createCta(activity: FragmentActivity) = DaxDialog(getDaxText(activity), activity.resources.getString(okButton))
+    override fun createCta(activity: FragmentActivity): DaxDialog = TypewriterDaxDialog(getDaxText(activity), activity.resources.getString(okButton))
 
     override fun pixelCancelParameters(): Map<String, String?> = mapOf(Pixel.PixelParameter.CTA_SHOWN to ctaPixelParam)
 
@@ -129,7 +129,7 @@ sealed class DaxDialogCta(
     ) {
 
         override fun createCta(activity: FragmentActivity): DaxDialog =
-            DaxDialog(getDaxText(activity), activity.resources.getString(okButton), false)
+            TypewriterDaxDialog(daxText = getDaxText(activity), primaryButtonText = activity.resources.getString(okButton), toolbarDimmed = false)
 
         override fun getDaxText(context: Context): String {
             val trackersFiltered = trackers.asSequence()
@@ -178,7 +178,9 @@ sealed class DaxDialogCta(
         }
 
         override fun createCta(activity: FragmentActivity): DaxDialog {
-            return DaxDialog(getDaxText(activity), activity.resources.getString(okButton)).apply {
+            return DaxDialogHighlightView(
+                TypewriterDaxDialog(daxText = getDaxText(activity), primaryButtonText = activity.resources.getString(okButton))
+            ).apply {
                 val privacyGradeButton = activity.findViewById<View>(R.id.privacyGradeButton)
                 onAnimationFinishedListener {
                     if (isFromSameNetworkDomain()) {
@@ -190,8 +192,8 @@ sealed class DaxDialogCta(
 
         fun setSecondDialog(dialog: DaxDialog, activity: FragmentActivity) {
             ctaPixelParam = Pixel.PixelValues.DAX_NETWORK_CTA_2
-            dialog.daxText = activity.resources.getString(R.string.daxMainNetworkStep2CtaText, firstParagraph(activity), network)
-            dialog.buttonText = activity.resources.getString(R.string.daxDialogGotIt)
+            dialog.setDaxText(activity.resources.getString(R.string.daxMainNetworkStep2CtaText, firstParagraph(activity), network))
+            dialog.setButtonText(activity.resources.getString(R.string.daxDialogGotIt))
             dialog.onAnimationFinishedListener { }
             dialog.setDialogAndStartAnimation()
         }
@@ -217,9 +219,13 @@ sealed class DaxDialogCta(
         onboardingStore,
         appInstallStore
     ) {
-
         override fun createCta(activity: FragmentActivity): DaxDialog {
-            return DaxDialog(getDaxText(activity), activity.resources.getString(okButton)).apply {
+            return DaxDialogHighlightView(
+                TypewriterDaxDialog(
+                    daxText = getDaxText(activity),
+                    primaryButtonText = activity.resources.getString(okButton)
+                )
+            ).apply {
                 val fireButton = activity.findViewById<View>(R.id.fire)
                 onAnimationFinishedListener {
                     startHighlightViewAnimation(fireButton)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -71,6 +71,12 @@ interface Cta {
     fun pixelOkParameters(): Map<String, String?>
 }
 
+interface SecondaryButtonCta {
+    val secondaryButtonPixel: Pixel.PixelName?
+
+    fun pixelSecondaryButtonParameters(): Map<String, String?>
+}
+
 sealed class DaxDialogCta(
     override val ctaId: CtaId,
     @AnyRes open val description: Int,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -111,6 +111,12 @@ class CtaViewModel @Inject constructor(
         }
     }
 
+    fun onUserClickCtaSecondaryButton(cta: SecondaryButtonCta) {
+        cta.secondaryButtonPixel?.let {
+            pixel.fire(it, cta.pixelSecondaryButtonParameters())
+        }
+    }
+
     suspend fun refreshCta(dispatcher: CoroutineContext, isBrowserShowing: Boolean, site: Site? = null): Cta? {
         surveyCta()?.let {
             return it

--- a/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
@@ -22,30 +22,44 @@ import android.graphics.Color
 import android.graphics.Rect
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.DialogFragment
-import com.duckduckgo.app.browser.R
-import android.view.Gravity
-import kotlinx.android.synthetic.main.content_dax_dialog.*
 import android.view.animation.Animation
 import android.view.animation.OvershootInterpolator
 import android.view.animation.ScaleAnimation
 import android.widget.ImageView
 import android.widget.RelativeLayout
 import androidx.core.content.ContextCompat.getColor
+import androidx.fragment.app.DialogFragment
+import com.duckduckgo.app.browser.R
+import kotlinx.android.synthetic.main.content_dax_dialog.*
 
-class DaxDialog(
-    var daxText: String,
-    var buttonText: String,
+interface DaxDialog {
+    fun setDaxText(daxText: String)
+    fun setButtonText(buttonText: String)
+    fun setDialogAndStartAnimation()
+    fun onAnimationFinishedListener(onAnimationFinished: () -> Unit)
+    fun setPrimaryCtaClickListener(clickListener: () -> Unit)
+    fun setSecondaryCtaClickListener(clickListener: () -> Unit)
+    fun setHideClickListener(clickListener: () -> Unit)
+    fun setDismissListener(clickListener: () -> Unit)
+    fun getDaxDialog(): DialogFragment
+}
+
+class TypewriterDaxDialog(
+    private var daxText: String,
+    private var primaryButtonText: String,
+    private var secondaryButtonText: String? = "",
     private val toolbarDimmed: Boolean = true,
     private val dismissible: Boolean = true,
     private val typingDelayInMs: Long = 20
-) : DialogFragment() {
+) : DialogFragment(), DaxDialog {
 
     private var onAnimationFinished: () -> Unit = {}
     private var primaryCtaClickListener: () -> Unit = { dismiss() }
+    private var secondaryCtaClickListener: (() -> Unit)? = null
     private var hideClickListener: () -> Unit = { dismiss() }
     private var dismissListener: () -> Unit = { }
 
@@ -82,40 +96,40 @@ class DaxDialog(
         super.onDismiss(dialog)
     }
 
-    fun setDialogAndStartAnimation() {
+    override fun getDaxDialog(): DialogFragment = this
+
+    override fun setDaxText(daxText: String) {
+        this.daxText = daxText
+    }
+
+    override fun setButtonText(buttonText: String) {
+        this.primaryButtonText = buttonText
+    }
+
+    override fun setDialogAndStartAnimation() {
         setDialog()
         setListeners()
         dialogText.startTypingAnimation(daxText, true, onAnimationFinished)
     }
 
-    fun onAnimationFinishedListener(onAnimationFinished: () -> Unit) {
+    override fun onAnimationFinishedListener(onAnimationFinished: () -> Unit) {
         this.onAnimationFinished = onAnimationFinished
     }
 
-    fun setPrimaryCtaClickListener(clickListener: () -> Unit) {
+    override fun setPrimaryCtaClickListener(clickListener: () -> Unit) {
         primaryCtaClickListener = clickListener
     }
 
-    fun setHideClickListener(clickListener: () -> Unit) {
+    override fun setSecondaryCtaClickListener(clickListener: () -> Unit) {
+        secondaryCtaClickListener = clickListener
+    }
+
+    override fun setHideClickListener(clickListener: () -> Unit) {
         hideClickListener = clickListener
     }
 
-    fun setDismissListener(clickListener: () -> Unit) {
+    override fun setDismissListener(clickListener: () -> Unit) {
         dismissListener = clickListener
-    }
-
-    fun startHighlightViewAnimation(targetView: View, duration: Long = 400, timesBigger: Float = 0f) {
-        val highlightImageView = addHighlightView(targetView, timesBigger)
-        val scaleAnimation = buildScaleAnimation(duration)
-        highlightImageView?.startAnimation(scaleAnimation)
-    }
-
-    private fun buildScaleAnimation(duration: Long = 400): Animation {
-        val scaleAnimation = ScaleAnimation(0f, 1f, 0f, 1f, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f)
-        scaleAnimation.duration = duration
-        scaleAnimation.fillAfter = true
-        scaleAnimation.interpolator = OvershootInterpolator(OVERSHOOT_TENSION)
-        return scaleAnimation
     }
 
     private fun setListeners() {
@@ -127,6 +141,13 @@ class DaxDialog(
         primaryCta.setOnClickListener {
             dialogText.cancelAnimation()
             primaryCtaClickListener()
+        }
+
+        secondaryCtaClickListener?.let {
+            secondaryCta.setOnClickListener {
+                dialogText.cancelAnimation()
+                it()
+            }
         }
 
         if (dismissible) {
@@ -147,14 +168,35 @@ class DaxDialog(
             val toolbarColor = if (toolbarDimmed) getColor(it, R.color.dimmed) else getColor(it, android.R.color.transparent)
             toolbarDialogLayout.setBackgroundColor(toolbarColor)
             hiddenText.text = daxText.html(it)
-            primaryCta.text = buttonText
+            primaryCta.text = primaryButtonText
+            secondaryCta.text = secondaryButtonText
+            secondaryCta.visibility = if (secondaryButtonText.isNullOrEmpty()) View.GONE else View.VISIBLE
             dialogText.typingDelayInMs = typingDelayInMs
         }
     }
+}
+
+class DaxDialogHighlightView(
+    daxDialog: TypewriterDaxDialog
+) : DaxDialog by daxDialog {
+
+    fun startHighlightViewAnimation(targetView: View, duration: Long = 400, timesBigger: Float = 0f) {
+        val highlightImageView = addHighlightView(targetView, timesBigger)
+        val scaleAnimation = buildScaleAnimation(duration)
+        highlightImageView?.startAnimation(scaleAnimation)
+    }
+
+    private fun buildScaleAnimation(duration: Long = 400): Animation {
+        val scaleAnimation = ScaleAnimation(0f, 1f, 0f, 1f, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f)
+        scaleAnimation.duration = duration
+        scaleAnimation.fillAfter = true
+        scaleAnimation.interpolator = OvershootInterpolator(OVERSHOOT_TENSION)
+        return scaleAnimation
+    }
 
     private fun addHighlightView(targetView: View, timesBigger: Float): View? {
-        return activity?.let {
-            val highlightImageView = ImageView(context)
+        return getDaxDialog().activity?.let {
+            val highlightImageView = ImageView(getDaxDialog().context)
             highlightImageView.id = View.generateViewId()
             highlightImageView.setImageResource(R.drawable.ic_circle)
 
@@ -174,7 +216,7 @@ class DaxDialog(
             val params = RelativeLayout.LayoutParams((width + timesBiggerX).toInt(), (height + timesBiggerY).toInt())
             params.leftMargin = locationOnScreen[0] - (timesBiggerX / 2).toInt()
             params.topMargin = (locationOnScreen[1] - statusBarHeight) - (timesBiggerY / 2).toInt()
-            dialogContainer.addView(highlightImageView, params)
+            getDaxDialog().dialogContainer.addView(highlightImageView, params)
             highlightImageView
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
@@ -74,9 +74,11 @@ class TypewriterDaxDialog(
         attributes?.gravity = Gravity.BOTTOM
         window?.attributes = attributes
         window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-        setStyle(STYLE_NO_TITLE, android.R.style.Theme_DeviceDefault_Light_NoActionBar)
-
         return dialog
+    }
+
+    override fun getTheme(): Int {
+        return R.style.DaxDialogFragment
     }
 
     override fun onStart() {

--- a/app/src/main/res/layout/content_dax_dialog.xml
+++ b/app/src/main/res/layout/content_dax_dialog.xml
@@ -122,7 +122,7 @@
                     style="@style/DaxDialogButton.Primary"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"/>
+                    android:layout_marginTop="10dp" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/secondaryCta"
@@ -130,7 +130,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="-6dp"
-                    android:visibility="visible"/>
+                    android:visibility="visible" />
             </LinearLayout>
         </androidx.cardview.widget.CardView>
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_dax_dialog.xml
+++ b/app/src/main/res/layout/content_dax_dialog.xml
@@ -18,7 +18,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/dialogContainer"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/content_dax_dialog.xml
+++ b/app/src/main/res/layout/content_dax_dialog.xml
@@ -119,27 +119,18 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/primaryCta"
-                    style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                    style="@style/DaxDialogButton.Primary"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:backgroundTint="@color/cornflowerBlue"
-                    android:textAllCaps="false"
-                    android:textColor="@color/white"
-                    app:cornerRadius="20dp" />
+                    android:layout_marginTop="10dp"/>
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/secondaryCta"
-                    style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                    style="@style/DaxDialogButton.Secondary"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="-6dp"
-                    android:backgroundTint="?attr/daxDialogBackgroundColor"
-                    android:textAllCaps="false"
-                    android:textColor="?attr/daxDialogSecondaryButtonTextColor"
-                    android:visibility="gone"
-                    app:cornerRadius="20dp"
-                    app:rippleColor="?attr/daxDialogSecondaryButtonRippleColor" />
+                    android:visibility="visible"/>
             </LinearLayout>
         </androidx.cardview.widget.CardView>
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_dax_dialog.xml
+++ b/app/src/main/res/layout/content_dax_dialog.xml
@@ -74,7 +74,7 @@
         <androidx.cardview.widget.CardView
             android:id="@+id/cardView"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="24dp"
@@ -84,61 +84,63 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <LinearLayout
                 android:id="@+id/cardContainer"
+                android:paddingStart="16dp"
+                android:paddingTop="26dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="20dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_behavior="@string/bottom_sheet_behavior">
+                android:orientation="vertical">
 
-                <TextView
-                    android:id="@+id/hiddenText"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginTop="26dp"
-                    android:layout_marginEnd="16dp"
-                    android:textColor="@color/grayishBrown"
-                    android:textSize="16sp"
-                    android:visibility="invisible"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
 
-                <com.duckduckgo.app.global.view.TypeAnimationTextView
-                    android:id="@+id/dialogText"
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginTop="26dp"
-                    android:layout_marginEnd="16dp"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:textColor="?attr/normalTextColor"
-                    android:textSize="16sp"
-                    app:layout_constraintBottom_toBottomOf="@id/hiddenText"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    <TextView
+                        android:id="@+id/hiddenText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/grayishBrown"
+                        android:textSize="16sp"
+                        android:visibility="invisible" />
+
+                    <com.duckduckgo.app.global.view.TypeAnimationTextView
+                        android:id="@+id/dialogText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:textColor="?attr/normalTextColor"
+                        android:textSize="16sp"
+                        android:visibility="visible" />
+                </FrameLayout>
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/primaryCta"
                     style="@style/Widget.AppCompat.Button.Borderless.Colored"
-                    android:layout_width="0dp"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginTop="24dp"
-                    android:layout_marginEnd="16dp"
-                    android:layout_marginBottom="24dp"
+                    android:layout_marginTop="10dp"
                     android:backgroundTint="@color/cornflowerBlue"
                     android:textAllCaps="false"
                     android:textColor="@color/white"
-                    app:cornerRadius="20dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/hiddenText" />
+                    app:cornerRadius="20dp" />
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/secondaryCta"
+                    style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="-6dp"
+                    android:backgroundTint="?attr/daxDialogBackgroundColor"
+                    android:textAllCaps="false"
+                    android:textColor="?attr/daxDialogSecondaryButtonTextColor"
+                    android:visibility="gone"
+                    app:cornerRadius="20dp"
+                    app:rippleColor="?attr/daxDialogSecondaryButtonRippleColor" />
+            </LinearLayout>
         </androidx.cardview.widget.CardView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </RelativeLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -49,5 +49,7 @@
     <attr name="feedbackEditTextBackgroundColor" format="color" />
     <attr name="feedbackEditTextHintColor" format="color" />
     <attr name="daxDialogBackgroundColor" format="color" />
+    <attr name="daxDialogSecondaryButtonTextColor" format="color" />
+    <attr name="daxDialogSecondaryButtonRippleColor" format="color" />
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -325,5 +325,21 @@
         <item name="android:layout_marginTop">9dp</item>
     </style>
 
+    <style name="DaxDialogButton" parent="@style/Widget.AppCompat.Button.Borderless.Colored">
+        <item name="android:textAllCaps">false</item>
+        <item name="cornerRadius">20dp</item>
+    </style>
+
+    <style name="DaxDialogButton.Primary">
+        <item name="android:backgroundTint">@color/cornflowerBlue</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="rippleColor">?attr/daxDialogSecondaryButtonRippleColor</item>
+    </style>
+
+    <style name="DaxDialogButton.Secondary">
+        <item name="android:backgroundTint">?attr/daxDialogBackgroundColor</item>
+        <item name="android:textColor">?attr/daxDialogSecondaryButtonTextColor</item>
+        <item name="rippleColor">?attr/daxDialogSecondaryButtonRippleColor</item>
+    </style>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -61,6 +61,8 @@
         <item name="callToActionTitleColor">@color/white</item>
         <item name="callToActionSubtitleColor">@color/grayishThree</item>
         <item name="daxDialogBackgroundColor">@color/charcoalGrey</item>
+        <item name="daxDialogSecondaryButtonTextColor">@color/white</item>
+        <item name="daxDialogSecondaryButtonRippleColor">@color/white</item>
 
         <item name="feedbackAnonymousFeedbackLabelColor">@color/grayish</item>
         <item name="feedbackListItemBackgroundColor">@color/almostBlack</item>
@@ -119,6 +121,8 @@
         <item name="callToActionTitleColor">@color/almostBlack</item>
         <item name="callToActionSubtitleColor">@color/brownishGrayTwo</item>
         <item name="daxDialogBackgroundColor">@color/white</item>
+        <item name="daxDialogSecondaryButtonTextColor">@color/grayishBrown</item>
+        <item name="daxDialogSecondaryButtonRippleColor">@color/subtleGrayTwo</item>
 
         <item name="feedbackAnonymousFeedbackLabelColor">@color/warmerGray</item>
         <item name="feedbackListItemBackgroundColor">@color/whiteFive</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -170,7 +170,7 @@
     </style>
 
     <style name="DaxDialogFragment" parent="android:Theme.DeviceDefault.Light.NoActionBar">
-        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowTranslucentStatus">true</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -169,4 +169,8 @@
         <item name="android:colorForeground">?attr/settingsSwitchBackgroundColor</item>
     </style>
 
+    <style name="DaxDialogFragment" parent="android:Theme.DeviceDefault.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1162132608576977/f
Tech Design URL: 
CC: https://app.asana.com/0/0/1158941144031452/f

**Description**:
This PR is some preparation work that will be related (and be used) in a future task, where we will implement new Ctas with two buttons. 
For context: To show our CTAs as Dax dialogs we will make use of a Dax dialog with two buttons. Usually, the secondary button will be used to dismiss the dialog.
Design can be found here: https://app.asana.com/0/0/1158941144031452/f

Within the scope of this PR, you will find the following changes:
* Refactor current DaxDialog to handle a new secondary button
* Decoupling view-highlighting related logic from simple Dax dialogs into a more concrete dialog.
* Changes in UI according to new design
* Enable sending pixels when the secondary button is clicked
* Small improvement to avoid showing a dark status bar when the dialog appears

**Steps to test this PR**:
Currently, the new Dax dialog with two buttons is not used in any part of the project (but it will be). Testing the new dialog with 2 buttons will be included on a future PR once we have the experiment ready to be reviewed.

**Then, do we need to test something?** yes, ensure new changes don't affect how normal dialogs are shown. To testing that part:
1. Hardcode variant `mv`
2. Navigate to BrowserActivity
3. Visit any site that triggers a Dax dialog
4. Ensure that dialog appears and it's rendered as in previous versions (except for commented changes in the description).
Example:
<img src="https://user-images.githubusercontent.com/4747865/74592334-690f3000-5020-11ea-95f7-ce70c47bd499.png" width="360px"/>

> Possible triggers: a site with trackers, a site without trackers (wikipedia.org), a major entity (google).
> To test different Ctas, you may need to perform a fresh install for each type, as showing some of them will disable showing others.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
