### PR TITLE
Remove deprecated work tags

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/job/JobCleanerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/job/JobCleanerTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.job
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.duckduckgo.app.job.JobCleaner.Companion.allDeprecatedNotificationWorkTags
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class JobCleanerTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private var workManager = WorkManager.getInstance(context)
+    private lateinit var testee: JobCleaner
+
+    @Before
+    fun before() {
+        testee = AndroidJobCleaner(workManager)
+    }
+
+    @Test
+    fun allDeprecatedWorkIsCancelledUponStart() {
+        testee.cleanDeprecatedJobs()
+
+        allDeprecatedNotificationWorkTags().forEach {
+            assertTrue(getScheduledWorkers(it).isEmpty())
+        }
+    }
+
+    private fun getScheduledWorkers(tag: String): List<WorkInfo> {
+        return workManager
+            .getWorkInfosByTag(tag)
+            .get()
+            .filter { it.state == WorkInfo.State.ENQUEUED }
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/job/WorkSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/job/WorkSchedulerTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.job
+
+import com.duckduckgo.app.notification.NotificationScheduler
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+class WorkSchedulerTest {
+
+    private val notificationScheduler: NotificationScheduler = mock()
+    private val jobCleaner: JobCleaner = mock()
+
+    private lateinit var testee: WorkScheduler
+
+    @Before
+    fun before() {
+        testee = AndroidWorkScheduler(
+            notificationScheduler,
+            jobCleaner
+        )
+    }
+
+    @Test
+    fun allDeprecatedWorkIsCancelledUponStart() = runBlocking<Unit> {
+        testee.scheduleWork()
+
+        verify(notificationScheduler).scheduleNextNotification()
+        verify(jobCleaner).cleanDeprecatedJobs()
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
@@ -31,7 +31,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -105,7 +104,7 @@ class AndroidNotificationSchedulerTest {
 
         testee.scheduleNextNotification()
 
-        NotificationScheduler.allDeprecatedWorkTags().forEach {
+        NotificationScheduler.allDeprecatedNotificationWorkTags().forEach {
             assertTrue(getScheduledWorkers(it).isEmpty())
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/di/JobsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/JobsModule.kt
@@ -18,10 +18,15 @@ package com.duckduckgo.app.di
 
 import android.app.job.JobScheduler
 import android.content.Context
+import androidx.work.WorkManager
+import com.duckduckgo.app.job.AndroidJobCleaner
+import com.duckduckgo.app.job.AndroidWorkScheduler
+import com.duckduckgo.app.job.JobCleaner
+import com.duckduckgo.app.job.WorkScheduler
+import com.duckduckgo.app.notification.NotificationScheduler
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
-
 
 @Module
 class JobsModule {
@@ -32,4 +37,15 @@ class JobsModule {
         return context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
     }
 
+    @Singleton
+    @Provides
+    fun providesJobCleaner(workManager: WorkManager): JobCleaner {
+        return AndroidJobCleaner(workManager)
+    }
+
+    @Singleton
+    @Provides
+    fun providesWorkScheduler(notificationScheduler: NotificationScheduler, jobCleaner: JobCleaner): WorkScheduler {
+        return AndroidWorkScheduler(notificationScheduler, jobCleaner)
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/job/JobCleaner.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/JobCleaner.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.job
+
+import androidx.work.WorkManager
+import com.duckduckgo.app.job.JobCleaner.Companion.allDeprecatedNotificationWorkTags
+
+interface JobCleaner {
+    fun cleanDeprecatedJobs()
+
+    companion object {
+        // below there is a list of TAGs that were used at some point but that are no longer active
+        // we want to make sure that this TAGs are cancelled to avoid inconsistencies
+        private const val CONTINUOUS_APP_USE_REQUEST_TAG = "com.duckduckgo.notification.schedule.continuous" // Sticky Search Experiment
+
+        fun allDeprecatedNotificationWorkTags() = listOf(CONTINUOUS_APP_USE_REQUEST_TAG)
+    }
+}
+
+class AndroidJobCleaner(private val workManager: WorkManager) : JobCleaner {
+
+    override fun cleanDeprecatedJobs() {
+        allDeprecatedNotificationWorkTags().forEach { tag ->
+            workManager.cancelAllWorkByTag(tag)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/job/WorkScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/WorkScheduler.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.job
+
+import com.duckduckgo.app.notification.NotificationScheduler
+
+interface WorkScheduler {
+    suspend fun scheduleWork()
+}
+
+class AndroidWorkScheduler(
+    private val notificationScheduler: NotificationScheduler,
+    private val jobCleaner: JobCleaner
+) : WorkScheduler {
+    override suspend fun scheduleWork() {
+        jobCleaner.cleanDeprecatedJobs()
+        notificationScheduler.scheduleNextNotification()
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -46,7 +46,15 @@ class NotificationScheduler(
 ) : AndroidNotificationScheduler {
 
     override suspend fun scheduleNextNotification() {
+        cancelAllUnnecessaryWork()
         scheduleInactiveUserNotifications()
+    }
+
+    private fun cancelAllUnnecessaryWork(){
+        allDeprecatedWorkTags().forEach { tag  ->
+            workManager.cancelAllWorkByTag(tag)
+        }
+
     }
 
     private suspend fun scheduleInactiveUserNotifications() {
@@ -109,5 +117,11 @@ class NotificationScheduler(
 
     companion object {
         const val UNUSED_APP_WORK_REQUEST_TAG = "com.duckduckgo.notification.schedule"
+
+        // below there is a list of TAGs that were used at some point but that are no longer active
+        // we want to make sure that this TAGs are cancelled to avoid inconsistencies
+        const val CONTINUOUS_APP_USE_REQUEST_TAG = "com.duckduckgo.notification.schedule.continuous" // Sticky Search Experiment
+
+        fun allDeprecatedWorkTags() = listOf(CONTINUOUS_APP_USE_REQUEST_TAG)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -51,7 +51,7 @@ class NotificationScheduler(
     }
 
     private fun cancelAllUnnecessaryWork(){
-        allDeprecatedWorkTags().forEach { tag  ->
+        allDeprecatedNotificationWorkTags().forEach { tag  ->
             workManager.cancelAllWorkByTag(tag)
         }
 
@@ -122,6 +122,6 @@ class NotificationScheduler(
         // we want to make sure that this TAGs are cancelled to avoid inconsistencies
         private const val CONTINUOUS_APP_USE_REQUEST_TAG = "com.duckduckgo.notification.schedule.continuous" // Sticky Search Experiment
 
-        fun allDeprecatedWorkTags() = listOf(CONTINUOUS_APP_USE_REQUEST_TAG)
+        fun allDeprecatedNotificationWorkTags() = listOf(CONTINUOUS_APP_USE_REQUEST_TAG)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -120,7 +120,7 @@ class NotificationScheduler(
 
         // below there is a list of TAGs that were used at some point but that are no longer active
         // we want to make sure that this TAGs are cancelled to avoid inconsistencies
-        const val CONTINUOUS_APP_USE_REQUEST_TAG = "com.duckduckgo.notification.schedule.continuous" // Sticky Search Experiment
+        private const val CONTINUOUS_APP_USE_REQUEST_TAG = "com.duckduckgo.notification.schedule.continuous" // Sticky Search Experiment
 
         fun allDeprecatedWorkTags() = listOf(CONTINUOUS_APP_USE_REQUEST_TAG)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1171986548569356

**Description**:
As part of the remove of the Sticky Search Experiment we also want to make sure that if there was a job already scheduled it's properly removed from the WorkManager

This PR adds that functionality, making it easier in the future to remove old jobs.

**Steps to test this PR**:
1. Install current Production apk
2. Create a release version of this branch and update 
3. Open the app
4. Use a db viewer to check that the old TAG `CONTINUOUS_APP_USE_REQUEST_TAG` is no longer present in the WorkManager