### PR TITLE
Initial working implementation of webview darkmode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -320,7 +320,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope, DaxDialogLi
 
             @OnLifecycleEvent(Lifecycle.Event.ON_START)
             fun onStart() {
-                if (isVisible && WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
                     WebSettingsCompat.setForceDark(webView!!.settings,
                             if (settingsDataStore.darkMode) WebSettingsCompat.FORCE_DARK_ON
                             else WebSettingsCompat.FORCE_DARK_OFF)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -56,6 +56,8 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.app.bookmarks.ui.EditBookmarkDialogFragment
 import com.duckduckgo.app.brokensite.BrokenSiteActivity
@@ -87,6 +89,7 @@ import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.app.global.model.orderedTrackingEntities
 import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.privacy.renderer.icon
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.model.Survey
@@ -185,6 +188,9 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope, DaxDialogLi
 
     @Inject
     lateinit var variantManager: VariantManager
+
+    @Inject
+    lateinit var settingsDataStore: SettingsDataStore
 
     val tabId get() = requireArguments()[TAB_ID_ARG] as String
 
@@ -309,6 +315,15 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope, DaxDialogLi
             fun onStop() {
                 if (isVisible) {
                     updateOrDeleteWebViewPreview()
+                }
+            }
+
+            @OnLifecycleEvent(Lifecycle.Event.ON_START)
+            fun onStart() {
+                if (isVisible && WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                    WebSettingsCompat.setForceDark(webView!!.settings,
+                            if (settingsDataStore.darkMode) WebSettingsCompat.FORCE_DARK_ON
+                            else WebSettingsCompat.FORCE_DARK_OFF)
                 }
             }
         })

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -62,6 +62,10 @@ class SettingsActivity : DuckDuckGoActivity(), SettingsAutomaticallyClearWhatFra
         viewModel.onLightThemeToggled(isChecked)
     }
 
+    private val darkModeToggleListener = OnCheckedChangeListener { _, isChecked ->
+        viewModel.onDarkModeToggled(isChecked)
+    }
+
     private val autocompleteToggleListener = OnCheckedChangeListener { _, isChecked ->
         viewModel.onAutocompleteSettingChanged(isChecked)
     }
@@ -87,6 +91,7 @@ class SettingsActivity : DuckDuckGoActivity(), SettingsAutomaticallyClearWhatFra
         fireproofWebsites.setOnClickListener { viewModel.onFireproofWebsitesClicked() }
 
         lightThemeToggle.setOnCheckedChangeListener(lightThemeToggleListener)
+        darkModeToogle.setOnCheckedChangeListener(darkModeToggleListener)
         autocompleteToggle.setOnCheckedChangeListener(autocompleteToggleListener)
         setAsDefaultBrowserSetting.setOnCheckedChangeListener(defaultBrowserChangeListener)
         automaticallyClearWhatSetting.setOnClickListener { launchAutomaticallyClearWhatDialog() }
