### PR TITLE
Add schema to host when retrieving and storing cookies

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -168,7 +168,7 @@ class BrowserModule {
         removeCookies: RemoveCookies,
         dispatcherProvider: DispatcherProvider
     ): DuckDuckGoCookieManager {
-        return WebViewCookieManager(cookieManager, AppUrl.Url.HOST, removeCookies, dispatcherProvider)
+        return WebViewCookieManager(cookieManager, AppUrl.Url.COOKIES, removeCookies, dispatcherProvider)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/AppUrl.kt
@@ -22,6 +22,7 @@ class AppUrl {
         const val HOST = "duckduckgo.com"
         const val API = "https://$HOST"
         const val HOME = "https://$HOST"
+        const val COOKIES = "https://$HOST"
         const val ABOUT = "https://$HOST/about"
         const val TOSDR = "https://tosdr.org"
         const val PIXEL = "https://improving.duckduckgo.com"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1177278105868185
Tech Design URL: 
CC: 

**Description**:
In Chromium 84 a change was introduce to add SameSite cookies. This triggered a change in the frontend to always set the secure flag whenever the protocol is https. 
Because of that change we are not able to fetch DDG settings cookies anymore and preserve them.

If possible test with different Chromium versions. We know we can't fetch secure cookies on older Chromium versions, i.e. 57 but it should work on newer ones (i.e. 80, 81, 82...)

**Steps to test this PR**:
1. Go to SERP.
1. Change the theme to dark.
1. Use the fire button.
1. Go back to SERP.
1. Dark theme should still be applied.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
