### PR TITLE
Spanish translation - Changing "Si" to "Sí" with correct accent

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2,7 +2,7 @@
 
     <string name="duckDuckGoLogoDescription">Logotipo de DuckDuckGo</string>
     <string name="duckDuckGoPrivacySimplified">La privacidad, simplificada.</string>
-    <string name="yes">Si</string>
+    <string name="yes">Sí</string>
     <string name="no">No</string>
     <string name="search">Buscar</string>
 


### PR DESCRIPTION
Task/Issue URL: N/A
Tech Design URL: 
CC: 

**Description**:
First time doing a fork/pull request in Github, so figure I pick something super easy!
"Si" can mean "if" or the musical note "B" in Spanish, but it needs an accent if written out to specify as "yes."
Added accent in edit.

**Steps to test this PR**:
1. No test needed


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
