### PR TITLE
Fix privacy grade bugs

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -653,6 +653,15 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenProgressChangesButIsTheSameAsBeforeThenDoNotUpdateState() {
+        setBrowserShowing(true)
+        testee.progressChanged(100)
+        testee.stopShowingEmptyGrade()
+        testee.progressChanged(100)
+        assertFalse(privacyGradeState().showEmptyGrade)
+    }
+
+    @Test
     fun whenNotShowingEmptyGradeAndPrivacyGradeIsNotUnknownThenIsEnableIsTrue() {
         val testee = BrowserTabViewModel.PrivacyGradeViewState(PrivacyGrade.A, shouldAnimate = false, showEmptyGrade = false)
         assertTrue(testee.isEnabled)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -565,10 +565,6 @@ class BrowserTabViewModelTest {
     fun whenBrowsingAndViewModelGetsProgressUpdateLowerThan50ThenViewStateIsUpdatedTo50() {
         setBrowserShowing(true)
 
-        testee.progressChanged(0)
-        assertEquals(50, loadingViewState().progress)
-        assertEquals(true, loadingViewState().isLoading)
-
         testee.progressChanged(15)
         assertEquals(50, loadingViewState().progress)
         assertEquals(true, loadingViewState().isLoading)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1512,7 +1512,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope, DaxDialogLi
 
                 if (canChangeGrade) {
                     context?.let {
-                        val drawable = if (viewState.showEmptyGrade) {
+                        val drawable = if (viewState.showEmptyGrade || viewState.shouldAnimate) {
                             ContextCompat.getDrawable(it, R.drawable.privacygrade_icon_loading)
                         } else {
                             ContextCompat.getDrawable(it, viewState.privacyGrade.icon())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -615,6 +615,7 @@ class BrowserTabViewModel(
         if (!currentBrowserViewState().browserShowing) return
         val isLoading = newProgress < 100
         val progress = currentLoadingViewState()
+        if (progress.progress == newProgress) return
         val visualProgress = if (newProgress < FIXED_PROGRESS) {
             FIXED_PROGRESS
         } else {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1176838543253371 
Tech Design URL: 
CC: 

**Description**:
There are two bugs related with the new privacy grade animation.

**Grade does not show in SERP**
In some cases we get notified twice about the progress reaching 100, when this happens the state of the privacy changes to be hidden.

1. Go to cnn.com, animation happens as usual.
1. Go to SERP, you can briefly see the grade and then it disappears.

**Grade shows during the animation for a brief time**
In some cases while navigating to a different page you can see the old grade showing up during the animation for a split second. This happens because the privacy state returns shouldAnimate as true and showEmptyGrade as false, showEmptyGrade takes precedence and hides the grade.

1. Go to SERP.
1. Go to cnn.com, you can briefly see the A grade during the animation.

**Steps to test this PR**:
1. Go to cnn.com
1. Go to SERP and notice how we show the A grade as usual.

**Second scenario**
1. Go to SERP.
1. Go to cnn.com, previous grade does not show during the animation.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
