### PR TITLE
Fix typo in Portuguese translation

### DIFF
--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -355,6 +355,6 @@
     <string name="feedbackInitialDisambiguationSubtitle">Como classificaria os seus comentários?</string>
     <string name="feedbackInitialDisambiguationHappyButtonContentDescription">Botão de comentário positivo</string>
     <string name="feedbackInitialDisambiguationSadButtonContentDescription">Botão de comentário negativo</string>
-    <string name="feedbackIsImportantToUs">Os seus comentários anónimos são importantes para nós.</string>
+    <string name="feedbackIsImportantToUs">Os seus comentários anônimos são importantes para nós.</string>
 
 </resources>


### PR DESCRIPTION
Task/Issue URL: N/A
Tech Design URL: N/A
CC: N/A

**Description**:
The word anonymous in Portuguese is: anônimo and NOT anónimo.

**Steps to test this PR**:

1. Change your device language to Portuguese, in order to see the app in Portuguese
2. Open App
3. Select Definições ( Settings ) 
4. Select Deixar comentários ( Leave Feedback )
5. Look at the message on the bottom of the screen