### PR TITLE
Fix/david/new link tab order

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.tabs.model
 
-
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -29,7 +28,8 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import java.util.*
+import java.util.LinkedHashMap
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -77,7 +77,7 @@ class TabDataRepository @Inject constructor(
             val lastTab = tabsDao.lastTab()
             val position = if (lastTab == null) {
                 0
-            }  else {
+            } else {
                 lastTab.position + 1
             }
             Timber.i("About to add a new tab, isDefaultTab: $isDefaultTab. $tabId, position: $position")

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -74,8 +74,14 @@ class TabDataRepository @Inject constructor(
                 return@scheduleDirect
             }
 
-            Timber.i("About to add a new tab, isDefaultTab: $isDefaultTab. $tabId")
-            val position = tabsDao.lastTab()?.position ?: 0
+            val lastTab = tabsDao.lastTab()
+            val position = if (lastTab == null) {
+                0
+            }  else {
+                lastTab.position + 1
+            }
+            Timber.i("About to add a new tab, isDefaultTab: $isDefaultTab. $tabId, position: $position")
+
             tabsDao.addAndSelectTab(TabEntity(tabId, data.value?.url, data.value?.title, skipHome, true, position))
         }
     }


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/414730916066338/1157894643192241

**Description**:
In the past, long tapping a link and opening it in a background tab, positioned the new tab immediately after the current tab. Now, when the new tab was added from any tab but the last one, it would not respect the proper order (See screencast for clarification)

**Solution**:
The code for adding a new tab was always using position = 0. The code for adding a tab in the background was properly adding 1 to the current position. For that reason, adding tabs in the background for the last tab was displayed properly, and not for the rest. This PR fixes that.

**Screencasts**:
| Before | After |
| ------ | ----- |
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/531613/74945604-5453e300-53f8-11ea-8015-eee0faf47393.gif)| ![ezgif com-video-to-gif](https://user-images.githubusercontent.com/531613/74945610-574ed380-53f8-11ea-9219-243600015928.gif)


**Steps to test this PR**:
On the current app in the Play Store
1. Open the app
2. Add a new tab (duckduckgo.com)
3. Add a second tab (wikipedia.com)
4. Switch to first tab
5. Long press on any link and select "Add tab in background"
6. New tab will be added as Tab in position 3 

Building this branch
1. Open the app
2. Add a new tab (duckduckgo.com)
3. Add a second tab (wikipedia.com)
4. Switch to first tab
5. Long press on any link and select "Add tab in background"
6. New tab will be added as Tab in position 2 (Between the current tab and wikipedia) 

---