### PR TITLE
Fix crash for underscored domains when getting favicons

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,7 +121,7 @@ ext {
     ankoVersion = "0.10.4"
     glide = "4.11.0"
     lottieVersion = "3.4.0"
-    okHttp = "3.14.7"
+    okHttp = "3.14.9"
     rxJava = "2.1.10"
     rxAndroid = "2.0.2"
     timber = "4.7.1"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1199654613486886/f
Tech Design URL: 
CC: 

**Description**:
The PR https://github.com/duckduckgo/Android/pull/1037 added the `okhttp-tls` which start causing internal crashes in okhttp when getting favicons from domains that contain underscores.
Bumping the patch version of okhttp to 3.14.9 fixes the internal crash, surfacing it like it did before so that we can catch it

**Steps to test this PR**:
1. Install develop branch
2. Navigate to https://example_underscore_123.s3.amazonaws.com/
3. App crashes

1. Install this branch
2. Navigate to https://example_underscore_123.s3.amazonaws.com/
3. verify app does not crash

(perform those tests for devices above and below N)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
