### PR TITLE
Interstitial search screen tweaks

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -210,7 +210,7 @@ class SystemSearchViewModelTest {
     @Test
     fun whenUserSubmitsBlankQueryThenIgnored() {
         testee.userSubmittedQuery(BLANK_QUERY)
-        verify(commandObserver, never()).onChanged(commandCaptor.capture())
+        assertFalse(commandCaptor.allValues.any { it is Command.LaunchBrowser })
         verify(mockPixel, never()).fire(INTERSTITIAL_LAUNCH_BROWSER_QUERY)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -192,7 +192,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUserSubmitsQueryThenBrowserLaunchedAndPixelSent() {
+    fun whenUserSubmitsQueryThenBrowserLaunchedWithQueryAndPixelSent() {
         testee.userSubmittedQuery(QUERY)
         verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertEquals(Command.LaunchBrowser(QUERY), commandCaptor.lastValue)
@@ -200,11 +200,25 @@ class SystemSearchViewModelTest {
     }
 
     @Test
+    fun whenUserSubmitsQueryWithSpaceThenBrowserLaunchedWithTrimmedQueryAndPixelSent() {
+        testee.userSubmittedQuery("$QUERY ")
+        verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertEquals(Command.LaunchBrowser(QUERY), commandCaptor.lastValue)
+        verify(mockPixel).fire(INTERSTITIAL_LAUNCH_BROWSER_QUERY)
+    }
+
+    @Test
+    fun whenUserSubmitsBlankQueryThenIgnored() {
+        testee.userSubmittedQuery(BLANK_QUERY)
+        verify(commandObserver, never()).onChanged(commandCaptor.capture())
+        verify(mockPixel, never()).fire(INTERSTITIAL_LAUNCH_BROWSER_QUERY)
+    }
+
+    @Test
     fun whenUserSubmitsQueryThenOnboardingCompleted() = coroutineRule.runBlocking {
         testee.userSubmittedQuery(QUERY)
         verify(mockUserStageStore).stageCompleted(AppStage.NEW)
     }
-
 
     @Test
     fun whenUserSubmitsAutocompleteResultThenBrowserLaunchedAndPixelSent() {

--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -33,7 +33,6 @@ import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckD
 import com.nhaarman.mockitokotlin2.*
 import io.reactivex.Observable
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.After
 import org.junit.Assert.*
@@ -155,7 +154,6 @@ class SystemSearchViewModelTest {
 
         val newViewState = testee.resultsViewState.value
         assertNotNull(newViewState)
-        assertEquals(QUERY, newViewState?.queryText)
         assertEquals(appQueryResult, newViewState?.appResults)
         assertEquals(autocompleteQueryResult, newViewState?.autocompleteResults)
     }
@@ -167,7 +165,6 @@ class SystemSearchViewModelTest {
 
         val newViewState = testee.resultsViewState.value
         assertNotNull(newViewState)
-        assertEquals("$QUERY ", newViewState?.queryText)
         assertEquals(appQueryResult, newViewState?.appResults)
         assertEquals(autocompleteQueryResult, newViewState?.autocompleteResults)
     }
@@ -175,12 +172,11 @@ class SystemSearchViewModelTest {
     @Test
     fun whenUserClearsQueryThenViewStateReset() = coroutineRule.runBlocking {
         testee.userUpdatedQuery(QUERY)
-        testee.userClearedQuery()
+        testee.userRequestedClear()
 
         val newViewState = testee.resultsViewState.value
         assertNotNull(newViewState)
-        assertTrue(newViewState!!.queryText.isEmpty())
-        assertTrue(newViewState.appResults.isEmpty())
+        assertTrue(newViewState!!.appResults.isEmpty())
         assertEquals(AutoCompleteResult("", emptyList()), newViewState.autocompleteResults)
     }
 
@@ -191,8 +187,7 @@ class SystemSearchViewModelTest {
 
         val newViewState = testee.resultsViewState.value
         assertNotNull(newViewState)
-        assertTrue(newViewState!!.queryText.isEmpty())
-        assertTrue(newViewState.appResults.isEmpty())
+        assertTrue(newViewState!!.appResults.isEmpty())
         assertEquals(AutoCompleteResult("", emptyList()), newViewState.autocompleteResults)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/DeviceAppLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/DeviceAppLookup.kt
@@ -60,6 +60,14 @@ class InstalledDeviceAppLookup(private val appListProvider: DeviceAppListProvide
         val wordPrefixMatchingRegex = ".*\\b${escapedQuery}.*".toRegex(IGNORE_CASE)
         return apps!!.filter {
             it.shortName.matches(wordPrefixMatchingRegex)
+        }.sortedWith(comparator(query))
+    }
+
+    private fun comparator(query: String): Comparator<DeviceApp> {
+        return compareByDescending<DeviceApp> {
+            it.shortName.startsWith(query, ignoreCase = true)
+        }.thenBy {
+            it.shortName
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -168,7 +168,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
 
         omnibarTextInput.removeTextChangedListener(textChangeWatcher)
         omnibarTextInput.addTextChangedListener(textChangeWatcher)
-        clearTextButton.setOnClickListener { viewModel.userClearedQuery() }
+        clearTextButton.setOnClickListener { viewModel.userRequestedClear() }
     }
 
     private fun renderOnboardingViewState(viewState: SystemSearchViewModel.OnboardingViewState) {
@@ -189,11 +189,6 @@ class SystemSearchActivity : DuckDuckGoActivity() {
     }
 
     private fun renderResultsViewState(viewState: SystemSearchResultsViewState) {
-        if (omnibarTextInput.text.toString() != viewState.queryText) {
-            omnibarTextInput.setText(viewState.queryText)
-            omnibarTextInput.setSelection(viewState.queryText.length)
-        }
-
         deviceLabel.isVisible = viewState.appResults.isNotEmpty()
         autocompleteSuggestionsAdapter.updateData(viewState.autocompleteResults.query, viewState.autocompleteResults.suggestions)
         deviceAppSuggestionsAdapter.updateData(viewState.appResults)
@@ -201,6 +196,11 @@ class SystemSearchActivity : DuckDuckGoActivity() {
 
     private fun processCommand(command: SystemSearchViewModel.Command) {
         when (command) {
+            is ClearInputText -> {
+                omnibarTextInput.removeTextChangedListener(textChangeWatcher)
+                omnibarTextInput.setText("")
+                omnibarTextInput.addTextChangedListener(textChangeWatcher)
+            }
             is LaunchDuckDuckGo -> {
                 launchDuckDuckGo()
             }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 
-typealias SystemSearchResult = Pair<AutoCompleteResult, List<DeviceApp>>
+data class SystemSearchResult(val autocomplete: AutoCompleteResult, val deviceApps: List<DeviceApp>)
 
 class SystemSearchViewModel(
     private var userStageStore: UserStageStore,
@@ -163,8 +163,8 @@ class SystemSearchViewModel(
     private fun updateResults(results: SystemSearchResult) {
         this.results = results
 
-        val suggestions = results.first.suggestions
-        val appResults = results.second
+        val suggestions = results.autocomplete.suggestions
+        val appResults = results.deviceApps
         val hasMultiResults = suggestions.isNotEmpty() && appResults.isNotEmpty()
 
         val updatedSuggestions = if (hasMultiResults) suggestions.take(RESULTS_MAX_RESULTS_PER_GROUP) else suggestions
@@ -172,7 +172,7 @@ class SystemSearchViewModel(
 
         resultsViewState.postValue(
             currentResultsState().copy(
-                autocompleteResults = AutoCompleteResult(results.first.query, updatedSuggestions),
+                autocompleteResults = AutoCompleteResult(results.autocomplete.query, updatedSuggestions),
                 appResults = updatedApps
             )
         )

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -197,9 +197,13 @@ class SystemSearchViewModel(
     }
 
     fun userSubmittedQuery(query: String) {
+        if (query.isBlank()) {
+            return
+        }
+
         viewModelScope.launch {
             userStageStore.stageCompleted(AppStage.NEW)
-            command.value = Command.LaunchBrowser(query)
+            command.value = Command.LaunchBrowser(query.trim())
             pixel.fire(INTERSTITIAL_LAUNCH_BROWSER_QUERY)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -89,6 +89,7 @@ class SystemSearchViewModel(
     private fun currentResultsState(): SystemSearchResultsViewState = resultsViewState.value!!
 
     fun resetViewState() {
+        command.value = Command.ClearInputText
         viewModelScope.launch {
             resetOnboardingState()
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

**Task/Issue URL:**
- https://app.asana.com/0/488551667048375/1161178882056507
- https://app.asana.com/0/488551667048375/1170451534984707

**Description**:
* Coordinate timing so interstitial results drop in smoothly together rather than shifting items on screen
* Update the list order to prefer items that start with search query, then alphabetically
* Remove circular updates between the omnibar and ViewModel to improve text input experience.

**Steps to test this PR**:

**Test Interstitial Results**
1. Install a fresh version of the app and add the widget to your home screen (it is recommended that other versions are uninstalled first as it is really easy to add the wrong widget)
1. Tap the widget to launch the interstitial screen
1. Enter a query for example "Pl" notice that the autocomplete and app results appear smoothly together
1. Notice that 

**Validate interstitial Screen Text input**
1. Enter text in the search bar,
1. Enter a space
1. Delete the space
1. Delete the last word
1. Make sure this respond as expected


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
