### PR TITLE
Snackbar action button color using accent color

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -293,4 +293,8 @@
         <item name="android:textSize">12sp</item>
     </style>
 
+    <style name="snackbarButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
+        <item name="android:textColor">?attr/colorAccent</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -30,6 +30,7 @@
         <item name="android:windowActivityTransitions">true</item>
         <item name="autoCompleteTextViewStyle">@style/AutoCompleteTextViewStyle</item>
         <item name="android:statusBarColor">?colorPrimary</item>
+        <item name="snackbarButtonStyle">@style/snackbarButtonStyle</item>
     </style>
 
     <style name="AppTheme.BaseDark">


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1172723636495153/f
Tech Design URL: 
CC: 

**Description**:
After updating to the latest version of material library `com.google.android.material`, seems like the color used for the action on snackbars is not `colorAccent` anymore. Even if the documentation says the opposite. 

Develop:
![image](https://user-images.githubusercontent.com/4747865/80201039-d0022400-8623-11ea-97b2-c8c1c57b55ff.png)

Fix:
![image](https://user-images.githubusercontent.com/4747865/80200695-4e11fb00-8623-11ea-8e06-faf3dd583cfd.png)

**Steps to test this PR**:
1. Open the app
1. Visit any site
1. Bookmark
1. Ensure snackbar action color is blue

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
