### PR TITLE
Fix pressed state in buttons that appear in the Onboarding

### DIFF
--- a/app/src/main/res/drawable/onboarding_primary_cta_button_rounded_bg.xml
+++ b/app/src/main/res/drawable/onboarding_primary_cta_button_rounded_bg.xml
@@ -13,11 +13,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/button_contained_background" />
-    <stroke
-        android:width="1dp"
-        android:color="@color/button_contained_background" />
-    <corners android:radius="22dp" />
-</shape>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/white">
+    <item>
+        <shape>
+            <solid android:color="@color/button_contained_background" />
+            <corners android:radius="22dp" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/onboarding_secondary_cta_button_rounded_bg.xml
+++ b/app/src/main/res/drawable/onboarding_secondary_cta_button_rounded_bg.xml
@@ -13,10 +13,13 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <stroke
-        android:width="1.5dp"
-        android:color="@color/cornflowerBlue" />
-    <corners android:radius="22dp" />
-</shape>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white" />
+            <stroke android:width="1.5dp" android:color="@color/cornflowerBlue"/>
+            <corners android:radius="22dp" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -168,20 +168,17 @@
         <item name="android:color">@color/browser_menu_text</item>
     </style>
 
-    <style name="OnboardingButtonPrimaryRoundedCta">
-        <item name="android:foreground">?attr/selectableItemBackground</item>
+    <style name="OnboardingButtonPrimaryRoundedCta" parent="Widget.AppCompat.Button.Borderless">
         <item name="android:layout_marginBottom">20dp</item>
         <item name="android:textSize">15sp</item>
         <item name="android:textColor">@color/white</item>
         <item name="layout_constraintWidth_max">400dp</item>
         <item name="layout_constraintWidth_percent">0.8</item>
-        <item name="backgroundTint">@color/cornflowerBlue</item>
         <item name="android:background">@drawable/onboarding_primary_cta_button_rounded_bg</item>
         <item name="android:textAllCaps">false</item>
     </style>
 
-    <style name="OnboardingButtonSecondaryRoundedCta">
-        <item name="android:foreground">?attr/selectableItemBackground</item>
+    <style name="OnboardingButtonSecondaryRoundedCta" parent="Widget.AppCompat.Button.Borderless">
         <item name="android:layout_marginBottom">20dp</item>
         <item name="android:textSize">15sp</item>
         <item name="android:textColor">@color/cornflowerDark</item>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1170298171161577/f
Tech Design URL: 
CC: 

**Description**:
The new Onboarding experience shows buttons that have a wrong pressed state.

**Before** 
![image](https://user-images.githubusercontent.com/4747865/78841375-797ad000-79fd-11ea-8ddc-b8a90f82b9da.png)

**After**
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/4747865/78841342-6831c380-79fd-11ea-896f-2ddc09fe3db1.gif)

**Steps to test this PR**:
1. Fresh install
1. Go to default browser screen
1. Ensure ripple effect gets rendered inside background button

Test this on different API levels.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
