### PR TITLE
Show Location Permission message only once

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2687,21 +2687,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun bla() = coroutineRule.runBlocking {
-        val domain = "http://example.com"
-
-        givenCurrentSite(domain)
-        givenDeviceLocationSharingIsEnabled(true)
-        givenLocationPermissionIsEnabled(true)
-
-        testee.onSiteLocationPermissionSelected(domain, LocationPermissionType.ALLOW_ALWAYS)
-
-        loadUrl(domain, isBrowserShowing = true)
-
-        assertCommandNotIssued<Command.ShowDomainHasPermissionMessage>()
-    }
-
-    @Test
     fun whenSystemLocationPermissionIsDeniedThenSiteLocationPermissionIsAlwaysDenied() = coroutineRule.runBlocking {
         val domain = "https://www.example.com/"
         givenDeviceLocationSharingIsEnabled(true)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2677,9 +2677,26 @@ class BrowserTabViewModelTest {
         givenDeviceLocationSharingIsEnabled(true)
         givenLocationPermissionIsEnabled(true)
 
-        testee.setDomainHasLocationPermissionShown(domain)
+        loadUrl("https://www.example.com", isBrowserShowing = true)
+
+        assertCommandIssued<Command.ShowDomainHasPermissionMessage>()
 
         loadUrl("https://www.example.com", isBrowserShowing = true)
+
+        assertCommandIssuedTimes<Command.ShowDomainHasPermissionMessage>(1)
+    }
+
+    @Test
+    fun bla() = coroutineRule.runBlocking {
+        val domain = "http://example.com"
+
+        givenCurrentSite(domain)
+        givenDeviceLocationSharingIsEnabled(true)
+        givenLocationPermissionIsEnabled(true)
+
+        testee.onSiteLocationPermissionSelected(domain, LocationPermissionType.ALLOW_ALWAYS)
+
+        loadUrl(domain, isBrowserShowing = true)
 
         assertCommandNotIssued<Command.ShowDomainHasPermissionMessage>()
     }
@@ -2997,6 +3014,11 @@ class BrowserTabViewModelTest {
     private inline fun <reified T : Command> assertCommandNotIssued() {
         val issuedCommand = commandCaptor.allValues.find { it is T }
         assertNull(issuedCommand)
+    }
+
+    private inline fun <reified T : Command> assertCommandIssuedTimes(times: Int) {
+        val timesIssued = commandCaptor.allValues.count { it is T }
+        assertEquals(times, timesIssued)
     }
 
     private fun pixelParams(showedBookmarks: Boolean, bookmarkCapable: Boolean) = mapOf(

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2687,6 +2687,21 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserSelectsPermissionAndRefreshesPageThenLocationMessageIsNotShown() = coroutineRule.runBlocking {
+        val domain = "http://example.com"
+
+        givenCurrentSite(domain)
+        givenDeviceLocationSharingIsEnabled(true)
+        givenLocationPermissionIsEnabled(true)
+
+        testee.onSiteLocationPermissionSelected(domain, LocationPermissionType.ALLOW_ALWAYS)
+
+        loadUrl(domain, isBrowserShowing = true)
+
+        assertCommandNotIssued<Command.ShowDomainHasPermissionMessage>()
+    }
+
+    @Test
     fun whenSystemLocationPermissionIsDeniedThenSiteLocationPermissionIsAlwaysDenied() = coroutineRule.runBlocking {
         val domain = "https://www.example.com/"
         givenDeviceLocationSharingIsEnabled(true)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2669,6 +2669,22 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserRefreshesASiteLocationMessageIsNotShownAgain() = coroutineRule.runBlocking {
+        val domain = "https://www.example.com/"
+
+        givenUserAlreadySelectedPermissionForDomain(domain, LocationPermissionType.ALLOW_ALWAYS)
+        givenCurrentSite(domain)
+        givenDeviceLocationSharingIsEnabled(true)
+        givenLocationPermissionIsEnabled(true)
+
+        testee.setDomainHasLocationPermissionShown(domain)
+
+        loadUrl("https://www.example.com", isBrowserShowing = true)
+
+        assertCommandNotIssued<Command.ShowDomainHasPermissionMessage>()
+    }
+
+    @Test
     fun whenSystemLocationPermissionIsDeniedThenSiteLocationPermissionIsAlwaysDenied() = coroutineRule.runBlocking {
         val domain = "https://www.example.com/"
         givenDeviceLocationSharingIsEnabled(true)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -866,7 +866,7 @@ class BrowserTabViewModel(
         val permissionEntity = locationPermissionsRepository.getDomainPermission(domain)
         permissionEntity?.let {
             if (it.permission == LocationPermissionType.ALLOW_ALWAYS) {
-                if (!locationPermissionMessages.containsKey(domain)){
+                if (!locationPermissionMessages.containsKey(domain)) {
                     setDomainHasLocationPermissionShown(domain)
                     command.postValue(ShowDomainHasPermissionMessage(domain))
                 }
@@ -875,7 +875,7 @@ class BrowserTabViewModel(
     }
 
     @VisibleForTesting
-    fun setDomainHasLocationPermissionShown(domain: String){
+    fun setDomainHasLocationPermissionShown(domain: String) {
         locationPermissionMessages[domain] = true
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -874,8 +874,7 @@ class BrowserTabViewModel(
         }
     }
 
-    @VisibleForTesting
-    fun setDomainHasLocationPermissionShown(domain: String) {
+    private fun setDomainHasLocationPermissionShown(domain: String) {
         locationPermissionMessages[domain] = true
     }
 
@@ -991,6 +990,7 @@ class BrowserTabViewModel(
             when (permission) {
                 LocationPermissionType.ALLOW_ALWAYS -> {
                     onSiteLocationPermissionAlwaysAllowed()
+                    setDomainHasLocationPermissionShown(domain)
                     pixel.fire(PixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
                     viewModelScope.launch {
                         locationPermissionsRepository.savePermission(domain, permission)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -300,6 +300,7 @@ class BrowserTabViewModel(
         get() = site?.title
 
     private var locationPermission: LocationPermission? = null
+    private val locationPermissionMessages: MutableMap<String, Boolean> = mutableMapOf()
 
     private val autoCompletePublishSubject = PublishRelay.create<String>()
     private val fireproofWebsiteState: LiveData<List<FireproofWebsiteEntity>> = fireproofWebsiteRepository.getFireproofWebsites()
@@ -865,9 +866,17 @@ class BrowserTabViewModel(
         val permissionEntity = locationPermissionsRepository.getDomainPermission(domain)
         permissionEntity?.let {
             if (it.permission == LocationPermissionType.ALLOW_ALWAYS) {
-                command.postValue(ShowDomainHasPermissionMessage(domain))
+                if (!locationPermissionMessages.containsKey(domain)){
+                    setDomainHasLocationPermissionShown(domain)
+                    command.postValue(ShowDomainHasPermissionMessage(domain))
+                }
             }
         }
+    }
+
+    @VisibleForTesting
+    fun setDomainHasLocationPermissionShown(domain: String){
+        locationPermissionMessages[domain] = true
     }
 
     private fun urlUpdated(url: String) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1198881849371917

**Description**:
In a previous release, we allowed sites to request the user's location. In order to remind our users that a site has location permission, we show a Toast indicating it. 

However, this Toast is very repetitive, because every time the site is refreshed this message appears again. This is particularly intrusive in sites that are refreshed often, like our SERP.

This PR fixes this, making sure that the message is only shown once per tab life span. Closing the tab and open another will prompt this message once.

**Steps to test this PR**:

***In current version in Production:***
1. Open app
2. Search for "Restaurants near me" in our SERP
3. Enable Precise Location
4. Allow system permission
5. Allow permission "Always" (Choosing only once this session will not show the Toast)
6. Refresh page
7. Toast should be shown
8. Refresh page
9. Toast should be shown

***In this branch***
1. Open app
2. Search for "Restaurants near me" in our SERP
3. Enable Precise Location
4. Allow system permission
5. Allow permission "Always" (Choosing only once this session will not show the Toast)
6. Refresh page
7. Toast should be shown
8. Refresh page
9. Toast should not appear 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
