### PR TITLE
Fix onboarding style

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
@@ -110,7 +110,7 @@ class DefaultBrowserPage : OnboardingPageFragment() {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
             }
-            statusBarColor = Color.WHITE
+            statusBarColor = Color.TRANSPARENT
         }
         requestApplyInsets(longDescriptionContainer)
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
@@ -20,13 +20,16 @@ import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
+import android.view.WindowManager
 import android.widget.Toast
+import androidx.core.view.ViewCompat.requestApplyInsets
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.duckduckgo.app.browser.BrowserActivity
@@ -67,6 +70,7 @@ class DefaultBrowserPage : OnboardingPageFragment() {
     override fun setUserVisibleHint(isVisibleToUser: Boolean) {
         super.setUserVisibleHint(isVisibleToUser)
         if (isVisibleToUser) {
+            applyStyle()
             viewModel.pageBecameVisible()
         }
     }
@@ -97,6 +101,18 @@ class DefaultBrowserPage : OnboardingPageFragment() {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putBoolean(SAVED_STATE_LAUNCHED_DEFAULT, userTriedToSetDDGAsDefault)
+    }
+
+    private fun applyStyle() {
+        activity?.window?.apply {
+            clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+            addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            }
+            statusBarColor = Color.WHITE
+        }
+        requestApplyInsets(longDescriptionContainer)
     }
 
     private fun observeViewModel() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
Tech Design URL: 
CC: 

**Description**:
This PR fixes an issue in the onboarding default browser screen where the toast message shown is not aligned with the instructions card.

![Screenshot 2020-03-30 at 11 23 24](https://user-images.githubusercontent.com/1773137/77902900-d649ee00-7279-11ea-8f5f-5084e3279ef0.png)

**Steps to test this PR**:
1. Launch the app and navigate to the default browser screen.
1. Click let's do it and notice how the toast and the instructions card are aligned.
1. Dismiss the default browser popup.
1. Press the back button to go back to the first onboarding screen.
1. Styles have been applied and the status bar is not white.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
