### PR TITLE
Add thesun.co.uk to the ua exclusion list

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
@@ -98,7 +98,8 @@ class UserAgentProvider constructor(private val defaultUserAgent: String, privat
             "cvs.com",
             "chase.com",
             "tirerack.com",
-            "sovietgames.su"
+            "sovietgames.su",
+            "thesun.co.uk"
         )
 
         val sitesThatOmitVersion = listOf(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1198974644439945
Tech Design URL: 
CC: 

**Description**:
Our user agent is breaking comments in thesun.co.uk

**Steps to test this PR**:
1. Open an article in thesun.co.uk, i.e. https://www.thesun.co.uk/news/13051418/france-terror-attack-nice-church-beheaded/  
1. Scroll down between all the ads until you find the comments section. I think just below the `more from the sun` section and above `promoted stories`.
1. Comments should be shown.
1. If you follow the same process using `develop` you will see an error message like the screenshot attached.

![Screenshot 2020-10-30 at 09 56 16](https://user-images.githubusercontent.com/1773137/97691878-e12a6280-1a96-11eb-9b1a-c6e6487dc2b9.png)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
