### PR TITLE
Feature/david/remove sticky search deprecated jobs

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
@@ -31,7 +31,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -105,7 +104,7 @@ class AndroidNotificationSchedulerTest {
 
         testee.scheduleNextNotification()
 
-        NotificationScheduler.allDeprecatedWorkTags().forEach {
+        NotificationScheduler.allDeprecatedNotificationWorkTags().forEach {
             assertTrue(getScheduledWorkers(it).isEmpty())
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -46,7 +46,15 @@ class NotificationScheduler(
 ) : AndroidNotificationScheduler {
 
     override suspend fun scheduleNextNotification() {
+        cancelAllUnnecessaryWork()
         scheduleInactiveUserNotifications()
+    }
+
+    private fun cancelAllUnnecessaryWork(){
+        allDeprecatedWorkTags().forEach { tag  ->
+            workManager.cancelAllWorkByTag(tag)
+        }
+
     }
 
     private suspend fun scheduleInactiveUserNotifications() {
@@ -109,5 +117,11 @@ class NotificationScheduler(
 
     companion object {
         const val UNUSED_APP_WORK_REQUEST_TAG = "com.duckduckgo.notification.schedule"
+
+        // below there is a list of TAGs that were used at some point but that are no longer active
+        // we want to make sure that this TAGs are cancelled to avoid inconsistencies
+        const val CONTINUOUS_APP_USE_REQUEST_TAG = "com.duckduckgo.notification.schedule.continuous" // Sticky Search Experiment
+
+        fun allDeprecatedWorkTags() = listOf(CONTINUOUS_APP_USE_REQUEST_TAG)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -51,7 +51,7 @@ class NotificationScheduler(
     }
 
     private fun cancelAllUnnecessaryWork(){
-        allDeprecatedWorkTags().forEach { tag  ->
+        allDeprecatedNotificationWorkTags().forEach { tag  ->
             workManager.cancelAllWorkByTag(tag)
         }
 
@@ -122,6 +122,6 @@ class NotificationScheduler(
         // we want to make sure that this TAGs are cancelled to avoid inconsistencies
         private const val CONTINUOUS_APP_USE_REQUEST_TAG = "com.duckduckgo.notification.schedule.continuous" // Sticky Search Experiment
 
-        fun allDeprecatedWorkTags() = listOf(CONTINUOUS_APP_USE_REQUEST_TAG)
+        fun allDeprecatedNotificationWorkTags() = listOf(CONTINUOUS_APP_USE_REQUEST_TAG)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -120,7 +120,7 @@ class NotificationScheduler(
 
         // below there is a list of TAGs that were used at some point but that are no longer active
         // we want to make sure that this TAGs are cancelled to avoid inconsistencies
-        const val CONTINUOUS_APP_USE_REQUEST_TAG = "com.duckduckgo.notification.schedule.continuous" // Sticky Search Experiment
+        private const val CONTINUOUS_APP_USE_REQUEST_TAG = "com.duckduckgo.notification.schedule.continuous" // Sticky Search Experiment
 
         fun allDeprecatedWorkTags() = listOf(CONTINUOUS_APP_USE_REQUEST_TAG)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1171986548569356

**Description**:
As part of the remove of the Sticky Search Experiment we also want to make sure that if there was a job already scheduled it's properly removed from the WorkManager

This PR adds that functionality, making it easier in the future to remove old jobs.

**Steps to test this PR**:
1. Install current Production apk
2. Create a release version of this branch and update 
3. Open the app
4. Use a db viewer to check that the old TAG `CONTINUOUS_APP_USE_REQUEST_TAG` is no longer present in the WorkManager