### PR TITLE
ApiRequestInterceptorTest.kt should not use literal for package name

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
@@ -49,11 +49,13 @@ class ApiRequestInterceptorTest {
         whenever(mockChain.request()).thenReturn(request())
         whenever(mockChain.proceed(any())).thenReturn(response())
 
+        val packageName = InstrumentationRegistry.getInstrumentation().context.applicationInfo.packageName
+
         val captor = ArgumentCaptor.forClass(Request::class.java)
         testee.intercept(mockChain)
         verify(mockChain).proceed(captor.capture())
 
-        val regex = "ddg_android/.*\\(com.duckduckgo.mobile.android.debug.test; Android API .*\\)".toRegex()
+        val regex = "ddg_android/.*\\($packageName; Android API .*\\)".toRegex()
         val result = captor.value.header(Header.USER_AGENT)!!
         assertTrue(result.matches(regex))
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1198978983891185

**Description**:
This test was using a hardcoded string instead of the package name. This was making the test fail in other build types.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
