### PR TITLE
Deactivate experiment: Android: Test notification drip campaign with inactive users

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -46,9 +46,9 @@ class VariantManagerTest {
     // Notification Drip Experiment
 
     @Test
-    fun notificationDripTestControlGroupVariantActive() {
+    fun notificationDripTestControlGroupVariantIsNotActive() {
         val variant = variants.firstOrNull { it.key == "za" }
-        assertEqualsDouble(1.0, variant!!.weight)
+        assertEqualsDouble(0.0, variant!!.weight)
     }
 
     @Test
@@ -61,9 +61,9 @@ class VariantManagerTest {
     }
 
     @Test
-    fun notificationDripTestNullVariantActive() {
+    fun notificationDripTestNullVariantIsNotActive() {
         val variant = variants.firstOrNull { it.key == "zb" }
-        assertEqualsDouble(1.0, variant!!.weight)
+        assertEqualsDouble(0.0, variant!!.weight)
     }
 
     @Test
@@ -74,9 +74,9 @@ class VariantManagerTest {
     }
 
     @Test
-    fun notificationDripA1TestVariantActive() {
+    fun notificationDripA1TestVariantIsNotActive() {
         val variant = variants.firstOrNull { it.key == "zc" }
-        assertEqualsDouble(1.0, variant!!.weight)
+        assertEqualsDouble(0.0, variant!!.weight)
     }
 
     @Test
@@ -89,9 +89,9 @@ class VariantManagerTest {
     }
 
     @Test
-    fun notificationDripA2TestVariantActive() {
+    fun notificationDripA2TestVariantIsNotActive() {
         val variant = variants.firstOrNull { it.key == "zd" }
-        assertEqualsDouble(1.0, variant!!.weight)
+        assertEqualsDouble(0.0, variant!!.weight)
     }
 
     @Test
@@ -104,9 +104,9 @@ class VariantManagerTest {
     }
 
     @Test
-    fun notificationDripB1TestVariantActive() {
+    fun notificationDripB1TestVariantIsNotActive() {
         val variant = variants.firstOrNull { it.key == "ze" }
-        assertEqualsDouble(1.0, variant!!.weight)
+        assertEqualsDouble(0.0, variant!!.weight)
     }
 
     @Test
@@ -119,9 +119,9 @@ class VariantManagerTest {
     }
 
     @Test
-    fun notificationDripB2TestVariantActive() {
+    fun notificationDripB2TestVariantIsNotActive() {
         val variant = variants.firstOrNull { it.key == "zf" }
-        assertEqualsDouble(1.0, variant!!.weight)
+        assertEqualsDouble(0.0, variant!!.weight)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -55,32 +55,32 @@ interface VariantManager {
             // Notification Drip Experiment
             Variant(
                 key = "za",
-                weight = 1.0,
+                weight = 0.0,
                 features = listOf(VariantFeature.DripNotification, VariantFeature.Day1PrivacyNotification, VariantFeature.Day3ClearDataNotification),
                 filterBy = { isEnglishLocale() }),
             Variant(
                 key = "zb",
-                weight = 1.0,
+                weight = 0.0,
                 features = listOf(VariantFeature.DripNotification),
                 filterBy = { isEnglishLocale() }),
             Variant(
                 key = "zc",
-                weight = 1.0,
+                weight = 0.0,
                 features = listOf(VariantFeature.DripNotification, VariantFeature.Day1DripA1Notification, VariantFeature.Day3ClearDataNotification),
                 filterBy = { isEnglishLocale() }),
             Variant(
                 key = "zd",
-                weight = 1.0,
+                weight = 0.0,
                 features = listOf(VariantFeature.DripNotification, VariantFeature.Day1DripA2Notification, VariantFeature.Day3ClearDataNotification),
                 filterBy = { isEnglishLocale() }),
             Variant(
                 key = "ze",
-                weight = 1.0,
+                weight = 0.0,
                 features = listOf(VariantFeature.DripNotification, VariantFeature.Day1DripB1Notification, VariantFeature.Day3ClearDataNotification),
                 filterBy = { isEnglishLocale() }),
             Variant(
                 key = "zf",
-                weight = 1.0,
+                weight = 0.0,
                 features = listOf(VariantFeature.DripNotification, VariantFeature.Day1DripB2Notification, VariantFeature.Day3ClearDataNotification),
                 filterBy = { isEnglishLocale() }),
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/inbox/1157893581871899/1182447818353798/1181690429267188

**Description**
We've reached sample size, therefore this feature can now be removed

**Steps to test this PR**:

1. Launch the app twice.
1. Kill the app and wait ~10 seconds
1. The usual privacy notification should show
1. Tap the notification
1. After ~10 seconds the clear data notification should show


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)