### PR TITLE
Allow to UNDO a closed tab

### DIFF
--- a/app/schemas/com.duckduckgo.app.global.db.AppDatabase/28.json
+++ b/app/schemas/com.duckduckgo.app.global.db.AppDatabase/28.json
@@ -1,0 +1,846 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 28,
+    "identityHash": "65b30523736804a4973282ffbe3ef731",
+    "entities": [
+      {
+        "tableName": "tds_tracker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, `defaultAction` TEXT NOT NULL, `ownerName` TEXT NOT NULL, `categories` TEXT NOT NULL, `rules` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultAction",
+            "columnName": "defaultAction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerName",
+            "columnName": "ownerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rules",
+            "columnName": "rules",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tds_entity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `displayName` TEXT NOT NULL, `prevalence` REAL NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prevalence",
+            "columnName": "prevalence",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "name"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tds_domain_entity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, `entityName` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityName",
+            "columnName": "entityName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "temporary_tracking_whitelist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "user_whitelist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "https_bloom_filter_spec",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `bitCount` INTEGER NOT NULL, `errorRate` REAL NOT NULL, `totalEntries` INTEGER NOT NULL, `sha256` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitCount",
+            "columnName": "bitCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorRate",
+            "columnName": "errorRate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalEntries",
+            "columnName": "totalEntries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "https_false_positive_domain",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "network_leaderboard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`networkName` TEXT NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`networkName`))",
+        "fields": [
+          {
+            "fieldPath": "networkName",
+            "columnName": "networkName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "networkName"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sites_visited",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tabs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tabId` TEXT NOT NULL, `url` TEXT, `title` TEXT, `skipHome` INTEGER NOT NULL, `viewed` INTEGER NOT NULL, `position` INTEGER NOT NULL, `tabPreviewFile` TEXT, `sourceTabId` TEXT, `deletable` INTEGER NOT NULL, PRIMARY KEY(`tabId`), FOREIGN KEY(`sourceTabId`) REFERENCES `tabs`(`tabId`) ON UPDATE SET NULL ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "skipHome",
+            "columnName": "skipHome",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewed",
+            "columnName": "viewed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabPreviewFile",
+            "columnName": "tabPreviewFile",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sourceTabId",
+            "columnName": "sourceTabId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deletable",
+            "columnName": "deletable",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "tabId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_tabs_tabId",
+            "unique": false,
+            "columnNames": [
+              "tabId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tabs_tabId` ON `${TABLE_NAME}` (`tabId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tabs",
+            "onDelete": "SET NULL",
+            "onUpdate": "SET NULL",
+            "columns": [
+              "sourceTabId"
+            ],
+            "referencedColumns": [
+              "tabId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tab_selection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `tabId` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`tabId`) REFERENCES `tabs`(`tabId`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_tab_selection_tabId",
+            "unique": false,
+            "columnNames": [
+              "tabId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tab_selection_tabId` ON `${TABLE_NAME}` (`tabId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tabs",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tabId"
+            ],
+            "referencedColumns": [
+              "tabId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "survey",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surveyId` TEXT NOT NULL, `url` TEXT, `daysInstalled` INTEGER, `status` TEXT NOT NULL, PRIMARY KEY(`surveyId`))",
+        "fields": [
+          {
+            "fieldPath": "surveyId",
+            "columnName": "surveyId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "daysInstalled",
+            "columnName": "daysInstalled",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "surveyId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "dismissed_cta",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ctaId` TEXT NOT NULL, PRIMARY KEY(`ctaId`))",
+        "fields": [
+          {
+            "fieldPath": "ctaId",
+            "columnName": "ctaId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "ctaId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "search_count",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "app_days_used",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "date"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "app_enjoyment",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventType` INTEGER NOT NULL, `promptCount` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `primaryKey` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptCount",
+            "columnName": "promptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryKey",
+            "columnName": "primaryKey",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "primaryKey"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "notification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`notificationId` TEXT NOT NULL, PRIMARY KEY(`notificationId`))",
+        "fields": [
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notificationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "notificationId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "privacy_protection_count",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `blocked_tracker_count` INTEGER NOT NULL, `upgrade_count` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockedTrackerCount",
+            "columnName": "blocked_tracker_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "upgradeCount",
+            "columnName": "upgrade_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "UncaughtExceptionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `exceptionSource` TEXT NOT NULL, `message` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `version` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exceptionSource",
+            "columnName": "exceptionSource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tdsMetadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `eTag` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "userStage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER NOT NULL, `appStage` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appStage",
+            "columnName": "appStage",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "fireproofWebsites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "user_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "locationPermissions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, `permission` INTEGER NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "permission",
+            "columnName": "permission",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pixel_store",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `pixelName` TEXT NOT NULL, `atb` TEXT NOT NULL, `additionalQueryParams` TEXT NOT NULL, `encodedQueryParams` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pixelName",
+            "columnName": "pixelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "atb",
+            "columnName": "atb",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "additionalQueryParams",
+            "columnName": "additionalQueryParams",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encodedQueryParams",
+            "columnName": "encodedQueryParams",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '65b30523736804a4973282ffbe3ef731')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/TestApplication.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/TestApplication.kt
@@ -18,6 +18,9 @@ package com.duckduckgo.app
 
 import com.duckduckgo.app.di.DaggerTestAppComponent
 import com.duckduckgo.app.global.DuckDuckGoApplication
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.TestCoroutineScope
 
 class TestApplication : DuckDuckGoApplication() {
 
@@ -27,9 +30,14 @@ class TestApplication : DuckDuckGoApplication() {
      * See [com.duckduckgo.app.di.TestAppComponent]
      */
 
+    @ExperimentalCoroutinesApi
+    private val applicationCoroutineScope = TestCoroutineScope(SupervisorJob())
+
+    @ExperimentalCoroutinesApi
     override fun configureDependencyInjection() {
         daggerAppComponent = DaggerTestAppComponent.builder()
             .application(this)
+            .applicationCoroutineScope(applicationCoroutineScope)
             .build()
         daggerAppComponent.inject(this)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/di/TestAppComponent.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/TestAppComponent.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.usage.di.AppUsageModule
 import dagger.BindsInstance
 import dagger.Component
 import dagger.android.support.AndroidSupportInjectionModule
+import kotlinx.coroutines.CoroutineScope
 import retrofit2.Retrofit
 import javax.inject.Named
 import javax.inject.Singleton
@@ -79,6 +80,9 @@ interface TestAppComponent : AppComponent {
 
         @BindsInstance
         fun application(application: Application): Builder
+
+        @BindsInstance
+        fun applicationCoroutineScope(@AppCoroutineScope applicationCoroutineScope: CoroutineScope): Builder
 
         fun build(): TestAppComponent
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/db/AppDatabaseTest.kt
@@ -298,8 +298,18 @@ class AppDatabaseTest {
     }
 
     @Test
+    fun whenMigratingFromVersion25To26ThenValidationSucceeds() {
+        createDatabaseAndMigrate(25, 26, migrationsProvider.MIGRATION_25_TO_26)
+    }
+
+    @Test
+    fun whenMigratingFromVersion26To27ThenValidationSucceeds() {
+        createDatabaseAndMigrate(26, 27, migrationsProvider.MIGRATION_26_TO_27)
+    }
+
+    @Test
     fun whenMigratingFromVersion27To28ThenValidationSucceeds() {
-        createDatabaseAndMigrate(27, 28, migrationsProvider.MIGRATION_25_TO_26)
+        createDatabaseAndMigrate(27, 28, migrationsProvider.MIGRATION_27_TO_28)
     }
 
     private fun givenUserStageIs(database: SupportSQLiteDatabase, appStage: AppStage) {

--- a/app/src/androidTest/java/com/duckduckgo/app/global/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/db/AppDatabaseTest.kt
@@ -297,6 +297,11 @@ class AppDatabaseTest {
         createDatabaseAndMigrate(24, 25, migrationsProvider.MIGRATION_24_TO_25)
     }
 
+    @Test
+    fun whenMigratingFromVersion27To28ThenValidationSucceeds() {
+        createDatabaseAndMigrate(27, 28, migrationsProvider.MIGRATION_25_TO_26)
+    }
+
     private fun givenUserStageIs(database: SupportSQLiteDatabase, appStage: AppStage) {
         database.execSQL("INSERT INTO `userStage` values (1, '${appStage.name}') ")
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/db/TabsDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/db/TabsDaoTest.kt
@@ -294,4 +294,31 @@ class TabsDaoTest {
 
         assertEquals(tab, testee.selectedTab())
     }
+
+    @Test
+    fun whenMarkTabAsDeletableThenModifyOnlyDeletableColumn() {
+        val tab = TabEntity(
+            tabId = "TAB_ID",
+            url = "www.duckduckgo.com",
+            position = 0)
+
+        testee.insertTab(tab)
+        testee.markTabAsDeletable(tab.copy(url = "www.other.com"))
+
+        assertEquals(tab.copy(deletable = true), testee.tab(tab.tabId))
+    }
+
+    @Test
+    fun whenUndoDeletableTabThenModifyOnlyDeletableColumn() {
+        val tab = TabEntity(
+            tabId = "TAB_ID",
+            url = "www.duckduckgo.com",
+            position = 0,
+            deletable = true)
+
+        testee.insertTab(tab)
+        testee.undoDeletableTab(tab.copy(url = "www.other.com"))
+
+        assertEquals(tab.copy(deletable = false), testee.tab(tab.tabId))
+    }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/db/TabsDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/db/TabsDaoTest.kt
@@ -56,6 +56,30 @@ class TabsDaoTest {
     }
 
     @Test
+    fun whenOnlyDeletableTabsExistTabsReturnsEmpty() {
+        val deletableTab = TabEntity(
+            tabId = "ID",
+            position = 0,
+            deletable = true
+        )
+        testee.insertTab(deletableTab)
+
+        assertTrue(testee.tabs().isEmpty())
+    }
+
+    @Test
+    fun whenOnlyDeletableTabsExistTabReturnsMatch() {
+        val deletableTab = TabEntity(
+            tabId = "ID",
+            position = 0,
+            deletable = true
+        )
+        testee.insertTab(deletableTab)
+
+        assertEquals(deletableTab, testee.tab("ID"))
+    }
+
+    @Test
     fun whenNoTabsThenFirstReturnsNull() {
         assertNull(testee.firstTab())
     }
@@ -238,5 +262,36 @@ class TabsDaoTest {
 
         assertNotNull(testee.tab("TAB_ID_1"))
         assertNull(testee.tab("TAB_ID_1")?.sourceTabId)
+    }
+
+    @Test
+    fun deleteTabsMarkedAsDeletableDeletesOnlyDeletableTabs() {
+        testee.insertTab(TabEntity("TAB_ID1", position = 0, deletable = true))
+        val tab = TabEntity("TAB_ID2", position = 1)
+        testee.insertTab(tab)
+
+        testee.deleteTabsMarkedAsDeletable()
+
+        assertNull(testee.tab("TAB_ID1"))
+        assertEquals(tab, testee.tab("TAB_ID2"))
+    }
+
+    @Test
+    fun whenSelectedTabMarkedAsDeletableAndPurgedThenUpdateSelection() {
+        val tab = TabEntity(
+            tabId = "TAB_ID",
+            url = "www.duckduckgo.com",
+            position = 0)
+        val deletableTab = TabEntity(
+            tabId = "TAB_ID_1",
+            url = "www.duckduckgo.com",
+            position = 1,
+            deletable = true)
+
+        testee.insertTab(tab)
+        testee.addAndSelectTab(deletableTab)
+        testee.purgeDeletableTabsAndUpdateSelection()
+
+        assertEquals(tab, testee.selectedTab())
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -395,8 +395,29 @@ class TabDataRepositoryTest {
             }
         }
 
-        daoDeletableTabs.send(listOf(tab))
+        daoDeletableTabs.send(listOf(tab)) // dropped
         daoDeletableTabs.send(listOf(expectedTab))
+        job.cancel()
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun whenDaoFLowDeletableTabsDoubleEmitsThenDistinctUntilChanged() = runBlocking {
+        val tab = TabEntity("ID1", position = 0)
+
+        var count = 0
+        val job = launch {
+            testee.flowDeletableTabs.collect {
+                ++count
+                assertEquals(1, count)
+            }
+        }
+
+        daoDeletableTabs.send(listOf(tab, tab, tab)) // dropped
+        daoDeletableTabs.send(listOf(tab, tab, tab))
+        daoDeletableTabs.send(listOf(tab, tab, tab))
+        daoDeletableTabs.send(listOf(tab, tab, tab))
+        daoDeletableTabs.send(listOf(tab, tab, tab))
         job.cancel()
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.app.tabs.db.TabsDao
 import com.duckduckgo.app.trackerdetection.EntityLookup
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
 import org.junit.Before
@@ -322,7 +323,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun markDeletableTrueThenMarksTabAsDeletable() = runBlocking {
+    fun whenMarkDeletableTrueThenMarksTabAsDeletable() = runBlocking {
         val tab = TabEntity(
             tabId = "tabid",
             position = 0,
@@ -334,7 +335,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun markDeletableFalseThenMarksTabAsNonDeletable() = runBlocking {
+    fun whenMarkDeletableFalseThenMarksTabAsNonDeletable() = runBlocking {
         val tab = TabEntity(
             tabId = "tabid",
             position = 0,
@@ -346,7 +347,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun purgeDeletableTabsThenPurgeDeletableTabsAndUpdateSelection() = runBlocking {
+    fun whenPurgeDeletableTabsThenPurgeDeletableTabsAndUpdateSelection() = runBlocking {
         testee.purgeDeletableTabs()
 
         verify(mockDao).purgeDeletableTabsAndUpdateSelection()
@@ -358,7 +359,8 @@ class TabDataRepositoryTest {
             SiteFactory(mockPrivacyPractices, mockEntityLookup),
             mockWebViewPreviewPersister,
             mockFaviconManager,
-            useOurAppDetector
+            useOurAppDetector,
+            GlobalScope
         )
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -321,6 +321,37 @@ class TabDataRepositoryTest {
         assertEquals(currentSelectedTabId, sourceTab.tabId)
     }
 
+    @Test
+    fun markDeletableTrueThenMarksTabAsDeletable() = runBlocking {
+        val tab = TabEntity(
+            tabId = "tabid",
+            position = 0,
+            deletable = false)
+
+        testee.markDeletable(tab, true)
+
+        verify(mockDao).updateTab(tab.copy(deletable = true))
+    }
+
+    @Test
+    fun markDeletableFalseThenMarksTabAsNonDeletable() = runBlocking {
+        val tab = TabEntity(
+            tabId = "tabid",
+            position = 0,
+            deletable = true)
+
+        testee.markDeletable(tab, false)
+
+        verify(mockDao).updateTab(tab.copy(deletable = false))
+    }
+
+    @Test
+    fun purgeDeletableTabsThenPurgeDeletableTabsAndUpdateSelection() = runBlocking {
+        testee.purgeDeletableTabs()
+
+        verify(mockDao).purgeDeletableTabsAndUpdateSelection()
+    }
+
     private fun tabDataRepository(dao: TabsDao): TabDataRepository {
         return TabDataRepository(
             dao,

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -328,9 +328,9 @@ class TabDataRepositoryTest {
             position = 0,
             deletable = false)
 
-        testee.markDeletable(tab, true)
+        testee.markDeletable(tab)
 
-        verify(mockDao).updateTab(tab.copy(deletable = true))
+        verify(mockDao).markTabAsDeletable(tab)
     }
 
     @Test
@@ -340,9 +340,9 @@ class TabDataRepositoryTest {
             position = 0,
             deletable = true)
 
-        testee.markDeletable(tab, false)
+        testee.undoDeletable(tab)
 
-        verify(mockDao).updateTab(tab.copy(deletable = false))
+        verify(mockDao).undoDeletableTab(tab)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -100,4 +100,26 @@ class TabSwitcherViewModelTest {
         assertEquals(Command.Close, commandCaptor.allValues[1])
     }
 
+    @Test
+    fun whenOnMarkTabAsDeletableThenCallMarkDeletable() = runBlocking {
+        val entity = TabEntity("abc", "", "", position = 0)
+        testee.onMarkTabAsDeletable(entity, true)
+
+        verify(mockTabRepository).markDeletable(entity, true)
+    }
+
+    @Test
+    fun whenOnMarkTabAsNotDeletableThenCallMarkDeletable() = runBlocking {
+        val entity = TabEntity("abc", "", "", position = 0)
+        testee.onMarkTabAsDeletable(entity, false)
+
+        verify(mockTabRepository).markDeletable(entity, false)
+    }
+
+    @Test
+    fun whenPurgeDeletableTabsThenCallRepositoryPurgeDeletableTabs() = runBlocking {
+        testee.purgeDeletableTabs()
+
+        verify(mockTabRepository).purgeDeletableTabs()
+    }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -103,17 +103,17 @@ class TabSwitcherViewModelTest {
     @Test
     fun whenOnMarkTabAsDeletableThenCallMarkDeletable() = runBlocking {
         val entity = TabEntity("abc", "", "", position = 0)
-        testee.onMarkTabAsDeletable(entity, true)
+        testee.onMarkTabAsDeletable(entity)
 
-        verify(mockTabRepository).markDeletable(entity, true)
+        verify(mockTabRepository).markDeletable(entity)
     }
 
     @Test
-    fun whenOnMarkTabAsNotDeletableThenCallMarkDeletable() = runBlocking {
+    fun whenUndoDeletableTabThenUndoDeletable() = runBlocking {
         val entity = TabEntity("abc", "", "", position = 0)
-        testee.onMarkTabAsDeletable(entity, false)
+        testee.undoDeletableTab(entity)
 
-        verify(mockTabRepository).markDeletable(entity, false)
+        verify(mockTabRepository).undoDeletable(entity)
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -243,10 +243,8 @@
             </intent-filter>
         </activity>
 
-        <!-- we handle orientation configChanges to ensure proper tab UNDO functionality -->
         <activity
             android:name="com.duckduckgo.app.tabs.ui.TabSwitcherActivity"
-            android:configChanges="orientation"
             android:label="@string/tabActivityTitle" />
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -243,8 +243,10 @@
             </intent-filter>
         </activity>
 
+        <!-- we handle orientation configChanges to ensure proper tab UNDO functionality -->
         <activity
             android:name="com.duckduckgo.app.tabs.ui.TabSwitcherActivity"
+            android:configChanges="orientation"
             android:label="@string/tabActivityTitle" />
 
         <activity

--- a/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
@@ -33,6 +33,7 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjector
 import dagger.android.support.AndroidSupportInjectionModule
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
 @Singleton
@@ -77,6 +78,9 @@ interface AppComponent : AndroidInjector<DuckDuckGoApplication> {
 
         @BindsInstance
         fun application(application: Application): Builder
+
+        @BindsInstance
+        fun applicationCoroutineScope(@AppCoroutineScope applicationCoroutineScope: CoroutineScope): Builder
 
         fun build(): AppComponent
     }

--- a/app/src/main/java/com/duckduckgo/app/di/AppCoroutineScope.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppCoroutineScope.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.di
+
+import javax.inject.Scope
+
+/**
+ * Identifies a coroutine scope type that is scope to the app lifecycle
+ */
+@Scope
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AppCoroutineScope

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -63,7 +63,9 @@ import dagger.android.HasAndroidInjector
 import io.reactivex.exceptions.UndeliverableException
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.jetbrains.anko.doAsync
 import timber.log.Timber
@@ -173,6 +175,8 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
 
     private var launchedByFireAction: Boolean = false
 
+    private val applicationCoroutineScope = CoroutineScope(SupervisorJob())
+
     open lateinit var daggerAppComponent: AppComponent
 
     override fun onCreate() {
@@ -260,6 +264,7 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
     protected open fun configureDependencyInjection() {
         daggerAppComponent = DaggerAppComponent.builder()
             .application(this)
+            .applicationCoroutineScope(applicationCoroutineScope)
             .build()
         daggerAppComponent.inject(this)
     }

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -54,6 +54,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.APP_LAUNCH
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.surrogates.ResourceSurrogateLoader
+import com.duckduckgo.app.tabs.db.TabsDbSanitizer
 import com.duckduckgo.app.trackerdetection.TrackerDataLoader
 import com.duckduckgo.app.usage.app.AppDaysUsedRecorder
 import dagger.android.AndroidInjector
@@ -167,6 +168,9 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
     @Inject
     lateinit var fireFireAnimationLoader: FireAnimationLoader
 
+    @Inject
+    lateinit var tabsDbSanitizer: TabsDbSanitizer
+
     private var launchedByFireAction: Boolean = false
 
     open lateinit var daggerAppComponent: AppComponent
@@ -192,6 +196,7 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
             it.addObserver(userStageStore)
             it.addObserver(pixelSender)
             it.addObserver(fireFireAnimationLoader)
+            it.addObserver(tabsDbSanitizer)
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -65,7 +65,7 @@ import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.app.usage.search.SearchCountEntity
 
 @Database(
-    exportSchema = true, version = 27, entities = [
+    exportSchema = true, version = 28, entities = [
         TdsTracker::class,
         TdsEntity::class,
         TdsDomainEntity::class,
@@ -365,6 +365,12 @@ class MigrationsProvider(
         }
     }
 
+    val MIGRATION_27_TO_28: Migration = object : Migration(27, 28) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("ALTER TABLE `tabs` ADD COLUMN `deletable` INTEGER DEFAULT 0 NOT NULL")
+        }
+    }
+
     val ALL_MIGRATIONS: List<Migration>
         get() = listOf(
             MIGRATION_1_TO_2,
@@ -392,7 +398,8 @@ class MigrationsProvider(
             MIGRATION_23_TO_24,
             MIGRATION_24_TO_25,
             MIGRATION_25_TO_26,
-            MIGRATION_26_TO_27
+            MIGRATION_26_TO_27,
+            MIGRATION_27_TO_28
         )
 
     @Deprecated(

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -367,7 +367,7 @@ class MigrationsProvider(
 
     val MIGRATION_27_TO_28: Migration = object : Migration(27, 28) {
         override fun migrate(database: SupportSQLiteDatabase) {
-            database.execSQL("ALTER TABLE `tabs` ADD COLUMN `deletable` INTEGER DEFAULT 0 NOT NULL")
+            database.execSQL("ALTER TABLE `tabs` ADD COLUMN `deletable` INTEGER NOT NULL DEFAULT 0")
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -64,6 +64,18 @@ abstract class TabsDao {
     abstract fun deleteTabsMarkedAsDeletable()
 
     @Transaction
+    open fun markTabAsDeletable(tab: TabEntity) {
+        // requirement: only one tab can be marked as deletable
+        deleteTabsMarkedAsDeletable()
+        updateTab(tab.copy(deletable = true))
+    }
+
+    @Transaction
+    open fun undoDeletableTab(tab: TabEntity) {
+        updateTab(tab.copy(deletable = false))
+    }
+
+    @Transaction
     open fun purgeDeletableTabsAndUpdateSelection() {
         deleteTabsMarkedAsDeletable()
         if (selectedTab() != null) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.LiveData
 import androidx.room.*
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSelectionEntity
-import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Singleton
 
 @Dao
@@ -43,7 +43,7 @@ abstract class TabsDao {
     abstract fun liveTabs(): LiveData<List<TabEntity>>
 
     @Query("select * from tabs where deletable is 1 order by position")
-    abstract fun deletableLiveTabs(): Observable<List<TabEntity>>
+    abstract fun flowDeletableTabs(): Flow<List<TabEntity>>
 
     @Query("select * from tabs where tabId = :tabId")
     abstract fun tab(tabId: String): TabEntity?

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -27,7 +27,7 @@ import javax.inject.Singleton
 @Singleton
 abstract class TabsDao {
 
-    @Query("select * from tabs order by position limit 1")
+    @Query("select * from tabs where deletable is 0 order by position limit 1")
     abstract fun firstTab(): TabEntity?
 
     @Query("select * from tabs inner join tab_selection on tabs.tabId = tab_selection.tabId order by position limit 1")

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -67,12 +67,20 @@ abstract class TabsDao {
     open fun markTabAsDeletable(tab: TabEntity) {
         // requirement: only one tab can be marked as deletable
         deleteTabsMarkedAsDeletable()
-        updateTab(tab.copy(deletable = true))
+        // ensure the tab is in the DB
+        val dbTab = tab(tab.tabId)
+        dbTab?.let {
+            updateTab(dbTab.copy(deletable = true))
+        }
     }
 
     @Transaction
     open fun undoDeletableTab(tab: TabEntity) {
-        updateTab(tab.copy(deletable = false))
+        // ensure the tab is in the DB
+        val dbTab = tab(tab.tabId)
+        dbTab?.let {
+            updateTab(dbTab.copy(deletable = false))
+        }
     }
 
     @Transaction

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.tabs.db
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class TabsDbSanitizer @Inject constructor(
+    private val tabsDao: TabsDao
+) : LifecycleObserver {
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    fun purgeTabsDatabase() {
+        runBlocking {
+            launch { purgeTabsDatabaseAsync() }
+        }
+    }
+
+    private suspend fun purgeTabsDatabaseAsync() = withContext(Dispatchers.IO) {
+        tabsDao.purgeDeletableTabsAndUpdateSelection()
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.tabs.db
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
+import com.duckduckgo.app.tabs.model.TabRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -26,7 +27,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class TabsDbSanitizer @Inject constructor(
-    private val tabsDao: TabsDao
+    private val tabRepository: TabRepository
 ) : LifecycleObserver {
 
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
@@ -37,6 +38,6 @@ class TabsDbSanitizer @Inject constructor(
     }
 
     private suspend fun purgeTabsDatabaseAsync() = withContext(Dispatchers.IO) {
-        tabsDao.purgeDeletableTabsAndUpdateSelection()
+        tabRepository.purgeDeletableTabs()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -26,10 +26,11 @@ import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.global.useourapp.UseOurAppDetector
 import com.duckduckgo.app.tabs.db.TabsDao
-import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.drop
 import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
@@ -47,7 +48,10 @@ class TabDataRepository @Inject constructor(
 
     override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs()
 
-    override val deletableLiveTabs: Observable<List<TabEntity>> = tabsDao.deletableLiveTabs()
+    // We only one the new emissions when subscribing, however Room does not honour that contract so we
+    // need to drop the first emission always (this is equivalent to the Observable semantics)
+    @ExperimentalCoroutinesApi
+    override val flowDeletableTabs: Flow<List<TabEntity>> = tabsDao.flowDeletableTabs().drop(1)
 
     override val liveSelectedTab: LiveData<TabEntity> = tabsDao.liveSelectedTab()
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -30,6 +30,7 @@ import io.reactivex.Scheduler
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import timber.log.Timber
 import java.util.*
@@ -48,10 +49,12 @@ class TabDataRepository @Inject constructor(
 
     override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs()
 
-    // We only one the new emissions when subscribing, however Room does not honour that contract so we
+    // We only want the new emissions when subscribing, however Room does not honour that contract so we
     // need to drop the first emission always (this is equivalent to the Observable semantics)
     @ExperimentalCoroutinesApi
-    override val flowDeletableTabs: Flow<List<TabEntity>> = tabsDao.flowDeletableTabs().drop(1)
+    override val flowDeletableTabs: Flow<List<TabEntity>> = tabsDao.flowDeletableTabs()
+        .drop(1)
+        .distinctUntilChanged()
 
     override val liveSelectedTab: LiveData<TabEntity> = tabsDao.liveSelectedTab()
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -28,8 +28,7 @@ import com.duckduckgo.app.tabs.db.TabsDao
 import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
@@ -200,10 +199,8 @@ class TabDataRepository @Inject constructor(
         }
     }
 
-    override suspend fun purgeDeletableTabs() {
-        databaseExecutor().scheduleDirect {
-            tabsDao.purgeDeletableTabsAndUpdateSelection()
-        }
+    override suspend fun purgeDeletableTabs() = withContext(Dispatchers.IO + NonCancellable) {
+        tabsDao.purgeDeletableTabsAndUpdateSelection()
     }
 
     override suspend fun deleteCurrentTabAndSelectSource() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -188,11 +188,15 @@ class TabDataRepository @Inject constructor(
         siteData.remove(tab.tabId)
     }
 
-    override suspend fun markDeletable(tab: TabEntity, deletable: Boolean) {
+    override suspend fun markDeletable(tab: TabEntity) {
         databaseExecutor().scheduleDirect {
-            tabsDao.updateTab(
-                tab.copy(deletable = deletable)
-            )
+            tabsDao.markTabAsDeletable(tab)
+        }
+    }
+
+    override suspend fun undoDeletable(tab: TabEntity) {
+        databaseExecutor().scheduleDirect {
+            tabsDao.undoDeletableTab(tab)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabEntitiy.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabEntitiy.kt
@@ -43,7 +43,8 @@ data class TabEntity(
     var viewed: Boolean = true,
     var position: Int,
     var tabPreviewFile: String? = null,
-    var sourceTabId: String? = null
+    var sourceTabId: String? = null,
+    var deletable: Boolean = false
 )
 
 val TabEntity.isBlank: Boolean

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -19,10 +19,19 @@ package com.duckduckgo.app.tabs.model
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.duckduckgo.app.global.model.Site
+import io.reactivex.Observable
 
 interface TabRepository {
 
+    /**
+     * @return the tabs that are NOT marked as deletable in the DB
+     */
     val liveTabs: LiveData<List<TabEntity>>
+
+    /**
+     * @return the tabs that are marked as "deletable" in the DB
+     */
+    val deletableLiveTabs: Observable<List<TabEntity>>
 
     val liveSelectedTab: LiveData<TabEntity>
 
@@ -45,6 +54,13 @@ interface TabRepository {
     fun retrieveSiteData(tabId: String): MutableLiveData<Site>
 
     suspend fun delete(tab: TabEntity)
+
+    suspend fun markDeletable(tab: TabEntity, deletable: Boolean)
+
+    /**
+     * Deletes from the DB all tabs that are marked as "deletable"
+     */
+    suspend fun purgeDeletableTabs()
 
     suspend fun deleteCurrentTabAndSelectSource()
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.app.tabs.model
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.duckduckgo.app.global.model.Site
-import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 
 interface TabRepository {
 
@@ -31,7 +31,7 @@ interface TabRepository {
     /**
      * @return the tabs that are marked as "deletable" in the DB
      */
-    val deletableLiveTabs: Observable<List<TabEntity>>
+    val flowDeletableTabs: Flow<List<TabEntity>>
 
     val liveSelectedTab: LiveData<TabEntity>
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -55,7 +55,9 @@ interface TabRepository {
 
     suspend fun delete(tab: TabEntity)
 
-    suspend fun markDeletable(tab: TabEntity, deletable: Boolean)
+    suspend fun markDeletable(tab: TabEntity)
+
+    suspend fun undoDeletable(tab: TabEntity)
 
     /**
      * Deletes from the DB all tabs that are marked as "deletable"

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -210,9 +210,10 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     private fun onDeletableTab(tab: TabEntity) {
         Snackbar.make(
             contentView!!,
-            getString(R.string.closedTab, tab.title.orEmpty()),
+            getString(R.string.tabClosed),
             Snackbar.LENGTH_LONG)
-            .setAction(R.string.closeTabUndo) {
+            .setDuration(3500) // 3.5 seconds
+            .setAction(R.string.tabClosedUndo) {
                 // noop, handled in onDismissed callback
             }
             .addCallback(object :

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -48,7 +48,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.anko.contentView
 import org.jetbrains.anko.longToast
 import javax.inject.Inject
@@ -259,7 +258,10 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     override fun onDestroy() {
         super.onDestroy()
         disposable.clear()
-        runBlocking { viewModel.purgeDeletableTabs() }
+        // we don't want to purge during device rotation
+        if (isFinishing) {
+            launch { viewModel.purgeDeletableTabs() }
+        }
     }
 
     private fun clearObserversEarlyToStopViewUpdates() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -19,17 +19,20 @@ package com.duckduckgo.app.tabs.ui
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
-import io.reactivex.Observable
 
 class TabSwitcherViewModel(private val tabRepository: TabRepository, private val webViewSessionStorage: WebViewSessionStorage) : ViewModel() {
 
     var tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
-    var deletableTabs: Observable<List<TabEntity>> = tabRepository.deletableLiveTabs
+    var deletableTabs: LiveData<List<TabEntity>> = tabRepository.flowDeletableTabs.asLiveData(
+        context = viewModelScope.coroutineContext
+    )
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
     sealed class Command {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -24,10 +24,12 @@ import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import io.reactivex.Observable
 
 class TabSwitcherViewModel(private val tabRepository: TabRepository, private val webViewSessionStorage: WebViewSessionStorage) : ViewModel() {
 
     var tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
+    var deletableTabs: Observable<List<TabEntity>> = tabRepository.deletableLiveTabs
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
     sealed class Command {
@@ -48,6 +50,14 @@ class TabSwitcherViewModel(private val tabRepository: TabRepository, private val
     suspend fun onTabDeleted(tab: TabEntity) {
         tabRepository.delete(tab)
         webViewSessionStorage.deleteSession(tab.tabId)
+    }
+
+    suspend fun onMarkTabAsDeletable(tab: TabEntity, deletable: Boolean = true) {
+        tabRepository.markDeletable(tab, deletable)
+    }
+
+    suspend fun purgeDeletableTabs() {
+        tabRepository.purgeDeletableTabs()
     }
 
     fun onClearComplete() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -52,8 +52,12 @@ class TabSwitcherViewModel(private val tabRepository: TabRepository, private val
         webViewSessionStorage.deleteSession(tab.tabId)
     }
 
-    suspend fun onMarkTabAsDeletable(tab: TabEntity, deletable: Boolean = true) {
-        tabRepository.markDeletable(tab, deletable)
+    suspend fun onMarkTabAsDeletable(tab: TabEntity) {
+        tabRepository.markDeletable(tab)
+    }
+
+    suspend fun undoDeletableTab(tab: TabEntity) {
+        tabRepository.undoDeletable(tab)
     }
 
     suspend fun purgeDeletableTabs() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,8 +75,8 @@
     <string name="closeContentDescription">Close</string>
     <string name="closeAllTabsMenuItem">Close All Tabs</string>
     <string name="closeTab">Close tab</string>
-    <string name="closedTab">Closed %s</string>
-    <string name="closeTabUndo">Undo</string>
+    <string name="tabClosed">Tab closed</string>
+    <string name="tabClosedUndo">Undo</string>
 
     <!-- Privacy Dashboard Activities -->
     <string name="privacyProtectionToggle">Site Privacy Protection</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,8 @@
     <string name="closeContentDescription">Close</string>
     <string name="closeAllTabsMenuItem">Close All Tabs</string>
     <string name="closeTab">Close tab</string>
+    <string name="closedTab">Closed %s</string>
+    <string name="closeTabUndo">Undo</string>
 
     <!-- Privacy Dashboard Activities -->
     <string name="privacyProtectionToggle">Site Privacy Protection</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1198194956794324/1199173078173336/f
Tech Design URL: 
CC: 

**Description**:
Impement the feature to be able to undo a tab close action in the tab switcher

* DB methods to get tabs filter out "deletable" tabs

* Added specific methods to mark/undo/delete "deletable" tabs in DB, repository and viewmodel classes

* TabSwitcher shows snackbar upon tab close(d) to undo the action

* Register `TabDbSanitizer` app lifecycle observer to clean pending "deletable" tabs upon app launch


**Steps to test this PR**:
Check DB migration
1. update app and relaunch
2. Verify app works normally

Check tab close undo
1. Open several tabs in background
2. Go to tabs screen
3. Close one tab
4. Verify snackbar to undo action pops
5. Let snackbar to auto-dismiss
6. Navitage to main browser screen and back to tabs screen
7. Verify tab is no longer there

Check subsequent tab close undo
1. Open several tabs in background
2. Go to tabs screen
3. Close more than 1 tab before snackbar could auto-dismiss
4. Verify snackbar updates showing the info about the last closed tab
5. Tap "UNDO" CTA in the last snackbar
6. Verify last closed tab reappears
7. Navitage to main browser screen and back to tabs screen
8. Verify tab is no longer there

Check tab (with parent) close undo
1. Open tabs that have a parent tab (long press in link + open in new tab)
2. Go to tabs screen
3. Close parent tab
4. Let snackbar to auto-dismiss
5. Select child tab
6. Navigate back (Android back press)
7. Verify app navigates to empty tab

Check sudden app close
1. Open several tabs in background
2. Go to tabs screen
3. Close one tab and close app before snackbar auto-dismisses (this will leave a "deletable" tab in DB)
4. Open app and navigate to tab switcher
5. Verified closed tab is no longer there

Check selectable tab close
1. Open several tabs in background
2. Go to tabs screen
3. Close the selected tab and let snackbar to auto-dismiss
4. Go back to main browser screen
5. Verify first tab is now showing
6. Repeat steps 1) and 2)
7. Closed the selected tab and immediately go back to browser screen
8. Verify first tab is now showing

Check config changes
1. Open several tabs in background
2. Go to tabs screen
3. Close a tab and immediately rotate the device (portrait -> landscape or vice-versa)
4. Verify the snackbar does not dissapear
5. Undo the close tab action
6. Verify the tab reappears
7. Repeat steps 1) to 3)
8. Let the snackbar auto-dismiss
9. Navigate back to main browser and back into tab switcher
10. Verify the tab is not there

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
