### PR TITLE
Invert string shown for enabling/disabling privacy protection

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1575,7 +1575,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope, DaxDialogLi
                 fireproofWebsitePopupMenuItem?.isChecked = viewState.canFireproofSite && viewState.isFireproofWebsite
                 sharePageMenuItem?.isEnabled = viewState.canSharePage
                 whitelistPopupMenuItem?.isEnabled = viewState.canWhitelist
-                whitelistPopupMenuItem?.text = getText(if (viewState.isWhitelisted) R.string.whitelistRemove else R.string.whitelistAdd)
+                whitelistPopupMenuItem?.text = getText(if (viewState.isWhitelisted) R.string.enablePrivacyProtection else R.string.disablePrivacyProtection)
                 brokenSitePopupMenuItem?.isEnabled = viewState.canReportSite
                 requestDesktopSiteCheckMenuItem?.isEnabled = viewState.canChangeBrowsingMode
                 requestDesktopSiteCheckMenuItem?.isChecked = viewState.isDesktopBrowsingMode

--- a/app/src/main/res/layout/popup_window_browser_menu.xml
+++ b/app/src/main/res/layout/popup_window_browser_menu.xml
@@ -140,7 +140,7 @@
             <TextView
                 android:id="@+id/whitelistPopupMenuItem"
                 style="@style/BrowserTextMenuItem"
-                android:text="@string/whitelistAdd" />
+                android:text="@string/enablePrivacyProtection" />
 
             <TextView
                 android:id="@+id/brokenSitePopupMenuItem"

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -423,8 +423,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Бял списък</string>
-    <string name="whitelistAdd">Добавяне към белия списък</string>
-    <string name="whitelistRemove">Премахване от белия списък</string>
+    <string name="enablePrivacyProtection">Добавяне към белия списък</string>
+    <string name="disablePrivacyProtection">Премахване от белия списък</string>
     <string name="whitelistEntryOverflowContentDescription">Още опции за въвеждане в белия списък %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Сигурни ли сте, че искате да изтриете &lt;b&gt;%s&lt;/b&gt; от белия списък?</string>
     <string name="whitelistExplanation">Тези сайтове в белия списък няма да бъдат надградени от Защитата на поверителността</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -430,8 +430,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Seznam povolených</string>
-    <string name="whitelistAdd">Přidat na seznam povolených</string>
-    <string name="whitelistRemove">Odebrat ze seznamu povolených</string>
+    <string name="enablePrivacyProtection">Přidat na seznam povolených</string>
+    <string name="disablePrivacyProtection">Odebrat ze seznamu povolených</string>
     <string name="whitelistEntryOverflowContentDescription">Další možnosti pro zápis na seznam povolených %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Opravdu chcete smazat &lt;b&gt;%s&lt;/b&gt; ze seznamu povolených?</string>
     <string name="whitelistExplanation">Tyto weby na seznamu povolených nebudou aktualizovány pomocí Ochrany osobních údajů</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -424,8 +424,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Whitelist</string>
-    <string name="whitelistAdd">Føj til Whitelist</string>
-    <string name="whitelistRemove">Fjern fra Whitelist</string>
+    <string name="enablePrivacyProtection">Føj til Whitelist</string>
+    <string name="disablePrivacyProtection">Fjern fra Whitelist</string>
     <string name="whitelistEntryOverflowContentDescription">Flere muligheder for tilføjelse af Whitelist %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Er du sikker på, at du vil slette &lt;b&gt;%s&lt;/b&gt; fra Whitelist?</string>
     <string name="whitelistExplanation">Disse Whitelist sider opgraderes ikke af beskyttelsen af personlige oplysninger</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -424,8 +424,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Whitelist</string>
-    <string name="whitelistAdd">Zur Whitelist hinzufügen</string>
-    <string name="whitelistRemove">Aus der Whitelist entfernen</string>
+    <string name="enablePrivacyProtection">Zur Whitelist hinzufügen</string>
+    <string name="disablePrivacyProtection">Aus der Whitelist entfernen</string>
     <string name="whitelistEntryOverflowContentDescription">Weitere Optionen für den Whitelist-Eintrag %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Möchten Sie &lt;b&gt;%s&lt;/b&gt; wirklich aus der Whitelist löschen?</string>
     <string name="whitelistExplanation">Diese Websites auf der Whitelist werden vom Datenschutz nicht aktualisiert</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -423,8 +423,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Λευκή λίστα</string>
