### PR TITLE
Enable [se,sc] variants

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -33,14 +33,14 @@ class VariantManagerTest {
     @Test
     fun serpControlVariantIsInactiveAndHasNoFeatures() {
         val variant = variants.first { it.key == "sc" }
-        assertEqualsDouble(0.0, variant.weight)
+        assertEqualsDouble(1.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
     fun serpExperimentalVariantIsInactiveAndHasNoFeatures() {
         val variant = variants.first { it.key == "se" }
-        assertEqualsDouble(0.0, variant.weight)
+        assertEqualsDouble(1.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -47,8 +47,8 @@ interface VariantManager {
         val ACTIVE_VARIANTS = listOf(
             // SERP variants. "sc" may also be used as a shared control for mobile experiments in
             // the future if we can filter by app version
-            Variant(key = "sc", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "sc", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "se", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
 
             // Concept test experiment
             Variant(key = "mc", weight = 0.0, features = emptyList(), filterBy = { isEnglishLocale() }),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1165064320902505/f
Tech Design URL: 
CC: https://app.asana.com/0/0/1163921857441241/f

**Description**:
Enable variants SC and SE as they are going to be used in project https://app.asana.com/0/0/1135937698028536

**Steps to test this PR**:
> SC variant
1. Hardcode variant "sc"
1. Fresh install
1. open the app and navigate to Browser screen
1. perform a search
1. Ensure from the logs that duckduckgo url contains "sc" as part of atb

> SC variant
1. Hardcode variant "se"
1. Fresh install
1. open the app and navigate to Browser screen
1. perform a search
1. Ensure from the logs that duckduckgo url contains "se" as part of atb


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
