### PR TITLE
Add FireDialog theme in order to fix navigation buttons hiden on some devices

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -25,7 +25,10 @@ import kotlinx.android.synthetic.main.sheet_fire_clear_data.*
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
-class FireDialog(context: Context, private val clearPersonalDataAction: ClearPersonalDataAction) : BottomSheetDialog(context) {
+class FireDialog(
+    context: Context,
+    private val clearPersonalDataAction: ClearPersonalDataAction
+) : BottomSheetDialog(context, R.style.FireDialog) {
 
     var clearStarted: (() -> Unit) = {}
     var clearComplete: (() -> Unit) = {}

--- a/app/src/main/res/values-v27/themes.xml
+++ b/app/src/main/res/values-v27/themes.xml
@@ -30,4 +30,10 @@
         <item name="android:navigationBarColor">@color/white</item>
     </style>
 
+    <style name="FireDialog" parent="@style/Theme.Design.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:navigationBarColor">?toolbarBgColor</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -310,4 +310,10 @@
         <item name="android:textColor">?attr/colorAccent</item>
     </style>
 
+    <style name="FireDialog" parent="@style/Theme.Design.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:navigationBarColor">?toolbarBgColor</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -312,7 +312,6 @@
 
     <style name="FireDialog" parent="@style/Theme.Design.BottomSheetDialog">
         <item name="android:windowIsFloating">false</item>
-        <item name="android:navigationBarColor">?toolbarBgColor</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 


### PR DESCRIPTION
Resolves [#754 ](https://github.com/duckduckgo/Android/issues/754)

**Description**:
* Added style to `FireDialog`, and override some properties in order to fix this issue :)

1. `windowIsFloating` as `true`
2. `navigationBarColor` as `?toolbarBgColor` (light/dark theme)
3. `statusBarColor` as `@android:color/transparent`

**Tested on:**
- Pixel XL api 29 emulator
- Pixel 3XL api 29 emulator
- Pixel 3a XL api 29 device


Old  |  New
:-------------------------:|:-------------------------:
<img width="412" alt="Screen Shot 2020-06-17 at 20 45 51" src="https://user-images.githubusercontent.com/5092994/84963557-1a61c780-b0e0-11ea-900a-43bf3f51ea6b.png">  | <img width="426" alt="Screen Shot 2020-06-17 at 20 55 48" src="https://user-images.githubusercontent.com/5092994/84963564-1df54e80-b0e0-11ea-85ad-513cb0d9569e.png">

**Live preview**

<img width="450" alt="live_demo" src="https://user-images.githubusercontent.com/5092994/84963802-c0adcd00-b0e0-11ea-9c0c-2681039b7174.gif">

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
