### PR TITLE
Fix Edit Bookmark and Authentication dialog theming

### DIFF
--- a/app/src/main/res/layout/edit_bookmark.xml
+++ b/app/src/main/res/layout/edit_bookmark.xml
@@ -20,18 +20,18 @@
     android:layout_height="match_parent"
     android:paddingTop="20dp">
 
-
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/bookmarkTitleInputContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="60dp"
         android:layout_marginStart="20dp"
         android:layout_marginEnd="20dp"
+        style="@style/TextInputLayoutTheme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/titleInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -43,12 +43,13 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/bookmarkUrlInputContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="60dp"
         android:layout_marginStart="20dp"
         android:layout_marginEnd="20dp"
+        style="@style/TextInputLayoutTheme"
         app:layout_constraintTop_toBottomOf="@id/bookmarkTitleInputContainer">
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/urlInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/http_authentication.xml
+++ b/app/src/main/res/layout/http_authentication.xml
@@ -15,38 +15,39 @@
   -->
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                   android:layout_width="match_parent"
-                                                   android:layout_height="match_parent" xmlns:tools="http://schemas.android.com/tools"
-                                                   android:paddingTop="20dp">
-
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="20dp">
 
     <TextView
         android:id="@+id/httpAuthInformationText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:layout_marginStart="20dp"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="20dp"
         app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/httpAuthUsernameContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="60dp"
+        style="@style/TextInputLayoutTheme"
         android:layout_marginStart="20dp"
-        android:layout_marginEnd="20dp"
         android:layout_marginTop="20dp"
+        android:layout_marginEnd="20dp"
         app:layout_constraintTop_toBottomOf="@id/httpAuthInformationText">
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/usernameInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/authenticationDialogUsernameHint"
-            android:inputType="text"
-            android:importantForAutofill="yes"
             android:autofillHints="username"
+            android:hint="@string/authenticationDialogUsernameHint"
+            android:importantForAutofill="yes"
+            android:inputType="text"
             tools:ignore="UnusedAttribute" />
 
     </com.google.android.material.textfield.TextInputLayout>
@@ -54,19 +55,20 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/httpAuthPasswordContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="60dp"
+        style="@style/TextInputLayoutTheme"
         android:layout_marginStart="20dp"
         android:layout_marginEnd="20dp"
         app:layout_constraintTop_toBottomOf="@id/httpAuthUsernameContainer">
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/passwordInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/authenticationDialogPasswordHint"
-            android:inputType="textWebPassword"
-            android:importantForAutofill="yes"
             android:autofillHints="password"
+            android:hint="@string/authenticationDialogPasswordHint"
+            android:importantForAutofill="yes"
+            android:inputType="textWebPassword"
             tools:ignore="UnusedAttribute" />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -192,6 +192,15 @@
         <item name="android:colorForeground">?attr/settingsSwitchBackgroundColor</item>
     </style>
 
+    <style name="TextInputLayoutTheme" parent="Widget.Design.TextInputLayout">
+        <item name="colorControlActivated">@color/cornflowerBlue</item>
+        <item name="colorControlNormal">@color/cornflowerBlue</item>
+        <item name="colorControlHighlight">@color/cornflowerBlue</item>
+        <item name="android:textColor">@color/grayish</item>
+        <item name="android:textColorSecondary">@color/grayish</item>
+        <item name="android:textColorHint">@color/grayish</item>
+    </style>
+
     <style name="AutoCompleteTextViewStyle" parent="Widget.AppCompat.AutoCompleteTextView">
         <item name="android:textCursorDrawable">@drawable/text_cursor</item>
         <item name="android:textColorHint">?attr/omnibarHintColor</item>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1172335675952700

**Description**:
The changes in Android Release 5.52.1 (Beta) have somehow messed up with the theming in the Edit Bookmark dialog. This PR fixes that.

**Screenshots**:
| Before | After SDK 21 | After SDK > 23 |
| ------ | ----- | ----- | 
![Screenshot_1587544933](https://user-images.githubusercontent.com/531613/80097010-dd0f0c80-856a-11ea-9e89-e2a181216264.png)|![Screenshot_1587642433](https://user-images.githubusercontent.com/531613/80097005-db454900-856a-11ea-87a3-6c15619f4420.png)|![Screenshot_1587643201](https://user-images.githubusercontent.com/531613/80097003-daacb280-856a-11ea-8b06-48e04e88a96c.png)|


**Steps to test this PR**:
1. Open app
2. Add a Bookmark
3. Tap on Edit

