### PR TITLE
Avoid injecting javascript on paused webview

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1583,7 +1583,7 @@ class BrowserTabFragment : Fragment(), FindListener, CoroutineScope, DaxDialogLi
                     }
                 }
 
-                if (!viewState.isLoading) {
+                if (!viewState.isLoading && lastSeenBrowserViewState?.browserShowing == true) {
                     swipeRefreshContainer.isRefreshing = false
                     webView?.detectOverscrollBehavior()
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1186457042345566/f
Tech Design URL: 
CC: 

**Description**:
This PR tries to fix some weird behavior we detected in some emulators that lately has been reported by some users: https://github.com/duckduckgo/Android/issues/919

The issue might be related to injecting javascript on a paused webview. We will add an additional check to avoid adding javascript if user is in home screen.

**Steps to test this PR**:
The problem seems possible to be reproduced if using a pixel 2 api 29 emulator:
1. Open the app
1. Open a new tab
1. Perform a search
1. The site will not load, instead, it appears a blank page

Using this branch, the site will load correctly.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
