### PR TITLE
Fix issue in activity_user_survey.xml

### DIFF
--- a/app/src/main/res/layout/activity_user_survey.xml
+++ b/app/src/main/res/layout/activity_user_survey.xml
@@ -78,6 +78,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:indeterminateTint="@color/white"
+            android:indeterminateTintMode="src_in"
             android:secondaryProgressTint="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Hi,

I found there is a issue in activity_user_survey.xml, you did not set `android:indeterminateTintMode="src_in"`, which can cause inconsistent color of ProgressBar in API Level 21. This pull request help you fix it.

Thanks and wish the information is useful for you.