### PR TITLE
Feature/david/serp header experiment url replacement

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -49,9 +49,12 @@ import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.DismissedCta
-import com.duckduckgo.app.cta.ui.*
+import com.duckduckgo.app.cta.ui.Cta
+import com.duckduckgo.app.cta.ui.CtaViewModel
+import com.duckduckgo.app.cta.ui.DaxBubbleCta
+import com.duckduckgo.app.cta.ui.DaxDialogCta
+import com.duckduckgo.app.cta.ui.HomePanelCta
 import com.duckduckgo.app.global.db.AppDatabase
-import com.duckduckgo.app.cta.ui.HomeTopPanelCta
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.onboarding.store.OnboardingStore
@@ -62,7 +65,6 @@ import com.duckduckgo.app.privacy.model.TestEntity
 import com.duckduckgo.app.privacy.store.PrivacySettingsStore
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
@@ -76,7 +78,14 @@ import com.duckduckgo.app.trackerdetection.EntityLookup
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.atLeastOnce
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.firstValue
+import com.nhaarman.mockitokotlin2.lastValue
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Observable
 import io.reactivex.Single
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -87,10 +96,14 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.*
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
 import java.util.concurrent.TimeUnit
 
 @ExperimentalCoroutinesApi
@@ -348,7 +361,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenSubmittedQueryHasWhitespaceItIsTrimmed() {
         testee.onUserSubmittedQuery(" nytimes.com ")
-
         assertEquals("nytimes.com", omnibarViewState().omnibarText)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -62,6 +62,7 @@ import com.duckduckgo.app.privacy.model.TestEntity
 import com.duckduckgo.app.privacy.store.PrivacySettingsStore
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
@@ -347,12 +348,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenSubmittedQueryHasWhitespaceItIsTrimmed() {
         testee.onUserSubmittedQuery(" nytimes.com ")
-        assertEquals("nytimes.com", omnibarViewState().omnibarText)
-    }
 
-    @Test
-    fun whenSubmittedQueryIsDDGWhitespaceItIsTrimmed() {
-        testee.onUserSubmittedQuery(" nytimes.com ")
         assertEquals("nytimes.com", omnibarViewState().omnibarText)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -242,6 +242,7 @@ class BrowserTabViewModelTest {
             ctaViewModel = ctaViewModel,
             searchCountDao = mockSearchCountDao,
             pixel = mockPixel,
+            variantManager = mockVariantManager,
             dispatchers = coroutineRule.testDispatcherProvider
         )
 
@@ -345,6 +346,12 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSubmittedQueryHasWhitespaceItIsTrimmed() {
+        testee.onUserSubmittedQuery(" nytimes.com ")
+        assertEquals("nytimes.com", omnibarViewState().omnibarText)
+    }
+
+    @Test
+    fun whenSubmittedQueryIsDDGWhitespaceItIsTrimmed() {
         testee.onUserSubmittedQuery(" nytimes.com ")
         assertEquals("nytimes.com", omnibarViewState().omnibarText)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -58,6 +58,29 @@ class VariantManagerTest {
         assertEqualsDouble(1.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(BottomBarNavigation))
+
+    }
+
+    // SERP Header Experiment
+    @Test
+    fun serpHeaderControlVariantHasExpectedWeightAndNoFeatures() {
+        val variant = variants.first { it.key == "zf" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(0, variant.features.size)
+    }
+
+    @Test
+    fun serpHeaderVariantHasExpectedWeightAndSERPRemovalFeature() {
+        val variant = variants.first { it.key == "zg" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+    }
+
+    @Test
+    fun serpHeaderVariantHasExpectedWeightAndSERPHeaderReplaceFeature() {
+        val variant = variants.first { it.key == "zh" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -531,17 +531,15 @@ class BrowserTabViewModel(
     private fun omnibarTextForUrl(url: String?): String {
         if (url == null) return ""
 
-        return if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SerpHeaderQueryReplacement)) {
-            url
-        } else {
-            if (duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)) {
-                duckDuckGoUrlDetector.extractQuery(url) ?: url
-            } else {
-                url
-            }
+        if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SerpHeaderQueryReplacement)) {
+            return url
         }
 
-        return url
+        return if (duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)) {
+            duckDuckGoUrlDetector.extractQuery(url) ?: url
+        } else {
+            url
+        }
     }
 
     private fun pageCleared() {

--- a/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
@@ -196,7 +196,8 @@ class ViewModelFactory @Inject constructor(
         addToHomeCapabilityDetector = addToHomeCapabilityDetector,
         ctaViewModel = ctaViewModel,
         searchCountDao = searchCountDao,
-        pixel = pixel
+        pixel = pixel,
+        variantManager = variantManager
     )
 
     private fun changeAppIconViewModel() =

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -50,19 +50,19 @@ interface VariantManager {
             // Bottom Bar Navigation Experiment
             Variant(
                 key = "mb",
-                weight = 1.0,
+                weight = 0.0,
                 features = emptyList(),
                 filterBy = { noFilter() }),
             Variant(
                 key = "mk",
-                weight = 1.0,
+                weight = 0.0,
                 features = listOf(BottomBarNavigation),
                 filterBy = { noFilter() }),
 
             // SERP Header Experiment
             Variant(
                 key = "zf",
-                weight = 1.0,
+                weight = 0.0,
                 features = emptyList(),
                 filterBy = { noFilter() }),
             Variant(
@@ -72,7 +72,7 @@ interface VariantManager {
                 filterBy = { noFilter() }),
             Variant(
                 key = "zh",
-                weight = 1.0,
+                weight = 0.0,
                 features = listOf(VariantFeature.SerpHeaderRemoval),
                 filterBy = { noFilter() })
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -30,6 +30,8 @@ interface VariantManager {
     // variant-dependant features listed here
     sealed class VariantFeature {
         object BottomBarNavigation : VariantFeature()
+        object SerpHeaderQueryReplacement : VariantFeature()
+        object SerpHeaderRemoval : VariantFeature()
     }
 
     companion object {
@@ -55,6 +57,23 @@ interface VariantManager {
                 key = "mk",
                 weight = 1.0,
                 features = listOf(BottomBarNavigation),
+                filterBy = { noFilter() }),
+
+            // SERP Header Experiment
+            Variant(
+                key = "zf",
+                weight = 1.0,
+                features = emptyList(),
+                filterBy = { noFilter() }),
+            Variant(
+                key = "zg",
+                weight = 1.0,
+                features = listOf(VariantFeature.SerpHeaderQueryReplacement),
+                filterBy = { noFilter() }),
+            Variant(
+                key = "zh",
+                weight = 1.0,
+                features = listOf(VariantFeature.SerpHeaderRemoval),
                 filterBy = { noFilter() })
 
             // All groups in an experiment (control and variants) MUST use the same filters

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -59,7 +59,7 @@ interface VariantManager {
                 features = listOf(BottomBarNavigation),
                 filterBy = { noFilter() }),
 
-            // SERP Header Experiment
+            // Single Search Bar Experiments
             Variant(
                 key = "zf",
                 weight = 1.0,

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -50,19 +50,19 @@ interface VariantManager {
             // Bottom Bar Navigation Experiment
             Variant(
                 key = "mb",
-                weight = 0.0,
+                weight = 1.0,
                 features = emptyList(),
                 filterBy = { noFilter() }),
             Variant(
                 key = "mk",
-                weight = 0.0,
+                weight = 1.0,
                 features = listOf(BottomBarNavigation),
                 filterBy = { noFilter() }),
 
             // SERP Header Experiment
             Variant(
                 key = "zf",
-                weight = 0.0,
+                weight = 1.0,
                 features = emptyList(),
                 filterBy = { noFilter() }),
             Variant(
@@ -72,7 +72,7 @@ interface VariantManager {
                 filterBy = { noFilter() }),
             Variant(
                 key = "zh",
-                weight = 0.0,
+                weight = 1.0,
                 features = listOf(VariantFeature.SerpHeaderRemoval),
                 filterBy = { noFilter() })
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1175100132980402

**Description**:
This experiment variant wants to show the full DDG url instead of the search query. In order to do that we'll show URL that is sent to the WebView.

**Steps to test this PR**:
1. Open app and enable variant `zg`
2. Make a search query in the native omnibar
3. After loading the page, the omnibar should show the full URL

1. Open app and enable variant `zg`
2. Make a search query in the SERP header
3. After loading the page, the omnibar should show the full URL

**Screenshots**:
![Screenshot_1589201518](https://user-images.githubusercontent.com/531613/81563791-0ca97b80-9397-11ea-94b7-8c64add1b048.png)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
