### PR TITLE
sort vowels to the end of the trackers animation to avoid dodgy words

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
@@ -440,4 +440,3 @@ sealed class TrackerLogo(val resId: Int) {
     class LetterLogo(val trackerLetter: String = "", resId: Int = R.drawable.other_tracker_bg) : TrackerLogo(resId)
     class StackedLogo(resId: Int = R.drawable.other_tracker_bg) : TrackerLogo(resId)
 }
-

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
@@ -234,7 +234,7 @@ class BrowserTrackersAnimatorHelper {
             .asSequence()
             .distinct()
             .take(MAX_LOGOS_SHOWN + 1)
-            .sortedWith(compareBy { "AEIOU".contains(it.displayName[0]) })
+            .sortedWithDisplayNamesStartingWithVowelsToTheEnd()
             .map {
                 val resId = TrackersRenderer().networkLogoIcon(activity, it.name)
                 if (resId == null) {
@@ -418,6 +418,10 @@ class BrowserTrackersAnimatorHelper {
         }
     }
 
+    private fun Sequence<Entity>.sortedWithDisplayNamesStartingWithVowelsToTheEnd(): Sequence<Entity> {
+        return sortedWith(compareBy { "AEIOU".contains(it.displayName.take(1)) })
+    }
+
     companion object {
         private const val TRACKER_LOGOS_DELAY_ON_SCREEN = 2400L
         private const val DEFAULT_ANIMATION_DURATION = 150L
@@ -436,3 +440,4 @@ sealed class TrackerLogo(val resId: Int) {
     class LetterLogo(val trackerLetter: String = "", resId: Int = R.drawable.other_tracker_bg) : TrackerLogo(resId)
     class StackedLogo(resId: Int = R.drawable.other_tracker_bg) : TrackerLogo(resId)
 }
+

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTrackersAnimatorHelper.kt
@@ -234,6 +234,7 @@ class BrowserTrackersAnimatorHelper {
             .asSequence()
             .distinct()
             .take(MAX_LOGOS_SHOWN + 1)
+            .sortedWith(compareBy { "AEIOU".contains(it.displayName[0]) })
             .map {
                 val resId = TrackersRenderer().networkLogoIcon(activity, it.name)
                 if (resId == null) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1179212544274947
Tech Design URL: 
CC: 

**Description**:

Sorts the icons to show so that vowels are at the end of the list to avoid dodgy words being spelled.

**Steps to test this PR**:
1. Visit imgur.com - the tracker icons that appear should spell GYA (A might be Amazon's logo)
1. Browse a few other sites and confirm no breakage


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
