### PR TITLE
Remove deprecated method from database tests

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/db/AppDatabaseTest.kt
@@ -16,45 +16,32 @@
 
 package com.duckduckgo.app.global.db
 
-import android.content.ContentValues
 import android.content.Context
 import android.content.SharedPreferences
-import android.database.sqlite.SQLiteDatabase
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.room.Room
 import androidx.room.migration.Migration
 import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.blockingObserve
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
-import com.duckduckgo.app.global.exception.UncaughtExceptionEntity
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource
 import com.duckduckgo.app.onboarding.store.AppStage
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-@ExperimentalCoroutinesApi
 class AppDatabaseTest {
 
     @get:Rule
     @Suppress("unused")
     var instantTaskExecutorRule = InstantTaskExecutorRule()
-
-    @get:Rule
-    @Suppress("unused")
-    val coroutineRule = CoroutineTestRule()
 
     @get:Rule
     val testHelper = MigrationTestHelper(getInstrumentation(), AppDatabase::class.qualifiedName, FrameworkSQLiteOpenHelperFactory())
@@ -85,8 +72,16 @@ class AppDatabaseTest {
     fun whenMigratingFromVersion2To3ThenOldLeaderboardDataIsDeleted() {
         testHelper.createDatabase(TEST_DB_NAME, 2).use {
             it.execSQL("INSERT INTO `network_leaderboard` VALUES ('Network2', 'example.com')")
+
+            testHelper.runMigrationsAndValidate(TEST_DB_NAME, 3, true, migrationsProvider.MIGRATION_2_TO_3)
+
+            val count = it.query("SELECT COUNT() FROM network_leaderboard").run {
+                moveToNext()
+                getInt(0)
+            }
+
+            assertEquals(0, count)
         }
-        assertTrue(database().networkLeaderboardDao().trackerNetworkLeaderboard().blockingObserve()!!.isEmpty())
     }
 
     @Test
@@ -101,22 +96,36 @@ class AppDatabaseTest {
 
     @Test
     fun whenMigratingFromVersion4To5ThenUpdatePositionsOfStoredTabs() {
-
         testHelper.createDatabase(TEST_DB_NAME, 4).use {
             it.execSQL("INSERT INTO `tabs` values ('tabid1', 'url', 'title') ")
             it.execSQL("INSERT INTO `tabs` values ('tabid2', 'url', 'title') ")
-        }
 
-        assertEquals(0, database().tabsDao().tabs()[0].position)
-        assertEquals(1, database().tabsDao().tabs()[1].position)
+            testHelper.runMigrationsAndValidate(TEST_DB_NAME, 5, true, migrationsProvider.MIGRATION_4_TO_5)
+
+            it.query("SELECT position FROM tabs ORDER BY position").apply {
+                moveToNext()
+                assertEquals(0, getInt(0))
+                moveToNext()
+                assertEquals(1, getInt(0))
+            }
+        }
     }
 
     @Test
     fun whenMigratingFromVersion4To5ThenTabsAreConsideredViewed() {
         testHelper.createDatabase(TEST_DB_NAME, 4).use {
+
             it.execSQL("INSERT INTO `tabs` values ('tabid1', 'url', 'title') ")
+
+            testHelper.runMigrationsAndValidate(TEST_DB_NAME, 5, true, migrationsProvider.MIGRATION_4_TO_5)
+
+            val viewed = it.query("SELECT viewed FROM tabs ORDER BY position").run {
+                moveToFirst()
+                getInt(0) > 0
+            }
+
+            assertTrue(viewed)
         }
-        assertTrue(database().tabsDao().tabs()[0].viewed)
     }
 
     @Test
@@ -157,9 +166,18 @@ class AppDatabaseTest {
     @Test
     fun whenMigratingFromVersion11To12ThenTabsDoNotSkipHome() {
         testHelper.createDatabase(TEST_DB_NAME, 11).use {
+
             it.execSQL("INSERT INTO `tabs` values ('tabid1', 'url', 'title', 1, 0) ")
+
+            testHelper.runMigrationsAndValidate(TEST_DB_NAME, 12, true, migrationsProvider.MIGRATION_11_TO_12)
+
+            val skipHome = it.query("SELECT skipHome FROM tabs ORDER BY position").run {
+                moveToFirst()
+                getInt(0) > 0
+            }
+
+            assertFalse(skipHome)
         }
-        assertFalse(database().tabsDao().tabs()[0].skipHome)
     }
 
     @Test
@@ -193,7 +211,7 @@ class AppDatabaseTest {
     }
 
     @Test
-    fun whenMigratingFromVersion17To18IfUserDidNotSeeOnboardingThenMigrateToNew() = coroutineRule.runBlocking {
+    fun whenMigratingFromVersion17To18IfUserDidNotSeeOnboardingThenMigrateToNew() {
         givenUserNeverSawOnboarding()
         val database = createDatabaseAndMigrate(17, 18, migrationsProvider.MIGRATION_17_TO_18)
         val stage = getUserStage(database)
@@ -210,15 +228,24 @@ class AppDatabaseTest {
 
     @Test
     fun whenMigratingFromVersion18To19ThenValidationSucceedsAndRowsDeletedFromTable() {
-        database().uncaughtExceptionDao().add(UncaughtExceptionEntity(1, UncaughtExceptionSource.GLOBAL, "version", 1234))
-        createDatabaseAndMigrate(18, 19, migrationsProvider.MIGRATION_18_TO_19)
-        assertEquals(0, database().uncaughtExceptionDao().count())
+        testHelper.createDatabase(TEST_DB_NAME, 18).use {
+
+            it.execSQL("INSERT INTO `UncaughtExceptionEntity` values (1, '${UncaughtExceptionSource.GLOBAL.name}', 'message') ")
+
+            testHelper.runMigrationsAndValidate(TEST_DB_NAME, 19, true, migrationsProvider.MIGRATION_18_TO_19)
+
+            val count = it.query("SELECT COUNT() FROM UncaughtExceptionEntity").run {
+                moveToFirst()
+                getInt(0)
+            }
+
+            assertEquals(0, count)
+        }
     }
 
     @Test
     fun whenMigratingFromVersion19To20ThenValidationSucceeds() {
         createDatabaseAndMigrate(19, 20, migrationsProvider.MIGRATION_19_TO_20)
-        assertEquals(0, database().uncaughtExceptionDao().count())
     }
 
     @Test
@@ -260,15 +287,18 @@ class AppDatabaseTest {
         }
     }
 
-    private fun givenUserStageIs(database: SupportSQLiteDatabase, appStage: AppStage) {
-        val values: ContentValues = ContentValues().apply {
-            put("key", 1)
-            put("appStage", appStage.name)
-        }
+    @Test
+    fun whenMigratingFromVersion23To24ThenValidationSucceeds() {
+        createDatabaseAndMigrate(23, 24, migrationsProvider.MIGRATION_23_TO_24)
+    }
 
-        database.apply {
-            insert("userStage", SQLiteDatabase.CONFLICT_REPLACE, values)
-        }
+    @Test
+    fun whenMigratingFromVersion24To25ThenValidationSucceeds() {
+        createDatabaseAndMigrate(24, 25, migrationsProvider.MIGRATION_24_TO_25)
+    }
+
+    private fun givenUserStageIs(database: SupportSQLiteDatabase, appStage: AppStage) {
+        database.execSQL("INSERT INTO `userStage` values (1, '${appStage.name}') ")
     }
 
     private fun getUserStage(database: SupportSQLiteDatabase): String {
@@ -279,16 +309,6 @@ class AppDatabaseTest {
             stage = getString(0)
         }
         return stage
-    }
-
-    @Test
-    fun whenMigratingFromVersion23To24ThenValidationSucceeds() {
-        createDatabaseAndMigrate(23, 24, migrationsProvider.MIGRATION_23_TO_24)
-    }
-
-    @Test
-    fun whenMigratingFromVersion24To25ThenValidationSucceeds() {
-        createDatabaseAndMigrate(24, 25, migrationsProvider.MIGRATION_24_TO_25)
     }
 
     private fun createDatabase(version: Int) {
@@ -302,19 +322,6 @@ class AppDatabaseTest {
     private fun createDatabaseAndMigrate(originalVersion: Int, newVersion: Int, vararg migrations: Migration): SupportSQLiteDatabase {
         createDatabase(originalVersion)
         return runMigrations(newVersion, *migrations)
-    }
-
-    @Deprecated("Don't use anymore, instead execute a query directly to the database, see getUserStage as an example. Using this methods runs all the migrations using the latest schema version and cannot be used to validate intermediate migrations")
-    private fun database(): AppDatabase {
-        val database = Room
-            .databaseBuilder(getInstrumentation().targetContext, AppDatabase::class.java, TEST_DB_NAME)
-            .addMigrations(*migrationsProvider.ALL_MIGRATIONS.toTypedArray())
-            .allowMainThreadQueries()
-            .build()
-
-        testHelper.closeWhenFinished(database)
-
-        return database
     }
 
     private fun givenSharedPreferencesEmpty() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1182726235746673
Tech Design URL: 
CC: 

**Description**:
We have historically used the database() function to validate some migrations, however that function executes all the migrations to the latest schema version which invalidates any intermediate steps.

We deprecated that method a while ago and this PR removes all of its usages.

**Steps to test this PR**:
1. Run the App Database Tests
1. Tests pass


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
