### PR TITLE
Animator helper crash

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.browser
 
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.graphics.drawable.AnimatedVectorDrawable
 import android.view.View
@@ -187,17 +186,23 @@ class BrowserTrackersAnimatorHelper {
         }
     }
 
-    @SuppressLint("ObjectAnimatorBinding")
-    fun animateFadeOut(view: Any): ObjectAnimator {
-        return ObjectAnimator.ofFloat(view, "alpha", 1f, 0f).apply {
-            duration = DEFAULT_ANIMATION_DURATION
+    private fun animateFadeOut(view: View?): ObjectAnimator? {
+        return if (view != null) {
+            ObjectAnimator.ofFloat(view, "alpha", 1f, 0f).apply {
+                duration = DEFAULT_ANIMATION_DURATION
+            }
+        } else {
+            null
         }
     }
 
-    @SuppressLint("ObjectAnimatorBinding")
-    fun animateFadeIn(view: Any): ObjectAnimator {
-        return ObjectAnimator.ofFloat(view, "alpha", 0f, 1f).apply {
-            duration = DEFAULT_ANIMATION_DURATION
+    private fun animateFadeIn(view: View?): ObjectAnimator? {
+        return if (view != null) {
+            ObjectAnimator.ofFloat(view, "alpha", 0f, 1f).apply {
+                duration = DEFAULT_ANIMATION_DURATION
+            }
+        } else {
+            null
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
@@ -186,23 +186,15 @@ class BrowserTrackersAnimatorHelper {
         }
     }
 
-    private fun animateFadeOut(view: View?): ObjectAnimator? {
-        return if (view != null) {
-            ObjectAnimator.ofFloat(view, "alpha", 1f, 0f).apply {
-                duration = DEFAULT_ANIMATION_DURATION
-            }
-        } else {
-            null
+    private fun animateFadeOut(view: View): ObjectAnimator {
+        return ObjectAnimator.ofFloat(view, "alpha", 1f, 0f).apply {
+            duration = DEFAULT_ANIMATION_DURATION
         }
     }
 
-    private fun animateFadeIn(view: View?): ObjectAnimator? {
-        return if (view != null) {
-            ObjectAnimator.ofFloat(view, "alpha", 0f, 1f).apply {
-                duration = DEFAULT_ANIMATION_DURATION
-            }
-        } else {
-            null
+    private fun animateFadeIn(view: View): ObjectAnimator {
+        return ObjectAnimator.ofFloat(view, "alpha", 0f, 1f).apply {
+            duration = DEFAULT_ANIMATION_DURATION
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
@@ -93,8 +93,10 @@ class TypewriterDaxDialog(
     }
 
     override fun onDismiss(dialog: DialogInterface) {
-        dialogText?.cancelAnimation()
-        dismissListener()
+        if (activity != null) {
+            dialogText?.cancelAnimation()
+            dismissListener()
+        }
         super.onDismiss(dialog)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1170001449666321
Tech Design URL: 
CC: 

**Description**:
In some cases when the trackers blocked CTA is shown it could lead to a crash when the tracker blocked animation finishes if some of the views have been killed and not longer exist.

**Steps to test this PR**:
**App crashes**
1. In the developer options set `Don't keep activities` to true.
1. Launch the existing app from develop.
1. Navigate to cnn.com and wait until the trackers blocked CTA is shown.
1. Send the app to the background and see a crash.

**App does not crash**
1. In the developer options set `Don't keep activities` to true.
1. Launch the app from this branch.
1. Navigate to cnn.com and wait until the trackers blocked CTA is shown.
1. Send the app to the background and the crash does not happen anymore.



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
