### PR TITLE
Added pixel for when download filename/type is not detected

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -16,12 +16,16 @@
 
 package com.duckduckgo.app.browser.downloader
 
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class UriUtilsFilenameExtractorTest {
 
-    private val testee: FilenameExtractor = FilenameExtractor()
+    private val mockedPixel: Pixel = mock()
+    private val testee: FilenameExtractor = FilenameExtractor(mockedPixel)
 
     @Test
     fun whenUrlEndsWithFilenameAsJpgNoMimeOrContentDispositionThenFilenameShouldBeExtracted() {
@@ -138,6 +142,24 @@ class UriUtilsFilenameExtractorTest {
         val contentDisposition: String? = null
         val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
         assertEquals("example.com", extracted)
+    }
+
+    @Test
+    fun whenNoFilenameAndPathSegmentsThenPathNameBinFileIsReturned() {
+        val url = "http://example.com/cat/600/400"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
+        assertEquals("cat.bin", extracted)
+    }
+
+    @Test
+    fun whenNoFilenameAndPathSegmentsThenFirePixel() {
+        val url = "http://example.com/cat/600/400"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+        val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
+        verify(mockedPixel).fire(Pixel.PixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
     }
 
     private fun buildPendingDownload(url: String, contentDisposition: String?, mimeType: String?): FileDownloader.PendingFileDownload {

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
@@ -21,10 +21,13 @@ import androidx.core.net.toUri
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import com.duckduckgo.app.browser.downloader.FilenameExtractor.GuessQuality.NotGoodEnough
 import com.duckduckgo.app.browser.downloader.FilenameExtractor.GuessQuality.TriedAllOptions
+import com.duckduckgo.app.statistics.pixels.Pixel
 import timber.log.Timber
 import javax.inject.Inject
 
-class FilenameExtractor @Inject constructor() {
+class FilenameExtractor @Inject constructor(
+    private val pixel: Pixel
+) {
 
     fun extract(pendingDownload: PendingFileDownload): String {
         val url = pendingDownload.url
@@ -73,6 +76,7 @@ class FilenameExtractor @Inject constructor() {
     private fun bestGuess(guesses: Guesses): String {
         val guess = guesses.bestGuess ?: guesses.latestGuess
         if (!guess.contains(".")) {
+            pixel.fire(Pixel.PixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
             return guess + DEFAULT_FILE_TYPE
         }
         return guess

--- a/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -113,6 +113,8 @@ interface Pixel {
         LONG_PRESS_COPY_URL("mlp_c"),
         LONG_PRESS_OPEN_IMAGE_IN_BACKGROUND_TAB("mlp_ibt"),
 
+        DOWNLOAD_FILE_DEFAULT_GUESSED_NAME("m_df_dgn"),
+
         SETTINGS_OPENED("ms"),
         SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),
         SETTINGS_THEME_TOGGLED_DARK("ms_td"),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1198194956794324/1199376188899581/f
Tech Design URL: 
CC: 

**Description**:
Add a pixel that will file when the `FilenameExtractor` is not able to guess the filename and extension (type) from the information provided in the `PendingFileDownload` data class.

When that happens, the resulting filename has extension `.bin` which causes issues when later opening file from the notification.

**Steps to test this PR**:
1. Go to https://placekitten.com/g/200/300
2. Long press in the image and select download file
3. Verify file is downloaded as `g.bin`
4. Verify in the logcat that `Pixel sent: mdf_dgn with params: {} {}` message is logged


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
