### PR TITLE
added variants for serp header experiments

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -61,7 +61,7 @@ class VariantManagerTest {
 
     }
 
-    // SERP Header Experiment
+    // Single Search Bar Experiments
     @Test
     fun serpHeaderControlVariantHasExpectedWeightAndNoFeatures() {
         val variant = variants.first { it.key == "zf" }
@@ -70,17 +70,19 @@ class VariantManagerTest {
     }
 
     @Test
-    fun serpHeaderVariantHasExpectedWeightAndSERPRemovalFeature() {
-        val variant = variants.first { it.key == "zg" }
-        assertEqualsDouble(1.0, variant.weight)
-        assertEquals(1, variant.features.size)
-    }
-
-    @Test
-    fun serpHeaderVariantHasExpectedWeightAndSERPHeaderReplaceFeature() {
+    fun serpHeaderVariantHasExpectedWeightAndSERPHeaderRemovalFeature() {
         val variant = variants.first { it.key == "zh" }
         assertEqualsDouble(1.0, variant.weight)
         assertEquals(1, variant.features.size)
+        assertEquals(SerpHeaderRemoval, variant.features[0])
+    }
+
+    @Test
+    fun serpHeaderVariantHasExpectedWeightAndSERPHeaderQueryReplacementFeature() {
+        val variant = variants.first { it.key == "zg" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertEquals(SerpHeaderQueryReplacement, variant.features[0])
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -58,6 +58,29 @@ class VariantManagerTest {
         assertEqualsDouble(1.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(BottomBarNavigation))
+
+    }
+
+    // SERP Header Experiment
+    @Test
+    fun serpHeaderControlVariantHasExpectedWeightAndNoFeatures() {
+        val variant = variants.first { it.key == "zf" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(0, variant.features.size)
+    }
+
+    @Test
+    fun serpHeaderVariantHasExpectedWeightAndSERPRemovalFeature() {
+        val variant = variants.first { it.key == "zg" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+    }
+
+    @Test
+    fun serpHeaderVariantHasExpectedWeightAndSERPHeaderReplaceFeature() {
+        val variant = variants.first { it.key == "zh" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -30,6 +30,8 @@ interface VariantManager {
     // variant-dependant features listed here
     sealed class VariantFeature {
         object BottomBarNavigation : VariantFeature()
+        object SerpHeaderQueryReplacement : VariantFeature()
+        object SerpHeaderRemoval : VariantFeature()
     }
 
     companion object {
@@ -55,6 +57,23 @@ interface VariantManager {
                 key = "mk",
                 weight = 1.0,
                 features = listOf(BottomBarNavigation),
+                filterBy = { noFilter() }),
+
+            // SERP Header Experiment
+            Variant(
+                key = "zf",
+                weight = 1.0,
+                features = emptyList(),
+                filterBy = { noFilter() }),
+            Variant(
+                key = "zg",
+                weight = 1.0,
+                features = listOf(VariantFeature.SerpHeaderQueryReplacement),
+                filterBy = { noFilter() }),
+            Variant(
+                key = "zh",
+                weight = 1.0,
+                features = listOf(VariantFeature.SerpHeaderRemoval),
                 filterBy = { noFilter() })
 
             // All groups in an experiment (control and variants) MUST use the same filters


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/715106103902962/1175100132980404

**Description**:
In preparation for the new SERP header features we want to add the new variants that represent them.

The experiment definition can be found [here](https://app.asana.com/0/1157893581871903/1174053487728482)

**Steps to test this PR**:
There are no visual identifications of the feature, but the `VariantManagerTest` hast the tests that verify the new variants.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
