### PR TITLE
Feature/david/location permissions improvements

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -975,12 +975,8 @@ class BrowserTabViewModel(
 
     override fun onSystemLocationPermissionNeverAllowed() {
         locationPermission?.let { locationPermission ->
-            val neverAllowedPermission = LocationPermissionType.DENY_ALWAYS
-            onSiteLocationPermissionSelected(locationPermission.origin, neverAllowedPermission)
+            onSiteLocationPermissionSelected(locationPermission.origin, LocationPermissionType.DENY_ALWAYS)
             pixel.fire(Pixel.PixelName.PRECISE_LOCATION_SYSTEM_DIALOG_NEVER)
-            viewModelScope.launch {
-                locationPermissionsRepository.savePermission(locationPermission.origin, neverAllowedPermission)
-            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/location/GeoLocationPermissionsManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/location/GeoLocationPermissionsManager.kt
@@ -68,14 +68,12 @@ class GeoLocationPermissionsManager @Inject constructor(
     }
 
     override suspend fun clearAllButFireproofed() {
-        withContext(dispatchers.io()) {
-            val geolocationPermissions = GeolocationPermissions.getInstance()
-            val permissions = permissionsRepository.getLocationPermissionsSync()
-            permissions.forEach {
-                if (!fireproofWebsiteRepository.isDomainFireproofed(it.domain)) {
-                    geolocationPermissions.clear(it.domain)
-                    permissionsRepository.deletePermission(it.domain)
-                }
+        val geolocationPermissions = GeolocationPermissions.getInstance()
+        val permissions = permissionsRepository.getLocationPermissionsSync()
+        permissions.forEach {
+            if (!fireproofWebsiteRepository.isDomainFireproofed(it.domain)) {
+                geolocationPermissions.clear(it.domain)
+                permissionsRepository.deletePermission(it.domain)
             }
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/duckduckgo/Android/issues/936

Task/Issue URL: https://app.asana.com/0/1157893581871903/1195578388698637
Task/Issue URL: https://app.asana.com/0/1157893581871903/1195559416160171

**Description**:
This PR fixes two code smells introduced as part of the Precise Location project:
1. When the user chose to always deny system permission we were inserting the option twice in the db (thanks for finding that @marcosholgado )
2. There was an unnecessary coroutine children created when removing permission from the `GeolocationPermissionsManager`. 
