### PR TITLE
Add REQUEST_INSTALL_PACKAGES permission to help improve browser parity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:name="com.duckduckgo.app.global.DuckDuckGoApplication"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/715106103902962/1171807866325827
Tech Design URL: 
CC: 

**Description**:
Adds `android.permission.REQUEST_INSTALL_PACKAGES` so that our app can download APKs on Android Oreo and newer

**Steps to test this PR**:

**On >= Android Oreo device**

1. Download an APK (e.g., Visit github.com/duckduckgo/android/releases, click on an APK from the assets)
2. Wait for download to complete
3. Click on the notification for the downloaded file; verify the system offers to take the user to settings to let you enable installing from our DDG app
4. Verify the app installs correctly

If you try repeating the above from `develop` instead of this feature branch, you'll note that you can't install any APK you downloaded from our app.

**On < Android Oreo device**
1. Verify there's no behavior changes from downloading and installing apps

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
