### PR TITLE
Rq Pixel should only be fired in SERP Header removal experiment

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -453,7 +453,7 @@ class BrowserTabViewModel(
         val oldQuery = currentOmnibarViewState().omnibarText.toUri()
         val newQuery = omnibarText.toUri()
 
-        if (!variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SerpHeaderRemoval)){
+        if (!variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SerpHeaderRemoval)) {
             return
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -450,12 +450,12 @@ class BrowserTabViewModel(
     }
 
     private fun fireQueryChangedPixel(omnibarText: String) {
-        val oldQuery = currentOmnibarViewState().omnibarText.toUri()
-        val newQuery = omnibarText.toUri()
-
         if (!variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SerpHeaderRemoval)) {
             return
         }
+
+        val oldQuery = currentOmnibarViewState().omnibarText.toUri()
+        val newQuery = omnibarText.toUri()
 
         if (oldQuery == newQuery) {
             pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_NOT_CHANGED))

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -454,22 +454,16 @@ class BrowserTabViewModel(
         val oldUri = currentOmnibarViewState().omnibarText.toUri()
         val newUri = omnibarText.toUri()
 
-        val oldParameter = try {
-            oldUri.getQueryParameter(AppUrl.ParamKey.QUERY)
-        } catch (e: UnsupportedOperationException) {
-            null
-        }
-        val newParameter = try {
-            newUri.getQueryParameter(AppUrl.ParamKey.QUERY)
-        } catch (e: UnsupportedOperationException) {
-            null
+        if (!variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SerpHeaderRemoval)){
+            return
         }
 
-        if (oldParameter == newParameter) {
+        if (oldUri == newUri) {
             pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_NOT_CHANGED))
         } else {
             pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_CHANGED))
         }
+
     }
 
     private fun shouldClearHistoryOnNewQuery(): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -92,7 +92,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import java.lang.UnsupportedOperationException
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
@@ -451,14 +450,14 @@ class BrowserTabViewModel(
     }
 
     private fun fireQueryChangedPixel(omnibarText: String) {
-        val oldUri = currentOmnibarViewState().omnibarText.toUri()
-        val newUri = omnibarText.toUri()
+        val oldQuery = currentOmnibarViewState().omnibarText.toUri()
+        val newQuery = omnibarText.toUri()
 
         if (!variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SerpHeaderRemoval)){
             return
         }
 
-        if (oldUri == newUri) {
+        if (oldQuery == newQuery) {
             pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_NOT_CHANGED))
         } else {
             pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_CHANGED))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1182605057307457

**Description**:
As part of Test improvements to the double search header we added a new pixel because. We should have only added this for the SERP Header Removal Experiment Variant, but it was enabled for all experiments.

Objective
Fix this, so the Pixel is only fired in this variant

**Steps to test this PR**:
*SERP Header Removal Variant*
1. Enable variant zi
2. Open the app
3. Type a query in the native toolbar
4. Check that pixel rq_1 has been fired
5. Type the same query again
6. Check that the pixel rq_0 has been fired  

*Control group*
1. Enable variant zg
2. Open the app
3. Type a query in the native toolbar
4. Check that pixel rq_1 has not been fired
5. Type the same query again
6. Check that the pixel rq_0 has not been fired  


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
