### PR TITLE
Fix: initialise ResultViewState before user submits a new query

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -100,13 +100,14 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenDatabaseIsSlowThenIntroducingTextDoesNotCrash() = coroutineRule.runBlocking {
-        whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
+    fun whenDatabaseIsSlowThenIntroducingTextDoesNotCrashTheApp() = coroutineRule.runBlocking {
         (coroutineRule.testDispatcherProvider.io() as TestCoroutineDispatcher).pauseDispatcher()
         testee =
             SystemSearchViewModel(givenEmptyUserStageStore(), mockAutoComplete, mockDeviceAppLookup, mockPixel, coroutineRule.testDispatcherProvider)
         testee.resetViewState()
         testee.userUpdatedQuery("test")
+
+        //no crash
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -88,8 +88,8 @@ class SystemSearchViewModel(
     fun resetViewState() {
         viewModelScope.launch {
             resetOnboardingState()
-            resetResultsState()
         }
+        resetResultsState()
     }
 
     private suspend fun resetOnboardingState() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1169575807989121/f
Tech Design URL: 
CC: 

**Description**:
This crash happens because init block inside ViewModel will initialise two viewStates: Onboarding and Results.
OnboardingViewState now needs some info from the database in order to be initialised, and ResultsViewState will initialise after OnboardingViewState.
If the database produces any delay (maybe because migration or just thread suspends), user might be able to submit a query before ViewStates are initialised, producing a nullPointer exception.

**Fix**
Initialise ResultsViewState out of the coroutine used to initialise OnboardingViewState.

**Steps to test this PR**:
> To reproduce the crash:
1. Hardcode the following code inside `SystemSearchViewModel.resetViewState()`
```
        viewModelScope.launch {
            delay(5000)
            resetOnboardingState()
            resetResultsState()
        }
```
1. Install the app
1. Fresh start from the widget
1. Perform a search in less than 5 seconds.

> Test the fix:
1. checkout this branch
1. Add only the delay inside launch block in `SystemSearchViewModel.resetViewState()`
```
        viewModelScope.launch {
            delay(5000)
            resetOnboardingState()
        }
        resetResultsState()
```
1. Install the app
1. Fresh start from the widget
1. Perform a search in less than 5 seconds.
1. Ensure crash doesn't happen

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
