### PR TITLE
Add ua application exclusion for tirerack to allow mobile site detection

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
@@ -96,7 +96,8 @@ class UserAgentProvider constructor(private val defaultUserAgent: String, privat
 
         val sitesThatOmitApplication = listOf(
             "cvs.com",
-            "chase.com"
+            "chase.com",
+            "tirerack.com"
         )
 
         val sitesThatOmitVersion = listOf(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1183556013880866

**Description**:
tirerack.com no longer loads mobile site by default on some devices, it instead loads the desktop site. 

**Steps to test this PR**:
1. Using a Pixel API 29 device or emulator and launch our app
1. Visit tirerack.com
1. Note that the mobile rather than desktop page loads

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
