### PR TITLE
Added support - NFC tags

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.NFC"/>
 
     <application
         android:name="com.duckduckgo.app.global.DuckDuckGoApplication"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.NFC"/>
 
     <application
         android:name="com.duckduckgo.app.global.DuckDuckGoApplication"
@@ -213,6 +214,17 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+
+            <!-- Allow app to be opened using an NFC tag -->
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+            </intent-filter>
+
         </activity>
 
         <activity


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/851
Tech Design URL: N/A
CC: 

**Description**:
On scanning an NFC tag that holds web URL, the DuckDuckGo Android app was unable able to open the URL. This PR now fixes that issue. I needed to set up a new `<intent-filter>` in `Manifest.xml`, that would look for `android.nfc.action.NDEF_DISCOVERED`.

**Steps to test this PR**:
1. Ideally should be tested using an NFC tag that holds a web URL.

2. I tested my changes by building another small application that sends a `android.nfc.action.NDEF_DISCOVERED` intent, thus mocking a physical NFC tag. I used the following code snippet to achieve this - 
```
                Intent intent = new Intent();
                intent.setAction("android.nfc.action.NDEF_DISCOVERED");
                intent.setData(Uri.parse("https://www.example.com"));
                startActivity(intent);
```
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