-    <string name="whitelistAdd">Προσθήκη στη λευκή λίστα</string>
-    <string name="whitelistRemove">Αφαίρεση από τη λευκή λίστα</string>
+    <string name="enablePrivacyProtection">Προσθήκη στη λευκή λίστα</string>
+    <string name="disablePrivacyProtection">Αφαίρεση από τη λευκή λίστα</string>
     <string name="whitelistEntryOverflowContentDescription">Περισσότερες επιλογές για καταχώριση στη λευκή λίστα %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Είστε βέβαιοι ότι θέλετε να διαγράψετε το &lt;b&gt;%s&lt;/b&gt; από τη λευκή λίστα;</string>
     <string name="whitelistExplanation">Αυτοί οι ιστότοποι στη λευκή λίστα δεν θα αναβαθμιστούν από την Προστασία της Ιδιωτικότητας</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -424,8 +424,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Sitios no protegidos</string>
-    <string name="whitelistAdd">Habilitar Protección</string>
-    <string name="whitelistRemove">Deshabilitar Protección</string>
+    <string name="enablePrivacyProtection">Habilitar Protección</string>
+    <string name="disablePrivacyProtection">Deshabilitar Protección</string>
     <string name="whitelistEntryOverflowContentDescription">Más opciones para el sitio no protegido %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">¿Seguro que quieres eliminar &lt;b>%s&lt;/b> de los sitios no protegidos?</string>
     <string name="whitelistExplanation">La Protección de Privacidad está deshabilitada para estos sitios</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -444,8 +444,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Valges nimekirjas</string>
-    <string name="whitelistAdd">Lisa valgesse nimekirja</string>
-    <string name="whitelistRemove">Eemalda lubatud loendist</string>
+    <string name="enablePrivacyProtection">Lisa valgesse nimekirja</string>
+    <string name="disablePrivacyProtection">Eemalda lubatud loendist</string>
     <string name="whitelistEntryOverflowContentDescription">Rohkem valikuid valgesse nimekirja lisamiseks %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Kas soovid kindlasti kustutada &lt;b&gt;%s&lt;/b&gt; lubatud loendist?</string>
     <string name="whitelistExplanation">Neid valgesse nimekirja lisatud saite privaatsuskaitse ei uuenda</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -424,8 +424,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Sallittujen lista</string>
-    <string name="whitelistAdd">Lisää sallittujen listaan</string>
-    <string name="whitelistRemove">Poista sallittujen listasta</string>
+    <string name="enablePrivacyProtection">Lisää sallittujen listaan</string>
+    <string name="disablePrivacyProtection">Poista sallittujen listasta</string>
     <string name="whitelistEntryOverflowContentDescription">Lisää sallittujen listaan merkitsemisen vaihtoehtoja %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Haluatko varmasti poistaa &lt;b&gt;%s&lt;/b&gt; sallittujen listoista?</string>
     <string name="whitelistExplanation">Tietosuoja ei päivitä näitä sallittujen listojen sivustoja</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -424,8 +424,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Liste blanche</string>
-    <string name="whitelistAdd">Ajouter à la liste blanche</string>
-    <string name="whitelistRemove">Supprimer de la liste blanche</string>
+    <string name="enablePrivacyProtection">Ajouter à la liste blanche</string>
+    <string name="disablePrivacyProtection">Supprimer de la liste blanche</string>
     <string name="whitelistEntryOverflowContentDescription">Plus d\'options pour l\'entrée dans la liste blanche %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Voulez-vous vraiment supprimer &lt;b&gt;%s&lt;/b&gt; de la liste blanche ?</string>
     <string name="whitelistExplanation">Ces sites en liste blanche ne seront pas mis à niveau par la protection de la vie privée</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -430,8 +430,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Popis dopuštenih</string>
