### PR TITLE
Don't unregister shortcut receiver

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -194,6 +194,7 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
         scheduleOfflinePixels()
 
         notificationRegistrar.registerApp()
+        registerReceiver(shortcutReceiver, IntentFilter(ShortcutBuilder.USE_OUR_APP_SHORTCUT_ADDED_ACTION))
 
         initializeHttpsUpgrader()
         submitUnsentFirePixels()
@@ -299,7 +300,6 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
             Timber.i("Suppressing app launch pixel")
             return
         }
-        registerReceiver(shortcutReceiver, IntentFilter(ShortcutBuilder.USE_OUR_APP_SHORTCUT_ADDED_ACTION))
         pixel.fire(APP_LAUNCH)
     }
 
@@ -310,11 +310,6 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
             workScheduler.scheduleWork()
             atbInitializer.initializeAfterReferrerAvailable()
         }
-    }
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    fun onAppStopped() {
-        unregisterReceiver(shortcutReceiver)
     }
 
     companion object {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1183093181516711
Tech Design URL: 
CC: 

**Description**:
App crashes when unregistering twice on application stopped. We don't really need to unregister here because it is done when the app gets killed anyways as per the documentation `If you register with the Application context, you receive broadcasts as long as the app is running.`

**Steps to test this PR**:
**Reproduce the crash**
1. Add another `unregisterReceiver(shortcutReceiver)` below the one that already exists in the `DuckDuckGoApplication` (line 317).
1. Launch the app and close it, you should see the crash in the logcat.

**Make sure the toast doesn't crash the app when is taken to the background by an OEM**
@CDRussell might be able to help with this one. This is an edge case that we have not been able to test yet.
1. Launch the app on a S6
1. Add a shortcut
1. App should go to the foreground and the toast message (if it shows) should not crash the app.

**Normal test**
1. Launch the app and close
1. The logcat should not show a crash

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
