### PR TITLE
In app usage flows now only applies to new users under a new variant.

### DIFF
--- a/app/schemas/com.duckduckgo.app.global.db.AppDatabase/23.json
+++ b/app/schemas/com.duckduckgo.app.global.db.AppDatabase/23.json
@@ -1,0 +1,746 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 23,
+    "identityHash": "d6e385bcc19ae0df396817590763b709",
+    "entities": [
+      {
+        "tableName": "tds_tracker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, `defaultAction` TEXT NOT NULL, `ownerName` TEXT NOT NULL, `categories` TEXT NOT NULL, `rules` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultAction",
+            "columnName": "defaultAction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerName",
+            "columnName": "ownerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rules",
+            "columnName": "rules",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tds_entity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `displayName` TEXT NOT NULL, `prevalence` REAL NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prevalence",
+            "columnName": "prevalence",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "name"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tds_domain_entity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, `entityName` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityName",
+            "columnName": "entityName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "temporary_tracking_whitelist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "user_whitelist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "https_bloom_filter_spec",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `errorRate` REAL NOT NULL, `totalEntries` INTEGER NOT NULL, `sha256` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorRate",
+            "columnName": "errorRate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalEntries",
+            "columnName": "totalEntries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "https_whitelisted_domain",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "network_leaderboard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkName` TEXT NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`networkName`))",
+        "fields": [
+          {
+            "fieldPath": "networkName",
+            "columnName": "networkName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "networkName"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sites_visited",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tabs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tabId` TEXT NOT NULL, `url` TEXT, `title` TEXT, `skipHome` INTEGER NOT NULL, `viewed` INTEGER NOT NULL, `position` INTEGER NOT NULL, `tabPreviewFile` TEXT, PRIMARY KEY(`tabId`))",
+        "fields": [
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "skipHome",
+            "columnName": "skipHome",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewed",
+            "columnName": "viewed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabPreviewFile",
+            "columnName": "tabPreviewFile",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "tabId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_tabs_tabId",
+            "unique": false,
+            "columnNames": [
+              "tabId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tabs_tabId` ON `${TABLE_NAME}` (`tabId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tab_selection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `tabId` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`tabId`) REFERENCES `tabs`(`tabId`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_tab_selection_tabId",
+            "unique": false,
+            "columnNames": [
+              "tabId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tab_selection_tabId` ON `${TABLE_NAME}` (`tabId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tabs",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tabId"
+            ],
+            "referencedColumns": [
+              "tabId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "survey",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surveyId` TEXT NOT NULL, `url` TEXT, `daysInstalled` INTEGER, `status` TEXT NOT NULL, PRIMARY KEY(`surveyId`))",
+        "fields": [
+          {
+            "fieldPath": "surveyId",
+            "columnName": "surveyId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "daysInstalled",
+            "columnName": "daysInstalled",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "surveyId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "dismissed_cta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ctaId` TEXT NOT NULL, PRIMARY KEY(`ctaId`))",
+        "fields": [
+          {
+            "fieldPath": "ctaId",
+            "columnName": "ctaId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "ctaId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "search_count",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "app_days_used",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "date"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "app_enjoyment",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventType` INTEGER NOT NULL, `promptCount` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `primaryKey` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptCount",
+            "columnName": "promptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryKey",
+            "columnName": "primaryKey",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "primaryKey"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "notification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`notificationId` TEXT NOT NULL, PRIMARY KEY(`notificationId`))",
+        "fields": [
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notificationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "notificationId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "privacy_protection_count",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `blocked_tracker_count` INTEGER NOT NULL, `upgrade_count` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockedTrackerCount",
+            "columnName": "blocked_tracker_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "upgradeCount",
+            "columnName": "upgrade_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "UncaughtExceptionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `exceptionSource` TEXT NOT NULL, `message` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `version` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exceptionSource",
+            "columnName": "exceptionSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tdsMetadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `eTag` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "userStage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER NOT NULL, `appStage` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appStage",
+            "columnName": "appStage",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "fireproofWebsites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "user_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd6e385bcc19ae0df396817590763b709')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2176,6 +2176,15 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenViewReadyIfDomainSameAsUseOurAppThenPixelSent() = coroutineRule.runBlocking {
+        givenUseOurAppSiteSelected()
+
+        testee.onViewReady()
+
+        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED)
+    }
+
+    @Test
     fun whenViewReadyIfDomainIsNotTheSameAsUseOurAppAfterNotificationSeenThenPixelNotSent() = coroutineRule.runBlocking {
         givenUseOurAppSiteIsNotSelected()
         whenever(mockNotificationDao.exists(UseOurAppNotification.ID)).thenReturn(true)
@@ -2203,6 +2212,15 @@ class BrowserTabViewModelTest {
         testee.onViewReady()
 
         verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED_AFTER_DELETE_CTA)
+    }
+
+    @Test
+    fun whenViewReadyIfDomainIsNotTheSameAsUseOurAppAThenPixelNotSent() = coroutineRule.runBlocking {
+        givenUseOurAppSiteIsNotSelected()
+
+        testee.onViewReady()
+
+        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED)
     }
 
     @Test
@@ -2236,6 +2254,15 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenPageChangedIfPreviousOneWasNotUseOurAppSiteThenPixelSent() = coroutineRule.runBlocking {
+        givenUseOurAppSiteIsNotSelected()
+
+        loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
+
+        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED)
+    }
+
+    @Test
     fun whenPageChangedIfPreviousOneWasUseOurAppSiteAfterNotificationSeenThenPixelNotSent() = coroutineRule.runBlocking {
         givenUseOurAppSiteSelected()
         whenever(mockNotificationDao.exists(UseOurAppNotification.ID)).thenReturn(true)
@@ -2264,6 +2291,15 @@ class BrowserTabViewModelTest {
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
         verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED_AFTER_DELETE_CTA)
+    }
+
+    @Test
+    fun whenPageChangedIfPreviousOneWasUseOurAppSiteThenNotSent() = coroutineRule.runBlocking {
+        givenUseOurAppSiteSelected()
+
+        loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
+
+        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED)
     }
 
     private inline fun <reified T : Command> assertCommandIssued(instanceAssertions: T.() -> Unit = {}) {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -23,13 +23,13 @@ import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.browser.BrowserViewModel.Command
 import com.duckduckgo.app.browser.BrowserViewModel.Command.DisplayMessage
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
-import com.duckduckgo.app.cta.db.DismissedCtaDao
-import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.fire.DataClearer
+import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptEmitter
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions
 import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
 import com.duckduckgo.app.global.rating.PromptCount
+import com.duckduckgo.app.global.useourapp.UseOurAppDetector
 import com.duckduckgo.app.global.useourapp.UseOurAppDetector.Companion.USE_OUR_APP_SHORTCUT_URL
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity
 import com.duckduckgo.app.runBlocking
@@ -85,7 +85,7 @@ class BrowserViewModelTest {
     private lateinit var mockPixel: Pixel
 
     @Mock
-    private lateinit var mockDismissedCtaDao: DismissedCtaDao
+    private lateinit var mockUserEventsStore: UserEventsStore
 
     private lateinit var testee: BrowserViewModel
 
@@ -101,7 +101,7 @@ class BrowserViewModelTest {
             dataClearer = mockAutomaticDataClearer,
             appEnjoymentPromptEmitter = mockAppEnjoymentPromptEmitter,
             appEnjoymentUserEventRecorder = mockAppEnjoymentUserEventRecorder,
-            ctaDao = mockDismissedCtaDao,
+            useOurAppDetector = UseOurAppDetector(mockUserEventsStore),
             dispatchers = coroutinesTestRule.testDispatcherProvider,
             pixel = mockPixel
         )
@@ -194,20 +194,10 @@ class BrowserViewModelTest {
 
     @Test
     fun whenOpenShortcutIfUrlIsUseOurAppUrlAndCtaHasBeenSeenThenFirePixel() {
-        givenUseOurAppCtaHasBeenSeen()
         val url = USE_OUR_APP_SHORTCUT_URL
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenShortcut(url)
         verify(mockPixel).fire(Pixel.PixelName.USE_OUR_APP_SHORTCUT_OPENED)
-    }
-
-    @Test
-    fun whenOpenShortcutIfUrlIsUseOurAppUrlAndCtaHasNotBeenSeenThenDoNotFireUseOurAppPixel() {
-        val url = USE_OUR_APP_SHORTCUT_URL
-        whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
-        testee.onOpenShortcut(url)
-        verify(mockPixel, never()).fire(Pixel.PixelName.USE_OUR_APP_SHORTCUT_OPENED)
-        verify(mockPixel).fire(Pixel.PixelName.SHORTCUT_OPENED)
     }
 
     @Test
@@ -216,10 +206,6 @@ class BrowserViewModelTest {
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenShortcut(url)
         verify(mockPixel).fire(Pixel.PixelName.SHORTCUT_OPENED)
-    }
-
-    private fun givenUseOurAppCtaHasBeenSeen() {
-        whenever(mockDismissedCtaDao.exists(CtaId.USE_OUR_APP)).thenReturn(true)
     }
 
     companion object {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -30,7 +30,7 @@ import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions
 import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
 import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.global.useourapp.UseOurAppDetector
-import com.duckduckgo.app.global.useourapp.UseOurAppDetector.Companion.USE_OUR_APP_SHORTCUT_URL
+import com.duckduckgo.app.global.useourapp.UseOurAppDetector.Companion.USE_OUR_APP_DOMAIN
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -193,8 +193,8 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenOpenShortcutIfUrlIsUseOurAppUrlAndCtaHasBeenSeenThenFirePixel() {
-        val url = USE_OUR_APP_SHORTCUT_URL
+    fun whenOpenShortcutIfUrlIsUseOurAppDomainThenFirePixel() {
+        val url = "http://m.$USE_OUR_APP_DOMAIN"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenShortcut(url)
         verify(mockPixel).fire(Pixel.PixelName.USE_OUR_APP_SHORTCUT_OPENED)

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
@@ -26,29 +26,15 @@ import androidx.work.WorkManager
 import androidx.work.impl.utils.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.notification.NotificationScheduler.ClearDataNotificationWorker
 import com.duckduckgo.app.notification.NotificationScheduler.PrivacyNotificationWorker
-import com.duckduckgo.app.notification.NotificationScheduler.DripA1NotificationWorker
-import com.duckduckgo.app.notification.NotificationScheduler.DripA2NotificationWorker
-import com.duckduckgo.app.notification.NotificationScheduler.DripB1NotificationWorker
-import com.duckduckgo.app.notification.NotificationScheduler.DripB2NotificationWorker
 import com.duckduckgo.app.notification.NotificationScheduler.UseOurAppNotificationWorker
 import com.duckduckgo.app.notification.model.SchedulableNotification
-import com.duckduckgo.app.onboarding.store.AppStage
-import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.DripNotification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1PrivacyNotification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1DripA1Notification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1DripA2Notification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1DripB1Notification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1DripB2Notification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day3ClearDataNotification
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -65,13 +51,10 @@ class AndroidNotificationSchedulerTest {
     var coroutinesTestRule = CoroutineTestRule()
 
     private val variantManager: VariantManager = mock()
-    private val mockUserStageStore: UserStageStore = mock()
     private val clearNotification: SchedulableNotification = mock()
     private val privacyNotification: SchedulableNotification = mock()
-    private val dripA1Notification: SchedulableNotification = mock()
-    private val dripA2Notification: SchedulableNotification = mock()
-    private val dripB1Notification: SchedulableNotification = mock()
-    private val dripB2Notification: SchedulableNotification = mock()
+    private val useOurAppNotification: SchedulableNotification = mock()
+    private val mockAddToHomeCapabilityDetector: AddToHomeCapabilityDetector = mock()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private lateinit var workManager: WorkManager
@@ -80,17 +63,14 @@ class AndroidNotificationSchedulerTest {
     @Before
     fun before() {
         initializeWorkManager()
-        whenever(variantManager.getVariant(any())).thenReturn(DEFAULT_VARIANT)
+
         testee = NotificationScheduler(
             workManager,
             clearNotification,
             privacyNotification,
-            dripA1Notification,
-            dripA2Notification,
-            dripB1Notification,
-            dripB2Notification,
-            variantManager,
-            mockUserStageStore
+            useOurAppNotification,
+            mockAddToHomeCapabilityDetector,
+            variantManager
         )
     }
 
@@ -107,7 +87,7 @@ class AndroidNotificationSchedulerTest {
 
     @Test
     fun whenPrivacyNotificationClearDataCanShowThenPrivacyNotificationIsScheduled() = runBlocking<Unit> {
-        whenever(variantManager.getVariant(any())).thenReturn(DEFAULT_VARIANT)
+        setDefaultVariant()
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(true)
         testee.scheduleNextNotification()
@@ -117,7 +97,7 @@ class AndroidNotificationSchedulerTest {
 
     @Test
     fun whenPrivacyNotificationCanShowButClearDataCannotThenPrivacyNotificationIsScheduled() = runBlocking<Unit> {
-        whenever(variantManager.getVariant(any())).thenReturn(DEFAULT_VARIANT)
+        setDefaultVariant()
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(false)
         testee.scheduleNextNotification()
@@ -127,7 +107,7 @@ class AndroidNotificationSchedulerTest {
 
     @Test
     fun whenPrivacyNotificationCannotShowAndClearNotificationCanShowThenClearNotificationIsScheduled() = runBlocking<Unit> {
-        whenever(variantManager.getVariant(any())).thenReturn(DEFAULT_VARIANT)
+        setDefaultVariant()
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(true)
         testee.scheduleNextNotification()
@@ -137,7 +117,7 @@ class AndroidNotificationSchedulerTest {
 
     @Test
     fun whenPrivacyNotificationAndClearNotificationCannotShowThenNoNotificationScheduled() = runBlocking<Unit> {
-        whenever(variantManager.getVariant(any())).thenReturn(DEFAULT_VARIANT)
+        setDefaultVariant()
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(false)
         testee.scheduleNextNotification()
@@ -145,268 +125,12 @@ class AndroidNotificationSchedulerTest {
         assertNoNotificationScheduled()
     }
 
-    // Drip A1
     @Test
-    fun whenDripA1VariantAndDripA1NotificationCanShowAndClearNotificationCannotShowThenDripA1NotificationIsScheduled() = runBlocking<Unit> {
-        setDripA1Variant()
-        whenever(dripA1Notification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(DripA1NotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenDripA1VariantAndClearNotificationCanShotAndDripA1NotificationCannotShowThenClearDataNotificationScheduled() = runBlocking<Unit> {
-        setDripA1Variant()
-        whenever(dripA1Notification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(ClearDataNotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenDripA1VariantAndNoNotificationCanShowThenNoNotificationScheduled() = runBlocking<Unit> {
-        setDripA1Variant()
-        whenever(dripA1Notification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNoNotificationScheduled()
-    }
-
-    @Test
-    fun whenDripA1VariantAndDripA1NotificationAndClearDataNotificationCanShowThenDripA1NotificationScheduled() = runBlocking<Unit> {
-        setDripA1Variant()
-        whenever(dripA1Notification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(DripA1NotificationWorker::class.jvmName)
-    }
-
-    // Drip A2
-    @Test
-    fun whenDripA2VariantAndDripA2NotificationCanShowAndClearNotificationCannotShowThenDripA2NotificationIsScheduled() = runBlocking<Unit> {
-        setDripA2Variant()
-        whenever(dripA2Notification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(DripA2NotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenDripA2VariantAndClearNotificationCanShotAndDripA2NotificationCannotShowThenClearDataNotificationScheduled() = runBlocking<Unit> {
-        setDripA2Variant()
-        whenever(dripA2Notification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(ClearDataNotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenDripA2VariantAndNoNotificationCanShowThenNoNotificationScheduled() = runBlocking<Unit> {
-        setDripA2Variant()
-        whenever(dripA2Notification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNoNotificationScheduled()
-    }
-
-    @Test
-    fun whenDripA2VariantAndDripA2NotificationAndClearDataNotificationCanShowThenDripA2NotificationScheduled() = runBlocking<Unit> {
-        setDripA2Variant()
-        whenever(dripA2Notification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(DripA2NotificationWorker::class.jvmName)
-    }
-
-    // Drip B1
-
-    @Test
-    fun whenDripB1VariantAndDripB1NotificationCanShowAndClearNotificationCannotShowThenDripB1NotificationIsScheduled() = runBlocking<Unit> {
-        setDripB1Variant()
-        whenever(dripB1Notification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(DripB1NotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenDripB1VariantAndClearNotificationCanShotAndDripB1NotificationCannotShowThenClearDataNotificationScheduled() = runBlocking<Unit> {
-        setDripB1Variant()
-        whenever(dripB1Notification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(ClearDataNotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenDripB1VariantAndNoNotificationCanShowThenNoNotificationScheduled() = runBlocking<Unit> {
-        setDripB1Variant()
-        whenever(dripB1Notification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNoNotificationScheduled()
-    }
-
-    @Test
-    fun whenDripB1VariantAndDripB1NotificationAndClearDataNotificationCanShowThenDripB1NotificationScheduled() = runBlocking<Unit> {
-        setDripB1Variant()
-        whenever(dripB1Notification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(DripB1NotificationWorker::class.jvmName)
-    }
-
-    // Drip B2
-
-    @Test
-    fun whenDripB2VariantAndDripB2NotificationCanShowAndClearNotificationCannotShowThenDripB2NotificationIsScheduled() = runBlocking<Unit> {
-        setDripB2Variant()
-        whenever(dripB2Notification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(DripB2NotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenDripB2VariantAndClearNotificationCanShotAndDripB2NotificationCannotShowThenClearDataNotificationScheduled() = runBlocking<Unit> {
-        setDripB2Variant()
-        whenever(dripB2Notification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(ClearDataNotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenDripB2VariantAndNoNotificationCanShowThenNoNotificationScheduled() = runBlocking<Unit> {
-        setDripB2Variant()
-        whenever(dripB2Notification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNoNotificationScheduled()
-    }
-
-    @Test
-    fun whenDripB2VariantAndDripB2NotificationAndClearDataNotificationCanShowThenDripB2NotificationScheduled() = runBlocking<Unit> {
-        setDripB2Variant()
-        whenever(dripB2Notification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(DripB2NotificationWorker::class.jvmName)
-    }
-
-    // Control
-    @Test
-    fun whenControlVariantAndPrivacyNotificationAndClearDataNotificationCanShowThenPrivacyNotificationScheduled() = runBlocking<Unit> {
-        setNotificationControlVariant()
-        whenever(privacyNotification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(PrivacyNotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenControlVariantAndPrivacyNotificationCanShowAndClearDataCannotShowThenPrivacyNotificationScheduled() = runBlocking<Unit> {
-        setNotificationControlVariant()
-        whenever(privacyNotification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(PrivacyNotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenControlVariantAndPrivacyNotificationCannotShowAndClearNotificationCanThenClearNotificationScheduled() = runBlocking<Unit> {
-        setNotificationControlVariant()
-        whenever(privacyNotification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(ClearDataNotificationWorker::class.jvmName)
-    }
-
-    @Test
-    fun whenControlVariantAndNoNotificationCanShowThenNoNotificationScheduled() = runBlocking<Unit> {
-        setNotificationControlVariant()
-        whenever(privacyNotification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNoNotificationScheduled()
-    }
-
-    // Null variant
-    @Test
-    fun whenNullVariantAndAllNotificationsCanShowThenNoNotificationScheduled() = runBlocking<Unit> {
-        setNotificationNullVariant()
-        whenever(privacyNotification.canShow()).thenReturn(true)
-        whenever(dripA1Notification.canShow()).thenReturn(true)
-        whenever(dripA2Notification.canShow()).thenReturn(true)
-        whenever(dripB1Notification.canShow()).thenReturn(true)
-        whenever(dripB2Notification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNoNotificationScheduled()
-    }
-
-    @Test
-    fun whenNullVariantAndNoNotificationCanShowThenNoNotificationScheduled() = runBlocking<Unit> {
-        setNotificationNullVariant()
-        whenever(privacyNotification.canShow()).thenReturn(false)
-        whenever(dripA1Notification.canShow()).thenReturn(false)
-        whenever(dripA2Notification.canShow()).thenReturn(false)
-        whenever(dripB1Notification.canShow()).thenReturn(false)
-        whenever(dripB2Notification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(false)
-
-        testee.scheduleNextNotification()
-
-        assertNoNotificationScheduled()
-    }
-
-    @Test
-    fun whenStageIsUseOurAppNotificationThenNotificationScheduled() = runBlocking {
+    fun whenVariantIsInAppUsageAndAddToHomeSupportedThenNotificationScheduled() = runBlocking {
         givenNoInactiveUserNotifications()
-        givenStageIsUseOurAppNotification()
+        setInAppUsageVariant()
+        whenever(useOurAppNotification.canShow()).thenReturn(true)
+        whenever(mockAddToHomeCapabilityDetector.isAddToHomeSupported()).thenReturn(true)
 
         testee.scheduleNextNotification()
 
@@ -414,18 +138,11 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenStageIsUseOurAppNotificationAndNotificationScheduledThenStageCompleted() = runBlocking<Unit> {
+    fun whenVariantIsInAppUsageAndAddToHomeNotSupportedThenNotificationScheduled() = runBlocking {
         givenNoInactiveUserNotifications()
-        givenStageIsUseOurAppNotification()
-
-        testee.scheduleNextNotification()
-
-        verify(mockUserStageStore).stageCompleted(AppStage.USE_OUR_APP_NOTIFICATION)
-    }
-
-    @Test
-    fun whenStageIsUseOurAppNotificationThenNoNotificationScheduled() = runBlocking {
-        givenStageIsEstablished()
+        setInAppUsageVariant()
+        whenever(useOurAppNotification.canShow()).thenReturn(true)
+        whenever(mockAddToHomeCapabilityDetector.isAddToHomeSupported()).thenReturn(false)
 
         testee.scheduleNextNotification()
 
@@ -433,48 +150,34 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenStageIsNotUseOurAppNotificationThenNoNotificationScheduled() = runBlocking {
-        givenStageIsEstablished()
+    fun whenVariantIsInAppUsageSecondControlAndNotificationCannotShowThenNoNotificationScheduled() = runBlocking<Unit> {
+        givenNoInactiveUserNotifications()
+        setInAppUsageVariant()
+        whenever(useOurAppNotification.canShow()).thenReturn(false)
+        whenever(mockAddToHomeCapabilityDetector.isAddToHomeSupported()).thenReturn(false)
 
         testee.scheduleNextNotification()
 
         assertNoNotificationScheduled(NotificationScheduler.USE_OUR_APP_WORK_REQUEST_TAG)
     }
 
-    private fun setDripA1Variant() {
-        whenever(variantManager.getVariant()).thenReturn(
-            Variant("test", features = listOf(DripNotification, Day1DripA1Notification, Day3ClearDataNotification), filterBy = { true })
-        )
+    @Test
+    fun whenVariantIsInAppUsageSecondControlThenNoNotificationScheduled() = runBlocking<Unit> {
+        setInAppUsageSecondControlVariant()
+
+        testee.scheduleNextNotification()
+
+        assertNoNotificationScheduled(NotificationScheduler.USE_OUR_APP_WORK_REQUEST_TAG)
     }
 
-    private fun setDripA2Variant() {
-        whenever(variantManager.getVariant()).thenReturn(
-            Variant("test", features = listOf(DripNotification, Day1DripA2Notification, Day3ClearDataNotification), filterBy = { true })
-        )
-    }
+    @Test
+    fun whenVariantIsInAppUsageControlThenNoNotificationScheduled() = runBlocking<Unit> {
+        givenNoInactiveUserNotifications()
+        setInAppUsageControlVariant()
 
-    private fun setDripB1Variant() {
-        whenever(variantManager.getVariant()).thenReturn(
-            Variant("test", features = listOf(DripNotification, Day1DripB1Notification, Day3ClearDataNotification), filterBy = { true })
-        )
-    }
+        testee.scheduleNextNotification()
 
-    private fun setDripB2Variant() {
-        whenever(variantManager.getVariant()).thenReturn(
-            Variant("test", features = listOf(DripNotification, Day1DripB2Notification, Day3ClearDataNotification), filterBy = { true })
-        )
-    }
-
-    private fun setNotificationControlVariant() {
-        whenever(variantManager.getVariant()).thenReturn(
-            Variant("test", features = listOf(DripNotification, Day1PrivacyNotification, Day3ClearDataNotification), filterBy = { true })
-        )
-    }
-
-    private fun setNotificationNullVariant() {
-        whenever(variantManager.getVariant()).thenReturn(
-            Variant("test", features = listOf(DripNotification), filterBy = { true })
-        )
+        assertNoNotificationScheduled(NotificationScheduler.USE_OUR_APP_WORK_REQUEST_TAG)
     }
 
     private suspend fun givenNoInactiveUserNotifications() {
@@ -482,14 +185,37 @@ class AndroidNotificationSchedulerTest {
         whenever(clearNotification.canShow()).thenReturn(false)
     }
 
-    private suspend fun givenStageIsUseOurAppNotification() {
-        whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.USE_OUR_APP_NOTIFICATION)
+    private fun setInAppUsageVariant() {
+        whenever(variantManager.getVariant()).thenReturn(
+            Variant(
+                "test",
+                features = listOf(
+                    VariantManager.VariantFeature.InAppUsage,
+                    VariantManager.VariantFeature.RemoveDay1AndDay3Notifications,
+                    VariantManager.VariantFeature.KillOnboarding
+                ),
+                filterBy = { true })
+        )
     }
 
-    private suspend fun givenStageIsEstablished() {
-        whenever(privacyNotification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(false)
-        whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.ESTABLISHED)
+    private fun setInAppUsageSecondControlVariant() {
+        whenever(variantManager.getVariant()).thenReturn(
+            Variant(
+                "test",
+                features = listOf(
+                    VariantManager.VariantFeature.RemoveDay1AndDay3Notifications,
+                    VariantManager.VariantFeature.KillOnboarding
+                ),
+                filterBy = { true })
+        )
+    }
+
+    private fun setInAppUsageControlVariant() {
+        whenever(variantManager.getVariant()).thenReturn(Variant("test", features = emptyList(), filterBy = { true }))
+    }
+
+    private fun setDefaultVariant() {
+        whenever(variantManager.getVariant()).thenReturn(DEFAULT_VARIANT)
     }
 
     private fun assertNotificationScheduled(workerName: String, tag: String = NotificationScheduler.UNUSED_APP_WORK_REQUEST_TAG) {

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/UseOurAppNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/UseOurAppNotificationTest.kt
@@ -41,7 +41,7 @@ class UseOurAppNotificationTest {
     }
 
     @Test
-    fun whenNotificationNotSeenThenCanShowIsTrue() = runBlocking {
+    fun whenNotificationNotSeenAndHiseTipsIsFalseThenCanShowIsTrue() = runBlocking {
         whenever(notificationsDao.exists(any())).thenReturn(false)
         whenever(mockSettingsDataStore.hideTips).thenReturn(false)
         assertTrue(testee.canShow())
@@ -52,13 +52,6 @@ class UseOurAppNotificationTest {
         whenever(notificationsDao.exists(any())).thenReturn(true)
         whenever(mockSettingsDataStore.hideTips).thenReturn(false)
         assertFalse(testee.canShow())
-    }
-
-    @Test
-    fun whenHideTipsIsFalseThenCanShowIsTrue() = runBlocking {
-        whenever(notificationsDao.exists(any())).thenReturn(false)
-        whenever(mockSettingsDataStore.hideTips).thenReturn(false)
-        assertTrue(testee.canShow())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/UseOurAppNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/UseOurAppNotificationTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.notification.model
 
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.notification.db.NotificationDao
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -30,23 +31,40 @@ class UseOurAppNotificationTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val notificationsDao: NotificationDao = mock()
+    private val mockSettingsDataStore: SettingsDataStore = mock()
 
     private lateinit var testee: UseOurAppNotification
 
     @Before
     fun before() {
-        testee = UseOurAppNotification(context, notificationsDao)
+        testee = UseOurAppNotification(context, notificationsDao, mockSettingsDataStore)
     }
 
     @Test
     fun whenNotificationNotSeenThenCanShowIsTrue() = runBlocking {
         whenever(notificationsDao.exists(any())).thenReturn(false)
+        whenever(mockSettingsDataStore.hideTips).thenReturn(false)
         assertTrue(testee.canShow())
     }
 
     @Test
-    fun whenNotificationAlreadySeenThenCanShowIsFalse() = runBlocking<Unit> {
+    fun whenNotificationAlreadySeenThenCanShowIsFalse() = runBlocking {
         whenever(notificationsDao.exists(any())).thenReturn(true)
+        whenever(mockSettingsDataStore.hideTips).thenReturn(false)
+        assertFalse(testee.canShow())
+    }
+
+    @Test
+    fun whenHideTipsIsFalseThenCanShowIsTrue() = runBlocking {
+        whenever(notificationsDao.exists(any())).thenReturn(false)
+        whenever(mockSettingsDataStore.hideTips).thenReturn(false)
+        assertTrue(testee.canShow())
+    }
+
+    @Test
+    fun whenHideTipsIsTrueThenCanShowIsFalse() = runBlocking {
+        whenever(notificationsDao.exists(any())).thenReturn(false)
+        whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         assertFalse(testee.canShow())
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/UseOurAppNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/UseOurAppNotificationTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.notification.model
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.nhaarman.mockitokotlin2.any
@@ -32,16 +33,18 @@ class UseOurAppNotificationTest {
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val notificationsDao: NotificationDao = mock()
     private val mockSettingsDataStore: SettingsDataStore = mock()
+    private val mockAddToHomeCapabilityDetector: AddToHomeCapabilityDetector = mock()
 
     private lateinit var testee: UseOurAppNotification
 
     @Before
     fun before() {
-        testee = UseOurAppNotification(context, notificationsDao, mockSettingsDataStore)
+        testee = UseOurAppNotification(context, notificationsDao, mockSettingsDataStore, mockAddToHomeCapabilityDetector)
     }
 
     @Test
-    fun whenNotificationNotSeenAndHiseTipsIsFalseThenCanShowIsTrue() = runBlocking {
+    fun whenNotificationNotSeenAndHideTipsIsFalseAndAddToHomeSupportedThenCanShowIsTrue() = runBlocking {
+        whenever(mockAddToHomeCapabilityDetector.isAddToHomeSupported()).thenReturn(true)
         whenever(notificationsDao.exists(any())).thenReturn(false)
         whenever(mockSettingsDataStore.hideTips).thenReturn(false)
         assertTrue(testee.canShow())
@@ -50,6 +53,7 @@ class UseOurAppNotificationTest {
     @Test
     fun whenNotificationAlreadySeenThenCanShowIsFalse() = runBlocking {
         whenever(notificationsDao.exists(any())).thenReturn(true)
+        whenever(mockAddToHomeCapabilityDetector.isAddToHomeSupported()).thenReturn(true)
         whenever(mockSettingsDataStore.hideTips).thenReturn(false)
         assertFalse(testee.canShow())
     }
@@ -57,7 +61,16 @@ class UseOurAppNotificationTest {
     @Test
     fun whenHideTipsIsTrueThenCanShowIsFalse() = runBlocking {
         whenever(notificationsDao.exists(any())).thenReturn(false)
+        whenever(mockAddToHomeCapabilityDetector.isAddToHomeSupported()).thenReturn(true)
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
+        assertFalse(testee.canShow())
+    }
+
+    @Test
+    fun whenAddToHomeNotSupportedThenCanShowIsFalse() = runBlocking {
+        whenever(notificationsDao.exists(any())).thenReturn(false)
+        whenever(mockAddToHomeCapabilityDetector.isAddToHomeSupported()).thenReturn(false)
+        whenever(mockSettingsDataStore.hideTips).thenReturn(false)
         assertFalse(testee.canShow())
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/store/AppUserStageStoreTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/store/AppUserStageStoreTest.kt
@@ -17,14 +17,21 @@
 package com.duckduckgo.app.onboarding.store
 
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.runBlocking
+import com.duckduckgo.app.statistics.Variant
+import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import java.util.concurrent.TimeUnit
 
 @ExperimentalCoroutinesApi
 class AppUserStageStoreTest {
@@ -32,9 +39,11 @@ class AppUserStageStoreTest {
     @get:Rule
     var coroutineRule = CoroutineTestRule()
 
-    private val userStageDao = mock<UserStageDao>()
+    private val userStageDao: UserStageDao = mock()
+    private val variantManager: VariantManager = mock()
+    private val appInstallStore: AppInstallStore = mock()
 
-    private val testee = AppUserStageStore(userStageDao, coroutineRule.testDispatcherProvider)
+    private val testee = AppUserStageStore(userStageDao, coroutineRule.testDispatcherProvider, variantManager, appInstallStore)
 
     @Test
     fun whenGetUserAppStageThenReturnCurrentStage() = coroutineRule.runBlocking {
@@ -94,6 +103,54 @@ class AppUserStageStoreTest {
     fun whenMoveToStageThenUpdateUserStageInDao() = coroutineRule.runBlocking {
         testee.moveToStage(AppStage.USE_OUR_APP_ONBOARDING)
         verify(userStageDao).updateUserStage(AppStage.USE_OUR_APP_ONBOARDING)
+    }
+
+    @Test
+    fun whenAppResumedAndInstalledFor3DaysAndKillOnboardingFeatureNotActiveIfUserInOnboardingThenDoNotUpdateUserStage() = coroutineRule.runBlocking {
+        givenDefaultVariant()
+        givenCurrentStage(AppStage.DAX_ONBOARDING)
+        givenAppInstalledByDays(days = 3)
+
+        testee.onAppResumed()
+
+        verify(userStageDao, never()).updateUserStage(AppStage.ESTABLISHED)
+    }
+
+    @Test
+    fun whenAppResumedAndInstalledFor3DaysAndKillOnboardingFeatureActiveIfUserInOnboardingThenMoveToEstablished() = coroutineRule.runBlocking {
+        givenKillOnboardingFeature()
+        givenCurrentStage(AppStage.DAX_ONBOARDING)
+        givenAppInstalledByDays(days = 3)
+
+        testee.onAppResumed()
+
+        verify(userStageDao).updateUserStage(AppStage.ESTABLISHED)
+    }
+
+    @Test
+    fun whenAppResumedAndInstalledForLess3DaysAndKillOnboardingFeatureActiveThenDoNotUpdateUserStage() = coroutineRule.runBlocking {
+        givenKillOnboardingFeature()
+        givenCurrentStage(AppStage.DAX_ONBOARDING)
+        givenAppInstalledByDays(days = 2)
+
+        testee.onAppResumed()
+
+        verify(userStageDao, never()).updateUserStage(any())
+    }
+
+    private fun givenAppInstalledByDays(days: Long) {
+        whenever(appInstallStore.hasInstallTimestampRecorded()).thenReturn(true)
+        whenever(appInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days) - 1)
+    }
+
+    private fun givenDefaultVariant() {
+        whenever(variantManager.getVariant(any())).thenReturn(DEFAULT_VARIANT)
+    }
+
+    private fun givenKillOnboardingFeature() {
+        whenever(variantManager.getVariant()).thenReturn(
+            Variant("test", features = listOf(VariantManager.VariantFeature.KillOnboarding), filterBy = { true })
+        )
     }
 
     private suspend fun givenCurrentStage(appStage: AppStage) {

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/store/AppUserStageStoreTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/store/AppUserStageStoreTest.kt
@@ -37,7 +37,7 @@ class AppUserStageStoreTest {
     private val testee = AppUserStageStore(userStageDao, coroutineRule.testDispatcherProvider)
 
     @Test
-    fun whenGetUserAppStageThenRetunCurrentStage() = coroutineRule.runBlocking {
+    fun whenGetUserAppStageThenReturnCurrentStage() = coroutineRule.runBlocking {
         givenCurrentStage(AppStage.DAX_ONBOARDING)
 
         val userAppStage = testee.getUserAppStage()

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -137,14 +137,14 @@ class VariantManagerTest {
     @Test
     fun serpHeaderControlVariantHasExpectedWeightAndNoFeatures() {
         val variant = variants.first { it.key == "zg" }
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
     fun serpHeaderVariantHasExpectedWeightAndSERPHeaderRemovalFeature() {
         val variant = variants.first { it.key == "zi" }
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertEquals(SerpHeaderRemoval, variant.features[0])
     }
@@ -152,9 +152,35 @@ class VariantManagerTest {
     @Test
     fun serpHeaderVariantHasExpectedWeightAndSERPHeaderQueryReplacementFeature() {
         val variant = variants.first { it.key == "zh" }
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertEquals(SerpHeaderQueryReplacement, variant.features[0])
+    }
+
+    @Test
+    fun inBrowserControlVariantHasExpectedWeightAndNoFeatures() {
+        val variant = variants.first { it.key == "zj" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(0, variant.features.size)
+    }
+
+    @Test
+    fun inBrowserSecondControlVariantHasExpectedWeightAndRemoveDay1And3NotificationsAndKillOnboardingFeatures() {
+        val variant = variants.first { it.key == "zk" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(2, variant.features.size)
+        assertTrue(variant.hasFeature(KillOnboarding))
+        assertTrue(variant.hasFeature(RemoveDay1AndDay3Notifications))
+    }
+
+    @Test
+    fun inBrowserInAppUsageVariantHasExpectedWeightAndRemoveDay1And3NotificationsAndKillOnboardingAndInAppUsageFeatures() {
+        val variant = variants.first { it.key == "zl" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(3, variant.features.size)
+        assertTrue(variant.hasFeature(KillOnboarding))
+        assertTrue(variant.hasFeature(RemoveDay1AndDay3Notifications))
+        assertTrue(variant.hasFeature(InAppUsage))
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -273,7 +273,7 @@ class SystemSearchViewModelTest {
             override suspend fun currentUserAppStage() = UserStage(appStage = AppStage.NEW)
             override fun insert(userStage: UserStage) {}
         }
-        return AppUserStageStore(emptyUserStageDao, coroutineRule.testDispatcherProvider)
+        return AppUserStageStore(emptyUserStageDao, coroutineRule.testDispatcherProvider, mock(), mock())
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -673,6 +673,7 @@ class BrowserTabViewModel(
                 deleteCtaShown -> pixel.fire(PixelName.UOA_VISITED_AFTER_DELETE_CTA)
                 isShortcutAdded != null -> pixel.fire(PixelName.UOA_VISITED_AFTER_SHORTCUT)
                 isUseOurAppNotificationSeen -> pixel.fire(PixelName.UOA_VISITED_AFTER_NOTIFICATION)
+                else -> pixel.fire(PixelName.UOA_VISITED)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -27,8 +27,6 @@ import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.rating.ui.AppEnjoymentDialogFragment
 import com.duckduckgo.app.browser.rating.ui.GiveFeedbackDialogFragment
 import com.duckduckgo.app.browser.rating.ui.RateAppDialogFragment
-import com.duckduckgo.app.cta.db.DismissedCtaDao
-import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.global.ApplicationClearDataState
 import com.duckduckgo.app.global.DefaultDispatcherProvider
@@ -38,7 +36,7 @@ import com.duckduckgo.app.global.rating.AppEnjoymentPromptEmitter
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions
 import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
 import com.duckduckgo.app.global.rating.PromptCount
-import com.duckduckgo.app.global.useourapp.UseOurAppDetector.Companion.USE_OUR_APP_SHORTCUT_URL
+import com.duckduckgo.app.global.useourapp.UseOurAppDetector
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity.Companion.RELOAD_RESULT_CODE
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -55,9 +53,9 @@ class BrowserViewModel(
     private val dataClearer: DataClearer,
     private val appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
     private val appEnjoymentUserEventRecorder: AppEnjoymentUserEventRecorder,
-    private val ctaDao: DismissedCtaDao,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
-    private val pixel: Pixel
+    private val pixel: Pixel,
+    private val useOurAppDetector: UseOurAppDetector
 ) : AppEnjoymentDialogFragment.Listener,
     RateAppDialogFragment.Listener,
     GiveFeedbackDialogFragment.Listener,
@@ -210,7 +208,7 @@ class BrowserViewModel(
     fun onOpenShortcut(url: String) {
         launch(dispatchers.io()) {
             tabRepository.selectByUrlOrNewTab(queryUrlConverter.convertQueryToUrl(url))
-            if (ctaDao.exists(CtaId.USE_OUR_APP) && url == USE_OUR_APP_SHORTCUT_URL) {
+            if (useOurAppDetector.isUseOurAppUrl(url)) {
                 pixel.fire(Pixel.PixelName.USE_OUR_APP_SHORTCUT_OPENED)
             } else {
                 pixel.fire(Pixel.PixelName.SHORTCUT_OPENED)

--- a/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutBuilder.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutBuilder.kt
@@ -26,11 +26,11 @@ import androidx.core.graphics.drawable.IconCompat
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.BrowserTabViewModel
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.app.global.useourapp.UseOurAppDetector.Companion.USE_OUR_APP_SHORTCUT_URL
+import com.duckduckgo.app.global.useourapp.UseOurAppDetector
 import java.util.UUID
 import javax.inject.Inject
 
-class ShortcutBuilder @Inject constructor() {
+class ShortcutBuilder @Inject constructor(private val useOurAppDetector: UseOurAppDetector) {
 
     private fun buildPinnedPageShortcut(context: Context, homeShortcut: BrowserTabViewModel.Command.AddHomeShortcut): ShortcutInfoCompat {
         val intent = Intent(context, BrowserActivity::class.java)
@@ -39,7 +39,7 @@ class ShortcutBuilder @Inject constructor() {
         intent.putExtra(SHORTCUT_EXTRA_ARG, true)
 
         val icon = when {
-            homeShortcut.url == USE_OUR_APP_SHORTCUT_URL -> IconCompat.createWithResource(context, R.drawable.ic_fb_favicon)
+            useOurAppDetector.isUseOurAppUrl(homeShortcut.url) -> IconCompat.createWithResource(context, R.drawable.ic_fb_favicon)
             homeShortcut.icon != null -> IconCompat.createWithBitmap(homeShortcut.icon)
             else -> IconCompat.createWithResource(context, R.drawable.logo_mini)
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiver.kt
@@ -24,12 +24,11 @@ import android.widget.Toast
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder.Companion.SHORTCUT_TITLE_ARG
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder.Companion.SHORTCUT_URL_ARG
-import com.duckduckgo.app.cta.db.DismissedCtaDao
-import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.events.db.UserEventKey
-import com.duckduckgo.app.global.useourapp.UseOurAppDetector.Companion.USE_OUR_APP_SHORTCUT_URL
+import com.duckduckgo.app.global.useourapp.UseOurAppDetector
+import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -37,8 +36,9 @@ import javax.inject.Inject
 
 class ShortcutReceiver @Inject constructor(
     private val userEventsStore: UserEventsStore,
-    private val ctaDao: DismissedCtaDao,
     private val dispatcher: DispatcherProvider,
+    private val useOurAppDetector: UseOurAppDetector,
+    private val variantManager: VariantManager,
     private val pixel: Pixel
 ) :
     BroadcastReceiver() {
@@ -54,9 +54,11 @@ class ShortcutReceiver @Inject constructor(
         }
 
         GlobalScope.launch(dispatcher.io()) {
-            if (ctaDao.exists(CtaId.USE_OUR_APP) && originUrl == USE_OUR_APP_SHORTCUT_URL) {
-                userEventsStore.registerUserEvent(UserEventKey.USE_OUR_APP_SHORTCUT_ADDED)
+            if (useOurAppDetector.isUseOurAppUrl(originUrl)) {
                 pixel.fire(Pixel.PixelName.USE_OUR_APP_SHORTCUT_ADDED)
+                if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.InAppUsage)) {
+                    userEventsStore.registerUserEvent(UserEventKey.USE_OUR_APP_SHORTCUT_ADDED)
+                }
             } else {
                 pixel.fire(Pixel.PixelName.SHORTCUT_ADDED)
             }

--- a/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
@@ -21,7 +21,6 @@ import androidx.room.Room
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.db.MigrationsProvider
-import com.duckduckgo.app.global.useourapp.UseOurAppMigrationManager
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import dagger.Module
 import dagger.Provides
@@ -42,9 +41,8 @@ class DatabaseModule {
     fun provideDatabaseMigrations(
         context: Context,
         settingsDataStore: SettingsDataStore,
-        addToHomeCapabilityDetector: AddToHomeCapabilityDetector,
-        useOurAppMigrationManager: UseOurAppMigrationManager
+        addToHomeCapabilityDetector: AddToHomeCapabilityDetector
     ): MigrationsProvider {
-        return MigrationsProvider(context, settingsDataStore, addToHomeCapabilityDetector, useOurAppMigrationManager)
+        return MigrationsProvider(context, settingsDataStore, addToHomeCapabilityDetector)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -65,9 +65,10 @@ class NotificationModule {
     fun provideUseOurAppNotification(
         context: Context,
         notificationDao: NotificationDao,
-        settingsDataStore: SettingsDataStore
+        settingsDataStore: SettingsDataStore,
+        addToHomeCapabilityDetector: AddToHomeCapabilityDetector
     ): UseOurAppNotification {
-        return UseOurAppNotification(context, notificationDao, settingsDataStore)
+        return UseOurAppNotification(context, notificationDao, settingsDataStore, addToHomeCapabilityDetector)
     }
 
     @Provides
@@ -158,7 +159,6 @@ class NotificationModule {
         clearDataNotification: ClearDataNotification,
         privacyProtectionNotification: PrivacyProtectionNotification,
         useOurAppNotification: UseOurAppNotification,
-        addToHomeCapabilityDetector: AddToHomeCapabilityDetector,
         variantManager: VariantManager
     ): AndroidNotificationScheduler {
         return NotificationScheduler(
@@ -166,7 +166,6 @@ class NotificationModule {
             clearDataNotification,
             privacyProtectionNotification,
             useOurAppNotification,
-            addToHomeCapabilityDetector,
             variantManager
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.work.WorkManager
+import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.duckduckgo.app.notification.NotificationFactory
 import com.duckduckgo.app.notification.NotificationHandlerService
@@ -31,7 +32,6 @@ import com.duckduckgo.app.notification.model.ClearDataNotification
 import com.duckduckgo.app.notification.model.UseOurAppNotification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.notification.model.WebsiteNotification
-import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
@@ -64,9 +64,10 @@ class NotificationModule {
     @Provides
     fun provideUseOurAppNotification(
         context: Context,
-        notificationDao: NotificationDao
+        notificationDao: NotificationDao,
+        settingsDataStore: SettingsDataStore
     ): UseOurAppNotification {
-        return UseOurAppNotification(context, notificationDao)
+        return UseOurAppNotification(context, notificationDao, settingsDataStore)
     }
 
     @Provides
@@ -156,23 +157,17 @@ class NotificationModule {
         workManager: WorkManager,
         clearDataNotification: ClearDataNotification,
         privacyProtectionNotification: PrivacyProtectionNotification,
-        @Named("dripA1Notification") dripA1Notification: WebsiteNotification,
-        @Named("dripA2Notification") dripA2Notification: WebsiteNotification,
-        @Named("dripB1Notification") dripB1Notification: AppFeatureNotification,
-        @Named("dripB2Notification") dripB2Notification: AppFeatureNotification,
-        variantManager: VariantManager,
-        stageStore: UserStageStore
+        useOurAppNotification: UseOurAppNotification,
+        addToHomeCapabilityDetector: AddToHomeCapabilityDetector,
+        variantManager: VariantManager
     ): AndroidNotificationScheduler {
         return NotificationScheduler(
             workManager,
             clearDataNotification,
             privacyProtectionNotification,
-            dripA1Notification,
-            dripA2Notification,
-            dripB1Notification,
-            dripB2Notification,
-            variantManager,
-            stageStore
+            useOurAppNotification,
+            addToHomeCapabilityDetector,
+            variantManager
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -329,7 +329,7 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
         GlobalScope.launch {
             workScheduler.scheduleWork()
             atbInitializer.initializeAfterReferrerAvailable()
-            if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.RemoveDay1AndDay3Notifications)) {
+            if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.KillOnboarding)) {
                 moveUserToEstablished3DaysAfterInstall()
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/ViewModelFactory.kt
@@ -181,7 +181,7 @@ class ViewModelFactory @Inject constructor(
             dataClearer = dataClearer,
             appEnjoymentPromptEmitter = appEnjoymentPromptEmitter,
             appEnjoymentUserEventRecorder = appEnjoymentUserEventRecorder,
-            ctaDao = dismissedCtaDao,
+            useOurAppDetector = userOurAppDetector,
             pixel = pixel
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -39,7 +39,6 @@ import com.duckduckgo.app.global.exception.UncaughtExceptionSourceConverter
 import com.duckduckgo.app.global.events.db.UserEventsDao
 import com.duckduckgo.app.global.events.db.UserEventEntity
 import com.duckduckgo.app.global.events.db.UserEventTypeConverter
-import com.duckduckgo.app.global.useourapp.MigrationManager
 import com.duckduckgo.app.httpsupgrade.db.HttpsBloomFilterSpecDao
 import com.duckduckgo.app.httpsupgrade.db.HttpsWhitelistDao
 import com.duckduckgo.app.httpsupgrade.model.HttpsBloomFilterSpec
@@ -62,7 +61,6 @@ import com.duckduckgo.app.usage.app.AppDaysUsedDao
 import com.duckduckgo.app.usage.app.AppDaysUsedEntity
 import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.app.usage.search.SearchCountEntity
-import java.util.Locale
 
 @Database(
     exportSchema = true, version = 22, entities = [
@@ -135,8 +133,7 @@ abstract class AppDatabase : RoomDatabase() {
 class MigrationsProvider(
     val context: Context,
     val settingsDataStore: SettingsDataStore,
-    val addToHomeCapabilityDetector: AddToHomeCapabilityDetector,
-    val useOurAppMigrationManager: MigrationManager
+    val addToHomeCapabilityDetector: AddToHomeCapabilityDetector
 ) {
 
     val MIGRATION_1_TO_2: Migration = object : Migration(1, 2) {
@@ -310,21 +307,7 @@ class MigrationsProvider(
     val MIGRATION_21_TO_22: Migration = object : Migration(21, 22) {
         override fun migrate(database: SupportSQLiteDatabase) {
             database.execSQL("CREATE TABLE IF NOT EXISTS `user_events` (`id` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))")
-
-            if (canUserBeMigratedToUseOurAppFlow(database)) {
-                if (useOurAppMigrationManager.shouldRunMigration()) {
-                    database.execSQL("UPDATE $USER_STAGE_TABLE_NAME SET appStage = \"${AppStage.USE_OUR_APP_NOTIFICATION}\" WHERE appStage = \"${AppStage.ESTABLISHED}\"")
-                }
-            }
         }
-    }
-
-    private fun canUserBeMigratedToUseOurAppFlow(database: SupportSQLiteDatabase): Boolean =
-        isEnglishLocale() && isUserEstablished(database) && !settingsDataStore.hideTips && addToHomeCapabilityDetector.isAddToHomeSupported()
-
-    private fun isEnglishLocale(): Boolean {
-        val locale = Locale.getDefault()
-        return locale != null && locale.language == "en"
     }
 
     val ALL_MIGRATIONS: List<Migration>
@@ -351,17 +334,6 @@ class MigrationsProvider(
             MIGRATION_20_TO_21,
             MIGRATION_21_TO_22
         )
-
-    private fun isUserEstablished(database: SupportSQLiteDatabase): Boolean {
-        var stage: String
-
-        database.query("SELECT appStage from userStage limit 1").apply {
-            moveToFirst()
-            if (count == 0) return false
-            stage = getString(0)
-        }
-        return (stage == AppStage.ESTABLISHED.name)
-    }
 
     @Deprecated(
         message = "This class should be only used by database migrations.",

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -63,7 +63,7 @@ import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.app.usage.search.SearchCountEntity
 
 @Database(
-    exportSchema = true, version = 22, entities = [
+    exportSchema = true, version = 23, entities = [
         TdsTracker::class,
         TdsEntity::class,
         TdsDomainEntity::class,
@@ -310,6 +310,12 @@ class MigrationsProvider(
         }
     }
 
+    val MIGRATION_22_TO_23: Migration = object : Migration(22, 23) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("UPDATE $USER_STAGE_TABLE_NAME SET appStage = \"${AppStage.ESTABLISHED}\" WHERE appStage = \"${AppStage.USE_OUR_APP_NOTIFICATION}\"")
+        }
+    }
+
     val ALL_MIGRATIONS: List<Migration>
         get() = listOf(
             MIGRATION_1_TO_2,
@@ -332,7 +338,8 @@ class MigrationsProvider(
             MIGRATION_18_TO_19,
             MIGRATION_19_TO_20,
             MIGRATION_20_TO_21,
-            MIGRATION_21_TO_22
+            MIGRATION_21_TO_22,
+            MIGRATION_22_TO_23
         )
 
     @Deprecated(

--- a/app/src/main/java/com/duckduckgo/app/global/useourapp/UseOurAppDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/useourapp/UseOurAppDetector.kt
@@ -69,5 +69,6 @@ class UseOurAppDetector @Inject constructor(val userEventsStore: UserEventsStore
         const val USE_OUR_APP_SHORTCUT_URL: String = "https://m.facebook.com/"
         const val USE_OUR_APP_SHORTCUT_TITLE: String = "Facebook"
         const val USE_OUR_APP_DOMAIN = "facebook.com"
+        const val USE_OUR_APP_DOMAIN_QUERY = "%facebook.com%"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -20,20 +20,11 @@ import android.content.Context
 import androidx.annotation.WorkerThread
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.*
+import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.Notification
 import com.duckduckgo.app.notification.model.SchedulableNotification
-import com.duckduckgo.app.onboarding.store.AppStage
-import com.duckduckgo.app.onboarding.store.UserStageStore
-import com.duckduckgo.app.onboarding.store.useOurAppNotification
 import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.DripNotification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1DripB2Notification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1DripB1Notification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1DripA2Notification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1DripA1Notification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day1PrivacyNotification
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.Day3ClearDataNotification
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.NOTIFICATION_SHOWN
 import timber.log.Timber
@@ -50,12 +41,9 @@ class NotificationScheduler(
     private val workManager: WorkManager,
     private val clearDataNotification: SchedulableNotification,
     private val privacyNotification: SchedulableNotification,
-    private val dripA1Notification: SchedulableNotification,
-    private val dripA2Notification: SchedulableNotification,
-    private val dripB1Notification: SchedulableNotification,
-    private val dripB2Notification: SchedulableNotification,
-    private val variantManager: VariantManager,
-    private val userStageStore: UserStageStore
+    private val useOurAppNotification: SchedulableNotification,
+    private val addToHomeCapabilityDetector: AddToHomeCapabilityDetector,
+    private val variantManager: VariantManager
 ) : AndroidNotificationScheduler {
 
     override suspend fun scheduleNextNotification() {
@@ -64,16 +52,15 @@ class NotificationScheduler(
     }
 
     private suspend fun scheduleUseOurAppNotification() {
-        if (userStageStore.useOurAppNotification()) {
+        if (variant().hasFeature(VariantManager.VariantFeature.InAppUsage) && addToHomeCapabilityDetector.isAddToHomeSupported() && useOurAppNotification.canShow()) {
             val operation = scheduleUniqueNotification(
                 OneTimeWorkRequestBuilder<UseOurAppNotificationWorker>(),
-                1,
+                3,
                 TimeUnit.DAYS,
                 USE_OUR_APP_WORK_REQUEST_TAG
             )
             try {
                 operation.await()
-                userStageStore.stageCompleted(AppStage.USE_OUR_APP_NOTIFICATION)
             } catch (e: Exception) {
                 Timber.v("Notification could not be scheduled: $e")
             }
@@ -84,22 +71,10 @@ class NotificationScheduler(
         workManager.cancelAllWorkByTag(UNUSED_APP_WORK_REQUEST_TAG)
 
         when {
-            variant().hasFeature(Day1DripA1Notification) && dripA1Notification.canShow() -> {
-                scheduleNotification(OneTimeWorkRequestBuilder<DripA1NotificationWorker>(), 1, TimeUnit.DAYS, UNUSED_APP_WORK_REQUEST_TAG)
-            }
-            variant().hasFeature(Day1DripA2Notification) && dripA2Notification.canShow() -> {
-                scheduleNotification(OneTimeWorkRequestBuilder<DripA2NotificationWorker>(), 1, TimeUnit.DAYS, UNUSED_APP_WORK_REQUEST_TAG)
-            }
-            variant().hasFeature(Day1DripB1Notification) && dripB1Notification.canShow() -> {
-                scheduleNotification(OneTimeWorkRequestBuilder<DripB1NotificationWorker>(), 1, TimeUnit.DAYS, UNUSED_APP_WORK_REQUEST_TAG)
-            }
-            variant().hasFeature(Day1DripB2Notification) && dripB2Notification.canShow() -> {
-                scheduleNotification(OneTimeWorkRequestBuilder<DripB2NotificationWorker>(), 1, TimeUnit.DAYS, UNUSED_APP_WORK_REQUEST_TAG)
-            }
-            (isNotDripVariant() || isDripVariantAndHasPrivacyFeature()) && privacyNotification.canShow() -> {
+            (!variant().hasFeature(VariantManager.VariantFeature.RemoveDay1AndDay3Notifications) && privacyNotification.canShow()) -> {
                 scheduleNotification(OneTimeWorkRequestBuilder<PrivacyNotificationWorker>(), 1, TimeUnit.DAYS, UNUSED_APP_WORK_REQUEST_TAG)
             }
-            (isNotDripVariant() || isDripVariantAndHasClearDataFeature()) && clearDataNotification.canShow() -> {
+            (!variant().hasFeature(VariantManager.VariantFeature.RemoveDay1AndDay3Notifications) && clearDataNotification.canShow()) -> {
                 scheduleNotification(OneTimeWorkRequestBuilder<ClearDataNotificationWorker>(), 3, TimeUnit.DAYS, UNUSED_APP_WORK_REQUEST_TAG)
             }
             else -> Timber.v("Notifications not enabled for this variant")
@@ -107,14 +82,6 @@ class NotificationScheduler(
     }
 
     private fun variant() = variantManager.getVariant()
-
-    private fun isDripVariantAndHasPrivacyFeature(): Boolean = isFromDripNotificationVariant() && variant().hasFeature(Day1PrivacyNotification)
-
-    private fun isDripVariantAndHasClearDataFeature(): Boolean = isFromDripNotificationVariant() && variant().hasFeature(Day3ClearDataNotification)
-
-    private fun isFromDripNotificationVariant(): Boolean = variant().hasFeature(DripNotification)
-
-    private fun isNotDripVariant(): Boolean = !variant().hasFeature(DripNotification)
 
     private fun scheduleUniqueNotification(builder: OneTimeWorkRequest.Builder, duration: Long, unit: TimeUnit, tag: String): Operation {
         Timber.v("Scheduling unique notification")

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import androidx.annotation.WorkerThread
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.*
-import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.Notification
 import com.duckduckgo.app.notification.model.SchedulableNotification
@@ -42,7 +41,6 @@ class NotificationScheduler(
     private val clearDataNotification: SchedulableNotification,
     private val privacyNotification: SchedulableNotification,
     private val useOurAppNotification: SchedulableNotification,
-    private val addToHomeCapabilityDetector: AddToHomeCapabilityDetector,
     private val variantManager: VariantManager
 ) : AndroidNotificationScheduler {
 
@@ -52,7 +50,7 @@ class NotificationScheduler(
     }
 
     private suspend fun scheduleUseOurAppNotification() {
-        if (variant().hasFeature(VariantManager.VariantFeature.InAppUsage) && addToHomeCapabilityDetector.isAddToHomeSupported() && useOurAppNotification.canShow()) {
+        if (variant().hasFeature(VariantManager.VariantFeature.InAppUsage) && useOurAppNotification.canShow()) {
             val operation = scheduleUniqueNotification(
                 OneTimeWorkRequestBuilder<UseOurAppNotificationWorker>(),
                 3,

--- a/app/src/main/java/com/duckduckgo/app/notification/model/UseOurAppNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/UseOurAppNotification.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.notification.model
 import android.content.Context
 import android.os.Bundle
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.notification.NotificationHandlerService
 import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.CANCEL
 import com.duckduckgo.app.notification.NotificationRegistrar
@@ -30,7 +31,8 @@ import timber.log.Timber
 class UseOurAppNotification(
     private val context: Context,
     private val notificationDao: NotificationDao,
-    private val settingsDataStore: SettingsDataStore
+    private val settingsDataStore: SettingsDataStore,
+    private val addToHomeCapabilityDetector: AddToHomeCapabilityDetector
 ) : SchedulableNotification {
 
     override val id = ID
@@ -38,7 +40,7 @@ class UseOurAppNotification(
     override val cancelIntent = CANCEL
 
     override suspend fun canShow(): Boolean {
-        if (notificationDao.exists(id) || settingsDataStore.hideTips) {
+        if (notificationDao.exists(id) || settingsDataStore.hideTips || !addToHomeCapabilityDetector.isAddToHomeSupported()) {
             Timber.v("Notification already seen")
             return false
         }

--- a/app/src/main/java/com/duckduckgo/app/notification/model/UseOurAppNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/UseOurAppNotification.kt
@@ -23,12 +23,14 @@ import com.duckduckgo.app.notification.NotificationHandlerService
 import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.CANCEL
 import com.duckduckgo.app.notification.NotificationRegistrar
 import com.duckduckgo.app.notification.db.NotificationDao
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import timber.log.Timber
 
 class UseOurAppNotification(
     private val context: Context,
-    private val notificationDao: NotificationDao
+    private val notificationDao: NotificationDao,
+    private val settingsDataStore: SettingsDataStore
 ) : SchedulableNotification {
 
     override val id = ID
@@ -36,7 +38,7 @@ class UseOurAppNotification(
     override val cancelIntent = CANCEL
 
     override suspend fun canShow(): Boolean {
-        if (notificationDao.exists(id)) {
+        if (notificationDao.exists(id) || settingsDataStore.hideTips) {
             Timber.v("Notification already seen")
             return false
         }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/UserStageStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/UserStageStore.kt
@@ -68,6 +68,10 @@ suspend fun UserStageStore.daxOnboardingActive(): Boolean {
     return this.getUserAppStage() == AppStage.DAX_ONBOARDING
 }
 
+suspend fun UserStageStore.isEstablished(): Boolean {
+    return this.getUserAppStage() == AppStage.ESTABLISHED
+}
+
 suspend fun UserStageStore.useOurAppOnboarding(): Boolean {
     return this.getUserAppStage() == AppStage.USE_OUR_APP_ONBOARDING
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/UserStageStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/UserStageStore.kt
@@ -16,11 +16,19 @@
 
 package com.duckduckgo.app.onboarding.store
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.statistics.VariantManager
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-interface UserStageStore {
+interface UserStageStore : LifecycleObserver {
     suspend fun getUserAppStage(): AppStage
     suspend fun stageCompleted(appStage: AppStage): AppStage
     suspend fun moveToStage(appStage: AppStage)
@@ -28,8 +36,18 @@ interface UserStageStore {
 
 class AppUserStageStore @Inject constructor(
     private val userStageDao: UserStageDao,
-    private val dispatcher: DispatcherProvider
-) : UserStageStore {
+    private val dispatcher: DispatcherProvider,
+    private val variantManager: VariantManager,
+    private val appInstallStore: AppInstallStore
+) : UserStageStore, LifecycleObserver {
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    fun onAppResumed() {
+        GlobalScope.launch(dispatcher.io()) {
+            moveUserToEstablished3DaysAfterInstall()
+        }
+    }
+
     override suspend fun getUserAppStage(): AppStage {
         return withContext(dispatcher.io()) {
             val userStage = userStageDao.currentUserAppStage()
@@ -57,6 +75,17 @@ class AppUserStageStore @Inject constructor(
 
     override suspend fun moveToStage(appStage: AppStage) {
         userStageDao.updateUserStage(appStage)
+    }
+
+    private suspend fun moveUserToEstablished3DaysAfterInstall() {
+        if (variantManager.getVariant().hasFeature(VariantManager.VariantFeature.KillOnboarding)) {
+            if (appInstallStore.hasInstallTimestampRecorded() && daxOnboardingActive()) {
+                val days = TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - appInstallStore.installTimestamp)
+                if (days >= 3) {
+                    moveToStage(AppStage.ESTABLISHED)
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -37,6 +37,9 @@ interface VariantManager {
         object Day1DripB2Notification : VariantFeature()
         object SerpHeaderQueryReplacement : VariantFeature()
         object SerpHeaderRemoval : VariantFeature()
+        object InAppUsage : VariantFeature()
+        object KillOnboarding : VariantFeature()
+        object RemoveDay1AndDay3Notifications : VariantFeature()
     }
 
     companion object {
@@ -85,22 +88,22 @@ interface VariantManager {
                 filterBy = { isEnglishLocale() }),
 
             // Single Search Bar Experiments
-            // Disabled until Drip Notifications Experiments are completed
+            Variant(key = "zg", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "zh", weight = 0.0, features = listOf(VariantFeature.SerpHeaderQueryReplacement), filterBy = { noFilter() }),
+            Variant(key = "zi", weight = 0.0, features = listOf(VariantFeature.SerpHeaderRemoval), filterBy = { noFilter() }),
+
+            // InAppUsage Experiments
+            Variant(key = "zj", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),
             Variant(
-                key = "zg",
+                key = "zk",
                 weight = 1.0,
-                features = emptyList(),
-                filterBy = { noFilter() }),
+                features = listOf(VariantFeature.KillOnboarding, VariantFeature.RemoveDay1AndDay3Notifications),
+                filterBy = { isEnglishLocale() }),
             Variant(
-                key = "zh",
+                key = "zl",
                 weight = 1.0,
-                features = listOf(VariantFeature.SerpHeaderQueryReplacement),
-                filterBy = { noFilter() }),
-            Variant(
-                key = "zi",
-                weight = 1.0,
-                features = listOf(VariantFeature.SerpHeaderRemoval),
-                filterBy = { noFilter() })
+                features = listOf(VariantFeature.KillOnboarding, VariantFeature.InAppUsage, VariantFeature.RemoveDay1AndDay3Notifications),
+                filterBy = { isEnglishLocale() })
 
             // All groups in an experiment (control and variants) MUST use the same filters
         )

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -203,6 +203,7 @@ interface Pixel {
         UOA_VISITED_AFTER_SHORTCUT("m_uoa_vas"),
         UOA_VISITED_AFTER_NOTIFICATION("m_uoa_van"),
         UOA_VISITED_AFTER_DELETE_CTA("m_uoa_vad"),
+        UOA_VISITED("m_uoa_v"),
 
         USE_OUR_APP_SHORTCUT_OPENED("m_sho_uoa_o"),
         SHORTCUT_ADDED("m_sho_a"),

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -44,8 +44,8 @@ abstract class TabsDao {
     @Query("select * from tabs where tabId = :tabId")
     abstract fun tab(tabId: String): TabEntity?
 
-    @Query("select tabId from tabs where url LIKE :url")
-    abstract suspend fun selectTabByUrl(url: String): String?
+    @Query("select tabId from tabs where url LIKE :query")
+    abstract suspend fun selectTabByUrl(query: String): String?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract fun insertTab(tab: TabEntity)

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -88,12 +88,13 @@ class TabDataRepository @Inject constructor(
     }
 
     override suspend fun selectByUrlOrNewTab(url: String) {
-        var searchUrl = url
-        if (useOurAppDetector.isUseOurAppUrl(url)) {
-            searchUrl = "%${UseOurAppDetector.USE_OUR_APP_DOMAIN}%"
+        val query = if (useOurAppDetector.isUseOurAppUrl(url)) {
+            UseOurAppDetector.USE_OUR_APP_DOMAIN_QUERY
+        } else {
+            url
         }
 
-        val tabId = tabsDao.selectTabByUrl(searchUrl)
+        val tabId = tabsDao.selectTabByUrl(query)
         if (tabId != null) {
             select(tabId)
         } else {

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.MutableLiveData
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.SiteFactory
+import com.duckduckgo.app.global.useourapp.UseOurAppDetector
 import com.duckduckgo.app.tabs.db.TabsDao
 import io.reactivex.Scheduler
 import io.reactivex.schedulers.Schedulers
@@ -36,7 +37,8 @@ import javax.inject.Singleton
 class TabDataRepository @Inject constructor(
     private val tabsDao: TabsDao,
     private val siteFactory: SiteFactory,
-    private val webViewPreviewPersister: WebViewPreviewPersister
+    private val webViewPreviewPersister: WebViewPreviewPersister,
+    private val useOurAppDetector: UseOurAppDetector
 ) : TabRepository {
 
     override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs()
@@ -86,7 +88,12 @@ class TabDataRepository @Inject constructor(
     }
 
     override suspend fun selectByUrlOrNewTab(url: String) {
-        val tabId = tabsDao.selectTabByUrl(url)
+        var searchUrl = url
+        if (useOurAppDetector.isUseOurAppUrl(url)) {
+            searchUrl = "%${UseOurAppDetector.USE_OUR_APP_DOMAIN}%"
+        }
+
+        val tabId = tabsDao.selectTabByUrl(searchUrl)
         if (tabId != null) {
             select(tabId)
         } else {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1186436893520548
Tech Design URL: 
CC: 

**Description**:
This PR prepares the in app usage flow for the second experiment, includes:
1. New variants.
1. Removes the migration to move old user into the new in app flow.
1. New pixel when a user visits the use our app URL before the initial notification.
1. Removes CTA checks before firing some pixels to be consistent with the control group.
1. Removes day 1 and 3 notifications and onboarding on day 3 in 2 of the new variants.
1. When opening a shortcut we now try to match the domain rather than the full URL only for use our app URLs.
1. Sets to 0 weight on old variants.
1. Removes code around old notifications used on a previous experiment for more readability purposes.

**Before testing**
In `DuckDuckGoApplication` lines 221 and 222 change the code to:

```
val days = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - appInstallStore.installTimestamp)
if (days >= 30) {
```

You will be now moved out of the onboarding stage after 30 seconds from install whenever you resume the app.

In `AndroidNotificationScheduler` lines 58 and 59 change the code to be `40` and `TimeUnit.SECONDS`. Also change the line 75 to be:

```
scheduleNotification(OneTimeWorkRequestBuilder<PrivacyNotificationWorker>(), 40, TimeUnit.SECONDS, UNUSED_APP_WORK_REQUEST_TAG)
```

The notifications will be now triggered after 40 seconds.

### **Steps to test this PR**:

#### **Updating from previous version when in use our app notification stage**
1. Install from develop.
1. Launch the app and manually change the `userStage` table in the database inspector to be `USE_OUR_APP_NOTIFICATION` in the appStage column.
1. Close the app and do not relaunch, this simulates users updating to this version that could potentially be trapped in this stage.
1. Change to this bran and before updating make sure you make the changes in the before testing section.
1. Update and launch the app.
1. The `appStage` in the database should now be `ESTABLISHED`
1. Wait for 40 seconds.
1. You should receive the privacy notification.

#### **Variant zl - In App usage flow**
Hardcode the variant to use `zl`

**Clicking the notification moves you out of the onboarding**
1. Install and launch the app.
1. Go to SERP.
1. You should see the SERP CTA, press Phew.
1. Stay in that screen for at least 40 seconds.
1. The new in-app usage notification should show app.
1. Notice the day 1 privacy notification does not show up.
1. Click on the notification, you should be taken to a new tab showing the hombre screen with the new CTA.
1. Ignore the CTA (click Not now) and go to `instagram.com`.
1. You should not see any onboarding CTAs since you are not in the onboarding stage anymore.

**After X time you are moved out of the onboarding**
1. Install and launch the app.
1. Go to SERP.
1. You should see the SERP CTA, press Phew.
1. Stay in that screen for at least 30 seconds (if you see the in app usage notification do not interact with it or change the timing to a higher value so you don't see it).
1. Send the app to the background or kill the app.
1. Relaunch the app
1. Go to instagram.com
1. You should not see any onboarding CTAs since you are not in the onboarding stage anymore.

**Hiding tips does not show the notification**
1. Install and launch the app.
1. Go to SERP.
1. You should see the SERP CTA, click hide tips and hide them forever.
1. Stay in that screen for at least 40 seconds 
1. You should not see any notifications.

#### **Variant zk - Removes onboarding and day1/3 notifications**
Hardcode the variant to use `zk`

**After X time you are moved out of the onboarding and no notifications are scheduled**
1. Install and launch the app.
1. Go to SERP.
1. You should see the SERP CTA, press Phew.
1. Stay in that screen for at least 40 seconds.
1. No notifications should be shown.
1. Send the app to the background or kill the app.
1. Relaunch the app
1. Go to instagram.com
1. You should not see any onboarding CTAs since you are not in the onboarding stage anymore.

**Pixels and tabs**
1. Launch the app .
1. Go to facebook.com
1. Pixel `m_uoa_v` should be sent.
1. In the menu click Add to Home.
1. The Add to Home Screen dialog should show with a high-res icon.
1. Click in Add.
1. Pixel `m_uoa_s_a` should be sent
1. Login to facebook.
1. The fireproof dialog should not be shown.
1. Navigate to your notifications.
1. Kill the app.
1. Open the shortcut you just created.
1. Pixels `m_sho_uoa_o` and `m_uoa_v` should be sent.
1. The notifications tab you had opened before should be opened instead of a new tab.
1. Close the tab and send the app to the background.
1. Open the shortcut.
1. A new tab should be created pointing to facebook.com

#### **Variant zj - Control**
Hardcode the variant to use `zk`

**Notification and onboarding**
1. Install and launch the app.
1. Go to SERP.
1. You should see the SERP CTA, press Phew.
1. Stay in that screen for at least 40 seconds.
1. The privacy notification should be shown.
1. Send the app to the background or kill the app.
1. Relaunch the app
1. Go to instagram.com
1. You should see a CTA.

**Pixels and tabs**
1. Launch the app .
1. Go to facebook.com
1. Pixel `m_uoa_v` should be sent.
1. In the menu click Add to Home.
1. The Add to Home Screen dialog should show with a high-res icon.
1. Click in Add.
1. Pixel `m_uoa_s_a` should be sent
1. Login to facebook.
1. The fireproof dialog should not be shown.
1. Navigate to your notifications.
1. Kill the app.
1. Open the shortcut you just created.
1. Pixels `m_sho_uoa_o` and `m_uoa_v` should be sent.
1. The notifications tab you had opened before should be opened instead of a new tab.
1. Close the tab and send the app to the background.
1. Open the shortcut.
1. A new tab should be created pointing to facebook.com

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
