### PR TITLE
Fix tab being redirected to first tab #879

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -541,7 +541,7 @@ class BrowserTabViewModelTest {
         testee.onUserSubmittedQuery("foo")
 
         coroutineRule.runBlocking {
-            verify(mockTabsRepository).delete(selectedTabLiveData.value!!)
+            verify(mockTabsRepository).deleteCurrentTabAndSelectSource()
         }
     }
 
@@ -1196,7 +1196,7 @@ class BrowserTabViewModelTest {
         testee.onRefreshRequested()
 
         coroutineRule.runBlocking {
-            verify(mockTabsRepository).delete(selectedTabLiveData.value!!)
+            verify(mockTabsRepository).deleteCurrentTabAndSelectSource()
         }
     }
 
@@ -1446,7 +1446,7 @@ class BrowserTabViewModelTest {
         showErrorWithAction.action()
 
         coroutineRule.runBlocking {
-            verify(mockTabsRepository).delete(selectedTabLiveData.value!!)
+            verify(mockTabsRepository).deleteCurrentTabAndSelectSource()
         }
     }
 
@@ -1618,7 +1618,7 @@ class BrowserTabViewModelTest {
     fun whenCloseCurrentTabSelectedThenTabDeletedFromRepository() = runBlocking {
         givenOneActiveTabSelected()
         testee.closeCurrentTab()
-        verify(mockTabsRepository).delete(selectedTabLiveData.value!!)
+        verify(mockTabsRepository).deleteCurrentTabAndSelectSource()
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -559,7 +559,7 @@ class BrowserTabViewModel(
     private suspend fun removeCurrentTabFromRepository() {
         val currentTab = tabRepository.liveSelectedTab.value
         currentTab?.let {
-            tabRepository.delete(currentTab)
+            tabRepository.deleteCurrentTabAndSelectSource()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL:  #879

**Description**:
It seems that what caused #879 was that after the tab is automatically closed `BrowserChromeClient::onCloseWindow` is called and  `BrowserTabViewModel::closeCurrentTab` will then be called but `removeCurrentTabFromRepository()` uses `tabRepository.delete(currentTab)` instead of `tabRepository.deleteCurrentTabAndSelectSource()` (which fixes the issue).


**Steps to test this PR**:
1. Have two tabs open, the second tab should have some sort of social login (I used canva.com).
2. On the second tab login into your account.
3. When the login finishes it must go back to the previous tab instead of the first one.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
