### PR TITLE
Remove scanning animation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -168,9 +168,6 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
     @Inject
     lateinit var privacySettingsStore: PrivacySettingsStore
 
-    @Inject
-    lateinit var animatorHelper: BrowserTrackersAnimatorHelper
-
     val tabId get() = arguments!![TAB_ID_ARG] as String
 
     lateinit var userAgentProvider: UserAgentProvider
@@ -197,6 +194,8 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         viewModel.loadData(tabId, initialUrl, skipHome)
         viewModel
     }
+
+    private val animatorHelper by lazy { BrowserTrackersAnimatorHelper() }
 
     private val smoothProgressAnimator by lazy { SmoothProgressAnimator(pageLoadingIndicator) }
 
@@ -1125,10 +1124,9 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         private const val AUTHENTICATION_DIALOG_TAG = "AUTH_DIALOG_TAG"
         private const val DAX_DIALOG_DIALOG_TAG = "DAX_DIALOG_TAG"
 
-        private const val MIN_PROGRESS = 50
         private const val MAX_PROGRESS = 100
-        private const val TRACKERS_INI_DELAY = 700L
-        private const val TRACKERS_SECONDARY_DELAY = 300L
+        private const val TRACKERS_INI_DELAY = 500L
+        private const val TRACKERS_SECONDARY_DELAY = 200L
 
         fun newInstance(tabId: String, query: String? = null, skipHome: Boolean): BrowserTabFragment {
             val fragment = BrowserTabFragment()
@@ -1204,18 +1202,14 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                         cancelAllAnimations()
                     }
 
-                    if (viewState.progress <= MIN_PROGRESS && viewState.isLoading && lastSeenOmnibarViewState?.isEditing != true) {
-                        animatorHelper.createLoadingAnimation(resources, omnibarViews(), loadingText)
-                    }
-
                     if (viewState.progress == MAX_PROGRESS) {
-                        createLoadedAnimation()
+                        createTrackersAnimation()
                     }
                 }
             }
         }
 
