### PR TITLE
Feature/david/location permission fixes

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2454,9 +2454,7 @@ class BrowserTabViewModelTest {
 
         givenNewPermissionRequestFromDomain(domain)
 
-        verify(mockPixel).fire(Pixel.PixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ONCE)
-
-        // how can we test that the locationPermissionCallback is invoked?
+        assertCommandNotIssued<Command.CheckSystemLocationPermission>()
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2443,6 +2443,23 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenDomainRequestsSitePermissionAndUserAllowedSessionPermissionAndThenPermissionIsAllowed() = coroutineRule.runBlocking {
+        val domain = "https://www.example.com/"
+
+        givenDeviceLocationSharingIsEnabled(true)
+        givenLocationPermissionIsEnabled(true)
+        givenCurrentSite(domain)
+
+        testee.onSiteLocationPermissionSelected(domain, LocationPermissionType.ALLOW_ONCE)
+
+        givenNewPermissionRequestFromDomain(domain)
+
+        verify(mockPixel).fire(Pixel.PixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ONCE)
+
+        // how can we test that the locationPermissionCallback is invoked?
+    }
+
+    @Test
     fun whenAppLocationPermissionIsDeniedThenSitePermissionIsDenied() = coroutineRule.runBlocking {
         val domain = "https://www.example.com/"
         givenDeviceLocationSharingIsEnabled(true)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2443,7 +2443,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenDomainRequestsSitePermissionAndUserAllowedSessionPermissionAndThenPermissionIsAllowed() = coroutineRule.runBlocking {
+    fun whenDomainRequestsSitePermissionAndUserAllowedSessionPermissionThenPermissionIsAllowed() = coroutineRule.runBlocking {
         val domain = "https://www.example.com/"
 
         givenDeviceLocationSharingIsEnabled(true)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -975,7 +975,7 @@ class BrowserTabViewModel(
             val previouslyDeniedForever = appSettingsPreferencesStore.appLocationPermissionDeniedForever
             val permissionEntity = locationPermissionsRepository.getDomainPermission(origin)
             if (permissionEntity == null) {
-                if (locationPermissionSession.containsKey(origin)){
+                if (locationPermissionSession.containsKey(origin)) {
                     reactToSiteSessionPermission(locationPermissionSession[origin]!!)
                 } else {
                     command.postValue(CheckSystemLocationPermission(origin, previouslyDeniedForever))
@@ -1062,9 +1062,9 @@ class BrowserTabViewModel(
         }
     }
 
-    private fun reactToSiteSessionPermission(permission: LocationPermissionType){
+    private fun reactToSiteSessionPermission(permission: LocationPermissionType) {
         locationPermission?.let { locationPermission ->
-            if (permission == LocationPermissionType.ALLOW_ONCE){
+            if (permission == LocationPermissionType.ALLOW_ONCE) {
                 locationPermission.callback.invoke(locationPermission.origin, true, false)
             } else {
                 locationPermission.callback.invoke(locationPermission.origin, false, false)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -301,6 +301,7 @@ class BrowserTabViewModel(
 
     private var locationPermission: LocationPermission? = null
     private val locationPermissionMessages: MutableMap<String, Boolean> = mutableMapOf()
+    private val locationPermissionSession: MutableMap<String, LocationPermissionType> = mutableMapOf()
 
     private val autoCompletePublishSubject = PublishRelay.create<String>()
     private val fireproofWebsiteState: LiveData<List<FireproofWebsiteEntity>> = fireproofWebsiteRepository.getFireproofWebsites()
@@ -974,7 +975,11 @@ class BrowserTabViewModel(
             val previouslyDeniedForever = appSettingsPreferencesStore.appLocationPermissionDeniedForever
             val permissionEntity = locationPermissionsRepository.getDomainPermission(origin)
             if (permissionEntity == null) {
-                command.postValue(CheckSystemLocationPermission(origin, previouslyDeniedForever))
+                if (locationPermissionSession.containsKey(origin)){
+                    reactToSiteSessionPermission(locationPermissionSession[origin]!!)
+                } else {
+                    command.postValue(CheckSystemLocationPermission(origin, previouslyDeniedForever))
+                }
             } else {
                 if (permissionEntity.permission == LocationPermissionType.DENY_ALWAYS) {
                     onSiteLocationPermissionAlwaysDenied()
@@ -999,6 +1004,7 @@ class BrowserTabViewModel(
                 }
                 LocationPermissionType.ALLOW_ONCE -> {
                     pixel.fire(PixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ONCE)
+                    locationPermissionSession[domain] = permission
                     locationPermission.callback.invoke(locationPermission.origin, true, false)
                 }
                 LocationPermissionType.DENY_ALWAYS -> {
@@ -1011,6 +1017,7 @@ class BrowserTabViewModel(
                 }
                 LocationPermissionType.DENY_ONCE -> {
                     pixel.fire(PixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ONCE)
+                    locationPermissionSession[domain] = permission
                     locationPermission.callback.invoke(locationPermission.origin, false, false)
                 }
             }
@@ -1053,6 +1060,17 @@ class BrowserTabViewModel(
             }
 
         }
+    }
+
+    private fun reactToSiteSessionPermission(permission: LocationPermissionType){
+        locationPermission?.let { locationPermission ->
+            if (permission == LocationPermissionType.ALLOW_ONCE){
+                locationPermission.callback.invoke(locationPermission.origin, true, false)
+            } else {
+                locationPermission.callback.invoke(locationPermission.origin, false, false)
+            }
+        }
+
     }
 
     override fun onSystemLocationPermissionAllowed() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/inbox/1157893581871899/1198943134762082/1198943698304239

**Description**:
The current implementation of location permission could be improved when it comes to permissions allowed / denied for a session. There are cases like Google Maps, that despite setting permissions that should last for a session, it would keep prompting every time.

This PR fixes that, ensuring that the permission selected by the user is honored as longs as the tab is opened.

**Steps to test this PR**:
*** App in Production ***
1. Enable Location Permissions 
2. Open maps.google.com
3. Tap on the location icon at the bottom right of the screen
4. Select Allow this session
5. Location should be updated
6. Tap on the location icon again
7. Location dialog appears again

*** Current Build ***
1. Enable Location Permissions 
2. Open maps.google.com
3. Tap on the location icon at the bottom right of the screen
4. Select Allow this session
5. Location should be updated
6. Tap on the location icon again
7. Location should be updated without any dialog being shown


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
