### PR TITLE
New variant: Showing DefaultBrowserCta and SearchWidgetCta as Dax dialogs

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -38,7 +38,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.ConceptTest
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.SuppressWidgetCta
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.SuppressHomeTabWidgetCta
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 import com.duckduckgo.app.survey.db.SurveyDao
@@ -286,7 +286,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenRefreshCtaOnHomeTabAndSuppressWidgetCtaFeatureThenDoNotShowWidgetAutoCta() = runBlockingTest {
-        setSuppressWidgetCtaFeature()
+        setSuppressHomeTabWidgetCtaFeature()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
@@ -298,7 +298,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenRefreshCtaOnHomeTabAndSuppressWidgetCtaFeatureActiveThenDoNotShowWidgetInstructionsCta() = runBlockingTest {
-        setSuppressWidgetCtaFeature()
+        setSuppressHomeTabWidgetCtaFeature()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
@@ -334,7 +334,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenRefreshCtaOnHomeTabAndSuppressWidgetCtaFeatureActiveThenReturnNullWhenTryngToShowWidgetCta() = runBlockingTest {
-        setSuppressWidgetCtaFeature()
+        setSuppressHomeTabWidgetCtaFeature()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
@@ -346,7 +346,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenRefreshCtaOnHomeTabAndSuppressWidgetCtaFeatureActiveThenReturnNullWhenTryngToShowWidgetInstructionsCta() = runBlockingTest {
-        setSuppressWidgetCtaFeature()
+        setSuppressHomeTabWidgetCtaFeature()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
@@ -431,9 +431,9 @@ class CtaViewModelTest {
         )
     }
 
-    private fun setSuppressWidgetCtaFeature() {
+    private fun setSuppressHomeTabWidgetCtaFeature() {
         whenever(mockVariantManager.getVariant()).thenReturn(
-            Variant("test", features = listOf(SuppressWidgetCta), filterBy = { true })
+            Variant("test", features = listOf(SuppressHomeTabWidgetCta), filterBy = { true })
         )
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerTest.kt
@@ -78,7 +78,7 @@ class OnboardingPageManagerTest {
         whenever(mockVariantManager.getVariant()).thenReturn(
             Variant("test", features = listOf(
                 VariantManager.VariantFeature.ConceptTest,
-                VariantManager.VariantFeature.SuppressDefaultBrowserContinueScreen
+                VariantManager.VariantFeature.SuppressOnboardingDefaultBrowserContinueScreen
             ), filterBy = { true })
         )
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
@@ -258,7 +258,7 @@ class DefaultBrowserPageViewModelTest {
 
     @Test
     fun whenUserSetDDGAsDefaultFromDialogAndSuppressContinueScreenVariantEnabledThenContinueToBrowserAndFirePixel() {
-        givenSuppressDefaultBrowserContinueScreen()
+        givenSuppressOnboardingDefaultBrowserContinueScreen()
         val params = mapOf(
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to DEFAULT_BROWSER_DIALOG
@@ -359,7 +359,7 @@ class DefaultBrowserPageViewModelTest {
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to Pixel.PixelValues.DEFAULT_BROWSER_EXTERNAL
         )
-        givenSuppressDefaultBrowserContinueScreen()
+        givenSuppressOnboardingDefaultBrowserContinueScreen()
         testee.loadUI()
         testee.onDefaultBrowserClicked()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
@@ -387,7 +387,7 @@ class DefaultBrowserPageViewModelTest {
 
     @Test
     fun whenUserWasTakenToSettingsAndSelectedDDGAsDefaultAndSuppressContinueScreenVariantEnabledThenContinueToBrowser() {
-        givenSuppressDefaultBrowserContinueScreen()
+        givenSuppressOnboardingDefaultBrowserContinueScreen()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
         whenever(mockDefaultBrowserDetector.hasDefaultBrowser()).thenReturn(true)
         testee.loadUI()
@@ -513,9 +513,9 @@ class DefaultBrowserPageViewModelTest {
         )
     }
 
-    private fun givenSuppressDefaultBrowserContinueScreen() {
+    private fun givenSuppressOnboardingDefaultBrowserContinueScreen() {
         whenever(mockVariantManager.getVariant()).thenReturn(
-            Variant("test", features = listOf(VariantManager.VariantFeature.SuppressDefaultBrowserContinueScreen), filterBy = { true })
+            Variant("test", features = listOf(VariantManager.VariantFeature.SuppressOnboardingDefaultBrowserContinueScreen), filterBy = { true })
         )
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -105,12 +105,6 @@ class VariantManagerTest {
     // CTA on Concept Test experiments
 
     @Test
-    fun insertCtaControlVariantIsActiveAndHasNoFeatures() {
-        val variant = variants.firstOrNull { it.key == "mu" }
-        assertEqualsDouble(1.0, variant!!.weight)
-        assertEquals(0, variant.features.size)
-    }
-
     @Test
     fun insertCtaConceptTestVariantIsActiveAndHasConceptTestAndSuppressCtaFeatures() {
         val variant = variants.firstOrNull { it.key == "mv" }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -105,9 +105,8 @@ class VariantManagerTest {
     // CTA on Concept Test experiments
 
     @Test
-    @Test
-    fun insertCtaConceptTestVariantIsActiveAndHasConceptTestAndSuppressCtaFeatures() {
-        val variant = variants.firstOrNull { it.key == "mv" }
+    fun insertCtaConceptControlVariantIsActiveAndHasConceptTestAndSuppressCtaFeatures() {
+        val variant = variants.firstOrNull { it.key == "mj" }
         assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(3, variant!!.features.size)
         assertTrue(variant.hasFeature(ConceptTest))
@@ -117,10 +116,11 @@ class VariantManagerTest {
 
     @Test
     fun insertCtaConceptTestWithAllCtaExperimentalVariantIsActiveAndHasConceptTestAndSuppressCtaFeatures() {
-        val variant = variants.firstOrNull { it.key == "mz" }
+        val variant = variants.firstOrNull { it.key == "ml" }
         assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(2, variant!!.features.size)
         assertTrue(variant.hasFeature(ConceptTest))
+        assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserContinueScreen))
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -54,8 +54,8 @@ class VariantManagerTest {
         val variant = variants.firstOrNull { it.key == "md" }
         assertEqualsDouble(0.0, variant!!.weight)
         assertEquals(2, variant!!.features.size)
-        assertTrue(variant.hasFeature(SuppressWidgetCta))
-        assertTrue(variant.hasFeature(SuppressDefaultBrowserCta))
+        assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
+        assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))
     }
 
     @Test
@@ -64,8 +64,8 @@ class VariantManagerTest {
         assertEqualsDouble(0.0, variant!!.weight)
         assertEquals(3, variant!!.features.size)
         assertTrue(variant.hasFeature(ConceptTest))
-        assertTrue(variant.hasFeature(SuppressWidgetCta))
-        assertTrue(variant.hasFeature(SuppressDefaultBrowserCta))
+        assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
+        assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))
     }
 
     // CTA Validation experiments
@@ -78,19 +78,19 @@ class VariantManagerTest {
     }
 
     @Test
-    fun ctaSuppressDefaultBrowserVariantIsInactiveAndHasSuppressDefaultBrowserFeature() {
+    fun ctaSuppressOnboardingDefaultBrowserVariantIsInactiveAndHasSuppressDefaultBrowserFeature() {
         val variant = variants.firstOrNull { it.key == "mr" }
         assertEqualsDouble(0.0, variant!!.weight)
         assertEquals(1, variant!!.features.size)
-        assertTrue(variant.hasFeature(SuppressDefaultBrowserCta))
+        assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))
     }
 
     @Test
-    fun ctaSuppressWidgetVariantIsInactiveAndHasSuppressWidgetCtaFeature() {
+    fun ctaSuppressHomeWidgetVariantIsInactiveAndHasSuppressWidgetCtaFeature() {
         val variant = variants.firstOrNull { it.key == "ms" }
         assertEqualsDouble(0.0, variant!!.weight)
         assertEquals(1, variant!!.features.size)
-        assertTrue(variant.hasFeature(SuppressWidgetCta))
+        assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
     }
 
     @Test
@@ -98,8 +98,8 @@ class VariantManagerTest {
         val variant = variants.firstOrNull { it.key == "mt" }
         assertEqualsDouble(0.0, variant!!.weight)
         assertEquals(2, variant!!.features.size)
-        assertTrue(variant.hasFeature(SuppressDefaultBrowserCta))
-        assertTrue(variant.hasFeature(SuppressWidgetCta))
+        assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))
+        assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
     }
 
     // CTA on Concept Test experiments
@@ -117,8 +117,8 @@ class VariantManagerTest {
         assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(3, variant!!.features.size)
         assertTrue(variant.hasFeature(ConceptTest))
-        assertTrue(variant.hasFeature(SuppressWidgetCta))
-        assertTrue(variant.hasFeature(SuppressDefaultBrowserCta))
+        assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
+        assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))
     }
 
     @Test
@@ -127,6 +127,18 @@ class VariantManagerTest {
         assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(2, variant!!.features.size)
         assertTrue(variant.hasFeature(ConceptTest))
+    }
+
+    @Test
+    fun insertCtaConceptTestWithCtasAsDaxDialogsExperimentalVariantIsActiveAndHasConceptTestAndSuppressCtaFeatures() {
+        val variant = variants.firstOrNull { it.key == "mh" }
+        assertEqualsDouble(1.0, variant!!.weight)
+        assertEquals(5, variant!!.features.size)
+        assertTrue(variant.hasFeature(ConceptTest))
+        assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
+        assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))
+        assertTrue(variant.hasFeature(DefaultBrowserDaxCta))
+        assertTrue(variant.hasFeature(SearchWidgetDaxCta))
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -31,7 +31,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.ConceptTest
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.SuppressWidgetCta
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.SuppressHomeTabWidgetCta
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
@@ -166,7 +166,7 @@ class CtaViewModel @Inject constructor(
         return widgetCapabilities.supportsStandardWidgetAdd &&
                 !widgetCapabilities.hasInstalledWidgets &&
                 !dismissedCtaDao.exists(CtaId.ADD_WIDGET) &&
-                !variant().hasFeature(SuppressWidgetCta)
+                !variant().hasFeature(SuppressHomeTabWidgetCta)
     }
 
     @WorkerThread

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -186,7 +186,7 @@ open class DuckDuckGoApplication : HasActivityInjector, HasServiceInjector, HasS
         }
 
         recordInstallationTimestamp()
-        initializeTheme(settingsDataStore, variantManager)
+        initializeTheme(settingsDataStore)
         loadTrackerData()
         configureDataDownloader()
         scheduleOfflinePixels()

--- a/app/src/main/java/com/duckduckgo/app/global/Theming.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/Theming.kt
@@ -34,13 +34,9 @@ enum class DuckDuckGoTheme {
 
 object Theming {
 
-    fun initializeTheme(settingsDataStore: SettingsDataStore, variantManager: VariantManager) {
+    fun initializeTheme(settingsDataStore: SettingsDataStore) {
         if (settingsDataStore.theme == null) {
-            if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.ConceptTest)) {
-                settingsDataStore.theme = DuckDuckGoTheme.LIGHT
-            } else {
-                settingsDataStore.theme = DuckDuckGoTheme.DARK
-            }
+            settingsDataStore.theme = DuckDuckGoTheme.LIGHT
         }
     }
 
@@ -59,10 +55,6 @@ fun DuckDuckGoActivity.applyTheme(): BroadcastReceiver? {
     val themeId = THEME_MAP[Pair(manifestThemeId(), settingsDataStore.theme)] ?: return null
     setTheme(themeId)
     return registerForThemeChangeBroadcast()
-}
-
-fun DuckDuckGoActivity.appTheme(): DuckDuckGoTheme? {
-    return settingsDataStore.theme
 }
 
 private fun DuckDuckGoActivity.registerForThemeChangeBroadcast(): BroadcastReceiver {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
@@ -28,7 +28,7 @@ import com.duckduckgo.app.onboarding.ui.page.OnboardingPageFragment
 import com.duckduckgo.app.onboarding.ui.page.UnifiedSummaryPage
 import com.duckduckgo.app.onboarding.ui.page.WelcomePage
 import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.SuppressDefaultBrowserCta
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.SuppressOnboardingDefaultBrowserCta
 
 interface OnboardingPageManager {
     fun pageCount(): Int
@@ -85,13 +85,13 @@ class OnboardingPageManagerWithTrackerBlocking(
 
     private fun shouldShowDefaultBrowserPage(): Boolean {
         return defaultWebBrowserCapability.deviceSupportsDefaultBrowserConfiguration()
-                && !variantManager.getVariant().hasFeature(SuppressDefaultBrowserCta)
+                && !variantManager.getVariant().hasFeature(SuppressOnboardingDefaultBrowserCta)
                 && !isDefaultBrowserAndSuppressedContinuationScreen()
     }
 
     private fun isDefaultBrowserAndSuppressedContinuationScreen(): Boolean {
         return defaultWebBrowserCapability.isDefaultBrowser()
-                && variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SuppressDefaultBrowserContinueScreen)
+                && variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SuppressOnboardingDefaultBrowserContinueScreen)
     }
 
     private fun isFinalPage(position: Int) = position == pageCount() - 1

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
@@ -146,7 +146,7 @@ class DefaultBrowserPageViewModel(
     }
 
     private fun shouldShowContinueScreen(): Boolean {
-        return !variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SuppressDefaultBrowserContinueScreen)
+        return !variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SuppressOnboardingDefaultBrowserContinueScreen)
     }
 
     private fun handleOriginInternalBrowser(): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -30,9 +30,11 @@ interface VariantManager {
     // variant-dependant features listed here
     sealed class VariantFeature {
         object ConceptTest : VariantFeature()
-        object SuppressWidgetCta : VariantFeature()
-        object SuppressDefaultBrowserCta : VariantFeature()
-        object SuppressDefaultBrowserContinueScreen : VariantFeature()
+        object SuppressHomeTabWidgetCta : VariantFeature()
+        object SuppressOnboardingDefaultBrowserCta : VariantFeature()
+        object SuppressOnboardingDefaultBrowserContinueScreen : VariantFeature()
+        object DefaultBrowserDaxCta : VariantFeature()
+        object SearchWidgetDaxCta : VariantFeature()
     }
 
     companion object {
@@ -53,25 +55,44 @@ interface VariantManager {
             Variant(
                 key = "me",
                 weight = 0.0,
-                features = listOf(ConceptTest, SuppressWidgetCta, SuppressDefaultBrowserCta),
+                features = listOf(ConceptTest, SuppressHomeTabWidgetCta, SuppressOnboardingDefaultBrowserCta),
                 filterBy = { isEnglishLocale() }),
-            Variant(key = "md", weight = 0.0, features = listOf(SuppressWidgetCta, SuppressDefaultBrowserCta), filterBy = { isEnglishLocale() }),
+            Variant(
+                key = "md",
+                weight = 0.0,
+                features = listOf(SuppressHomeTabWidgetCta, SuppressOnboardingDefaultBrowserCta),
+                filterBy = { isEnglishLocale() }),
 
             // Validate CTAs experiment
             Variant(key = "mq", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "mr", weight = 0.0, features = listOf(SuppressDefaultBrowserCta), filterBy = { noFilter() }),
-            Variant(key = "ms", weight = 0.0, features = listOf(SuppressWidgetCta), filterBy = { noFilter() }),
-            Variant(key = "mt", weight = 0.0, features = listOf(SuppressWidgetCta, SuppressDefaultBrowserCta), filterBy = { noFilter() }),
+            Variant(key = "mr", weight = 0.0, features = listOf(SuppressOnboardingDefaultBrowserCta), filterBy = { noFilter() }),
+            Variant(key = "ms", weight = 0.0, features = listOf(SuppressHomeTabWidgetCta), filterBy = { noFilter() }),
+            Variant(
+                key = "mt",
+                weight = 0.0,
+                features = listOf(SuppressHomeTabWidgetCta, SuppressOnboardingDefaultBrowserCta),
+                filterBy = { noFilter() }),
 
             // Insert CTAs on Concept test experiment
             Variant(key = "mu", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),
             Variant(key = "mv", weight = 1.0,
-                features = listOf(ConceptTest, SuppressWidgetCta, SuppressDefaultBrowserCta),
+                features = listOf(ConceptTest, SuppressHomeTabWidgetCta, SuppressOnboardingDefaultBrowserCta),
                 filterBy = { isEnglishLocale() }),
             Variant(
                 key = "mz",
                 weight = 1.0,
-                features = listOf(ConceptTest, SuppressDefaultBrowserContinueScreen),
+                features = listOf(ConceptTest, SuppressOnboardingDefaultBrowserContinueScreen),
+                filterBy = { isEnglishLocale() }),
+            Variant(
+                key = "mh",
+                weight = 1.0,
+                features = listOf(
+                    ConceptTest,
+                    SuppressHomeTabWidgetCta,
+                    SuppressOnboardingDefaultBrowserCta,
+                    DefaultBrowserDaxCta,
+                    SearchWidgetDaxCta
+                ),
                 filterBy = { isEnglishLocale() })
 
             // All groups in an experiment (control and variants) MUST use the same filters

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -74,11 +74,11 @@ interface VariantManager {
                 filterBy = { noFilter() }),
 
             // Insert CTAs on Concept test experiment
-            Variant(key = "mv", weight = 1.0,
+            Variant(key = "mj", weight = 1.0,
                 features = listOf(ConceptTest, SuppressHomeTabWidgetCta, SuppressOnboardingDefaultBrowserCta),
                 filterBy = { isEnglishLocale() }),
             Variant(
-                key = "mz",
+                key = "ml",
                 weight = 1.0,
                 features = listOf(ConceptTest, SuppressOnboardingDefaultBrowserContinueScreen),
                 filterBy = { isEnglishLocale() }),

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -74,7 +74,6 @@ interface VariantManager {
                 filterBy = { noFilter() }),
 
             // Insert CTAs on Concept test experiment
-            Variant(key = "mu", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),
             Variant(key = "mv", weight = 1.0,
                 features = listOf(ConceptTest, SuppressHomeTabWidgetCta, SuppressOnboardingDefaultBrowserCta),
                 filterBy = { isEnglishLocale() }),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->
Task/Issue URL: https://app.asana.com/0/0/1162228349959213/f
Tech Design URL: 
CC: 

**Description**:

- Introducing a new variant to control displaying Ctas as Dax dialogs during Dax journey.
- According to https://app.asana.com/0/72649045549333/1161278038072568/f, the new control group will be the concept test without any Ctas.
- Additionally, removing theme-variant logic to avoid allocating users into any variant before referrer logic is executed. This will avoid overriding an initial variant if the installation comes from an ad campaign.

**Steps to test this PR**:
1. 
1. 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