@@ -99,6 +104,7 @@ class SettingsActivity : DuckDuckGoActivity(), SettingsAutomaticallyClearWhatFra
             viewState?.let {
                 version.setSubtitle(it.version)
                 lightThemeToggle.quietlySetIsChecked(it.lightThemeEnabled, lightThemeToggleListener)
+                darkModeToogle.quietlySetIsChecked(it.darkModeEnabled, darkModeToggleListener)
                 autocompleteToggle.quietlySetIsChecked(it.autoCompleteSuggestionsEnabled, autocompleteToggleListener)
                 updateDefaultBrowserViewVisibility(it)
                 updateAutomaticClearDataOptions(it.automaticallyClearData)

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -87,7 +87,7 @@ class SettingsViewModel @Inject constructor(
         viewState.value = currentViewState().copy(
             loading = false,
             lightThemeEnabled = isLightTheme,
-                darkModeEnabled = settingsDataStore.darkMode,
+            darkModeEnabled = settingsDataStore.darkMode,
             autoCompleteSuggestionsEnabled = settingsDataStore.autoCompleteSuggestionsEnabled,
             isAppDefaultBrowser = defaultBrowserAlready,
             showDefaultBrowserSetting = defaultWebBrowserCapability.deviceSupportsDefaultBrowserConfiguration(),

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -44,6 +44,7 @@ class SettingsViewModel @Inject constructor(
         val loading: Boolean = true,
         val version: String = "",
         val lightThemeEnabled: Boolean = false,
+        val darkModeEnabled: Boolean = false,
         val autoCompleteSuggestionsEnabled: Boolean = true,
         val showDefaultBrowserSetting: Boolean = false,
         val isAppDefaultBrowser: Boolean = false,
@@ -86,6 +87,7 @@ class SettingsViewModel @Inject constructor(
         viewState.value = currentViewState().copy(
             loading = false,
             lightThemeEnabled = isLightTheme,
+                darkModeEnabled = settingsDataStore.darkMode,
             autoCompleteSuggestionsEnabled = settingsDataStore.autoCompleteSuggestionsEnabled,
             isAppDefaultBrowser = defaultBrowserAlready,
             showDefaultBrowserSetting = defaultWebBrowserCapability.deviceSupportsDefaultBrowserConfiguration(),
@@ -115,6 +117,12 @@ class SettingsViewModel @Inject constructor(
 
         val pixelName = if (enabled) SETTINGS_THEME_TOGGLED_LIGHT else SETTINGS_THEME_TOGGLED_DARK
         pixel.fire(pixelName)
+    }
+
+    fun onDarkModeToggled(enabled: Boolean) {
+        Timber.i("User toggled dark mode, is now enabled: $enabled")
+        settingsDataStore.darkMode = enabled
+        viewState.value = currentViewState().copy(darkModeEnabled = enabled)
     }
 
     fun onAutocompleteSettingChanged(enabled: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
@@ -30,6 +30,7 @@ interface SettingsDataStore {
 
     var lastExecutedJobId: String?
     var theme: DuckDuckGoTheme?
+    var darkMode: Boolean
     var hideTips: Boolean
     var autoCompleteSuggestionsEnabled: Boolean
     var appIcon: AppIcon
@@ -70,6 +71,10 @@ class SettingsSharedPreferences @Inject constructor(private val context: Context
             return DuckDuckGoTheme.valueOf(themeName)
         }
         set(theme) = preferences.edit { putString(KEY_THEME, theme.toString()) }
+
+    override var darkMode: Boolean
+        get() = preferences.getBoolean(KEY_DARK_MODE, false)
+        set(enabled) = preferences.edit { putBoolean(KEY_DARK_MODE, enabled) }
 
     override var hideTips: Boolean
         get() = preferences.getBoolean(KEY_HIDE_TIPS, false)
@@ -143,6 +148,7 @@ class SettingsSharedPreferences @Inject constructor(private val context: Context
         const val FILENAME = "com.duckduckgo.app.settings_activity.settings"
         const val KEY_BACKGROUND_JOB_ID = "BACKGROUND_JOB_ID"
         const val KEY_THEME = "THEME"
+        const val KEY_DARK_MODE = "DARK_MODE"
         const val KEY_AUTOCOMPLETE_ENABLED = "AUTOCOMPLETE_ENABLED"
         const val KEY_AUTOMATICALLY_CLEAR_WHAT_OPTION = "AUTOMATICALLY_CLEAR_WHAT_OPTION"
         const val KEY_AUTOMATICALLY_CLEAR_WHEN_OPTION = "AUTOMATICALLY_CLEAR_WHEN_OPTION"

--- a/app/src/main/res/layout/content_settings_general.xml
+++ b/app/src/main/res/layout/content_settings_general.xml
@@ -39,13 +39,22 @@
         app:layout_constraintTop_toBottomOf="@id/settingsGeneralTitle" />
 
     <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/darkModeToogle"
+        style="@style/SettingsSwitch"
+        android:text="@string/settingsDarkMode"
+        android:theme="@style/SettingsSwitchTheme"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/lightThemeToggle" />
+
+    <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/autocompleteToggle"
         style="@style/SettingsSwitch"
         android:text="@string/settingsAutocompleteEnabled"
         android:theme="@style/SettingsSwitchTheme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/lightThemeToggle" />
+        app:layout_constraintTop_toBottomOf="@id/darkModeToogle" />
 
     <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/setAsDefaultBrowserSetting"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,7 @@
     <string name="settingsHeadingOther">Other</string>
     <string name="settingsHeadingPrivacy">Privacy</string>
     <string name="settingsLightTheme">Light Theme</string>
+    <string name="settingsDarkMode">Dark Mode</string>
     <string name="settingsAboutDuckduckgo">About DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Leave Feedback</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:  https://github.com/duckduckgo/Android/issues/840
Tech Design URL: N/A
CC: @cmonfortep 

**Description**:
Hello 👋 A few days ago I moved from Kiwi browser (chromium fork) to DuckDuckGo and the biggest missing feature was having a settings option to enable Dark Mode within the web views (not just the theme).

Since it is an open-source project I tried it out following the same code standards that I found in the codebase. Open to suggestions and alternatives.

Update: Discovered the issue after playing around on my end, see comment [here](https://github.com/duckduckgo/Android/issues/840#issuecomment-640115154).

**Steps to test this PR**:
1. Open App -> Settings -> Enable Dark Mode Switch
2. Leaving Settings should refresh dark mode on any existing Tabs
3. New tabs created should have dark mode enabled

GIF to display current feature implementation
![DuckDuckGo-DarkMode-GitHub-PR](https://user-images.githubusercontent.com/5630683/83953881-12a94580-a7f9-11ea-9fcb-9f7dd30108c2.gif)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
