### PR TITLE
Feature/craig/check for downloadmanager before downloading

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/DataUriDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/DataUriDownloader.kt
@@ -38,7 +38,7 @@ class DataUriDownloader @Inject constructor(
             when (val parsedDataUri = dataUriParser.generate(pending.url)) {
                 is ParseResult.Invalid -> {
                     Timber.w("Failed to extract data from data URI")
-                    callback?.downloadFailed("Failed to extract data from data URI")
+                    callback?.downloadFailed("Failed to extract data from data URI", DownloadFailReason.DataUriParseException)
                     return
                 }
                 is ParseResult.ParsedDataUri -> {
@@ -50,7 +50,7 @@ class DataUriDownloader @Inject constructor(
             }
         } catch (e: IOException) {
             Timber.e(e, "Failed to save data uri")
-            callback?.downloadFailed("Failed to download data uri")
+            callback?.downloadFailed("Failed to download data uri", DownloadFailReason.DataUriParseException)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloadNotificationManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloadNotificationManager.kt
@@ -70,7 +70,6 @@ class FileDownloadNotificationManager @Inject constructor(
 
     fun showDownloadFailedNotification() {
         applicationContext.runOnUiThread {
-            applicationContext.longToast(getString(R.string.downloadFailed))
 
             val notification = NotificationCompat.Builder(applicationContext, ChannelType.FILE_DOWNLOADED.id)
                 .setContentTitle(applicationContext.getString(R.string.downloadFailed))

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/NetworkFileDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/NetworkFileDownloader.kt
@@ -18,14 +18,22 @@ package com.duckduckgo.app.browser.downloader
 
 import android.app.DownloadManager
 import android.content.Context
+import android.content.pm.PackageManager.*
 import android.webkit.CookieManager
 import androidx.core.net.toUri
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import javax.inject.Inject
 
 class NetworkFileDownloader @Inject constructor(private val context: Context) {
 
-    fun download(pendingDownload: PendingFileDownload) {
+    fun download(pendingDownload: PendingFileDownload, callback: FileDownloader.FileDownloadListener) {
+
+        if (!downloadManagerAvailable()) {
+            callback.downloadFailed(context.getString(R.string.downloadManagerDisabled), DownloadFailReason.DownloadManagerDisabled)
+            return
+        }
+
         val guessedFileName = pendingDownload.guessFileName()
 
         val request = DownloadManager.Request(pendingDownload.url.toUri()).apply {
@@ -38,5 +46,18 @@ class NetworkFileDownloader @Inject constructor(private val context: Context) {
         }
         val manager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager?
         manager?.enqueue(request)
+    }
+
+    private fun downloadManagerAvailable(): Boolean {
+        return when (context.packageManager.getApplicationEnabledSetting(DOWNLOAD_MANAGER_PACKAGE)) {
+            COMPONENT_ENABLED_STATE_DISABLED -> false
+            COMPONENT_ENABLED_STATE_DISABLED_USER -> false
+            COMPONENT_ENABLED_STATE_DISABLED_UNTIL_USED -> false
+            else -> true
+        }
+    }
+
+    companion object {
+        private const val DOWNLOAD_MANAGER_PACKAGE = "com.android.providers.downloads"
     }
 }

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -71,7 +71,7 @@
     <string name="fireproofWebsiteOverflowContentDescription">More options for fireproof website %s</string>
 
     <!-- Download Manager problems -->
-    <string name="downloadManagerDisabled">Download failed because Download Manager is disabled</string>
+    <string name="downloadManagerDisabled">Download Manager is disabled</string>
     <string name="downloadManagerIncompatible">Download Manager not available on this device</string>
     <string name="enable">Enable</string>
 

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -69,4 +69,10 @@
     <string name="fireproofWebsiteEmptyListHint">No websites fireproofed yet</string>
     <string name="fireproofWebsiteFeatureDescription">Websites rely on cookies to keep you signed in. When you Fireproof a site, cookies won\'t be erased and you\'ll stay signed in, even after using the Fire Button.</string>
     <string name="fireproofWebsiteOverflowContentDescription">More options for fireproof website %s</string>
+
+    <!-- Download Manager problems -->
+    <string name="downloadManagerDisabled">Download failed because Download Manager is disabled</string>
+    <string name="downloadManagerIncompatible">Download Manager not available on this device</string>
+    <string name="enable">Enable</string>
+
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1177254132666789
Tech Design URL: 
CC: 

**Description**:
Check for `DownloadManager` being disabled before downloading files to prevent a crash

Useful for testing: being able to go disable `DownloadManager`

        val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
        intent.data = Uri.parse("package:com.android.providers.downloads")
        startActivity(intent)


**Steps to test this PR**:
1. Disable `DownloadManager` (see above)
1. Attempt to download a file (e.g, http://www.granditaliaperth.co.uk/menus.html and find the download link)
1. Verify the app doesn't crash, and that a snackbar is shown
1. Click on `ENABLE`
1. Verify download manager app settings screen is shown
1. Enable `DownloadManager`
1. Try download again


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
