### PR TITLE
Ensure navigation buttons are visible when BottomSheetDialog is displayed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.global.view
 
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import com.duckduckgo.app.browser.R
@@ -33,6 +34,10 @@ class FireDialog(context: Context, private val clearPersonalDataAction: ClearPer
     init {
         val contentView = View.inflate(context, R.layout.sheet_fire_clear_data, null)
         setContentView(contentView)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            window?.decorView?.systemUiVisibility = View.NOT_FOCUSABLE
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
**Description**:
When the fire button is clicked on the light theme, the **navigation buttons**, as well as the **icons in the action bar**, are hard, if not impossible, to see on Android 8+.  This PR brings the UI focus loss in line with what one may expect from a normal `Dialog` etc.  Attempts to fix #754

**Steps to test this PR**:
1. Ensure that the navigation buttons and actionbar icons are _clearly_ visible on light and dark theme with intended contrast.

Below are two screenshots from a **Pixel 3XL API 29**: the first is a picture of what the navbar and actionbar will look like after this PR, and the second is of an alternative UI candidate that does not dim the navbar since I thought it looked decent and could be another acceptable way of handling this since `BottomSheetDialogs` are not floating dialogs hence the navbar doesn't _necessarily_ need to be dimmed here in my opinion.  I would be happy to submit a PR implementing the second approach if desired.

![Screenshot_1586118185](https://user-images.githubusercontent.com/21976019/78510907-a5305880-7766-11ea-8082-876a29b3f0b9.png)

![Screenshot_1586129038](https://user-images.githubusercontent.com/21976019/78512504-12e28180-7773-11ea-945d-bba35c0a125d.png)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
