### PR TITLE
Prevent elements in overflow menu from overlapping

### DIFF
--- a/app/src/main/res/layout/popup_window_browser_menu.xml
+++ b/app/src/main/res/layout/popup_window_browser_menu.xml
@@ -27,6 +27,7 @@
         android:background="@color/white"
         android:gravity="center"
         android:orientation="horizontal"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
 
@@ -68,6 +69,7 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:layout_constrainedHeight="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/header">
 


### PR DESCRIPTION
**Description**:
When in landscape or split-screen mode, the `ScrollView` in the overflow menu clips into the `LinearLayout` header.  This is fixed by adding `app:layout_constrainedHeight="true"` to the `ScrollView`.  I also added `app:layout_constraintTop_toTopOf="parent"` to the `LinearLayout`, which really isn't necessary since we want it up top anyway, but it suppresses an Android Studio warning about not having vertical constraints on the LL and is more explicit than using the possibly ambiguous `tools:ignore="MissingConstraints"`. See GIF below.

**Steps to test this PR**:
1. Ensure that the overflow menu is properly rendered and that all hitboxes work as intended in both landscape and portrait mode.

![clipnew](https://user-images.githubusercontent.com/21976019/75841917-ed8ddc80-5d9c-11ea-9e2c-0858e458f7c7.gif)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
