### PR TITLE
Fixed toolbar issue with RTL #961

### DIFF
--- a/app/src/main/res/layout/view_tab_switcher_button.xml
+++ b/app/src/main/res/layout/view_tab_switcher_button.xml
@@ -22,7 +22,6 @@
         android:id="@+id/tabCount"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
         android:textAlignment="center"
         android:textColor="?toolbarIconColor"
         android:textSize="12sp"


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/961
Tech Design URL: N/A
CC: 

**Description**:
Switcher button is not visible on RTL language

**Steps to test this PR**:
1. Use RTL language or RTL developer mode.
2. Run app and try to open new tab.
3. The switcher button Is not visible.

**Overview**:
Before changes toolbar layout:
<img width="356" alt="Screenshot 2020-10-07 at 20 58 44" src="https://user-images.githubusercontent.com/18151158/95382542-b444be80-08e1-11eb-8259-e89fb3a9aca6.png">

After changes toolbar layout:
<img width="359" alt="Screenshot 2020-10-07 at 20 57 22" src="https://user-images.githubusercontent.com/18151158/95382560-b9a20900-08e1-11eb-9b85-e60e3115d6be.png">

Layout inspector:
![Screenshot 2020-10-07 at 20 44 06](https://user-images.githubusercontent.com/18151158/95382615-cf173300-08e1-11eb-981c-2a41eba972eb.png)


