### PR TITLE
New control group and changes on when to show search widget cta

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelNextCtaTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelNextCtaTest.kt
@@ -59,14 +59,26 @@ class CtaViewModelNextCtaTest {
         supportsStandardWidgetAdd: Boolean,
         hasInstalledWidget: Boolean,
         hasSearchWidgetDaxCtaFeature: Boolean,
-        daxSearchWidgetShown: Boolean
+        daxSearchWidgetShown: Boolean,
+        daxNetworkDialogShown: Boolean,
+        daxTrackersDialogShown: Boolean,
+        daxOtherDialogShown: Boolean
     ) {
         val previousCta = DaxDialogCta.DaxSerpCta(mock(), mock())
         assumeTrue(supportsStandardWidgetAdd)
         assumeFalse(hasInstalledWidget)
         assumeTrue(hasSearchWidgetDaxCtaFeature)
         assumeFalse(daxSearchWidgetShown)
-        givenSearchWidgetScenario(supportsStandardWidgetAdd, hasInstalledWidget, hasSearchWidgetDaxCtaFeature, daxSearchWidgetShown)
+        assumeTrue(daxNetworkDialogShown || daxTrackersDialogShown || daxOtherDialogShown)
+        givenSearchWidgetScenario(
+            supportsStandardWidgetAdd,
+            hasInstalledWidget,
+            hasSearchWidgetDaxCtaFeature,
+            daxSearchWidgetShown,
+            daxNetworkDialogShown,
+            daxTrackersDialogShown,
+            daxOtherDialogShown
+        )
 
         val nextCta = testee.obtainNextCta(previousCta)
 
@@ -78,11 +90,28 @@ class CtaViewModelNextCtaTest {
         supportsStandardWidgetAdd: Boolean,
         hasInstalledWidget: Boolean,
         hasSearchWidgetDaxCtaFeature: Boolean,
-        daxSearchWidgetShown: Boolean
+        daxSearchWidgetShown: Boolean,
+        daxNetworkDialogShown: Boolean,
+        daxTrackersDialogShown: Boolean,
+        daxOtherDialogShown: Boolean
     ) {
         val previousCta = DaxDialogCta.DaxSerpCta(mock(), mock())
-        assumeFalse(supportsStandardWidgetAdd && !hasInstalledWidget && hasSearchWidgetDaxCtaFeature && !daxSearchWidgetShown)
-        givenSearchWidgetScenario(supportsStandardWidgetAdd, hasInstalledWidget, hasSearchWidgetDaxCtaFeature, daxSearchWidgetShown)
+        assumeFalse(
+            supportsStandardWidgetAdd &&
+                    !hasInstalledWidget &&
+                    hasSearchWidgetDaxCtaFeature &&
+                    !daxSearchWidgetShown &&
+                    (daxNetworkDialogShown || daxTrackersDialogShown || daxOtherDialogShown)
+        )
+        givenSearchWidgetScenario(
+            supportsStandardWidgetAdd,
+            hasInstalledWidget,
+            hasSearchWidgetDaxCtaFeature,
+            daxSearchWidgetShown,
+            daxNetworkDialogShown,
+            daxTrackersDialogShown,
+            daxOtherDialogShown
+        )
 
         val nextCta = testee.obtainNextCta(previousCta)
 
@@ -152,7 +181,10 @@ class CtaViewModelNextCtaTest {
         supportsStandardWidgetAdd: Boolean,
         hasInstalledWidget: Boolean,
         hasSearchWidgetDaxCtaFeature: Boolean,
-        daxSearchWidgetShown: Boolean
+        daxSearchWidgetShown: Boolean,
+        daxNetworkDialogShown: Boolean,
+        daxTrackersDialogShown: Boolean,
+        daxOtherDialogShown: Boolean
     ) {
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(supportsStandardWidgetAdd)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(hasInstalledWidget)
@@ -160,6 +192,9 @@ class CtaViewModelNextCtaTest {
             Variant("test", features = getFeatures(hasSearchWidgetDaxCtaFeature, false), filterBy = { true })
         )
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SEARCH_WIDGET)).thenReturn(daxSearchWidgetShown)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_NETWORK)).thenReturn(daxNetworkDialogShown)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(daxTrackersDialogShown)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_OTHER)).thenReturn(daxOtherDialogShown)
     }
 
     private fun getFeatures(searchWidgetFeature: Boolean, defaultBrowserFeature: Boolean): List<VariantManager.VariantFeature> {
@@ -205,5 +240,17 @@ class CtaViewModelNextCtaTest {
         @JvmStatic
         @DataPoint
         fun daxDefaultBrowserShown() = listOf(true, false)
+
+        @JvmStatic
+        @DataPoint
+        fun daxNetworkDialogShown() = listOf(true, false)
+
+        @JvmStatic
+        @DataPoint
+        fun daxTrackersDialogShown() = listOf(true, false)
+
+        @JvmStatic
+        @DataPoint
+        fun daxOtherDialogShown() = listOf(true, false)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -425,6 +425,8 @@ class CtaViewModelTest {
         setConceptTestFeature(SearchWidgetDaxCta)
         givenSerpCtaShown()
         givenAtLeastOneNonSerpCtaShown()
+        whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SEARCH_WIDGET)).thenReturn(true)
         val site = site(url = "http://www.duckduckgo.com")
 

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -38,8 +38,7 @@ import com.duckduckgo.app.privacy.store.PrivacySettingsStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.ConceptTest
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.SuppressHomeTabWidgetCta
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.*
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
 import com.duckduckgo.app.survey.db.SurveyDao
@@ -398,12 +397,40 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnWhileBrowsingAndConceptTestFeatureActiveThenReturnSerpCta() = runBlockingTest {
+    fun whenRefreshCtaOnSerpWhileBrowsingAndConceptTestFeatureActiveThenReturnSerpCta() = runBlockingTest {
         setConceptTestFeature()
         val site = site(url = "http://www.duckduckgo.com")
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
 
         assertTrue(value is DaxDialogCta.DaxSerpCta)
+    }
+
+    @Test
+    fun whenRefreshCtaOnSerpWhereSerpAndAnyNonSerpCtaShownAndWidgetCtaActiveThenReturnWidgetCta() = runBlockingTest {
+        setConceptTestFeature(SearchWidgetDaxCta)
+        givenSerpCtaShown()
+        givenAtLeastOneNonSerpCtaShown()
+        whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SEARCH_WIDGET)).thenReturn(false)
+        val site = site(url = "http://www.duckduckgo.com")
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
+
+        assertTrue(value is DaxDialogCta.SearchWidgetCta)
+    }
+
+    @Test
+    fun whenRefreshCtaOnSerpSiteWhereSerpCtaShownAndWidgetCtaShownAndConceptTestActiveThenReturnNull() = runBlockingTest {
+        setConceptTestFeature(SearchWidgetDaxCta)
+        givenSerpCtaShown()
+        givenAtLeastOneNonSerpCtaShown()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SEARCH_WIDGET)).thenReturn(true)
+        val site = site(url = "http://www.duckduckgo.com")
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
+
+        assertNull(value)
     }
 
     @Test
