### PR TITLE
Add comment to explain why we preserve DuckDuckGo cookies

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/DuckDuckGoCookieManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DuckDuckGoCookieManager.kt
@@ -39,11 +39,10 @@ class WebViewCookieManager(
         withContext(dispatcher.io()) {
             flush()
         }
-        // We preserve DuckDuckGo cookies when the fire button is used to keep the previously DuckDuckGo Search Engine Result Pages settings set
-        // by the user. Removing these cookies would reset them and have undesired consequences, i.e. changing the theme, default language, etc.
-        // At DuckDuckGo, no cookies are used by default. If you have changed any settings, then cookies are used to store those changes.
-        // However, in that case, they are not stored in a personally identifiable way. For example, the large size setting is stored as 's=l';
-        // no unique identifier is in there. More info in https://duckduckgo.com/privacy
+        // The Fire Button does not delete the user's DuckDuckGo search settings, which are saved as cookies.
+        // Removing these cookies would reset them and have undesired consequences, i.e. changing the theme, default language, etc.
+        // These cookies are not stored in a personally identifiable way. For example, the large size setting is stored as 's=l.'
+        // More info in https://duckduckgo.com/privacy
         val ddgCookies = getDuckDuckGoCookies()
         if (cookieManager.hasCookies()) {
             removeCookies.removeCookies()

--- a/app/src/main/java/com/duckduckgo/app/fire/DuckDuckGoCookieManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DuckDuckGoCookieManager.kt
@@ -39,6 +39,11 @@ class WebViewCookieManager(
         withContext(dispatcher.io()) {
             flush()
         }
+        // We preserve DuckDuckGo cookies when the fire button is used to keep the previously DuckDuckGo Search Engine Result Pages settings set
+        // by the user. Removing these cookies would reset them and have undesired consequences, i.e. changing the theme, default language, etc.
+        // At DuckDuckGo, no cookies are used by default. If you have changed any settings, then cookies are used to store those changes.
+        // However, in that case, they are not stored in a personally identifiable way. For example, the large size setting is stored as 's=l';
+        // no unique identifier is in there. More info in https://duckduckgo.com/privacy
         val ddgCookies = getDuckDuckGoCookies()
         if (cookieManager.hasCookies()) {
             removeCookies.removeCookies()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1192531917430354
Tech Design URL: 
CC: 

**Description**:
This PR adds a comment to explain why we preserve DuckDuckGo cookies when using the fire button.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
