### PR TITLE
Includes language in autocomplete service requests, using device preferred language

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteService.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteService.kt
@@ -20,11 +20,15 @@ import com.duckduckgo.app.global.AppUrl
 import io.reactivex.Observable
 import retrofit2.http.GET
 import retrofit2.http.Query
+import java.util.*
 
 interface AutoCompleteService {
 
     @GET("${AppUrl.Url.API}/ac/")
-    fun autoComplete(@Query("q") query: String): Observable<List<AutoCompleteServiceRawResult>>
+    fun autoComplete(
+        @Query("q") query: String,
+        @Query("kl") languageCode: String = Locale.getDefault().language
+    ): Observable<List<AutoCompleteServiceRawResult>>
 }
 
 data class AutoCompleteServiceRawResult(val phrase: String)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1199086911994413/f
Tech Design URL: 
CC: 

**Description**:
This PR adds a language code onto the autocomplete requests, to help get autocomplete results in the right language for the user. We do this by adding the `kl` query param onto the requests, and including the two-letter language code (e.g., `en`, `es`, `ar` etc...)

As discussed in the task, we will use the device preferred language in the first instance, even though that can be a different language than the app shows in. We might quickly revisit that to make it match the app language.

**Steps to test this PR**:
Set up some way of monitoring the network requests made from the app (`Charles`, `AS Network Profiler` etc...)

### Spanish
1. Set device language to Spanish
1. Make a request to autocomplete service by typing `Facebook` into the URL box
1. Verify the request includes `kl=es`

### English
1. Set device language to English
1. Make a request to autocomplete service by typing `Facebook` into the URL box
1. Verify the request includes `kl=en`



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
