### PR TITLE
Fix space deletion from user query

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -86,6 +86,18 @@ class SystemSearchViewModelTest {
     }
 
     @Test
+    fun whenUserAddsSpaceToQueryThenViewStateMatchesAndSpaceTrimmedFromAutocomplete() = ruleRunBlockingTest {
+        testee.userUpdatedQuery(QUERY)
+        testee.userUpdatedQuery("$QUERY ")
+
+        val newViewState = testee.viewState.value
+        assertNotNull(newViewState)
+        assertEquals("$QUERY ", newViewState?.queryText)
+        assertEquals(appQueryResult, newViewState?.appResults)
+        assertEquals(autocompleteQueryResult, newViewState?.autocompleteResults)
+    }
+
+    @Test
     fun whenUserClearsQueryThenViewStateReset() = ruleRunBlockingTest {
         testee.userUpdatedQuery(QUERY)
         testee.userClearedQuery()

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -91,22 +91,21 @@ class SystemSearchViewModel(
 
         appsJob?.cancel()
 
-        val trimmedQuery = query.trim()
-
-        if (trimmedQuery == currentViewState().queryText) {
+        if (query == currentViewState().queryText) {
             return
         }
 
-        if (trimmedQuery.isBlank()) {
+        if (query.isBlank()) {
             userClearedQuery()
             return
         }
 
-        viewState.value = currentViewState().copy(queryText = trimmedQuery)
-        autoCompletePublishSubject.accept(trimmedQuery)
+        viewState.value = currentViewState().copy(queryText = query)
 
+        val trimmedQuery = query.trim()
+        autoCompletePublishSubject.accept(trimmedQuery)
         appsJob = viewModelScope.launch(dispatchers.io()) {
-            updateAppResults(deviceAppLookup.query(query))
+            updateAppResults(deviceAppLookup.query(trimmedQuery))
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1163849208167805/f

**Description**:
Fix issue where view state would update and delete space from user query

**Steps to test this PR**:
1. Install the app and add the widget to your home screen
1. Tap the widget to launch the interstitial search screen
1. Type a few words really fast and check that the spaces are not being deleted.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