-    <string name="whitelistAdd">Dodaj u popis dopuštenih</string>
-    <string name="whitelistRemove">Ukloni s popisa dopuštenih</string>
+    <string name="enablePrivacyProtection">Dodaj u popis dopuštenih</string>
+    <string name="disablePrivacyProtection">Ukloni s popisa dopuštenih</string>
     <string name="whitelistEntryOverflowContentDescription">Dodatne mogućnosti za unos u popis dopuštenih %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Jeste li sigurni da želite izbrisati &lt;b&gt;%s&lt;/b&gt; s popisa dopuštenih?</string>
     <string name="whitelistExplanation">Web lokacije sa popisa dopuštenih neće biti nadograđene Zaštitom privatnosti</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -424,8 +424,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Engedélyezési lista</string>
-    <string name="whitelistAdd">Hozzáadás az engedélyezési listához</string>
-    <string name="whitelistRemove">Eltávolítás az engedélyezési listáról</string>
+    <string name="enablePrivacyProtection">Hozzáadás az engedélyezési listához</string>
+    <string name="disablePrivacyProtection">Eltávolítás az engedélyezési listáról</string>
     <string name="whitelistEntryOverflowContentDescription">További lehetőségek a bejegyzéshez az engedélyezési listában %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Biztosan törlöd  az engedélyezési listáról ezt: &lt;b&gt;%s&lt;/b&gt;?</string>
     <string name="whitelistExplanation">Ezeket az engedélyezett oldalakat az Adatvédelem nem frissíti</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -440,8 +440,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Whitelist</string>
-    <string name="whitelistAdd">Aggiungi alla whitelist</string>
-    <string name="whitelistRemove">Rimuovi dalla whitelist</string>
+    <string name="enablePrivacyProtection">Aggiungi alla whitelist</string>
+    <string name="disablePrivacyProtection">Rimuovi dalla whitelist</string>
     <string name="whitelistEntryOverflowContentDescription">Altre opzioni per l\'inserimento nella whitelist %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Sei sicuro di voler eliminare &lt;b&gt;%s&lt;/b&gt; dalla whitelist?</string>
     <string name="whitelistExplanation">Questi siti autorizzati non verranno aggiornati da Privacy Protection</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -430,8 +430,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Baltasis sąrašas</string>
-    <string name="whitelistAdd">Įtraukti į baltąjį sąrašą</string>
-    <string name="whitelistRemove">Pašalinti iš baltojo sąrašo</string>
+    <string name="enablePrivacyProtection">Įtraukti į baltąjį sąrašą</string>
+    <string name="disablePrivacyProtection">Pašalinti iš baltojo sąrašo</string>
     <string name="whitelistEntryOverflowContentDescription">Daugiau baltojo sąrašo įrašo parinkčių %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Ar tikrai norite ištrinti &lt;b&gt;%s&lt;/b&gt; iš baltojo sąrašo?</string>
     <string name="whitelistExplanation">Šios į baltąjį sąrašą įtrauktos svetainės nebus atnaujintos privatumo apsauga</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -448,8 +448,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Baltais saraksts</string>
-    <string name="whitelistAdd">Pievienot baltajam sarakstam</string>
-    <string name="whitelistRemove">Noņemt no baltā saraksta</string>
+    <string name="enablePrivacyProtection">Pievienot baltajam sarakstam</string>
+    <string name="disablePrivacyProtection">Noņemt no baltā saraksta</string>
     <string name="whitelistEntryOverflowContentDescription">Papildu iespējas baltā saraksta ierakstam %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Vai tiešām vēlaties izdzēst &lt;b&gt;%s&lt;/b&gt; no baltā saraksta?</string>
     <string name="whitelistExplanation">Šīs baltajā sarakstā iekļautās vietnes netiks atjauninātas, izmantojot privātuma aizsardzību</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -424,8 +424,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Hviteliste</string>
