### PR TITLE
Downgrade mockito version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,7 +127,7 @@ ext {
     timber = "4.7.1"
     rxRelay = "2.0.0"
     leakCanary = "2.5"
-    mockito = "3.6.0"
+    mockito = "3.4.6"
     mockitoKotlin = "2.2.0"
     commonsMath = "3.6.1"
 }
@@ -216,10 +216,8 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$testRunner"
     androidTestImplementation "androidx.test:rules:$testRunner"
     androidTestUtil "androidx.test:orchestrator:$testRunner"
-    androidTestImplementation ("org.mockito:mockito-android:$mockito") {
-        exclude group: 'org.mockito', module: 'mockito-core' // Fixes https://github.com/mockito/mockito/issues/2007
-    }
-    androidTestImplementation "com.squareup.okhttp3:mockwebserver:$okHttp"
+    androidTestImplementation "org.mockito:mockito-android:$mockito"
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlin"
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:$okHttp"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1199164056051997
Tech Design URL: 
CC: 

**Description**:
When I upgraded Mockito to the latest version that caused some issues with testing on lower APIs. By fixing those problems we then created more testing issues on devices with API > 26. This PR downgrades Mockito to the last "stable" version which should fix all the tests.

I have also created https://app.asana.com/0/1125189844152671/1199164056052000 to add J8 desugaring which will allow us to upgrade to the latest version.

**Steps to test this PR**:
1. Run tests on API < 24, API 26 and API > 26 (you can rely on Bitrise for any API < 26)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
