### PR TITLE
Add region filter to SERP experiments

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -43,8 +43,8 @@ interface VariantManager {
         val ACTIVE_VARIANTS = listOf(
             // SERP variants. "sc" may also be used as a shared control for mobile experiments in
             // the future if we can filter by app version
-            Variant(key = "sc", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "se", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "sc", weight = 1.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
+            Variant(key = "se", weight = 1.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
 
             // Single Search Bar Experiments
             Variant(key = "zg", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
@@ -65,6 +65,22 @@ interface VariantManager {
             Variant(RESERVED_EU_AUCTION_VARIANT, features = emptyList(), filterBy = { noFilter() })
         )
 
+        private val serpRegionToggleTargetCountries = listOf (
+            "AU",
+            "AT",
+            "DK",
+            "FI",
+            "FR",
+            "DE",
+            "IT",
+            "IE",
+            "NZ",
+            "NO",
+            "ES",
+            "SE",
+            "GB"
+        )
+
         fun referrerVariant(key: String): Variant {
             val knownReferrer = REFERRER_VARIANTS.firstOrNull { it.key == key }
             return knownReferrer ?: Variant(key, features = emptyList(), filterBy = { noFilter() })
@@ -75,6 +91,11 @@ interface VariantManager {
         private fun isEnglishLocale(): Boolean {
             val locale = Locale.getDefault()
             return locale != null && locale.language == "en"
+        }
+
+        private fun isSerpRegionToggleCountry(): Boolean {
+            val locale = Locale.getDefault()
+            return locale != null && serpRegionToggleTargetCountries.contains(locale.country)
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/500019618144197/1171576252605602

**Description**:
Add regions listed in 

**Steps to test this PR**:
1. Go to VariantManager.kt and comment out all variants other than "sc" and "se"

1. On your device, go to Settings, Languages and Input and add a new locale e.g Spanish in Spain
1. Install a fresh version of the app and ensure that se or sc variants are selected
1. No go to Settings -> Languages and Input and switch to English US
1. Install a fresh version of the app and ensure that no variant is selected


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
