### PR TITLE
Fix copy substitutions in other languages

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -38,7 +38,6 @@ import kotlinx.android.synthetic.main.include_cta_buttons.view.*
 import kotlinx.android.synthetic.main.include_cta_content.view.*
 import kotlinx.android.synthetic.main.include_dax_dialog_cta.view.*
 import kotlinx.android.synthetic.main.include_top_cta.view.*
-import java.util.*
 
 interface DialogCta {
     fun createCta(activity: FragmentActivity): DaxDialog
@@ -221,24 +220,12 @@ sealed class DaxDialogCta(
             return if (isFromSameNetworkDomain()) {
                 context.resources.getString(R.string.daxMainNetworkCtaText, network, percentage, network)
             } else {
-                val locale = Locale.getDefault()
-                if (locale != null && locale.language == "en") {
-                    context.resources.getString(
-                        R.string.daxMainNetworkOwnedCtaText,
-                        network,
-                        Uri.parse(siteHost).baseHost?.removePrefix("m."),
-                        network
-                    )
-                } else {
-                    context.resources.getString(
-                        R.string.daxMainNetworkOwnedCtaText,
-                        Uri.parse(siteHost).baseHost?.removePrefix("m.")?.capitalize(Locale.getDefault()),
-                        network,
-                        network,
-                        percentage,
-                        network
-                    )
-                }
+                context.resources.getString(
+                    R.string.daxMainNetworkOwnedCtaText,
+                    network,
+                    Uri.parse(siteHost).baseHost?.removePrefix("m."),
+                    network
+                )
             }
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1197140896017476
Tech Design URL: 
CC: 

**Description**:
A while ago in https://github.com/duckduckgo/Android/pull/907 we added an if/else statement while waiting for translations. However in https://github.com/duckduckgo/Android/pull/929 we never removed that if/else statement and the substitutions in one dialog are wrong.

**Steps to test this PR**:
1. Change the language of your phone to Spanish.
1. Install the app and go to `instagram.com`
1. The copy should say `Facebook es el dueño de instagram.com` where before it was saying `instagram.com es el dueño de Facebook`


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