-        private fun createLoadedAnimation() {
+        private fun createTrackersAnimation() {
             launch {
                 delay(TRACKERS_INI_DELAY)
                 viewModel.refreshCta()
@@ -1225,11 +1219,10 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                     val events = site?.trackingEvents
 
                     activity?.let { activity ->
-                        animatorHelper.createLoadedAnimation(
+                        animatorHelper.startTrackersAnimation(
                             lastSeenCtaViewState?.cta,
                             activity,
                             networksContainer,
-                            loadingText,
                             omnibarViews(),
                             events
                         )
@@ -1242,7 +1235,6 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.ConceptTest)) {
                 animatorHelper.cancelAnimations()
                 networksContainer.alpha = 0f
-                loadingText.alpha = 0f
                 clearTextButton.alpha = 1f
                 omnibarTextInput.alpha = 1f
                 privacyGradeButton.alpha = 1f

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
@@ -20,74 +20,31 @@ import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.content.res.Resources
 import android.graphics.drawable.AnimatedVectorDrawable
 import android.view.View
 import android.widget.ImageView
-import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import com.duckduckgo.app.cta.ui.Cta
 import com.duckduckgo.app.cta.ui.DaxDialogCta
 import com.duckduckgo.app.privacy.renderer.TrackersRenderer
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import javax.inject.Inject
-import kotlin.coroutines.CoroutineContext
 
-class BrowserTrackersAnimatorHelper @Inject constructor() : CoroutineScope {
-
-    override val coroutineContext: CoroutineContext
-        get() = SupervisorJob() + Dispatchers.Main
+class BrowserTrackersAnimatorHelper {
 
     private var logosStayOnScreenDuration: Long = TRACKER_LOGOS_DELAY_ON_SCREEN
-
-    private var loadingAnimation: AnimatorSet = AnimatorSet()
     private var trackersAnimation: AnimatorSet = AnimatorSet()
-    private var typingAnimationJob: Job? = null
 
-    private fun createScanningAnimation(resources: Resources, loadingText: TextView): Job {
-        return launch {
-            while (true) {
-                if (loadingText.text.contains("...")) {
-                    loadingText.text = resources.getString(R.string.trackersAnimationText)
-                } else {
-                    loadingText.text = resources.getString(R.string.trackersAnimationDotText, loadingText.text)
-                }
-                delay(SCANNING_DELAY)
-            }
-        }
-    }
-
-    fun createLoadedAnimation(
-        cta: Cta?,
-        activity: Activity,
-        container: ConstraintLayout,
-        loadingText: View,
-        views: List<View>,
-        events: List<TrackingEvent>?
-    ) {
-        if (loadingAnimation.isRunning) {
-            loadingAnimation.end()
-        }
+    fun startTrackersAnimation(cta: Cta?, activity: Activity, container: ConstraintLayout, views: List<View>, events: List<TrackingEvent>?) {
+        if (events.isNullOrEmpty()) return
 
         if (!trackersAnimation.isRunning) {
-            views.map {
-                it.alpha = 0f
-            }
-            typingAnimationJob?.cancel()
-            typingAnimationJob = null
             trackersAnimation = if (cta is DaxDialogCta.DaxTrackersBlockedCta) {
-                createTrackersAnimation(activity, container, loadingText, events).apply {
+                createPartialTrackersAnimation(activity, container, views, events).apply {
                     start()
                 }
             } else {
-                createCompleteTrackersAnimation(activity, container, loadingText, views, events).apply {
+                createFullTrackersAnimation(activity, container, views, events).apply {
                     start()
                 }
             }
@@ -95,46 +52,16 @@ class BrowserTrackersAnimatorHelper @Inject constructor() : CoroutineScope {
     }
 
     fun cancelAnimations() {
-        typingAnimationJob?.cancel()
-        typingAnimationJob = null
-        if (loadingAnimation.isRunning) {
-            loadingAnimation.end()
-        }
         if (trackersAnimation.isRunning) {
             trackersAnimation.end()
         }
     }
 
-    fun createLoadingAnimation(resources: Resources, fadeOutViews: List<View>, fadeInView: View) {
-        if (!loadingAnimation.isRunning && !trackersAnimation.isRunning) {
-
-            val animators = fadeOutViews.map {
-                animateFadeOut(it)
-            }
-
-            val fadeLoadingIn = animateFadeIn(fadeInView)
-            val transition = AnimatorSet().apply {
-                playTogether(animators)
-            }
-
-            loadingAnimation = AnimatorSet().apply {
-                play(fadeLoadingIn).after(transition)
-                start()
-            }
-
-            if (typingAnimationJob == null) {
-                if (fadeInView is TextView) {
-                    typingAnimationJob = createScanningAnimation(resources, fadeInView)
-                }
-            }
-        }
-    }
-
     fun finishTrackerAnimation(fadeInViews: List<View>, container: ConstraintLayout) {
         val animateOmnibarIn = animateOmnibarIn(fadeInViews)
-        val fadeLogosOut = animateFadeOut(container)
+        val animateLogosOut = animateFadeOut(container)
         trackersAnimation = AnimatorSet().apply {
-            play(fadeLogosOut).before(animateOmnibarIn)
+            play(animateLogosOut).before(animateOmnibarIn)
             start()
         }
     }
@@ -171,42 +98,45 @@ class BrowserTrackersAnimatorHelper @Inject constructor() : CoroutineScope {
         }
     }
 
-    private fun createCompleteTrackersAnimation(
+    private fun createFullTrackersAnimation(
         activity: Activity,
         container: ConstraintLayout,
-        loadingText: View,
         views: List<View>,
         events: List<TrackingEvent>?
     ): AnimatorSet {
         return AnimatorSet().apply {
-            play(createTrackersAnimation(activity, container, loadingText, events))
+            play(createPartialTrackersAnimation(activity, container, views, events))
             play(animateFadeOut(container))
                 .after(logosStayOnScreenDuration)
                 .before(animateOmnibarIn(views))
         }
     }
 
-    private fun createTrackersAnimation(
+    private fun createPartialTrackersAnimation(
         activity: Activity,
         container: ConstraintLayout,
-        loadingText: View,
+        views: List<View>,
         events: List<TrackingEvent>?
     ): AnimatorSet {
         container.removeAllViews()
         container.alpha = 0f
 
         val logos = createResourcesIdList(activity, events)
-        val views: List<View> = createLogosViewList(activity, container, logos)
-
-        applyConstraintSet(container, views)
-
-        val fadeLoadingOut = animateFadeOut(loadingText)
+        val logoViews: List<View> = createLogosViewList(activity, container, logos)
+        val fadeOmnibarOut = animateOmnibarOut(views)
         val fadeLogosIn = animateFadeIn(container)
 
-        animateBlockedLogos(views)
+        logosStayOnScreenDuration = if (logoViews.isEmpty()) {
+            TRACKER_LOGOS_REMOVE_DELAY
+        } else {
+            TRACKER_LOGOS_DELAY_ON_SCREEN
+        }
+
+        applyConstraintSet(container, logoViews)
+        animateBlockedLogos(logoViews)
 
         return AnimatorSet().apply {
-            play(fadeLogosIn).after(fadeLoadingOut)
+            play(fadeLogosIn).after(fadeOmnibarOut)
         }
     }
 
@@ -241,13 +171,16 @@ class BrowserTrackersAnimatorHelper @Inject constructor() : CoroutineScope {
             )
         }
 
-        logosStayOnScreenDuration = if (viewIds.isEmpty()) {
-            TRACKER_LOGOS_REMOVE_DELAY
-        } else {
-            TRACKER_LOGOS_DELAY_ON_SCREEN
-        }
-
         constraints.applyTo(container)
+    }
+
+    private fun animateOmnibarOut(views: List<View>): AnimatorSet {
+        val animators = views.map {
+            animateFadeOut(it)
+        }
+        return AnimatorSet().apply {
+            playTogether(animators)
+        }
     }
 
     private fun animateOmnibarIn(views: List<View>): AnimatorSet {
@@ -275,9 +208,8 @@ class BrowserTrackersAnimatorHelper @Inject constructor() : CoroutineScope {
 
     companion object {
         private const val TRACKER_LOGOS_REMOVE_DELAY = 0L
-        private const val TRACKER_LOGOS_DELAY_ON_SCREEN = 3000L
-        private const val DEFAULT_ANIMATION_DURATION = 250L
+        private const val TRACKER_LOGOS_DELAY_ON_SCREEN = 2400L
+        private const val DEFAULT_ANIMATION_DURATION = 150L
         private const val MAX_LOGOS_SHOWN = 4
-        const val SCANNING_DELAY = 340L
     }
 }

--- a/app/src/main/res/layout/include_omnibar_toolbar.xml
+++ b/app/src/main/res/layout/include_omnibar_toolbar.xml
@@ -64,32 +64,6 @@
                     android:paddingStart="6dp"
                     android:paddingEnd="6dp">
 
-                    <androidx.constraintlayout.widget.Guideline
-                        android:id="@+id/guideline"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintGuide_percent="0.4"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <TextView
-                        android:id="@+id/loadingText"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:alpha="0"
-                        android:fontFamily="sans-serif-medium"
-                        android:text="@string/trackersAnimationText"
-                        android:textAlignment="textStart"
-                        android:textColor="?attr/omnibarTextColor"
-                        android:textSize="13sp"
-                        android:textStyle="normal"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toEndOf="@id/guideline"
-                        app:layout_constraintTop_toTopOf="parent" />
-
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/networksContainer"
                     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -18,10 +18,6 @@
     <string name="crashedWebViewErrorMessage">"The webpage could not be displayed."</string>
     <string name="crashedWebViewErrorAction">"Reload"</string>
 
-    <!-- Omnibar Animation -->
-    <string name="trackersAnimationText">Scanning</string>
-    <string name="trackersAnimationDotText">%s.</string>
-
     <!-- New Onboarding Experience -->
     <string name="onboardingWelcomeTitle">"Welcome to DuckDuckGo!"</string>
     <string name="onboardingDaxText"><![CDATA[The Internet can be kinda creepy.<br/><br/>Not to worry! Searching and browsing privately is easier than you think.]]></string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1157213430036875
Tech Design URL: 
CC: 

**Description**:
This PR removes the "Scanning" part of the new URL animation. I have removed all the code related to that animation and took the opportunity to rename some methods and variables to make them more meaningful. I did also adjust the animation timings to make them a little bit quicker while still giving the results we want (i.e. returning trackers, etc).

**Steps to test this PR**:
1. Use a variant that has the concept test feature, `mv` would do.
1. Go to cnn.com and notice how the "Scanning" animation doesn't exist anymore but we still have the trackers blocked animation.
1. Go to SERP and notice how the "Scanning" animation is gone and since we do not detect trackers there are no further animations.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
