### PR TITLE
Add LE root certificates to Glide

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,6 +149,7 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$swipeRefreshLayout"
     implementation "androidx.webkit:webkit:$webkit"
     implementation "com.squareup.okhttp3:okhttp:$okHttp"
+    implementation "com.squareup.okhttp3:okhttp-tls:$okHttp"
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit"
     implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit"
@@ -201,6 +202,7 @@ dependencies {
 
     // Glide
     implementation "com.github.bumptech.glide:glide:$glide"
+    implementation "com.github.bumptech.glide:okhttp3-integration:$glide"
     kapt "com.github.bumptech.glide:compiler:$glide"
 
     // Lottie

--- a/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
@@ -16,8 +16,54 @@
 
 package com.duckduckgo.app.global.image
 
+import android.content.Context
+import android.os.Build
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
+import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.module.AppGlideModule
+import com.duckduckgo.app.browser.certificates.rootstore.IsrgRootX1
+import com.duckduckgo.app.browser.certificates.rootstore.IsrgRootX2
+import okhttp3.OkHttpClient
+import okhttp3.tls.HandshakeCertificates
+import timber.log.Timber
+import java.io.InputStream
+import java.security.cert.X509Certificate
 
 @GlideModule
-class GlobalGlideModule : AppGlideModule()
+class GlobalGlideModule : AppGlideModule() {
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) {
+            try {
+                Timber.d("Registering OkHttp-based ModelLoader for GlideUrl")
+
+                val isrgRootX1 = IsrgRootX1(context)
+                val isrgRootX2 = IsrgRootX2(context)
+
+                val handshakeCertificates = HandshakeCertificates.Builder()
+                    .addTrustedCertificate(isrgRootX1.certificate() as X509Certificate)
+                    .addTrustedCertificate(isrgRootX2.certificate() as X509Certificate)
+                    .addPlatformTrustedCertificates()
+                    .build()
+
+                val okHttpClient = OkHttpClient.Builder()
+                    .sslSocketFactory(handshakeCertificates.sslSocketFactory())
+                    .build()
+
+                // use our custom okHttp instead of default HTTPUrlConnection
+                registry.replace(
+                    GlideUrl::class.java,
+                    InputStream::class.java,
+                    OkHttpUrlLoader.Factory(okHttpClient)
+                )
+            } catch (t: Throwable) {
+                Timber.d("Error registering GlideModule for GlideUrl: $t")
+                super.registerComponents(context, glide, registry)
+            }
+        } else {
+            super.registerComponents(context, glide, registry)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
@@ -48,9 +48,8 @@ class GlobalGlideModule : AppGlideModule() {
                     .addPlatformTrustedCertificates()
                     .build()
 
-                @Suppress("DEPRECATION")
                 val okHttpClient = OkHttpClient.Builder()
-                    .sslSocketFactory(handshakeCertificates.sslSocketFactory())
+                    .sslSocketFactory(handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager())
                     .build()
 
                 // use our custom okHttp instead of default HTTPUrlConnection

--- a/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
@@ -48,6 +48,7 @@ class GlobalGlideModule : AppGlideModule() {
                     .addPlatformTrustedCertificates()
                     .build()
 
+                @Suppress("DEPRECATION")
                 val okHttpClient = OkHttpClient.Builder()
                     .sslSocketFactory(handshakeCertificates.sslSocketFactory())
                     .build()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1199598987755231/f
Tech Design URL: 
CC: 

**Description**:
We need to add the LE root certificates to Glide so that fetchinf favicons don't fail in old devices (API <= 25) when LE starts issuing certificates with its own self-signed cert chain

* created custom okHttp and added LE root certs to its SSL socket factory

* registered custom okHttp as `GlideUrl` extension to handle fetches

**Steps to test this PR**:
API <= 25

1. Install app from develop
2. Navigate to https://valid-isrgrootx1.letsencrypt.org/
3. Verify in logcat that glide throws `CertPathValidatorException` when trying to fetch site favicon

API <= 25

1. Install app from this branch
2. Verify `Registering OkHttp-based ModelLoader for GlideUrl` message appears in logcat
3. Navigate to https://valid-isrgrootx1.letsencrypt.org/
4. Verify in logcat that glide does not throw `CertPathValidatorException`
5. Verify in logcat that `TabDataRepository` updates the favicon

API > 25

1. Install app from this branch
2. Verify `Registering OkHttp-based ModelLoader for GlideUrl` message does NOT appear in logcat
3. Navigate to https://valid-isrgrootx1.letsencrypt.org/
4. Verify in logcat that glide does not throw `CertPathValidatorException`
5. Verify in logcat that `TabDataRepository` updates the favicon

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