-    <string name="whitelistAdd">Legg til hviteliste</string>
-    <string name="whitelistRemove">Fjern fra hvitelisten</string>
+    <string name="enablePrivacyProtection">Legg til hviteliste</string>
+    <string name="disablePrivacyProtection">Fjern fra hvitelisten</string>
     <string name="whitelistEntryOverflowContentDescription">Flere alternativer for hvitelisteoppføring %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Er du sikker på at du vil slette &lt;b&gt;%s&lt;/b&gt; fra hvitelisten?</string>
     <string name="whitelistExplanation">Disse hvitelistenettstedene vil ikke bli oppgradert av Personvern</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -424,8 +424,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Witte lijst</string>
-    <string name="whitelistAdd">Toevoegen aan witte lijst</string>
-    <string name="whitelistRemove">Verwijderen uit witte lijst</string>
+    <string name="enablePrivacyProtection">Toevoegen aan witte lijst</string>
+    <string name="disablePrivacyProtection">Verwijderen uit witte lijst</string>
     <string name="whitelistEntryOverflowContentDescription">Meer opties voor vermelding op de witte lijst %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Weet je zeker dat je &lt;b&gt;%s&lt;/b&gt; van de witte lijst wilt verwijderen?</string>
     <string name="whitelistExplanation">Deze sites op de witte lijst worden niet bijgewerkt door Privacybescherming</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -436,8 +436,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Biała lista</string>
-    <string name="whitelistAdd">Dodaj do białej listy</string>
-    <string name="whitelistRemove">Usuń z białej listy</string>
+    <string name="enablePrivacyProtection">Dodaj do białej listy</string>
+    <string name="disablePrivacyProtection">Usuń z białej listy</string>
     <string name="whitelistEntryOverflowContentDescription">Więcej opcji wpisu na białej liście %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Czy na pewno chcesz usunąć &lt;b&gt;%s&lt;/b&gt; z białej listy?</string>
     <string name="whitelistExplanation">Te witryny z białej listy nie zostaną zaktualizowane przez Ochronę prywatności</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -424,8 +424,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Lista de permissões</string>
-    <string name="whitelistAdd">Adicionar à lista de permissões</string>
-    <string name="whitelistRemove">Remover da lista de permissões</string>
+    <string name="enablePrivacyProtection">Adicionar à lista de permissões</string>
+    <string name="disablePrivacyProtection">Remover da lista de permissões</string>
     <string name="whitelistEntryOverflowContentDescription">Mais opções para a entrada da lista de permissões %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Tem a certeza de que deseja eliminar &lt;b&gt;%s&lt;/b&gt; da lista de permissões?</string>
     <string name="whitelistExplanation">Esses sites da lista de permissões não serão atualizados pela Proteção de Privacidade</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -430,8 +430,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Lista albă</string>
-    <string name="whitelistAdd">Adăugați la lista albă</string>
-    <string name="whitelistRemove">Înlocuiți din lista albă</string>
+    <string name="enablePrivacyProtection">Adăugați la lista albă</string>
+    <string name="disablePrivacyProtection">Înlocuiți din lista albă</string>
     <string name="whitelistEntryOverflowContentDescription">Mai multe opțiuni pentru intrarea în lista albă %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Sigur doriți să ștergeți &lt;b&gt;%s&lt;/b&gt; din lista albă?</string>
     <string name="whitelistExplanation">Aceste site-uri listate în alb nu vor fi actualizate de Protecția confidențialității</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -451,8 +451,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Белый список</string>
-    <string name="whitelistAdd">Добавить в белый список</string>
-    <string name="whitelistRemove">Удалить из белого списка</string>
+    <string name="enablePrivacyProtection">Добавить в белый список</string>
+    <string name="disablePrivacyProtection">Удалить из белого списка</string>
     <string name="whitelistEntryOverflowContentDescription">Дополнительные параметры для внесения записей в белый список %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Вы уверены, что хотите удалить &lt;b&gt;%s&lt;/b&gt; из белого списка?</string>
     <string name="whitelistExplanation">Эти сайты из белого списка не будут обновлены с помощью защиты конфиденциальности</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -430,8 +430,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Biela listina</string>
