### PR TITLE
Android: Dax Dialogs - quick improvements on big screens

### DIFF
--- a/app/src/main/res/layout-land/content_onboarding_welcome.xml
+++ b/app/src/main/res/layout-land/content_onboarding_welcome.xml
@@ -59,11 +59,12 @@
 
     <include
         layout="@layout/include_dax_dialog_cta"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="93dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_max="600dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_dax_dialog.xml
+++ b/app/src/main/res/layout/content_dax_dialog.xml
@@ -60,7 +60,7 @@
             android:layout_marginStart="24dp"
             android:layout_marginBottom="16dp"
             app:layout_constraintBottom_toTopOf="@id/cardView"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@id/cardView"
             app:srcCompat="@drawable/ic_dax_icon" />
 
         <androidx.appcompat.widget.AppCompatImageView
@@ -74,7 +74,7 @@
 
         <androidx.cardview.widget.CardView
             android:id="@+id/cardView"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"
@@ -83,7 +83,8 @@
             app:cardCornerRadius="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintWidth_max="600dp">
 
             <LinearLayout
                 android:id="@+id/cardContainer"

--- a/app/src/main/res/layout/content_onboarding_welcome.xml
+++ b/app/src/main/res/layout/content_onboarding_welcome.xml
@@ -59,11 +59,12 @@
 
     <include
         layout="@layout/include_dax_dialog_cta"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="93dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_max="600dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -57,7 +57,6 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="40dp"
-        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -54,12 +54,14 @@
 
     <include
         layout="@layout/include_dax_dialog_cta"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="40dp"
+        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_max="600dp"/>
 
     <LinearLayout
         android:id="@+id/ctaContainer"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1169355936992923/f
Tech Design URL: https://app.asana.com/0/0/1169315285491563/f
CC: 

**Description**:
When making the new onboarding and Dax dialogs the new default experience, we noticed that the UI for some big screens (specially tablets) could be improved. To avoid delaying the release, we decided just to introduce a few quick improvements. Those include:
- introducing a max width of 600dp for all devices
- centering the dialog

**Onboarding dialog**
![Screenshot_1585744086](https://user-images.githubusercontent.com/4747865/78137742-1a79f180-7426-11ea-8c9f-5a6bb5454137.png)
![Screenshot_1585744094](https://user-images.githubusercontent.com/4747865/78137756-21086900-7426-11ea-9480-4978d7033017.png)

**Intro dialog:**
![Screenshot_1585744107](https://user-images.githubusercontent.com/4747865/78137758-21a0ff80-7426-11ea-9704-ac8af5ad9010.png)
![Screenshot_1585744114](https://user-images.githubusercontent.com/4747865/78137761-22399600-7426-11ea-99f4-37d2fc195d49.png)

**Dax dialog:**
![Screenshot_1585744125](https://user-images.githubusercontent.com/4747865/78137763-22d22c80-7426-11ea-9fab-7d9bba238dde.png)
![Screenshot_1585744130](https://user-images.githubusercontent.com/4747865/78137764-22d22c80-7426-11ea-9c8c-c3a8cd7b5be6.png)

**Steps to test this PR**:
1. Fresh install on a big screen device -> use a tablet
1. Ensure this first dialog during the onboarding process is shown as the attached image
1. Navigate to the browser screen
1. Ensure intro dialog is shown as the attached image (test it in both modes portrait and landscape)
1. Visit a site to trigger any Dax dialog (cnn.com)
1. Ensure Dax dialog si shown as the attached image (test it in both modes portrait and landscape)

Additional test:
1. you can try running the same flow on a phone
1. Ensure everything looks as before, except for some devices in landscape mode where the same rules should apply (max 600dp and centered)

Side note: COVID Cta stays as it is right now.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
