### PR TITLE
Prevent incorrect tab image previews from loading

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -119,10 +119,15 @@ class TabSwitcherAdapter(private val itemClickListener: TabSwitcherListener, pri
     }
 
     private fun loadTabPreviewImage(tab: TabEntity, glide: GlideRequests, holder: TabViewHolder) {
-        val previewFile = tab.tabPreviewFile ?: return
+        val previewFile = tab.tabPreviewFile
+        if (previewFile == null) {
+            glide.clear(holder.tabPreview)
+            return
+        }
 
         val cachedWebViewPreview = File(webViewPreviewPersister.fullPathForFile(tab.tabId, previewFile))
         if (!cachedWebViewPreview.exists()) {
+            glide.clear(holder.tabPreview)
             return
         }
 


### PR DESCRIPTION
**Description:** Image previews for tabs can load incorrectly due to uncleared pending requests from recycling for instances when `loadTabPreviewImage(...)` returns without calling `glide.into(...)`.

**Relevant Documentation:** https://bumptech.github.io/glide/doc/getting-started.html - Read the part titled "ListView and RecyclerView" which states:

> By calling clear() or into(View) on the View, you’re cancelling the load and guaranteeing that Glide will not change the contents of the view after the call completes. If you forget to call clear() and don’t start a new load, the load you started into the same View for a previous position may complete after you set your special Drawable and change the contents of the View to an old image.

**Steps to reproduce:**
There are many ways to reproduce this bug, but the most reliable method that does not require precise timing is to:
1. Open 14 tabs (possibly more; this could be dependent on screen resolution.  I am using a Pixel 2 XL emulator) and launch a search query on each, such that each tab has a preview image displayed that is not null.
2. Request a new tab (this will be the 15th tab at position 14), but do not launch any queries, such that its tab preview image is null.  Alternatively, we can also open one or more links in a background tab.  The goal here is to have _at least_ one tab with a null image preview, so feel free to get creative!
3. Go to the tab switcher activity.
4. Scroll all the way up to tab position 0, and then back down to the last tab and notice that the new tab from step 2 shows an incorrect preview image (i.e. it is not null).

Please see the GIF below that demonstrates steps 2-4

**Steps to test this PR:**
Follow the steps to reproduce the bug above and ensure that the tab preview image displays correctly this time in step 4.

This bug can get pretty nasty over time.  I have a collection of tabs on my actual device that load their image previews incorrectly since the image caches for those tabs are empty.

![720gifgif](https://user-images.githubusercontent.com/21976019/75831066-86622f00-5d80-11ea-926b-404760583c00.gif)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
