### PR TITLE
Aligned bookmarks autocomplete matching algorithm with iOS

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -40,7 +40,7 @@ class AutoCompleteApiTest {
 
     @Before
     fun before() {
-        MockitoAnnotations.initMocks(this)
+        MockitoAnnotations.openMocks(this)
         testee = AutoCompleteApi(mockAutoCompleteService, mockBookmarksDao)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -116,6 +116,7 @@ class AutoCompleteApiTest {
             Single.just(
                 listOf(
                     BookmarkEntity(0, "title example", "https://example.com"),
+                    BookmarkEntity(0, "title foo", "https://foo.com/path/to/foo"),
                     BookmarkEntity(0, "title foo", "https://foo.com"),
                     BookmarkEntity(0, "title bar", "https://bar.com")
                 )
@@ -128,7 +129,8 @@ class AutoCompleteApiTest {
         assertEquals(
             listOf(
                 AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "example.com", "title example", "https://example.com"),
-                AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "foo.com", "title foo", "https://foo.com"),
+                AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "foo.com/path/to/foo", "title foo", "https://foo.com/path/to/foo"),
+                AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion(phrase = "foo.com", true),
                 AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion(phrase = "bar.com", true),
                 AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion(phrase = "baz.com", true)
             ),

--- a/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -252,7 +252,7 @@ class AutoCompleteApiTest {
     }
 
     @Test
-    fun whenSingleTokenQueryContainsSlashThenIgnoreItWhileMatching() {
+    fun whenSingleTokenQueryEndsWithSlashThenIgnoreItWhileMatching() {
         whenever(mockAutoCompleteService.autoComplete("reddit.com/")).thenReturn(Observable.just(listOf()))
         whenever(mockBookmarksDao.bookmarksObservable()).thenReturn(
             Single.just(
@@ -269,6 +269,53 @@ class AutoCompleteApiTest {
         assertEquals(
             listOf(
                 AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "reddit.com", "Reddit", "https://reddit.com"),
+                AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "reddit.com/r/duckduckgo", "Reddit - duckduckgo", "https://reddit.com/r/duckduckgo"),
+            ),
+            value.suggestions
+        )
+    }
+
+    @Test
+    fun whenSingleTokenQueryEndsWithMultipleSlashThenIgnoreThemWhileMatching() {
+        whenever(mockAutoCompleteService.autoComplete("reddit.com///")).thenReturn(Observable.just(listOf()))
+        whenever(mockBookmarksDao.bookmarksObservable()).thenReturn(
+            Single.just(
+                listOf(
+                    BookmarkEntity(0, "Reddit", "https://reddit.com"),
+                    BookmarkEntity(0, "Reddit - duckduckgo", "https://reddit.com/r/duckduckgo"),
+                )
+            )
+        )
+
+        val result = testee.autoComplete("reddit.com///").test()
+        val value = result.values()[0] as AutoCompleteResult
+
+        assertEquals(
+            listOf(
+                AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "reddit.com", "Reddit", "https://reddit.com"),
+                AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "reddit.com/r/duckduckgo", "Reddit - duckduckgo", "https://reddit.com/r/duckduckgo"),
+            ),
+            value.suggestions
+        )
+    }
+
+    @Test
+    fun whenSingleTokenQueryContainsMultipleSlashThenIgnoreThemWhileMatching() {
+        whenever(mockAutoCompleteService.autoComplete("reddit.com/r//")).thenReturn(Observable.just(listOf()))
+        whenever(mockBookmarksDao.bookmarksObservable()).thenReturn(
+            Single.just(
+                listOf(
+                    BookmarkEntity(0, "Reddit", "https://reddit.com"),
+                    BookmarkEntity(0, "Reddit - duckduckgo", "https://reddit.com/r/duckduckgo"),
+                )
+            )
+        )
+
+        val result = testee.autoComplete("reddit.com/r//").test()
+        val value = result.values()[0] as AutoCompleteResult
+
+        assertEquals(
+            listOf(
                 AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "reddit.com/r/duckduckgo", "Reddit - duckduckgo", "https://reddit.com/r/duckduckgo"),
             ),
             value.suggestions

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -953,7 +953,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenEnteringQueryWithAutoCompleteEnabledThenAutoCompleteSuggestionsShown() {
-        whenever(mockBookmarksDao.bookmarksByQuery("%foo%")).thenReturn(Single.just(emptyList()))
+        whenever(mockBookmarksDao.bookmarksObservable()).thenReturn(Single.just(emptyList()))
         whenever(mockAutoCompleteService.autoComplete("foo")).thenReturn(Observable.just(emptyList()))
         doReturn(true).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
         testee.onOmnibarInputStateChanged("foo", true, hasQueryChanged = true)

--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
@@ -234,4 +234,16 @@ class UriExtensionTest {
     fun whenUrlHasSchemeReturnDomain() {
         assertEquals("www.example.com", "http://www.example.com".toUri().domain())
     }
+
+    @Test
+    fun whenUriHasResourceNameThenReturnResourceName() {
+        assertEquals("www.foo.com", "https://www.foo.com".toUri().resourceNameAndPath())
+        assertEquals("www.foo.com", "http://www.foo.com".toUri().resourceNameAndPath())
+    }
+
+    @Test
+    fun whenUriHasResourceNameAndPathThenReturnResourceNameAndPath() {
+        assertEquals("www.foo.com/path/to/foo", "https://www.foo.com/path/to/foo".toUri().resourceNameAndPath())
+        assertEquals("www.foo.com/path/to/foo", "http://www.foo.com/path/to/foo".toUri().resourceNameAndPath())
+    }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/UriExtensionTest.kt
@@ -236,14 +236,20 @@ class UriExtensionTest {
     }
 
     @Test
-    fun whenUriHasResourceNameThenReturnResourceName() {
-        assertEquals("www.foo.com", "https://www.foo.com".toUri().resourceNameAndPath())
-        assertEquals("www.foo.com", "http://www.foo.com".toUri().resourceNameAndPath())
+    fun whenUriHasResourceNameThenDropSchemeReturnResourceName() {
+        assertEquals("www.foo.com", "https://www.foo.com".toUri().toStringDropScheme())
+        assertEquals("www.foo.com", "http://www.foo.com".toUri().toStringDropScheme())
     }
 
     @Test
-    fun whenUriHasResourceNameAndPathThenReturnResourceNameAndPath() {
-        assertEquals("www.foo.com/path/to/foo", "https://www.foo.com/path/to/foo".toUri().resourceNameAndPath())
-        assertEquals("www.foo.com/path/to/foo", "http://www.foo.com/path/to/foo".toUri().resourceNameAndPath())
+    fun whenUriHasResourceNameAndPathThenDropSchemeReturnResourceNameAndPath() {
+        assertEquals("www.foo.com/path/to/foo", "https://www.foo.com/path/to/foo".toUri().toStringDropScheme())
+        assertEquals("www.foo.com/path/to/foo", "http://www.foo.com/path/to/foo".toUri().toStringDropScheme())
+    }
+
+    @Test
+    fun whenUriHasResourceNamePathAndParamsThenDropSchemeReturnResourceNamePathAndParams() {
+        assertEquals("www.foo.com/path/to/foo?key=value", "https://www.foo.com/path/to/foo?key=value".toUri().toStringDropScheme())
+        assertEquals("www.foo.com/path/to/foo?key=value", "http://www.foo.com/path/to/foo?key=value".toUri().toStringDropScheme())
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -85,6 +85,7 @@ class AutoCompleteApi @Inject constructor(
             .map {
                 AutoCompleteBookmarkSuggestion(phrase = it.url.toUri().toStringDropScheme(), title = it.title.orEmpty(), url = it.url)
             }
+            .distinctUntilChanged()
             .take(2)
             .toList()
             .onErrorReturn { emptyList() }
@@ -133,7 +134,7 @@ class AutoCompleteApi @Inject constructor(
                 rankedBookmark.score += 50
             }
 
-        } else if (domain?.startsWith(tokens.first(), ignoreCase = true) == true) {
+        } else if (domain?.startsWith(tokens.first().split("/").first(), ignoreCase = true) == true) {
             rankedBookmark.score += 300
         }
 

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.global.UriString
 import com.duckduckgo.app.global.baseHost
+import com.duckduckgo.app.global.resourceNameAndPath
 import io.reactivex.Observable
 import io.reactivex.functions.BiFunction
 import javax.inject.Inject
@@ -82,7 +83,7 @@ class AutoCompleteApi @Inject constructor(
             .map { rankBookmarks(query, it) }
             .flattenAsObservable { it }
             .map {
-                AutoCompleteBookmarkSuggestion(phrase = it.url.toUri().baseHost.orEmpty(), title = it.title.orEmpty(), url = it.url)
+                AutoCompleteBookmarkSuggestion(phrase = it.url.toUri().resourceNameAndPath(), title = it.title.orEmpty(), url = it.url)
             }
             .take(2)
             .toList()

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -96,7 +96,7 @@ class AutoCompleteApi @Inject constructor(
             .map { scoreTitle(it, query) }
             .map { scoreTokens(it, query) }
             .filter { it.score >= 0 }
-            .sortedBy { it.score }
+            .sortedByDescending { it.score }
             .map { it.bookmarkEntity }
             .toList()
     }

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -24,7 +24,7 @@ import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.global.UriString
 import com.duckduckgo.app.global.baseHost
-import com.duckduckgo.app.global.resourceNameAndPath
+import com.duckduckgo.app.global.toStringDropScheme
 import io.reactivex.Observable
 import io.reactivex.functions.BiFunction
 import javax.inject.Inject
@@ -83,7 +83,7 @@ class AutoCompleteApi @Inject constructor(
             .map { rankBookmarks(query, it) }
             .flattenAsObservable { it }
             .map {
-                AutoCompleteBookmarkSuggestion(phrase = it.url.toUri().resourceNameAndPath(), title = it.title.orEmpty(), url = it.url)
+                AutoCompleteBookmarkSuggestion(phrase = it.url.toUri().toStringDropScheme(), title = it.title.orEmpty(), url = it.url)
             }
             .take(2)
             .toList()

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -134,7 +134,7 @@ class AutoCompleteApi @Inject constructor(
                 rankedBookmark.score += 50
             }
 
-        } else if (domain?.startsWith(tokens.first().split("/").first(), ignoreCase = true) == true) {
+        } else if (bookmark.url.toUri().toStringDropScheme().startsWith(tokens.first().trimEnd { it == '/' }, ignoreCase = true)) {
             rankedBookmark.score += 300
         }
 

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -16,11 +16,14 @@
 
 package com.duckduckgo.app.autocomplete.api
 
+import androidx.core.net.toUri
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteResult
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
+import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.global.UriString
+import com.duckduckgo.app.global.baseHost
 import io.reactivex.Observable
 import io.reactivex.functions.BiFunction
 import javax.inject.Inject
@@ -33,11 +36,11 @@ interface AutoComplete {
         val suggestions: List<AutoCompleteSuggestion>
     )
 
-    sealed class AutoCompleteSuggestion(val phrase: String) {
-        class AutoCompleteSearchSuggestion(phrase: String, val isUrl: Boolean) :
+    sealed class AutoCompleteSuggestion(open val phrase: String) {
+        data class AutoCompleteSearchSuggestion(override val phrase: String, val isUrl: Boolean) :
             AutoCompleteSuggestion(phrase)
 
-        class AutoCompleteBookmarkSuggestion(phrase: String, val title: String, val url: String) :
+        data class AutoCompleteBookmarkSuggestion(override val phrase: String, val title: String, val url: String) :
             AutoCompleteSuggestion(phrase)
     }
 }
@@ -58,7 +61,7 @@ class AutoCompleteApi @Inject constructor(
             BiFunction { bookmarksResults, searchResults ->
                 AutoCompleteResult(
                     query = query,
-                    suggestions = (bookmarksResults + searchResults).distinct()
+                    suggestions = (bookmarksResults + searchResults).distinctBy { it.phrase }
                 )
             }
         )
@@ -75,12 +78,69 @@ class AutoCompleteApi @Inject constructor(
             .toObservable()
 
     private fun getAutoCompleteBookmarkResults(query: String) =
-        bookmarksDao.bookmarksByQuery("%$query%")
+        bookmarksDao.bookmarksObservable()
+            .map { rankBookmarks(query, it) }
             .flattenAsObservable { it }
             .map {
-                AutoCompleteBookmarkSuggestion(phrase = it.url, title = it.title ?: "", url = it.url)
+                AutoCompleteBookmarkSuggestion(phrase = it.url.toUri().baseHost.orEmpty(), title = it.title.orEmpty(), url = it.url)
             }
+            .take(2)
             .toList()
             .onErrorReturn { emptyList() }
             .toObservable()
+
+    private fun rankBookmarks(query: String, bookmarks: List<BookmarkEntity>): List<BookmarkEntity> {
+        return bookmarks.asSequence()
+            .map { RankedBookmark(bookmarkEntity = it) }
+            .map { scoreTitle(it, query) }
+            .map { scoreTokens(it, query) }
+            .filter { it.score >= 0 }
+            .sortedBy { it.score }
+            .map { it.bookmarkEntity }
+            .toList()
+    }
+
+    private fun scoreTitle(rankedBookmark: RankedBookmark, query: String): RankedBookmark {
+        if (rankedBookmark.bookmarkEntity.title?.startsWith(query, ignoreCase = true) == true) {
+            rankedBookmark.score += 200
+        } else if (rankedBookmark.bookmarkEntity.title?.contains(" $query", ignoreCase = true) == true) {
+            rankedBookmark.score += 100
+        }
+
+        return rankedBookmark
+    }
+
+    private fun scoreTokens(rankedBookmark: RankedBookmark, query: String): RankedBookmark {
+        val bookmark = rankedBookmark.bookmarkEntity
+        val domain = bookmark.url.toUri().baseHost
+        val tokens = query.split(" ")
+        if (tokens.size > 1) {
+            tokens.forEach { token ->
+                if (bookmark.title?.startsWith(token, ignoreCase = true) == false &&
+                    bookmark.title?.contains(" $token", ignoreCase = true) == false &&
+                    domain?.startsWith(token, ignoreCase = true) == false
+                ) {
+                    return rankedBookmark
+                }
+            }
+
+            rankedBookmark.score += 10
+
+            if (domain?.startsWith(tokens.first(), ignoreCase = true) == true) {
+                rankedBookmark.score += 300
+            } else if (bookmark.title?.startsWith(tokens.first(), ignoreCase = true) == true) {
+                rankedBookmark.score += 50
+            }
+
+        } else if (domain?.startsWith(tokens.first(), ignoreCase = true) == true) {
+            rankedBookmark.score += 300
+        }
+
+        return rankedBookmark
+    }
+
+    private data class RankedBookmark(
+        val bookmarkEntity: BookmarkEntity,
+        var score: Int = -1
+    )
 }

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -141,6 +141,10 @@ class AutoCompleteApi @Inject constructor(
 
     private data class RankedBookmark(
         val bookmarkEntity: BookmarkEntity,
-        var score: Int = -1
+        var score: Int = BOOKMARK_SCORE
     )
+
+    companion object {
+        private const val BOOKMARK_SCORE = -1
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/db/BookmarksDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/db/BookmarksDao.kt
@@ -38,8 +38,8 @@ interface BookmarksDao {
     @Update(onConflict = OnConflictStrategy.REPLACE)
     fun update(bookmarkEntity: BookmarkEntity)
 
-    @Query("select * from bookmarks WHERE title LIKE :query OR url LIKE :query")
-    fun bookmarksByQuery(query: String): Single<List<BookmarkEntity>>
+    @Query("select * from bookmarks")
+    fun bookmarksObservable(): Single<List<BookmarkEntity>>
 
     @Query("select CAST(COUNT(*) AS BIT) from bookmarks")
     suspend fun hasBookmarks(): Boolean

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -427,9 +427,8 @@ class BrowserTabViewModel(
     }
 
     private fun onAutoCompleteResultReceived(result: AutoCompleteResult) {
-        val results = result.suggestions.take(6)
         val currentViewState = currentAutoCompleteViewState()
-        autoCompleteViewState.value = currentViewState.copy(searchResults = AutoCompleteResult(result.query, results))
+        autoCompleteViewState.value = currentViewState.copy(searchResults = AutoCompleteResult(result.query, result.suggestions))
     }
 
     @VisibleForTesting

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -58,6 +58,10 @@ val Uri.absoluteString: String
         return "$scheme://$host$path"
     }
 
+fun Uri.resourceNameAndPath(): String {
+    return "$host$path"
+}
+
 fun Uri.isHttpsVersionOfUri(other: Uri): Boolean {
     return isHttps && other.isHttp && other.toHttps == this
 }

--- a/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -58,8 +58,8 @@ val Uri.absoluteString: String
         return "$scheme://$host$path"
     }
 
-fun Uri.resourceNameAndPath(): String {
-    return "$host$path"
+fun Uri.toStringDropScheme(): String {
+    return if (scheme != null) this.toString().substringAfter("$scheme://") else this.toString()
 }
 
 fun Uri.isHttpsVersionOfUri(other: Uri): Boolean {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1199525460093862/f
Tech Design URL: https://app.asana.com/0/0/1199656369239103/f
CC: 

**Description**:
Align the autocomplete matching algorithm with iOS. This diff:

* removes the max limit of 6 auto complete items

* impose a max limit of 2 bookmark autocomplete items

* aligns with the iOS algorithm to select bookmark autocomplete items

**Steps to test this PR**:

Autocomplete results limit

1. install app from develop
2. clean all bookmarks
3. search for "cnn"
4. verify the autocomplete result items are limited to 6 items


1. install app from this branch
2. clean all bookmarks
3. search for "cnn"
4. verify the autocomplete result items are not limited to 6 suggestions

Bookmark autocomplete items limit

1. install app from develop
2. search for "cnn" and add more than 2 bookmarks from the results
3. restart the app and search for "cnn"
4. verify the autocomplete items contains all bookmarks added in step 2 (more than 2)
5. verify the autocomplete items are limited to 6 suggestions

1. install app from this branch
2. (only if not done before) search for "cnn" and add more than 2 bookmarks from the results
3. (only if not done beforee) restart the app and search for "cnn"
4. verify the autocomplete items contains max of 2 bookmark items
5. verify the autocomplete items are not limited to 6 suggestions

Item deduplication

1. install the app from develop
2. add https://edition.cnn.com to bookmarks
3. in main browser, search for edition.cnn.com
4. verify edition.cnn.com appears twice (from local bookmarks and autocomplete results from backend)

1. install the app from this branch
2. (only if not done before) add https://edition.cnn.com to bookmarks
3. in main browser, search for edition.cnn.com
4. verify edition.cnn.com appears just once


Bonus test

1. install the app from this branch
2. install develop from iOS repo in iOS
3. have both Android and iOS apps with same bookmarks
4. verify searches match for both devices

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
