### PR TITLE
light theme will now use light navigation bar

### DIFF
--- a/app/src/main/res/values-v27/themes.xml
+++ b/app/src/main/res/values-v27/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  ~ Copyright (c) 2018 DuckDuckGo
+  ~ Copyright (c) 2020 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -20,11 +20,13 @@
 
     <style name="AppTheme.Dark" parent="AppTheme.BaseDark">
         <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
         <item name="android:navigationBarColor">@color/black</item>
     </style>
 
     <style name="AppTheme.Light" parent="AppTheme.BaseLight">
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
         <item name="android:navigationBarColor">@color/white</item>
     </style>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -41,6 +41,7 @@
     <color name="midnight">#161616</color>
     <color name="almostBlackDark">#222222</color>
     <color name="almostBlack">#333333</color>
+    <color name="black">#000000</color>
 
     <color name="charcoalGrey">#383838</color>
     <color name="charcoalGreyTwoSemiTransparent">#d6333339</color>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1162814661890319

**Description**:
When the user selected Light Mode, the navigation bar was still showed in Dark. This PR fixes that.

Fixes: https://github.com/duckduckgo/Android/issues/695


**Steps to test this PR**:
1. Open current app in Google Play
2. Open Settings and select Light Theme
3. Check that Navigation bar is shown in Dark

Building this branch
1. Open app
2. Open Settings and select Light Theme
3. Check that Navigation bar is shown in Light

**Screenshots**:
| Before | After |
| ------ | ----- |
![device-2020-02-24-092707](https://user-images.githubusercontent.com/531613/75138641-fb7f9580-56ea-11ea-8d16-d27de6736d91.png)|![device-2020-02-24-092531](https://user-images.githubusercontent.com/531613/75138648-fd495900-56ea-11ea-999b-9809dd5ffef1.png)