### PR TITLE
Removed the experiment for the new default browser dialog for full release

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/di/TestAppComponent.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/TestAppComponent.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.browser.rating.di.RatingModule
 import com.duckduckgo.app.global.exception.UncaughtExceptionModule
 import com.duckduckgo.app.httpsupgrade.di.HttpsUpgraderModule
 import com.duckduckgo.app.onboarding.di.OnboardingModule
+import com.duckduckgo.app.onboarding.di.WelcomePageModule
 import com.duckduckgo.app.surrogates.di.ResourceSurrogateModule
 import com.duckduckgo.app.trackerdetection.di.TrackerDetectionModule
 import com.duckduckgo.app.usage.di.AppUsageModule
@@ -72,7 +73,8 @@ import javax.inject.Singleton
         UncaughtExceptionModule::class,
         PlayStoreReferralModule::class,
         CoroutinesModule::class,
-        CertificateTrustedStoreModule::class
+        CertificateTrustedStoreModule::class,
+        WelcomePageModule::class
     ]
 )
 interface TestAppComponent : AppComponent {

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerPageCountTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerPageCountTest.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.onboarding.ui
 
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
-import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
+import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.statistics.Variant
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -33,11 +33,11 @@ class OnboardingPageManagerPageCountTest(private val testCase: TestCase) {
     private lateinit var testee: OnboardingPageManager
     private val onboardingPageBuilder: OnboardingPageBuilder = mock()
     private val mockDefaultBrowserDetector: DefaultBrowserDetector = mock()
-    private val defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment = mock()
+    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog = mock()
 
     @Before
     fun setup() {
-        testee = OnboardingPageManagerWithTrackerBlocking(defaultRoleBrowserDialogExperiment, onboardingPageBuilder, mockDefaultBrowserDetector)
+        testee = OnboardingPageManagerWithTrackerBlocking(defaultRoleBrowserDialog, onboardingPageBuilder, mockDefaultBrowserDetector)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerPageCountTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerPageCountTest.kt
@@ -17,8 +17,8 @@
 package com.duckduckgo.app.onboarding.ui
 
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
 import com.duckduckgo.app.statistics.Variant
-import com.duckduckgo.app.statistics.VariantManager
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
@@ -33,11 +33,11 @@ class OnboardingPageManagerPageCountTest(private val testCase: TestCase) {
     private lateinit var testee: OnboardingPageManager
     private val onboardingPageBuilder: OnboardingPageBuilder = mock()
     private val mockDefaultBrowserDetector: DefaultBrowserDetector = mock()
-    private val variantManager: VariantManager = mock()
+    private val defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment = mock()
 
     @Before
     fun setup() {
-        testee = OnboardingPageManagerWithTrackerBlocking(variantManager, onboardingPageBuilder, mockDefaultBrowserDetector)
+        testee = OnboardingPageManagerWithTrackerBlocking(defaultRoleBrowserDialogExperiment, onboardingPageBuilder, mockDefaultBrowserDetector)
     }
 
     @Test
@@ -49,7 +49,6 @@ class OnboardingPageManagerPageCountTest(private val testCase: TestCase) {
     }
 
     private fun configureDefaultBrowserPageConfig() {
-        whenever(variantManager.getVariant()).thenReturn(testCase.variant)
         if (testCase.defaultBrowserPage) {
             configureDeviceSupportsDefaultBrowser()
         } else {
@@ -60,20 +59,13 @@ class OnboardingPageManagerPageCountTest(private val testCase: TestCase) {
     companion object {
 
         private val otherVariant = Variant(key = "variant", features = listOf(), filterBy = { true })
-        private val defaultBrowserVariant = Variant(
-            key = "variant",
-            features = listOf(VariantManager.VariantFeature.SetDefaultBrowserDialog),
-            filterBy = { true }
-        )
 
         @JvmStatic
         @Parameterized.Parameters(name = "Test case: {index} - {0}")
         fun testData(): Array<TestCase> {
             return arrayOf(
                 TestCase(false, 1, otherVariant),
-                TestCase(true, 2, otherVariant),
-                TestCase(false, 1, defaultBrowserVariant),
-                TestCase(true, 1, defaultBrowserVariant)
+                TestCase(true, 2, otherVariant)
             )
         }
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerTest.kt
@@ -17,8 +17,7 @@
 package com.duckduckgo.app.onboarding.ui
 
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
-import com.duckduckgo.app.statistics.Variant
-import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
@@ -30,24 +29,18 @@ class OnboardingPageManagerTest {
     private lateinit var testee: OnboardingPageManager
     private val onboardingPageBuilder: OnboardingPageBuilder = mock()
     private val mockDefaultBrowserDetector: DefaultBrowserDetector = mock()
-    private val variantManager: VariantManager = mock()
-    private val defaultBrowserVariant = Variant(
-        key = "variant",
-        features = listOf(VariantManager.VariantFeature.SetDefaultBrowserDialog),
-        filterBy = { true }
-    )
-    private val otherVariant = Variant(key = "variant", features = listOf(), filterBy = { true })
+    private val defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment = mock()
 
     @Before
     fun setup() {
-        testee = OnboardingPageManagerWithTrackerBlocking(variantManager, onboardingPageBuilder, mockDefaultBrowserDetector)
+        testee = OnboardingPageManagerWithTrackerBlocking(defaultRoleBrowserDialogExperiment, onboardingPageBuilder, mockDefaultBrowserDetector)
     }
 
     @Test
     fun whenDDGIsNotDefaultBrowserThenExpectedOnboardingPagesAreTwo() {
         configureDeviceSupportsDefaultBrowser()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
-        whenever(variantManager.getVariant()).thenReturn(otherVariant)
+        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(false)
 
         testee.buildPageBlueprints()
 
@@ -58,7 +51,7 @@ class OnboardingPageManagerTest {
     fun whenDDGIsNotDefaultBrowserAndBrowserDialogVariantThenExpectedOnboardingPagesAre1() {
         configureDeviceSupportsDefaultBrowser()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
-        whenever(variantManager.getVariant()).thenReturn(defaultBrowserVariant)
+        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(true)
 
         testee.buildPageBlueprints()
 
@@ -69,7 +62,7 @@ class OnboardingPageManagerTest {
     fun whenDDGAsDefaultBrowserThenSinglePageOnBoarding() {
         configureDeviceSupportsDefaultBrowser()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(variantManager.getVariant()).thenReturn(otherVariant)
+        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(false)
 
         testee.buildPageBlueprints()
 
@@ -80,7 +73,7 @@ class OnboardingPageManagerTest {
     fun whenDDGAsDefaultBrowserAndBrowserDialogVariantThenSinglePageOnBoarding() {
         configureDeviceSupportsDefaultBrowser()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(variantManager.getVariant()).thenReturn(defaultBrowserVariant)
+        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(true)
 
         testee.buildPageBlueprints()
 
@@ -90,7 +83,7 @@ class OnboardingPageManagerTest {
     @Test
     fun whenDeviceDoesNotSupportDefaultBrowserThenSinglePageOnBoarding() {
         configureDeviceDoesNotSupportDefaultBrowser()
-        whenever(variantManager.getVariant()).thenReturn(otherVariant)
+        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(false)
 
         testee.buildPageBlueprints()
 
@@ -100,7 +93,7 @@ class OnboardingPageManagerTest {
     @Test
     fun whenDeviceDoesNotSupportDefaultBrowserAndBrowserDialogVariantThenSinglePageOnBoarding() {
         configureDeviceDoesNotSupportDefaultBrowser()
-        whenever(variantManager.getVariant()).thenReturn(defaultBrowserVariant)
+        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(true)
 
         testee.buildPageBlueprints()
 

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManagerTest.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.onboarding.ui
 
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
-import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
+import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
@@ -29,18 +29,18 @@ class OnboardingPageManagerTest {
     private lateinit var testee: OnboardingPageManager
     private val onboardingPageBuilder: OnboardingPageBuilder = mock()
     private val mockDefaultBrowserDetector: DefaultBrowserDetector = mock()
-    private val defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment = mock()
+    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog = mock()
 
     @Before
     fun setup() {
-        testee = OnboardingPageManagerWithTrackerBlocking(defaultRoleBrowserDialogExperiment, onboardingPageBuilder, mockDefaultBrowserDetector)
+        testee = OnboardingPageManagerWithTrackerBlocking(defaultRoleBrowserDialog, onboardingPageBuilder, mockDefaultBrowserDetector)
     }
 
     @Test
     fun whenDDGIsNotDefaultBrowserThenExpectedOnboardingPagesAreTwo() {
         configureDeviceSupportsDefaultBrowser()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
-        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(false)
+        whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(false)
 
         testee.buildPageBlueprints()
 
@@ -48,10 +48,10 @@ class OnboardingPageManagerTest {
     }
 
     @Test
-    fun whenDDGIsNotDefaultBrowserAndBrowserDialogVariantThenExpectedOnboardingPagesAre1() {
+    fun whenDDGIsNotDefaultBrowserAndShouldShowBrowserDialogThenExpectedOnboardingPagesAre1() {
         configureDeviceSupportsDefaultBrowser()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
-        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(true)
+        whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
 
         testee.buildPageBlueprints()
 
@@ -62,7 +62,7 @@ class OnboardingPageManagerTest {
     fun whenDDGAsDefaultBrowserThenSinglePageOnBoarding() {
         configureDeviceSupportsDefaultBrowser()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(false)
+        whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(false)
 
         testee.buildPageBlueprints()
 
@@ -70,10 +70,10 @@ class OnboardingPageManagerTest {
     }
 
     @Test
-    fun whenDDGAsDefaultBrowserAndBrowserDialogVariantThenSinglePageOnBoarding() {
+    fun whenDDGAsDefaultBrowserAndShouldShowBrowserDialogThenSinglePageOnBoarding() {
         configureDeviceSupportsDefaultBrowser()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(true)
+        whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
 
         testee.buildPageBlueprints()
 
@@ -83,7 +83,7 @@ class OnboardingPageManagerTest {
     @Test
     fun whenDeviceDoesNotSupportDefaultBrowserThenSinglePageOnBoarding() {
         configureDeviceDoesNotSupportDefaultBrowser()
-        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(false)
+        whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(false)
 
         testee.buildPageBlueprints()
 
@@ -91,9 +91,9 @@ class OnboardingPageManagerTest {
     }
 
     @Test
-    fun whenDeviceDoesNotSupportDefaultBrowserAndBrowserDialogVariantThenSinglePageOnBoarding() {
+    fun whenDeviceDoesNotSupportDefaultBrowserAndShouldShowBrowserDialogThenSinglePageOnBoarding() {
         configureDeviceDoesNotSupportDefaultBrowser()
-        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment()).thenReturn(true)
+        whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
 
         testee.buildPageBlueprints()
 

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -20,7 +20,7 @@ import android.content.Intent
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
+import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -58,7 +58,7 @@ class WelcomePageViewModelTest {
     private lateinit var appInstallStore: AppInstallStore
 
     @Mock
-    private lateinit var defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment
+    private lateinit var defaultRoleBrowserDialog: DefaultRoleBrowserDialog
 
     private val events = ConflatedBroadcastChannel<WelcomePageView.Event>()
 
@@ -73,15 +73,15 @@ class WelcomePageViewModelTest {
             appInstallStore,
             InstrumentationRegistry.getInstrumentation().targetContext,
             pixel,
-            defaultRoleBrowserDialogExperiment
+            defaultRoleBrowserDialog
         )
 
         viewEvents = events.asFlow().flatMapLatest { viewModel.reduce(it) }
     }
 
     @Test
-    fun whenOnPrimaryCtaClickedAndShouldNotShowXpThenFinish() = coroutineRule.runBlocking {
-        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment())
+    fun whenOnPrimaryCtaClickedAndShouldNotShowDialogThenFinish() = coroutineRule.runBlocking {
+        whenever(defaultRoleBrowserDialog.shouldShowDialog())
             .thenReturn(false)
 
         val launch = launch {
@@ -95,11 +95,11 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnPrimaryCtaClickedAndShouldShowXpAndShowThenEmitShowDialog() = coroutineRule.runBlocking {
-        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment())
+    fun whenOnPrimaryCtaClickedAndShouldShowDialogAndShowThenEmitShowDialog() = coroutineRule.runBlocking {
+        whenever(defaultRoleBrowserDialog.shouldShowDialog())
             .thenReturn(true)
         val intent = Intent()
-        whenever(defaultRoleBrowserDialogExperiment.createIntent(any()))
+        whenever(defaultRoleBrowserDialog.createIntent(any()))
             .thenReturn(intent)
 
         val launch = launch {
@@ -113,10 +113,10 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnPrimaryCtaClickedAndShouldShowXpNullIntentThenFireAndFinish() = coroutineRule.runBlocking {
-        whenever(defaultRoleBrowserDialogExperiment.shouldShowExperiment())
+    fun whenOnPrimaryCtaClickedAndShouldShowDialogNullIntentThenFireAndFinish() = coroutineRule.runBlocking {
+        whenever(defaultRoleBrowserDialog.shouldShowDialog())
             .thenReturn(true)
-        whenever(defaultRoleBrowserDialogExperiment.createIntent(any()))
+        whenever(defaultRoleBrowserDialog.createIntent(any()))
             .thenReturn(null)
 
         val launch = launch {
@@ -132,7 +132,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnDefaultBrowserSetThenCallExperimentShownFireAndFinish() = coroutineRule.runBlocking {
+    fun whenOnDefaultBrowserSetThenCallDialogShownFireAndFinish() = coroutineRule.runBlocking {
         val launch = launch {
             viewEvents.collect { state ->
                 assertTrue(state == WelcomePageView.State.Finish)
@@ -140,7 +140,7 @@ class WelcomePageViewModelTest {
         }
         events.send(WelcomePageView.Event.OnDefaultBrowserSet)
 
-        verify(defaultRoleBrowserDialogExperiment).experimentShown()
+        verify(defaultRoleBrowserDialog).dialogShown()
         verify(pixel).fire(
             Pixel.PixelName.DEFAULT_BROWSER_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())
@@ -150,7 +150,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnDefaultBrowserNotSetThenCallExperimentShownFireAndFinish() = coroutineRule.runBlocking {
+    fun whenOnDefaultBrowserNotSetThenCallDialogShownFireAndFinish() = coroutineRule.runBlocking {
         val launch = launch {
             viewEvents.collect { state ->
                 assertTrue(state == WelcomePageView.State.Finish)
@@ -158,7 +158,7 @@ class WelcomePageViewModelTest {
         }
         events.send(WelcomePageView.Event.OnDefaultBrowserNotSet)
 
-        verify(defaultRoleBrowserDialogExperiment).experimentShown()
+        verify(defaultRoleBrowserDialog).dialogShown()
         verify(pixel).fire(
             Pixel.PixelName.DEFAULT_BROWSER_NOT_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -68,20 +68,6 @@ class VariantManagerTest {
     }
 
     @Test
-    fun roleManagerDefaultBrowserDialogControlHasExpectedWeightAndFeatures() {
-        val variant = variants.first { it.key == "zt" }
-        assertEqualsDouble(1.0, variant.weight)
-        assertTrue(variant.features.isEmpty())
-    }
-
-    @Test
-    fun roleManagerDefaultBrowserDialogTreatmentHasExpectedWeightAndFeatures() {
-        val variant = variants.first { it.key == "zu" }
-        assertEqualsDouble(1.0, variant.weight)
-        assertTrue(variant.features == listOf(SetDefaultBrowserDialog))
-    }
-
-    @Test
     fun verifyNoDuplicateVariantNames() {
         val existingNames = mutableSetOf<String>()
         variants.forEach {

--- a/app/src/main/java/com/duckduckgo/app/di/AndroidBindingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AndroidBindingModule.kt
@@ -41,7 +41,6 @@ import com.duckduckgo.app.launch.LaunchBridgeActivity
 import com.duckduckgo.app.location.ui.LocationPermissionsActivity
 import com.duckduckgo.app.location.ui.SiteLocationPermissionDialog
 import com.duckduckgo.app.notification.NotificationHandlerService
-import com.duckduckgo.app.onboarding.di.WelcomePageModule
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPage
 import com.duckduckgo.app.onboarding.ui.page.WelcomePage
@@ -185,9 +184,7 @@ abstract class AndroidBindingModule {
     @ContributesAndroidInjector
     abstract fun brokenSiteNegativeFeedbackFragment(): BrokenSiteNegativeFeedbackFragment
 
-    @ContributesAndroidInjector(
-        modules = [WelcomePageModule::class]
-    )
+    @ContributesAndroidInjector
     abstract fun welcomePage(): WelcomePage
 
     @ContributesAndroidInjector

--- a/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.global.exception.UncaughtExceptionModule
 import com.duckduckgo.app.httpsupgrade.di.HttpsUpgraderModule
 import com.duckduckgo.app.onboarding.di.OnboardingModule
+import com.duckduckgo.app.onboarding.di.WelcomePageModule
 import com.duckduckgo.app.surrogates.di.ResourceSurrogateModule
 import com.duckduckgo.app.trackerdetection.di.TrackerDetectionModule
 import com.duckduckgo.app.usage.di.AppUsageModule
@@ -70,7 +71,8 @@ import javax.inject.Singleton
         UncaughtExceptionModule::class,
         PlayStoreReferralModule::class,
         CoroutinesModule::class,
-        CertificateTrustedStoreModule::class
+        CertificateTrustedStoreModule::class,
+        WelcomePageModule::class
     ]
 )
 interface AppComponent : AndroidInjector<DuckDuckGoApplication> {

--- a/app/src/main/java/com/duckduckgo/app/global/DefaultRoleBrowserDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DefaultRoleBrowserDialog.kt
@@ -23,15 +23,15 @@ import android.os.Build
 import com.duckduckgo.app.global.install.AppInstallStore
 import timber.log.Timber
 
-interface DefaultRoleBrowserDialogExperiment {
+interface DefaultRoleBrowserDialog {
     fun createIntent(context: Context): Intent?
-    fun shouldShowExperiment(): Boolean
-    fun experimentShown()
+    fun shouldShowDialog(): Boolean
+    fun dialogShown()
 }
 
-class RealDefaultRoleBrowserDialogExperiment(
+class RealDefaultRoleBrowserDialog(
     private val appInstallStore: AppInstallStore
-) : DefaultRoleBrowserDialogExperiment {
+) : DefaultRoleBrowserDialog {
 
     /**
      * @return an Intent to launch the role browser dialog
@@ -54,14 +54,14 @@ class RealDefaultRoleBrowserDialogExperiment(
         return null
     }
 
-    override fun shouldShowExperiment(): Boolean {
+    override fun shouldShowDialog(): Boolean {
         // The second and subsequent times the dialog is shown, the system allows the user to click on "don't show again"
         // we will get the same result as if the dialog was just dismissed.
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
             appInstallStore.newDefaultBrowserDialogCount < DEFAULT_BROWSER_DIALOG_MAX_ATTEMPTS
     }
 
-    override fun experimentShown() {
+    override fun dialogShown() {
         appInstallStore.newDefaultBrowserDialogCount++
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/DefaultRoleBrowserDialogExperiment.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DefaultRoleBrowserDialogExperiment.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import com.duckduckgo.app.global.install.AppInstallStore
-import com.duckduckgo.app.statistics.VariantManager
 import timber.log.Timber
 
 interface DefaultRoleBrowserDialogExperiment {
@@ -31,8 +30,7 @@ interface DefaultRoleBrowserDialogExperiment {
 }
 
 class RealDefaultRoleBrowserDialogExperiment(
-    private val appInstallStore: AppInstallStore,
-    private val variantManager: VariantManager
+    private val appInstallStore: AppInstallStore
 ) : DefaultRoleBrowserDialogExperiment {
 
     /**
@@ -59,7 +57,7 @@ class RealDefaultRoleBrowserDialogExperiment(
     override fun shouldShowExperiment(): Boolean {
         // The second and subsequent times the dialog is shown, the system allows the user to click on "don't show again"
         // we will get the same result as if the dialog was just dismissed.
-        return variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SetDefaultBrowserDialog) &&
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
             appInstallStore.newDefaultBrowserDialogCount < DEFAULT_BROWSER_DIALOG_MAX_ATTEMPTS
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/di/OnboardingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/di/OnboardingModule.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.onboarding.di
 
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
-import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
+import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.onboarding.ui.OnboardingFragmentPageBuilder
 import com.duckduckgo.app.onboarding.ui.OnboardingPageBuilder
 import com.duckduckgo.app.onboarding.ui.OnboardingPageManager
@@ -31,11 +31,11 @@ class OnboardingModule {
 
     @Provides
     fun onboardingPageManger(
-        defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment,
+        defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
         onboardingPageBuilder: OnboardingPageBuilder,
         defaultBrowserDetector: DefaultBrowserDetector
     ): OnboardingPageManager {
-        return OnboardingPageManagerWithTrackerBlocking(defaultRoleBrowserDialogExperiment, onboardingPageBuilder, defaultBrowserDetector)
+        return OnboardingPageManagerWithTrackerBlocking(defaultRoleBrowserDialog, onboardingPageBuilder, defaultBrowserDetector)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/onboarding/di/OnboardingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/di/OnboardingModule.kt
@@ -17,11 +17,11 @@
 package com.duckduckgo.app.onboarding.di
 
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
 import com.duckduckgo.app.onboarding.ui.OnboardingFragmentPageBuilder
 import com.duckduckgo.app.onboarding.ui.OnboardingPageBuilder
 import com.duckduckgo.app.onboarding.ui.OnboardingPageManager
 import com.duckduckgo.app.onboarding.ui.OnboardingPageManagerWithTrackerBlocking
-import com.duckduckgo.app.statistics.VariantManager
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -31,11 +31,11 @@ class OnboardingModule {
 
     @Provides
     fun onboardingPageManger(
-        variantManager: VariantManager,
+        defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment,
         onboardingPageBuilder: OnboardingPageBuilder,
         defaultBrowserDetector: DefaultBrowserDetector
     ): OnboardingPageManager {
-        return OnboardingPageManagerWithTrackerBlocking(variantManager, onboardingPageBuilder, defaultBrowserDetector)
+        return OnboardingPageManagerWithTrackerBlocking(defaultRoleBrowserDialogExperiment, onboardingPageBuilder, defaultBrowserDetector)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
@@ -21,7 +21,6 @@ import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
 import com.duckduckgo.app.global.RealDefaultRoleBrowserDialogExperiment
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModelFactory
-import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import dagger.Module
 import dagger.Provides
@@ -39,7 +38,6 @@ class WelcomePageModule {
 
     @Provides
     fun defaultRoleBrowserDialogExperiment(
-        appInstallStore: AppInstallStore,
-        variantManager: VariantManager
-    ): DefaultRoleBrowserDialogExperiment = RealDefaultRoleBrowserDialogExperiment(appInstallStore, variantManager)
+        appInstallStore: AppInstallStore
+    ): DefaultRoleBrowserDialogExperiment = RealDefaultRoleBrowserDialogExperiment(appInstallStore)
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
@@ -17,8 +17,8 @@
 package com.duckduckgo.app.onboarding.di
 
 import android.content.Context
-import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
-import com.duckduckgo.app.global.RealDefaultRoleBrowserDialogExperiment
+import com.duckduckgo.app.global.DefaultRoleBrowserDialog
+import com.duckduckgo.app.global.RealDefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModelFactory
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -33,11 +33,11 @@ class WelcomePageModule {
         appInstallStore: AppInstallStore,
         context: Context,
         pixel: Pixel,
-        defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment
-    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialogExperiment)
+        defaultRoleBrowserDialog: DefaultRoleBrowserDialog
+    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialog)
 
     @Provides
-    fun defaultRoleBrowserDialogExperiment(
+    fun defaultRoleBrowserDialog(
         appInstallStore: AppInstallStore
-    ): DefaultRoleBrowserDialogExperiment = RealDefaultRoleBrowserDialogExperiment(appInstallStore)
+    ): DefaultRoleBrowserDialog = RealDefaultRoleBrowserDialog(appInstallStore)
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.onboarding.ui
 
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
-import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
+import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.onboarding.ui.OnboardingPageBuilder.OnboardingPageBlueprint
 import com.duckduckgo.app.onboarding.ui.OnboardingPageBuilder.OnboardingPageBlueprint.DefaultBrowserBlueprint
 import com.duckduckgo.app.onboarding.ui.OnboardingPageBuilder.OnboardingPageBlueprint.WelcomeBlueprint
@@ -32,7 +32,7 @@ interface OnboardingPageManager {
 }
 
 class OnboardingPageManagerWithTrackerBlocking(
-    private val defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment,
+    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
     private val onboardingPageBuilder: OnboardingPageBuilder,
     private val defaultWebBrowserCapability: DefaultBrowserDetector
 ) : OnboardingPageManager {
@@ -62,7 +62,7 @@ class OnboardingPageManagerWithTrackerBlocking(
     private fun shouldShowDefaultBrowserPage(): Boolean {
         return defaultWebBrowserCapability.deviceSupportsDefaultBrowserConfiguration() &&
             !defaultWebBrowserCapability.isDefaultBrowser() &&
-            !defaultRoleBrowserDialogExperiment.shouldShowExperiment()
+            !defaultRoleBrowserDialog.shouldShowDialog()
     }
 
     private fun buildDefaultBrowserPage(): DefaultBrowserPage {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
@@ -17,13 +17,13 @@
 package com.duckduckgo.app.onboarding.ui
 
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
 import com.duckduckgo.app.onboarding.ui.OnboardingPageBuilder.OnboardingPageBlueprint
 import com.duckduckgo.app.onboarding.ui.OnboardingPageBuilder.OnboardingPageBlueprint.DefaultBrowserBlueprint
 import com.duckduckgo.app.onboarding.ui.OnboardingPageBuilder.OnboardingPageBlueprint.WelcomeBlueprint
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPage
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPageFragment
 import com.duckduckgo.app.onboarding.ui.page.WelcomePage
-import com.duckduckgo.app.statistics.VariantManager
 
 interface OnboardingPageManager {
     fun pageCount(): Int
@@ -32,7 +32,7 @@ interface OnboardingPageManager {
 }
 
 class OnboardingPageManagerWithTrackerBlocking(
-    private val variantManager: VariantManager,
+    private val defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment,
     private val onboardingPageBuilder: OnboardingPageBuilder,
     private val defaultWebBrowserCapability: DefaultBrowserDetector
 ) : OnboardingPageManager {
@@ -62,7 +62,7 @@ class OnboardingPageManagerWithTrackerBlocking(
     private fun shouldShowDefaultBrowserPage(): Boolean {
         return defaultWebBrowserCapability.deviceSupportsDefaultBrowserConfiguration() &&
             !defaultWebBrowserCapability.isDefaultBrowser() &&
-            !variantManager.getVariant().hasFeature(VariantManager.VariantFeature.SetDefaultBrowserDialog)
+            !defaultRoleBrowserDialogExperiment.shouldShowExperiment()
     }
 
     private fun buildDefaultBrowserPage(): DefaultBrowserPage {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.app.onboarding.ui.page
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.duckduckgo.app.global.DefaultRoleBrowserDialogExperiment
+import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import kotlinx.coroutines.flow.Flow
@@ -29,7 +29,7 @@ class WelcomePageViewModel(
     private val appInstallStore: AppInstallStore,
     private val context: Context,
     private val pixel: Pixel,
-    private val defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment
+    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog
 ) : ViewModel() {
 
     fun reduce(event: WelcomePageView.Event): Flow<WelcomePageView.State> {
@@ -41,8 +41,8 @@ class WelcomePageViewModel(
     }
 
     private fun onPrimaryCtaClicked(): Flow<WelcomePageView.State> = flow {
-        if (defaultRoleBrowserDialogExperiment.shouldShowExperiment()) {
-            val intent = defaultRoleBrowserDialogExperiment.createIntent(context)
+        if (defaultRoleBrowserDialog.shouldShowDialog()) {
+            val intent = defaultRoleBrowserDialog.createIntent(context)
             if (intent != null) {
                 emit(WelcomePageView.State.ShowDefaultBrowserDialog(intent))
             } else {
@@ -55,7 +55,7 @@ class WelcomePageViewModel(
     }
 
     private fun onDefaultBrowserSet(): Flow<WelcomePageView.State> = flow {
-        defaultRoleBrowserDialogExperiment.experimentShown()
+        defaultRoleBrowserDialog.dialogShown()
 
         appInstallStore.defaultBrowser = true
 
@@ -68,7 +68,7 @@ class WelcomePageViewModel(
     }
 
     private fun onDefaultBrowserNotSet(): Flow<WelcomePageView.State> = flow {
-        defaultRoleBrowserDialogExperiment.experimentShown()
+        defaultRoleBrowserDialog.dialogShown()
 
         appInstallStore.defaultBrowser = false
 
@@ -86,14 +86,14 @@ class WelcomePageViewModelFactory(
     private val appInstallStore: AppInstallStore,
     private val context: Context,
     private val pixel: Pixel,
-    private val defaultRoleBrowserDialogExperiment: DefaultRoleBrowserDialogExperiment
+    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog
 ) : ViewModelProvider.NewInstanceFactory() {
 
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         return with(modelClass) {
             when {
                 isAssignableFrom(WelcomePageViewModel::class.java) -> WelcomePageViewModel(
-                    appInstallStore, context, pixel, defaultRoleBrowserDialogExperiment
+                    appInstallStore, context, pixel, defaultRoleBrowserDialog
                 )
                 else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.statistics
 
-import android.os.Build
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.VariantManager.Companion.referrerVariant
@@ -85,8 +84,6 @@ interface VariantManager {
             val locale = Locale.getDefault()
             return locale != null && locale.language == "en"
         }
-
-        private fun isAtLeastApiVersion(version: Int) = Build.VERSION.SDK_INT >= version
 
         private fun isSerpRegionToggleCountry(): Boolean {
             val locale = Locale.getDefault()

--- a/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.statistics
 
 import android.os.Build
-import android.os.Build.VERSION_CODES.Q
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.VariantManager.Companion.referrerVariant
@@ -32,7 +31,6 @@ interface VariantManager {
     sealed class VariantFeature {
         object SerpHeaderQueryReplacement : VariantFeature()
         object SerpHeaderRemoval : VariantFeature()
-        object SetDefaultBrowserDialog : VariantFeature()
     }
 
     companion object {
@@ -53,14 +51,6 @@ interface VariantManager {
             Variant(key = "zh", weight = 0.0, features = listOf(VariantFeature.SerpHeaderQueryReplacement), filterBy = { noFilter() }),
             Variant(key = "zi", weight = 0.0, features = listOf(VariantFeature.SerpHeaderRemoval), filterBy = { noFilter() }),
 
-            // Role manager default browser dialog
-            Variant(key = "zt", weight = 1.0, features = emptyList(), filterBy = { isAtLeastApiVersion(Q) }),
-            Variant(
-                key = "zu",
-                weight = 1.0,
-                features = listOf(VariantFeature.SetDefaultBrowserDialog),
-                filterBy = { isAtLeastApiVersion(Q) }
-            )
             // All groups in an experiment (control and variants) MUST use the same filters
         )
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1199628713920165/f
Tech Design URL: 
CC: https://app.asana.com/0/1142021229838617/1199633113249889/f

**Description**:
After the successfull experiment, see https://app.asana.com/0/0/1199361498013999/f, this PR:
* Removes the `zu` and `zt` variants
* Modifies the `DefaultRoleBrowserDialogExperiment#shouldShowExperiment` to remove the variant check
* Modifies the `OnboardingPageManagerWithTrackerBlocking` to remove the variant check and to ensure it shows when the "new Chrome default browser dialog" does not
* Fixed the tests

**Steps to test this PR**:

==Test case 1==

Device API >=29
* Fresh install the app and launch it
* In Welcome page press "let's do it"
* Select ddg as default browser in the dialog
* Verify app proceeds to main browser page
* Verify pixel m_db_s with fo param set as true
* Verify browser is set as default

==Test case 2==

* Device API >=29
* Fresh install the app and launch it
* In Welcome page press "let's do it"
* Press "Cancel" in the dialog
* Verify app proceeds to main browser page
* Verify pixel m_db_ns with fo param set as true
* Verify browser is NOT set as default

==Test case 3==

* Device API <29
* Fresh install the app and launch it
* In Welcome page press "let's do it"
* Verify (legacy) onboarding proceeds unmodified

==Test case 4==

* Device with any API
* Upgrade the app and launch it (onboarding should have been done already)
* Verify onboarding is skipped and user taken to main browser page


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