@@ -438,9 +465,9 @@ class CtaViewModelTest {
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("test", features = emptyList(), filterBy = { true }))
     }
 
-    private fun setConceptTestFeature() {
+    private fun setConceptTestFeature(vararg features: VariantManager.VariantFeature) {
         whenever(mockVariantManager.getVariant()).thenReturn(
-            Variant("test", features = listOf(ConceptTest), filterBy = { true })
+            Variant("test", features = listOf(ConceptTest) + features, filterBy = { true })
         )
     }
 
@@ -448,6 +475,14 @@ class CtaViewModelTest {
         whenever(mockVariantManager.getVariant()).thenReturn(
             Variant("test", features = listOf(SuppressHomeTabWidgetCta), filterBy = { true })
         )
+    }
+
+    private fun givenSerpCtaShown() {
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
+    }
+
+    private fun givenAtLeastOneNonSerpCtaShown() {
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
     }
 
     private fun site(

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -32,15 +32,15 @@ class VariantManagerTest {
 
     @Test
     fun serpControlVariantIsInactiveAndHasNoFeatures() {
-        val variant = variants.firstOrNull { it.key == "sc" }
-        assertEqualsDouble(0.0, variant!!.weight)
+        val variant = variants.first { it.key == "sc" }
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
     fun serpExperimentalVariantIsInactiveAndHasNoFeatures() {
-        val variant = variants.firstOrNull { it.key == "se" }
-        assertEqualsDouble(0.0, variant!!.weight)
+        val variant = variants.first { it.key == "se" }
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 
@@ -48,25 +48,25 @@ class VariantManagerTest {
 
     @Test
     fun conceptTestControlVariantIsInactiveAndHasNoFeatures() {
-        val variant = variants.firstOrNull { it.key == "mc" }
-        assertEqualsDouble(0.0, variant!!.weight)
+        val variant = variants.first { it.key == "mc" }
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
     fun conceptTestNoCtaVariantIsInactiveAndHasSuppressCtaFeatures() {
-        val variant = variants.firstOrNull { it.key == "md" }
-        assertEqualsDouble(0.0, variant!!.weight)
-        assertEquals(2, variant!!.features.size)
+        val variant = variants.first { it.key == "md" }
+        assertEqualsDouble(0.0, variant.weight)
+        assertEquals(2, variant.features.size)
         assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
         assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))
     }
 
     @Test
     fun conceptTestExperimentalVariantIsInactiveAndHasConceptTestAndSuppressCtaFeatures() {
-        val variant = variants.firstOrNull { it.key == "me" }
-        assertEqualsDouble(0.0, variant!!.weight)
-        assertEquals(3, variant!!.features.size)
+        val variant = variants.first { it.key == "me" }
+        assertEqualsDouble(0.0, variant.weight)
+        assertEquals(3, variant.features.size)
         assertTrue(variant.hasFeature(ConceptTest))
         assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
         assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))
@@ -85,9 +85,9 @@ class VariantManagerTest {
 
     @Test
     fun insertCtaConceptTestWithCtasAsDaxDialogsExperimentalVariantIsActiveAndHasExpectedFeatures() {
-        val variant = variants.firstOrNull { it.key == "mh" }
-        assertEqualsDouble(1.0, variant!!.weight)
-        assertEquals(5, variant!!.features.size)
+        val variant = variants.first { it.key == "mh" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(5, variant.features.size)
         assertTrue(variant.hasFeature(ConceptTest))
         assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
         assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -71,17 +71,7 @@ class VariantManagerTest {
     // CTA on Concept Test experiments
 
     @Test
-    fun insertCtaConceptControlVariantIsActiveAndHasConceptTestAndSuppressCtaFeatures() {
-        val variant = variants.firstOrNull { it.key == "mj" }
-        assertEqualsDouble(1.0, variant!!.weight)
-        assertEquals(3, variant!!.features.size)
-        assertTrue(variant.hasFeature(ConceptTest))
-        assertTrue(variant.hasFeature(SuppressHomeTabWidgetCta))
-        assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserCta))
-    }
-
-    @Test
-    fun insertCtaConceptTestWithAllCtaExperimentalVariantIsActiveAndHasConceptTestAndSuppressCtaFeatures() {
+    fun insertCtaConceptTestControlVariantIsActiveAndHasConceptTestAndHasExpectedFeatures() {
         val variant = variants.firstOrNull { it.key == "ml" }
         assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(2, variant!!.features.size)
@@ -90,7 +80,7 @@ class VariantManagerTest {
     }
 
     @Test
-    fun insertCtaConceptTestWithCtasAsDaxDialogsExperimentalVariantIsActiveAndHasConceptTestAndSuppressCtaFeatures() {
+    fun insertCtaConceptTestWithCtasAsDaxDialogsExperimentalVariantIsActiveAndHasExpectedFeatures() {
         val variant = variants.firstOrNull { it.key == "mh" }
         assertEqualsDouble(1.0, variant!!.weight)
         assertEquals(5, variant!!.features.size)
@@ -110,7 +100,6 @@ class VariantManagerTest {
             }
         }
     }
-
 
     @Suppress("SameParameterValue")
     private fun assertEqualsDouble(expected: Double, actual: Double) {

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -16,13 +16,17 @@
 
 package com.duckduckgo.app.statistics
 
+import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
+import com.duckduckgo.app.statistics.VariantManager.Companion.RESERVED_EU_AUCTION_VARIANT
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.*
 import org.junit.Assert.*
 import org.junit.Test
 
 class VariantManagerTest {
 
-    private val variants = VariantManager.ACTIVE_VARIANTS
+    private val variants = VariantManager.ACTIVE_VARIANTS +
+            variantWithKey(RESERVED_EU_AUCTION_VARIANT) +
+            DEFAULT_VARIANT
 
     // SERP Experiment(s)
 
@@ -72,9 +76,9 @@ class VariantManagerTest {
 
     @Test
     fun insertCtaConceptTestControlVariantIsActiveAndHasConceptTestAndHasExpectedFeatures() {
-        val variant = variants.firstOrNull { it.key == "ml" }
-        assertEqualsDouble(1.0, variant!!.weight)
-        assertEquals(2, variant!!.features.size)
+        val variant = variants.first { it.key == "mj" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(2, variant.features.size)
         assertTrue(variant.hasFeature(ConceptTest))
         assertTrue(variant.hasFeature(SuppressOnboardingDefaultBrowserContinueScreen))
     }
@@ -107,5 +111,10 @@ class VariantManagerTest {
         if (comparison != 0) {
             fail("Doubles are not equal. Expected $expected but was $actual")
         }
+    }
+
+    @Suppress("SameParameterValue")
+    private fun variantWithKey(key: String): Variant {
+        return DEFAULT_VARIANT.copy(key = key)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -210,7 +210,6 @@ class CtaViewModel @Inject constructor(
                 }
             }
 
-            // Is Serp
             if (isSerpUrl(it.url)) {
                 val ctaOnSerp = getCtaOnSerp()
                 if (ctaOnSerp != null) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -209,10 +209,15 @@ class CtaViewModel @Inject constructor(
                     }
                 }
             }
+
             // Is Serp
-            if (!daxDialogSerpShown() && isSerpUrl(it.url)) {
-                return DaxDialogCta.DaxSerpCta(onboardingStore, appInstallStore)
+            if (isSerpUrl(it.url)) {
+                val ctaOnSerp = getCtaOnSerp()
+                if (ctaOnSerp != null) {
+                    return ctaOnSerp
+                }
             }
+
             // Trackers blocked
             return if (!daxDialogTrackersFoundShown() && !isSerpUrl(it.url) && hasTrackersInformation(it.trackingEvents) && host != null) {
                 DaxDialogCta.DaxTrackersBlockedCta(onboardingStore, appInstallStore, it.trackingEvents, host)
@@ -238,6 +243,15 @@ class CtaViewModel @Inject constructor(
     }
 
     @WorkerThread
+    private fun getCtaOnSerp(): DaxDialogCta? {
+        return when {
+            !daxDialogSerpShown() -> DaxDialogCta.DaxSerpCta(onboardingStore, appInstallStore)
+            canShowWidgetDaxCta() -> DaxDialogCta.SearchWidgetCta(widgetCapabilities, onboardingStore, appInstallStore)
+            else -> null
+        }
+    }
+
+    @WorkerThread
     private fun canShowDefaultBrowserDaxCta(): Boolean {
         return defaultBrowserDetector.deviceSupportsDefaultBrowserConfiguration() &&
                 !defaultBrowserDetector.isDefaultBrowser() &&
@@ -250,7 +264,8 @@ class CtaViewModel @Inject constructor(
         return widgetCapabilities.supportsStandardWidgetAdd &&
                 !widgetCapabilities.hasInstalledWidgets &&
                 variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SearchWidgetDaxCta) &&
-                !daxSearchWidgetShown()
+                !daxSearchWidgetShown() &&
+                daxNonSerpDialogShown()
     }
 
     private fun hasTrackersInformation(events: List<TrackingEvent>): Boolean =
@@ -277,6 +292,8 @@ class CtaViewModel @Inject constructor(
     private fun daxDialogTrackersFoundShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)
 
     private fun daxDialogNetworkShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_DIALOG_NETWORK)
+
+    private fun daxNonSerpDialogShown(): Boolean = daxDialogNetworkShown() || daxDialogTrackersFoundShown() || daxDialogOtherShown()
 
     private fun daxDefaultBrowserShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_DIALOG_DEFAULT_BROWSER)
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -64,9 +64,6 @@ interface VariantManager {
                 filterBy = { isEnglishLocale() }),
 
             // Insert CTAs on Concept test experiment
-            Variant(key = "mj", weight = 1.0,
-                features = listOf(ConceptTest, SuppressHomeTabWidgetCta, SuppressOnboardingDefaultBrowserCta),
-                filterBy = { isEnglishLocale() }),
             Variant(
                 key = "ml",
                 weight = 1.0,

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -65,7 +65,7 @@ interface VariantManager {
 
             // Insert CTAs on Concept test experiment
             Variant(
-                key = "ml",
+                key = "mj",
                 weight = 1.0,
                 features = listOf(ConceptTest, SuppressOnboardingDefaultBrowserContinueScreen),
                 filterBy = { isEnglishLocale() }),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1163707393081881/f
Tech Design URL: 
CC: https://app.asana.com/0/0/1163228561849713/f

### **Description**:
>_VariantManager changes_

Moving as a control group a variant with concept test + Ctas.
Dropping variant only showing concept test.

>_SearchWidget cta changes_

Only show search widget Cta if the user has seen at least on nonSerp Cta.

### **Steps to test this PR**:
>_VariantManager changes_

**Concept test variant ml: Concept test with old ctas**
1. Hardcode into variantManager variant **"ml"**
1. Perform a fresh install
1. Run the app and ensure during the onboarding Default browser cta appears
1. Visit a web with trackers like cnn.com
1. Ensure dax dialog appears informing about trackers found
1. Click on "High five!"
1. Ensure no more Ctas are shown
1. Visit duckduckgo.com
1. Ensure dax dialog appears
1. Click on "Phew!"
1. Ensure no more Ctas are shown
1. Continue the Dax journey till the end (open new tab, visit a website, open a new tab)
1. Ensure Search widget cta appears in home screen

**Concept test variant mh: concept test with ctas as dax dialogs**:

1. Hardcode into variantManager variant **"mh"**
2. Perform a fresh install
3. Run the app and ensure onboarding doesn't show any default browser cta
4. Visit a web with trackers like cnn.com
5. Ensure dax dialog appears informing about trackers found
6. Click on "High five!"
7. Ensure DefaultBrowser cta appears 
9. Click on "Ok"
11. Ensure Dialog asking to set ddg as default browser appears
1. Visit duckduckgo.com
1. Ensure dax dialog appears
1. Click on "Phew!"
1. Ensure SearchWidget cta appears 
1. Click on "Add"
1. Ensure dialog appears asking the user to add the search widget

>_SearchWidget cta new user flow_
1. Hardcode into variantManager variant **"mh"**
2. Perform a fresh install
3. Run the app and ensure onboarding doesn't show any default browser cta
1. Visit duckduckgo.com
1. Ensure dax dialog appears
1. Click on "Phew!"
1. Ensure SearchWidget cta DOES NOT appear
1. Visit a site with trackers, a major network site or a site without trackers (wikipedia.org)
5. Ensure nonSerp dax dialog appears
6. Accept or dismiss dialog
1. Visit duckduckgo.com again
1. Ensure SearchWidget cta appears

Side note: a more detailed way of testing all the different combinations is explained inside https://github.com/duckduckgo/Android/pull/716 . If the reviewer decides to use any test scenario from that PR, please ensure it's still valid taking into account the changes introduced in this PR.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
