### PR TITLE
change icon in first permission dialog to use DAX icon and remove it'…

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/location/ui/SystemLocationPermissionDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/location/ui/SystemLocationPermissionDialog.kt
@@ -17,15 +17,11 @@
 package com.duckduckgo.app.location.ui
 
 import android.app.Dialog
-import android.net.Uri
 import android.os.Bundle
-import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.app.global.faviconLocation
-import com.duckduckgo.app.global.image.GlideApp
 import com.duckduckgo.app.global.view.websiteFromGeoLocationsApiOrigin
 import org.jetbrains.anko.find
 

--- a/app/src/main/java/com/duckduckgo/app/location/ui/SystemLocationPermissionDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/location/ui/SystemLocationPermissionDialog.kt
@@ -46,7 +46,6 @@ class SystemLocationPermissionDialog : DialogFragment() {
         val rootView = layoutInflater.inflate(R.layout.content_system_location_permission_dialog, null)
 
         val subtitle = rootView.find<TextView>(R.id.systemPermissionDialogSubtitle)
-        val favicon = rootView.find<ImageView>(R.id.faviconImage)
         val allowLocationPermission = rootView.find<TextView>(R.id.allowLocationPermission)
         val denyLocationPermission = rootView.find<TextView>(R.id.denyLocationPermission)
         val neverAllowLocationPermission = rootView.find<TextView>(R.id.neverAllowLocationPermission)
@@ -56,7 +55,6 @@ class SystemLocationPermissionDialog : DialogFragment() {
 
         validateBundleArguments()
         populateSubtitle(subtitle)
-        populateFavicon(favicon)
         configureListeners(allowLocationPermission, denyLocationPermission, neverAllowLocationPermission)
 
         return alertBuilder.create()
@@ -75,18 +73,6 @@ class SystemLocationPermissionDialog : DialogFragment() {
             val originUrl = args.getString(KEY_REQUEST_ORIGIN)!!.websiteFromGeoLocationsApiOrigin()
             val subtitle = getString(R.string.preciseLocationSystemDialogSubtitle, originUrl, originUrl)
             view.text = subtitle
-        }
-    }
-
-    private fun populateFavicon(imageView: ImageView) {
-        arguments?.let { args ->
-            val originUrl = args.getString(KEY_REQUEST_ORIGIN)
-            val faviconUrl = Uri.parse(originUrl).faviconLocation()
-
-            GlideApp.with(requireContext())
-                .load(faviconUrl)
-                .error(R.drawable.ic_globe_gray_16dp)
-                .into(imageView)
         }
     }
 

--- a/app/src/main/res/layout/content_system_location_permission_dialog.xml
+++ b/app/src/main/res/layout/content_system_location_permission_dialog.xml
@@ -20,71 +20,64 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
+    android:background="?toolbarBgColor"
     android:gravity="center"
-    android:background="?toolbarBgColor">
+    android:orientation="vertical">
 
-        <FrameLayout
-            android:id="@+id/systemPermissionDialogFaviconContainer"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_marginTop="24dp"
-            android:background="@drawable/subtle_favicon_background"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+    <ImageView
+        android:id="@+id/faviconImage"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginTop="24dp"
+        android:layout_gravity="center"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_dax_icon"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-                <ImageView
-                    android:id="@+id/faviconImage"
-                    android:layout_width="22dp"
-                    android:layout_height="22dp"
-                    android:layout_gravity="center"
-                    android:importantForAccessibility="no"
-                    android:src="@drawable/ic_globe_gray_16dp" />
-        </FrameLayout>
+    <TextView
+        android:id="@+id/systemPermissionDialogTitle"
+        style="@style/LocationPermissionDialogTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/preciseLocationSystemDialogTitle" />
 
-        <TextView
-            android:id="@+id/systemPermissionDialogTitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="@style/LocationPermissionDialogTitle"
-            android:layout_marginTop="16dp"
-            android:text="@string/preciseLocationSystemDialogTitle" />
+    <TextView
+        android:id="@+id/systemPermissionDialogSubtitle"
+        style="@style/LocationPermissionDialogSubtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="24dp"
+        android:text="@string/preciseLocationSystemDialogSubtitle" />
 
-        <TextView
-            android:id="@+id/systemPermissionDialogSubtitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="@style/LocationPermissionDialogSubtitle"
-            android:layout_marginTop="12dp"
-            android:layout_marginBottom="24dp"
-            android:text="@string/preciseLocationSystemDialogSubtitle" />
+    <View style="@style/LocationPermissionDialogSplitter" />
 
-        <View style="@style/LocationPermissionDialogSplitter" />
+    <Button
+        android:id="@+id/allowLocationPermission"
+        style="@style/LocationPermissionDialogButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/preciseLocationSystemDialogAllow" />
 
-        <Button
-            android:id="@+id/allowLocationPermission"
-            style="@style/LocationPermissionDialogButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSystemDialogAllow" />
+    <View style="@style/LocationPermissionDialogSplitter" />
 
-        <View style="@style/LocationPermissionDialogSplitter" />
+    <Button
+        android:id="@+id/denyLocationPermission"
+        style="@style/LocationPermissionDialogButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/preciseLocationSystemDialogDeny" />
 
-        <Button
-            android:id="@+id/denyLocationPermission"
-            style="@style/LocationPermissionDialogButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSystemDialogDeny" />
+    <View style="@style/LocationPermissionDialogSplitter" />
 
-        <View style="@style/LocationPermissionDialogSplitter" />
-
-        <Button
-            android:id="@+id/neverAllowLocationPermission"
-            style="@style/LocationPermissionDialogButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSystemDialogNeverAllow" />
+    <Button
+        android:id="@+id/neverAllowLocationPermission"
+        style="@style/LocationPermissionDialogButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/preciseLocationSystemDialogNeverAllow" />
 
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1192902318004122

**Description**:
After releasing the project we think that the first dialog could be improved by swapping the site icon for the dax icon. We will also get rid of the shadow around the icon.

**Steps to test this PR**:
1. Install app from Play Store
2. Navigate to homedepot.com
3. The permission dialog should appear and homedepot.com favicon should be shown in the dialog

1. Install apk from this branch
2. Navigate to homedepot.com
3. The permission dialog should appear and the app ico should be shown in the dialog

**Screenshots**:
| Before  | Afterl |
| ------ | ----- | 
![Screenshot_20200906-112513_DuckDuckGo (2)](https://user-images.githubusercontent.com/531613/92569243-a66b3180-f280-11ea-903b-4926c4035da2.jpg)|![device-2020-09-08-150413](https://user-images.githubusercontent.com/531613/92569051-5f7d3c00-f280-11ea-8662-a013dcdcf7d5.png)|


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
