### PR TITLE
Check savestate of activity before trying to modify DialogFragment

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -66,7 +66,6 @@ import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAda
 import com.duckduckgo.app.browser.downloader.DownloadFailReason
 import com.duckduckgo.app.browser.downloader.FileDownloadNotificationManager
 import com.duckduckgo.app.browser.downloader.FileDownloader
-import com.duckduckgo.app.browser.downloader.FileDownloader.FileDownloadListener
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import com.duckduckgo.app.browser.filechooser.FileChooserIntentBuilder
 import com.duckduckgo.app.browser.logindetection.DOMLoginDetector
@@ -1131,16 +1130,14 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope, DaxDialogLi
     }
 
     private fun requestDownloadConfirmation(pendingDownload: PendingFileDownload) {
+        if (isStateSaved) return
+
         val downloadConfirmationFragment = DownloadConfirmationFragment.instance(pendingDownload)
         childFragmentManager.findFragmentByTag(DOWNLOAD_CONFIRMATION_TAG)?.let {
             Timber.i("Found existing dialog; removing it now")
-            childFragmentManager.commitNow { remove(it) }
+            childFragmentManager.commitNow(allowStateLoss = true) { remove(it) }
         }
         downloadConfirmationFragment.show(childFragmentManager, DOWNLOAD_CONFIRMATION_TAG)
-    }
-
-    private fun completeDownload(pendingDownload: PendingFileDownload, callback: FileDownloadListener) {
-        viewModel.download(pendingDownload)
     }
 
     private fun launchFilePicker(command: Command.ShowFileChooser) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1188775556223787/f
Tech Design URL: 
CC: 

**Description**:
This fixes some reported crashes when trying to show the download confirmation dialog.

**Steps to test this PR**:
I suspect it might be triggered more on slower internet and/or slower devices, and as is, isn't easy to replicate. However, a good emulation of the problem can be achieved by modifying `BrowserTabFragment.requestDownloadConfirmation`; wrap the function in a `Handler().postDelayed({})` e.g., 👇

```
 private fun requestDownloadConfirmation(pendingDownload: PendingFileDownload) {
    Handler().postDelayed({
            if (isStateSaved) return@postDelayed
            val downloadConfirmationFragment = DownloadConfirmationFragment.instance(pendingDownload)
            childFragmentManager.findFragmentByTag(DOWNLOAD_CONFIRMATION_TAG)?.let {
                Timber.i("Found existing dialog; removing it now")
                childFragmentManager.commitNow(allowStateLoss = true) { remove(it) }
            }
            downloadConfirmationFragment.show(childFragmentManager, DOWNLOAD_CONFIRMATION_TAG)
        }, 3_000)
}
```

1. Visit https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_a_download
1. Download the file by tapping on the image (note, no confirmation dialog will show first time)
1. After it's downloaded, tap the image again. Press the home button **immediately** after tapping
1. Verify the app does not crash after 3s.
1. Remove the ` if (isStateSaved) return@postDelayed` line, and repeat. This time, you should see the crash happening after 3s.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
