### PR TITLE
Fix favicon display view recycling

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
@@ -38,7 +38,6 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
@@ -129,7 +129,7 @@ class DuckDuckGoFaviconManagerTest {
 
     @Test
     fun whenLoadToViewFromTempIfCannotFindFaviconThenDownloadFromUrl() = coroutineRule.runBlocking {
-        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
+        val view: ImageView = mock()
         val url = "https://example.com"
 
         testee.loadToViewFromTemp("subFolder", url, view)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.favicon
 import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.core.net.toUri
+import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_PERSISTED_DIR
@@ -37,6 +38,7 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
@@ -89,7 +91,7 @@ class DuckDuckGoFaviconManagerTest {
     @Test
     fun whenLoadToViewFromPersistedThenLoadView() = coroutineRule.runBlocking {
         givenFaviconExistsInDirectory(FAVICON_PERSISTED_DIR)
-        val view: ImageView = mock()
+        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
 
         testee.loadToViewFromPersisted("example.com", view)
 
@@ -98,7 +100,7 @@ class DuckDuckGoFaviconManagerTest {
 
     @Test
     fun whenLoadToViewFromPersistedIfCannotFindFaviconThenDownloadFromUrl() = coroutineRule.runBlocking {
-        val view: ImageView = mock()
+        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
         val url = "https://example.com"
 
         testee.loadToViewFromPersisted(url, view)
@@ -107,9 +109,19 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
+    fun whenLoadToViewFromPersistedIfCannotFindFaviconThenLoadDefaultFaviconIntoView() = coroutineRule.runBlocking {
+        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
+        val url = "https://example.com"
+
+        testee.loadToViewFromPersisted(url, view)
+
+        assertNotNull(view.drawable)
+    }
+
+    @Test
     fun whenLoadToViewFromTempThenLoadView() = coroutineRule.runBlocking {
         givenFaviconExistsInDirectory(FAVICON_TEMP_DIR)
-        val view: ImageView = mock()
+        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
 
         testee.loadToViewFromTemp("subFolder", "example.com", view)
 
@@ -118,12 +130,21 @@ class DuckDuckGoFaviconManagerTest {
 
     @Test
     fun whenLoadToViewFromTempIfCannotFindFaviconThenDownloadFromUrl() = coroutineRule.runBlocking {
-        val view: ImageView = mock()
+        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
         val url = "https://example.com"
 
         testee.loadToViewFromTemp("subFolder", url, view)
 
         verify(mockFaviconDownloader).getFaviconFromUrl(url.toUri().faviconLocation()!!)
+    }
+
+    @Test
+    fun whenLoadToViewFromTempIfCannotFindFaviconThenLoadDefaultFaviconIntoView() = coroutineRule.runBlocking {
+        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
+
+        testee.loadToViewFromTemp("subFolder", "example.com", view)
+
+        assertNotNull(view.drawable)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
@@ -91,7 +91,7 @@ class DuckDuckGoFaviconManagerTest {
     @Test
     fun whenLoadToViewFromPersistedThenLoadView() = coroutineRule.runBlocking {
         givenFaviconExistsInDirectory(FAVICON_PERSISTED_DIR)
-        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
+        val view: ImageView = mock()
 
         testee.loadToViewFromPersisted("example.com", view)
 
@@ -100,7 +100,7 @@ class DuckDuckGoFaviconManagerTest {
 
     @Test
     fun whenLoadToViewFromPersistedIfCannotFindFaviconThenDownloadFromUrl() = coroutineRule.runBlocking {
-        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
+        val view: ImageView = mock()
         val url = "https://example.com"
 
         testee.loadToViewFromPersisted(url, view)
@@ -110,18 +110,18 @@ class DuckDuckGoFaviconManagerTest {
 
     @Test
     fun whenLoadToViewFromPersistedIfCannotFindFaviconThenLoadDefaultFaviconIntoView() = coroutineRule.runBlocking {
-        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
+        val view: ImageView = mock()
         val url = "https://example.com"
 
         testee.loadToViewFromPersisted(url, view)
 
-        assertNotNull(view.drawable)
+        verify(mockFaviconDownloader).loadDefaultFaviconToView(view)
     }
 
     @Test
     fun whenLoadToViewFromTempThenLoadView() = coroutineRule.runBlocking {
         givenFaviconExistsInDirectory(FAVICON_TEMP_DIR)
-        val view = ImageView(InstrumentationRegistry.getInstrumentation().targetContext)
+        val view: ImageView = mock()
 
         testee.loadToViewFromTemp("subFolder", "example.com", view)
 
@@ -144,7 +144,7 @@ class DuckDuckGoFaviconManagerTest {
 
         testee.loadToViewFromTemp("subFolder", "example.com", view)
 
-        assertNotNull(view.drawable)
+        verify(mockFaviconDownloader).loadDefaultFaviconToView(view)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.widget.ImageView
+import androidx.core.content.ContextCompat
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.duckduckgo.app.browser.R
@@ -32,6 +33,7 @@ interface FaviconDownloader {
     suspend fun getFaviconFromDisk(file: File): Bitmap?
     suspend fun getFaviconFromUrl(uri: Uri): Bitmap?
     suspend fun loadFaviconToView(file: File, view: ImageView)
+    suspend fun loadDefaultFaviconToView(view: ImageView)
 }
 
 class GlideFaviconDownloader @Inject constructor(
@@ -77,4 +79,9 @@ class GlideFaviconDownloader @Inject constructor(
         }
     }
 
+    override suspend fun loadDefaultFaviconToView(view: ImageView) {
+        withContext(dispatcherProvider.main()) {
+            view.setImageDrawable(ContextCompat.getDrawable(view.context, R.drawable.ic_globe_gray_16dp))
+        }
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
@@ -19,10 +19,8 @@ package com.duckduckgo.app.browser.favicon
 import android.graphics.Bitmap
 import android.net.Uri
 import android.widget.ImageView
-import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
-import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_PERSISTED_DIR
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_TEMP_DIR
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.NO_SUBFOLDER

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
@@ -67,20 +67,14 @@ class DuckDuckGoFaviconManager constructor(
 
     override suspend fun loadToViewFromPersisted(url: String, view: ImageView) {
         // avoid displaying the previous favicon when the holder is recycled
-        preloadDefaultImageIntoView(view)
+        faviconDownloader.loadDefaultFaviconToView(view)
         loadToViewFromDirectory(url, FAVICON_PERSISTED_DIR, NO_SUBFOLDER, view)
     }
 
     override suspend fun loadToViewFromTemp(subFolder: String, url: String, view: ImageView) {
         // avoid displaying the previous favicon when the holder is recycled
-        preloadDefaultImageIntoView(view)
+        faviconDownloader.loadDefaultFaviconToView(view)
         loadToViewFromDirectory(url, FAVICON_TEMP_DIR, subFolder, view)
-    }
-
-    private suspend fun preloadDefaultImageIntoView(view: ImageView) {
-        withContext(dispatcherProvider.main()) {
-            view.setImageDrawable(ContextCompat.getDrawable(view.context, R.drawable.ic_globe_gray_16dp))
-        }
     }
 
     override suspend fun prefetchToTemp(subFolder: String, url: String): File? {

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
@@ -19,8 +19,10 @@ package com.duckduckgo.app.browser.favicon
 import android.graphics.Bitmap
 import android.net.Uri
 import android.widget.ImageView
+import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_PERSISTED_DIR
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_TEMP_DIR
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.NO_SUBFOLDER
@@ -64,11 +66,21 @@ class DuckDuckGoFaviconManager constructor(
     }
 
     override suspend fun loadToViewFromPersisted(url: String, view: ImageView) {
+        // avoid displaying the previous favicon when the holder is recycled
+        preloadDefaultImageIntoView(view)
         loadToViewFromDirectory(url, FAVICON_PERSISTED_DIR, NO_SUBFOLDER, view)
     }
 
     override suspend fun loadToViewFromTemp(subFolder: String, url: String, view: ImageView) {
+        // avoid displaying the previous favicon when the holder is recycled
+        preloadDefaultImageIntoView(view)
         loadToViewFromDirectory(url, FAVICON_TEMP_DIR, subFolder, view)
+    }
+
+    private suspend fun preloadDefaultImageIntoView(view: ImageView) {
+        withContext(dispatcherProvider.main()) {
+            view.setImageDrawable(ContextCompat.getDrawable(view.context, R.drawable.ic_globe_gray_16dp))
+        }
     }
 
     override suspend fun prefetchToTemp(subFolder: String, url: String): File? {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1198194956794324/1198918323600485/f
Tech Design URL: 
CC: 

**Description**:
Favicons are displayed in a number of places, eg. tab switcher, bookmarks, fireproof websites etc.
All those places use a listview adapter. The bug appears when the view holder is recycled and the new item
to be displayed in it does not have a favicon. In which case, whatever icon was set in the recycled holder is showed.

This PR fixes that issue in the `FaviconManager` as it is the common entry point for bookmarks, tab switcher, fireproof websites etc

Fixes #975

NOTE: I also considered doing this in the `FaviconDownloader` by allowing a nullable `File` in the `loadFaviconToView` method. However this is too late as results in a UX that shows the previous (holder) icon and then it changes to the proper one.


**Steps to test this PR**:
1. open multiple tabs to trigger view recycling (20-25)
2. open as (one of the) last tab(s) one website without favicon (eg. http://http://aosabook.org)
3. go to tab switcher and scroll down
4. websites that have no favicon should show the (default) globe icon - previously they would show the icon of a previously recycled view)

Similar steps would work for bookmarks and fireproof websites


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
