### PR TITLE
InterruptedException and IOException now excluded exceptions to alert on

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
@@ -19,10 +19,13 @@ package com.duckduckgo.app.global
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
+import io.reactivex.exceptions.UndeliverableException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.io.IOException
 
 class AlertingUncaughtExceptionHandler(
     private val originalHandler: Thread.UncaughtExceptionHandler,
@@ -32,12 +35,30 @@ class AlertingUncaughtExceptionHandler(
 
     override fun uncaughtException(t: Thread?, originalException: Throwable?) {
 
+        if (shouldIgnore(originalException)) {
+            Timber.w(originalException, "An exception occurred but we don't need to handle it")
+            return
+        }
+
         GlobalScope.launch(Dispatchers.IO + NonCancellable) {
             uncaughtExceptionRepository.recordUncaughtException(originalException, UncaughtExceptionSource.GLOBAL)
             offlinePixelCountDataStore.applicationCrashCount += 1
 
             // wait until the exception has been fully processed before propagating exception
             originalHandler.uncaughtException(t, originalException)
+        }
+    }
+
+    /**
+     * Some exceptions happen due to lifecycle issues, such as our sync service being forced to stop.
+     * In such cases, we don't need to alert about the exception as they are exceptions essentially signalling that work was interrupted.
+     * Examples of this would be if the internet was lost during the sync,
+     * or when two or more sync operations are scheduled to run at the same time; one would run and the rest would be interrupted.
+     */
+    private fun shouldIgnore(exception: Throwable?): Boolean {
+        return when (exception) {
+            is UndeliverableException, is InterruptedException, is IOException -> true
+            else -> false
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandler.kt
@@ -20,7 +20,6 @@ import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
-import io.reactivex.exceptions.UndeliverableException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.NonCancellable
@@ -54,7 +53,7 @@ class AlertingUncaughtExceptionHandler(
      */
     private fun shouldRecordExceptionAndCrashApp(exception: Throwable?): Boolean {
         return when (exception) {
-            is UndeliverableException, is InterruptedException, is InterruptedIOException -> false
+            is InterruptedException, is InterruptedIOException -> false
             else -> true
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1172356004360461
Tech Design URL: 
CC: 

**Description**:
Adds `InterruptedIOException` and `InterruptedException` to the list that we don't want to crash the app on. These exceptions were observed to be happening in the 5.22.3 release. These are essentially the ones signalling that there was an internet issue or that the sync job was instructed to stop mid way through; they aren't real exceptions that should cause the app to stop.

**Steps to test this PR**:
1. Similar to https://github.com/duckduckgo/Android/pull/787, it's hard to replicate. But I found I could replicate by making the `TrackerDataDownloader` do lots of extra work, and killing the wifi off while it's looping. e.g., 👇

```
for (i in 0..100) {
    Timber.i("Running TDS download #$i")
    val call = trackerListService.tds()
    val response = call.execute()
}
```



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
