### PR TITLE
Fix query change pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1219,6 +1219,24 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenRefreshRequestedWithQuerySearchThenFireQueryChangePixelZero() {
+        loadUrl("query")
+
+        testee.onRefreshRequested()
+
+        verify(mockPixel).fire("rq_0")
+    }
+
+    @Test
+    fun whenRefreshRequestedWithUrlThenDoNotFireQueryChangePixel() {
+        loadUrl("https://example.com")
+
+        testee.onRefreshRequested()
+
+        verify(mockPixel, never()).fire("rq_0")
+    }
+
+    @Test
     fun whenUserBrowsingPressesBackAndBrowserCanGoBackThenNavigatesToPreviousPageAndHandledTrue() {
         setupNavigation(isBrowsing = true, canGoBack = true, stepsToPreviousPage = 2)
         assertTrue(testee.onUserPressedBack())

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1237,6 +1237,28 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserSubmittedQueryWithPreviousBlankQueryThenDoNotSendQueryChangePixel() {
+        whenever(mockOmnibarConverter.convertQueryToUrl("another query", null)).thenReturn("another query")
+        loadUrl("")
+
+        testee.onUserSubmittedQuery("another query")
+
+        verify(mockPixel, never()).fire("rq_0")
+        verify(mockPixel, never()).fire("rq_1")
+    }
+
+    @Test
+    fun whenUserSubmittedQueryWithDifferentPreviousQueryThenSendQueryChangePixel() {
+        whenever(mockOmnibarConverter.convertQueryToUrl("another query", null)).thenReturn("another query")
+        loadUrl("query")
+
+        testee.onUserSubmittedQuery("another query")
+
+        verify(mockPixel, never()).fire("rq_0")
+        verify(mockPixel).fire("rq_1")
+    }
+
+    @Test
     fun whenUserBrowsingPressesBackAndBrowserCanGoBackThenNavigatesToPreviousPageAndHandledTrue() {
         setupNavigation(isBrowsing = true, canGoBack = true, stepsToPreviousPage = 2)
         assertTrue(testee.onUserPressedBack())

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/FakeChain.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/FakeChain.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import okhttp3.*
+import java.util.concurrent.TimeUnit
+
+class FakeChain(private val url: String) : Interceptor.Chain {
+    override fun call(): Call {
+        TODO("Not yet implemented")
+    }
+
+    override fun connectTimeoutMillis(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun connection(): Connection? {
+        TODO("Not yet implemented")
+    }
+
+    override fun proceed(request: Request): Response {
+        return Response.Builder().request(request).protocol(Protocol.HTTP_2).code(200).message("").build()
+    }
+
+    override fun readTimeoutMillis(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun request(): Request {
+        return Request.Builder().url(url).build()
+    }
+
+    override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+        TODO("Not yet implemented")
+    }
+
+    override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+        TODO("Not yet implemented")
+    }
+
+    override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+        TODO("Not yet implemented")
+    }
+
+    override fun writeTimeoutMillis(): Int {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/PixelReQueryInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/PixelReQueryInterceptorTest.kt
@@ -16,12 +16,10 @@
 
 package com.duckduckgo.app.global.api
 
-import okhttp3.*
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.TimeUnit
 
 class PixelReQueryInterceptorTest {
 
@@ -84,49 +82,5 @@ class PixelReQueryInterceptorTest {
         private const val EXPECTED_RQ_1_URL = "https://improving.duckduckgo.com/t/rq_1?atb=v255-7zu&appVersion=5.74.0&test=1"
         private const val EXPECTED_OTHER_PIXEL_PHONE_URL = "https://improving.duckduckgo.com/t/my_pixel_android_phone?atb=v255-7zu&appVersion=5.74.0&test=1"
         private const val EXPECTED_OTHER_PIXEL_TABLET_URL = "https://improving.duckduckgo.com/t/my_pixel_android_tablet?atb=v255-7zu&appVersion=5.74.0&test=1"
-    }
-
-    // implement just request and proceed methods
-    private class FakeChain(private val url: String) : Interceptor.Chain {
-        override fun call(): Call {
-            TODO("Not yet implemented")
-        }
-
-        override fun connectTimeoutMillis(): Int {
-            TODO("Not yet implemented")
-        }
-
-        override fun connection(): Connection? {
-            TODO("Not yet implemented")
-        }
-
-        override fun proceed(request: Request): Response {
-            return Response.Builder().request(request).protocol(Protocol.HTTP_2).code(200).message("").build()
-        }
-
-        override fun readTimeoutMillis(): Int {
-            TODO("Not yet implemented")
-        }
-
-        override fun request(): Request {
-            return Request.Builder().url(url).build()
-        }
-
-        override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
-            TODO("Not yet implemented")
-        }
-
-        override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
-            TODO("Not yet implemented")
-        }
-
-        override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
-            TODO("Not yet implemented")
-        }
-
-        override fun writeTimeoutMillis(): Int {
-            TODO("Not yet implemented")
-        }
-
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/PixelReQueryInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/PixelReQueryInterceptorTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import okhttp3.*
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class PixelReQueryInterceptorTest {
+
+    private lateinit var pixelReQueryInterceptor: PixelReQueryInterceptor
+
+    @Before
+    fun setup() {
+        pixelReQueryInterceptor = PixelReQueryInterceptor()
+    }
+
+    @Test
+    fun whenRq0PixelIsSendThenRemoveDeviceAndFormFactor() {
+        assertEquals(
+            EXPECTED_RQ_0_URL.toHttpUrl(),
+            pixelReQueryInterceptor.intercept(FakeChain(RQ_0_PHONE_URL)).request.url
+        )
+
+        assertEquals(
+            EXPECTED_RQ_0_URL.toHttpUrl(),
+            pixelReQueryInterceptor.intercept(FakeChain(RQ_0_TABLET_URL)).request.url
+        )
+    }
+
+    @Test
+    fun whenRq1PixelIsSendThenRemoveDeviceAndFormFactor() {
+        assertEquals(
+            EXPECTED_RQ_1_URL.toHttpUrl(),
+            pixelReQueryInterceptor.intercept(FakeChain(RQ_1_PHONE_URL)).request.url
+        )
+
+        assertEquals(
+            EXPECTED_RQ_1_URL.toHttpUrl(),
+            pixelReQueryInterceptor.intercept(FakeChain(RQ_1_TABLET_URL)).request.url
+        )
+    }
+
+    @Test
+    fun whenPixelOtherThanRqIsSendThenDoNotModify() {
+        assertEquals(
+            EXPECTED_OTHER_PIXEL_PHONE_URL.toHttpUrl(),
+            pixelReQueryInterceptor.intercept(FakeChain(OTHER_PIXEL_PHONE_URL)).request.url
+        )
+
+        assertEquals(
+            EXPECTED_OTHER_PIXEL_TABLET_URL.toHttpUrl(),
+            pixelReQueryInterceptor.intercept(FakeChain(OTHER_PIXEL_TABLET_URL)).request.url
+        )
+
+    }
+
+    private companion object {
+        private const val RQ_0_PHONE_URL = "https://improving.duckduckgo.com/t/rq_0_android_phone?atb=v255-7zu&appVersion=5.74.0&test=1"
+        private const val RQ_0_TABLET_URL = "https://improving.duckduckgo.com/t/rq_0_android_tablet?atb=v255-7zu&appVersion=5.74.0&test=1"
+        private const val RQ_1_PHONE_URL = "https://improving.duckduckgo.com/t/rq_1_android_phone?atb=v255-7zu&appVersion=5.74.0&test=1"
+        private const val RQ_1_TABLET_URL = "https://improving.duckduckgo.com/t/rq_1_android_tablet?atb=v255-7zu&appVersion=5.74.0&test=1"
+        private const val OTHER_PIXEL_PHONE_URL = "https://improving.duckduckgo.com/t/my_pixel_android_phone?atb=v255-7zu&appVersion=5.74.0&test=1"
+        private const val OTHER_PIXEL_TABLET_URL = "https://improving.duckduckgo.com/t/my_pixel_android_tablet?atb=v255-7zu&appVersion=5.74.0&test=1"
+
+        private const val EXPECTED_RQ_0_URL = "https://improving.duckduckgo.com/t/rq_0?atb=v255-7zu&appVersion=5.74.0&test=1"
+        private const val EXPECTED_RQ_1_URL = "https://improving.duckduckgo.com/t/rq_1?atb=v255-7zu&appVersion=5.74.0&test=1"
+        private const val EXPECTED_OTHER_PIXEL_PHONE_URL = "https://improving.duckduckgo.com/t/my_pixel_android_phone?atb=v255-7zu&appVersion=5.74.0&test=1"
+        private const val EXPECTED_OTHER_PIXEL_TABLET_URL = "https://improving.duckduckgo.com/t/my_pixel_android_tablet?atb=v255-7zu&appVersion=5.74.0&test=1"
+    }
+
+    // implement just request and proceed methods
+    private class FakeChain(private val url: String) : Interceptor.Chain {
+        override fun call(): Call {
+            TODO("Not yet implemented")
+        }
+
+        override fun connectTimeoutMillis(): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun connection(): Connection? {
+            TODO("Not yet implemented")
+        }
+
+        override fun proceed(request: Request): Response {
+            return Response.Builder().request(request).protocol(Protocol.HTTP_2).code(200).message("").build()
+        }
+
+        override fun readTimeoutMillis(): Int {
+            TODO("Not yet implemented")
+        }
+
+        override fun request(): Request {
+            return Request.Builder().url(url).build()
+        }
+
+        override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+            TODO("Not yet implemented")
+        }
+
+        override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+            TODO("Not yet implemented")
+        }
+
+        override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+            TODO("Not yet implemented")
+        }
+
+        override fun writeTimeoutMillis(): Int {
+            TODO("Not yet implemented")
+        }
+
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Message
+import android.util.Patterns
 import android.view.ContextMenu
 import android.view.MenuItem
 import android.view.View
@@ -626,6 +627,10 @@ class BrowserTabViewModel(
     }
 
     fun onRefreshRequested() {
+        val omnibarContent = currentOmnibarViewState().omnibarText
+        if (!Patterns.WEB_URL.matcher(omnibarContent).matches()) {
+            fireQueryChangedPixel(currentOmnibarViewState().omnibarText)
+        }
         navigationAwareLoginDetector.onEvent(NavigationEvent.UserAction.Refresh)
         if (currentGlobalLayoutState() is Invalidated) {
             recoverTabWithQuery(url.orEmpty())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -549,7 +549,7 @@ class BrowserTabViewModel(
 
         if (oldQuery == newQuery) {
             pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_NOT_CHANGED))
-        } else {
+        } else if (oldQuery.toString().isNotBlank()) { // blank means no previous search, don't send pixel
             pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_CHANGED))
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
@@ -18,7 +18,9 @@ package com.duckduckgo.app.browser.omnibar
 
 import android.content.Context
 import android.graphics.Rect
+import android.text.Editable
 import android.util.AttributeSet
+import android.util.Patterns
 import android.view.KeyEvent
 import androidx.appcompat.widget.AppCompatEditText
 import com.duckduckgo.app.global.view.showKeyboard
@@ -33,10 +35,25 @@ class KeyboardAwareEditText : AppCompatEditText {
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
+    private var didFocusAlready = false
+
+    private fun Editable.isWebUrl(): Boolean {
+        return Patterns.WEB_URL.matcher(this.toString()).matches()
+    }
+
     override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
         super.onFocusChanged(focused, direction, previouslyFocusedRect)
+        // stop the auto-selection of text after the first focus
+        setSelectAllOnFocus(!didFocusAlready)
         if (focused) {
+            if (didFocusAlready && text != null && text?.isWebUrl() == false) {
+                // trigger the text change listener so that we can show autocomplete
+                text = text
+                // cursor at the end of the word
+                setSelection(text!!.length)
+            }
             showKeyboard()
+            didFocusAlready = true
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
@@ -43,7 +43,6 @@ class KeyboardAwareEditText : AppCompatEditText {
 
     override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
         super.onFocusChanged(focused, direction, previouslyFocusedRect)
-        // stop the auto-selection of text after the first focus
         setSelectAllOnFocus(!didFocusAlready)
         if (focused) {
             if (didFocusAlready && text != null && text?.isWebUrl() == false) {

--- a/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
@@ -21,6 +21,7 @@ import androidx.work.WorkManager
 import com.duckduckgo.app.autocomplete.api.AutoCompleteService
 import com.duckduckgo.app.brokensite.api.BrokenSiteSender
 import com.duckduckgo.app.brokensite.api.BrokenSiteSubmitter
+import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.feedback.api.FeedbackService
 import com.duckduckgo.app.feedback.api.FeedbackSubmitter
 import com.duckduckgo.app.feedback.api.FireAndForgetFeedbackSubmitter
@@ -108,8 +109,11 @@ class NetworkModule {
     }
 
     @Provides
-    fun apiRequestInterceptor(context: Context): ApiRequestInterceptor {
-        return ApiRequestInterceptor(context)
+    fun apiRequestInterceptor(
+        context: Context,
+        userAgentProvider: UserAgentProvider
+    ): ApiRequestInterceptor {
+        return ApiRequestInterceptor(context, userAgentProvider)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
@@ -26,8 +26,7 @@ import com.duckduckgo.app.feedback.api.FeedbackSubmitter
 import com.duckduckgo.app.feedback.api.FireAndForgetFeedbackSubmitter
 import com.duckduckgo.app.feedback.api.SubReasonApiMapper
 import com.duckduckgo.app.global.AppUrl.Url
-import com.duckduckgo.app.global.api.ApiRequestInterceptor
-import com.duckduckgo.app.global.api.NetworkApiCache
+import com.duckduckgo.app.global.api.*
 import com.duckduckgo.app.global.job.AppConfigurationSyncWorkRequestBuilder
 import com.duckduckgo.app.globalprivacycontrol.GlobalPrivacyControl
 import com.duckduckgo.app.httpsupgrade.api.HttpsUpgradeService
@@ -72,9 +71,13 @@ class NetworkModule {
     @Provides
     @Singleton
     @Named("nonCaching")
-    fun pixelOkHttpClient(apiRequestInterceptor: ApiRequestInterceptor): OkHttpClient {
+    fun pixelOkHttpClient(
+        apiRequestInterceptor: ApiRequestInterceptor,
+        pixelReQueryInterceptor: PixelReQueryInterceptor,
+    ): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(apiRequestInterceptor)
+            .addInterceptor(pixelReQueryInterceptor)
             .build()
     }
 
@@ -107,6 +110,11 @@ class NetworkModule {
     @Provides
     fun apiRequestInterceptor(context: Context): ApiRequestInterceptor {
         return ApiRequestInterceptor(context)
+    }
+
+    @Provides
+    fun pixelReQueryInterceptor(): PixelReQueryInterceptor {
+        return PixelReQueryInterceptor()
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/global/api/ApiRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/ApiRequestInterceptor.kt
@@ -18,21 +18,31 @@ package com.duckduckgo.app.global.api
 
 import android.content.Context
 import com.duckduckgo.app.browser.BuildConfig
+import com.duckduckgo.app.browser.useragent.UserAgentProvider
+import com.duckduckgo.app.global.AppUrl
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class ApiRequestInterceptor(context: Context) : Interceptor {
+class ApiRequestInterceptor(
+    context: Context,
+    private val userAgentProvider: UserAgentProvider
+) : Interceptor {
 
     private val userAgent: String by lazy {
         "ddg_android/${BuildConfig.VERSION_NAME} (${context.applicationInfo.packageName}; Android API ${android.os.Build.VERSION.SDK_INT})"
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request()
-            .newBuilder()
-            .addHeader(Header.USER_AGENT, userAgent)
-            .build()
+        val request = chain.request().newBuilder()
 
-        return chain.proceed(request)
+        val url = chain.request().url
+        if (url.toString().startsWith("${AppUrl.Url.PIXEL}/t/rq_")) {
+            // user agent for re-query pixels needs to be the same for the webview
+            request.addHeader(Header.USER_AGENT, userAgentProvider.userAgent())
+        } else {
+            request.addHeader(Header.USER_AGENT, userAgent)
+        }
+
+        return chain.proceed(request.build())
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelReQueryInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelReQueryInterceptor.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import com.duckduckgo.app.global.device.DeviceInfo
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
+import okhttp3.Response
+import timber.log.Timber
+
+/**
+ * This interceptor fixes the re-query pixels without being invasive to the Pixel APIs.
+ * When the search box was removed, the rq pixels were moved into the mobile app, however ALL pixels sent
+ * from the mobile app have _android_{formFactor} appended to the pixel name, and this broke all existing
+ * monitoring and dashboards.
+ *
+ * This interceptor removes the _android_{formFactor} appended suffix
+ */
+class PixelReQueryInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        var url = chain.request().url
+        val request = chain.request().newBuilder()
+
+        url = url.toUrl().toString().replace("rq_0_android_${DeviceInfo.FormFactor.PHONE.description}", "rq_0").toHttpUrl()
+        url = url.toUrl().toString().replace("rq_0_android_${DeviceInfo.FormFactor.TABLET.description}", "rq_0").toHttpUrl()
+        url = url.toUrl().toString().replace("rq_1_android_${DeviceInfo.FormFactor.PHONE.description}", "rq_1").toHttpUrl()
+        url = url.toUrl().toString().replace("rq_1_android_${DeviceInfo.FormFactor.TABLET.description}", "rq_1").toHttpUrl()
+
+        Timber.d("Pixel interceptor: $url")
+
+        return chain.proceed(request.url(url).build())
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1199568299173487/f
Tech Design URL: https://app.asana.com/0/481882893211075/1199538898514883/f
CC: 

**Description**:

This PR fixes the `rq_x` pixels that got broke when removing the double search header. The main issue was that pixels have a suffix `android_{formFactor}`, but also under the [iOS implementation](https://app.asana.com/0/481882893211075/1199403269515656/f) a few more fine tuning was done to improve them. This PR will:

* Remove the android_tablet/phone suffix from the rq_x pixels
* Override the user agent so that rq_x pixels are sent with the same UA as the webview
* Align the search bar behavior with iOS
* rq.0 will fire when
  * the user resubmits the search through the search box in our app.
  * the SERP is reloaded 
  * hitting refresh button
  * resubmitting query without editing
  * selecting autocomplete item that matches what was just searched
* rq.1 will fire when
  * the user has the SERP loaded in the current tab and submits a different search (by typing or selecting different autocomplete entry).

**Steps to test this PR**:
Note: to check `rq_x` are being sent, just filter for `Pixel interceptor` in logcat

The following should test all scenarios.

* open app and search reddit
* Verify `rq.x` pixels are not sent
* pull to refresh
* verify `rq.0` pixel is sent
* overflow menu -> refresh
* verify `rq.0` is sent
* tap on search bar 
* verify "reddit" word is not selected, cursor is at the end of the word and autocomplete appears
* select "🔎 reddit" from autocomplete
* verify `rq.0` is sent
* tap on search bar and select "🔎 reddit politics" (or any other reddit xxx autocomplete result)
* Verify `rq.1` pixel is sent
* click on a link in SERP, open it in a new tab and wait for it to load
* tap on the search bar
* verify autocomplete results don't appear
* verify URL in search bar is selected - ❌ this check will fail, I didn't manage to make it work
* close the app and re-open
* Verify `rq.x` pixels are not sent
* switch to the tab with the query search, ie "reddit..."
* verify `rq.1` pixel is sent
* (here use Charles to inspect UA)
* change the query in the search bar and ENTER
* verify the UA is the one used for webview when `rq.1` is sent
* pull to refresh
* verify the UA is the one used for webview when `rq.1` is sent


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
