### PR TITLE
Add COVID-19 CTA

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1574,7 +1574,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserDismissedHOmeTopPanelCtaAndVariantIsNotConceptTestThenRefreshCta() {
+    fun whenUserDismissedHomeTopPanelCtaAndVariantIsNotConceptTestThenRefreshCta() {
         val cta = HomeTopPanelCta.CovidCta()
         whenever(mockDismissedCtaDao.exists(cta.ctaId)).thenReturn(true)
         testee.onUserDismissedCta(cta)
@@ -1583,7 +1583,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserDismissedHOmeTopPanelCtaAndVariantIsConceptTestThenReturnEmtpyCta() {
+    fun whenUserDismissedHomeTopPanelCtaAndVariantIsConceptTestThenReturnEmptyCta() {
         whenever(mockVariantManager.getVariant()).thenReturn(
             Variant("test", features = listOf(VariantManager.VariantFeature.ConceptTest), filterBy = { true })
         )

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1380,8 +1380,14 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenSurveyCtaDismissedAndCovidCtaNotShownthenCtaIsCovid() {
+        testee.onSurveyChanged(Survey("abc", "http://example.com", daysInstalled = 1, status = Survey.Status.SCHEDULED))
+        testee.onUserDismissedCta(testee.ctaViewState.value!!.cta!!)
+        assertEquals(HomeTopPanelCta.CovidCta(), testee.ctaViewState.value!!.cta)
+    }
+
+    @Test
     fun whenSurveyCtaDismissedAndWidgetCtaIsPossibleThenNextCtaIsWidget() {
-        setCovidCtaShown()
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
@@ -1393,7 +1399,6 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndAutoAddSupportedAndWidgetNotInstalledThenCtaIsAutoWidget() = ruleRunBlockingTest {
-        setCovidCtaShown()
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
@@ -1413,7 +1418,6 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndOnlyStandardAddSupportedAndWidgetNotInstalledThenCtaIsInstructionsWidget() = ruleRunBlockingTest {
-        setCovidCtaShown()
         givenExpectedCtaAddWidgetInstructions()
         testee.refreshCta()
         assertEquals(HomePanelCta.AddWidgetInstructions, testee.ctaViewState.value!!.cta)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.DismissedCta
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.cta.ui.DaxBubbleCta
@@ -1359,6 +1360,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenScheduledSurveyChangesAndInstalledDaysDontMatchThenCtaIsNull() {
+        setCovidCtaShown()
         testee.onSurveyChanged(Survey("abc", "http://example.com", daysInstalled = 2, status = Survey.Status.SCHEDULED))
         assertNull(testee.ctaViewState.value!!.cta)
     }
@@ -1371,6 +1373,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSurveyCtaDismissedAndNoOtherCtaPossibleCtaIsNull() {
+        setCovidCtaShown()
         testee.onSurveyChanged(Survey("abc", "http://example.com", daysInstalled = 1, status = Survey.Status.SCHEDULED))
         testee.onUserDismissedCta(testee.ctaViewState.value!!.cta!!)
         assertNull(testee.ctaViewState.value!!.cta)
@@ -1378,6 +1381,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSurveyCtaDismissedAndWidgetCtaIsPossibleThenNextCtaIsWidget() {
+        setCovidCtaShown()
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
@@ -1389,6 +1393,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndAutoAddSupportedAndWidgetNotInstalledThenCtaIsAutoWidget() = ruleRunBlockingTest {
+        setCovidCtaShown()
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
@@ -1398,6 +1403,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndAutoAddSupportedAndWidgetAlreadyInstalledThenCtaIsNull() = ruleRunBlockingTest {
+        setCovidCtaShown()
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
@@ -1407,6 +1413,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndOnlyStandardAddSupportedAndWidgetNotInstalledThenCtaIsInstructionsWidget() = ruleRunBlockingTest {
+        setCovidCtaShown()
         givenExpectedCtaAddWidgetInstructions()
         testee.refreshCta()
         assertEquals(HomePanelCta.AddWidgetInstructions, testee.ctaViewState.value!!.cta)
@@ -1414,6 +1421,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndOnlyStandardAddSupportedAndWidgetAlreadyInstalledThenCtaIsNull() = ruleRunBlockingTest {
+        setCovidCtaShown()
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
@@ -1423,6 +1431,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndStandardAddNotSupportedAndWidgetNotInstalledThenCtaIsNull() = ruleRunBlockingTest {
+        setCovidCtaShown()
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
@@ -1432,6 +1441,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndStandardAddNotSupportedAndWidgetAlreadyInstalledThenCtaIsNull() = ruleRunBlockingTest {
+        setCovidCtaShown()
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
@@ -1850,6 +1860,10 @@ class BrowserTabViewModelTest {
     private fun updateUrl(originalUrl: String?, currentUrl: String?, isBrowserShowing: Boolean) {
         setBrowserShowing(isBrowserShowing)
         testee.navigationStateChanged(buildWebNavigation(originalUrl = originalUrl, currentUrl = currentUrl))
+    }
+
+    private fun setCovidCtaShown() {
+        whenever(mockDismissedCtaDao.exists(CtaId.COVID)).thenReturn(true)
     }
 
     private fun setupNavigation(

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1380,7 +1380,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenSurveyCtaDismissedAndCovidCtaNotShownthenCtaIsCovid() {
+    fun whenSurveyCtaDismissedAndWidgetNotCompatibleAndCovidCtaNotShownThenCtaIsCovid() {
         testee.onSurveyChanged(Survey("abc", "http://example.com", daysInstalled = 1, status = Survey.Status.SCHEDULED))
         testee.onUserDismissedCta(testee.ctaViewState.value!!.cta!!)
         assertEquals(HomeTopPanelCta.CovidCta(), testee.ctaViewState.value!!.cta)

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -477,7 +477,6 @@ class CtaViewModelTest {
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
         assertFalse(value is HomeTopPanelCta.CovidCta)
-        assertTrue(value is DaxBubbleCta.DaxIntroCta)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -499,16 +499,6 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndConceptTestFeatureActiveAndIntroCtaWasPreviouslyShownThenCovidCtaNotShown() = runBlockingTest {
-        setConceptTestFeature()
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
-        whenever(mockDismissedCtaDao.exists(CtaId.COVID)).thenReturn(false)
-
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
-        assertFalse(value is HomeTopPanelCta.CovidCta)
-    }
-
-    @Test
     fun whenRefreshCtaOnHomeTabAndConceptTestFeatureActiveAndDaxEndCtaWasPreviouslyShownThenCovidCtaShown() = runBlockingTest {
         setConceptTestFeature()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -470,7 +470,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndConceptTestFeatureActiveAndIntroCtaWasNotPreviouslyShownThenEndCovidCtaNotShown() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndConceptTestFeatureActiveAndIntroCtaWasNotPreviouslyShownThenCovidCtaNotShown() = runBlockingTest {
         setConceptTestFeature()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(false)
         whenever(mockDismissedCtaDao.exists(CtaId.COVID)).thenReturn(false)
@@ -491,7 +491,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndCovidCtaNotShownThenShowCovidCtaTakesPrecedenceOverWidgetCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndCovidCtaNotShownThenCovidCtaTakesPrecedenceOverWidgetCta() = runBlockingTest {
         setNoFeatures()
         whenever(mockDismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
         whenever(mockDismissedCtaDao.exists(CtaId.COVID)).thenReturn(false)

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -273,7 +273,6 @@ class CtaViewModelTest {
     @Test
     fun whenRefreshCtaOnHomeTabAndConceptTestFeatureActiveThenReturnDaxEndCta() = runBlockingTest {
         setConceptTestFeature()
-        setCovidCtaShown()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
 
@@ -325,7 +324,6 @@ class CtaViewModelTest {
     @Test
     fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnWidgetAutoCta() = runBlockingTest {
         setNoFeatures()
-        setCovidCtaShown()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
@@ -338,7 +336,6 @@ class CtaViewModelTest {
     @Test
     fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnWidgetInstructionsCta() = runBlockingTest {
         setNoFeatures()
-        setCovidCtaShown()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
@@ -362,7 +359,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndSuppressWidgetCtaFeatureActiveThenReturnNullWhenTryngToShowWidgetInstructionsCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndSuppressWidgetCtaFeatureActiveThenReturnNullWhenTryingToShowWidgetInstructionsCta() = runBlockingTest {
         setSuppressHomeTabWidgetCtaFeature()
         setCovidCtaShown()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
@@ -490,34 +487,35 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndCovidCtaNotShownThenCovidCtaTakesPrecedenceOverWidgetCta() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndCovidCtaNotShownThenWidgetCtaTakesPrecedenceOverCovidCta() = runBlockingTest {
         setNoFeatures()
+        whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
         whenever(mockDismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
         whenever(mockDismissedCtaDao.exists(CtaId.COVID)).thenReturn(false)
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
-        assertTrue(value is HomeTopPanelCta.CovidCta)
+        assertTrue(value is HomePanelCta.AddWidgetInstructions)
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndConceptTestFeatureActiveAndIntroCtaWasPreviouslyShownThenCovidCtaShown() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndConceptTestFeatureActiveAndIntroCtaWasPreviouslyShownThenCovidCtaNotShown() = runBlockingTest {
         setConceptTestFeature()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.COVID)).thenReturn(false)
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
-        assertTrue(value is HomeTopPanelCta.CovidCta)
+        assertFalse(value is HomeTopPanelCta.CovidCta)
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndConceptTestFeatureActiveAndDaxCtasAndCovidCtaWasPreviouslyShownThenDaxEndCtaShown() = runBlockingTest {
+    fun whenRefreshCtaOnHomeTabAndConceptTestFeatureActiveAndDaxEndCtaWasPreviouslyShownThenCovidCtaShown() = runBlockingTest {
         setConceptTestFeature()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
-        whenever(mockDismissedCtaDao.exists(CtaId.COVID)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
-        assertTrue(value is DaxBubbleCta.DaxEndCta)
+        assertTrue(value is HomeTopPanelCta.CovidCta)
     }
 
     private fun setCovidCtaShown() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1406,7 +1406,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 } else {
                     hideHomeCta()
                     hideDaxCta()
-                    hideTopHomeCta()
+                    hideHomeTopCta()
                 }
             }
         }
@@ -1416,7 +1416,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 is HomePanelCta -> showHomeCta(configuration)
                 is DaxBubbleCta -> showDaxCta(configuration)
                 is DaxDialogCta -> showDaxDialogCta(configuration)
-                is HomeTopPanelCta -> showTopHomeCta(configuration)
+                is HomeTopPanelCta -> showHomeTopCta(configuration)
             }
 
             viewModel.onCtaShown()
@@ -1482,11 +1482,11 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         private fun showDaxCta(configuration: DaxBubbleCta) {
             ddgLogo.hide()
             hideHomeCta()
-            hideTopHomeCta()
+            hideHomeTopCta()
             configuration.showCta(daxCtaContainer)
         }
 
-        private fun showTopHomeCta(configuration: HomeTopPanelCta) {
+        private fun showHomeTopCta(configuration: HomeTopPanelCta) {
             hideDaxCta()
             hideHomeCta()
 
@@ -1503,7 +1503,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
         private fun showHomeCta(configuration: HomePanelCta) {
             hideDaxCta()
-            hideTopHomeCta()
+            hideHomeTopCta()
             if (ctaContainer.isEmpty()) {
                 renderHomeCta()
             } else {
@@ -1520,7 +1520,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
             ctaContainer.gone()
         }
 
-        private fun hideTopHomeCta() {
+        private fun hideHomeTopCta() {
             ctaTopContainer.gone()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -101,6 +101,7 @@ import kotlinx.android.synthetic.main.include_find_in_page.*
 import kotlinx.android.synthetic.main.include_new_browser_tab.*
 import kotlinx.android.synthetic.main.include_omnibar_toolbar.*
 import kotlinx.android.synthetic.main.include_omnibar_toolbar.view.*
+import kotlinx.android.synthetic.main.include_top_cta.view.*
 import kotlinx.android.synthetic.main.popup_window_browser_menu.view.*
 import kotlinx.coroutines.*
 import org.jetbrains.anko.longToast
@@ -1405,6 +1406,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 } else {
                     hideHomeCta()
                     hideDaxCta()
+                    hideTopHomeCta()
                 }
             }
         }
@@ -1414,6 +1416,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
                 is HomePanelCta -> showHomeCta(configuration)
                 is DaxBubbleCta -> showDaxCta(configuration)
                 is DaxDialogCta -> showDaxDialogCta(configuration)
+                is HomeTopPanelCta -> showTopHomeCta(configuration)
             }
 
             viewModel.onCtaShown()
@@ -1479,11 +1482,28 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
         private fun showDaxCta(configuration: DaxBubbleCta) {
             ddgLogo.hide()
             hideHomeCta()
+            hideTopHomeCta()
             configuration.showCta(daxCtaContainer)
+        }
+
+        private fun showTopHomeCta(configuration: HomeTopPanelCta) {
+            hideDaxCta()
+            hideHomeCta()
+
+            logoHidingListener.callToActionView = ctaTopContainer
+
+            configuration.showCta(ctaTopContainer)
+            ctaTopContainer.setOnClickListener {
+                viewModel.onUserClickTopCta(configuration)
+            }
+            ctaTopContainer.closeButton.setOnClickListener {
+                viewModel.onUserDismissedCta(configuration)
+            }
         }
 
         private fun showHomeCta(configuration: HomePanelCta) {
             hideDaxCta()
+            hideTopHomeCta()
             if (ctaContainer.isEmpty()) {
                 renderHomeCta()
             } else {
@@ -1498,6 +1518,10 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope {
 
         private fun hideHomeCta() {
             ctaContainer.gone()
+        }
+
+        private fun hideTopHomeCta() {
+            ctaTopContainer.gone()
         }
 
         fun renderHomeCta() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -933,6 +933,12 @@ class BrowserTabViewModel(
         ctaViewModel.registerDaxBubbleCtaDismissed(cta)
     }
 
+    fun onUserClickTopCta(cta: HomeTopPanelCta) {
+        if (cta is HomeTopPanelCta.CovidCta) {
+            onUserSubmittedQuery(cta.searchTerm)
+        }
+    }
+
     fun onUserClickCtaOkButton(cta: Cta) {
         ctaViewModel.onUserClickCtaOkButton(cta)
         viewModelScope.launch {
@@ -949,10 +955,16 @@ class BrowserTabViewModel(
 
     fun onUserDismissedCta(dismissedCta: Cta) {
         ctaViewModel.onUserDismissedCta(dismissedCta)
-        if (dismissedCta is HomePanelCta) {
-            refreshCta()
-        } else {
-            ctaViewState.value = currentCtaViewState().copy(cta = null)
+        when (dismissedCta) {
+            is HomeTopPanelCta -> {
+                if (!variantManager.getVariant().hasFeature(VariantManager.VariantFeature.ConceptTest)) {
+                    refreshCta()
+                } else {
+                    ctaViewState.value = currentCtaViewState().copy(cta = null)
+                }
+            }
+            is HomePanelCta -> refreshCta()
+            else -> ctaViewState.value = currentCtaViewState().copy(cta = null)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/model/DismissedCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/model/DismissedCta.kt
@@ -31,7 +31,8 @@ enum class CtaId {
     DAX_DIALOG_TRACKERS_FOUND,
     DAX_DIALOG_NETWORK,
     DAX_DIALOG_OTHER,
-    DAX_END
+    DAX_END,
+    COVID
 }
 
 @Entity(

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import kotlinx.android.synthetic.main.include_cta_buttons.view.*
 import kotlinx.android.synthetic.main.include_cta_content.view.*
 import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.*
+import kotlinx.android.synthetic.main.include_top_cta.view.*
 
 interface DialogCta {
     fun createCta(activity: FragmentActivity): DaxDialog
@@ -468,6 +469,32 @@ sealed class HomePanelCta(
         Pixel.PixelName.WIDGET_LEGACY_CTA_LAUNCHED,
         Pixel.PixelName.WIDGET_LEGACY_CTA_DISMISSED
     )
+}
+
+sealed class HomeTopPanelCta(
+    override val ctaId: CtaId,
+    override val shownPixel: Pixel.PixelName?,
+    override val okPixel: Pixel.PixelName?,
+    override val cancelPixel: Pixel.PixelName?,
+    @StringRes open val description: Int
+) : Cta, ViewCta {
+
+    override fun pixelCancelParameters(): Map<String, String> = emptyMap()
+
+    override fun pixelOkParameters(): Map<String, String> = emptyMap()
+
+    override fun pixelShownParameters(): Map<String, String> = emptyMap()
+
+    override fun showCta(view: View) {
+        view.upperCtaTitle.text = view.context.getString(description)
+        view.show()
+    }
+
+    class CovidCta(val searchTerm: String = COVID_SEARCH_TERM) : HomeTopPanelCta(CtaId.COVID, null, null, null, R.string.covidCtaText) {
+        companion object {
+            private const val COVID_SEARCH_TERM = "covid 19"
+        }
+    }
 }
 
 fun DaxCta.addCtaToHistory(newCta: String): String {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -490,7 +490,7 @@ sealed class HomeTopPanelCta(
         view.show()
     }
 
-    class CovidCta(val searchTerm: String = COVID_SEARCH_TERM) : HomeTopPanelCta(CtaId.COVID, null, null, null, R.string.covidCtaText) {
+    data class CovidCta(val searchTerm: String = COVID_SEARCH_TERM) : HomeTopPanelCta(CtaId.COVID, null, null, null, R.string.covidCtaText) {
         companion object {
             private const val COVID_SEARCH_TERM = "covid 19"
         }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -135,6 +135,9 @@ class CtaViewModel @Inject constructor(
 
     private fun getHomeCta(): Cta? {
         return when {
+            canShowCovidCta() -> {
+                HomeTopPanelCta.CovidCta()
+            }
             canShowDaxIntroCta() -> {
                 DaxBubbleCta.DaxIntroCta(onboardingStore, appInstallStore)
             }
@@ -184,6 +187,7 @@ class CtaViewModel @Inject constructor(
     private fun canShowDaxCtaEndOfJourney(): Boolean = isFromConceptTestVariant() &&
             hasPrivacySettingsOn() &&
             !daxDialogEndShown() &&
+            covidCtaShown() &&
             daxDialogIntroShown() &&
             !settingsDataStore.hideTips &&
             (daxDialogNetworkShown() || daxDialogOtherShown() || daxDialogSerpShown() || daxDialogTrackersFoundShown())
@@ -267,6 +271,15 @@ class CtaViewModel @Inject constructor(
                 daxNonSerpDialogShown()
     }
 
+    @WorkerThread
+    private fun canShowCovidCta(): Boolean {
+        return if (variantManager.getVariant().hasFeature(ConceptTest)) {
+            daxDialogIntroShown() && !covidCtaShown()
+        } else {
+            !covidCtaShown()
+        }
+    }
+
     private fun hasTrackersInformation(events: List<TrackingEvent>): Boolean =
         events.asSequence()
             .filter { it.entity?.isMajor == true }
@@ -297,6 +310,8 @@ class CtaViewModel @Inject constructor(
     private fun daxDefaultBrowserShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_DIALOG_DEFAULT_BROWSER)
 
     private fun daxSearchWidgetShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_DIALOG_SEARCH_WIDGET)
+
+    private fun covidCtaShown(): Boolean = dismissedCtaDao.exists(CtaId.COVID)
 
     private fun isSerpUrl(url: String): Boolean = url.contains(DaxDialogCta.SERP)
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -135,9 +135,6 @@ class CtaViewModel @Inject constructor(
 
     private fun getHomeCta(): Cta? {
         return when {
-            canShowCovidCta() -> {
-                HomeTopPanelCta.CovidCta()
-            }
             canShowDaxIntroCta() -> {
                 DaxBubbleCta.DaxIntroCta(onboardingStore, appInstallStore)
             }
@@ -146,6 +143,9 @@ class CtaViewModel @Inject constructor(
             }
             canShowWidgetCta() -> {
                 if (widgetCapabilities.supportsAutomaticWidgetAdd) AddWidgetAuto else AddWidgetInstructions
+            }
+            canShowCovidCta() -> {
+                HomeTopPanelCta.CovidCta()
             }
             else -> null
         }
@@ -187,7 +187,6 @@ class CtaViewModel @Inject constructor(
     private fun canShowDaxCtaEndOfJourney(): Boolean = isFromConceptTestVariant() &&
             hasPrivacySettingsOn() &&
             !daxDialogEndShown() &&
-            covidCtaShown() &&
             daxDialogIntroShown() &&
             !settingsDataStore.hideTips &&
             (daxDialogNetworkShown() || daxDialogOtherShown() || daxDialogSerpShown() || daxDialogTrackersFoundShown())
@@ -274,7 +273,7 @@ class CtaViewModel @Inject constructor(
     @WorkerThread
     private fun canShowCovidCta(): Boolean {
         return if (variantManager.getVariant().hasFeature(ConceptTest)) {
-            daxDialogIntroShown() && !covidCtaShown()
+            daxDialogEndShown() && !covidCtaShown()
         } else {
             !covidCtaShown()
         }

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -49,7 +49,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHeight_max="180dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ctaTopContainer"
         app:layout_constraintWidth_max="180dp" />
 
     <include

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -29,7 +29,7 @@
     <include
         layout="@layout/include_top_cta"
         android:id="@+id/ctaTopContainer"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:visibility="gone"

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -26,6 +26,17 @@
     tools:menu="@menu/menu_browser_activity"
     tools:showIn="@layout/fragment_browser_tab">
 
+    <include
+        layout="@layout/include_top_cta"
+        android:id="@+id/ctaTopContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
     <ImageView
         android:id="@+id/ddgLogo"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/include_top_cta.xml
+++ b/app/src/main/res/layout/include_top_cta.xml
@@ -36,19 +36,20 @@
 
         <TextView
             android:id="@+id/upperCtaTitle"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="11dp"
-            android:layout_marginEnd="30dp"
+            android:layout_marginEnd="7dp"
             android:layout_marginBottom="11dp"
             android:letterSpacing="0.02"
             android:textColor="?attr/topCallToActionDescriptionColor"
             android:textSize="16sp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@id/closeButton"
+            app:layout_constraintEnd_toStartOf="@+id/closeButton"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="Get official COVID-19 info and tips." />
+            tools:text="@string/covidCtaText" />
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/closeButton"

--- a/app/src/main/res/layout/include_top_cta.xml
+++ b/app/src/main/res/layout/include_top_cta.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2020 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/ctaTopContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    app:cardBackgroundColor="?attr/topCallToActionBackgroundColor"
+    app:cardCornerRadius="7dp"
+    app:cardElevation="2dp"
+    app:cardUseCompatPadding="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <TextView
+            android:id="@+id/upperCtaTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="11dp"
+            android:layout_marginEnd="30dp"
+            android:layout_marginBottom="11dp"
+            android:letterSpacing="0.02"
+            android:textColor="?attr/topCallToActionDescriptionColor"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/closeButton"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Get official COVID-19 info and tips." />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/closeButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="11dp"
+            android:layout_marginEnd="7dp"
+            android:layout_marginBottom="11dp"
+            android:padding="5dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_close_tab" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Само няколко са и се постарахме да са информативни.</string>
     <string name="hideTipsButton">Скрий съветите за постоянно</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Официална информация и съвети относно COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -401,4 +401,6 @@
     <string name="hideTipsText">Je jich jen pár a snažili jsme se udělat je informativní.</string>
     <string name="hideTipsButton">Navždy skrýt tipy</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Odebírejte oficiální informace a tipy o COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Der er kun få, og vi forsøgte at gøre dem oplysende.</string>
     <string name="hideTipsButton">Skjul tip for evigt</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Få officielle COVID-19 info og tip.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Es gibt nur wenige, und wir haben versucht, sie informativ zu gestalten.</string>
     <string name="hideTipsButton">Tipps für immer ausblenden</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Offizielle COVID-19 Infos &amp; Tipps.</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Υπάρχουν λίγες μόνο και προσπαθήσαμε να τις καταστήσουμε ενημερωτικές.</string>
     <string name="hideTipsButton">Απόκρυψη συμβουλών για πάντα</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Αποκτήστε τις επίσημες πληροφορίες και συμβουλές για το COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Sólo hay unos cuantos, y tratamos de hacerlos informativos.</string>
     <string name="hideTipsButton">Ocultar consejos para siempre</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Obtén información y consejos oficiales sobre COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -418,4 +418,6 @@
     <string name="hideTipsText">Neid on üsna vähe ja püüdsime muuta need informatiivseks.</string>
     <string name="hideTipsButton">Peida näpunäited igaveseks</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Hankige ametlikku teavet COVID-19 kohta ja näpunäiteid.</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Niitä on vain pari, ja yritimme tehdä niistä informatiivisia.</string>
     <string name="hideTipsButton">Piilota vinkit ikuisesti</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Hanki COVID-19:ää koskevia virallisia tietoja ja neuvoja.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Il n\'y en a que quelques-uns, et nous avons essayé de les rendre informatifs.</string>
     <string name="hideTipsButton">Masquer les conseils pour toujours</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Accédez aux informations officielles et aux recommandations sur le COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Ima ih samo nekoliko, a pokušali smo ih učiniti što informativnijima.</string>
     <string name="hideTipsButton">Sakrij savjete zauvijek</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Dobijte službene informacije i savjete o COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Csak néhány van, és megpróbáltuk őket informatívvá tenni.</string>
     <string name="hideTipsButton">Ötletek elrejtése örökre</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Kapjon hivatalos információt és tippeket a COVID-19-ről.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -413,4 +413,6 @@
     <string name="hideTipsText">Ce ne sono solo alcuni e abbiamo cercato di renderli informativi.</string>
     <string name="hideTipsButton">Nascondi suggerimenti per sempre</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Leggi informazioni e consigli ufficiali sul COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -401,4 +401,6 @@
     <string name="hideTipsText">Jų tik keletas, stengėmės, kad jie būtų informatyvūs.</string>
     <string name="hideTipsButton">Slėpti patarimus visam laikui</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Gaukite oficialiosios informacijos apie COVID-19 ir patarimų.</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -421,4 +421,6 @@
     <string name="hideTipsText">Tie ir tikai daži, un mēs centāmies padarīt tos informatīvus.</string>
     <string name="hideTipsButton">Paslēpt padomus uz visiem laikiem</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Iegūstiet oficiālo informāciju un padomus par COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Det er bare noen få, og vi prøvde å gjøre dem informative.</string>
     <string name="hideTipsButton">Skjul tips for alltid</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Få offisiell info og tips om COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Het zijn er maar een paar en we hebben geprobeerd ze informatief te maken.</string>
     <string name="hideTipsButton">Tips voor altijd verbergen</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Ontvang officiële COVID-19 info en tips.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -408,4 +408,6 @@
     <string name="hideTipsText">Jest tylko kilka i staraliśmy się, aby były one pouczające.</string>
     <string name="hideTipsButton">Ukryj wskazówki na zawsze</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Zobacz oficjalne informacje i wskazówki dotyczące COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -397,4 +397,6 @@
     <string name="hideTipsText">Há apenas algumas, e tentamos torná-las informativas.</string>
     <string name="hideTipsButton">Ocultar dicas para sempre</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Obtenha informações oficiais e sugestões sobre a COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -401,4 +401,6 @@
     <string name="hideTipsText">Sunt doar câteva, iar noi am încercat să le facem informative.</string>
     <string name="hideTipsButton">Ascunde sfaturile definitiv</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Obține informații și sfaturi oficiale COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -420,4 +420,6 @@
     <string name="hideTipsText">Их немного, и мы постарались сделать их информативными.</string>
     <string name="hideTipsButton">Скрыть подсказки навсегда</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Получить официальную информацию и советы в связи с COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -398,4 +398,6 @@
     <string name="hideTipsText">Je ich len niekoľko, snažili sme sa, aby mali informatívny charakter.</string>
     <string name="hideTipsButton">Navždy skryť tipy</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Získajte oficiálne informácie a tipy ohľadom COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -405,4 +405,6 @@
     <string name="hideTipsText">Le nekaj jih je in poskušali smo jih narediti informativne.</string>
     <string name="hideTipsButton">Skrivaj nasvete za vedno</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Pridobite uradne informacije in nasvete za COVID-19.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -413,4 +413,6 @@
     <string name="hideTipsText">Det finns bara några få, och vi försökte göra dem informativa.</string>
     <string name="hideTipsButton">Dölj tipsen för alltid</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Ta emot officiell COVID-19 information och tips.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -420,4 +420,6 @@
     <string name="hideTipsText">Sadece birkaç tane var ve onları da bilgilendirici hale getirmeye çalıştık.</string>
     <string name="hideTipsButton">İpuçlarını sonsuza kadar gizle</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Resmi COVID-19 hakkında bilgi ve ipuçları alın.</string>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -56,5 +56,7 @@
     <attr name="brokenSitesButtonDisabledBackgroundColor" format="color" />
     <attr name="brokenSitesButtonDisabledTextColor" format="color" />
     <attr name="brokenSitesButtonRippleColor" format="color" />
+    <attr name="topCallToActionDescriptionColor" format="color" />
+    <attr name="topCallToActionBackgroundColor" format="color" />
 
 </resources>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -57,4 +57,6 @@
     <string name="stickySearchPromptRemove">Remove</string>
     <string name="notificationChannelSearch">Search</string>
 
+    <string name="covidCtaText">Get official COVID-19 info and tips.</string>
+
 </resources>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -57,6 +57,7 @@
     <string name="stickySearchPromptRemove">Remove</string>
     <string name="notificationChannelSearch">Search</string>
 
+    <!-- Covid Cta-->
     <string name="covidCtaText">Get official COVID-19 info and tips.</string>
 
 </resources>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -57,7 +57,4 @@
     <string name="stickySearchPromptRemove">Remove</string>
     <string name="notificationChannelSearch">Search</string>
 
-    <!-- Covid Cta-->
-    <string name="covidCtaText">Get official COVID-19 info and tips.</string>
-
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,4 +406,6 @@
     <string name="hideTipsText">There are only a few, and we tried to make them informative.</string>
     <string name="hideTipsButton">Hide tips forever</string>
 
+    <!-- Covid Cta-->
+    <string name="covidCtaText">Get official COVID-19 info and tips.</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -70,6 +70,8 @@
         <item name="brokenSitesButtonDisabledBackgroundColor">@color/greyishBrownTwo</item>
         <item name="brokenSitesButtonDisabledTextColor">@color/warGreyTwo</item>
         <item name="brokenSitesButtonRippleColor">@color/white</item>
+        <item name="topCallToActionDescriptionColor">@color/grayish</item>
+        <item name="topCallToActionBackgroundColor">@color/greyishBrownTwo</item>
 
         <item name="feedbackAnonymousFeedbackLabelColor">@color/grayish</item>
         <item name="feedbackListItemBackgroundColor">@color/almostBlack</item>
@@ -135,6 +137,8 @@
         <item name="brokenSitesButtonDisabledBackgroundColor">@color/subtleGrayTwo</item>
         <item name="brokenSitesButtonDisabledTextColor">@color/white</item>
         <item name="brokenSitesButtonRippleColor">@color/subtleGrayTwo</item>
+        <item name="topCallToActionDescriptionColor">@color/almostBlack</item>
+        <item name="topCallToActionBackgroundColor">@color/white</item>
 
         <item name="feedbackAnonymousFeedbackLabelColor">@color/warmerGray</item>
         <item name="feedbackListItemBackgroundColor">@color/whiteFive</item>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1125189844075764/1168011560246855/1168197361406699
Tech Design URL: https://app.asana.com/0/inbox/1125189844075764/1167999555509653/1168197361406699
CC: 

**Description**:
This PR introduces a new CTA to help our users get official information and tips for COVID-19

I will be updating different translations as they come but we won't wait for all of them before releasing which means I I will potentially create another PR after releasing containing the translations that didn't make it on time.

**Steps to test this PR**:
**User without concept test**
1. Hardcode variant to `mg` or other without the `ConceptTest` feature.
1. Launch the app and go through the onboarding.
1. After the onboarding is completed you should see WidgetCTA depending on the device.
1. Dismiss the Widget CTA.
1. After the onboarding is completed you should see the COVID CTA.
1. Click on the CTA which should perform a "covid 19" search.
1. Open a new tab and the COVID CTA should be visible.
1. Dismiss the CTA by clicking on the cross.
1. COVID CTA should disappear.

**User with concept test**
1. Hardcode variant to `mh` or any other which contains the `ConceptTest` feature.
1. Launch the app and go through the onboarding.
1. After the onboarding is completed you should see the first Dax CTA ("Next, try visiting...").
1. Go to any website or perform a search, you will probably see another Dax CTA depending on the site.
1. Open a new tab.
1. The last Dax Dialog should be now shown ("You've got this...").
1. Perform another search on the new tab.
1. Open a new tab/
1. COVID CTA should be now visible.
1. Click on the CTA which should perform a "covid 19" search.
1. Open a new tab and the COVID CTA should be visible.
1. Dismiss the CTA by clicking on the cross.
1. Notice how the COVID CTA disappears and nothing else is shown.

**Other tests**
1.  Change to dark/light theme and see how the UIO changes accordingly.
1. Rotating to landscape still shows the CTA and if not enough space hides the Dax logo.
1. Testing on a tablet will possibly show the COVID CTA and the Dax logo when on landscape depending on the space.
1. Change language to Spanish and check on a phone that text needs two lines but UI still works fine.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
