### PR TITLE
Improve algorithm to generate a filename from an image download

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.downloader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UriUtilsFilenameExtractorTest {
+
+    private val testee: FilenameExtractor = FilenameExtractor()
+
+    @Test
+    fun whenUrlEndsWithFilenameAsJpgNoMimeOrContentDispositionThenFilenameShouldBeExtracted() {
+        val url = "https://example.com/realFilename.jpg"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("realFilename.jpg", extracted)
+    }
+
+    @Test
+    fun whenUrlContainsFilenameButContainsAdditionalPathSegmentsThenFilenameShouldBeExtracted() {
+        val url = "https://foo.example.com/path/images/b/b1/realFilename.jpg/other/stuff"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("realFilename.jpg", extracted)
+    }
+
+    @Test
+    fun whenUrlContainsFilenameButContainsAdditionalPathSegmentsAndQueryParamsThenFilenameShouldBeExtracted() {
+        val url = "https://foo.example.com/path/images/b/b1/realFilename.jpg/other/stuff?cb=123"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("realFilename.jpg", extracted)
+    }
+
+    @Test
+    fun whenUrlContainsFilenameButContainsAdditionalPathSegmentsAndQueryParamsWhichLookLikeAFilenameThenFilenameShouldBeExtracted() {
+        val url = "https://foo.example.com/path/images/b/b1/realFilename.jpg/other/stuff?cb=123.com"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("realFilename.jpg", extracted)
+    }
+
+    @Test
+    fun whenUrlContainsFilenameButContentDispositionSaysOtherwiseThenExtractFromContentDisposition() {
+        val url = "https://example.com/filename.jpg"
+        val mimeType: String? = null
+        val contentDisposition: String? = "Content-Disposition: attachment; filename=fromDisposition.jpg"
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("fromDisposition.jpg", extracted)
+    }
+
+    @Test
+    fun whenFilenameActuallyEndsInBinThenThatIsExtracted() {
+        val url = "https://example.com/realFilename.bin"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("realFilename.bin", extracted)
+    }
+
+    @Test
+    fun whenUrlIsEmptyStringAndNoOtherDataProvidedThenDefaultNameAndBinFiletypeReturned() {
+        val url = ""
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("downloadfile.bin", extracted)
+    }
+
+    @Test
+    fun whenUrlIsEmptyStringAndMimeTypeProvidedThenDefaultNameAndFiletypeFromMimeReturned() {
+        val url = ""
+        val mimeType: String? = "image/jpeg"
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("downloadfile.jpg", extracted)
+    }
+
+    @Test
+    fun whenUrlIsEmptyStringAndContentDispositionProvidedThenExtractFromContentDisposition() {
+        val url = ""
+        val mimeType: String? = null
+        val contentDisposition: String? = "Content-Disposition: attachment; filename=fromDisposition.jpg"
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("fromDisposition.jpg", extracted)
+    }
+
+    @Test
+    fun whenNoFilenameAndNoPathSegmentsThenDomainNameReturned() {
+        val url = "http://example.com"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("example.com", extracted)
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -69,8 +69,26 @@ class UriUtilsFilenameExtractorTest {
     }
 
     @Test
-    fun whenFilenameActuallyEndsInBinThenThatIsExtracted() {
+    fun whenFilenameEndsInBinThenThatIsExtracted() {
         val url = "https://example.com/realFilename.bin"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("realFilename.bin", extracted)
+    }
+
+    @Test
+    fun whenFilenameEndsInBinWithASlashThenThatIsExtracted() {
+        val url = "https://example.com/realFilename.bin/"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("realFilename.bin", extracted)
+    }
+
+    @Test
+    fun whenFilenameContainsBinThenThatIsExtracted() {
+        val url = "https://example.com/realFilename.bin/foo/bar"
         val mimeType: String? = null
         val contentDisposition: String? = null
         val extracted = testee.extract(url, contentDisposition, mimeType)
@@ -83,7 +101,7 @@ class UriUtilsFilenameExtractorTest {
         val mimeType: String? = null
         val contentDisposition: String? = null
         val extracted = testee.extract(url, contentDisposition, mimeType)
-        assertEquals("downloadfile.bin", extracted)
+        assertEquals("downloadfile", extracted)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -83,7 +83,7 @@ class UriUtilsFilenameExtractorTest {
         val mimeType: String? = null
         val contentDisposition: String? = null
         val extracted = testee.extract(url, contentDisposition, mimeType)
-        assertEquals("foo", extracted)
+        assertEquals("foo.bin", extracted)
     }
 
     @Test
@@ -110,7 +110,7 @@ class UriUtilsFilenameExtractorTest {
         val mimeType: String? = null
         val contentDisposition: String? = null
         val extracted = testee.extract(url, contentDisposition, mimeType)
-        assertEquals("downloadfile", extracted)
+        assertEquals("downloadfile.bin", extracted)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -132,15 +132,6 @@ class UriUtilsFilenameExtractorTest {
     }
 
     @Test
-    fun whenUrlIsEmptyStringAndConflictingContentDispositionAndMimeTypeProvidedThenExtractFromContentDisposition() {
-        val url = ""
-        val mimeType: String? = "image/jpeg"
-        val contentDisposition: String? = "Content-Disposition: attachment; filename=fromDisposition.json"
-        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
-        assertEquals("fromDisposition.jpg", extracted)
-    }
-
-    @Test
     fun whenNoFilenameAndNoPathSegmentsThenDomainNameReturned() {
         val url = "http://example.com"
         val mimeType: String? = null

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -28,7 +28,7 @@ class UriUtilsFilenameExtractorTest {
         val url = "https://example.com/realFilename.jpg"
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("realFilename.jpg", extracted)
     }
 
@@ -37,7 +37,7 @@ class UriUtilsFilenameExtractorTest {
         val url = "https://foo.example.com/path/images/b/b1/realFilename.jpg/other/stuff"
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("realFilename.jpg", extracted)
     }
 
@@ -46,7 +46,7 @@ class UriUtilsFilenameExtractorTest {
         val url = "https://foo.example.com/path/images/b/b1/realFilename.jpg/other/stuff?cb=123"
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("realFilename.jpg", extracted)
     }
 
@@ -55,7 +55,7 @@ class UriUtilsFilenameExtractorTest {
         val url = "https://foo.example.com/path/images/b/b1/realFilename.jpg/other/stuff?cb=123.com"
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("realFilename.jpg", extracted)
     }
 
@@ -64,7 +64,7 @@ class UriUtilsFilenameExtractorTest {
         val url = "https://example.com/filename.jpg"
         val mimeType: String? = null
         val contentDisposition: String? = "Content-Disposition: attachment; filename=fromDisposition.jpg"
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("fromDisposition.jpg", extracted)
     }
 
@@ -73,7 +73,7 @@ class UriUtilsFilenameExtractorTest {
         val url = "https://example.com/realFilename.bin"
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("realFilename.bin", extracted)
     }
 
@@ -82,7 +82,7 @@ class UriUtilsFilenameExtractorTest {
         val url = "https://example.com/foo/bar/files"
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("foo.bin", extracted)
     }
 
@@ -91,7 +91,7 @@ class UriUtilsFilenameExtractorTest {
         val url = "https://example.com/realFilename.bin/"
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("realFilename.bin", extracted)
     }
 
@@ -100,7 +100,7 @@ class UriUtilsFilenameExtractorTest {
         val url = "https://example.com/realFilename.bin/foo/bar"
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("realFilename.bin", extracted)
     }
 
@@ -109,7 +109,7 @@ class UriUtilsFilenameExtractorTest {
         val url = ""
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("downloadfile.bin", extracted)
     }
 
@@ -118,7 +118,7 @@ class UriUtilsFilenameExtractorTest {
         val url = ""
         val mimeType: String? = "image/jpeg"
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("downloadfile.jpg", extracted)
     }
 
@@ -127,7 +127,7 @@ class UriUtilsFilenameExtractorTest {
         val url = ""
         val mimeType: String? = null
         val contentDisposition: String? = "Content-Disposition: attachment; filename=fromDisposition.jpg"
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("fromDisposition.jpg", extracted)
     }
 
@@ -136,7 +136,7 @@ class UriUtilsFilenameExtractorTest {
         val url = ""
         val mimeType: String? = "image/jpeg"
         val contentDisposition: String? = "Content-Disposition: attachment; filename=fromDisposition.json"
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("fromDisposition.jpg", extracted)
     }
 
@@ -145,7 +145,17 @@ class UriUtilsFilenameExtractorTest {
         val url = "http://example.com"
         val mimeType: String? = null
         val contentDisposition: String? = null
-        val extracted = testee.extract(url, contentDisposition, mimeType)
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("example.com", extracted)
+    }
+
+    private fun buildPendingDownload(url: String, contentDisposition: String?, mimeType: String?): FileDownloader.PendingFileDownload {
+        return FileDownloader.PendingFileDownload(
+            url = url,
+            contentDisposition = contentDisposition,
+            mimeType = mimeType,
+            subfolder = "aFolder",
+            userAgent = "aUserAgent"
+        )
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -78,6 +78,15 @@ class UriUtilsFilenameExtractorTest {
     }
 
     @Test
+    fun whenUrlContainsNoFileNameButLotsOfPathsSegmentsThenFirstSegmentNameIsUsed() {
+        val url = "https://example.com/foo/bar/files"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("foo", extracted)
+    }
+
+    @Test
     fun whenFilenameEndsInBinWithASlashThenThatIsExtracted() {
         val url = "https://example.com/realFilename.bin/"
         val mimeType: String? = null

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -132,6 +132,15 @@ class UriUtilsFilenameExtractorTest {
     }
 
     @Test
+    fun whenUrlIsEmptyStringAndConflictingContentDispositionAndMimeTypeProvidedThenExtractFromContentDisposition() {
+        val url = ""
+        val mimeType: String? = "image/jpeg"
+        val contentDisposition: String? = "Content-Disposition: attachment; filename=fromDisposition.json"
+        val extracted = testee.extract(url, contentDisposition, mimeType)
+        assertEquals("fromDisposition.jpg", extracted)
+    }
+
+    @Test
     fun whenNoFilenameAndNoPathSegmentsThenDomainNameReturned() {
         val url = "http://example.com"
         val mimeType: String? = null

--- a/app/src/main/java/com/duckduckgo/app/browser/DownloadConfirmationFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DownloadConfirmationFragment.kt
@@ -28,7 +28,6 @@ import com.duckduckgo.app.browser.downloader.FileDownloader
 import com.duckduckgo.app.browser.downloader.FileDownloader.FileDownloadListener
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import com.duckduckgo.app.browser.downloader.FilenameExtractor
-import com.duckduckgo.app.browser.downloader.guessFileName
 import com.duckduckgo.app.browser.downloader.isDataUrl
 import com.duckduckgo.app.global.view.gone
 import com.duckduckgo.app.global.view.leftDrawable
@@ -71,7 +70,7 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupDownload() {
-        file = if (!pendingDownload.isDataUrl) File(pendingDownload.directory, pendingDownload.guessFileName(filenameExtractor)) else null
+        file = if (!pendingDownload.isDataUrl) File(pendingDownload.directory, filenameExtractor.extract(pendingDownload)) else null
     }
 
     private fun setupViews(view: View) {

--- a/app/src/main/java/com/duckduckgo/app/browser/DownloadConfirmationFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DownloadConfirmationFragment.kt
@@ -27,6 +27,7 @@ import androidx.core.content.FileProvider.getUriForFile
 import com.duckduckgo.app.browser.downloader.FileDownloader
 import com.duckduckgo.app.browser.downloader.FileDownloader.FileDownloadListener
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
+import com.duckduckgo.app.browser.downloader.FilenameExtractor
 import com.duckduckgo.app.browser.downloader.guessFileName
 import com.duckduckgo.app.browser.downloader.isDataUrl
 import com.duckduckgo.app.global.view.gone
@@ -45,6 +46,9 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
 
     @Inject
     lateinit var downloader: FileDownloader
+
+    @Inject
+    lateinit var filenameExtractor: FilenameExtractor
 
     lateinit var downloadListener: FileDownloadListener
 
@@ -67,7 +71,7 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupDownload() {
-        file = if (!pendingDownload.isDataUrl) File(pendingDownload.directory, pendingDownload.guessFileName()) else null
+        file = if (!pendingDownload.isDataUrl) File(pendingDownload.directory, pendingDownload.guessFileName(filenameExtractor)) else null
     }
 
     private fun setupViews(view: View) {

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloader.kt
@@ -27,7 +27,8 @@ import javax.inject.Inject
 
 class FileDownloader @Inject constructor(
     private val dataUriDownloader: DataUriDownloader,
-    private val networkFileDownloader: NetworkFileDownloader
+    private val networkFileDownloader: NetworkFileDownloader,
+    private val filenameExtractor: FilenameExtractor
 ) {
 
     @WorkerThread
@@ -57,8 +58,8 @@ class FileDownloader @Inject constructor(
     }
 }
 
-fun FileDownloader.PendingFileDownload.guessFileName(): String {
-    val guessedFileName = URLUtil.guessFileName(url, contentDisposition, mimeType)
+fun FileDownloader.PendingFileDownload.guessFileName(filenameExtractor: FilenameExtractor): String {
+    val guessedFileName = filenameExtractor.extract(url, contentDisposition, mimeType)
     Timber.i("Guessed filename of $guessedFileName for url $url")
     return guessedFileName
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloader.kt
@@ -20,7 +20,6 @@ import android.net.Uri
 import android.os.Environment
 import android.webkit.URLUtil
 import androidx.annotation.WorkerThread
-import timber.log.Timber
 import java.io.File
 import java.io.Serializable
 import javax.inject.Inject
@@ -52,12 +51,6 @@ class FileDownloader @Inject constructor(private val dataUriDownloader: DataUriD
         fun downloadCancelled()
         fun downloadOpened()
     }
-}
-
-fun FileDownloader.PendingFileDownload.guessFileName(filenameExtractor: FilenameExtractor): String {
-    val guessedFileName = filenameExtractor.extract(url, contentDisposition, mimeType)
-    Timber.i("Guessed filename of $guessedFileName for url $url")
-    return guessedFileName
 }
 
 val FileDownloader.PendingFileDownload.isDataUrl get() = URLUtil.isDataUrl(url)

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloader.kt
@@ -25,11 +25,7 @@ import java.io.File
 import java.io.Serializable
 import javax.inject.Inject
 
-class FileDownloader @Inject constructor(
-    private val dataUriDownloader: DataUriDownloader,
-    private val networkFileDownloader: NetworkFileDownloader,
-    private val filenameExtractor: FilenameExtractor
-) {
+class FileDownloader @Inject constructor(private val dataUriDownloader: DataUriDownloader, private val networkFileDownloader: NetworkFileDownloader) {
 
     @WorkerThread
     fun download(pending: PendingFileDownload, callback: FileDownloadListener) {

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
@@ -20,6 +20,7 @@ import android.webkit.URLUtil
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.downloader.FilenameExtractor.GuessQuality.NotGoodEnough
 import com.duckduckgo.app.browser.downloader.FilenameExtractor.GuessQuality.TriedAllOptions
+import timber.log.Timber
 import javax.inject.Inject
 
 class FilenameExtractor @Inject constructor() {
@@ -46,7 +47,7 @@ class FilenameExtractor @Inject constructor() {
             guesses.bestGuess = latestGuess
         }
 
-        if (pathSegments.isEmpty()) return TriedAllOptions
+        if (pathSegments.size < 2) return TriedAllOptions
 
         return NotGoodEnough
     }
@@ -60,6 +61,7 @@ class FilenameExtractor @Inject constructor() {
             guessedFilename = guessedFilename.removeSuffix(DEFAULT_FILE_TYPE)
         }
 
+        Timber.v("From URL [$url], guessed [$guessedFilename]")
         return guessedFilename
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.downloader
+
+import android.webkit.URLUtil
+import androidx.core.net.toUri
+import com.duckduckgo.app.browser.downloader.FilenameExtractor.GuessQuality.*
+import timber.log.Timber
+import javax.inject.Inject
+
+class FilenameExtractor @Inject constructor() {
+
+    fun extract(url: String, contentDisposition: String?, mimeType: String?): String {
+        val firstGuess = guessFromUrl(url, contentDisposition, mimeType)
+        var pathSegments = pathSegments(url)
+        var bestGuess = firstGuess
+
+        while (true) {
+
+            when (determineGuessQuality(bestGuess, pathSegments)) {
+                is GoodEnough -> return bestGuess
+                is OutOfOptions -> return firstGuess
+                is NotGoodEnough -> {
+                    pathSegments = pathSegments.dropLast(1)
+                    bestGuess = guessFromUrl(pathSegments.rebuildUrl(), contentDisposition, mimeType)
+                }
+            }
+
+        }
+    }
+
+    private fun determineGuessQuality(guess: String, pathSegments: List<String>): GuessQuality {
+        Timber.v("Best guess is now $guess")
+
+        if (!guess.endsWith(DEFAULT_FILE_TYPE)) return GoodEnough
+        if (pathSegments.isEmpty()) return OutOfOptions
+
+        return NotGoodEnough
+    }
+
+    private fun guessFromUrl(url: String, contentDisposition: String?, mimeType: String?): String {
+        return URLUtil.guessFileName(url, contentDisposition, mimeType)
+    }
+
+    private fun pathSegments(url: String): List<String> {
+        val uri = url.toUri()
+        return uri.pathSegments ?: emptyList()
+    }
+
+    private fun List<String>.rebuildUrl(): String {
+        return joinToString(separator = "/")
+    }
+
+    companion object {
+        private const val DEFAULT_FILE_TYPE = ".bin"
+    }
+
+    sealed class GuessQuality {
+        object GoodEnough : GuessQuality()
+        object NotGoodEnough : GuessQuality()
+        object OutOfOptions : GuessQuality()
+    }
+
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser.downloader
 
 import android.webkit.URLUtil
 import androidx.core.net.toUri
+import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import com.duckduckgo.app.browser.downloader.FilenameExtractor.GuessQuality.NotGoodEnough
 import com.duckduckgo.app.browser.downloader.FilenameExtractor.GuessQuality.TriedAllOptions
 import timber.log.Timber
@@ -25,7 +26,11 @@ import javax.inject.Inject
 
 class FilenameExtractor @Inject constructor() {
 
-    fun extract(url: String, contentDisposition: String?, mimeType: String?): String {
+    fun extract(pendingDownload: PendingFileDownload): String {
+        val url = pendingDownload.url
+        val mimeType = pendingDownload.mimeType
+        val contentDisposition = pendingDownload.contentDisposition
+
         val firstGuess = guessFilename(url, contentDisposition, mimeType)
         val guesses = Guesses(bestGuess = null, latestGuess = firstGuess)
         val baseUrl = url.toUri().host ?: ""

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/NetworkFileDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/NetworkFileDownloader.kt
@@ -34,7 +34,7 @@ class NetworkFileDownloader @Inject constructor(private val context: Context, pr
             return
         }
 
-        val guessedFileName = pendingDownload.guessFileName(filenameExtractor)
+        val guessedFileName = filenameExtractor.extract(pendingDownload)
 
         val request = DownloadManager.Request(pendingDownload.url.toUri()).apply {
             allowScanningByMediaScanner()

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/NetworkFileDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/NetworkFileDownloader.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import javax.inject.Inject
 
-class NetworkFileDownloader @Inject constructor(private val context: Context) {
+class NetworkFileDownloader @Inject constructor(private val context: Context, private val filenameExtractor: FilenameExtractor) {
 
     fun download(pendingDownload: PendingFileDownload, callback: FileDownloader.FileDownloadListener) {
 
@@ -34,7 +34,7 @@ class NetworkFileDownloader @Inject constructor(private val context: Context) {
             return
         }
 
-        val guessedFileName = pendingDownload.guessFileName()
+        val guessedFileName = pendingDownload.guessFileName(filenameExtractor)
 
         val request = DownloadManager.Request(pendingDownload.url.toUri()).apply {
             allowScanningByMediaScanner()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1187737416677993/f
Tech Design URL: 
CC: 

**Description**:
When trying to download images, our app currently tries to guess what a good filename for the download will be, and often fails to produce something nice; it'll often end in a .*bin file type as its current implementation is somewhat naive in turning a URL into a filename.

This PR improves that situation by walking back the URL path, trying each to make a filename, and then returning the best filename produced. Worst case, this should produce the same result as the old algorithm, but best case it will pick out a much better filename.


**Steps to test this PR**:
1. Visit https://vignette3.wikia.nocookie.net/guns/images/b/b1/FHJ84.jpg/revision/latest?cb=20160824141549 and long press to download the image; verify the filename produced is `FHJ84.jpg` and not `latest.bin` as it was before
1. Try other image downloads, and verify they produce a sensible enough filename


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
