### PR TITLE
Fix: Enhanced grade 'A' not shown correctly in Privacy Dashboard

### DIFF
--- a/app/src/main/res/drawable/privacygrade_icon_small_a.xml
+++ b/app/src/main/res/drawable/privacygrade_icon_small_a.xml
@@ -1,8 +1,8 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="16dp"
     android:height="16dp"
-    android:viewportWidth="16"
-    android:viewportHeight="16">
+    android:viewportWidth="24"
+    android:viewportHeight="24">
   <path
       android:pathData="M12,23C5.925,23 1,18.075 1,12S5.925,1 12,1s11,4.925 11,11 -4.925,11 -11,11zM16.758,16.4l-3.534,-9.171h-2.448L7.242,16.4h2.214l0.578,-1.554h3.932l0.578,1.554h2.213zM13.43,13.128h-2.86L12,9.18l1.43,3.947z"
       android:fillColor="#3FA047"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1173797528771833/f
Tech Design URL: 
CC: 

**Description**:
Reported issue: https://github.com/duckduckgo/Android/issues/802

When showing enhanced grade 'A' in Privacy Dashboard, letter gets rendered out of view bounds. 

| Before | After |
| - | - |
| Before | After |
<image src="https://user-images.githubusercontent.com/4747865/81266064-667f0e00-9044-11ea-8c86-680f99ad8b84.png" width="300px"/>|<image src="https://user-images.githubusercontent.com/4747865/81266133-86aecd00-9044-11ea-824e-a66372a30c08.png" width="360px"/>|

**Steps to test this PR**:
1. Visit github.com
1. Access privacy dashboard
1. Ensure A privacy grade is displayed correctly


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
