### PR TITLE
Feature/craig/fix overflow menu state upon navigating back home

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1831,6 +1831,62 @@ class BrowserTabViewModelTest {
         verify(mockPixel).fire(Pixel.PixelName.FIREPROOF_WEBSITE_UNDO)
     }
 
+    @Test
+    fun whenUserBrowsingPressesBackThenCannotAddBookmark() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        assertTrue(testee.onUserPressedBack())
+        assertFalse(browserViewState().canAddBookmarks)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackThenCannotSharePage() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        assertTrue(testee.onUserPressedBack())
+        assertFalse(browserViewState().canSharePage)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackThenCannotReportSite() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        assertTrue(testee.onUserPressedBack())
+        assertFalse(browserViewState().canReportSite)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackThenCannotAddToHome() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        assertTrue(testee.onUserPressedBack())
+        assertFalse(browserViewState().addToHomeEnabled)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackThenCannotWhitelist() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        assertTrue(testee.onUserPressedBack())
+        assertFalse(browserViewState().canWhitelist)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackThenCannotNavigateBack() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        assertTrue(testee.onUserPressedBack())
+        assertFalse(browserViewState().canGoBack)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackThenCannotFindInPage() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        assertTrue(testee.onUserPressedBack())
+        assertFalse(findInPageViewState().canFindInPage)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackThenCanGoForward() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        assertTrue(testee.onUserPressedBack())
+        assertTrue(browserViewState().canGoForward)
+    }
+
     private inline fun <reified T : Command> assertCommandIssued(instanceAssertions: T.() -> Unit = {}) {
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         val issuedCommand = commandCaptor.allValues.find { it is T }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1887,6 +1887,54 @@ class BrowserTabViewModelTest {
         assertTrue(browserViewState().canGoForward)
     }
 
+    @Test
+    fun whenUserBrowsingPressesBackAndForwardThenCanAddBookmark() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        testee.onUserPressedBack()
+        testee.onUserPressedForward()
+        assertTrue(browserViewState().canAddBookmarks)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackAndForwardThenCanWhitelist() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        testee.onUserPressedBack()
+        testee.onUserPressedForward()
+        assertTrue(browserViewState().canWhitelist)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackAndForwardThenCanShare() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        testee.onUserPressedBack()
+        testee.onUserPressedForward()
+        assertTrue(browserViewState().canSharePage)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackAndForwardThenCanReportSite() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        testee.onUserPressedBack()
+        testee.onUserPressedForward()
+        assertTrue(browserViewState().canReportSite)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackAndForwardThenCanAddToHome() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        testee.onUserPressedBack()
+        testee.onUserPressedForward()
+        assertTrue(browserViewState().addToHomeEnabled)
+    }
+
+    @Test
+    fun whenUserBrowsingPressesBackAndForwardThenCanFindInPage() {
+        setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
+        testee.onUserPressedBack()
+        testee.onUserPressedForward()
+        assertTrue(findInPageViewState().canFindInPage)
+    }
+
     private inline fun <reified T : Command> assertCommandIssued(instanceAssertions: T.() -> Unit = {}) {
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         val issuedCommand = commandCaptor.allValues.find { it is T }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserStateModifier.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserStateModifier.kt
@@ -1,0 +1,5 @@
+package com.duckduckgo.app.browser
+
+
+interface BrowserStateModifier {
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserStateModifier.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserStateModifier.kt
@@ -1,5 +1,50 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.duckduckgo.app.browser
 
+import com.duckduckgo.app.browser.BrowserTabViewModel.BrowserViewState
+import io.reactivex.annotations.CheckReturnValue
 
-interface BrowserStateModifier {
+class BrowserStateModifier {
+
+    @CheckReturnValue
+    fun copyForBrowserShowing(original: BrowserViewState): BrowserViewState {
+        return original.copy(
+            browserShowing = true,
+            canWhitelist = true,
+            canFireproofSite = true,
+            canReportSite = true,
+            canSharePage = true,
+            canAddBookmarks = true,
+            addToHomeEnabled = true
+        )
+    }
+
+    @CheckReturnValue
+    fun copyForHomeShowing(original: BrowserViewState): BrowserViewState {
+        return original.copy(
+            browserShowing = false,
+            canWhitelist = false,
+            canFireproofSite = false,
+            canReportSite = false,
+            canSharePage = false,
+            canAddBookmarks = false,
+            addToHomeEnabled = false,
+            canGoBack = false
+        )
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -249,6 +249,7 @@ class BrowserTabViewModel(
     private lateinit var tabId: String
     private var webNavigationState: WebNavigationState? = null
     private var httpsUpgraded = false
+    private val browserStateModifier = BrowserStateModifier()
     private val fireproofWebsitesObserver = Observer<List<FireproofWebsiteEntity>> {
         browserViewState.value = currentBrowserViewState().copy(canFireproofSite = canFireproofWebsite())
     }
@@ -417,7 +418,8 @@ class BrowserTabViewModel(
 
     fun onUserPressedForward() {
         if (!currentBrowserViewState().browserShowing) {
-            browserViewState.value = currentBrowserViewState().copy(browserShowing = true)
+            browserViewState.value = browserStateModifier.copyForBrowserShowing(currentBrowserViewState())
+            findInPageViewState.value = currentFindInPageViewState().copy(canFindInPage = true)
             command.value = Refresh
         } else {
             command.value = NavigateForward
@@ -467,17 +469,10 @@ class BrowserTabViewModel(
         site = null
         onSiteChanged()
 
-        browserViewState.value = currentBrowserViewState().copy(
-            browserShowing = false,
-            canGoBack = false,
-            canFireproofSite = false,
-            canSharePage = false,
-            canAddBookmarks = false,
-            canReportSite = false,
-            addToHomeEnabled = false,
-            canWhitelist = false,
+        val browserState = browserStateModifier.copyForHomeShowing(currentBrowserViewState()).copy(
             canGoForward = currentGlobalLayoutState() !is Invalidated
         )
+        browserViewState.value = browserState
 
         findInPageViewState.value = FindInPageViewState()
         omnibarViewState.value = currentOmnibarViewState().copy(omnibarText = "", shouldMoveCaretToEnd = false)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -471,8 +471,15 @@ class BrowserTabViewModel(
             browserShowing = false,
             canGoBack = false,
             canFireproofSite = false,
+            canSharePage = false,
+            canAddBookmarks = false,
+            canReportSite = false,
+            addToHomeEnabled = false,
+            canWhitelist = false,
             canGoForward = currentGlobalLayoutState() !is Invalidated
         )
+
+        findInPageViewState.value = FindInPageViewState()
         omnibarViewState.value = currentOmnibarViewState().copy(omnibarText = "", shouldMoveCaretToEnd = false)
         loadingViewState.value = currentLoadingViewState().copy(isLoading = false)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -468,6 +468,7 @@ class BrowserTabViewModel(
     private fun navigateHome() {
         site = null
         onSiteChanged()
+        webNavigationState = null
 
         val browserState = browserStateModifier.copyForHomeShowing(currentBrowserViewState()).copy(
             canGoForward = currentGlobalLayoutState() !is Invalidated


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 

- https://app.asana.com/0/1154922490698650/1170812542831705
- https://app.asana.com/0/1154922490698650/1178243318846520


**Description**:
Fixes the navigation state problems for the overflow and privacy grade.

**Steps to test this PR**:
1. From a fresh tab, perform a search
1. Go back to return to blank tab
1. Verify the overflow menu options are correct for this state. Everything disabled except:[go forward, bookmarks desktop site, settings]
1. Go forward to return to SERP
1. Verify the privacy grade shown correctly as `A`
1. Verify the overflow menu options are correct; everything enabled except `go forward`


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
