### PR TITLE
Fixed the bookmark url matching when domain has www.

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -323,6 +323,30 @@ class AutoCompleteApiTest {
     }
 
     @Test
+    fun whenSingleTokenQueryDomainContainsWwwThenResultMathUrl() {
+        whenever(mockAutoCompleteService.autoComplete("reddit")).thenReturn(Observable.just(listOf()))
+        whenever(mockBookmarksDao.bookmarksObservable()).thenReturn(
+            Single.just(
+                listOf(
+                    BookmarkEntity(0, "Reddit", "https://www.reddit.com"),
+                    BookmarkEntity(0, "duckduckgo", "https://www.reddit.com/r/duckduckgo"),
+                )
+            )
+        )
+
+        val result = testee.autoComplete("reddit").test()
+        val value = result.values()[0] as AutoCompleteResult
+
+        assertEquals(
+            listOf(
+                AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "www.reddit.com", "Reddit", "https://www.reddit.com"),
+                AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "www.reddit.com/r/duckduckgo", "duckduckgo", "https://www.reddit.com/r/duckduckgo"),
+            ),
+            value.suggestions
+        )
+    }
+
+    @Test
     fun whenMultipleTokenQueryAndNoTokenMatchThenReturnEmpty() {
         val query = "example title foo"
         whenever(mockAutoCompleteService.autoComplete(query)).thenReturn(Observable.just(listOf()))

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -134,7 +134,7 @@ class AutoCompleteApi @Inject constructor(
                 rankedBookmark.score += 50
             }
 
-        } else if (bookmark.url.toUri().toStringDropScheme().startsWith(tokens.first().trimEnd { it == '/' }, ignoreCase = true)) {
+        } else if (bookmark.url.toUri().toStringDropScheme().removePrefix("www.").startsWith(tokens.first().trimEnd { it == '/' }, ignoreCase = true)) {
             rankedBookmark.score += 300
         }
 

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -134,11 +134,15 @@ class AutoCompleteApi @Inject constructor(
                 rankedBookmark.score += 50
             }
 
-        } else if (bookmark.url.toUri().toStringDropScheme().removePrefix("www.").startsWith(tokens.first().trimEnd { it == '/' }, ignoreCase = true)) {
+        } else if (bookmark.url.redactSchemeAndWwwSubDomain().startsWith(tokens.first().trimEnd { it == '/' }, ignoreCase = true)) {
             rankedBookmark.score += 300
         }
 
         return rankedBookmark
+    }
+
+    private fun String.redactSchemeAndWwwSubDomain(): String {
+        return this.toUri().toStringDropScheme().removePrefix("www.")
     }
 
     private data class RankedBookmark(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1199525460093862/f
Tech Design URL: 
CC: 

**Description**:
Fixes the URL matching when returning bookmark results upon search query.


**Steps to test this PR**:
1. Install the app from this branch
2. Bookmark `https://www.reddit.com` and `https://www.reddit.com/r/duckduckgo`
3. In the search bar, search for `reddit`
4. Verify both bookmarks appear

(In develop branch, only `https://www.reddit.com` will appear)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
