### PR TITLE
duckduckgo#687 make cursor in feedback edit text visible

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -259,7 +259,7 @@
         <item name="android:layout_height">match_parent</item>
     </style>
 
-    <style name="BlueCursor" parent="ThemeOverlay.MaterialComponents.TextInputEditText.OutlinedBox">
+    <style name="TextInputEditTextTheme" parent="ThemeOverlay.MaterialComponents.TextInputEditText.OutlinedBox">
         <item name="android:colorControlActivated">@color/cornflowerBlue</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -268,7 +268,7 @@
         <item name="hintTextColor">@color/cornflowerBlue</item>
         <item name="android:textColorHint">?attr/feedbackEditTextHintColor</item>
         <item name="boxBackgroundColor">?attr/feedbackEditTextBackgroundColor</item>
-        <item name="android:theme">@style/BlueCursor</item>
+        <item name="android:theme">@style/TextInputEditTextTheme</item>
     </style>
 
     <style name="FeedbackEditTextInputStyle" parent="Widget.MaterialComponents.TextInputEditText.FilledBox">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -259,11 +259,16 @@
         <item name="android:layout_height">match_parent</item>
     </style>
 
+    <style name="BlueCursor" parent="ThemeOverlay.MaterialComponents.TextInputEditText.OutlinedBox">
+        <item name="android:colorControlActivated">@color/cornflowerBlue</item>
+    </style>
+
     <style name="FeedbackInputBoxStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="boxStrokeColor">@color/cornflowerBlue</item>
         <item name="hintTextColor">@color/cornflowerBlue</item>
         <item name="android:textColorHint">?attr/feedbackEditTextHintColor</item>
         <item name="boxBackgroundColor">?attr/feedbackEditTextBackgroundColor</item>
+        <item name="android:theme">@style/BlueCursor</item>
     </style>
 
     <style name="FeedbackEditTextInputStyle" parent="Widget.MaterialComponents.TextInputEditText.FilledBox">
@@ -274,7 +279,6 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">match_parent</item>
         <item name="android:gravity">top</item>
-        <item name="android:textCursorDrawable">@null</item>
         <item name="android:textColor">?attr/normalTextColor</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -274,6 +274,7 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">match_parent</item>
         <item name="android:gravity">top</item>
+        <item name="android:textCursorDrawable">@null</item>
         <item name="android:textColor">?attr/normalTextColor</item>
     </style>
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
Tech Design URL: https://github.com/duckduckgo/Android/issues/687
CC: 

**Description**:
![image](https://user-images.githubusercontent.com/8261416/85942066-dad87e00-b91e-11ea-8715-50ef3091648a.png)


**Steps to test this PR**:
1. go to feedback form
1. type something
1. see cursor appearing



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
