### PR TITLE
Hotfix/5.47.1.fixes

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
@@ -22,7 +22,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.notification.AndroidNotificationScheduler.*
+import com.duckduckgo.app.notification.NotificationScheduler.*
 import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.duckduckgo.app.notification.model.SearchNotification
 import com.duckduckgo.app.statistics.VariantManager
@@ -39,7 +39,7 @@ import org.junit.Rule
 import org.junit.Test
 import kotlin.reflect.jvm.jvmName
 
-class NotificationSchedulerTest {
+class AndroidNotificationSchedulerTest {
 
     @ExperimentalCoroutinesApi
     @get:Rule
@@ -57,7 +57,7 @@ class NotificationSchedulerTest {
     @Before
     fun before() {
         whenever(variantManager.getVariant(any())).thenReturn(DEFAULT_VARIANT)
-        testee = AndroidNotificationScheduler(
+        testee = NotificationScheduler(
             workManager,
             clearNotification,
             privacyNotification,
@@ -67,7 +67,7 @@ class NotificationSchedulerTest {
 
     @After
     fun resetWorkers() {
-        workManager.cancelAllWorkByTag(AndroidNotificationScheduler.CONTINUOUS_APP_USE_REQUEST_TAG)
+        workManager.cancelAllWorkByTag(NotificationScheduler.CONTINUOUS_APP_USE_REQUEST_TAG)
     }
 
     @Test
@@ -141,6 +141,7 @@ class NotificationSchedulerTest {
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(false)
         whenever(searchPromptNotification.canShow()).thenReturn(true)
+
         testee.scheduleNextNotification()
 
         assertContinuousAppUseNotificationScheduled(SearchPromptNotificationWorker::class.jvmName)
@@ -180,14 +181,14 @@ class NotificationSchedulerTest {
 
     private fun getUnusedAppScheduledWorkers(): List<WorkInfo> {
         return workManager
-            .getWorkInfosByTag(AndroidNotificationScheduler.UNUSED_APP_WORK_REQUEST_TAG)
+            .getWorkInfosByTag(NotificationScheduler.UNUSED_APP_WORK_REQUEST_TAG)
             .get()
             .filter { it.state == WorkInfo.State.ENQUEUED }
     }
 
     private fun getContinuousAppUseScheduledWorkers(): List<WorkInfo> {
         return workManager
-            .getWorkInfosByTag(AndroidNotificationScheduler.CONTINUOUS_APP_USE_REQUEST_TAG)
+            .getWorkInfosByTag(NotificationScheduler.CONTINUOUS_APP_USE_REQUEST_TAG)
             .get()
             .filter { it.state == WorkInfo.State.ENQUEUED }
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.global.DuckDuckGoTheme
 import com.duckduckgo.app.icon.api.AppIcon
-import com.duckduckgo.app.notification.NotificationScheduler
+import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.duckduckgo.app.settings.SettingsViewModel.Command
 import com.duckduckgo.app.settings.clear.ClearWhatOption.CLEAR_NONE
 import com.duckduckgo.app.settings.clear.ClearWhenOption.APP_EXIT_ONLY
@@ -68,7 +68,7 @@ class SettingsViewModelTest {
     private lateinit var mockVariantManager: VariantManager
 
     @Mock
-    private lateinit var notificationScheduler: NotificationScheduler
+    private lateinit var notificationScheduler: AndroidNotificationScheduler
 
     @Mock
     private lateinit var mockPixel: Pixel

--- a/app/src/main/java/com/duckduckgo/app/di/DaggerWorkerFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DaggerWorkerFactory.kt
@@ -74,7 +74,7 @@ class DaggerWorkerFactory(
 
             return instance
         } catch (exception: Exception){
-            Timber.i("Worker $workerClassName could not be created")
+            Timber.e(exception, "Worker $workerClassName could not be created")
             return null
         }
 

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -21,9 +21,9 @@ import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.work.WorkManager
-import com.duckduckgo.app.notification.AndroidNotificationScheduler
-import com.duckduckgo.app.notification.NotificationFactory
 import com.duckduckgo.app.notification.NotificationScheduler
+import com.duckduckgo.app.notification.NotificationFactory
+import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.ClearDataNotification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
@@ -100,8 +100,8 @@ class NotificationModule {
         clearDataNotification: ClearDataNotification,
         privacyProtectionNotification: PrivacyProtectionNotification,
         stickySearchNotification: StickySearchNotification
-    ): NotificationScheduler {
-        return AndroidNotificationScheduler(
+    ): AndroidNotificationScheduler {
+        return NotificationScheduler(
             workManager,
             clearDataNotification,
             privacyProtectionNotification,

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -41,7 +41,7 @@ import com.duckduckgo.app.global.shortcut.AppShortcutCreator
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.job.AppConfigurationSyncer
 import com.duckduckgo.app.notification.NotificationRegistrar
-import com.duckduckgo.app.notification.NotificationScheduler
+import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.duckduckgo.app.referral.AppInstallationReferrerStateListener
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.AtbInitializer
@@ -129,7 +129,7 @@ open class DuckDuckGoApplication : HasActivityInjector, HasServiceInjector, HasS
     lateinit var dataClearer: DataClearer
 
     @Inject
-    lateinit var notificationScheduler: NotificationScheduler
+    lateinit var notificationScheduler: AndroidNotificationScheduler
 
     @Inject
     lateinit var workerFactory: WorkerFactory

--- a/app/src/main/java/com/duckduckgo/app/global/Theming.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/Theming.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.Theming.Constants.BROADCAST_THEME_CHANGED
 import com.duckduckgo.app.global.Theming.Constants.THEME_MAP
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.app.statistics.VariantManager
 
 enum class DuckDuckGoTheme {
     DARK,
@@ -74,5 +73,9 @@ fun DuckDuckGoActivity.sendThemeChangedBroadcast() {
 }
 
 private fun DuckDuckGoActivity.manifestThemeId(): Int {
-    return packageManager.getActivityInfo(componentName, 0).themeResource
+    return try {
+        packageManager.getActivityInfo(componentName, 0).themeResource
+    } catch (exception: Exception) {
+        R.style.AppTheme
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
@@ -41,11 +41,10 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptEmitter
 import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
-import com.duckduckgo.app.icon.api.AppIconModifier
 import com.duckduckgo.app.icon.api.IconModifier
 import com.duckduckgo.app.icon.ui.ChangeIconViewModel
 import com.duckduckgo.app.launch.LaunchViewModel
-import com.duckduckgo.app.notification.NotificationScheduler
+import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.OnboardingPageManager
 import com.duckduckgo.app.onboarding.ui.OnboardingViewModel
@@ -112,7 +111,7 @@ class ViewModelFactory @Inject constructor(
     private val onboardingPageManager: OnboardingPageManager,
     private val appInstallationReferrerStateListener: AppInstallationReferrerStateListener,
     private val appIconModifier: IconModifier,
-    private val notificationScheduler: NotificationScheduler
+    private val notificationScheduler: AndroidNotificationScheduler
 ) : ViewModelProvider.NewInstanceFactory() {
 
     override fun <T : ViewModel> create(modelClass: Class<T>) =

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.notification
 
 import android.content.Context
-import android.content.Intent
 import androidx.annotation.WorkerThread
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.CoroutineWorker
@@ -25,34 +24,32 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
-import com.duckduckgo.app.notification.NotificationHandlerService.Companion.NOTIFICATION_AUTO_CANCEL
-import com.duckduckgo.app.notification.NotificationHandlerService.Companion.NOTIFICATION_SYSTEM_ID_EXTRA
-import com.duckduckgo.app.notification.NotificationHandlerService.Companion.PIXEL_SUFFIX_EXTRA
 import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.Notification
 import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.duckduckgo.app.notification.model.SearchNotification
-import com.duckduckgo.app.notification.model.SearchPromptNotification
-import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.NOTIFICATION_SHOWN
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 
+
+// Please don't rename any Worker class name or class path.
+// More information: https://craigrussell.io/2019/04/a-workmanager-pitfall-modifying-a-scheduled-worker/
 @WorkerThread
-interface NotificationScheduler {
+interface AndroidNotificationScheduler {
     suspend fun scheduleNextNotification()
     fun launchStickySearchNotification()
     fun dismissStickySearchNotification()
     fun launchSearchPromptNotification()
 }
 
-class AndroidNotificationScheduler(
+class NotificationScheduler(
     private val workManager: WorkManager,
     private val clearDataNotification: SchedulableNotification,
     private val privacyNotification: SchedulableNotification,
     private val searchPromptNotification: SearchNotification
-) : NotificationScheduler {
+) : AndroidNotificationScheduler {
 
     override suspend fun scheduleNextNotification() {
         scheduleInactiveUserNotifications()
@@ -66,7 +63,7 @@ class AndroidNotificationScheduler(
     }
 
     private suspend fun scheduleInactiveUserNotifications() {
-        workManager.cancelAllWorkByTag(UNUSED_APP_WORK_REQUEST_TAG)
+        workManager.cancelUniqueWork(UNUSED_APP_WORK_REQUEST_TAG)
 
         when {
             privacyNotification.canShow() -> {

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -34,7 +34,7 @@ import timber.log.Timber
 import java.util.concurrent.TimeUnit
 
 
-// Please don't rename any Worker class name or class path.
+// Please don't rename any Worker class name or class path
 // More information: https://craigrussell.io/2019/04/a-workmanager-pitfall-modifying-a-scheduled-worker/
 @WorkerThread
 interface AndroidNotificationScheduler {
@@ -63,7 +63,7 @@ class NotificationScheduler(
     }
 
     private suspend fun scheduleInactiveUserNotifications() {
-        workManager.cancelUniqueWork(UNUSED_APP_WORK_REQUEST_TAG)
+        workManager.cancelAllWorkByTag(UNUSED_APP_WORK_REQUEST_TAG)
 
         when {
             privacyNotification.canShow() -> {

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationHandlerService.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationHandlerService.kt
@@ -54,7 +54,7 @@ class NotificationHandlerService : IntentService("NotificationHandlerService") {
     lateinit var notificationManager: NotificationManagerCompat
 
     @Inject
-    lateinit var notificationScheduler: NotificationScheduler
+    lateinit var notificationScheduler: AndroidNotificationScheduler
 
     @Inject
     lateinit var settingsDataStore: SettingsDataStore

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.global.DuckDuckGoTheme
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.icon.api.AppIcon
-import com.duckduckgo.app.notification.NotificationScheduler
+import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.clear.ClearWhenOption
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -40,7 +40,7 @@ class SettingsViewModel @Inject constructor(
     private val defaultWebBrowserCapability: DefaultBrowserDetector,
     private val variantManager: VariantManager,
     private val pixel: Pixel,
-    private val notificationScheduler: NotificationScheduler
+    private val notificationScheduler: AndroidNotificationScheduler
 ) : ViewModel() {
 
     data class ViewState(


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/inbox/1157893581871899/1119619712088571/1167491198050484

**Description**:
Renaming `NotificationScheduler` introduced a bug that made it impossible for `DaggerWorkerFactory`  to create Workers. The classpath had changed and therefore no longer possible to find.

This PR fixes this issue, also adding a layer of security in `DaggerWorkerFactory` preventing it from crashing if the worker can't be found.

As part of this PR we also fixed a new issue that was introduced with the Change App Icon feature. On some devices the `themeResourceId` was not found after changing the icon, so we added a default option for that too based on the `AppTheme`