### PR TITLE
Render ER diagrams with FloorPlan

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply from: '../versioning.gradle'
 apply from: "$rootDir/ktlint.gradle"
+apply plugin: 'com.juliozynger.floorplan'
 
 ext {
     USE_ORCHESTRATOR = project.hasProperty('orchestrator') ? project.property('orchestrator') : false
@@ -93,6 +94,16 @@ android {
     } else {
         println "Signing properties not found at ${propertiesPath}, releases will NOT succeed"
         android.buildTypes.release.signingConfig = null
+    }
+}
+
+floorPlan {
+    schemaLocation = "$projectDir/schemas".toString()
+    outputLocation = "$projectDir/floorplan-output".toString()
+    outputFormat {
+        svg {
+            enabled = true
+        }
     }
 }
 

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/1.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/1.svg
@@ -1,0 +1,77 @@
+<svg width="315px" height="590px"
+ viewBox="0.00 0.00 315.00 590.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 554)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-554 279,-554 279,36 -36,36"/>
+<!-- https_upgrade_domain -->
+<g id="node1" class="node">
+<title>https_upgrade_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="54.5,-22 54.5,-44 188.5,-44 188.5,-22 54.5,-22"/>
+<polygon fill="none" stroke="black" points="54.5,-22 54.5,-44 188.5,-44 188.5,-22 54.5,-22"/>
+<text text-anchor="start" x="57.34" y="-29.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_upgrade_domain</text>
+<polygon fill="none" stroke="black" points="54.5,0 54.5,-22 188.5,-22 188.5,0 54.5,0"/>
+<text text-anchor="start" x="78.92" y="-7.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-7.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- disconnect_tracker -->
+<g id="node2" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-168 57.5,-190 185.5,-190 185.5,-168 57.5,-168"/>
+<polygon fill="none" stroke="black" points="57.5,-168 57.5,-190 185.5,-190 185.5,-168 57.5,-168"/>
+<text text-anchor="start" x="68.64" y="-175.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-146 57.5,-168 185.5,-168 185.5,-146 57.5,-146"/>
+<text text-anchor="start" x="92.15" y="-153.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-153.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-124 57.5,-146 185.5,-146 185.5,-124 57.5,-124"/>
+<text text-anchor="start" x="75.83" y="-131.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-131.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-102 57.5,-124 185.5,-124 185.5,-102 57.5,-102"/>
+<text text-anchor="start" x="60.27" y="-109.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-109.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-80 57.5,-102 185.5,-102 185.5,-80 57.5,-80"/>
+<text text-anchor="start" x="67.66" y="-87.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-87.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node3" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-270 56.5,-292 187.5,-292 187.5,-270 56.5,-270"/>
+<polygon fill="none" stroke="black" points="56.5,-270 56.5,-292 187.5,-292 187.5,-270 56.5,-270"/>
+<text text-anchor="start" x="62.53" y="-277.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-248 56.5,-270 187.5,-270 187.5,-248 56.5,-248"/>
+<text text-anchor="start" x="60.77" y="-255.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-255.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-226 56.5,-248 187.5,-248 187.5,-226 56.5,-226"/>
+<text text-anchor="start" x="59.21" y="-233.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-233.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node4" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-372 0.5,-394 243.5,-394 243.5,-372 0.5,-372"/>
+<polygon fill="none" stroke="black" points="0.5,-372 0.5,-394 243.5,-394 243.5,-372 0.5,-372"/>
+<text text-anchor="start" x="70.68" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-350 0.5,-372 243.5,-372 243.5,-350 0.5,-350"/>
+<text text-anchor="start" x="90.32" y="-357.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-357.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-328 0.5,-350 243.5,-350 243.5,-328 0.5,-328"/>
+<text text-anchor="start" x="3.22" y="-335.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-335.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- bookmarks -->
+<g id="node5" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-496 79.5,-518 163.5,-518 163.5,-496 79.5,-496"/>
+<polygon fill="none" stroke="black" points="79.5,-496 79.5,-518 163.5,-518 163.5,-496 79.5,-496"/>
+<text text-anchor="start" x="90.39" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-474 79.5,-496 163.5,-496 163.5,-474 79.5,-474"/>
+<text text-anchor="start" x="82.43" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-452 79.5,-474 163.5,-474 163.5,-452 79.5,-452"/>
+<text text-anchor="start" x="89.03" y="-459.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-459.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-430 79.5,-452 163.5,-452 163.5,-430 79.5,-430"/>
+<text text-anchor="start" x="92.15" y="-437.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-437.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/10.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/10.svg
@@ -1,0 +1,252 @@
+<svg width="596px" height="1698px"
+ viewBox="0.00 0.00 595.66 1698.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1662)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1662 559.66,-1662 559.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<polygon fill="none" stroke="black" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<text text-anchor="start" x="62.53" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-394 56.5,-416 187.5,-416 187.5,-394 56.5,-394"/>
+<text text-anchor="start" x="60.77" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-372 56.5,-394 187.5,-394 187.5,-372 56.5,-372"/>
+<text text-anchor="start" x="59.21" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-379.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node5" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<polygon fill="none" stroke="black" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<text text-anchor="start" x="90.11" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-474 76.5,-496 167.5,-496 167.5,-474 76.5,-474"/>
+<text text-anchor="start" x="79.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="70.68" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="90.32" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-554 0.5,-576 243.5,-576 243.5,-554 0.5,-554"/>
+<text text-anchor="start" x="3.22" y="-561.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<text text-anchor="start" x="453.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 523.66,-722 523.66,-700 405.66,-700"/>
+<text text-anchor="start" x="428.7" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="464.86" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 523.66,-700 523.66,-678 405.66,-678"/>
+<text text-anchor="start" x="435.31" y="-685.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="458.25" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 523.66,-678 523.66,-656 405.66,-656"/>
+<text text-anchor="start" x="432.19" y="-663.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="461.36" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 523.66,-656 523.66,-634 405.66,-634"/>
+<text text-anchor="start" x="410.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="458.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 523.66,-634 523.66,-612 405.66,-612"/>
+<text text-anchor="start" x="408.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="460.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<polygon fill="none" stroke="black" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<text text-anchor="start" x="444.45" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-568 405.66,-590 523.66,-590 523.66,-568 405.66,-568"/>
+<text text-anchor="start" x="416.45" y="-574.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="85.07" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="82.93" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="86.04" y="-707.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="101.79" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-656 45.5,-678 198.5,-678 198.5,-656 45.5,-656"/>
+<text text-anchor="start" x="48.13" y="-662.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-711C287.64,-711 312.19,-711 395.48,-711"/>
+<polygon fill="black" stroke="black" points="395.66,-714.5 405.66,-711 395.66,-707.5 395.66,-714.5"/>
+<text text-anchor="middle" x="324.33" y="-715.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="90.39" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="82.43" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-853.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="89.03" y="-831.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-802 79.5,-824 163.5,-824 163.5,-802 79.5,-802"/>
+<text text-anchor="start" x="92.15" y="-809.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="93.5" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="62.21" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-926 59.5,-948 183.5,-948 183.5,-926 59.5,-926"/>
+<text text-anchor="start" x="67.27" y="-933.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node11" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<polygon fill="none" stroke="black" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<text text-anchor="start" x="103.34" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="48.5,-1094 48.5,-1116 195.5,-1116 195.5,-1094 48.5,-1094"/>
+<text text-anchor="start" x="75.93" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="132.3" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1072 48.5,-1094 195.5,-1094 195.5,-1072 48.5,-1072"/>
+<text text-anchor="start" x="92.65" y="-1079.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.59" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1050 48.5,-1072 195.5,-1072 195.5,-1050 48.5,-1050"/>
+<text text-anchor="start" x="51.44" y="-1057.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="132.69" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1028 48.5,-1050 195.5,-1050 195.5,-1028 48.5,-1028"/>
+<text text-anchor="start" x="84.48" y="-1035.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="123.76" y="-1035.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node12" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<polygon fill="none" stroke="black" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<text text-anchor="start" x="82.23" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="79.5,-1174 79.5,-1196 163.5,-1196 163.5,-1174 79.5,-1174"/>
+<text text-anchor="start" x="85.93" y="-1181.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="121.3" y="-1181.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node13" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="69.5,-1298 69.5,-1320 173.5,-1320 173.5,-1298 69.5,-1298"/>
+<polygon fill="none" stroke="black" points="69.5,-1298 69.5,-1320 173.5,-1320 173.5,-1298 69.5,-1298"/>
+<text text-anchor="start" x="84.57" y="-1305.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="69.5,-1276 69.5,-1298 173.5,-1298 173.5,-1276 69.5,-1276"/>
+<text text-anchor="start" x="89.82" y="-1283.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.42" y="-1283.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="69.5,-1254 69.5,-1276 173.5,-1276 173.5,-1254 69.5,-1254"/>
+<text text-anchor="start" x="72.32" y="-1261.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-1261.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node14" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-1378 76.5,-1400 167.5,-1400 167.5,-1378 76.5,-1378"/>
+<polygon fill="none" stroke="black" points="76.5,-1378 76.5,-1400 167.5,-1400 167.5,-1378 76.5,-1378"/>
+<text text-anchor="start" x="79.23" y="-1385.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="76.5,-1356 76.5,-1378 167.5,-1378 167.5,-1356 76.5,-1356"/>
+<text text-anchor="start" x="88.76" y="-1363.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="119.47" y="-1363.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node15" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1524 48.5,-1546 195.5,-1546 195.5,-1524 48.5,-1524"/>
+<polygon fill="none" stroke="black" points="48.5,-1524 48.5,-1546 195.5,-1546 195.5,-1524 48.5,-1524"/>
+<text text-anchor="start" x="78.84" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="48.5,-1502 48.5,-1524 195.5,-1524 195.5,-1502 48.5,-1502"/>
+<text text-anchor="start" x="58.83" y="-1509.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="125.3" y="-1509.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1480 48.5,-1502 195.5,-1502 195.5,-1480 48.5,-1480"/>
+<text text-anchor="start" x="51.04" y="-1487.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="133.1" y="-1487.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1458 48.5,-1480 195.5,-1480 195.5,-1458 48.5,-1458"/>
+<text text-anchor="start" x="59.21" y="-1465.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="124.92" y="-1465.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1436 48.5,-1458 195.5,-1458 195.5,-1436 48.5,-1436"/>
+<text text-anchor="start" x="54.55" y="-1443.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="129.58" y="-1443.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node16" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1604 59.5,-1626 184.5,-1626 184.5,-1604 59.5,-1604"/>
+<polygon fill="none" stroke="black" points="59.5,-1604 59.5,-1626 184.5,-1626 184.5,-1604 59.5,-1604"/>
+<text text-anchor="start" x="89.73" y="-1611.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="59.5,-1582 59.5,-1604 184.5,-1604 184.5,-1582 59.5,-1582"/>
+<text text-anchor="start" x="62.32" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="145.91" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/11.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/11.svg
@@ -1,0 +1,268 @@
+<svg width="596px" height="1822px"
+ viewBox="0.00 0.00 595.66 1822.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1786)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1786 559.66,-1786 559.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<polygon fill="none" stroke="black" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<text text-anchor="start" x="62.53" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-394 56.5,-416 187.5,-416 187.5,-394 56.5,-394"/>
+<text text-anchor="start" x="60.77" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-372 56.5,-394 187.5,-394 187.5,-372 56.5,-372"/>
+<text text-anchor="start" x="59.21" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-379.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node5" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<polygon fill="none" stroke="black" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<text text-anchor="start" x="90.11" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-474 76.5,-496 167.5,-496 167.5,-474 76.5,-474"/>
+<text text-anchor="start" x="79.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="70.68" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="90.32" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-554 0.5,-576 243.5,-576 243.5,-554 0.5,-554"/>
+<text text-anchor="start" x="3.22" y="-561.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<text text-anchor="start" x="453.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 523.66,-722 523.66,-700 405.66,-700"/>
+<text text-anchor="start" x="428.7" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="464.86" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 523.66,-700 523.66,-678 405.66,-678"/>
+<text text-anchor="start" x="435.31" y="-685.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="458.25" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 523.66,-678 523.66,-656 405.66,-656"/>
+<text text-anchor="start" x="432.19" y="-663.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="461.36" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 523.66,-656 523.66,-634 405.66,-634"/>
+<text text-anchor="start" x="410.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="458.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 523.66,-634 523.66,-612 405.66,-612"/>
+<text text-anchor="start" x="408.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="460.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<polygon fill="none" stroke="black" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<text text-anchor="start" x="444.45" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-568 405.66,-590 523.66,-590 523.66,-568 405.66,-568"/>
+<text text-anchor="start" x="416.45" y="-574.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="85.07" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="82.93" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="86.04" y="-707.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="101.79" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-656 45.5,-678 198.5,-678 198.5,-656 45.5,-656"/>
+<text text-anchor="start" x="48.13" y="-662.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-711C287.64,-711 312.19,-711 395.48,-711"/>
+<polygon fill="black" stroke="black" points="395.66,-714.5 405.66,-711 395.66,-707.5 395.66,-714.5"/>
+<text text-anchor="middle" x="324.33" y="-715.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="90.39" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="82.43" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-853.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="89.03" y="-831.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-802 79.5,-824 163.5,-824 163.5,-802 79.5,-802"/>
+<text text-anchor="start" x="92.15" y="-809.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="93.5" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="62.21" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-926 59.5,-948 183.5,-948 183.5,-926 59.5,-926"/>
+<text text-anchor="start" x="67.27" y="-933.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node11" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<polygon fill="none" stroke="black" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<text text-anchor="start" x="103.34" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="48.5,-1094 48.5,-1116 195.5,-1116 195.5,-1094 48.5,-1094"/>
+<text text-anchor="start" x="75.93" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="132.3" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1072 48.5,-1094 195.5,-1094 195.5,-1072 48.5,-1072"/>
+<text text-anchor="start" x="92.65" y="-1079.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.59" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1050 48.5,-1072 195.5,-1072 195.5,-1050 48.5,-1050"/>
+<text text-anchor="start" x="51.44" y="-1057.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="132.69" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1028 48.5,-1050 195.5,-1050 195.5,-1028 48.5,-1028"/>
+<text text-anchor="start" x="84.48" y="-1035.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="123.76" y="-1035.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node12" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<polygon fill="none" stroke="black" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<text text-anchor="start" x="82.23" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="79.5,-1174 79.5,-1196 163.5,-1196 163.5,-1174 79.5,-1174"/>
+<text text-anchor="start" x="85.93" y="-1181.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="121.3" y="-1181.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node13" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="69.5,-1298 69.5,-1320 173.5,-1320 173.5,-1298 69.5,-1298"/>
+<polygon fill="none" stroke="black" points="69.5,-1298 69.5,-1320 173.5,-1320 173.5,-1298 69.5,-1298"/>
+<text text-anchor="start" x="84.57" y="-1305.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="69.5,-1276 69.5,-1298 173.5,-1298 173.5,-1276 69.5,-1276"/>
+<text text-anchor="start" x="89.82" y="-1283.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.42" y="-1283.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="69.5,-1254 69.5,-1276 173.5,-1276 173.5,-1254 69.5,-1254"/>
+<text text-anchor="start" x="72.32" y="-1261.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-1261.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node14" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-1378 76.5,-1400 167.5,-1400 167.5,-1378 76.5,-1378"/>
+<polygon fill="none" stroke="black" points="76.5,-1378 76.5,-1400 167.5,-1400 167.5,-1378 76.5,-1378"/>
+<text text-anchor="start" x="79.23" y="-1385.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="76.5,-1356 76.5,-1378 167.5,-1378 167.5,-1356 76.5,-1356"/>
+<text text-anchor="start" x="88.76" y="-1363.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="119.47" y="-1363.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node15" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1524 48.5,-1546 195.5,-1546 195.5,-1524 48.5,-1524"/>
+<polygon fill="none" stroke="black" points="48.5,-1524 48.5,-1546 195.5,-1546 195.5,-1524 48.5,-1524"/>
+<text text-anchor="start" x="78.84" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="48.5,-1502 48.5,-1524 195.5,-1524 195.5,-1502 48.5,-1502"/>
+<text text-anchor="start" x="58.83" y="-1509.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="125.3" y="-1509.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1480 48.5,-1502 195.5,-1502 195.5,-1480 48.5,-1480"/>
+<text text-anchor="start" x="51.04" y="-1487.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="133.1" y="-1487.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1458 48.5,-1480 195.5,-1480 195.5,-1458 48.5,-1458"/>
+<text text-anchor="start" x="59.21" y="-1465.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="124.92" y="-1465.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1436 48.5,-1458 195.5,-1458 195.5,-1436 48.5,-1436"/>
+<text text-anchor="start" x="54.55" y="-1443.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="129.58" y="-1443.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node16" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1604 59.5,-1626 184.5,-1626 184.5,-1604 59.5,-1604"/>
+<polygon fill="none" stroke="black" points="59.5,-1604 59.5,-1626 184.5,-1626 184.5,-1604 59.5,-1604"/>
+<text text-anchor="start" x="89.73" y="-1611.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="59.5,-1582 59.5,-1604 184.5,-1604 184.5,-1582 59.5,-1582"/>
+<text text-anchor="start" x="62.32" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="145.91" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node17" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="21.5,-1728 21.5,-1750 222.5,-1750 222.5,-1728 21.5,-1728"/>
+<polygon fill="none" stroke="black" points="21.5,-1728 21.5,-1750 222.5,-1750 222.5,-1728 21.5,-1728"/>
+<text text-anchor="start" x="50.08" y="-1735.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="21.5,-1706 21.5,-1728 222.5,-1728 222.5,-1706 21.5,-1706"/>
+<text text-anchor="start" x="90.32" y="-1713.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-1713.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="21.5,-1684 21.5,-1706 222.5,-1706 222.5,-1684 21.5,-1684"/>
+<text text-anchor="start" x="24.23" y="-1691.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="159.9" y="-1691.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="21.5,-1662 21.5,-1684 222.5,-1684 222.5,-1662 21.5,-1662"/>
+<text text-anchor="start" x="46.77" y="-1669.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="137.36" y="-1669.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/12.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/12.svg
@@ -1,0 +1,271 @@
+<svg width="608px" height="1822px"
+ viewBox="0.00 0.00 607.66 1822.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1786)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1786 571.66,-1786 571.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<polygon fill="none" stroke="black" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<text text-anchor="start" x="62.53" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-394 56.5,-416 187.5,-416 187.5,-394 56.5,-394"/>
+<text text-anchor="start" x="60.77" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-372 56.5,-394 187.5,-394 187.5,-372 56.5,-372"/>
+<text text-anchor="start" x="59.21" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-379.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node5" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<polygon fill="none" stroke="black" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<text text-anchor="start" x="90.11" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-474 76.5,-496 167.5,-496 167.5,-474 76.5,-474"/>
+<text text-anchor="start" x="79.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="70.68" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="90.32" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-554 0.5,-576 243.5,-576 243.5,-554 0.5,-554"/>
+<text text-anchor="start" x="3.22" y="-561.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-722 405.66,-744 535.66,-744 535.66,-722 405.66,-722"/>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 535.66,-744 535.66,-722 405.66,-722"/>
+<text text-anchor="start" x="459.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 535.66,-722 535.66,-700 405.66,-700"/>
+<text text-anchor="start" x="434.7" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="470.86" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 535.66,-700 535.66,-678 405.66,-678"/>
+<text text-anchor="start" x="441.31" y="-685.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="464.25" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 535.66,-678 535.66,-656 405.66,-656"/>
+<text text-anchor="start" x="438.19" y="-663.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="467.36" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 535.66,-656 535.66,-634 405.66,-634"/>
+<text text-anchor="start" x="408.26" y="-641.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="473.2" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 535.66,-634 535.66,-612 405.66,-612"/>
+<text text-anchor="start" x="416.82" y="-619.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="464.63" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-590 405.66,-612 535.66,-612 535.66,-590 405.66,-590"/>
+<text text-anchor="start" x="414.47" y="-597.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="466.98" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-568 405.66,-590 535.66,-590 535.66,-568 405.66,-568"/>
+<polygon fill="none" stroke="black" points="405.66,-568 405.66,-590 535.66,-590 535.66,-568 405.66,-568"/>
+<text text-anchor="start" x="450.45" y="-575.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-546 405.66,-568 535.66,-568 535.66,-546 405.66,-546"/>
+<text text-anchor="start" x="422.45" y="-552.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="85.07" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="82.93" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="86.04" y="-707.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="101.79" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-656 45.5,-678 198.5,-678 198.5,-656 45.5,-656"/>
+<text text-anchor="start" x="48.13" y="-662.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-711C287.64,-711 312.19,-711 395.48,-711"/>
+<polygon fill="black" stroke="black" points="395.66,-714.5 405.66,-711 395.66,-707.5 395.66,-714.5"/>
+<text text-anchor="middle" x="324.33" y="-715.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="90.39" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="82.43" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-853.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="89.03" y="-831.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-802 79.5,-824 163.5,-824 163.5,-802 79.5,-802"/>
+<text text-anchor="start" x="92.15" y="-809.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="93.5" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="62.21" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-926 59.5,-948 183.5,-948 183.5,-926 59.5,-926"/>
+<text text-anchor="start" x="67.27" y="-933.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node11" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<polygon fill="none" stroke="black" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<text text-anchor="start" x="103.34" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="48.5,-1094 48.5,-1116 195.5,-1116 195.5,-1094 48.5,-1094"/>
+<text text-anchor="start" x="75.93" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="132.3" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1072 48.5,-1094 195.5,-1094 195.5,-1072 48.5,-1072"/>
+<text text-anchor="start" x="92.65" y="-1079.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.59" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1050 48.5,-1072 195.5,-1072 195.5,-1050 48.5,-1050"/>
+<text text-anchor="start" x="51.44" y="-1057.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="132.69" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1028 48.5,-1050 195.5,-1050 195.5,-1028 48.5,-1028"/>
+<text text-anchor="start" x="84.48" y="-1035.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="123.76" y="-1035.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node12" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<polygon fill="none" stroke="black" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<text text-anchor="start" x="82.23" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="79.5,-1174 79.5,-1196 163.5,-1196 163.5,-1174 79.5,-1174"/>
+<text text-anchor="start" x="85.93" y="-1181.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="121.3" y="-1181.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node13" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="69.5,-1298 69.5,-1320 173.5,-1320 173.5,-1298 69.5,-1298"/>
+<polygon fill="none" stroke="black" points="69.5,-1298 69.5,-1320 173.5,-1320 173.5,-1298 69.5,-1298"/>
+<text text-anchor="start" x="84.57" y="-1305.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="69.5,-1276 69.5,-1298 173.5,-1298 173.5,-1276 69.5,-1276"/>
+<text text-anchor="start" x="89.82" y="-1283.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.42" y="-1283.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="69.5,-1254 69.5,-1276 173.5,-1276 173.5,-1254 69.5,-1254"/>
+<text text-anchor="start" x="72.32" y="-1261.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-1261.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node14" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-1378 76.5,-1400 167.5,-1400 167.5,-1378 76.5,-1378"/>
+<polygon fill="none" stroke="black" points="76.5,-1378 76.5,-1400 167.5,-1400 167.5,-1378 76.5,-1378"/>
+<text text-anchor="start" x="79.23" y="-1385.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="76.5,-1356 76.5,-1378 167.5,-1378 167.5,-1356 76.5,-1356"/>
+<text text-anchor="start" x="88.76" y="-1363.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="119.47" y="-1363.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node15" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1524 48.5,-1546 195.5,-1546 195.5,-1524 48.5,-1524"/>
+<polygon fill="none" stroke="black" points="48.5,-1524 48.5,-1546 195.5,-1546 195.5,-1524 48.5,-1524"/>
+<text text-anchor="start" x="78.84" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="48.5,-1502 48.5,-1524 195.5,-1524 195.5,-1502 48.5,-1502"/>
+<text text-anchor="start" x="58.83" y="-1509.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="125.3" y="-1509.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1480 48.5,-1502 195.5,-1502 195.5,-1480 48.5,-1480"/>
+<text text-anchor="start" x="51.04" y="-1487.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="133.1" y="-1487.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1458 48.5,-1480 195.5,-1480 195.5,-1458 48.5,-1458"/>
+<text text-anchor="start" x="59.21" y="-1465.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="124.92" y="-1465.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1436 48.5,-1458 195.5,-1458 195.5,-1436 48.5,-1436"/>
+<text text-anchor="start" x="54.55" y="-1443.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="129.58" y="-1443.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node16" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1604 59.5,-1626 184.5,-1626 184.5,-1604 59.5,-1604"/>
+<polygon fill="none" stroke="black" points="59.5,-1604 59.5,-1626 184.5,-1626 184.5,-1604 59.5,-1604"/>
+<text text-anchor="start" x="89.73" y="-1611.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="59.5,-1582 59.5,-1604 184.5,-1604 184.5,-1582 59.5,-1582"/>
+<text text-anchor="start" x="62.32" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="145.91" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node17" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="21.5,-1728 21.5,-1750 222.5,-1750 222.5,-1728 21.5,-1728"/>
+<polygon fill="none" stroke="black" points="21.5,-1728 21.5,-1750 222.5,-1750 222.5,-1728 21.5,-1728"/>
+<text text-anchor="start" x="50.08" y="-1735.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="21.5,-1706 21.5,-1728 222.5,-1728 222.5,-1706 21.5,-1706"/>
+<text text-anchor="start" x="90.32" y="-1713.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-1713.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="21.5,-1684 21.5,-1706 222.5,-1706 222.5,-1684 21.5,-1684"/>
+<text text-anchor="start" x="24.23" y="-1691.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="159.9" y="-1691.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="21.5,-1662 21.5,-1684 222.5,-1684 222.5,-1662 21.5,-1662"/>
+<text text-anchor="start" x="46.77" y="-1669.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="137.36" y="-1669.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/13.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/13.svg
@@ -1,0 +1,274 @@
+<svg width="608px" height="1844px"
+ viewBox="0.00 0.00 607.66 1844.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1808)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1808 571.66,-1808 571.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-416 57.5,-438 185.5,-438 185.5,-416 57.5,-416"/>
+<polygon fill="none" stroke="black" points="57.5,-416 57.5,-438 185.5,-438 185.5,-416 57.5,-416"/>
+<text text-anchor="start" x="62.03" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="57.5,-394 57.5,-416 185.5,-416 185.5,-394 57.5,-394"/>
+<text text-anchor="start" x="60.27" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-372 57.5,-394 185.5,-394 185.5,-372 57.5,-372"/>
+<text text-anchor="start" x="72.32" y="-379.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-379.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node5" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="69.5,-518 69.5,-540 173.5,-540 173.5,-518 69.5,-518"/>
+<polygon fill="none" stroke="black" points="69.5,-518 69.5,-540 173.5,-540 173.5,-518 69.5,-518"/>
+<text text-anchor="start" x="86.89" y="-525.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="69.5,-496 69.5,-518 173.5,-518 173.5,-496 69.5,-496"/>
+<text text-anchor="start" x="89.82" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.42" y="-503.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="69.5,-474 69.5,-496 173.5,-496 173.5,-474 69.5,-474"/>
+<text text-anchor="start" x="72.32" y="-481.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-481.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-620 0.5,-642 243.5,-642 243.5,-620 0.5,-620"/>
+<polygon fill="none" stroke="black" points="0.5,-620 0.5,-642 243.5,-642 243.5,-620 0.5,-620"/>
+<text text-anchor="start" x="70.68" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="90.32" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-605.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="3.22" y="-583.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-583.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-744 405.66,-766 535.66,-766 535.66,-744 405.66,-744"/>
+<polygon fill="none" stroke="black" points="405.66,-744 405.66,-766 535.66,-766 535.66,-744 405.66,-744"/>
+<text text-anchor="start" x="459.39" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 535.66,-744 535.66,-722 405.66,-722"/>
+<text text-anchor="start" x="434.7" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="470.86" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 535.66,-722 535.66,-700 405.66,-700"/>
+<text text-anchor="start" x="441.31" y="-707.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="464.25" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 535.66,-700 535.66,-678 405.66,-678"/>
+<text text-anchor="start" x="438.19" y="-685.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="467.36" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 535.66,-678 535.66,-656 405.66,-656"/>
+<text text-anchor="start" x="408.26" y="-663.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="473.2" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 535.66,-656 535.66,-634 405.66,-634"/>
+<text text-anchor="start" x="416.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="464.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 535.66,-634 535.66,-612 405.66,-612"/>
+<text text-anchor="start" x="414.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="466.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-590 405.66,-612 535.66,-612 535.66,-590 405.66,-590"/>
+<polygon fill="none" stroke="black" points="405.66,-590 405.66,-612 535.66,-612 535.66,-590 405.66,-590"/>
+<text text-anchor="start" x="450.45" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-568 405.66,-590 535.66,-590 535.66,-568 405.66,-568"/>
+<text text-anchor="start" x="422.45" y="-574.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-766 45.5,-788 198.5,-788 198.5,-766 45.5,-766"/>
+<polygon fill="none" stroke="black" points="45.5,-766 45.5,-788 198.5,-788 198.5,-766 45.5,-766"/>
+<text text-anchor="start" x="85.07" y="-773.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="82.93" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-751.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="86.04" y="-729.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-729.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="101.79" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="48.13" y="-684.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-733C287.64,-733 312.19,-733 395.48,-733"/>
+<polygon fill="black" stroke="black" points="395.66,-736.5 405.66,-733 395.66,-729.5 395.66,-736.5"/>
+<text text-anchor="middle" x="324.33" y="-737.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-890 79.5,-912 163.5,-912 163.5,-890 79.5,-890"/>
+<polygon fill="none" stroke="black" points="79.5,-890 79.5,-912 163.5,-912 163.5,-890 79.5,-890"/>
+<text text-anchor="start" x="90.39" y="-897.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="82.43" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-875.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="89.03" y="-853.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-853.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="92.15" y="-831.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-992 59.5,-1014 183.5,-1014 183.5,-992 59.5,-992"/>
+<polygon fill="none" stroke="black" points="59.5,-992 59.5,-1014 183.5,-1014 183.5,-992 59.5,-992"/>
+<text text-anchor="start" x="93.5" y="-999.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="62.21" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-977.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="67.27" y="-955.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-955.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node11" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1138 48.5,-1160 195.5,-1160 195.5,-1138 48.5,-1138"/>
+<polygon fill="none" stroke="black" points="48.5,-1138 48.5,-1160 195.5,-1160 195.5,-1138 48.5,-1138"/>
+<text text-anchor="start" x="103.34" y="-1145.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<text text-anchor="start" x="75.93" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="132.3" y="-1123.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1094 48.5,-1116 195.5,-1116 195.5,-1094 48.5,-1094"/>
+<text text-anchor="start" x="92.65" y="-1101.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.59" y="-1101.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1072 48.5,-1094 195.5,-1094 195.5,-1072 48.5,-1072"/>
+<text text-anchor="start" x="51.44" y="-1079.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="132.69" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1050 48.5,-1072 195.5,-1072 195.5,-1050 48.5,-1050"/>
+<text text-anchor="start" x="84.48" y="-1057.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="123.76" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node12" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-1218 79.5,-1240 163.5,-1240 163.5,-1218 79.5,-1218"/>
+<polygon fill="none" stroke="black" points="79.5,-1218 79.5,-1240 163.5,-1240 163.5,-1218 79.5,-1218"/>
+<text text-anchor="start" x="82.23" y="-1225.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<text text-anchor="start" x="85.93" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="121.3" y="-1203.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node13" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="69.5,-1320 69.5,-1342 173.5,-1342 173.5,-1320 69.5,-1320"/>
+<polygon fill="none" stroke="black" points="69.5,-1320 69.5,-1342 173.5,-1342 173.5,-1320 69.5,-1320"/>
+<text text-anchor="start" x="84.57" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="69.5,-1298 69.5,-1320 173.5,-1320 173.5,-1298 69.5,-1298"/>
+<text text-anchor="start" x="89.82" y="-1305.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.42" y="-1305.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="69.5,-1276 69.5,-1298 173.5,-1298 173.5,-1276 69.5,-1276"/>
+<text text-anchor="start" x="72.32" y="-1283.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-1283.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node14" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-1400 76.5,-1422 167.5,-1422 167.5,-1400 76.5,-1400"/>
+<polygon fill="none" stroke="black" points="76.5,-1400 76.5,-1422 167.5,-1422 167.5,-1400 76.5,-1400"/>
+<text text-anchor="start" x="79.23" y="-1407.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="76.5,-1378 76.5,-1400 167.5,-1400 167.5,-1378 76.5,-1378"/>
+<text text-anchor="start" x="88.76" y="-1385.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="119.47" y="-1385.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node15" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1546 48.5,-1568 195.5,-1568 195.5,-1546 48.5,-1546"/>
+<polygon fill="none" stroke="black" points="48.5,-1546 48.5,-1568 195.5,-1568 195.5,-1546 48.5,-1546"/>
+<text text-anchor="start" x="78.84" y="-1553.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="48.5,-1524 48.5,-1546 195.5,-1546 195.5,-1524 48.5,-1524"/>
+<text text-anchor="start" x="58.83" y="-1531.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="125.3" y="-1531.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1502 48.5,-1524 195.5,-1524 195.5,-1502 48.5,-1502"/>
+<text text-anchor="start" x="51.04" y="-1509.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="133.1" y="-1509.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1480 48.5,-1502 195.5,-1502 195.5,-1480 48.5,-1480"/>
+<text text-anchor="start" x="59.21" y="-1487.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="124.92" y="-1487.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1458 48.5,-1480 195.5,-1480 195.5,-1458 48.5,-1458"/>
+<text text-anchor="start" x="54.55" y="-1465.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="129.58" y="-1465.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node16" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1626 59.5,-1648 184.5,-1648 184.5,-1626 59.5,-1626"/>
+<polygon fill="none" stroke="black" points="59.5,-1626 59.5,-1648 184.5,-1648 184.5,-1626 59.5,-1626"/>
+<text text-anchor="start" x="89.73" y="-1633.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="59.5,-1604 59.5,-1626 184.5,-1626 184.5,-1604 59.5,-1604"/>
+<text text-anchor="start" x="62.32" y="-1611.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="145.91" y="-1611.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node17" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="21.5,-1750 21.5,-1772 222.5,-1772 222.5,-1750 21.5,-1750"/>
+<polygon fill="none" stroke="black" points="21.5,-1750 21.5,-1772 222.5,-1772 222.5,-1750 21.5,-1750"/>
+<text text-anchor="start" x="50.08" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="21.5,-1728 21.5,-1750 222.5,-1750 222.5,-1728 21.5,-1728"/>
+<text text-anchor="start" x="90.32" y="-1735.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-1735.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="21.5,-1706 21.5,-1728 222.5,-1728 222.5,-1706 21.5,-1706"/>
+<text text-anchor="start" x="24.23" y="-1713.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="159.9" y="-1713.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="21.5,-1684 21.5,-1706 222.5,-1706 222.5,-1684 21.5,-1684"/>
+<text text-anchor="start" x="46.77" y="-1691.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="137.36" y="-1691.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/14.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/14.svg
@@ -1,0 +1,277 @@
+<svg width="611px" height="1844px"
+ viewBox="0.00 0.00 610.66 1844.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1808)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1808 574.66,-1808 574.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-416 57.5,-438 185.5,-438 185.5,-416 57.5,-416"/>
+<polygon fill="none" stroke="black" points="57.5,-416 57.5,-438 185.5,-438 185.5,-416 57.5,-416"/>
+<text text-anchor="start" x="62.03" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="57.5,-394 57.5,-416 185.5,-416 185.5,-394 57.5,-394"/>
+<text text-anchor="start" x="60.27" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-372 57.5,-394 185.5,-394 185.5,-372 57.5,-372"/>
+<text text-anchor="start" x="72.32" y="-379.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-379.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node5" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="69.5,-518 69.5,-540 173.5,-540 173.5,-518 69.5,-518"/>
+<polygon fill="none" stroke="black" points="69.5,-518 69.5,-540 173.5,-540 173.5,-518 69.5,-518"/>
+<text text-anchor="start" x="86.89" y="-525.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="69.5,-496 69.5,-518 173.5,-518 173.5,-496 69.5,-496"/>
+<text text-anchor="start" x="89.82" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.42" y="-503.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="69.5,-474 69.5,-496 173.5,-496 173.5,-474 69.5,-474"/>
+<text text-anchor="start" x="72.32" y="-481.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-481.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-620 0.5,-642 243.5,-642 243.5,-620 0.5,-620"/>
+<polygon fill="none" stroke="black" points="0.5,-620 0.5,-642 243.5,-642 243.5,-620 0.5,-620"/>
+<text text-anchor="start" x="70.68" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="90.32" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-605.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="3.22" y="-583.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-583.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="406.16,-744 406.16,-766 539.16,-766 539.16,-744 406.16,-744"/>
+<polygon fill="none" stroke="black" points="406.16,-744 406.16,-766 539.16,-766 539.16,-744 406.16,-744"/>
+<text text-anchor="start" x="461.39" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="406.16,-722 406.16,-744 539.16,-744 539.16,-722 406.16,-722"/>
+<text text-anchor="start" x="436.7" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="472.86" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="406.16,-700 406.16,-722 539.16,-722 539.16,-700 406.16,-700"/>
+<text text-anchor="start" x="443.31" y="-707.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="466.25" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="406.16,-678 406.16,-700 539.16,-700 539.16,-678 406.16,-678"/>
+<text text-anchor="start" x="440.19" y="-685.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="469.36" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="406.16,-656 406.16,-678 539.16,-678 539.16,-656 406.16,-656"/>
+<text text-anchor="start" x="410.26" y="-663.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="475.2" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="406.16,-634 406.16,-656 539.16,-656 539.16,-634 406.16,-634"/>
+<text text-anchor="start" x="418.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="466.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="406.16,-612 406.16,-634 539.16,-634 539.16,-612 406.16,-612"/>
+<text text-anchor="start" x="416.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="468.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="406.16,-590 406.16,-612 539.16,-612 539.16,-590 406.16,-590"/>
+<text text-anchor="start" x="408.71" y="-597.4" font-family="Times,serif" font-size="14.00">tabPreviewFile: </text>
+<text text-anchor="start" x="500.85" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="406.16,-568 406.16,-590 539.16,-590 539.16,-568 406.16,-568"/>
+<polygon fill="none" stroke="black" points="406.16,-568 406.16,-590 539.16,-590 539.16,-568 406.16,-568"/>
+<text text-anchor="start" x="452.45" y="-575.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="406.16,-546 406.16,-568 539.16,-568 539.16,-546 406.16,-546"/>
+<text text-anchor="start" x="424.45" y="-552.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-766 45.5,-788 198.5,-788 198.5,-766 45.5,-766"/>
+<polygon fill="none" stroke="black" points="45.5,-766 45.5,-788 198.5,-788 198.5,-766 45.5,-766"/>
+<text text-anchor="start" x="85.07" y="-773.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="82.93" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-751.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="86.04" y="-729.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-729.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="101.79" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="48.13" y="-684.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-733C287.64,-733 312.19,-733 395.48,-733"/>
+<polygon fill="black" stroke="black" points="395.66,-736.5 405.66,-733 395.66,-729.5 395.66,-736.5"/>
+<text text-anchor="middle" x="324.33" y="-737.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-890 79.5,-912 163.5,-912 163.5,-890 79.5,-890"/>
+<polygon fill="none" stroke="black" points="79.5,-890 79.5,-912 163.5,-912 163.5,-890 79.5,-890"/>
+<text text-anchor="start" x="90.39" y="-897.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="82.43" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-875.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="89.03" y="-853.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-853.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="92.15" y="-831.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-992 59.5,-1014 183.5,-1014 183.5,-992 59.5,-992"/>
+<polygon fill="none" stroke="black" points="59.5,-992 59.5,-1014 183.5,-1014 183.5,-992 59.5,-992"/>
+<text text-anchor="start" x="93.5" y="-999.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="62.21" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-977.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="67.27" y="-955.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-955.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node11" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1138 48.5,-1160 195.5,-1160 195.5,-1138 48.5,-1138"/>
+<polygon fill="none" stroke="black" points="48.5,-1138 48.5,-1160 195.5,-1160 195.5,-1138 48.5,-1138"/>
+<text text-anchor="start" x="103.34" y="-1145.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<text text-anchor="start" x="75.93" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="132.3" y="-1123.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1094 48.5,-1116 195.5,-1116 195.5,-1094 48.5,-1094"/>
+<text text-anchor="start" x="92.65" y="-1101.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.59" y="-1101.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1072 48.5,-1094 195.5,-1094 195.5,-1072 48.5,-1072"/>
+<text text-anchor="start" x="51.44" y="-1079.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="132.69" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1050 48.5,-1072 195.5,-1072 195.5,-1050 48.5,-1050"/>
+<text text-anchor="start" x="84.48" y="-1057.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="123.76" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node12" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-1218 79.5,-1240 163.5,-1240 163.5,-1218 79.5,-1218"/>
+<polygon fill="none" stroke="black" points="79.5,-1218 79.5,-1240 163.5,-1240 163.5,-1218 79.5,-1218"/>
+<text text-anchor="start" x="82.23" y="-1225.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<text text-anchor="start" x="85.93" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="121.3" y="-1203.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node13" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="69.5,-1320 69.5,-1342 173.5,-1342 173.5,-1320 69.5,-1320"/>
+<polygon fill="none" stroke="black" points="69.5,-1320 69.5,-1342 173.5,-1342 173.5,-1320 69.5,-1320"/>
+<text text-anchor="start" x="84.57" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="69.5,-1298 69.5,-1320 173.5,-1320 173.5,-1298 69.5,-1298"/>
+<text text-anchor="start" x="89.82" y="-1305.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.42" y="-1305.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="69.5,-1276 69.5,-1298 173.5,-1298 173.5,-1276 69.5,-1276"/>
+<text text-anchor="start" x="72.32" y="-1283.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-1283.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node14" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-1400 76.5,-1422 167.5,-1422 167.5,-1400 76.5,-1400"/>
+<polygon fill="none" stroke="black" points="76.5,-1400 76.5,-1422 167.5,-1422 167.5,-1400 76.5,-1400"/>
+<text text-anchor="start" x="79.23" y="-1407.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="76.5,-1378 76.5,-1400 167.5,-1400 167.5,-1378 76.5,-1378"/>
+<text text-anchor="start" x="88.76" y="-1385.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="119.47" y="-1385.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node15" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1546 48.5,-1568 195.5,-1568 195.5,-1546 48.5,-1546"/>
+<polygon fill="none" stroke="black" points="48.5,-1546 48.5,-1568 195.5,-1568 195.5,-1546 48.5,-1546"/>
+<text text-anchor="start" x="78.84" y="-1553.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="48.5,-1524 48.5,-1546 195.5,-1546 195.5,-1524 48.5,-1524"/>
+<text text-anchor="start" x="58.83" y="-1531.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="125.3" y="-1531.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1502 48.5,-1524 195.5,-1524 195.5,-1502 48.5,-1502"/>
+<text text-anchor="start" x="51.04" y="-1509.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="133.1" y="-1509.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1480 48.5,-1502 195.5,-1502 195.5,-1480 48.5,-1480"/>
+<text text-anchor="start" x="59.21" y="-1487.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="124.92" y="-1487.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1458 48.5,-1480 195.5,-1480 195.5,-1458 48.5,-1458"/>
+<text text-anchor="start" x="54.55" y="-1465.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="129.58" y="-1465.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node16" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1626 59.5,-1648 184.5,-1648 184.5,-1626 59.5,-1626"/>
+<polygon fill="none" stroke="black" points="59.5,-1626 59.5,-1648 184.5,-1648 184.5,-1626 59.5,-1626"/>
+<text text-anchor="start" x="89.73" y="-1633.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="59.5,-1604 59.5,-1626 184.5,-1626 184.5,-1604 59.5,-1604"/>
+<text text-anchor="start" x="62.32" y="-1611.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="145.91" y="-1611.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node17" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="21.5,-1750 21.5,-1772 222.5,-1772 222.5,-1750 21.5,-1750"/>
+<polygon fill="none" stroke="black" points="21.5,-1750 21.5,-1772 222.5,-1772 222.5,-1750 21.5,-1750"/>
+<text text-anchor="start" x="50.08" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="21.5,-1728 21.5,-1750 222.5,-1750 222.5,-1728 21.5,-1728"/>
+<text text-anchor="start" x="90.32" y="-1735.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-1735.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="21.5,-1706 21.5,-1728 222.5,-1728 222.5,-1706 21.5,-1706"/>
+<text text-anchor="start" x="24.23" y="-1713.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="159.9" y="-1713.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="21.5,-1684 21.5,-1706 222.5,-1706 222.5,-1684 21.5,-1684"/>
+<text text-anchor="start" x="46.77" y="-1691.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="137.36" y="-1691.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/15.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/15.svg
@@ -1,0 +1,293 @@
+<svg width="611px" height="1968px"
+ viewBox="0.00 0.00 610.66 1968.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1932)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1932 574.66,-1932 574.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-416 57.5,-438 185.5,-438 185.5,-416 57.5,-416"/>
+<polygon fill="none" stroke="black" points="57.5,-416 57.5,-438 185.5,-438 185.5,-416 57.5,-416"/>
+<text text-anchor="start" x="62.03" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="57.5,-394 57.5,-416 185.5,-416 185.5,-394 57.5,-394"/>
+<text text-anchor="start" x="60.27" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-372 57.5,-394 185.5,-394 185.5,-372 57.5,-372"/>
+<text text-anchor="start" x="72.32" y="-379.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-379.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node5" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="69.5,-518 69.5,-540 173.5,-540 173.5,-518 69.5,-518"/>
+<polygon fill="none" stroke="black" points="69.5,-518 69.5,-540 173.5,-540 173.5,-518 69.5,-518"/>
+<text text-anchor="start" x="86.89" y="-525.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="69.5,-496 69.5,-518 173.5,-518 173.5,-496 69.5,-496"/>
+<text text-anchor="start" x="89.82" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.42" y="-503.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="69.5,-474 69.5,-496 173.5,-496 173.5,-474 69.5,-474"/>
+<text text-anchor="start" x="72.32" y="-481.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-481.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-620 0.5,-642 243.5,-642 243.5,-620 0.5,-620"/>
+<polygon fill="none" stroke="black" points="0.5,-620 0.5,-642 243.5,-642 243.5,-620 0.5,-620"/>
+<text text-anchor="start" x="70.68" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="90.32" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-605.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="3.22" y="-583.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-583.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="406.16,-744 406.16,-766 539.16,-766 539.16,-744 406.16,-744"/>
+<polygon fill="none" stroke="black" points="406.16,-744 406.16,-766 539.16,-766 539.16,-744 406.16,-744"/>
+<text text-anchor="start" x="461.39" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="406.16,-722 406.16,-744 539.16,-744 539.16,-722 406.16,-722"/>
+<text text-anchor="start" x="436.7" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="472.86" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="406.16,-700 406.16,-722 539.16,-722 539.16,-700 406.16,-700"/>
+<text text-anchor="start" x="443.31" y="-707.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="466.25" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="406.16,-678 406.16,-700 539.16,-700 539.16,-678 406.16,-678"/>
+<text text-anchor="start" x="440.19" y="-685.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="469.36" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="406.16,-656 406.16,-678 539.16,-678 539.16,-656 406.16,-656"/>
+<text text-anchor="start" x="410.26" y="-663.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="475.2" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="406.16,-634 406.16,-656 539.16,-656 539.16,-634 406.16,-634"/>
+<text text-anchor="start" x="418.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="466.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="406.16,-612 406.16,-634 539.16,-634 539.16,-612 406.16,-612"/>
+<text text-anchor="start" x="416.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="468.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="406.16,-590 406.16,-612 539.16,-612 539.16,-590 406.16,-590"/>
+<text text-anchor="start" x="408.71" y="-597.4" font-family="Times,serif" font-size="14.00">tabPreviewFile: </text>
+<text text-anchor="start" x="500.85" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="406.16,-568 406.16,-590 539.16,-590 539.16,-568 406.16,-568"/>
+<polygon fill="none" stroke="black" points="406.16,-568 406.16,-590 539.16,-590 539.16,-568 406.16,-568"/>
+<text text-anchor="start" x="452.45" y="-575.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="406.16,-546 406.16,-568 539.16,-568 539.16,-546 406.16,-546"/>
+<text text-anchor="start" x="424.45" y="-552.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-766 45.5,-788 198.5,-788 198.5,-766 45.5,-766"/>
+<polygon fill="none" stroke="black" points="45.5,-766 45.5,-788 198.5,-788 198.5,-766 45.5,-766"/>
+<text text-anchor="start" x="85.07" y="-773.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="82.93" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-751.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="86.04" y="-729.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-729.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="101.79" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="48.13" y="-684.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-733C287.64,-733 312.19,-733 395.48,-733"/>
+<polygon fill="black" stroke="black" points="395.66,-736.5 405.66,-733 395.66,-729.5 395.66,-736.5"/>
+<text text-anchor="middle" x="324.33" y="-737.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-890 79.5,-912 163.5,-912 163.5,-890 79.5,-890"/>
+<polygon fill="none" stroke="black" points="79.5,-890 79.5,-912 163.5,-912 163.5,-890 79.5,-890"/>
+<text text-anchor="start" x="90.39" y="-897.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="82.43" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-875.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="89.03" y="-853.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-853.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="92.15" y="-831.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-992 59.5,-1014 183.5,-1014 183.5,-992 59.5,-992"/>
+<polygon fill="none" stroke="black" points="59.5,-992 59.5,-1014 183.5,-1014 183.5,-992 59.5,-992"/>
+<text text-anchor="start" x="93.5" y="-999.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="62.21" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-977.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="67.27" y="-955.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-955.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node11" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1138 48.5,-1160 195.5,-1160 195.5,-1138 48.5,-1138"/>
+<polygon fill="none" stroke="black" points="48.5,-1138 48.5,-1160 195.5,-1160 195.5,-1138 48.5,-1138"/>
+<text text-anchor="start" x="103.34" y="-1145.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<text text-anchor="start" x="75.93" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="132.3" y="-1123.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1094 48.5,-1116 195.5,-1116 195.5,-1094 48.5,-1094"/>
+<text text-anchor="start" x="92.65" y="-1101.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.59" y="-1101.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1072 48.5,-1094 195.5,-1094 195.5,-1072 48.5,-1072"/>
+<text text-anchor="start" x="51.44" y="-1079.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="132.69" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1050 48.5,-1072 195.5,-1072 195.5,-1050 48.5,-1050"/>
+<text text-anchor="start" x="84.48" y="-1057.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="123.76" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node12" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-1218 79.5,-1240 163.5,-1240 163.5,-1218 79.5,-1218"/>
+<polygon fill="none" stroke="black" points="79.5,-1218 79.5,-1240 163.5,-1240 163.5,-1218 79.5,-1218"/>
+<text text-anchor="start" x="82.23" y="-1225.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<text text-anchor="start" x="85.93" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="121.3" y="-1203.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node13" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="69.5,-1320 69.5,-1342 173.5,-1342 173.5,-1320 69.5,-1320"/>
+<polygon fill="none" stroke="black" points="69.5,-1320 69.5,-1342 173.5,-1342 173.5,-1320 69.5,-1320"/>
+<text text-anchor="start" x="84.57" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="69.5,-1298 69.5,-1320 173.5,-1320 173.5,-1298 69.5,-1298"/>
+<text text-anchor="start" x="89.82" y="-1305.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.42" y="-1305.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="69.5,-1276 69.5,-1298 173.5,-1298 173.5,-1276 69.5,-1276"/>
+<text text-anchor="start" x="72.32" y="-1283.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="110.81" y="-1283.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node14" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-1400 76.5,-1422 167.5,-1422 167.5,-1400 76.5,-1400"/>
+<polygon fill="none" stroke="black" points="76.5,-1400 76.5,-1422 167.5,-1422 167.5,-1400 76.5,-1400"/>
+<text text-anchor="start" x="79.23" y="-1407.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="76.5,-1378 76.5,-1400 167.5,-1400 167.5,-1378 76.5,-1378"/>
+<text text-anchor="start" x="88.76" y="-1385.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="119.47" y="-1385.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node15" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1546 48.5,-1568 195.5,-1568 195.5,-1546 48.5,-1546"/>
+<polygon fill="none" stroke="black" points="48.5,-1546 48.5,-1568 195.5,-1568 195.5,-1546 48.5,-1546"/>
+<text text-anchor="start" x="78.84" y="-1553.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="48.5,-1524 48.5,-1546 195.5,-1546 195.5,-1524 48.5,-1524"/>
+<text text-anchor="start" x="58.83" y="-1531.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="125.3" y="-1531.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1502 48.5,-1524 195.5,-1524 195.5,-1502 48.5,-1502"/>
+<text text-anchor="start" x="51.04" y="-1509.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="133.1" y="-1509.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1480 48.5,-1502 195.5,-1502 195.5,-1480 48.5,-1480"/>
+<text text-anchor="start" x="59.21" y="-1487.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="124.92" y="-1487.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1458 48.5,-1480 195.5,-1480 195.5,-1458 48.5,-1458"/>
+<text text-anchor="start" x="54.55" y="-1465.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="129.58" y="-1465.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node16" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1626 59.5,-1648 184.5,-1648 184.5,-1626 59.5,-1626"/>
+<polygon fill="none" stroke="black" points="59.5,-1626 59.5,-1648 184.5,-1648 184.5,-1626 59.5,-1626"/>
+<text text-anchor="start" x="89.73" y="-1633.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="59.5,-1604 59.5,-1626 184.5,-1626 184.5,-1604 59.5,-1604"/>
+<text text-anchor="start" x="62.32" y="-1611.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="145.91" y="-1611.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node17" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="21.5,-1750 21.5,-1772 222.5,-1772 222.5,-1750 21.5,-1750"/>
+<polygon fill="none" stroke="black" points="21.5,-1750 21.5,-1772 222.5,-1772 222.5,-1750 21.5,-1750"/>
+<text text-anchor="start" x="50.08" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="21.5,-1728 21.5,-1750 222.5,-1750 222.5,-1728 21.5,-1728"/>
+<text text-anchor="start" x="90.32" y="-1735.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-1735.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="21.5,-1706 21.5,-1728 222.5,-1728 222.5,-1706 21.5,-1706"/>
+<text text-anchor="start" x="24.23" y="-1713.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="159.9" y="-1713.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="21.5,-1684 21.5,-1706 222.5,-1706 222.5,-1684 21.5,-1684"/>
+<text text-anchor="start" x="46.77" y="-1691.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="137.36" y="-1691.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- UncaughtExceptionEntity -->
+<g id="node18" class="node">
+<title>UncaughtExceptionEntity</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-1874 46.5,-1896 197.5,-1896 197.5,-1874 46.5,-1874"/>
+<polygon fill="none" stroke="black" points="46.5,-1874 46.5,-1896 197.5,-1896 197.5,-1874 46.5,-1874"/>
+<text text-anchor="start" x="49.29" y="-1881.4" font-family="Times,serif" font-weight="bold" font-size="14.00">UncaughtExceptionEntity</text>
+<polygon fill="none" stroke="black" points="46.5,-1852 46.5,-1874 197.5,-1874 197.5,-1852 46.5,-1852"/>
+<text text-anchor="start" x="82.93" y="-1859.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-1859.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="46.5,-1830 46.5,-1852 197.5,-1852 197.5,-1830 46.5,-1830"/>
+<text text-anchor="start" x="53.77" y="-1837.4" font-family="Times,serif" font-size="14.00">exceptionSource: </text>
+<text text-anchor="start" x="154.46" y="-1837.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="46.5,-1808 46.5,-1830 197.5,-1830 197.5,-1808 46.5,-1808"/>
+<text text-anchor="start" x="76.71" y="-1815.4" font-family="Times,serif" font-size="14.00">message: </text>
+<text text-anchor="start" x="131.52" y="-1815.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/16.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/16.svg
@@ -1,0 +1,309 @@
+<svg width="569px" height="2092px"
+ viewBox="0.00 0.00 568.66 2092.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 2056)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-2056 532.66,-2056 532.66,36 -36,36"/>
+<!-- tds_tracker -->
+<g id="node1" class="node">
+<title>tds_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<polygon fill="none" stroke="black" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<text text-anchor="start" x="69.4" y="-117.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_tracker</text>
+<polygon fill="none" stroke="black" points="37.5,-88 37.5,-110 163.5,-110 163.5,-88 37.5,-88"/>
+<text text-anchor="start" x="57.92" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-95.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-66 37.5,-88 163.5,-88 163.5,-66 37.5,-66"/>
+<text text-anchor="start" x="40.44" y="-73.4" font-family="Times,serif" font-size="14.00">defaultAction: </text>
+<text text-anchor="start" x="124.8" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-44 37.5,-66 163.5,-66 163.5,-44 37.5,-44"/>
+<text text-anchor="start" x="44.72" y="-51.4" font-family="Times,serif" font-size="14.00">ownerName: </text>
+<text text-anchor="start" x="120.52" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-22 37.5,-44 163.5,-44 163.5,-22 37.5,-22"/>
+<text text-anchor="start" x="50.55" y="-29.4" font-family="Times,serif" font-size="14.00">categories: </text>
+<text text-anchor="start" x="114.69" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,0 37.5,-22 163.5,-22 163.5,0 37.5,0"/>
+<text text-anchor="start" x="65.32" y="-7.4" font-family="Times,serif" font-size="14.00">rules: </text>
+<text text-anchor="start" x="99.92" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tds_entity -->
+<g id="node2" class="node">
+<title>tds_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<polygon fill="none" stroke="black" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<text text-anchor="start" x="73.39" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_entity</text>
+<polygon fill="none" stroke="black" points="39.5,-212 39.5,-234 162.5,-234 162.5,-212 39.5,-212"/>
+<text text-anchor="start" x="64.26" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">name: </text>
+<text text-anchor="start" x="101.97" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-190 39.5,-212 162.5,-212 162.5,-190 39.5,-190"/>
+<text text-anchor="start" x="42.49" y="-197.4" font-family="Times,serif" font-size="14.00">displayName: </text>
+<text text-anchor="start" x="123.75" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-168 39.5,-190 162.5,-190 162.5,-168 39.5,-168"/>
+<text text-anchor="start" x="48.72" y="-175.4" font-family="Times,serif" font-size="14.00">prevalence: </text>
+<text text-anchor="start" x="116.73" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+</g>
+<!-- tds_domain_entity -->
+<g id="node3" class="node">
+<title>tds_domain_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<polygon fill="none" stroke="black" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<text text-anchor="start" x="48.39" y="-343.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_domain_entity</text>
+<polygon fill="none" stroke="black" points="43.5,-314 43.5,-336 157.5,-336 157.5,-314 43.5,-314"/>
+<text text-anchor="start" x="57.92" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-321.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="43.5,-292 43.5,-314 157.5,-314 157.5,-292 43.5,-292"/>
+<text text-anchor="start" x="46.27" y="-299.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="118.97" y="-299.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- temporary_tracking_whitelist -->
+<g id="node4" class="node">
+<title>temporary_tracking_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<polygon fill="none" stroke="black" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<text text-anchor="start" x="18.19" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">temporary_tracking_whitelist</text>
+<polygon fill="none" stroke="black" points="15.5,-394 15.5,-416 186.5,-416 186.5,-394 15.5,-394"/>
+<text text-anchor="start" x="58.42" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node5" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="29.5,-562 29.5,-584 171.5,-584 171.5,-562 29.5,-562"/>
+<polygon fill="none" stroke="black" points="29.5,-562 29.5,-584 171.5,-584 171.5,-562 29.5,-562"/>
+<text text-anchor="start" x="32.46" y="-569.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="29.5,-540 29.5,-562 171.5,-562 171.5,-540 29.5,-540"/>
+<text text-anchor="start" x="61.43" y="-547.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-547.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-518 29.5,-540 171.5,-540 171.5,-518 29.5,-518"/>
+<text text-anchor="start" x="52.1" y="-525.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="112.35" y="-525.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="29.5,-496 29.5,-518 171.5,-518 171.5,-496 29.5,-496"/>
+<text text-anchor="start" x="34.6" y="-503.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="106.53" y="-503.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-474 29.5,-496 171.5,-496 171.5,-474 29.5,-474"/>
+<text text-anchor="start" x="59.09" y="-481.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="106.14" y="-481.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node6" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-642 25.5,-664 175.5,-664 175.5,-642 25.5,-642"/>
+<polygon fill="none" stroke="black" points="25.5,-642 25.5,-664 175.5,-664 175.5,-642 25.5,-642"/>
+<text text-anchor="start" x="28.17" y="-649.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="25.5,-620 25.5,-642 175.5,-642 175.5,-620 25.5,-620"/>
+<text text-anchor="start" x="57.92" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-627.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node7" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="36.5,-744 36.5,-766 164.5,-766 164.5,-744 36.5,-744"/>
+<polygon fill="none" stroke="black" points="36.5,-744 36.5,-766 164.5,-766 164.5,-744 36.5,-744"/>
+<text text-anchor="start" x="41.03" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="36.5,-722 36.5,-744 164.5,-744 164.5,-722 36.5,-722"/>
+<text text-anchor="start" x="39.27" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="125.96" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="36.5,-700 36.5,-722 164.5,-722 164.5,-700 36.5,-700"/>
+<text text-anchor="start" x="51.32" y="-707.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node8" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-846 48.5,-868 152.5,-868 152.5,-846 48.5,-846"/>
+<polygon fill="none" stroke="black" points="48.5,-846 48.5,-868 152.5,-868 152.5,-846 48.5,-846"/>
+<text text-anchor="start" x="65.89" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="48.5,-824 48.5,-846 152.5,-846 152.5,-824 48.5,-824"/>
+<text text-anchor="start" x="68.82" y="-831.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-831.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-802 48.5,-824 152.5,-824 152.5,-802 48.5,-802"/>
+<text text-anchor="start" x="51.32" y="-809.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node9" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="364.16,-970 364.16,-992 497.16,-992 497.16,-970 364.16,-970"/>
+<polygon fill="none" stroke="black" points="364.16,-970 364.16,-992 497.16,-992 497.16,-970 364.16,-970"/>
+<text text-anchor="start" x="419.39" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="364.16,-948 364.16,-970 497.16,-970 497.16,-948 364.16,-948"/>
+<text text-anchor="start" x="394.7" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="430.86" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-926 364.16,-948 497.16,-948 497.16,-926 364.16,-926"/>
+<text text-anchor="start" x="401.31" y="-933.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="424.25" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-904 364.16,-926 497.16,-926 497.16,-904 364.16,-904"/>
+<text text-anchor="start" x="398.19" y="-911.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="427.36" y="-911.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-882 364.16,-904 497.16,-904 497.16,-882 364.16,-882"/>
+<text text-anchor="start" x="368.26" y="-889.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="433.2" y="-889.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-860 364.16,-882 497.16,-882 497.16,-860 364.16,-860"/>
+<text text-anchor="start" x="376.82" y="-867.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="424.63" y="-867.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-838 364.16,-860 497.16,-860 497.16,-838 364.16,-838"/>
+<text text-anchor="start" x="374.47" y="-845.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="426.98" y="-845.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-816 364.16,-838 497.16,-838 497.16,-816 364.16,-816"/>
+<text text-anchor="start" x="366.71" y="-823.4" font-family="Times,serif" font-size="14.00">tabPreviewFile: </text>
+<text text-anchor="start" x="458.85" y="-823.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="364.16,-794 364.16,-816 497.16,-816 497.16,-794 364.16,-794"/>
+<polygon fill="none" stroke="black" points="364.16,-794 364.16,-816 497.16,-816 497.16,-794 364.16,-794"/>
+<text text-anchor="start" x="410.45" y="-801.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="364.16,-772 364.16,-794 497.16,-794 497.16,-772 364.16,-772"/>
+<text text-anchor="start" x="382.45" y="-778.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node10" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="24.5,-992 24.5,-1014 177.5,-1014 177.5,-992 24.5,-992"/>
+<polygon fill="none" stroke="black" points="24.5,-992 24.5,-1014 177.5,-1014 177.5,-992 24.5,-992"/>
+<text text-anchor="start" x="64.07" y="-999.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="24.5,-970 24.5,-992 177.5,-992 177.5,-970 24.5,-970"/>
+<text text-anchor="start" x="61.93" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-977.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="24.5,-948 24.5,-970 177.5,-970 177.5,-948 24.5,-948"/>
+<text text-anchor="start" x="65.04" y="-955.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="101.2" y="-955.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="24.5,-926 24.5,-948 177.5,-948 177.5,-926 24.5,-926"/>
+<polygon fill="none" stroke="black" points="24.5,-926 24.5,-948 177.5,-948 177.5,-926 24.5,-926"/>
+<text text-anchor="start" x="80.79" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="24.5,-904 24.5,-926 177.5,-926 177.5,-904 24.5,-904"/>
+<text text-anchor="start" x="27.13" y="-910.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M178.5,-959C257.26,-959 279.49,-959 353.38,-959"/>
+<polygon fill="black" stroke="black" points="353.66,-962.5 363.66,-959 353.66,-955.5 353.66,-962.5"/>
+<text text-anchor="middle" x="282.33" y="-963.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node11" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1116 58.5,-1138 142.5,-1138 142.5,-1116 58.5,-1116"/>
+<polygon fill="none" stroke="black" points="58.5,-1116 58.5,-1138 142.5,-1138 142.5,-1116 58.5,-1116"/>
+<text text-anchor="start" x="69.39" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="58.5,-1094 58.5,-1116 142.5,-1116 142.5,-1094 58.5,-1094"/>
+<text text-anchor="start" x="61.43" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-1072 58.5,-1094 142.5,-1094 142.5,-1072 58.5,-1072"/>
+<text text-anchor="start" x="68.03" y="-1079.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="97.2" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="58.5,-1050 58.5,-1072 142.5,-1072 142.5,-1050 58.5,-1050"/>
+<text text-anchor="start" x="71.15" y="-1057.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.09" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node12" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1262 27.5,-1284 174.5,-1284 174.5,-1262 27.5,-1262"/>
+<polygon fill="none" stroke="black" points="27.5,-1262 27.5,-1284 174.5,-1284 174.5,-1262 27.5,-1262"/>
+<text text-anchor="start" x="82.34" y="-1269.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="27.5,-1240 27.5,-1262 174.5,-1262 174.5,-1240 27.5,-1240"/>
+<text text-anchor="start" x="54.93" y="-1247.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="111.3" y="-1247.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1218 27.5,-1240 174.5,-1240 174.5,-1218 27.5,-1218"/>
+<text text-anchor="start" x="71.65" y="-1225.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.59" y="-1225.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1196 27.5,-1218 174.5,-1218 174.5,-1196 27.5,-1196"/>
+<text text-anchor="start" x="30.44" y="-1203.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="111.69" y="-1203.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1174 27.5,-1196 174.5,-1196 174.5,-1174 27.5,-1174"/>
+<text text-anchor="start" x="63.48" y="-1181.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="102.76" y="-1181.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node13" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1342 58.5,-1364 142.5,-1364 142.5,-1342 58.5,-1342"/>
+<polygon fill="none" stroke="black" points="58.5,-1342 58.5,-1364 142.5,-1364 142.5,-1342 58.5,-1342"/>
+<text text-anchor="start" x="61.23" y="-1349.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="58.5,-1320 58.5,-1342 142.5,-1342 142.5,-1320 58.5,-1320"/>
+<text text-anchor="start" x="64.93" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="100.3" y="-1327.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node14" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1444 48.5,-1466 152.5,-1466 152.5,-1444 48.5,-1444"/>
+<polygon fill="none" stroke="black" points="48.5,-1444 48.5,-1466 152.5,-1466 152.5,-1444 48.5,-1444"/>
+<text text-anchor="start" x="63.57" y="-1451.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="48.5,-1422 48.5,-1444 152.5,-1444 152.5,-1422 48.5,-1422"/>
+<text text-anchor="start" x="68.82" y="-1429.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-1429.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1400 48.5,-1422 152.5,-1422 152.5,-1400 48.5,-1400"/>
+<text text-anchor="start" x="51.32" y="-1407.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-1407.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node15" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-1524 55.5,-1546 146.5,-1546 146.5,-1524 55.5,-1524"/>
+<polygon fill="none" stroke="black" points="55.5,-1524 55.5,-1546 146.5,-1546 146.5,-1524 55.5,-1524"/>
+<text text-anchor="start" x="58.23" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="55.5,-1502 55.5,-1524 146.5,-1524 146.5,-1502 55.5,-1502"/>
+<text text-anchor="start" x="67.76" y="-1509.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="98.47" y="-1509.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node16" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1670 27.5,-1692 174.5,-1692 174.5,-1670 27.5,-1670"/>
+<polygon fill="none" stroke="black" points="27.5,-1670 27.5,-1692 174.5,-1692 174.5,-1670 27.5,-1670"/>
+<text text-anchor="start" x="57.84" y="-1677.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="27.5,-1648 27.5,-1670 174.5,-1670 174.5,-1648 27.5,-1648"/>
+<text text-anchor="start" x="37.83" y="-1655.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="104.3" y="-1655.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1626 27.5,-1648 174.5,-1648 174.5,-1626 27.5,-1626"/>
+<text text-anchor="start" x="30.04" y="-1633.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="112.1" y="-1633.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1604 27.5,-1626 174.5,-1626 174.5,-1604 27.5,-1604"/>
+<text text-anchor="start" x="38.21" y="-1611.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-1611.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1582 27.5,-1604 174.5,-1604 174.5,-1582 27.5,-1582"/>
+<text text-anchor="start" x="33.55" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="108.58" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node17" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="38.5,-1750 38.5,-1772 163.5,-1772 163.5,-1750 38.5,-1750"/>
+<polygon fill="none" stroke="black" points="38.5,-1750 38.5,-1772 163.5,-1772 163.5,-1750 38.5,-1750"/>
+<text text-anchor="start" x="68.73" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="38.5,-1728 38.5,-1750 163.5,-1750 163.5,-1728 38.5,-1728"/>
+<text text-anchor="start" x="41.32" y="-1735.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="124.91" y="-1735.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node18" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1874 0.5,-1896 201.5,-1896 201.5,-1874 0.5,-1874"/>
+<polygon fill="none" stroke="black" points="0.5,-1874 0.5,-1896 201.5,-1896 201.5,-1874 0.5,-1874"/>
+<text text-anchor="start" x="29.08" y="-1881.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="0.5,-1852 0.5,-1874 201.5,-1874 201.5,-1852 0.5,-1852"/>
+<text text-anchor="start" x="69.32" y="-1859.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.92" y="-1859.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-1830 0.5,-1852 201.5,-1852 201.5,-1830 0.5,-1830"/>
+<text text-anchor="start" x="3.23" y="-1837.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="138.9" y="-1837.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1808 0.5,-1830 201.5,-1830 201.5,-1808 0.5,-1808"/>
+<text text-anchor="start" x="25.77" y="-1815.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="116.36" y="-1815.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- UncaughtExceptionEntity -->
+<g id="node19" class="node">
+<title>UncaughtExceptionEntity</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-1998 25.5,-2020 176.5,-2020 176.5,-1998 25.5,-1998"/>
+<polygon fill="none" stroke="black" points="25.5,-1998 25.5,-2020 176.5,-2020 176.5,-1998 25.5,-1998"/>
+<text text-anchor="start" x="28.29" y="-2005.4" font-family="Times,serif" font-weight="bold" font-size="14.00">UncaughtExceptionEntity</text>
+<polygon fill="none" stroke="black" points="25.5,-1976 25.5,-1998 176.5,-1998 176.5,-1976 25.5,-1976"/>
+<text text-anchor="start" x="61.93" y="-1983.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-1983.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-1954 25.5,-1976 176.5,-1976 176.5,-1954 25.5,-1954"/>
+<text text-anchor="start" x="32.77" y="-1961.4" font-family="Times,serif" font-size="14.00">exceptionSource: </text>
+<text text-anchor="start" x="133.46" y="-1961.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-1932 25.5,-1954 176.5,-1954 176.5,-1932 25.5,-1932"/>
+<text text-anchor="start" x="55.71" y="-1939.4" font-family="Times,serif" font-size="14.00">message: </text>
+<text text-anchor="start" x="110.52" y="-1939.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/17.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/17.svg
@@ -1,0 +1,322 @@
+<svg width="569px" height="2194px"
+ viewBox="0.00 0.00 568.66 2194.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 2158)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-2158 532.66,-2158 532.66,36 -36,36"/>
+<!-- tds_tracker -->
+<g id="node1" class="node">
+<title>tds_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<polygon fill="none" stroke="black" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<text text-anchor="start" x="69.4" y="-117.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_tracker</text>
+<polygon fill="none" stroke="black" points="37.5,-88 37.5,-110 163.5,-110 163.5,-88 37.5,-88"/>
+<text text-anchor="start" x="57.92" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-95.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-66 37.5,-88 163.5,-88 163.5,-66 37.5,-66"/>
+<text text-anchor="start" x="40.44" y="-73.4" font-family="Times,serif" font-size="14.00">defaultAction: </text>
+<text text-anchor="start" x="124.8" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-44 37.5,-66 163.5,-66 163.5,-44 37.5,-44"/>
+<text text-anchor="start" x="44.72" y="-51.4" font-family="Times,serif" font-size="14.00">ownerName: </text>
+<text text-anchor="start" x="120.52" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-22 37.5,-44 163.5,-44 163.5,-22 37.5,-22"/>
+<text text-anchor="start" x="50.55" y="-29.4" font-family="Times,serif" font-size="14.00">categories: </text>
+<text text-anchor="start" x="114.69" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,0 37.5,-22 163.5,-22 163.5,0 37.5,0"/>
+<text text-anchor="start" x="65.32" y="-7.4" font-family="Times,serif" font-size="14.00">rules: </text>
+<text text-anchor="start" x="99.92" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tds_entity -->
+<g id="node2" class="node">
+<title>tds_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<polygon fill="none" stroke="black" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<text text-anchor="start" x="73.39" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_entity</text>
+<polygon fill="none" stroke="black" points="39.5,-212 39.5,-234 162.5,-234 162.5,-212 39.5,-212"/>
+<text text-anchor="start" x="64.26" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">name: </text>
+<text text-anchor="start" x="101.97" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-190 39.5,-212 162.5,-212 162.5,-190 39.5,-190"/>
+<text text-anchor="start" x="42.49" y="-197.4" font-family="Times,serif" font-size="14.00">displayName: </text>
+<text text-anchor="start" x="123.75" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-168 39.5,-190 162.5,-190 162.5,-168 39.5,-168"/>
+<text text-anchor="start" x="48.72" y="-175.4" font-family="Times,serif" font-size="14.00">prevalence: </text>
+<text text-anchor="start" x="116.73" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+</g>
+<!-- tds_domain_entity -->
+<g id="node3" class="node">
+<title>tds_domain_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<polygon fill="none" stroke="black" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<text text-anchor="start" x="48.39" y="-343.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_domain_entity</text>
+<polygon fill="none" stroke="black" points="43.5,-314 43.5,-336 157.5,-336 157.5,-314 43.5,-314"/>
+<text text-anchor="start" x="57.92" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-321.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="43.5,-292 43.5,-314 157.5,-314 157.5,-292 43.5,-292"/>
+<text text-anchor="start" x="46.27" y="-299.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="118.97" y="-299.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- temporary_tracking_whitelist -->
+<g id="node4" class="node">
+<title>temporary_tracking_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<polygon fill="none" stroke="black" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<text text-anchor="start" x="18.19" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">temporary_tracking_whitelist</text>
+<polygon fill="none" stroke="black" points="15.5,-394 15.5,-416 186.5,-416 186.5,-394 15.5,-394"/>
+<text text-anchor="start" x="58.42" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node5" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="29.5,-562 29.5,-584 171.5,-584 171.5,-562 29.5,-562"/>
+<polygon fill="none" stroke="black" points="29.5,-562 29.5,-584 171.5,-584 171.5,-562 29.5,-562"/>
+<text text-anchor="start" x="32.46" y="-569.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="29.5,-540 29.5,-562 171.5,-562 171.5,-540 29.5,-540"/>
+<text text-anchor="start" x="61.43" y="-547.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-547.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-518 29.5,-540 171.5,-540 171.5,-518 29.5,-518"/>
+<text text-anchor="start" x="52.1" y="-525.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="112.35" y="-525.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="29.5,-496 29.5,-518 171.5,-518 171.5,-496 29.5,-496"/>
+<text text-anchor="start" x="34.6" y="-503.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="106.53" y="-503.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-474 29.5,-496 171.5,-496 171.5,-474 29.5,-474"/>
+<text text-anchor="start" x="59.09" y="-481.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="106.14" y="-481.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node6" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-642 25.5,-664 175.5,-664 175.5,-642 25.5,-642"/>
+<polygon fill="none" stroke="black" points="25.5,-642 25.5,-664 175.5,-664 175.5,-642 25.5,-642"/>
+<text text-anchor="start" x="28.17" y="-649.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="25.5,-620 25.5,-642 175.5,-642 175.5,-620 25.5,-620"/>
+<text text-anchor="start" x="57.92" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-627.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node7" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="36.5,-744 36.5,-766 164.5,-766 164.5,-744 36.5,-744"/>
+<polygon fill="none" stroke="black" points="36.5,-744 36.5,-766 164.5,-766 164.5,-744 36.5,-744"/>
+<text text-anchor="start" x="41.03" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="36.5,-722 36.5,-744 164.5,-744 164.5,-722 36.5,-722"/>
+<text text-anchor="start" x="39.27" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="125.96" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="36.5,-700 36.5,-722 164.5,-722 164.5,-700 36.5,-700"/>
+<text text-anchor="start" x="51.32" y="-707.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node8" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-846 48.5,-868 152.5,-868 152.5,-846 48.5,-846"/>
+<polygon fill="none" stroke="black" points="48.5,-846 48.5,-868 152.5,-868 152.5,-846 48.5,-846"/>
+<text text-anchor="start" x="65.89" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="48.5,-824 48.5,-846 152.5,-846 152.5,-824 48.5,-824"/>
+<text text-anchor="start" x="68.82" y="-831.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-831.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-802 48.5,-824 152.5,-824 152.5,-802 48.5,-802"/>
+<text text-anchor="start" x="51.32" y="-809.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node9" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="364.16,-970 364.16,-992 497.16,-992 497.16,-970 364.16,-970"/>
+<polygon fill="none" stroke="black" points="364.16,-970 364.16,-992 497.16,-992 497.16,-970 364.16,-970"/>
+<text text-anchor="start" x="419.39" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="364.16,-948 364.16,-970 497.16,-970 497.16,-948 364.16,-948"/>
+<text text-anchor="start" x="394.7" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="430.86" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-926 364.16,-948 497.16,-948 497.16,-926 364.16,-926"/>
+<text text-anchor="start" x="401.31" y="-933.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="424.25" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-904 364.16,-926 497.16,-926 497.16,-904 364.16,-904"/>
+<text text-anchor="start" x="398.19" y="-911.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="427.36" y="-911.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-882 364.16,-904 497.16,-904 497.16,-882 364.16,-882"/>
+<text text-anchor="start" x="368.26" y="-889.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="433.2" y="-889.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-860 364.16,-882 497.16,-882 497.16,-860 364.16,-860"/>
+<text text-anchor="start" x="376.82" y="-867.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="424.63" y="-867.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-838 364.16,-860 497.16,-860 497.16,-838 364.16,-838"/>
+<text text-anchor="start" x="374.47" y="-845.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="426.98" y="-845.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-816 364.16,-838 497.16,-838 497.16,-816 364.16,-816"/>
+<text text-anchor="start" x="366.71" y="-823.4" font-family="Times,serif" font-size="14.00">tabPreviewFile: </text>
+<text text-anchor="start" x="458.85" y="-823.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="364.16,-794 364.16,-816 497.16,-816 497.16,-794 364.16,-794"/>
+<polygon fill="none" stroke="black" points="364.16,-794 364.16,-816 497.16,-816 497.16,-794 364.16,-794"/>
+<text text-anchor="start" x="410.45" y="-801.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="364.16,-772 364.16,-794 497.16,-794 497.16,-772 364.16,-772"/>
+<text text-anchor="start" x="382.45" y="-778.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node10" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="24.5,-992 24.5,-1014 177.5,-1014 177.5,-992 24.5,-992"/>
+<polygon fill="none" stroke="black" points="24.5,-992 24.5,-1014 177.5,-1014 177.5,-992 24.5,-992"/>
+<text text-anchor="start" x="64.07" y="-999.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="24.5,-970 24.5,-992 177.5,-992 177.5,-970 24.5,-970"/>
+<text text-anchor="start" x="61.93" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-977.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="24.5,-948 24.5,-970 177.5,-970 177.5,-948 24.5,-948"/>
+<text text-anchor="start" x="65.04" y="-955.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="101.2" y="-955.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="24.5,-926 24.5,-948 177.5,-948 177.5,-926 24.5,-926"/>
+<polygon fill="none" stroke="black" points="24.5,-926 24.5,-948 177.5,-948 177.5,-926 24.5,-926"/>
+<text text-anchor="start" x="80.79" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="24.5,-904 24.5,-926 177.5,-926 177.5,-904 24.5,-904"/>
+<text text-anchor="start" x="27.13" y="-910.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M178.5,-959C257.26,-959 279.49,-959 353.38,-959"/>
+<polygon fill="black" stroke="black" points="353.66,-962.5 363.66,-959 353.66,-955.5 353.66,-962.5"/>
+<text text-anchor="middle" x="282.33" y="-963.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node11" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1116 58.5,-1138 142.5,-1138 142.5,-1116 58.5,-1116"/>
+<polygon fill="none" stroke="black" points="58.5,-1116 58.5,-1138 142.5,-1138 142.5,-1116 58.5,-1116"/>
+<text text-anchor="start" x="69.39" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="58.5,-1094 58.5,-1116 142.5,-1116 142.5,-1094 58.5,-1094"/>
+<text text-anchor="start" x="61.43" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-1072 58.5,-1094 142.5,-1094 142.5,-1072 58.5,-1072"/>
+<text text-anchor="start" x="68.03" y="-1079.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="97.2" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="58.5,-1050 58.5,-1072 142.5,-1072 142.5,-1050 58.5,-1050"/>
+<text text-anchor="start" x="71.15" y="-1057.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.09" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node12" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1262 27.5,-1284 174.5,-1284 174.5,-1262 27.5,-1262"/>
+<polygon fill="none" stroke="black" points="27.5,-1262 27.5,-1284 174.5,-1284 174.5,-1262 27.5,-1262"/>
+<text text-anchor="start" x="82.34" y="-1269.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="27.5,-1240 27.5,-1262 174.5,-1262 174.5,-1240 27.5,-1240"/>
+<text text-anchor="start" x="54.93" y="-1247.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="111.3" y="-1247.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1218 27.5,-1240 174.5,-1240 174.5,-1218 27.5,-1218"/>
+<text text-anchor="start" x="71.65" y="-1225.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.59" y="-1225.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1196 27.5,-1218 174.5,-1218 174.5,-1196 27.5,-1196"/>
+<text text-anchor="start" x="30.44" y="-1203.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="111.69" y="-1203.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1174 27.5,-1196 174.5,-1196 174.5,-1174 27.5,-1174"/>
+<text text-anchor="start" x="63.48" y="-1181.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="102.76" y="-1181.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node13" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1342 58.5,-1364 142.5,-1364 142.5,-1342 58.5,-1342"/>
+<polygon fill="none" stroke="black" points="58.5,-1342 58.5,-1364 142.5,-1364 142.5,-1342 58.5,-1342"/>
+<text text-anchor="start" x="61.23" y="-1349.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="58.5,-1320 58.5,-1342 142.5,-1342 142.5,-1320 58.5,-1320"/>
+<text text-anchor="start" x="64.93" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="100.3" y="-1327.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node14" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1444 48.5,-1466 152.5,-1466 152.5,-1444 48.5,-1444"/>
+<polygon fill="none" stroke="black" points="48.5,-1444 48.5,-1466 152.5,-1466 152.5,-1444 48.5,-1444"/>
+<text text-anchor="start" x="63.57" y="-1451.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="48.5,-1422 48.5,-1444 152.5,-1444 152.5,-1422 48.5,-1422"/>
+<text text-anchor="start" x="68.82" y="-1429.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-1429.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1400 48.5,-1422 152.5,-1422 152.5,-1400 48.5,-1400"/>
+<text text-anchor="start" x="51.32" y="-1407.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-1407.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node15" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-1524 55.5,-1546 146.5,-1546 146.5,-1524 55.5,-1524"/>
+<polygon fill="none" stroke="black" points="55.5,-1524 55.5,-1546 146.5,-1546 146.5,-1524 55.5,-1524"/>
+<text text-anchor="start" x="58.23" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="55.5,-1502 55.5,-1524 146.5,-1524 146.5,-1502 55.5,-1502"/>
+<text text-anchor="start" x="67.76" y="-1509.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="98.47" y="-1509.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node16" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1670 27.5,-1692 174.5,-1692 174.5,-1670 27.5,-1670"/>
+<polygon fill="none" stroke="black" points="27.5,-1670 27.5,-1692 174.5,-1692 174.5,-1670 27.5,-1670"/>
+<text text-anchor="start" x="57.84" y="-1677.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="27.5,-1648 27.5,-1670 174.5,-1670 174.5,-1648 27.5,-1648"/>
+<text text-anchor="start" x="37.83" y="-1655.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="104.3" y="-1655.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1626 27.5,-1648 174.5,-1648 174.5,-1626 27.5,-1626"/>
+<text text-anchor="start" x="30.04" y="-1633.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="112.1" y="-1633.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1604 27.5,-1626 174.5,-1626 174.5,-1604 27.5,-1604"/>
+<text text-anchor="start" x="38.21" y="-1611.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-1611.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1582 27.5,-1604 174.5,-1604 174.5,-1582 27.5,-1582"/>
+<text text-anchor="start" x="33.55" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="108.58" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node17" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="38.5,-1750 38.5,-1772 163.5,-1772 163.5,-1750 38.5,-1750"/>
+<polygon fill="none" stroke="black" points="38.5,-1750 38.5,-1772 163.5,-1772 163.5,-1750 38.5,-1750"/>
+<text text-anchor="start" x="68.73" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="38.5,-1728 38.5,-1750 163.5,-1750 163.5,-1728 38.5,-1728"/>
+<text text-anchor="start" x="41.32" y="-1735.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="124.91" y="-1735.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node18" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1874 0.5,-1896 201.5,-1896 201.5,-1874 0.5,-1874"/>
+<polygon fill="none" stroke="black" points="0.5,-1874 0.5,-1896 201.5,-1896 201.5,-1874 0.5,-1874"/>
+<text text-anchor="start" x="29.08" y="-1881.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="0.5,-1852 0.5,-1874 201.5,-1874 201.5,-1852 0.5,-1852"/>
+<text text-anchor="start" x="69.32" y="-1859.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.92" y="-1859.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-1830 0.5,-1852 201.5,-1852 201.5,-1830 0.5,-1830"/>
+<text text-anchor="start" x="3.23" y="-1837.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="138.9" y="-1837.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1808 0.5,-1830 201.5,-1830 201.5,-1808 0.5,-1808"/>
+<text text-anchor="start" x="25.77" y="-1815.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="116.36" y="-1815.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- UncaughtExceptionEntity -->
+<g id="node19" class="node">
+<title>UncaughtExceptionEntity</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-1998 25.5,-2020 176.5,-2020 176.5,-1998 25.5,-1998"/>
+<polygon fill="none" stroke="black" points="25.5,-1998 25.5,-2020 176.5,-2020 176.5,-1998 25.5,-1998"/>
+<text text-anchor="start" x="28.29" y="-2005.4" font-family="Times,serif" font-weight="bold" font-size="14.00">UncaughtExceptionEntity</text>
+<polygon fill="none" stroke="black" points="25.5,-1976 25.5,-1998 176.5,-1998 176.5,-1976 25.5,-1976"/>
+<text text-anchor="start" x="61.93" y="-1983.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-1983.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-1954 25.5,-1976 176.5,-1976 176.5,-1954 25.5,-1954"/>
+<text text-anchor="start" x="32.77" y="-1961.4" font-family="Times,serif" font-size="14.00">exceptionSource: </text>
+<text text-anchor="start" x="133.46" y="-1961.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-1932 25.5,-1954 176.5,-1954 176.5,-1932 25.5,-1932"/>
+<text text-anchor="start" x="55.71" y="-1939.4" font-family="Times,serif" font-size="14.00">message: </text>
+<text text-anchor="start" x="110.52" y="-1939.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tdsMetadata -->
+<g id="node20" class="node">
+<title>tdsMetadata</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-2100 58.5,-2122 142.5,-2122 142.5,-2100 58.5,-2100"/>
+<polygon fill="none" stroke="black" points="58.5,-2100 58.5,-2122 142.5,-2122 142.5,-2100 58.5,-2100"/>
+<text text-anchor="start" x="66.29" y="-2107.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tdsMetadata</text>
+<polygon fill="none" stroke="black" points="58.5,-2078 58.5,-2100 142.5,-2100 142.5,-2078 58.5,-2078"/>
+<text text-anchor="start" x="61.43" y="-2085.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-2085.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-2056 58.5,-2078 142.5,-2078 142.5,-2056 58.5,-2056"/>
+<text text-anchor="start" x="64.93" y="-2063.4" font-family="Times,serif" font-size="14.00">eTag: </text>
+<text text-anchor="start" x="100.3" y="-2063.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/18.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/18.svg
@@ -1,0 +1,335 @@
+<svg width="569px" height="2296px"
+ viewBox="0.00 0.00 568.66 2296.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 2260)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-2260 532.66,-2260 532.66,36 -36,36"/>
+<!-- tds_tracker -->
+<g id="node1" class="node">
+<title>tds_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<polygon fill="none" stroke="black" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<text text-anchor="start" x="69.4" y="-117.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_tracker</text>
+<polygon fill="none" stroke="black" points="37.5,-88 37.5,-110 163.5,-110 163.5,-88 37.5,-88"/>
+<text text-anchor="start" x="57.92" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-95.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-66 37.5,-88 163.5,-88 163.5,-66 37.5,-66"/>
+<text text-anchor="start" x="40.44" y="-73.4" font-family="Times,serif" font-size="14.00">defaultAction: </text>
+<text text-anchor="start" x="124.8" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-44 37.5,-66 163.5,-66 163.5,-44 37.5,-44"/>
+<text text-anchor="start" x="44.72" y="-51.4" font-family="Times,serif" font-size="14.00">ownerName: </text>
+<text text-anchor="start" x="120.52" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-22 37.5,-44 163.5,-44 163.5,-22 37.5,-22"/>
+<text text-anchor="start" x="50.55" y="-29.4" font-family="Times,serif" font-size="14.00">categories: </text>
+<text text-anchor="start" x="114.69" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,0 37.5,-22 163.5,-22 163.5,0 37.5,0"/>
+<text text-anchor="start" x="65.32" y="-7.4" font-family="Times,serif" font-size="14.00">rules: </text>
+<text text-anchor="start" x="99.92" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tds_entity -->
+<g id="node2" class="node">
+<title>tds_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<polygon fill="none" stroke="black" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<text text-anchor="start" x="73.39" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_entity</text>
+<polygon fill="none" stroke="black" points="39.5,-212 39.5,-234 162.5,-234 162.5,-212 39.5,-212"/>
+<text text-anchor="start" x="64.26" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">name: </text>
+<text text-anchor="start" x="101.97" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-190 39.5,-212 162.5,-212 162.5,-190 39.5,-190"/>
+<text text-anchor="start" x="42.49" y="-197.4" font-family="Times,serif" font-size="14.00">displayName: </text>
+<text text-anchor="start" x="123.75" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-168 39.5,-190 162.5,-190 162.5,-168 39.5,-168"/>
+<text text-anchor="start" x="48.72" y="-175.4" font-family="Times,serif" font-size="14.00">prevalence: </text>
+<text text-anchor="start" x="116.73" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+</g>
+<!-- tds_domain_entity -->
+<g id="node3" class="node">
+<title>tds_domain_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<polygon fill="none" stroke="black" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<text text-anchor="start" x="48.39" y="-343.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_domain_entity</text>
+<polygon fill="none" stroke="black" points="43.5,-314 43.5,-336 157.5,-336 157.5,-314 43.5,-314"/>
+<text text-anchor="start" x="57.92" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-321.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="43.5,-292 43.5,-314 157.5,-314 157.5,-292 43.5,-292"/>
+<text text-anchor="start" x="46.27" y="-299.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="118.97" y="-299.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- temporary_tracking_whitelist -->
+<g id="node4" class="node">
+<title>temporary_tracking_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<polygon fill="none" stroke="black" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<text text-anchor="start" x="18.19" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">temporary_tracking_whitelist</text>
+<polygon fill="none" stroke="black" points="15.5,-394 15.5,-416 186.5,-416 186.5,-394 15.5,-394"/>
+<text text-anchor="start" x="58.42" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node5" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="29.5,-562 29.5,-584 171.5,-584 171.5,-562 29.5,-562"/>
+<polygon fill="none" stroke="black" points="29.5,-562 29.5,-584 171.5,-584 171.5,-562 29.5,-562"/>
+<text text-anchor="start" x="32.46" y="-569.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="29.5,-540 29.5,-562 171.5,-562 171.5,-540 29.5,-540"/>
+<text text-anchor="start" x="61.43" y="-547.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-547.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-518 29.5,-540 171.5,-540 171.5,-518 29.5,-518"/>
+<text text-anchor="start" x="52.1" y="-525.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="112.35" y="-525.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="29.5,-496 29.5,-518 171.5,-518 171.5,-496 29.5,-496"/>
+<text text-anchor="start" x="34.6" y="-503.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="106.53" y="-503.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-474 29.5,-496 171.5,-496 171.5,-474 29.5,-474"/>
+<text text-anchor="start" x="59.09" y="-481.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="106.14" y="-481.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node6" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-642 25.5,-664 175.5,-664 175.5,-642 25.5,-642"/>
+<polygon fill="none" stroke="black" points="25.5,-642 25.5,-664 175.5,-664 175.5,-642 25.5,-642"/>
+<text text-anchor="start" x="28.17" y="-649.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="25.5,-620 25.5,-642 175.5,-642 175.5,-620 25.5,-620"/>
+<text text-anchor="start" x="57.92" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-627.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node7" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="36.5,-744 36.5,-766 164.5,-766 164.5,-744 36.5,-744"/>
+<polygon fill="none" stroke="black" points="36.5,-744 36.5,-766 164.5,-766 164.5,-744 36.5,-744"/>
+<text text-anchor="start" x="41.03" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="36.5,-722 36.5,-744 164.5,-744 164.5,-722 36.5,-722"/>
+<text text-anchor="start" x="39.27" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="125.96" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="36.5,-700 36.5,-722 164.5,-722 164.5,-700 36.5,-700"/>
+<text text-anchor="start" x="51.32" y="-707.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node8" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-846 48.5,-868 152.5,-868 152.5,-846 48.5,-846"/>
+<polygon fill="none" stroke="black" points="48.5,-846 48.5,-868 152.5,-868 152.5,-846 48.5,-846"/>
+<text text-anchor="start" x="65.89" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="48.5,-824 48.5,-846 152.5,-846 152.5,-824 48.5,-824"/>
+<text text-anchor="start" x="68.82" y="-831.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-831.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-802 48.5,-824 152.5,-824 152.5,-802 48.5,-802"/>
+<text text-anchor="start" x="51.32" y="-809.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node9" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="364.16,-970 364.16,-992 497.16,-992 497.16,-970 364.16,-970"/>
+<polygon fill="none" stroke="black" points="364.16,-970 364.16,-992 497.16,-992 497.16,-970 364.16,-970"/>
+<text text-anchor="start" x="419.39" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="364.16,-948 364.16,-970 497.16,-970 497.16,-948 364.16,-948"/>
+<text text-anchor="start" x="394.7" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="430.86" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-926 364.16,-948 497.16,-948 497.16,-926 364.16,-926"/>
+<text text-anchor="start" x="401.31" y="-933.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="424.25" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-904 364.16,-926 497.16,-926 497.16,-904 364.16,-904"/>
+<text text-anchor="start" x="398.19" y="-911.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="427.36" y="-911.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-882 364.16,-904 497.16,-904 497.16,-882 364.16,-882"/>
+<text text-anchor="start" x="368.26" y="-889.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="433.2" y="-889.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-860 364.16,-882 497.16,-882 497.16,-860 364.16,-860"/>
+<text text-anchor="start" x="376.82" y="-867.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="424.63" y="-867.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-838 364.16,-860 497.16,-860 497.16,-838 364.16,-838"/>
+<text text-anchor="start" x="374.47" y="-845.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="426.98" y="-845.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-816 364.16,-838 497.16,-838 497.16,-816 364.16,-816"/>
+<text text-anchor="start" x="366.71" y="-823.4" font-family="Times,serif" font-size="14.00">tabPreviewFile: </text>
+<text text-anchor="start" x="458.85" y="-823.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="364.16,-794 364.16,-816 497.16,-816 497.16,-794 364.16,-794"/>
+<polygon fill="none" stroke="black" points="364.16,-794 364.16,-816 497.16,-816 497.16,-794 364.16,-794"/>
+<text text-anchor="start" x="410.45" y="-801.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="364.16,-772 364.16,-794 497.16,-794 497.16,-772 364.16,-772"/>
+<text text-anchor="start" x="382.45" y="-778.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node10" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="24.5,-992 24.5,-1014 177.5,-1014 177.5,-992 24.5,-992"/>
+<polygon fill="none" stroke="black" points="24.5,-992 24.5,-1014 177.5,-1014 177.5,-992 24.5,-992"/>
+<text text-anchor="start" x="64.07" y="-999.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="24.5,-970 24.5,-992 177.5,-992 177.5,-970 24.5,-970"/>
+<text text-anchor="start" x="61.93" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-977.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="24.5,-948 24.5,-970 177.5,-970 177.5,-948 24.5,-948"/>
+<text text-anchor="start" x="65.04" y="-955.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="101.2" y="-955.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="24.5,-926 24.5,-948 177.5,-948 177.5,-926 24.5,-926"/>
+<polygon fill="none" stroke="black" points="24.5,-926 24.5,-948 177.5,-948 177.5,-926 24.5,-926"/>
+<text text-anchor="start" x="80.79" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="24.5,-904 24.5,-926 177.5,-926 177.5,-904 24.5,-904"/>
+<text text-anchor="start" x="27.13" y="-910.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M178.5,-959C257.26,-959 279.49,-959 353.38,-959"/>
+<polygon fill="black" stroke="black" points="353.66,-962.5 363.66,-959 353.66,-955.5 353.66,-962.5"/>
+<text text-anchor="middle" x="282.33" y="-963.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node11" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1116 58.5,-1138 142.5,-1138 142.5,-1116 58.5,-1116"/>
+<polygon fill="none" stroke="black" points="58.5,-1116 58.5,-1138 142.5,-1138 142.5,-1116 58.5,-1116"/>
+<text text-anchor="start" x="69.39" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="58.5,-1094 58.5,-1116 142.5,-1116 142.5,-1094 58.5,-1094"/>
+<text text-anchor="start" x="61.43" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-1072 58.5,-1094 142.5,-1094 142.5,-1072 58.5,-1072"/>
+<text text-anchor="start" x="68.03" y="-1079.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="97.2" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="58.5,-1050 58.5,-1072 142.5,-1072 142.5,-1050 58.5,-1050"/>
+<text text-anchor="start" x="71.15" y="-1057.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.09" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node12" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1262 27.5,-1284 174.5,-1284 174.5,-1262 27.5,-1262"/>
+<polygon fill="none" stroke="black" points="27.5,-1262 27.5,-1284 174.5,-1284 174.5,-1262 27.5,-1262"/>
+<text text-anchor="start" x="82.34" y="-1269.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="27.5,-1240 27.5,-1262 174.5,-1262 174.5,-1240 27.5,-1240"/>
+<text text-anchor="start" x="54.93" y="-1247.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="111.3" y="-1247.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1218 27.5,-1240 174.5,-1240 174.5,-1218 27.5,-1218"/>
+<text text-anchor="start" x="71.65" y="-1225.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.59" y="-1225.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1196 27.5,-1218 174.5,-1218 174.5,-1196 27.5,-1196"/>
+<text text-anchor="start" x="30.44" y="-1203.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="111.69" y="-1203.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1174 27.5,-1196 174.5,-1196 174.5,-1174 27.5,-1174"/>
+<text text-anchor="start" x="63.48" y="-1181.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="102.76" y="-1181.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node13" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1342 58.5,-1364 142.5,-1364 142.5,-1342 58.5,-1342"/>
+<polygon fill="none" stroke="black" points="58.5,-1342 58.5,-1364 142.5,-1364 142.5,-1342 58.5,-1342"/>
+<text text-anchor="start" x="61.23" y="-1349.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="58.5,-1320 58.5,-1342 142.5,-1342 142.5,-1320 58.5,-1320"/>
+<text text-anchor="start" x="64.93" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="100.3" y="-1327.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node14" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1444 48.5,-1466 152.5,-1466 152.5,-1444 48.5,-1444"/>
+<polygon fill="none" stroke="black" points="48.5,-1444 48.5,-1466 152.5,-1466 152.5,-1444 48.5,-1444"/>
+<text text-anchor="start" x="63.57" y="-1451.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="48.5,-1422 48.5,-1444 152.5,-1444 152.5,-1422 48.5,-1422"/>
+<text text-anchor="start" x="68.82" y="-1429.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-1429.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1400 48.5,-1422 152.5,-1422 152.5,-1400 48.5,-1400"/>
+<text text-anchor="start" x="51.32" y="-1407.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-1407.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node15" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-1524 55.5,-1546 146.5,-1546 146.5,-1524 55.5,-1524"/>
+<polygon fill="none" stroke="black" points="55.5,-1524 55.5,-1546 146.5,-1546 146.5,-1524 55.5,-1524"/>
+<text text-anchor="start" x="58.23" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="55.5,-1502 55.5,-1524 146.5,-1524 146.5,-1502 55.5,-1502"/>
+<text text-anchor="start" x="67.76" y="-1509.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="98.47" y="-1509.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node16" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1670 27.5,-1692 174.5,-1692 174.5,-1670 27.5,-1670"/>
+<polygon fill="none" stroke="black" points="27.5,-1670 27.5,-1692 174.5,-1692 174.5,-1670 27.5,-1670"/>
+<text text-anchor="start" x="57.84" y="-1677.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="27.5,-1648 27.5,-1670 174.5,-1670 174.5,-1648 27.5,-1648"/>
+<text text-anchor="start" x="37.83" y="-1655.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="104.3" y="-1655.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1626 27.5,-1648 174.5,-1648 174.5,-1626 27.5,-1626"/>
+<text text-anchor="start" x="30.04" y="-1633.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="112.1" y="-1633.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1604 27.5,-1626 174.5,-1626 174.5,-1604 27.5,-1604"/>
+<text text-anchor="start" x="38.21" y="-1611.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-1611.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1582 27.5,-1604 174.5,-1604 174.5,-1582 27.5,-1582"/>
+<text text-anchor="start" x="33.55" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="108.58" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node17" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="38.5,-1750 38.5,-1772 163.5,-1772 163.5,-1750 38.5,-1750"/>
+<polygon fill="none" stroke="black" points="38.5,-1750 38.5,-1772 163.5,-1772 163.5,-1750 38.5,-1750"/>
+<text text-anchor="start" x="68.73" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="38.5,-1728 38.5,-1750 163.5,-1750 163.5,-1728 38.5,-1728"/>
+<text text-anchor="start" x="41.32" y="-1735.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="124.91" y="-1735.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node18" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1874 0.5,-1896 201.5,-1896 201.5,-1874 0.5,-1874"/>
+<polygon fill="none" stroke="black" points="0.5,-1874 0.5,-1896 201.5,-1896 201.5,-1874 0.5,-1874"/>
+<text text-anchor="start" x="29.08" y="-1881.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="0.5,-1852 0.5,-1874 201.5,-1874 201.5,-1852 0.5,-1852"/>
+<text text-anchor="start" x="69.32" y="-1859.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.92" y="-1859.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-1830 0.5,-1852 201.5,-1852 201.5,-1830 0.5,-1830"/>
+<text text-anchor="start" x="3.23" y="-1837.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="138.9" y="-1837.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1808 0.5,-1830 201.5,-1830 201.5,-1808 0.5,-1808"/>
+<text text-anchor="start" x="25.77" y="-1815.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="116.36" y="-1815.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- UncaughtExceptionEntity -->
+<g id="node19" class="node">
+<title>UncaughtExceptionEntity</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-1998 25.5,-2020 176.5,-2020 176.5,-1998 25.5,-1998"/>
+<polygon fill="none" stroke="black" points="25.5,-1998 25.5,-2020 176.5,-2020 176.5,-1998 25.5,-1998"/>
+<text text-anchor="start" x="28.29" y="-2005.4" font-family="Times,serif" font-weight="bold" font-size="14.00">UncaughtExceptionEntity</text>
+<polygon fill="none" stroke="black" points="25.5,-1976 25.5,-1998 176.5,-1998 176.5,-1976 25.5,-1976"/>
+<text text-anchor="start" x="61.93" y="-1983.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-1983.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-1954 25.5,-1976 176.5,-1976 176.5,-1954 25.5,-1954"/>
+<text text-anchor="start" x="32.77" y="-1961.4" font-family="Times,serif" font-size="14.00">exceptionSource: </text>
+<text text-anchor="start" x="133.46" y="-1961.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-1932 25.5,-1954 176.5,-1954 176.5,-1932 25.5,-1932"/>
+<text text-anchor="start" x="55.71" y="-1939.4" font-family="Times,serif" font-size="14.00">message: </text>
+<text text-anchor="start" x="110.52" y="-1939.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tdsMetadata -->
+<g id="node20" class="node">
+<title>tdsMetadata</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-2100 58.5,-2122 142.5,-2122 142.5,-2100 58.5,-2100"/>
+<polygon fill="none" stroke="black" points="58.5,-2100 58.5,-2122 142.5,-2122 142.5,-2100 58.5,-2100"/>
+<text text-anchor="start" x="66.29" y="-2107.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tdsMetadata</text>
+<polygon fill="none" stroke="black" points="58.5,-2078 58.5,-2100 142.5,-2100 142.5,-2078 58.5,-2078"/>
+<text text-anchor="start" x="61.43" y="-2085.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-2085.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-2056 58.5,-2078 142.5,-2078 142.5,-2056 58.5,-2056"/>
+<text text-anchor="start" x="64.93" y="-2063.4" font-family="Times,serif" font-size="14.00">eTag: </text>
+<text text-anchor="start" x="100.3" y="-2063.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- userStage -->
+<g id="node21" class="node">
+<title>userStage</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-2202 50.5,-2224 150.5,-2224 150.5,-2202 50.5,-2202"/>
+<polygon fill="none" stroke="black" points="50.5,-2202 50.5,-2224 150.5,-2224 150.5,-2202 50.5,-2202"/>
+<text text-anchor="start" x="73.29" y="-2209.4" font-family="Times,serif" font-weight="bold" font-size="14.00">userStage</text>
+<polygon fill="none" stroke="black" points="50.5,-2180 50.5,-2202 150.5,-2202 150.5,-2180 50.5,-2180"/>
+<text text-anchor="start" x="56.76" y="-2187.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="84.37" y="-2187.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-2158 50.5,-2180 150.5,-2180 150.5,-2158 50.5,-2158"/>
+<text text-anchor="start" x="53.26" y="-2165.4" font-family="Times,serif" font-size="14.00">appStage: </text>
+<text text-anchor="start" x="111.97" y="-2165.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/19.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/19.svg
@@ -1,0 +1,341 @@
+<svg width="569px" height="2340px"
+ viewBox="0.00 0.00 568.66 2340.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 2304)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-2304 532.66,-2304 532.66,36 -36,36"/>
+<!-- tds_tracker -->
+<g id="node1" class="node">
+<title>tds_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<polygon fill="none" stroke="black" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<text text-anchor="start" x="69.4" y="-117.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_tracker</text>
+<polygon fill="none" stroke="black" points="37.5,-88 37.5,-110 163.5,-110 163.5,-88 37.5,-88"/>
+<text text-anchor="start" x="57.92" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-95.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-66 37.5,-88 163.5,-88 163.5,-66 37.5,-66"/>
+<text text-anchor="start" x="40.44" y="-73.4" font-family="Times,serif" font-size="14.00">defaultAction: </text>
+<text text-anchor="start" x="124.8" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-44 37.5,-66 163.5,-66 163.5,-44 37.5,-44"/>
+<text text-anchor="start" x="44.72" y="-51.4" font-family="Times,serif" font-size="14.00">ownerName: </text>
+<text text-anchor="start" x="120.52" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-22 37.5,-44 163.5,-44 163.5,-22 37.5,-22"/>
+<text text-anchor="start" x="50.55" y="-29.4" font-family="Times,serif" font-size="14.00">categories: </text>
+<text text-anchor="start" x="114.69" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,0 37.5,-22 163.5,-22 163.5,0 37.5,0"/>
+<text text-anchor="start" x="65.32" y="-7.4" font-family="Times,serif" font-size="14.00">rules: </text>
+<text text-anchor="start" x="99.92" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tds_entity -->
+<g id="node2" class="node">
+<title>tds_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<polygon fill="none" stroke="black" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<text text-anchor="start" x="73.39" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_entity</text>
+<polygon fill="none" stroke="black" points="39.5,-212 39.5,-234 162.5,-234 162.5,-212 39.5,-212"/>
+<text text-anchor="start" x="64.26" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">name: </text>
+<text text-anchor="start" x="101.97" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-190 39.5,-212 162.5,-212 162.5,-190 39.5,-190"/>
+<text text-anchor="start" x="42.49" y="-197.4" font-family="Times,serif" font-size="14.00">displayName: </text>
+<text text-anchor="start" x="123.75" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-168 39.5,-190 162.5,-190 162.5,-168 39.5,-168"/>
+<text text-anchor="start" x="48.72" y="-175.4" font-family="Times,serif" font-size="14.00">prevalence: </text>
+<text text-anchor="start" x="116.73" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+</g>
+<!-- tds_domain_entity -->
+<g id="node3" class="node">
+<title>tds_domain_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<polygon fill="none" stroke="black" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<text text-anchor="start" x="48.39" y="-343.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_domain_entity</text>
+<polygon fill="none" stroke="black" points="43.5,-314 43.5,-336 157.5,-336 157.5,-314 43.5,-314"/>
+<text text-anchor="start" x="57.92" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-321.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="43.5,-292 43.5,-314 157.5,-314 157.5,-292 43.5,-292"/>
+<text text-anchor="start" x="46.27" y="-299.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="118.97" y="-299.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- temporary_tracking_whitelist -->
+<g id="node4" class="node">
+<title>temporary_tracking_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<polygon fill="none" stroke="black" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<text text-anchor="start" x="18.19" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">temporary_tracking_whitelist</text>
+<polygon fill="none" stroke="black" points="15.5,-394 15.5,-416 186.5,-416 186.5,-394 15.5,-394"/>
+<text text-anchor="start" x="58.42" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node5" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="29.5,-562 29.5,-584 171.5,-584 171.5,-562 29.5,-562"/>
+<polygon fill="none" stroke="black" points="29.5,-562 29.5,-584 171.5,-584 171.5,-562 29.5,-562"/>
+<text text-anchor="start" x="32.46" y="-569.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="29.5,-540 29.5,-562 171.5,-562 171.5,-540 29.5,-540"/>
+<text text-anchor="start" x="61.43" y="-547.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-547.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-518 29.5,-540 171.5,-540 171.5,-518 29.5,-518"/>
+<text text-anchor="start" x="52.1" y="-525.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="112.35" y="-525.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="29.5,-496 29.5,-518 171.5,-518 171.5,-496 29.5,-496"/>
+<text text-anchor="start" x="34.6" y="-503.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="106.53" y="-503.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-474 29.5,-496 171.5,-496 171.5,-474 29.5,-474"/>
+<text text-anchor="start" x="59.09" y="-481.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="106.14" y="-481.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node6" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-642 25.5,-664 175.5,-664 175.5,-642 25.5,-642"/>
+<polygon fill="none" stroke="black" points="25.5,-642 25.5,-664 175.5,-664 175.5,-642 25.5,-642"/>
+<text text-anchor="start" x="28.17" y="-649.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="25.5,-620 25.5,-642 175.5,-642 175.5,-620 25.5,-620"/>
+<text text-anchor="start" x="57.92" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-627.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node7" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="36.5,-744 36.5,-766 164.5,-766 164.5,-744 36.5,-744"/>
+<polygon fill="none" stroke="black" points="36.5,-744 36.5,-766 164.5,-766 164.5,-744 36.5,-744"/>
+<text text-anchor="start" x="41.03" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="36.5,-722 36.5,-744 164.5,-744 164.5,-722 36.5,-722"/>
+<text text-anchor="start" x="39.27" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="125.96" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="36.5,-700 36.5,-722 164.5,-722 164.5,-700 36.5,-700"/>
+<text text-anchor="start" x="51.32" y="-707.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node8" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-846 48.5,-868 152.5,-868 152.5,-846 48.5,-846"/>
+<polygon fill="none" stroke="black" points="48.5,-846 48.5,-868 152.5,-868 152.5,-846 48.5,-846"/>
+<text text-anchor="start" x="65.89" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="48.5,-824 48.5,-846 152.5,-846 152.5,-824 48.5,-824"/>
+<text text-anchor="start" x="68.82" y="-831.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-831.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-802 48.5,-824 152.5,-824 152.5,-802 48.5,-802"/>
+<text text-anchor="start" x="51.32" y="-809.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node9" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="364.16,-970 364.16,-992 497.16,-992 497.16,-970 364.16,-970"/>
+<polygon fill="none" stroke="black" points="364.16,-970 364.16,-992 497.16,-992 497.16,-970 364.16,-970"/>
+<text text-anchor="start" x="419.39" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="364.16,-948 364.16,-970 497.16,-970 497.16,-948 364.16,-948"/>
+<text text-anchor="start" x="394.7" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="430.86" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-926 364.16,-948 497.16,-948 497.16,-926 364.16,-926"/>
+<text text-anchor="start" x="401.31" y="-933.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="424.25" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-904 364.16,-926 497.16,-926 497.16,-904 364.16,-904"/>
+<text text-anchor="start" x="398.19" y="-911.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="427.36" y="-911.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-882 364.16,-904 497.16,-904 497.16,-882 364.16,-882"/>
+<text text-anchor="start" x="368.26" y="-889.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="433.2" y="-889.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-860 364.16,-882 497.16,-882 497.16,-860 364.16,-860"/>
+<text text-anchor="start" x="376.82" y="-867.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="424.63" y="-867.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-838 364.16,-860 497.16,-860 497.16,-838 364.16,-838"/>
+<text text-anchor="start" x="374.47" y="-845.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="426.98" y="-845.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-816 364.16,-838 497.16,-838 497.16,-816 364.16,-816"/>
+<text text-anchor="start" x="366.71" y="-823.4" font-family="Times,serif" font-size="14.00">tabPreviewFile: </text>
+<text text-anchor="start" x="458.85" y="-823.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="364.16,-794 364.16,-816 497.16,-816 497.16,-794 364.16,-794"/>
+<polygon fill="none" stroke="black" points="364.16,-794 364.16,-816 497.16,-816 497.16,-794 364.16,-794"/>
+<text text-anchor="start" x="410.45" y="-801.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="364.16,-772 364.16,-794 497.16,-794 497.16,-772 364.16,-772"/>
+<text text-anchor="start" x="382.45" y="-778.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node10" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="24.5,-992 24.5,-1014 177.5,-1014 177.5,-992 24.5,-992"/>
+<polygon fill="none" stroke="black" points="24.5,-992 24.5,-1014 177.5,-1014 177.5,-992 24.5,-992"/>
+<text text-anchor="start" x="64.07" y="-999.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="24.5,-970 24.5,-992 177.5,-992 177.5,-970 24.5,-970"/>
+<text text-anchor="start" x="61.93" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-977.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="24.5,-948 24.5,-970 177.5,-970 177.5,-948 24.5,-948"/>
+<text text-anchor="start" x="65.04" y="-955.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="101.2" y="-955.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="24.5,-926 24.5,-948 177.5,-948 177.5,-926 24.5,-926"/>
+<polygon fill="none" stroke="black" points="24.5,-926 24.5,-948 177.5,-948 177.5,-926 24.5,-926"/>
+<text text-anchor="start" x="80.79" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="24.5,-904 24.5,-926 177.5,-926 177.5,-904 24.5,-904"/>
+<text text-anchor="start" x="27.13" y="-910.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M178.5,-959C257.26,-959 279.49,-959 353.38,-959"/>
+<polygon fill="black" stroke="black" points="353.66,-962.5 363.66,-959 353.66,-955.5 353.66,-962.5"/>
+<text text-anchor="middle" x="282.33" y="-963.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node11" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1116 58.5,-1138 142.5,-1138 142.5,-1116 58.5,-1116"/>
+<polygon fill="none" stroke="black" points="58.5,-1116 58.5,-1138 142.5,-1138 142.5,-1116 58.5,-1116"/>
+<text text-anchor="start" x="69.39" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="58.5,-1094 58.5,-1116 142.5,-1116 142.5,-1094 58.5,-1094"/>
+<text text-anchor="start" x="61.43" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-1072 58.5,-1094 142.5,-1094 142.5,-1072 58.5,-1072"/>
+<text text-anchor="start" x="68.03" y="-1079.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="97.2" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="58.5,-1050 58.5,-1072 142.5,-1072 142.5,-1050 58.5,-1050"/>
+<text text-anchor="start" x="71.15" y="-1057.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.09" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node12" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1262 27.5,-1284 174.5,-1284 174.5,-1262 27.5,-1262"/>
+<polygon fill="none" stroke="black" points="27.5,-1262 27.5,-1284 174.5,-1284 174.5,-1262 27.5,-1262"/>
+<text text-anchor="start" x="82.34" y="-1269.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="27.5,-1240 27.5,-1262 174.5,-1262 174.5,-1240 27.5,-1240"/>
+<text text-anchor="start" x="54.93" y="-1247.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="111.3" y="-1247.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1218 27.5,-1240 174.5,-1240 174.5,-1218 27.5,-1218"/>
+<text text-anchor="start" x="71.65" y="-1225.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.59" y="-1225.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1196 27.5,-1218 174.5,-1218 174.5,-1196 27.5,-1196"/>
+<text text-anchor="start" x="30.44" y="-1203.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="111.69" y="-1203.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1174 27.5,-1196 174.5,-1196 174.5,-1174 27.5,-1174"/>
+<text text-anchor="start" x="63.48" y="-1181.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="102.76" y="-1181.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node13" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1342 58.5,-1364 142.5,-1364 142.5,-1342 58.5,-1342"/>
+<polygon fill="none" stroke="black" points="58.5,-1342 58.5,-1364 142.5,-1364 142.5,-1342 58.5,-1342"/>
+<text text-anchor="start" x="61.23" y="-1349.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="58.5,-1320 58.5,-1342 142.5,-1342 142.5,-1320 58.5,-1320"/>
+<text text-anchor="start" x="64.93" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="100.3" y="-1327.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node14" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1444 48.5,-1466 152.5,-1466 152.5,-1444 48.5,-1444"/>
+<polygon fill="none" stroke="black" points="48.5,-1444 48.5,-1466 152.5,-1466 152.5,-1444 48.5,-1444"/>
+<text text-anchor="start" x="63.57" y="-1451.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="48.5,-1422 48.5,-1444 152.5,-1444 152.5,-1422 48.5,-1422"/>
+<text text-anchor="start" x="68.82" y="-1429.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-1429.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1400 48.5,-1422 152.5,-1422 152.5,-1400 48.5,-1400"/>
+<text text-anchor="start" x="51.32" y="-1407.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-1407.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node15" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-1524 55.5,-1546 146.5,-1546 146.5,-1524 55.5,-1524"/>
+<polygon fill="none" stroke="black" points="55.5,-1524 55.5,-1546 146.5,-1546 146.5,-1524 55.5,-1524"/>
+<text text-anchor="start" x="58.23" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="55.5,-1502 55.5,-1524 146.5,-1524 146.5,-1502 55.5,-1502"/>
+<text text-anchor="start" x="67.76" y="-1509.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="98.47" y="-1509.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node16" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1670 27.5,-1692 174.5,-1692 174.5,-1670 27.5,-1670"/>
+<polygon fill="none" stroke="black" points="27.5,-1670 27.5,-1692 174.5,-1692 174.5,-1670 27.5,-1670"/>
+<text text-anchor="start" x="57.84" y="-1677.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="27.5,-1648 27.5,-1670 174.5,-1670 174.5,-1648 27.5,-1648"/>
+<text text-anchor="start" x="37.83" y="-1655.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="104.3" y="-1655.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1626 27.5,-1648 174.5,-1648 174.5,-1626 27.5,-1626"/>
+<text text-anchor="start" x="30.04" y="-1633.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="112.1" y="-1633.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1604 27.5,-1626 174.5,-1626 174.5,-1604 27.5,-1604"/>
+<text text-anchor="start" x="38.21" y="-1611.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-1611.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1582 27.5,-1604 174.5,-1604 174.5,-1582 27.5,-1582"/>
+<text text-anchor="start" x="33.55" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="108.58" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node17" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="38.5,-1750 38.5,-1772 163.5,-1772 163.5,-1750 38.5,-1750"/>
+<polygon fill="none" stroke="black" points="38.5,-1750 38.5,-1772 163.5,-1772 163.5,-1750 38.5,-1750"/>
+<text text-anchor="start" x="68.73" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="38.5,-1728 38.5,-1750 163.5,-1750 163.5,-1728 38.5,-1728"/>
+<text text-anchor="start" x="41.32" y="-1735.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="124.91" y="-1735.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node18" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1874 0.5,-1896 201.5,-1896 201.5,-1874 0.5,-1874"/>
+<polygon fill="none" stroke="black" points="0.5,-1874 0.5,-1896 201.5,-1896 201.5,-1874 0.5,-1874"/>
+<text text-anchor="start" x="29.08" y="-1881.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="0.5,-1852 0.5,-1874 201.5,-1874 201.5,-1852 0.5,-1852"/>
+<text text-anchor="start" x="69.32" y="-1859.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.92" y="-1859.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-1830 0.5,-1852 201.5,-1852 201.5,-1830 0.5,-1830"/>
+<text text-anchor="start" x="3.23" y="-1837.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="138.9" y="-1837.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1808 0.5,-1830 201.5,-1830 201.5,-1808 0.5,-1808"/>
+<text text-anchor="start" x="25.77" y="-1815.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="116.36" y="-1815.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- UncaughtExceptionEntity -->
+<g id="node19" class="node">
+<title>UncaughtExceptionEntity</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-2042 25.5,-2064 176.5,-2064 176.5,-2042 25.5,-2042"/>
+<polygon fill="none" stroke="black" points="25.5,-2042 25.5,-2064 176.5,-2064 176.5,-2042 25.5,-2042"/>
+<text text-anchor="start" x="28.29" y="-2049.4" font-family="Times,serif" font-weight="bold" font-size="14.00">UncaughtExceptionEntity</text>
+<polygon fill="none" stroke="black" points="25.5,-2020 25.5,-2042 176.5,-2042 176.5,-2020 25.5,-2020"/>
+<text text-anchor="start" x="61.93" y="-2027.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-2027.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-1998 25.5,-2020 176.5,-2020 176.5,-1998 25.5,-1998"/>
+<text text-anchor="start" x="32.77" y="-2005.4" font-family="Times,serif" font-size="14.00">exceptionSource: </text>
+<text text-anchor="start" x="133.46" y="-2005.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-1976 25.5,-1998 176.5,-1998 176.5,-1976 25.5,-1976"/>
+<text text-anchor="start" x="55.71" y="-1983.4" font-family="Times,serif" font-size="14.00">message: </text>
+<text text-anchor="start" x="110.52" y="-1983.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-1954 25.5,-1976 176.5,-1976 176.5,-1954 25.5,-1954"/>
+<text text-anchor="start" x="38.21" y="-1961.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-1961.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-1932 25.5,-1954 176.5,-1954 176.5,-1932 25.5,-1932"/>
+<text text-anchor="start" x="58.82" y="-1939.4" font-family="Times,serif" font-size="14.00">version: </text>
+<text text-anchor="start" x="107.42" y="-1939.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tdsMetadata -->
+<g id="node20" class="node">
+<title>tdsMetadata</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-2144 58.5,-2166 142.5,-2166 142.5,-2144 58.5,-2144"/>
+<polygon fill="none" stroke="black" points="58.5,-2144 58.5,-2166 142.5,-2166 142.5,-2144 58.5,-2144"/>
+<text text-anchor="start" x="66.29" y="-2151.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tdsMetadata</text>
+<polygon fill="none" stroke="black" points="58.5,-2122 58.5,-2144 142.5,-2144 142.5,-2122 58.5,-2122"/>
+<text text-anchor="start" x="61.43" y="-2129.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-2129.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-2100 58.5,-2122 142.5,-2122 142.5,-2100 58.5,-2100"/>
+<text text-anchor="start" x="64.93" y="-2107.4" font-family="Times,serif" font-size="14.00">eTag: </text>
+<text text-anchor="start" x="100.3" y="-2107.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- userStage -->
+<g id="node21" class="node">
+<title>userStage</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-2246 50.5,-2268 150.5,-2268 150.5,-2246 50.5,-2246"/>
+<polygon fill="none" stroke="black" points="50.5,-2246 50.5,-2268 150.5,-2268 150.5,-2246 50.5,-2246"/>
+<text text-anchor="start" x="73.29" y="-2253.4" font-family="Times,serif" font-weight="bold" font-size="14.00">userStage</text>
+<polygon fill="none" stroke="black" points="50.5,-2224 50.5,-2246 150.5,-2246 150.5,-2224 50.5,-2224"/>
+<text text-anchor="start" x="56.76" y="-2231.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="84.37" y="-2231.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-2202 50.5,-2224 150.5,-2224 150.5,-2202 50.5,-2202"/>
+<text text-anchor="start" x="53.26" y="-2209.4" font-family="Times,serif" font-size="14.00">appStage: </text>
+<text text-anchor="start" x="111.97" y="-2209.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/2.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/2.svg
@@ -1,0 +1,123 @@
+<svg width="580px" height="736px"
+ viewBox="0.00 0.00 579.66 736.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 700)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-700 543.66,-700 543.66,36 -36,36"/>
+<!-- https_upgrade_domain -->
+<g id="node1" class="node">
+<title>https_upgrade_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="54.5,-22 54.5,-44 188.5,-44 188.5,-22 54.5,-22"/>
+<polygon fill="none" stroke="black" points="54.5,-22 54.5,-44 188.5,-44 188.5,-22 54.5,-22"/>
+<text text-anchor="start" x="57.34" y="-29.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_upgrade_domain</text>
+<polygon fill="none" stroke="black" points="54.5,0 54.5,-22 188.5,-22 188.5,0 54.5,0"/>
+<text text-anchor="start" x="78.92" y="-7.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-7.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- disconnect_tracker -->
+<g id="node2" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-168 57.5,-190 185.5,-190 185.5,-168 57.5,-168"/>
+<polygon fill="none" stroke="black" points="57.5,-168 57.5,-190 185.5,-190 185.5,-168 57.5,-168"/>
+<text text-anchor="start" x="68.64" y="-175.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-146 57.5,-168 185.5,-168 185.5,-146 57.5,-146"/>
+<text text-anchor="start" x="92.15" y="-153.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-153.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-124 57.5,-146 185.5,-146 185.5,-124 57.5,-124"/>
+<text text-anchor="start" x="75.83" y="-131.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-131.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-102 57.5,-124 185.5,-124 185.5,-102 57.5,-102"/>
+<text text-anchor="start" x="60.27" y="-109.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-109.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-80 57.5,-102 185.5,-102 185.5,-80 57.5,-80"/>
+<text text-anchor="start" x="67.66" y="-87.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-87.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node3" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-270 56.5,-292 187.5,-292 187.5,-270 56.5,-270"/>
+<polygon fill="none" stroke="black" points="56.5,-270 56.5,-292 187.5,-292 187.5,-270 56.5,-270"/>
+<text text-anchor="start" x="62.53" y="-277.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-248 56.5,-270 187.5,-270 187.5,-248 56.5,-248"/>
+<text text-anchor="start" x="60.77" y="-255.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-255.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-226 56.5,-248 187.5,-248 187.5,-226 56.5,-226"/>
+<text text-anchor="start" x="59.21" y="-233.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-233.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node4" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-372 0.5,-394 243.5,-394 243.5,-372 0.5,-372"/>
+<polygon fill="none" stroke="black" points="0.5,-372 0.5,-394 243.5,-394 243.5,-372 0.5,-372"/>
+<text text-anchor="start" x="70.68" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-350 0.5,-372 243.5,-372 243.5,-350 0.5,-350"/>
+<text text-anchor="start" x="90.32" y="-357.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-357.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-328 0.5,-350 243.5,-350 243.5,-328 0.5,-328"/>
+<text text-anchor="start" x="3.22" y="-335.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-335.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node5" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-496 405.66,-518 507.66,-518 507.66,-496 405.66,-496"/>
+<polygon fill="none" stroke="black" points="405.66,-496 405.66,-518 507.66,-518 507.66,-496 405.66,-496"/>
+<text text-anchor="start" x="445.39" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-474 405.66,-496 507.66,-496 507.66,-474 405.66,-474"/>
+<text text-anchor="start" x="420.7" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="456.86" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-452 405.66,-474 507.66,-474 507.66,-452 405.66,-452"/>
+<text text-anchor="start" x="427.31" y="-459.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="450.25" y="-459.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-430 405.66,-452 507.66,-452 507.66,-430 405.66,-430"/>
+<text text-anchor="start" x="424.19" y="-437.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="453.36" y="-437.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-408 405.66,-430 507.66,-430 507.66,-408 405.66,-408"/>
+<polygon fill="none" stroke="black" points="405.66,-408 405.66,-430 507.66,-430 507.66,-408 405.66,-408"/>
+<text text-anchor="start" x="436.45" y="-415.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-386 405.66,-408 507.66,-408 507.66,-386 405.66,-386"/>
+<text text-anchor="start" x="408.45" y="-392.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node6" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-518 45.5,-540 198.5,-540 198.5,-518 45.5,-518"/>
+<polygon fill="none" stroke="black" points="45.5,-518 45.5,-540 198.5,-540 198.5,-518 45.5,-518"/>
+<text text-anchor="start" x="85.07" y="-525.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-496 45.5,-518 198.5,-518 198.5,-496 45.5,-496"/>
+<text text-anchor="start" x="82.93" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-503.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-474 45.5,-496 198.5,-496 198.5,-474 45.5,-474"/>
+<text text-anchor="start" x="86.04" y="-481.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-481.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-452 45.5,-474 198.5,-474 198.5,-452 45.5,-452"/>
+<polygon fill="none" stroke="black" points="45.5,-452 45.5,-474 198.5,-474 198.5,-452 45.5,-452"/>
+<text text-anchor="start" x="101.79" y="-459.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-430 45.5,-452 198.5,-452 198.5,-430 45.5,-430"/>
+<text text-anchor="start" x="48.13" y="-436.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-485C287.64,-485 312.19,-485 395.48,-485"/>
+<polygon fill="black" stroke="black" points="395.66,-488.5 405.66,-485 395.66,-481.5 395.66,-488.5"/>
+<text text-anchor="middle" x="324.33" y="-489.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node7" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-642 79.5,-664 163.5,-664 163.5,-642 79.5,-642"/>
+<polygon fill="none" stroke="black" points="79.5,-642 79.5,-664 163.5,-664 163.5,-642 79.5,-642"/>
+<text text-anchor="start" x="90.39" y="-649.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-620 79.5,-642 163.5,-642 163.5,-620 79.5,-620"/>
+<text text-anchor="start" x="82.43" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-627.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-598 79.5,-620 163.5,-620 163.5,-598 79.5,-598"/>
+<text text-anchor="start" x="89.03" y="-605.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-605.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-576 79.5,-598 163.5,-598 163.5,-576 79.5,-576"/>
+<text text-anchor="start" x="92.15" y="-583.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-583.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/20.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/20.svg
@@ -1,0 +1,351 @@
+<svg width="569px" height="2420px"
+ viewBox="0.00 0.00 568.66 2420.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 2384)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-2384 532.66,-2384 532.66,36 -36,36"/>
+<!-- tds_tracker -->
+<g id="node1" class="node">
+<title>tds_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<polygon fill="none" stroke="black" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<text text-anchor="start" x="69.4" y="-117.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_tracker</text>
+<polygon fill="none" stroke="black" points="37.5,-88 37.5,-110 163.5,-110 163.5,-88 37.5,-88"/>
+<text text-anchor="start" x="57.92" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-95.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-66 37.5,-88 163.5,-88 163.5,-66 37.5,-66"/>
+<text text-anchor="start" x="40.44" y="-73.4" font-family="Times,serif" font-size="14.00">defaultAction: </text>
+<text text-anchor="start" x="124.8" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-44 37.5,-66 163.5,-66 163.5,-44 37.5,-44"/>
+<text text-anchor="start" x="44.72" y="-51.4" font-family="Times,serif" font-size="14.00">ownerName: </text>
+<text text-anchor="start" x="120.52" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-22 37.5,-44 163.5,-44 163.5,-22 37.5,-22"/>
+<text text-anchor="start" x="50.55" y="-29.4" font-family="Times,serif" font-size="14.00">categories: </text>
+<text text-anchor="start" x="114.69" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,0 37.5,-22 163.5,-22 163.5,0 37.5,0"/>
+<text text-anchor="start" x="65.32" y="-7.4" font-family="Times,serif" font-size="14.00">rules: </text>
+<text text-anchor="start" x="99.92" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tds_entity -->
+<g id="node2" class="node">
+<title>tds_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<polygon fill="none" stroke="black" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<text text-anchor="start" x="73.39" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_entity</text>
+<polygon fill="none" stroke="black" points="39.5,-212 39.5,-234 162.5,-234 162.5,-212 39.5,-212"/>
+<text text-anchor="start" x="64.26" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">name: </text>
+<text text-anchor="start" x="101.97" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-190 39.5,-212 162.5,-212 162.5,-190 39.5,-190"/>
+<text text-anchor="start" x="42.49" y="-197.4" font-family="Times,serif" font-size="14.00">displayName: </text>
+<text text-anchor="start" x="123.75" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-168 39.5,-190 162.5,-190 162.5,-168 39.5,-168"/>
+<text text-anchor="start" x="48.72" y="-175.4" font-family="Times,serif" font-size="14.00">prevalence: </text>
+<text text-anchor="start" x="116.73" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+</g>
+<!-- tds_domain_entity -->
+<g id="node3" class="node">
+<title>tds_domain_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<polygon fill="none" stroke="black" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<text text-anchor="start" x="48.39" y="-343.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_domain_entity</text>
+<polygon fill="none" stroke="black" points="43.5,-314 43.5,-336 157.5,-336 157.5,-314 43.5,-314"/>
+<text text-anchor="start" x="57.92" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-321.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="43.5,-292 43.5,-314 157.5,-314 157.5,-292 43.5,-292"/>
+<text text-anchor="start" x="46.27" y="-299.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="118.97" y="-299.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- temporary_tracking_whitelist -->
+<g id="node4" class="node">
+<title>temporary_tracking_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<polygon fill="none" stroke="black" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<text text-anchor="start" x="18.19" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">temporary_tracking_whitelist</text>
+<polygon fill="none" stroke="black" points="15.5,-394 15.5,-416 186.5,-416 186.5,-394 15.5,-394"/>
+<text text-anchor="start" x="58.42" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- user_whitelist -->
+<g id="node5" class="node">
+<title>user_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-496 55.5,-518 146.5,-518 146.5,-496 55.5,-496"/>
+<polygon fill="none" stroke="black" points="55.5,-496 55.5,-518 146.5,-518 146.5,-496 55.5,-496"/>
+<text text-anchor="start" x="61.73" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">user_whitelist</text>
+<polygon fill="none" stroke="black" points="55.5,-474 55.5,-496 146.5,-496 146.5,-474 55.5,-474"/>
+<text text-anchor="start" x="58.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node6" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="29.5,-642 29.5,-664 171.5,-664 171.5,-642 29.5,-642"/>
+<polygon fill="none" stroke="black" points="29.5,-642 29.5,-664 171.5,-664 171.5,-642 29.5,-642"/>
+<text text-anchor="start" x="32.46" y="-649.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="29.5,-620 29.5,-642 171.5,-642 171.5,-620 29.5,-620"/>
+<text text-anchor="start" x="61.43" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-627.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-598 29.5,-620 171.5,-620 171.5,-598 29.5,-598"/>
+<text text-anchor="start" x="52.1" y="-605.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="112.35" y="-605.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="29.5,-576 29.5,-598 171.5,-598 171.5,-576 29.5,-576"/>
+<text text-anchor="start" x="34.6" y="-583.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="106.53" y="-583.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-554 29.5,-576 171.5,-576 171.5,-554 29.5,-554"/>
+<text text-anchor="start" x="59.09" y="-561.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="106.14" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node7" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-722 25.5,-744 175.5,-744 175.5,-722 25.5,-722"/>
+<polygon fill="none" stroke="black" points="25.5,-722 25.5,-744 175.5,-744 175.5,-722 25.5,-722"/>
+<text text-anchor="start" x="28.17" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="25.5,-700 25.5,-722 175.5,-722 175.5,-700 25.5,-700"/>
+<text text-anchor="start" x="57.92" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node8" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="36.5,-824 36.5,-846 164.5,-846 164.5,-824 36.5,-824"/>
+<polygon fill="none" stroke="black" points="36.5,-824 36.5,-846 164.5,-846 164.5,-824 36.5,-824"/>
+<text text-anchor="start" x="41.03" y="-831.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="36.5,-802 36.5,-824 164.5,-824 164.5,-802 36.5,-802"/>
+<text text-anchor="start" x="39.27" y="-809.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="125.96" y="-809.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="36.5,-780 36.5,-802 164.5,-802 164.5,-780 36.5,-780"/>
+<text text-anchor="start" x="51.32" y="-787.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-787.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node9" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-926 48.5,-948 152.5,-948 152.5,-926 48.5,-926"/>
+<polygon fill="none" stroke="black" points="48.5,-926 48.5,-948 152.5,-948 152.5,-926 48.5,-926"/>
+<text text-anchor="start" x="65.89" y="-933.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="48.5,-904 48.5,-926 152.5,-926 152.5,-904 48.5,-904"/>
+<text text-anchor="start" x="68.82" y="-911.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-911.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-882 48.5,-904 152.5,-904 152.5,-882 48.5,-882"/>
+<text text-anchor="start" x="51.32" y="-889.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-889.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node10" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="364.16,-1050 364.16,-1072 497.16,-1072 497.16,-1050 364.16,-1050"/>
+<polygon fill="none" stroke="black" points="364.16,-1050 364.16,-1072 497.16,-1072 497.16,-1050 364.16,-1050"/>
+<text text-anchor="start" x="419.39" y="-1057.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="364.16,-1028 364.16,-1050 497.16,-1050 497.16,-1028 364.16,-1028"/>
+<text text-anchor="start" x="394.7" y="-1035.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="430.86" y="-1035.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-1006 364.16,-1028 497.16,-1028 497.16,-1006 364.16,-1006"/>
+<text text-anchor="start" x="401.31" y="-1013.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="424.25" y="-1013.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-984 364.16,-1006 497.16,-1006 497.16,-984 364.16,-984"/>
+<text text-anchor="start" x="398.19" y="-991.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="427.36" y="-991.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-962 364.16,-984 497.16,-984 497.16,-962 364.16,-962"/>
+<text text-anchor="start" x="368.26" y="-969.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="433.2" y="-969.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-940 364.16,-962 497.16,-962 497.16,-940 364.16,-940"/>
+<text text-anchor="start" x="376.82" y="-947.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="424.63" y="-947.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-918 364.16,-940 497.16,-940 497.16,-918 364.16,-918"/>
+<text text-anchor="start" x="374.47" y="-925.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="426.98" y="-925.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-896 364.16,-918 497.16,-918 497.16,-896 364.16,-896"/>
+<text text-anchor="start" x="366.71" y="-903.4" font-family="Times,serif" font-size="14.00">tabPreviewFile: </text>
+<text text-anchor="start" x="458.85" y="-903.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="364.16,-874 364.16,-896 497.16,-896 497.16,-874 364.16,-874"/>
+<polygon fill="none" stroke="black" points="364.16,-874 364.16,-896 497.16,-896 497.16,-874 364.16,-874"/>
+<text text-anchor="start" x="410.45" y="-881.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="364.16,-852 364.16,-874 497.16,-874 497.16,-852 364.16,-852"/>
+<text text-anchor="start" x="382.45" y="-858.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node11" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="24.5,-1072 24.5,-1094 177.5,-1094 177.5,-1072 24.5,-1072"/>
+<polygon fill="none" stroke="black" points="24.5,-1072 24.5,-1094 177.5,-1094 177.5,-1072 24.5,-1072"/>
+<text text-anchor="start" x="64.07" y="-1079.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="24.5,-1050 24.5,-1072 177.5,-1072 177.5,-1050 24.5,-1050"/>
+<text text-anchor="start" x="61.93" y="-1057.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-1057.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="24.5,-1028 24.5,-1050 177.5,-1050 177.5,-1028 24.5,-1028"/>
+<text text-anchor="start" x="65.04" y="-1035.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="101.2" y="-1035.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="24.5,-1006 24.5,-1028 177.5,-1028 177.5,-1006 24.5,-1006"/>
+<polygon fill="none" stroke="black" points="24.5,-1006 24.5,-1028 177.5,-1028 177.5,-1006 24.5,-1006"/>
+<text text-anchor="start" x="80.79" y="-1013.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="24.5,-984 24.5,-1006 177.5,-1006 177.5,-984 24.5,-984"/>
+<text text-anchor="start" x="27.13" y="-990.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M178.5,-1039C257.26,-1039 279.49,-1039 353.38,-1039"/>
+<polygon fill="black" stroke="black" points="353.66,-1042.5 363.66,-1039 353.66,-1035.5 353.66,-1042.5"/>
+<text text-anchor="middle" x="282.33" y="-1043.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node12" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1196 58.5,-1218 142.5,-1218 142.5,-1196 58.5,-1196"/>
+<polygon fill="none" stroke="black" points="58.5,-1196 58.5,-1218 142.5,-1218 142.5,-1196 58.5,-1196"/>
+<text text-anchor="start" x="69.39" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="58.5,-1174 58.5,-1196 142.5,-1196 142.5,-1174 58.5,-1174"/>
+<text text-anchor="start" x="61.43" y="-1181.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-1181.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-1152 58.5,-1174 142.5,-1174 142.5,-1152 58.5,-1152"/>
+<text text-anchor="start" x="68.03" y="-1159.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="97.2" y="-1159.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="58.5,-1130 58.5,-1152 142.5,-1152 142.5,-1130 58.5,-1130"/>
+<text text-anchor="start" x="71.15" y="-1137.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.09" y="-1137.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node13" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1342 27.5,-1364 174.5,-1364 174.5,-1342 27.5,-1342"/>
+<polygon fill="none" stroke="black" points="27.5,-1342 27.5,-1364 174.5,-1364 174.5,-1342 27.5,-1342"/>
+<text text-anchor="start" x="82.34" y="-1349.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="27.5,-1320 27.5,-1342 174.5,-1342 174.5,-1320 27.5,-1320"/>
+<text text-anchor="start" x="54.93" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="111.3" y="-1327.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1298 27.5,-1320 174.5,-1320 174.5,-1298 27.5,-1298"/>
+<text text-anchor="start" x="71.65" y="-1305.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.59" y="-1305.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1276 27.5,-1298 174.5,-1298 174.5,-1276 27.5,-1276"/>
+<text text-anchor="start" x="30.44" y="-1283.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="111.69" y="-1283.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1254 27.5,-1276 174.5,-1276 174.5,-1254 27.5,-1254"/>
+<text text-anchor="start" x="63.48" y="-1261.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="102.76" y="-1261.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node14" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1422 58.5,-1444 142.5,-1444 142.5,-1422 58.5,-1422"/>
+<polygon fill="none" stroke="black" points="58.5,-1422 58.5,-1444 142.5,-1444 142.5,-1422 58.5,-1422"/>
+<text text-anchor="start" x="61.23" y="-1429.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="58.5,-1400 58.5,-1422 142.5,-1422 142.5,-1400 58.5,-1400"/>
+<text text-anchor="start" x="64.93" y="-1407.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="100.3" y="-1407.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node15" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1524 48.5,-1546 152.5,-1546 152.5,-1524 48.5,-1524"/>
+<polygon fill="none" stroke="black" points="48.5,-1524 48.5,-1546 152.5,-1546 152.5,-1524 48.5,-1524"/>
+<text text-anchor="start" x="63.57" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="48.5,-1502 48.5,-1524 152.5,-1524 152.5,-1502 48.5,-1502"/>
+<text text-anchor="start" x="68.82" y="-1509.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-1509.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1480 48.5,-1502 152.5,-1502 152.5,-1480 48.5,-1480"/>
+<text text-anchor="start" x="51.32" y="-1487.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-1487.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node16" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-1604 55.5,-1626 146.5,-1626 146.5,-1604 55.5,-1604"/>
+<polygon fill="none" stroke="black" points="55.5,-1604 55.5,-1626 146.5,-1626 146.5,-1604 55.5,-1604"/>
+<text text-anchor="start" x="58.23" y="-1611.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="55.5,-1582 55.5,-1604 146.5,-1604 146.5,-1582 55.5,-1582"/>
+<text text-anchor="start" x="67.76" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="98.47" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node17" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1750 27.5,-1772 174.5,-1772 174.5,-1750 27.5,-1750"/>
+<polygon fill="none" stroke="black" points="27.5,-1750 27.5,-1772 174.5,-1772 174.5,-1750 27.5,-1750"/>
+<text text-anchor="start" x="57.84" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="27.5,-1728 27.5,-1750 174.5,-1750 174.5,-1728 27.5,-1728"/>
+<text text-anchor="start" x="37.83" y="-1735.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="104.3" y="-1735.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1706 27.5,-1728 174.5,-1728 174.5,-1706 27.5,-1706"/>
+<text text-anchor="start" x="30.04" y="-1713.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="112.1" y="-1713.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1684 27.5,-1706 174.5,-1706 174.5,-1684 27.5,-1684"/>
+<text text-anchor="start" x="38.21" y="-1691.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-1691.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1662 27.5,-1684 174.5,-1684 174.5,-1662 27.5,-1662"/>
+<text text-anchor="start" x="33.55" y="-1669.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="108.58" y="-1669.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node18" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="38.5,-1830 38.5,-1852 163.5,-1852 163.5,-1830 38.5,-1830"/>
+<polygon fill="none" stroke="black" points="38.5,-1830 38.5,-1852 163.5,-1852 163.5,-1830 38.5,-1830"/>
+<text text-anchor="start" x="68.73" y="-1837.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="38.5,-1808 38.5,-1830 163.5,-1830 163.5,-1808 38.5,-1808"/>
+<text text-anchor="start" x="41.32" y="-1815.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="124.91" y="-1815.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node19" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1954 0.5,-1976 201.5,-1976 201.5,-1954 0.5,-1954"/>
+<polygon fill="none" stroke="black" points="0.5,-1954 0.5,-1976 201.5,-1976 201.5,-1954 0.5,-1954"/>
+<text text-anchor="start" x="29.08" y="-1961.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="0.5,-1932 0.5,-1954 201.5,-1954 201.5,-1932 0.5,-1932"/>
+<text text-anchor="start" x="69.32" y="-1939.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.92" y="-1939.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-1910 0.5,-1932 201.5,-1932 201.5,-1910 0.5,-1910"/>
+<text text-anchor="start" x="3.23" y="-1917.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="138.9" y="-1917.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1888 0.5,-1910 201.5,-1910 201.5,-1888 0.5,-1888"/>
+<text text-anchor="start" x="25.77" y="-1895.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="116.36" y="-1895.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- UncaughtExceptionEntity -->
+<g id="node20" class="node">
+<title>UncaughtExceptionEntity</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-2122 25.5,-2144 176.5,-2144 176.5,-2122 25.5,-2122"/>
+<polygon fill="none" stroke="black" points="25.5,-2122 25.5,-2144 176.5,-2144 176.5,-2122 25.5,-2122"/>
+<text text-anchor="start" x="28.29" y="-2129.4" font-family="Times,serif" font-weight="bold" font-size="14.00">UncaughtExceptionEntity</text>
+<polygon fill="none" stroke="black" points="25.5,-2100 25.5,-2122 176.5,-2122 176.5,-2100 25.5,-2100"/>
+<text text-anchor="start" x="61.93" y="-2107.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-2107.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-2078 25.5,-2100 176.5,-2100 176.5,-2078 25.5,-2078"/>
+<text text-anchor="start" x="32.77" y="-2085.4" font-family="Times,serif" font-size="14.00">exceptionSource: </text>
+<text text-anchor="start" x="133.46" y="-2085.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-2056 25.5,-2078 176.5,-2078 176.5,-2056 25.5,-2056"/>
+<text text-anchor="start" x="55.71" y="-2063.4" font-family="Times,serif" font-size="14.00">message: </text>
+<text text-anchor="start" x="110.52" y="-2063.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-2034 25.5,-2056 176.5,-2056 176.5,-2034 25.5,-2034"/>
+<text text-anchor="start" x="38.21" y="-2041.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-2041.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-2012 25.5,-2034 176.5,-2034 176.5,-2012 25.5,-2012"/>
+<text text-anchor="start" x="58.82" y="-2019.4" font-family="Times,serif" font-size="14.00">version: </text>
+<text text-anchor="start" x="107.42" y="-2019.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tdsMetadata -->
+<g id="node21" class="node">
+<title>tdsMetadata</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-2224 58.5,-2246 142.5,-2246 142.5,-2224 58.5,-2224"/>
+<polygon fill="none" stroke="black" points="58.5,-2224 58.5,-2246 142.5,-2246 142.5,-2224 58.5,-2224"/>
+<text text-anchor="start" x="66.29" y="-2231.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tdsMetadata</text>
+<polygon fill="none" stroke="black" points="58.5,-2202 58.5,-2224 142.5,-2224 142.5,-2202 58.5,-2202"/>
+<text text-anchor="start" x="61.43" y="-2209.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-2209.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-2180 58.5,-2202 142.5,-2202 142.5,-2180 58.5,-2180"/>
+<text text-anchor="start" x="64.93" y="-2187.4" font-family="Times,serif" font-size="14.00">eTag: </text>
+<text text-anchor="start" x="100.3" y="-2187.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- userStage -->
+<g id="node22" class="node">
+<title>userStage</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-2326 50.5,-2348 150.5,-2348 150.5,-2326 50.5,-2326"/>
+<polygon fill="none" stroke="black" points="50.5,-2326 50.5,-2348 150.5,-2348 150.5,-2326 50.5,-2326"/>
+<text text-anchor="start" x="73.29" y="-2333.4" font-family="Times,serif" font-weight="bold" font-size="14.00">userStage</text>
+<polygon fill="none" stroke="black" points="50.5,-2304 50.5,-2326 150.5,-2326 150.5,-2304 50.5,-2304"/>
+<text text-anchor="start" x="56.76" y="-2311.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="84.37" y="-2311.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-2282 50.5,-2304 150.5,-2304 150.5,-2282 50.5,-2282"/>
+<text text-anchor="start" x="53.26" y="-2289.4" font-family="Times,serif" font-size="14.00">appStage: </text>
+<text text-anchor="start" x="111.97" y="-2289.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/21.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/21.svg
@@ -1,0 +1,361 @@
+<svg width="569px" height="2500px"
+ viewBox="0.00 0.00 568.66 2500.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 2464)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-2464 532.66,-2464 532.66,36 -36,36"/>
+<!-- tds_tracker -->
+<g id="node1" class="node">
+<title>tds_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<polygon fill="none" stroke="black" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<text text-anchor="start" x="69.4" y="-117.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_tracker</text>
+<polygon fill="none" stroke="black" points="37.5,-88 37.5,-110 163.5,-110 163.5,-88 37.5,-88"/>
+<text text-anchor="start" x="57.92" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-95.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-66 37.5,-88 163.5,-88 163.5,-66 37.5,-66"/>
+<text text-anchor="start" x="40.44" y="-73.4" font-family="Times,serif" font-size="14.00">defaultAction: </text>
+<text text-anchor="start" x="124.8" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-44 37.5,-66 163.5,-66 163.5,-44 37.5,-44"/>
+<text text-anchor="start" x="44.72" y="-51.4" font-family="Times,serif" font-size="14.00">ownerName: </text>
+<text text-anchor="start" x="120.52" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-22 37.5,-44 163.5,-44 163.5,-22 37.5,-22"/>
+<text text-anchor="start" x="50.55" y="-29.4" font-family="Times,serif" font-size="14.00">categories: </text>
+<text text-anchor="start" x="114.69" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,0 37.5,-22 163.5,-22 163.5,0 37.5,0"/>
+<text text-anchor="start" x="65.32" y="-7.4" font-family="Times,serif" font-size="14.00">rules: </text>
+<text text-anchor="start" x="99.92" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tds_entity -->
+<g id="node2" class="node">
+<title>tds_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<polygon fill="none" stroke="black" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<text text-anchor="start" x="73.39" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_entity</text>
+<polygon fill="none" stroke="black" points="39.5,-212 39.5,-234 162.5,-234 162.5,-212 39.5,-212"/>
+<text text-anchor="start" x="64.26" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">name: </text>
+<text text-anchor="start" x="101.97" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-190 39.5,-212 162.5,-212 162.5,-190 39.5,-190"/>
+<text text-anchor="start" x="42.49" y="-197.4" font-family="Times,serif" font-size="14.00">displayName: </text>
+<text text-anchor="start" x="123.75" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-168 39.5,-190 162.5,-190 162.5,-168 39.5,-168"/>
+<text text-anchor="start" x="48.72" y="-175.4" font-family="Times,serif" font-size="14.00">prevalence: </text>
+<text text-anchor="start" x="116.73" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+</g>
+<!-- tds_domain_entity -->
+<g id="node3" class="node">
+<title>tds_domain_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<polygon fill="none" stroke="black" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<text text-anchor="start" x="48.39" y="-343.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_domain_entity</text>
+<polygon fill="none" stroke="black" points="43.5,-314 43.5,-336 157.5,-336 157.5,-314 43.5,-314"/>
+<text text-anchor="start" x="57.92" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-321.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="43.5,-292 43.5,-314 157.5,-314 157.5,-292 43.5,-292"/>
+<text text-anchor="start" x="46.27" y="-299.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="118.97" y="-299.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- temporary_tracking_whitelist -->
+<g id="node4" class="node">
+<title>temporary_tracking_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<polygon fill="none" stroke="black" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<text text-anchor="start" x="18.19" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">temporary_tracking_whitelist</text>
+<polygon fill="none" stroke="black" points="15.5,-394 15.5,-416 186.5,-416 186.5,-394 15.5,-394"/>
+<text text-anchor="start" x="58.42" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- user_whitelist -->
+<g id="node5" class="node">
+<title>user_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-496 55.5,-518 146.5,-518 146.5,-496 55.5,-496"/>
+<polygon fill="none" stroke="black" points="55.5,-496 55.5,-518 146.5,-518 146.5,-496 55.5,-496"/>
+<text text-anchor="start" x="61.73" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">user_whitelist</text>
+<polygon fill="none" stroke="black" points="55.5,-474 55.5,-496 146.5,-496 146.5,-474 55.5,-474"/>
+<text text-anchor="start" x="58.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node6" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="29.5,-642 29.5,-664 171.5,-664 171.5,-642 29.5,-642"/>
+<polygon fill="none" stroke="black" points="29.5,-642 29.5,-664 171.5,-664 171.5,-642 29.5,-642"/>
+<text text-anchor="start" x="32.46" y="-649.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="29.5,-620 29.5,-642 171.5,-642 171.5,-620 29.5,-620"/>
+<text text-anchor="start" x="61.43" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-627.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-598 29.5,-620 171.5,-620 171.5,-598 29.5,-598"/>
+<text text-anchor="start" x="52.1" y="-605.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="112.35" y="-605.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="29.5,-576 29.5,-598 171.5,-598 171.5,-576 29.5,-576"/>
+<text text-anchor="start" x="34.6" y="-583.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="106.53" y="-583.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-554 29.5,-576 171.5,-576 171.5,-554 29.5,-554"/>
+<text text-anchor="start" x="59.09" y="-561.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="106.14" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node7" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-722 25.5,-744 175.5,-744 175.5,-722 25.5,-722"/>
+<polygon fill="none" stroke="black" points="25.5,-722 25.5,-744 175.5,-744 175.5,-722 25.5,-722"/>
+<text text-anchor="start" x="28.17" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="25.5,-700 25.5,-722 175.5,-722 175.5,-700 25.5,-700"/>
+<text text-anchor="start" x="57.92" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node8" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="36.5,-824 36.5,-846 164.5,-846 164.5,-824 36.5,-824"/>
+<polygon fill="none" stroke="black" points="36.5,-824 36.5,-846 164.5,-846 164.5,-824 36.5,-824"/>
+<text text-anchor="start" x="41.03" y="-831.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="36.5,-802 36.5,-824 164.5,-824 164.5,-802 36.5,-802"/>
+<text text-anchor="start" x="39.27" y="-809.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="125.96" y="-809.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="36.5,-780 36.5,-802 164.5,-802 164.5,-780 36.5,-780"/>
+<text text-anchor="start" x="51.32" y="-787.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-787.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node9" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-926 48.5,-948 152.5,-948 152.5,-926 48.5,-926"/>
+<polygon fill="none" stroke="black" points="48.5,-926 48.5,-948 152.5,-948 152.5,-926 48.5,-926"/>
+<text text-anchor="start" x="65.89" y="-933.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="48.5,-904 48.5,-926 152.5,-926 152.5,-904 48.5,-904"/>
+<text text-anchor="start" x="68.82" y="-911.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-911.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-882 48.5,-904 152.5,-904 152.5,-882 48.5,-882"/>
+<text text-anchor="start" x="51.32" y="-889.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-889.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node10" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="364.16,-1050 364.16,-1072 497.16,-1072 497.16,-1050 364.16,-1050"/>
+<polygon fill="none" stroke="black" points="364.16,-1050 364.16,-1072 497.16,-1072 497.16,-1050 364.16,-1050"/>
+<text text-anchor="start" x="419.39" y="-1057.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="364.16,-1028 364.16,-1050 497.16,-1050 497.16,-1028 364.16,-1028"/>
+<text text-anchor="start" x="394.7" y="-1035.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="430.86" y="-1035.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-1006 364.16,-1028 497.16,-1028 497.16,-1006 364.16,-1006"/>
+<text text-anchor="start" x="401.31" y="-1013.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="424.25" y="-1013.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-984 364.16,-1006 497.16,-1006 497.16,-984 364.16,-984"/>
+<text text-anchor="start" x="398.19" y="-991.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="427.36" y="-991.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-962 364.16,-984 497.16,-984 497.16,-962 364.16,-962"/>
+<text text-anchor="start" x="368.26" y="-969.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="433.2" y="-969.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-940 364.16,-962 497.16,-962 497.16,-940 364.16,-940"/>
+<text text-anchor="start" x="376.82" y="-947.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="424.63" y="-947.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-918 364.16,-940 497.16,-940 497.16,-918 364.16,-918"/>
+<text text-anchor="start" x="374.47" y="-925.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="426.98" y="-925.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-896 364.16,-918 497.16,-918 497.16,-896 364.16,-896"/>
+<text text-anchor="start" x="366.71" y="-903.4" font-family="Times,serif" font-size="14.00">tabPreviewFile: </text>
+<text text-anchor="start" x="458.85" y="-903.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="364.16,-874 364.16,-896 497.16,-896 497.16,-874 364.16,-874"/>
+<polygon fill="none" stroke="black" points="364.16,-874 364.16,-896 497.16,-896 497.16,-874 364.16,-874"/>
+<text text-anchor="start" x="410.45" y="-881.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="364.16,-852 364.16,-874 497.16,-874 497.16,-852 364.16,-852"/>
+<text text-anchor="start" x="382.45" y="-858.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node11" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="24.5,-1072 24.5,-1094 177.5,-1094 177.5,-1072 24.5,-1072"/>
+<polygon fill="none" stroke="black" points="24.5,-1072 24.5,-1094 177.5,-1094 177.5,-1072 24.5,-1072"/>
+<text text-anchor="start" x="64.07" y="-1079.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="24.5,-1050 24.5,-1072 177.5,-1072 177.5,-1050 24.5,-1050"/>
+<text text-anchor="start" x="61.93" y="-1057.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-1057.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="24.5,-1028 24.5,-1050 177.5,-1050 177.5,-1028 24.5,-1028"/>
+<text text-anchor="start" x="65.04" y="-1035.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="101.2" y="-1035.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="24.5,-1006 24.5,-1028 177.5,-1028 177.5,-1006 24.5,-1006"/>
+<polygon fill="none" stroke="black" points="24.5,-1006 24.5,-1028 177.5,-1028 177.5,-1006 24.5,-1006"/>
+<text text-anchor="start" x="80.79" y="-1013.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="24.5,-984 24.5,-1006 177.5,-1006 177.5,-984 24.5,-984"/>
+<text text-anchor="start" x="27.13" y="-990.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M178.5,-1039C257.26,-1039 279.49,-1039 353.38,-1039"/>
+<polygon fill="black" stroke="black" points="353.66,-1042.5 363.66,-1039 353.66,-1035.5 353.66,-1042.5"/>
+<text text-anchor="middle" x="282.33" y="-1043.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node12" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1196 58.5,-1218 142.5,-1218 142.5,-1196 58.5,-1196"/>
+<polygon fill="none" stroke="black" points="58.5,-1196 58.5,-1218 142.5,-1218 142.5,-1196 58.5,-1196"/>
+<text text-anchor="start" x="69.39" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="58.5,-1174 58.5,-1196 142.5,-1196 142.5,-1174 58.5,-1174"/>
+<text text-anchor="start" x="61.43" y="-1181.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-1181.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-1152 58.5,-1174 142.5,-1174 142.5,-1152 58.5,-1152"/>
+<text text-anchor="start" x="68.03" y="-1159.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="97.2" y="-1159.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="58.5,-1130 58.5,-1152 142.5,-1152 142.5,-1130 58.5,-1130"/>
+<text text-anchor="start" x="71.15" y="-1137.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.09" y="-1137.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node13" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1342 27.5,-1364 174.5,-1364 174.5,-1342 27.5,-1342"/>
+<polygon fill="none" stroke="black" points="27.5,-1342 27.5,-1364 174.5,-1364 174.5,-1342 27.5,-1342"/>
+<text text-anchor="start" x="82.34" y="-1349.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="27.5,-1320 27.5,-1342 174.5,-1342 174.5,-1320 27.5,-1320"/>
+<text text-anchor="start" x="54.93" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="111.3" y="-1327.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1298 27.5,-1320 174.5,-1320 174.5,-1298 27.5,-1298"/>
+<text text-anchor="start" x="71.65" y="-1305.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.59" y="-1305.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1276 27.5,-1298 174.5,-1298 174.5,-1276 27.5,-1276"/>
+<text text-anchor="start" x="30.44" y="-1283.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="111.69" y="-1283.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1254 27.5,-1276 174.5,-1276 174.5,-1254 27.5,-1254"/>
+<text text-anchor="start" x="63.48" y="-1261.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="102.76" y="-1261.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node14" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1422 58.5,-1444 142.5,-1444 142.5,-1422 58.5,-1422"/>
+<polygon fill="none" stroke="black" points="58.5,-1422 58.5,-1444 142.5,-1444 142.5,-1422 58.5,-1422"/>
+<text text-anchor="start" x="61.23" y="-1429.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="58.5,-1400 58.5,-1422 142.5,-1422 142.5,-1400 58.5,-1400"/>
+<text text-anchor="start" x="64.93" y="-1407.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="100.3" y="-1407.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node15" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1524 48.5,-1546 152.5,-1546 152.5,-1524 48.5,-1524"/>
+<polygon fill="none" stroke="black" points="48.5,-1524 48.5,-1546 152.5,-1546 152.5,-1524 48.5,-1524"/>
+<text text-anchor="start" x="63.57" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="48.5,-1502 48.5,-1524 152.5,-1524 152.5,-1502 48.5,-1502"/>
+<text text-anchor="start" x="68.82" y="-1509.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-1509.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1480 48.5,-1502 152.5,-1502 152.5,-1480 48.5,-1480"/>
+<text text-anchor="start" x="51.32" y="-1487.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-1487.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node16" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-1604 55.5,-1626 146.5,-1626 146.5,-1604 55.5,-1604"/>
+<polygon fill="none" stroke="black" points="55.5,-1604 55.5,-1626 146.5,-1626 146.5,-1604 55.5,-1604"/>
+<text text-anchor="start" x="58.23" y="-1611.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="55.5,-1582 55.5,-1604 146.5,-1604 146.5,-1582 55.5,-1582"/>
+<text text-anchor="start" x="67.76" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="98.47" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node17" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1750 27.5,-1772 174.5,-1772 174.5,-1750 27.5,-1750"/>
+<polygon fill="none" stroke="black" points="27.5,-1750 27.5,-1772 174.5,-1772 174.5,-1750 27.5,-1750"/>
+<text text-anchor="start" x="57.84" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="27.5,-1728 27.5,-1750 174.5,-1750 174.5,-1728 27.5,-1728"/>
+<text text-anchor="start" x="37.83" y="-1735.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="104.3" y="-1735.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1706 27.5,-1728 174.5,-1728 174.5,-1706 27.5,-1706"/>
+<text text-anchor="start" x="30.04" y="-1713.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="112.1" y="-1713.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1684 27.5,-1706 174.5,-1706 174.5,-1684 27.5,-1684"/>
+<text text-anchor="start" x="38.21" y="-1691.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-1691.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1662 27.5,-1684 174.5,-1684 174.5,-1662 27.5,-1662"/>
+<text text-anchor="start" x="33.55" y="-1669.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="108.58" y="-1669.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node18" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="38.5,-1830 38.5,-1852 163.5,-1852 163.5,-1830 38.5,-1830"/>
+<polygon fill="none" stroke="black" points="38.5,-1830 38.5,-1852 163.5,-1852 163.5,-1830 38.5,-1830"/>
+<text text-anchor="start" x="68.73" y="-1837.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="38.5,-1808 38.5,-1830 163.5,-1830 163.5,-1808 38.5,-1808"/>
+<text text-anchor="start" x="41.32" y="-1815.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="124.91" y="-1815.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node19" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1954 0.5,-1976 201.5,-1976 201.5,-1954 0.5,-1954"/>
+<polygon fill="none" stroke="black" points="0.5,-1954 0.5,-1976 201.5,-1976 201.5,-1954 0.5,-1954"/>
+<text text-anchor="start" x="29.08" y="-1961.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="0.5,-1932 0.5,-1954 201.5,-1954 201.5,-1932 0.5,-1932"/>
+<text text-anchor="start" x="69.32" y="-1939.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.92" y="-1939.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-1910 0.5,-1932 201.5,-1932 201.5,-1910 0.5,-1910"/>
+<text text-anchor="start" x="3.23" y="-1917.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="138.9" y="-1917.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1888 0.5,-1910 201.5,-1910 201.5,-1888 0.5,-1888"/>
+<text text-anchor="start" x="25.77" y="-1895.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="116.36" y="-1895.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- UncaughtExceptionEntity -->
+<g id="node20" class="node">
+<title>UncaughtExceptionEntity</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-2122 25.5,-2144 176.5,-2144 176.5,-2122 25.5,-2122"/>
+<polygon fill="none" stroke="black" points="25.5,-2122 25.5,-2144 176.5,-2144 176.5,-2122 25.5,-2122"/>
+<text text-anchor="start" x="28.29" y="-2129.4" font-family="Times,serif" font-weight="bold" font-size="14.00">UncaughtExceptionEntity</text>
+<polygon fill="none" stroke="black" points="25.5,-2100 25.5,-2122 176.5,-2122 176.5,-2100 25.5,-2100"/>
+<text text-anchor="start" x="61.93" y="-2107.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-2107.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-2078 25.5,-2100 176.5,-2100 176.5,-2078 25.5,-2078"/>
+<text text-anchor="start" x="32.77" y="-2085.4" font-family="Times,serif" font-size="14.00">exceptionSource: </text>
+<text text-anchor="start" x="133.46" y="-2085.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-2056 25.5,-2078 176.5,-2078 176.5,-2056 25.5,-2056"/>
+<text text-anchor="start" x="55.71" y="-2063.4" font-family="Times,serif" font-size="14.00">message: </text>
+<text text-anchor="start" x="110.52" y="-2063.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-2034 25.5,-2056 176.5,-2056 176.5,-2034 25.5,-2034"/>
+<text text-anchor="start" x="38.21" y="-2041.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-2041.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-2012 25.5,-2034 176.5,-2034 176.5,-2012 25.5,-2012"/>
+<text text-anchor="start" x="58.82" y="-2019.4" font-family="Times,serif" font-size="14.00">version: </text>
+<text text-anchor="start" x="107.42" y="-2019.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tdsMetadata -->
+<g id="node21" class="node">
+<title>tdsMetadata</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-2224 58.5,-2246 142.5,-2246 142.5,-2224 58.5,-2224"/>
+<polygon fill="none" stroke="black" points="58.5,-2224 58.5,-2246 142.5,-2246 142.5,-2224 58.5,-2224"/>
+<text text-anchor="start" x="66.29" y="-2231.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tdsMetadata</text>
+<polygon fill="none" stroke="black" points="58.5,-2202 58.5,-2224 142.5,-2224 142.5,-2202 58.5,-2202"/>
+<text text-anchor="start" x="61.43" y="-2209.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-2209.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-2180 58.5,-2202 142.5,-2202 142.5,-2180 58.5,-2180"/>
+<text text-anchor="start" x="64.93" y="-2187.4" font-family="Times,serif" font-size="14.00">eTag: </text>
+<text text-anchor="start" x="100.3" y="-2187.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- userStage -->
+<g id="node22" class="node">
+<title>userStage</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-2326 50.5,-2348 150.5,-2348 150.5,-2326 50.5,-2326"/>
+<polygon fill="none" stroke="black" points="50.5,-2326 50.5,-2348 150.5,-2348 150.5,-2326 50.5,-2326"/>
+<text text-anchor="start" x="73.29" y="-2333.4" font-family="Times,serif" font-weight="bold" font-size="14.00">userStage</text>
+<polygon fill="none" stroke="black" points="50.5,-2304 50.5,-2326 150.5,-2326 150.5,-2304 50.5,-2304"/>
+<text text-anchor="start" x="56.76" y="-2311.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="84.37" y="-2311.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-2282 50.5,-2304 150.5,-2304 150.5,-2282 50.5,-2282"/>
+<text text-anchor="start" x="53.26" y="-2289.4" font-family="Times,serif" font-size="14.00">appStage: </text>
+<text text-anchor="start" x="111.97" y="-2289.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- fireproofWebsites -->
+<g id="node23" class="node">
+<title>fireproofWebsites</title>
+<polygon fill="#caff70" stroke="transparent" points="47.5,-2406 47.5,-2428 154.5,-2428 154.5,-2406 47.5,-2406"/>
+<polygon fill="none" stroke="black" points="47.5,-2406 47.5,-2428 154.5,-2428 154.5,-2406 47.5,-2406"/>
+<text text-anchor="start" x="50.47" y="-2413.4" font-family="Times,serif" font-weight="bold" font-size="14.00">fireproofWebsites</text>
+<polygon fill="none" stroke="black" points="47.5,-2384 47.5,-2406 154.5,-2406 154.5,-2384 47.5,-2384"/>
+<text text-anchor="start" x="58.42" y="-2391.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-2391.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/22.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/22.svg
@@ -1,0 +1,374 @@
+<svg width="569px" height="2602px"
+ viewBox="0.00 0.00 568.66 2602.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 2566)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-2566 532.66,-2566 532.66,36 -36,36"/>
+<!-- tds_tracker -->
+<g id="node1" class="node">
+<title>tds_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<polygon fill="none" stroke="black" points="37.5,-110 37.5,-132 163.5,-132 163.5,-110 37.5,-110"/>
+<text text-anchor="start" x="69.4" y="-117.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_tracker</text>
+<polygon fill="none" stroke="black" points="37.5,-88 37.5,-110 163.5,-110 163.5,-88 37.5,-88"/>
+<text text-anchor="start" x="57.92" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-95.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-66 37.5,-88 163.5,-88 163.5,-66 37.5,-66"/>
+<text text-anchor="start" x="40.44" y="-73.4" font-family="Times,serif" font-size="14.00">defaultAction: </text>
+<text text-anchor="start" x="124.8" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-44 37.5,-66 163.5,-66 163.5,-44 37.5,-44"/>
+<text text-anchor="start" x="44.72" y="-51.4" font-family="Times,serif" font-size="14.00">ownerName: </text>
+<text text-anchor="start" x="120.52" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,-22 37.5,-44 163.5,-44 163.5,-22 37.5,-22"/>
+<text text-anchor="start" x="50.55" y="-29.4" font-family="Times,serif" font-size="14.00">categories: </text>
+<text text-anchor="start" x="114.69" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="37.5,0 37.5,-22 163.5,-22 163.5,0 37.5,0"/>
+<text text-anchor="start" x="65.32" y="-7.4" font-family="Times,serif" font-size="14.00">rules: </text>
+<text text-anchor="start" x="99.92" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tds_entity -->
+<g id="node2" class="node">
+<title>tds_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<polygon fill="none" stroke="black" points="39.5,-234 39.5,-256 162.5,-256 162.5,-234 39.5,-234"/>
+<text text-anchor="start" x="73.39" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_entity</text>
+<polygon fill="none" stroke="black" points="39.5,-212 39.5,-234 162.5,-234 162.5,-212 39.5,-212"/>
+<text text-anchor="start" x="64.26" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">name: </text>
+<text text-anchor="start" x="101.97" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-190 39.5,-212 162.5,-212 162.5,-190 39.5,-190"/>
+<text text-anchor="start" x="42.49" y="-197.4" font-family="Times,serif" font-size="14.00">displayName: </text>
+<text text-anchor="start" x="123.75" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="39.5,-168 39.5,-190 162.5,-190 162.5,-168 39.5,-168"/>
+<text text-anchor="start" x="48.72" y="-175.4" font-family="Times,serif" font-size="14.00">prevalence: </text>
+<text text-anchor="start" x="116.73" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+</g>
+<!-- tds_domain_entity -->
+<g id="node3" class="node">
+<title>tds_domain_entity</title>
+<polygon fill="#caff70" stroke="transparent" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<polygon fill="none" stroke="black" points="43.5,-336 43.5,-358 157.5,-358 157.5,-336 43.5,-336"/>
+<text text-anchor="start" x="48.39" y="-343.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tds_domain_entity</text>
+<polygon fill="none" stroke="black" points="43.5,-314 43.5,-336 157.5,-336 157.5,-314 43.5,-314"/>
+<text text-anchor="start" x="57.92" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-321.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="43.5,-292 43.5,-314 157.5,-314 157.5,-292 43.5,-292"/>
+<text text-anchor="start" x="46.27" y="-299.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="118.97" y="-299.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- temporary_tracking_whitelist -->
+<g id="node4" class="node">
+<title>temporary_tracking_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<polygon fill="none" stroke="black" points="15.5,-416 15.5,-438 186.5,-438 186.5,-416 15.5,-416"/>
+<text text-anchor="start" x="18.19" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">temporary_tracking_whitelist</text>
+<polygon fill="none" stroke="black" points="15.5,-394 15.5,-416 186.5,-416 186.5,-394 15.5,-394"/>
+<text text-anchor="start" x="58.42" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- user_whitelist -->
+<g id="node5" class="node">
+<title>user_whitelist</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-496 55.5,-518 146.5,-518 146.5,-496 55.5,-496"/>
+<polygon fill="none" stroke="black" points="55.5,-496 55.5,-518 146.5,-518 146.5,-496 55.5,-496"/>
+<text text-anchor="start" x="61.73" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">user_whitelist</text>
+<polygon fill="none" stroke="black" points="55.5,-474 55.5,-496 146.5,-496 146.5,-474 55.5,-474"/>
+<text text-anchor="start" x="58.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node6" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="29.5,-642 29.5,-664 171.5,-664 171.5,-642 29.5,-642"/>
+<polygon fill="none" stroke="black" points="29.5,-642 29.5,-664 171.5,-664 171.5,-642 29.5,-642"/>
+<text text-anchor="start" x="32.46" y="-649.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="29.5,-620 29.5,-642 171.5,-642 171.5,-620 29.5,-620"/>
+<text text-anchor="start" x="61.43" y="-627.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-627.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-598 29.5,-620 171.5,-620 171.5,-598 29.5,-598"/>
+<text text-anchor="start" x="52.1" y="-605.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="112.35" y="-605.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="29.5,-576 29.5,-598 171.5,-598 171.5,-576 29.5,-576"/>
+<text text-anchor="start" x="34.6" y="-583.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="106.53" y="-583.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="29.5,-554 29.5,-576 171.5,-576 171.5,-554 29.5,-554"/>
+<text text-anchor="start" x="59.09" y="-561.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="106.14" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node7" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-722 25.5,-744 175.5,-744 175.5,-722 25.5,-722"/>
+<polygon fill="none" stroke="black" points="25.5,-722 25.5,-744 175.5,-744 175.5,-722 25.5,-722"/>
+<text text-anchor="start" x="28.17" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="25.5,-700 25.5,-722 175.5,-722 175.5,-700 25.5,-700"/>
+<text text-anchor="start" x="57.92" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.31" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node8" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="36.5,-824 36.5,-846 164.5,-846 164.5,-824 36.5,-824"/>
+<polygon fill="none" stroke="black" points="36.5,-824 36.5,-846 164.5,-846 164.5,-824 36.5,-824"/>
+<text text-anchor="start" x="41.03" y="-831.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="36.5,-802 36.5,-824 164.5,-824 164.5,-802 36.5,-802"/>
+<text text-anchor="start" x="39.27" y="-809.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="125.96" y="-809.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="36.5,-780 36.5,-802 164.5,-802 164.5,-780 36.5,-780"/>
+<text text-anchor="start" x="51.32" y="-787.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-787.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- sites_visited -->
+<g id="node9" class="node">
+<title>sites_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-926 48.5,-948 152.5,-948 152.5,-926 48.5,-926"/>
+<polygon fill="none" stroke="black" points="48.5,-926 48.5,-948 152.5,-948 152.5,-926 48.5,-926"/>
+<text text-anchor="start" x="65.89" y="-933.4" font-family="Times,serif" font-weight="bold" font-size="14.00">sites_visited</text>
+<polygon fill="none" stroke="black" points="48.5,-904 48.5,-926 152.5,-926 152.5,-904 48.5,-904"/>
+<text text-anchor="start" x="68.82" y="-911.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-911.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-882 48.5,-904 152.5,-904 152.5,-882 48.5,-882"/>
+<text text-anchor="start" x="51.32" y="-889.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-889.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node10" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="364.16,-1050 364.16,-1072 497.16,-1072 497.16,-1050 364.16,-1050"/>
+<polygon fill="none" stroke="black" points="364.16,-1050 364.16,-1072 497.16,-1072 497.16,-1050 364.16,-1050"/>
+<text text-anchor="start" x="419.39" y="-1057.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="364.16,-1028 364.16,-1050 497.16,-1050 497.16,-1028 364.16,-1028"/>
+<text text-anchor="start" x="394.7" y="-1035.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="430.86" y="-1035.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-1006 364.16,-1028 497.16,-1028 497.16,-1006 364.16,-1006"/>
+<text text-anchor="start" x="401.31" y="-1013.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="424.25" y="-1013.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-984 364.16,-1006 497.16,-1006 497.16,-984 364.16,-984"/>
+<text text-anchor="start" x="398.19" y="-991.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="427.36" y="-991.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="364.16,-962 364.16,-984 497.16,-984 497.16,-962 364.16,-962"/>
+<text text-anchor="start" x="368.26" y="-969.4" font-family="Times,serif" font-size="14.00">skipHome: </text>
+<text text-anchor="start" x="433.2" y="-969.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-940 364.16,-962 497.16,-962 497.16,-940 364.16,-940"/>
+<text text-anchor="start" x="376.82" y="-947.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="424.63" y="-947.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-918 364.16,-940 497.16,-940 497.16,-918 364.16,-918"/>
+<text text-anchor="start" x="374.47" y="-925.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="426.98" y="-925.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="364.16,-896 364.16,-918 497.16,-918 497.16,-896 364.16,-896"/>
+<text text-anchor="start" x="366.71" y="-903.4" font-family="Times,serif" font-size="14.00">tabPreviewFile: </text>
+<text text-anchor="start" x="458.85" y="-903.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="364.16,-874 364.16,-896 497.16,-896 497.16,-874 364.16,-874"/>
+<polygon fill="none" stroke="black" points="364.16,-874 364.16,-896 497.16,-896 497.16,-874 364.16,-874"/>
+<text text-anchor="start" x="410.45" y="-881.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="364.16,-852 364.16,-874 497.16,-874 497.16,-852 364.16,-852"/>
+<text text-anchor="start" x="382.45" y="-858.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node11" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="24.5,-1072 24.5,-1094 177.5,-1094 177.5,-1072 24.5,-1072"/>
+<polygon fill="none" stroke="black" points="24.5,-1072 24.5,-1094 177.5,-1094 177.5,-1072 24.5,-1072"/>
+<text text-anchor="start" x="64.07" y="-1079.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="24.5,-1050 24.5,-1072 177.5,-1072 177.5,-1050 24.5,-1050"/>
+<text text-anchor="start" x="61.93" y="-1057.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-1057.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="24.5,-1028 24.5,-1050 177.5,-1050 177.5,-1028 24.5,-1028"/>
+<text text-anchor="start" x="65.04" y="-1035.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="101.2" y="-1035.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="24.5,-1006 24.5,-1028 177.5,-1028 177.5,-1006 24.5,-1006"/>
+<polygon fill="none" stroke="black" points="24.5,-1006 24.5,-1028 177.5,-1028 177.5,-1006 24.5,-1006"/>
+<text text-anchor="start" x="80.79" y="-1013.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="24.5,-984 24.5,-1006 177.5,-1006 177.5,-984 24.5,-984"/>
+<text text-anchor="start" x="27.13" y="-990.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M178.5,-1039C257.26,-1039 279.49,-1039 353.38,-1039"/>
+<polygon fill="black" stroke="black" points="353.66,-1042.5 363.66,-1039 353.66,-1035.5 353.66,-1042.5"/>
+<text text-anchor="middle" x="282.33" y="-1043.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node12" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1196 58.5,-1218 142.5,-1218 142.5,-1196 58.5,-1196"/>
+<polygon fill="none" stroke="black" points="58.5,-1196 58.5,-1218 142.5,-1218 142.5,-1196 58.5,-1196"/>
+<text text-anchor="start" x="69.39" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="58.5,-1174 58.5,-1196 142.5,-1196 142.5,-1174 58.5,-1174"/>
+<text text-anchor="start" x="61.43" y="-1181.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-1181.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-1152 58.5,-1174 142.5,-1174 142.5,-1152 58.5,-1152"/>
+<text text-anchor="start" x="68.03" y="-1159.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="97.2" y="-1159.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="58.5,-1130 58.5,-1152 142.5,-1152 142.5,-1130 58.5,-1130"/>
+<text text-anchor="start" x="71.15" y="-1137.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.09" y="-1137.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node13" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1342 27.5,-1364 174.5,-1364 174.5,-1342 27.5,-1342"/>
+<polygon fill="none" stroke="black" points="27.5,-1342 27.5,-1364 174.5,-1364 174.5,-1342 27.5,-1342"/>
+<text text-anchor="start" x="82.34" y="-1349.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="27.5,-1320 27.5,-1342 174.5,-1342 174.5,-1320 27.5,-1320"/>
+<text text-anchor="start" x="54.93" y="-1327.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="111.3" y="-1327.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1298 27.5,-1320 174.5,-1320 174.5,-1298 27.5,-1298"/>
+<text text-anchor="start" x="71.65" y="-1305.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="94.59" y="-1305.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="27.5,-1276 27.5,-1298 174.5,-1298 174.5,-1276 27.5,-1276"/>
+<text text-anchor="start" x="30.44" y="-1283.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="111.69" y="-1283.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1254 27.5,-1276 174.5,-1276 174.5,-1254 27.5,-1254"/>
+<text text-anchor="start" x="63.48" y="-1261.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="102.76" y="-1261.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node14" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-1422 58.5,-1444 142.5,-1444 142.5,-1422 58.5,-1422"/>
+<polygon fill="none" stroke="black" points="58.5,-1422 58.5,-1444 142.5,-1444 142.5,-1422 58.5,-1422"/>
+<text text-anchor="start" x="61.23" y="-1429.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="58.5,-1400 58.5,-1422 142.5,-1422 142.5,-1400 58.5,-1400"/>
+<text text-anchor="start" x="64.93" y="-1407.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="100.3" y="-1407.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- search_count -->
+<g id="node15" class="node">
+<title>search_count</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1524 48.5,-1546 152.5,-1546 152.5,-1524 48.5,-1524"/>
+<polygon fill="none" stroke="black" points="48.5,-1524 48.5,-1546 152.5,-1546 152.5,-1524 48.5,-1524"/>
+<text text-anchor="start" x="63.57" y="-1531.4" font-family="Times,serif" font-weight="bold" font-size="14.00">search_count</text>
+<polygon fill="none" stroke="black" points="48.5,-1502 48.5,-1524 152.5,-1524 152.5,-1502 48.5,-1502"/>
+<text text-anchor="start" x="68.82" y="-1509.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.42" y="-1509.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1480 48.5,-1502 152.5,-1502 152.5,-1480 48.5,-1480"/>
+<text text-anchor="start" x="51.32" y="-1487.4" font-family="Times,serif" font-size="14.00">count: </text>
+<text text-anchor="start" x="89.81" y="-1487.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- app_days_used -->
+<g id="node16" class="node">
+<title>app_days_used</title>
+<polygon fill="#caff70" stroke="transparent" points="55.5,-1604 55.5,-1626 146.5,-1626 146.5,-1604 55.5,-1604"/>
+<polygon fill="none" stroke="black" points="55.5,-1604 55.5,-1626 146.5,-1626 146.5,-1604 55.5,-1604"/>
+<text text-anchor="start" x="58.23" y="-1611.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_days_used</text>
+<polygon fill="none" stroke="black" points="55.5,-1582 55.5,-1604 146.5,-1604 146.5,-1582 55.5,-1582"/>
+<text text-anchor="start" x="67.76" y="-1589.4" font-family="Times,serif" font-weight="bold" font-size="14.00">date: </text>
+<text text-anchor="start" x="98.47" y="-1589.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_enjoyment -->
+<g id="node17" class="node">
+<title>app_enjoyment</title>
+<polygon fill="#caff70" stroke="transparent" points="27.5,-1750 27.5,-1772 174.5,-1772 174.5,-1750 27.5,-1750"/>
+<polygon fill="none" stroke="black" points="27.5,-1750 27.5,-1772 174.5,-1772 174.5,-1750 27.5,-1750"/>
+<text text-anchor="start" x="57.84" y="-1757.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_enjoyment</text>
+<polygon fill="none" stroke="black" points="27.5,-1728 27.5,-1750 174.5,-1750 174.5,-1728 27.5,-1728"/>
+<text text-anchor="start" x="37.83" y="-1735.4" font-family="Times,serif" font-size="14.00">eventType: </text>
+<text text-anchor="start" x="104.3" y="-1735.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1706 27.5,-1728 174.5,-1728 174.5,-1706 27.5,-1706"/>
+<text text-anchor="start" x="30.04" y="-1713.4" font-family="Times,serif" font-size="14.00">promptCount: </text>
+<text text-anchor="start" x="112.1" y="-1713.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1684 27.5,-1706 174.5,-1706 174.5,-1684 27.5,-1684"/>
+<text text-anchor="start" x="38.21" y="-1691.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-1691.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="27.5,-1662 27.5,-1684 174.5,-1684 174.5,-1662 27.5,-1662"/>
+<text text-anchor="start" x="33.55" y="-1669.4" font-family="Times,serif" font-weight="bold" font-size="14.00">primaryKey: </text>
+<text text-anchor="start" x="108.58" y="-1669.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- notification -->
+<g id="node18" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="38.5,-1830 38.5,-1852 163.5,-1852 163.5,-1830 38.5,-1830"/>
+<polygon fill="none" stroke="black" points="38.5,-1830 38.5,-1852 163.5,-1852 163.5,-1830 38.5,-1830"/>
+<text text-anchor="start" x="68.73" y="-1837.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="38.5,-1808 38.5,-1830 163.5,-1830 163.5,-1808 38.5,-1808"/>
+<text text-anchor="start" x="41.32" y="-1815.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="124.91" y="-1815.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- privacy_protection_count -->
+<g id="node19" class="node">
+<title>privacy_protection_count</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-1954 0.5,-1976 201.5,-1976 201.5,-1954 0.5,-1954"/>
+<polygon fill="none" stroke="black" points="0.5,-1954 0.5,-1976 201.5,-1976 201.5,-1954 0.5,-1954"/>
+<text text-anchor="start" x="29.08" y="-1961.4" font-family="Times,serif" font-weight="bold" font-size="14.00">privacy_protection_count</text>
+<polygon fill="none" stroke="black" points="0.5,-1932 0.5,-1954 201.5,-1954 201.5,-1932 0.5,-1932"/>
+<text text-anchor="start" x="69.32" y="-1939.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="96.92" y="-1939.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-1910 0.5,-1932 201.5,-1932 201.5,-1910 0.5,-1910"/>
+<text text-anchor="start" x="3.23" y="-1917.4" font-family="Times,serif" font-size="14.00">blocked_tracker_count: </text>
+<text text-anchor="start" x="138.9" y="-1917.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="0.5,-1888 0.5,-1910 201.5,-1910 201.5,-1888 0.5,-1888"/>
+<text text-anchor="start" x="25.77" y="-1895.4" font-family="Times,serif" font-size="14.00">upgrade_count: </text>
+<text text-anchor="start" x="116.36" y="-1895.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- UncaughtExceptionEntity -->
+<g id="node20" class="node">
+<title>UncaughtExceptionEntity</title>
+<polygon fill="#caff70" stroke="transparent" points="25.5,-2122 25.5,-2144 176.5,-2144 176.5,-2122 25.5,-2122"/>
+<polygon fill="none" stroke="black" points="25.5,-2122 25.5,-2144 176.5,-2144 176.5,-2122 25.5,-2122"/>
+<text text-anchor="start" x="28.29" y="-2129.4" font-family="Times,serif" font-weight="bold" font-size="14.00">UncaughtExceptionEntity</text>
+<polygon fill="none" stroke="black" points="25.5,-2100 25.5,-2122 176.5,-2122 176.5,-2100 25.5,-2100"/>
+<text text-anchor="start" x="61.93" y="-2107.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="80.21" y="-2107.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-2078 25.5,-2100 176.5,-2100 176.5,-2078 25.5,-2078"/>
+<text text-anchor="start" x="32.77" y="-2085.4" font-family="Times,serif" font-size="14.00">exceptionSource: </text>
+<text text-anchor="start" x="133.46" y="-2085.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-2056 25.5,-2078 176.5,-2078 176.5,-2056 25.5,-2056"/>
+<text text-anchor="start" x="55.71" y="-2063.4" font-family="Times,serif" font-size="14.00">message: </text>
+<text text-anchor="start" x="110.52" y="-2063.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="25.5,-2034 25.5,-2056 176.5,-2056 176.5,-2034 25.5,-2034"/>
+<text text-anchor="start" x="38.21" y="-2041.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-2041.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="25.5,-2012 25.5,-2034 176.5,-2034 176.5,-2012 25.5,-2012"/>
+<text text-anchor="start" x="58.82" y="-2019.4" font-family="Times,serif" font-size="14.00">version: </text>
+<text text-anchor="start" x="107.42" y="-2019.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- tdsMetadata -->
+<g id="node21" class="node">
+<title>tdsMetadata</title>
+<polygon fill="#caff70" stroke="transparent" points="58.5,-2224 58.5,-2246 142.5,-2246 142.5,-2224 58.5,-2224"/>
+<polygon fill="none" stroke="black" points="58.5,-2224 58.5,-2246 142.5,-2246 142.5,-2224 58.5,-2224"/>
+<text text-anchor="start" x="66.29" y="-2231.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tdsMetadata</text>
+<polygon fill="none" stroke="black" points="58.5,-2202 58.5,-2224 142.5,-2224 142.5,-2202 58.5,-2202"/>
+<text text-anchor="start" x="61.43" y="-2209.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="79.71" y="-2209.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="58.5,-2180 58.5,-2202 142.5,-2202 142.5,-2180 58.5,-2180"/>
+<text text-anchor="start" x="64.93" y="-2187.4" font-family="Times,serif" font-size="14.00">eTag: </text>
+<text text-anchor="start" x="100.3" y="-2187.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- userStage -->
+<g id="node22" class="node">
+<title>userStage</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-2326 50.5,-2348 150.5,-2348 150.5,-2326 50.5,-2326"/>
+<polygon fill="none" stroke="black" points="50.5,-2326 50.5,-2348 150.5,-2348 150.5,-2326 50.5,-2326"/>
+<text text-anchor="start" x="73.29" y="-2333.4" font-family="Times,serif" font-weight="bold" font-size="14.00">userStage</text>
+<polygon fill="none" stroke="black" points="50.5,-2304 50.5,-2326 150.5,-2326 150.5,-2304 50.5,-2304"/>
+<text text-anchor="start" x="56.76" y="-2311.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="84.37" y="-2311.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-2282 50.5,-2304 150.5,-2304 150.5,-2282 50.5,-2282"/>
+<text text-anchor="start" x="53.26" y="-2289.4" font-family="Times,serif" font-size="14.00">appStage: </text>
+<text text-anchor="start" x="111.97" y="-2289.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- fireproofWebsites -->
+<g id="node23" class="node">
+<title>fireproofWebsites</title>
+<polygon fill="#caff70" stroke="transparent" points="47.5,-2406 47.5,-2428 154.5,-2428 154.5,-2406 47.5,-2406"/>
+<polygon fill="none" stroke="black" points="47.5,-2406 47.5,-2428 154.5,-2428 154.5,-2406 47.5,-2406"/>
+<text text-anchor="start" x="50.47" y="-2413.4" font-family="Times,serif" font-weight="bold" font-size="14.00">fireproofWebsites</text>
+<polygon fill="none" stroke="black" points="47.5,-2384 47.5,-2406 154.5,-2406 154.5,-2384 47.5,-2384"/>
+<text text-anchor="start" x="58.42" y="-2391.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="107.81" y="-2391.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- user_events -->
+<g id="node24" class="node">
+<title>user_events</title>
+<polygon fill="#caff70" stroke="transparent" points="35.5,-2508 35.5,-2530 166.5,-2530 166.5,-2508 35.5,-2508"/>
+<polygon fill="none" stroke="black" points="35.5,-2508 35.5,-2530 166.5,-2530 166.5,-2508 35.5,-2508"/>
+<text text-anchor="start" x="67.96" y="-2515.4" font-family="Times,serif" font-weight="bold" font-size="14.00">user_events</text>
+<polygon fill="none" stroke="black" points="35.5,-2486 35.5,-2508 166.5,-2508 166.5,-2486 35.5,-2486"/>
+<text text-anchor="start" x="73.98" y="-2493.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="92.26" y="-2493.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="35.5,-2464 35.5,-2486 166.5,-2486 166.5,-2464 35.5,-2464"/>
+<text text-anchor="start" x="38.21" y="-2471.4" font-family="Times,serif" font-size="14.00">timestamp: </text>
+<text text-anchor="start" x="103.92" y="-2471.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/3.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/3.svg
@@ -1,0 +1,133 @@
+<svg width="580px" height="816px"
+ viewBox="0.00 0.00 579.66 816.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 780)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-780 543.66,-780 543.66,36 -36,36"/>
+<!-- https_upgrade_domain -->
+<g id="node1" class="node">
+<title>https_upgrade_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="54.5,-22 54.5,-44 188.5,-44 188.5,-22 54.5,-22"/>
+<polygon fill="none" stroke="black" points="54.5,-22 54.5,-44 188.5,-44 188.5,-22 54.5,-22"/>
+<text text-anchor="start" x="57.34" y="-29.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_upgrade_domain</text>
+<polygon fill="none" stroke="black" points="54.5,0 54.5,-22 188.5,-22 188.5,0 54.5,0"/>
+<text text-anchor="start" x="78.92" y="-7.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-7.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- disconnect_tracker -->
+<g id="node2" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-168 57.5,-190 185.5,-190 185.5,-168 57.5,-168"/>
+<polygon fill="none" stroke="black" points="57.5,-168 57.5,-190 185.5,-190 185.5,-168 57.5,-168"/>
+<text text-anchor="start" x="68.64" y="-175.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-146 57.5,-168 185.5,-168 185.5,-146 57.5,-146"/>
+<text text-anchor="start" x="92.15" y="-153.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-153.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-124 57.5,-146 185.5,-146 185.5,-124 57.5,-124"/>
+<text text-anchor="start" x="75.83" y="-131.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-131.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-102 57.5,-124 185.5,-124 185.5,-102 57.5,-102"/>
+<text text-anchor="start" x="60.27" y="-109.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-109.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-80 57.5,-102 185.5,-102 185.5,-80 57.5,-80"/>
+<text text-anchor="start" x="67.66" y="-87.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-87.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node3" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-270 56.5,-292 187.5,-292 187.5,-270 56.5,-270"/>
+<polygon fill="none" stroke="black" points="56.5,-270 56.5,-292 187.5,-292 187.5,-270 56.5,-270"/>
+<text text-anchor="start" x="62.53" y="-277.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-248 56.5,-270 187.5,-270 187.5,-248 56.5,-248"/>
+<text text-anchor="start" x="60.77" y="-255.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-255.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-226 56.5,-248 187.5,-248 187.5,-226 56.5,-226"/>
+<text text-anchor="start" x="59.21" y="-233.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-233.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node4" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-350 76.5,-372 167.5,-372 167.5,-350 76.5,-350"/>
+<polygon fill="none" stroke="black" points="76.5,-350 76.5,-372 167.5,-372 167.5,-350 76.5,-350"/>
+<text text-anchor="start" x="90.11" y="-357.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-328 76.5,-350 167.5,-350 167.5,-328 76.5,-328"/>
+<text text-anchor="start" x="79.42" y="-335.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-335.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node5" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-452 0.5,-474 243.5,-474 243.5,-452 0.5,-452"/>
+<polygon fill="none" stroke="black" points="0.5,-452 0.5,-474 243.5,-474 243.5,-452 0.5,-452"/>
+<text text-anchor="start" x="70.68" y="-459.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-430 0.5,-452 243.5,-452 243.5,-430 0.5,-430"/>
+<text text-anchor="start" x="90.32" y="-437.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-437.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-408 0.5,-430 243.5,-430 243.5,-408 0.5,-408"/>
+<text text-anchor="start" x="3.22" y="-415.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-415.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node6" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-576 405.66,-598 507.66,-598 507.66,-576 405.66,-576"/>
+<polygon fill="none" stroke="black" points="405.66,-576 405.66,-598 507.66,-598 507.66,-576 405.66,-576"/>
+<text text-anchor="start" x="445.39" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-554 405.66,-576 507.66,-576 507.66,-554 405.66,-554"/>
+<text text-anchor="start" x="420.7" y="-561.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="456.86" y="-561.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-532 405.66,-554 507.66,-554 507.66,-532 405.66,-532"/>
+<text text-anchor="start" x="427.31" y="-539.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="450.25" y="-539.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-510 405.66,-532 507.66,-532 507.66,-510 405.66,-510"/>
+<text text-anchor="start" x="424.19" y="-517.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="453.36" y="-517.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-488 405.66,-510 507.66,-510 507.66,-488 405.66,-488"/>
+<polygon fill="none" stroke="black" points="405.66,-488 405.66,-510 507.66,-510 507.66,-488 405.66,-488"/>
+<text text-anchor="start" x="436.45" y="-495.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-466 405.66,-488 507.66,-488 507.66,-466 405.66,-466"/>
+<text text-anchor="start" x="408.45" y="-472.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node7" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-598 45.5,-620 198.5,-620 198.5,-598 45.5,-598"/>
+<polygon fill="none" stroke="black" points="45.5,-598 45.5,-620 198.5,-620 198.5,-598 45.5,-598"/>
+<text text-anchor="start" x="85.07" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-576 45.5,-598 198.5,-598 198.5,-576 45.5,-576"/>
+<text text-anchor="start" x="82.93" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-554 45.5,-576 198.5,-576 198.5,-554 45.5,-554"/>
+<text text-anchor="start" x="86.04" y="-561.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-532 45.5,-554 198.5,-554 198.5,-532 45.5,-532"/>
+<polygon fill="none" stroke="black" points="45.5,-532 45.5,-554 198.5,-554 198.5,-532 45.5,-532"/>
+<text text-anchor="start" x="101.79" y="-539.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-510 45.5,-532 198.5,-532 198.5,-510 45.5,-510"/>
+<text text-anchor="start" x="48.13" y="-516.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-565C287.64,-565 312.19,-565 395.48,-565"/>
+<polygon fill="black" stroke="black" points="395.66,-568.5 405.66,-565 395.66,-561.5 395.66,-568.5"/>
+<text text-anchor="middle" x="324.33" y="-569.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node8" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-722 79.5,-744 163.5,-744 163.5,-722 79.5,-722"/>
+<polygon fill="none" stroke="black" points="79.5,-722 79.5,-744 163.5,-744 163.5,-722 79.5,-722"/>
+<text text-anchor="start" x="90.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-700 79.5,-722 163.5,-722 163.5,-700 79.5,-700"/>
+<text text-anchor="start" x="82.43" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-678 79.5,-700 163.5,-700 163.5,-678 79.5,-678"/>
+<text text-anchor="start" x="89.03" y="-685.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-656 79.5,-678 163.5,-678 163.5,-656 79.5,-656"/>
+<text text-anchor="start" x="92.15" y="-663.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/4.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/4.svg
@@ -1,0 +1,152 @@
+<svg width="580px" height="962px"
+ viewBox="0.00 0.00 579.66 962.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 926)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-926 543.66,-926 543.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.83" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<polygon fill="none" stroke="black" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<text text-anchor="start" x="62.53" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-394 56.5,-416 187.5,-416 187.5,-394 56.5,-394"/>
+<text text-anchor="start" x="60.77" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-372 56.5,-394 187.5,-394 187.5,-372 56.5,-372"/>
+<text text-anchor="start" x="59.21" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-379.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node5" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<polygon fill="none" stroke="black" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<text text-anchor="start" x="90.11" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-474 76.5,-496 167.5,-496 167.5,-474 76.5,-474"/>
+<text text-anchor="start" x="79.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="70.68" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="90.32" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-554 0.5,-576 243.5,-576 243.5,-554 0.5,-554"/>
+<text text-anchor="start" x="3.22" y="-561.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-722 405.66,-744 507.66,-744 507.66,-722 405.66,-722"/>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 507.66,-744 507.66,-722 405.66,-722"/>
+<text text-anchor="start" x="445.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 507.66,-722 507.66,-700 405.66,-700"/>
+<text text-anchor="start" x="420.7" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="456.86" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 507.66,-700 507.66,-678 405.66,-678"/>
+<text text-anchor="start" x="427.31" y="-685.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="450.25" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 507.66,-678 507.66,-656 405.66,-656"/>
+<text text-anchor="start" x="424.19" y="-663.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="453.36" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-634 405.66,-656 507.66,-656 507.66,-634 405.66,-634"/>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 507.66,-656 507.66,-634 405.66,-634"/>
+<text text-anchor="start" x="436.45" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 507.66,-634 507.66,-612 405.66,-612"/>
+<text text-anchor="start" x="408.45" y="-618.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="85.07" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="82.93" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="86.04" y="-707.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="101.79" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-656 45.5,-678 198.5,-678 198.5,-656 45.5,-656"/>
+<text text-anchor="start" x="48.13" y="-662.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-711C287.64,-711 312.19,-711 395.48,-711"/>
+<polygon fill="black" stroke="black" points="395.66,-714.5 405.66,-711 395.66,-707.5 395.66,-714.5"/>
+<text text-anchor="middle" x="324.33" y="-715.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="90.39" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="82.43" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-853.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="89.03" y="-831.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-802 79.5,-824 163.5,-824 163.5,-802 79.5,-802"/>
+<text text-anchor="start" x="92.15" y="-809.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/5.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/5.svg
@@ -1,0 +1,158 @@
+<svg width="596px" height="962px"
+ viewBox="0.00 0.00 595.66 962.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 926)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-926 559.66,-926 559.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<polygon fill="none" stroke="black" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<text text-anchor="start" x="62.53" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-394 56.5,-416 187.5,-416 187.5,-394 56.5,-394"/>
+<text text-anchor="start" x="60.77" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-372 56.5,-394 187.5,-394 187.5,-372 56.5,-372"/>
+<text text-anchor="start" x="59.21" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-379.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node5" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<polygon fill="none" stroke="black" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<text text-anchor="start" x="90.11" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-474 76.5,-496 167.5,-496 167.5,-474 76.5,-474"/>
+<text text-anchor="start" x="79.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="70.68" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="90.32" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-554 0.5,-576 243.5,-576 243.5,-554 0.5,-554"/>
+<text text-anchor="start" x="3.22" y="-561.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<text text-anchor="start" x="453.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 523.66,-722 523.66,-700 405.66,-700"/>
+<text text-anchor="start" x="428.7" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="464.86" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 523.66,-700 523.66,-678 405.66,-678"/>
+<text text-anchor="start" x="435.31" y="-685.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="458.25" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 523.66,-678 523.66,-656 405.66,-656"/>
+<text text-anchor="start" x="432.19" y="-663.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="461.36" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 523.66,-656 523.66,-634 405.66,-634"/>
+<text text-anchor="start" x="410.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="458.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 523.66,-634 523.66,-612 405.66,-612"/>
+<text text-anchor="start" x="408.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="460.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<polygon fill="none" stroke="black" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<text text-anchor="start" x="444.45" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-568 405.66,-590 523.66,-590 523.66,-568 405.66,-568"/>
+<text text-anchor="start" x="416.45" y="-574.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="85.07" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="82.93" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="86.04" y="-707.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="101.79" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-656 45.5,-678 198.5,-678 198.5,-656 45.5,-656"/>
+<text text-anchor="start" x="48.13" y="-662.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-711C287.64,-711 312.19,-711 395.48,-711"/>
+<polygon fill="black" stroke="black" points="395.66,-714.5 405.66,-711 395.66,-707.5 395.66,-714.5"/>
+<text text-anchor="middle" x="324.33" y="-715.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="90.39" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="82.43" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-853.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="89.03" y="-831.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-802 79.5,-824 163.5,-824 163.5,-802 79.5,-802"/>
+<text text-anchor="start" x="92.15" y="-809.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/6.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/6.svg
@@ -1,0 +1,171 @@
+<svg width="596px" height="1064px"
+ viewBox="0.00 0.00 595.66 1064.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1028)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1028 559.66,-1028 559.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<polygon fill="none" stroke="black" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<text text-anchor="start" x="62.53" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-394 56.5,-416 187.5,-416 187.5,-394 56.5,-394"/>
+<text text-anchor="start" x="60.77" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-372 56.5,-394 187.5,-394 187.5,-372 56.5,-372"/>
+<text text-anchor="start" x="59.21" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-379.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node5" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<polygon fill="none" stroke="black" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<text text-anchor="start" x="90.11" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-474 76.5,-496 167.5,-496 167.5,-474 76.5,-474"/>
+<text text-anchor="start" x="79.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="70.68" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="90.32" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-554 0.5,-576 243.5,-576 243.5,-554 0.5,-554"/>
+<text text-anchor="start" x="3.22" y="-561.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<text text-anchor="start" x="453.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 523.66,-722 523.66,-700 405.66,-700"/>
+<text text-anchor="start" x="428.7" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="464.86" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 523.66,-700 523.66,-678 405.66,-678"/>
+<text text-anchor="start" x="435.31" y="-685.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="458.25" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 523.66,-678 523.66,-656 405.66,-656"/>
+<text text-anchor="start" x="432.19" y="-663.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="461.36" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 523.66,-656 523.66,-634 405.66,-634"/>
+<text text-anchor="start" x="410.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="458.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 523.66,-634 523.66,-612 405.66,-612"/>
+<text text-anchor="start" x="408.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="460.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<polygon fill="none" stroke="black" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<text text-anchor="start" x="444.45" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-568 405.66,-590 523.66,-590 523.66,-568 405.66,-568"/>
+<text text-anchor="start" x="416.45" y="-574.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="85.07" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="82.93" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="86.04" y="-707.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="101.79" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-656 45.5,-678 198.5,-678 198.5,-656 45.5,-656"/>
+<text text-anchor="start" x="48.13" y="-662.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-711C287.64,-711 312.19,-711 395.48,-711"/>
+<polygon fill="black" stroke="black" points="395.66,-714.5 405.66,-711 395.66,-707.5 395.66,-714.5"/>
+<text text-anchor="middle" x="324.33" y="-715.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="90.39" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="82.43" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-853.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="89.03" y="-831.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-802 79.5,-824 163.5,-824 163.5,-802 79.5,-802"/>
+<text text-anchor="start" x="92.15" y="-809.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="93.5" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="67.27" y="-955.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-955.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-926 59.5,-948 183.5,-948 183.5,-926 59.5,-926"/>
+<text text-anchor="start" x="62.21" y="-933.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-933.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/7.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/7.svg
@@ -1,0 +1,190 @@
+<svg width="596px" height="1210px"
+ viewBox="0.00 0.00 595.66 1210.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1174)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1174 559.66,-1174 559.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<polygon fill="none" stroke="black" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<text text-anchor="start" x="62.53" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-394 56.5,-416 187.5,-416 187.5,-394 56.5,-394"/>
+<text text-anchor="start" x="60.77" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-372 56.5,-394 187.5,-394 187.5,-372 56.5,-372"/>
+<text text-anchor="start" x="59.21" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-379.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node5" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<polygon fill="none" stroke="black" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<text text-anchor="start" x="90.11" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-474 76.5,-496 167.5,-496 167.5,-474 76.5,-474"/>
+<text text-anchor="start" x="79.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="70.68" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="90.32" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-554 0.5,-576 243.5,-576 243.5,-554 0.5,-554"/>
+<text text-anchor="start" x="3.22" y="-561.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<text text-anchor="start" x="453.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 523.66,-722 523.66,-700 405.66,-700"/>
+<text text-anchor="start" x="428.7" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="464.86" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 523.66,-700 523.66,-678 405.66,-678"/>
+<text text-anchor="start" x="435.31" y="-685.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="458.25" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 523.66,-678 523.66,-656 405.66,-656"/>
+<text text-anchor="start" x="432.19" y="-663.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="461.36" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 523.66,-656 523.66,-634 405.66,-634"/>
+<text text-anchor="start" x="410.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="458.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 523.66,-634 523.66,-612 405.66,-612"/>
+<text text-anchor="start" x="408.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="460.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<polygon fill="none" stroke="black" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<text text-anchor="start" x="444.45" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-568 405.66,-590 523.66,-590 523.66,-568 405.66,-568"/>
+<text text-anchor="start" x="416.45" y="-574.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="85.07" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="82.93" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="86.04" y="-707.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="101.79" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-656 45.5,-678 198.5,-678 198.5,-656 45.5,-656"/>
+<text text-anchor="start" x="48.13" y="-662.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-711C287.64,-711 312.19,-711 395.48,-711"/>
+<polygon fill="black" stroke="black" points="395.66,-714.5 405.66,-711 395.66,-707.5 395.66,-714.5"/>
+<text text-anchor="middle" x="324.33" y="-715.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="90.39" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="82.43" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-853.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="89.03" y="-831.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-802 79.5,-824 163.5,-824 163.5,-802 79.5,-802"/>
+<text text-anchor="start" x="92.15" y="-809.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="93.5" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="62.21" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-926 59.5,-948 183.5,-948 183.5,-926 59.5,-926"/>
+<text text-anchor="start" x="67.27" y="-933.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node11" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<polygon fill="none" stroke="black" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<text text-anchor="start" x="103.34" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="48.5,-1094 48.5,-1116 195.5,-1116 195.5,-1094 48.5,-1094"/>
+<text text-anchor="start" x="75.93" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="132.3" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1072 48.5,-1094 195.5,-1094 195.5,-1072 48.5,-1072"/>
+<text text-anchor="start" x="92.65" y="-1079.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.59" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1050 48.5,-1072 195.5,-1072 195.5,-1050 48.5,-1050"/>
+<text text-anchor="start" x="51.44" y="-1057.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="132.69" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1028 48.5,-1050 195.5,-1050 195.5,-1028 48.5,-1028"/>
+<text text-anchor="start" x="84.48" y="-1035.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="123.76" y="-1035.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/8.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/8.svg
@@ -1,0 +1,200 @@
+<svg width="596px" height="1290px"
+ viewBox="0.00 0.00 595.66 1290.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1254)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1254 559.66,-1254 559.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<polygon fill="none" stroke="black" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<text text-anchor="start" x="62.53" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-394 56.5,-416 187.5,-416 187.5,-394 56.5,-394"/>
+<text text-anchor="start" x="60.77" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-372 56.5,-394 187.5,-394 187.5,-372 56.5,-372"/>
+<text text-anchor="start" x="59.21" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-379.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node5" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<polygon fill="none" stroke="black" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<text text-anchor="start" x="90.11" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-474 76.5,-496 167.5,-496 167.5,-474 76.5,-474"/>
+<text text-anchor="start" x="79.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="70.68" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="90.32" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-554 0.5,-576 243.5,-576 243.5,-554 0.5,-554"/>
+<text text-anchor="start" x="3.22" y="-561.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<text text-anchor="start" x="453.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 523.66,-722 523.66,-700 405.66,-700"/>
+<text text-anchor="start" x="428.7" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="464.86" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 523.66,-700 523.66,-678 405.66,-678"/>
+<text text-anchor="start" x="435.31" y="-685.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="458.25" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 523.66,-678 523.66,-656 405.66,-656"/>
+<text text-anchor="start" x="432.19" y="-663.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="461.36" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 523.66,-656 523.66,-634 405.66,-634"/>
+<text text-anchor="start" x="410.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="458.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 523.66,-634 523.66,-612 405.66,-612"/>
+<text text-anchor="start" x="408.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="460.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<polygon fill="none" stroke="black" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<text text-anchor="start" x="444.45" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-568 405.66,-590 523.66,-590 523.66,-568 405.66,-568"/>
+<text text-anchor="start" x="416.45" y="-574.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="85.07" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="82.93" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="86.04" y="-707.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="101.79" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-656 45.5,-678 198.5,-678 198.5,-656 45.5,-656"/>
+<text text-anchor="start" x="48.13" y="-662.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-711C287.64,-711 312.19,-711 395.48,-711"/>
+<polygon fill="black" stroke="black" points="395.66,-714.5 405.66,-711 395.66,-707.5 395.66,-714.5"/>
+<text text-anchor="middle" x="324.33" y="-715.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="90.39" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="82.43" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-853.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="89.03" y="-831.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-802 79.5,-824 163.5,-824 163.5,-802 79.5,-802"/>
+<text text-anchor="start" x="92.15" y="-809.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="93.5" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="62.21" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-926 59.5,-948 183.5,-948 183.5,-926 59.5,-926"/>
+<text text-anchor="start" x="67.27" y="-933.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node11" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<polygon fill="none" stroke="black" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<text text-anchor="start" x="103.34" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="48.5,-1094 48.5,-1116 195.5,-1116 195.5,-1094 48.5,-1094"/>
+<text text-anchor="start" x="75.93" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="132.3" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1072 48.5,-1094 195.5,-1094 195.5,-1072 48.5,-1072"/>
+<text text-anchor="start" x="92.65" y="-1079.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.59" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1050 48.5,-1072 195.5,-1072 195.5,-1050 48.5,-1050"/>
+<text text-anchor="start" x="51.44" y="-1057.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="132.69" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1028 48.5,-1050 195.5,-1050 195.5,-1028 48.5,-1028"/>
+<text text-anchor="start" x="84.48" y="-1035.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="123.76" y="-1035.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node12" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<polygon fill="none" stroke="black" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<text text-anchor="start" x="82.23" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="79.5,-1174 79.5,-1196 163.5,-1196 163.5,-1174 79.5,-1174"/>
+<text text-anchor="start" x="85.93" y="-1181.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="121.3" y="-1181.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/9.svg
+++ b/app/floorplan-output/com.duckduckgo.app.global.db.AppDatabase/9.svg
@@ -1,0 +1,210 @@
+<svg width="596px" height="1370px"
+ viewBox="0.00 0.00 595.66 1370.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 1334)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-1334 559.66,-1334 559.66,36 -36,36"/>
+<!-- disconnect_tracker -->
+<g id="node1" class="node">
+<title>disconnect_tracker</title>
+<polygon fill="#caff70" stroke="transparent" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<polygon fill="none" stroke="black" points="57.5,-88 57.5,-110 185.5,-110 185.5,-88 57.5,-88"/>
+<text text-anchor="start" x="68.64" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">disconnect_tracker</text>
+<polygon fill="none" stroke="black" points="57.5,-66 57.5,-88 185.5,-88 185.5,-66 57.5,-66"/>
+<text text-anchor="start" x="92.15" y="-73.4" font-family="Times,serif" font-weight="bold" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-73.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-44 57.5,-66 185.5,-66 185.5,-44 57.5,-44"/>
+<text text-anchor="start" x="75.82" y="-51.4" font-family="Times,serif" font-size="14.00">category: </text>
+<text text-anchor="start" x="131.41" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,-22 57.5,-44 185.5,-44 185.5,-22 57.5,-22"/>
+<text text-anchor="start" x="60.27" y="-29.4" font-family="Times,serif" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="146.96" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="57.5,0 57.5,-22 185.5,-22 185.5,0 57.5,0"/>
+<text text-anchor="start" x="67.66" y="-7.4" font-family="Times,serif" font-size="14.00">networkUrl: </text>
+<text text-anchor="start" x="139.58" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_bloom_filter_spec -->
+<g id="node2" class="node">
+<title>https_bloom_filter_spec</title>
+<polygon fill="#caff70" stroke="transparent" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<polygon fill="none" stroke="black" points="50.5,-234 50.5,-256 192.5,-256 192.5,-234 50.5,-234"/>
+<text text-anchor="start" x="53.46" y="-241.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_bloom_filter_spec</text>
+<polygon fill="none" stroke="black" points="50.5,-212 50.5,-234 192.5,-234 192.5,-212 50.5,-212"/>
+<text text-anchor="start" x="82.43" y="-219.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-219.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-190 50.5,-212 192.5,-212 192.5,-190 50.5,-190"/>
+<text text-anchor="start" x="73.1" y="-197.4" font-family="Times,serif" font-size="14.00">errorRate: </text>
+<text text-anchor="start" x="133.35" y="-197.4" font-family="Times,serif" font-style="italic" font-size="14.00">REAL</text>
+<polygon fill="none" stroke="black" points="50.5,-168 50.5,-190 192.5,-190 192.5,-168 50.5,-168"/>
+<text text-anchor="start" x="55.6" y="-175.4" font-family="Times,serif" font-size="14.00">totalEntries: </text>
+<text text-anchor="start" x="127.53" y="-175.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="50.5,-146 50.5,-168 192.5,-168 192.5,-146 50.5,-146"/>
+<text text-anchor="start" x="80.09" y="-153.4" font-family="Times,serif" font-size="14.00">sha256: </text>
+<text text-anchor="start" x="127.14" y="-153.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- https_whitelisted_domain -->
+<g id="node3" class="node">
+<title>https_whitelisted_domain</title>
+<polygon fill="#caff70" stroke="transparent" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<polygon fill="none" stroke="black" points="46.5,-314 46.5,-336 196.5,-336 196.5,-314 46.5,-314"/>
+<text text-anchor="start" x="49.17" y="-321.4" font-family="Times,serif" font-weight="bold" font-size="14.00">https_whitelisted_domain</text>
+<polygon fill="none" stroke="black" points="46.5,-292 46.5,-314 196.5,-314 196.5,-292 46.5,-292"/>
+<text text-anchor="start" x="78.92" y="-299.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.31" y="-299.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- network_leaderboard -->
+<g id="node4" class="node">
+<title>network_leaderboard</title>
+<polygon fill="#caff70" stroke="transparent" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<polygon fill="none" stroke="black" points="56.5,-416 56.5,-438 187.5,-438 187.5,-416 56.5,-416"/>
+<text text-anchor="start" x="62.53" y="-423.4" font-family="Times,serif" font-weight="bold" font-size="14.00">network_leaderboard</text>
+<polygon fill="none" stroke="black" points="56.5,-394 56.5,-416 187.5,-416 187.5,-394 56.5,-394"/>
+<text text-anchor="start" x="60.77" y="-401.4" font-family="Times,serif" font-weight="bold" font-size="14.00">networkName: </text>
+<text text-anchor="start" x="147.46" y="-401.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="56.5,-372 56.5,-394 187.5,-394 187.5,-372 56.5,-372"/>
+<text text-anchor="start" x="59.21" y="-379.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainVisited: </text>
+<text text-anchor="start" x="149.03" y="-379.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- site_visited -->
+<g id="node5" class="node">
+<title>site_visited</title>
+<polygon fill="#caff70" stroke="transparent" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<polygon fill="none" stroke="black" points="76.5,-496 76.5,-518 167.5,-518 167.5,-496 76.5,-496"/>
+<text text-anchor="start" x="90.11" y="-503.4" font-family="Times,serif" font-weight="bold" font-size="14.00">site_visited</text>
+<polygon fill="none" stroke="black" points="76.5,-474 76.5,-496 167.5,-496 167.5,-474 76.5,-474"/>
+<text text-anchor="start" x="79.42" y="-481.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domain: </text>
+<text text-anchor="start" x="128.81" y="-481.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- app_configuration -->
+<g id="node6" class="node">
+<title>app_configuration</title>
+<polygon fill="#caff70" stroke="transparent" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<polygon fill="none" stroke="black" points="0.5,-598 0.5,-620 243.5,-620 243.5,-598 0.5,-598"/>
+<text text-anchor="start" x="70.68" y="-605.4" font-family="Times,serif" font-weight="bold" font-size="14.00">app_configuration</text>
+<polygon fill="none" stroke="black" points="0.5,-576 0.5,-598 243.5,-598 243.5,-576 0.5,-576"/>
+<text text-anchor="start" x="90.32" y="-583.4" font-family="Times,serif" font-weight="bold" font-size="14.00">key: </text>
+<text text-anchor="start" x="117.92" y="-583.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="0.5,-554 0.5,-576 243.5,-576 243.5,-554 0.5,-554"/>
+<text text-anchor="start" x="3.22" y="-561.4" font-family="Times,serif" font-size="14.00">appConfigurationDownloaded: </text>
+<text text-anchor="start" x="180.91" y="-561.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+</g>
+<!-- tabs -->
+<g id="node7" class="node">
+<title>tabs</title>
+<polygon fill="#caff70" stroke="transparent" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<polygon fill="none" stroke="black" points="405.66,-722 405.66,-744 523.66,-744 523.66,-722 405.66,-722"/>
+<text text-anchor="start" x="453.39" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabs</text>
+<polygon fill="none" stroke="black" points="405.66,-700 405.66,-722 523.66,-722 523.66,-700 405.66,-700"/>
+<text text-anchor="start" x="428.7" y="-707.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="464.86" y="-707.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-678 405.66,-700 523.66,-700 523.66,-678 405.66,-678"/>
+<text text-anchor="start" x="435.31" y="-685.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="458.25" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-656 405.66,-678 523.66,-678 523.66,-656 405.66,-656"/>
+<text text-anchor="start" x="432.19" y="-663.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="461.36" y="-663.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="405.66,-634 405.66,-656 523.66,-656 523.66,-634 405.66,-634"/>
+<text text-anchor="start" x="410.82" y="-641.4" font-family="Times,serif" font-size="14.00">viewed: </text>
+<text text-anchor="start" x="458.63" y="-641.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="405.66,-612 405.66,-634 523.66,-634 523.66,-612 405.66,-612"/>
+<text text-anchor="start" x="408.47" y="-619.4" font-family="Times,serif" font-size="14.00">position: </text>
+<text text-anchor="start" x="460.98" y="-619.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<polygon fill="none" stroke="black" points="405.66,-590 405.66,-612 523.66,-612 523.66,-590 405.66,-590"/>
+<text text-anchor="start" x="444.45" y="-597.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="405.66,-568 405.66,-590 523.66,-590 523.66,-568 405.66,-568"/>
+<text text-anchor="start" x="416.45" y="-574.4" font-family="Times,serif" font-size="14.00">index_tabs_tabId</text>
+</g>
+<!-- tab_selection -->
+<g id="node8" class="node">
+<title>tab_selection</title>
+<polygon fill="#caff70" stroke="transparent" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<polygon fill="none" stroke="black" points="45.5,-744 45.5,-766 198.5,-766 198.5,-744 45.5,-744"/>
+<text text-anchor="start" x="85.07" y="-751.4" font-family="Times,serif" font-weight="bold" font-size="14.00">tab_selection</text>
+<polygon fill="none" stroke="black" points="45.5,-722 45.5,-744 198.5,-744 198.5,-722 45.5,-722"/>
+<text text-anchor="start" x="82.93" y="-729.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="101.21" y="-729.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="45.5,-700 45.5,-722 198.5,-722 198.5,-700 45.5,-700"/>
+<text text-anchor="start" x="86.04" y="-707.4" font-family="Times,serif" font-size="14.00">tabId: </text>
+<text text-anchor="start" x="122.2" y="-707.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="#c1cdcd" stroke="transparent" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<polygon fill="none" stroke="black" points="45.5,-678 45.5,-700 198.5,-700 198.5,-678 45.5,-678"/>
+<text text-anchor="start" x="101.79" y="-685.4" font-family="Times,serif" font-style="italic" font-size="14.00">Indices</text>
+<polygon fill="none" stroke="black" points="45.5,-656 45.5,-678 198.5,-678 198.5,-656 45.5,-656"/>
+<text text-anchor="start" x="48.13" y="-662.4" font-family="Times,serif" font-size="14.00">index_tab_selection_tabId</text>
+</g>
+<!-- tab_selection&#45;&gt;tabs -->
+<g id="edge1" class="edge">
+<title>tab_selection:tabId&#45;&gt;tabs:tabId</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M199.5,-711C287.64,-711 312.19,-711 395.48,-711"/>
+<polygon fill="black" stroke="black" points="395.66,-714.5 405.66,-711 395.66,-707.5 395.66,-714.5"/>
+<text text-anchor="middle" x="324.33" y="-715.2" font-family="Times,serif" font-size="14.00">1&#45;1</text>
+</g>
+<!-- bookmarks -->
+<g id="node9" class="node">
+<title>bookmarks</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<polygon fill="none" stroke="black" points="79.5,-868 79.5,-890 163.5,-890 163.5,-868 79.5,-868"/>
+<text text-anchor="start" x="90.39" y="-875.4" font-family="Times,serif" font-weight="bold" font-size="14.00">bookmarks</text>
+<polygon fill="none" stroke="black" points="79.5,-846 79.5,-868 163.5,-868 163.5,-846 79.5,-846"/>
+<text text-anchor="start" x="82.43" y="-853.4" font-family="Times,serif" font-weight="bold" font-size="14.00">id: </text>
+<text text-anchor="start" x="100.71" y="-853.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="79.5,-824 79.5,-846 163.5,-846 163.5,-824 79.5,-824"/>
+<text text-anchor="start" x="89.03" y="-831.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="118.2" y="-831.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="79.5,-802 79.5,-824 163.5,-824 163.5,-802 79.5,-802"/>
+<text text-anchor="start" x="92.15" y="-809.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.09" y="-809.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- entity_list -->
+<g id="node10" class="node">
+<title>entity_list</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<polygon fill="none" stroke="black" points="59.5,-970 59.5,-992 183.5,-992 183.5,-970 59.5,-970"/>
+<text text-anchor="start" x="93.5" y="-977.4" font-family="Times,serif" font-weight="bold" font-size="14.00">entity_list</text>
+<polygon fill="none" stroke="black" points="59.5,-948 59.5,-970 183.5,-970 183.5,-948 59.5,-948"/>
+<text text-anchor="start" x="62.21" y="-955.4" font-family="Times,serif" font-weight="bold" font-size="14.00">domainName: </text>
+<text text-anchor="start" x="145.02" y="-955.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="59.5,-926 59.5,-948 183.5,-948 183.5,-926 59.5,-926"/>
+<text text-anchor="start" x="67.27" y="-933.4" font-family="Times,serif" font-size="14.00">entityName: </text>
+<text text-anchor="start" x="139.97" y="-933.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- survey -->
+<g id="node11" class="node">
+<title>survey</title>
+<polygon fill="#caff70" stroke="transparent" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<polygon fill="none" stroke="black" points="48.5,-1116 48.5,-1138 195.5,-1138 195.5,-1116 48.5,-1116"/>
+<text text-anchor="start" x="103.34" y="-1123.4" font-family="Times,serif" font-weight="bold" font-size="14.00">survey</text>
+<polygon fill="none" stroke="black" points="48.5,-1094 48.5,-1116 195.5,-1116 195.5,-1094 48.5,-1094"/>
+<text text-anchor="start" x="75.93" y="-1101.4" font-family="Times,serif" font-weight="bold" font-size="14.00">surveyId: </text>
+<text text-anchor="start" x="132.3" y="-1101.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1072 48.5,-1094 195.5,-1094 195.5,-1072 48.5,-1072"/>
+<text text-anchor="start" x="92.65" y="-1079.4" font-family="Times,serif" font-size="14.00">url: </text>
+<text text-anchor="start" x="115.59" y="-1079.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="48.5,-1050 48.5,-1072 195.5,-1072 195.5,-1050 48.5,-1050"/>
+<text text-anchor="start" x="51.44" y="-1057.4" font-family="Times,serif" font-size="14.00">daysInstalled: </text>
+<text text-anchor="start" x="132.69" y="-1057.4" font-family="Times,serif" font-style="italic" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="48.5,-1028 48.5,-1050 195.5,-1050 195.5,-1028 48.5,-1028"/>
+<text text-anchor="start" x="84.48" y="-1035.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="123.76" y="-1035.4" font-family="Times,serif" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- dismissed_cta -->
+<g id="node12" class="node">
+<title>dismissed_cta</title>
+<polygon fill="#caff70" stroke="transparent" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<polygon fill="none" stroke="black" points="79.5,-1196 79.5,-1218 163.5,-1218 163.5,-1196 79.5,-1196"/>
+<text text-anchor="start" x="82.23" y="-1203.4" font-family="Times,serif" font-weight="bold" font-size="14.00">dismissed_cta</text>
+<polygon fill="none" stroke="black" points="79.5,-1174 79.5,-1196 163.5,-1196 163.5,-1174 79.5,-1174"/>
+<text text-anchor="start" x="85.93" y="-1181.4" font-family="Times,serif" font-weight="bold" font-size="14.00">ctaId: </text>
+<text text-anchor="start" x="121.3" y="-1181.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+<!-- notification -->
+<g id="node13" class="node">
+<title>notification</title>
+<polygon fill="#caff70" stroke="transparent" points="59.5,-1276 59.5,-1298 184.5,-1298 184.5,-1276 59.5,-1276"/>
+<polygon fill="none" stroke="black" points="59.5,-1276 59.5,-1298 184.5,-1298 184.5,-1276 59.5,-1276"/>
+<text text-anchor="start" x="89.73" y="-1283.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notification</text>
+<polygon fill="none" stroke="black" points="59.5,-1254 59.5,-1276 184.5,-1276 184.5,-1254 59.5,-1254"/>
+<text text-anchor="start" x="62.32" y="-1261.4" font-family="Times,serif" font-weight="bold" font-size="14.00">notificationId: </text>
+<text text-anchor="start" x="145.91" y="-1261.4" font-family="Times,serif" font-weight="bold" font-style="italic" font-size="14.00">TEXT</text>
+</g>
+</g>
+</svg>

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.android.tools.build.jetifier:jetifier-processor:$jetifier"
+        classpath "com.juliozynger.floorplan:floorplan-gradle-plugin:0.2"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
[FloorPlan](https://github.com/julioz/FloorPlan) translates Room schemas into entity-relationship diagrams, to make it easier to inspect changes in the persistance-layer schema of the app.

Here, I am configuring FloorPlan to output `SVG` files by mimicking the Room directory structure, into a sibling directory under the `:app` module.
The first commit is the plugin configuration, the second is checking in the actual diagrams.

You can manually generate the diagrams by running

```
./gradlew generateFloorPlan
```

Optionally, we could also make `compileDebugJava`/`kaptDebugKotlin` depend on `generateFloorPlan`, and we would get automatic diagram generation on builds for that module, similarly to how [Room hooks into the build process to generate the JSON schemas](https://stackoverflow.com/a/57103344/12511149).

On top of that, there's also an (incubating) IntelliJ plugin to help with discoverability of the schemas:
![floorplan-intellij-plugin](https://user-images.githubusercontent.com/1541701/86735421-1405a200-c033-11ea-815a-24c6e8c81d0d.gif)

Let me know your thoughts on this.