### PR TITLE
Fix Pressing back when new tab is open does not return to the previous tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -638,6 +638,9 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope, DaxDialogLi
             is Command.ShowErrorWithAction -> showErrorSnackbar(it)
             is Command.DaxCommand.FinishTrackerAnimation -> finishTrackerAnimation()
             is Command.DaxCommand.HideDaxDialog -> showHideTipsDialog(it.cta)
+            is Command.CloseCurrentTab -> {
+                viewModel.closeCurrentTab()
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -199,6 +199,7 @@ class BrowserTabViewModel(
             object FinishTrackerAnimation : DaxCommand()
             class HideDaxDialog(val cta: Cta) : DaxCommand()
         }
+        object CloseCurrentTab : Command()
     }
 
     val autoCompleteViewState: MutableLiveData<AutoCompleteViewState> = MutableLiveData()
@@ -422,7 +423,10 @@ class BrowserTabViewModel(
         if (navigation.canGoBack) {
             command.value = NavigateBack(navigation.stepsToPreviousPage)
             return true
-        } else if (!skipHome) {
+        }else if ((tabs.value?.size?:0) > 0) {
+            command.value = CloseCurrentTab
+            return true
+        }  else if (!skipHome) {
             navigateHome()
             return true
         }


### PR DESCRIPTION
Issue URL: [815](https://github.com/duckduckgo/Android/issues/815)

**Steps to test this PR**:
1. Navigate to any website
2. Open any link as new tab
3. Press back button then tab will close and return the previous tab
 
