### PR TITLE
Add David and Cristian to codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 #These people are listed as being the code owners for this project. As such, they will be automatically added as a reviewer when a PR is created.
 #For more details on how this is configured, see https://help.github.com/articles/about-code-owners/
 
-*       @CDRussell @subsymbolic @marcosholgado
+*       @CDRussell @subsymbolic @marcosholgado @cmonfortep @malmstein


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->
Task/Issue URL: https://app.asana.com/0/0/1160050773844673/f
Tech Design URL: 
CC: 

**Description**:
Adding @cmonfortep and @malmstein as codeowners.

![](https://user-images.githubusercontent.com/4747865/74964961-a0148580-5414-11ea-80eb-abad7433f34d.gif)

**Steps to test this PR**:
1. Open a PR
1. Ensure new ducks are added as reviewers

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