-    <string name="whitelistAdd">Pridať na bielu listinu</string>
-    <string name="whitelistRemove">Odstrániť z bielej listiny</string>
+    <string name="enablePrivacyProtection">Pridať na bielu listinu</string>
+    <string name="disablePrivacyProtection">Odstrániť z bielej listiny</string>
     <string name="whitelistEntryOverflowContentDescription">Ďalšie možnosti pre vstup na bielu listinu %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Naozaj chcete odstrániť &lt;b&gt;%s&lt;/b&gt; zo zoznamu povolených?</string>
     <string name="whitelistExplanation">Tieto weby na zozname povolených položiek nebudú inovované pomocou ochrany osobných údajov</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -436,8 +436,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Beli seznam</string>
-    <string name="whitelistAdd">Dodaj na beli seznam</string>
-    <string name="whitelistRemove">Odstrani z belega seznama</string>
+    <string name="enablePrivacyProtection">Dodaj na beli seznam</string>
+    <string name="disablePrivacyProtection">Odstrani z belega seznama</string>
     <string name="whitelistEntryOverflowContentDescription">Več možnosti za vnašanje na beli seznam %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Ste prepričani, da želite ta naslov izbrisati &lt;b&gt;%s&lt;/b&gt; z belega seznama?</string>
     <string name="whitelistExplanation">Naslednje strani na belem seznamu ne bodo nadgrajene z zaščito zasebnosti.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -440,8 +440,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Vitlista</string>
-    <string name="whitelistAdd">Lägg till i vitlista</string>
-    <string name="whitelistRemove">Ta bort från vitlista</string>
+    <string name="enablePrivacyProtection">Lägg till i vitlista</string>
+    <string name="disablePrivacyProtection">Ta bort från vitlista</string>
     <string name="whitelistEntryOverflowContentDescription">Fler alternativ för inmatning av vitlista %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Är du säker på att du vill ta bort &lt;b&gt;%s&lt;/b&gt; från vitlistan?</string>
     <string name="whitelistExplanation">Dessa vitlistade webbplatser kommer inte att uppgraderas av Integritetsskydd</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -446,8 +446,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Beyaz Liste</string>
-    <string name="whitelistAdd">Beyaz Listeye Ekle</string>
-    <string name="whitelistRemove">Beyaz Listeden Sil</string>
+    <string name="enablePrivacyProtection">Beyaz Listeye Ekle</string>
+    <string name="disablePrivacyProtection">Beyaz Listeden Sil</string>
     <string name="whitelistEntryOverflowContentDescription">Beyaz liste girişi %s için daha fazla seçenek</string>
     <string name="whitelistEntryDeleteConfirmMessage">&lt;b&gt;%s&lt;/b&gt; \'ı beyaz listeden silmek istediğinizden emin misiniz?</string>
     <string name="whitelistExplanation">Beyaz listeye alınan bu siteler Gizlilik Koruması tarafından yeni sürüme geçirilmez</string>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -56,8 +56,8 @@
 
     <!-- Whitelist -->
     <string name="whitelisetActivityTitle">Unprotected Sites</string>
-    <string name="whitelistAdd">Enable Privacy Protection</string>
-    <string name="whitelistRemove">Disable Privacy Protection</string>
+    <string name="enablePrivacyProtection">Enable Privacy Protection</string>
+    <string name="disablePrivacyProtection">Disable Privacy Protection</string>
     <string name="whitelistEntryOverflowContentDescription">More options for unprotected site %s</string>
     <string name="whitelistEntryDeleteConfirmMessage">Are you sure you want to remove &lt;b>%s&lt;/b> from unprotected sites?</string>
     <string name="whitelistExplanation">These sites will not be enhanced by Privacy Protection</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1184397698929617/f
Tech Design URL: 
CC: 

**Description**:
The app displays the wrong label for the overflow option for enabling/disable privacy protection. This PR corrects that logic


**Steps to test this PR**:
1. Open cnn.com
1. Open the overflow menu; verify that "**Disable** privacy protection" is shown in overflow
1. Open privacy grade; verify that "Site Privacy Protection" is **enabled**
1. From privacy grade; **disable** "Site Privacy Protection"
1. Return to browser screen, launch overflow
1. Verify that **Enable** privacy protection is in overflow
1. Click it
1. Launch overflow; verify it now says **Disable** privacy protection
1. Open privacy grade; verify the toggle shows as **enabled**




---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
