### PR TITLE
Don't send https update service pixels when local filter is reloading.

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -97,7 +97,7 @@ class HttpsUpgraderImpl(
             } else {
                 pixel.fire(if (serviceUpgradeResult.isCached) HTTPS_SERVICE_CACHE_NO_UPGRADE else HTTPS_SERVICE_REQUEST_NO_UPGRADE)
             }
-        } 
+        }
         Timber.d("$host ${if (serviceUpgradeResult.isUpgradable) "is" else "is not"} service upgradable")
         return serviceUpgradeResult.isUpgradable
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1195088920676367

**Description**:
Don't send https upgrade service pixels when local filter is reloading as doing so inflates service percentage when in reality the item may exist in local filter. This is a temporary change to get better percentages, a PR to remove service altogether is already implemented on another branch and will be released soon.

**Steps to test this PR**:
**TEST ONE: Service pixel fires when local filter loaded**
1. Run the app give it a few seconds to let everything load (if it's a fresh install allow it to download all the config)
1. Make up a super long random url that won't be in the https upgrade list e.g `http://abclksdfhsdjfadhsjfgakfgdshfgdshjfgdsfdfdsfgjfgdsjfgf.com`
1. Note from the console that a service pixel fires `m_https_srn`

**TEST TWO: Service pixel doesn't fires when local filter reloading**
1. Add a massive sleep delay to the Https reload lock in `HttpsUpgrader.kt`
```
override fun reloadData() {
    localDataReloadLock.lock()
    Thread.sleep(50000)
 ```
1. Run the app and again use a super long random url that won't be in the https upgrade list e.g `http://abclksdfhsdjfadhsjfgakfgdshfgdshjfgdsfdfdsfgjfgdsjfgf.com`
1. Note from the console that the `m_https_srn` pixel does not fire this time

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
