### PR TITLE
When user tries to edit query by using the edit icon, modify the quer…

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -85,7 +85,7 @@ class SystemSearchViewModelTest {
 
         val viewState = testee.onboardingViewState.value
         assertFalse(viewState!!.visible)
-        assertFalse(viewState!!.expanded)
+        assertFalse(viewState.expanded)
     }
 
     @Test
@@ -95,7 +95,7 @@ class SystemSearchViewModelTest {
 
         val viewState = testee.onboardingViewState.value
         assertTrue(viewState!!.visible)
-        assertFalse(viewState!!.expanded)
+        assertFalse(viewState.expanded)
     }
 
     @Test
@@ -261,6 +261,14 @@ class SystemSearchViewModelTest {
         verify(mockDeviceAppLookup, times(2)).refreshAppList()
         verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertEquals(Command.ShowAppNotFoundMessage(deviceApp.shortName), commandCaptor.lastValue)
+    }
+
+    @Test
+    fun whenUserSelectedToUpdateQueryThenEditQueryCommandSent() {
+        val query = "test"
+        testee.onUserSelectedToEditQuery(query)
+        verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertEquals(Command.EditQuery(query), commandCaptor.lastValue)
     }
 
     private suspend fun whenOnboardingShowing() {

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -129,7 +129,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
                 viewModel.userSubmittedAutocompleteResult(it.phrase)
             },
             editableSearchClickListener = {
-                viewModel.userUpdatedQuery(it.phrase)
+                viewModel.onUserSelectedToEditQuery(it.phrase)
             }
         )
         autocompleteSuggestions.adapter = autocompleteSuggestionsAdapter
@@ -222,7 +222,15 @@ class SystemSearchActivity : DuckDuckGoActivity() {
             is DismissKeyboard -> {
                 omnibarTextInput.hideKeyboard()
             }
+            is EditQuery -> {
+                editQuery(command.query)
+            }
         }
+    }
+
+    private fun editQuery(query: String) {
+        omnibarTextInput.setText(query)
+        omnibarTextInput.setSelection(query.length)
     }
 
     private fun launchDuckDuckGo() {

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -67,6 +67,7 @@ class SystemSearchViewModel(
         data class LaunchDeviceApplication(val deviceApp: DeviceApp) : Command()
         data class ShowAppNotFoundMessage(val appName: String) : Command()
         object DismissKeyboard : Command()
+        data class EditQuery(val query: String) : Command()
     }
 
     val onboardingViewState: MutableLiveData<OnboardingViewState> = MutableLiveData()
@@ -147,6 +148,10 @@ class SystemSearchViewModel(
             userStageStore.stageCompleted(AppStage.NEW)
             pixel.fire(INTERSTITIAL_ONBOARDING_DISMISSED)
         }
+    }
+
+    fun onUserSelectedToEditQuery(query: String) {
+        command.value = Command.EditQuery(query)
     }
 
     fun userUpdatedQuery(query: String) {

--- a/app/src/main/res/layout/item_autocomplete_search_suggestion.xml
+++ b/app/src/main/res/layout/item_autocomplete_search_suggestion.xml
@@ -59,6 +59,7 @@
         android:padding="6dp"
         android:paddingStart="16dp"
         android:paddingEnd="14dp"
+        android:background="?selectableItemBackground"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent">


### PR DESCRIPTION
…y rather than do a new search.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1185449784809161
Tech Design URL: 
CC: 

**Description**:
This PR changes the behaviour of the edit search icon in the system search. Right now when a user clicks on the icon it triggers a new search and the query input doesn't change . The purpose of the icon is to edit the query so the user can further edit it (as the app's omnibar behaves).

**Steps to test this PR**:
1. Add the app widget and open it.
1. Do a search.
1. Click on the icon with an arrow in the right side of a search result.
1. It should change the query in the omnibar to the result selected and move the caret to the end.

**Item selectable widget**
1. Add the app widget and open it.
1. Do a search.
1. Click on the icon with an arrow in the right side of a search result.
1. Notice how the arrow view has a selectable background that highlights the user is clicking it.

**Item selectable normal search**
1. Launch the app without using the widget.
1. Do a search.
1. Click on the icon with an arrow in the right side of a search result.
1. Notice how the arrow view has a selectable background that highlights the user is clicking it.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
