### PR TITLE
User Credential on Android system being presented when accessing Mutu…

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -35,7 +35,6 @@ import com.duckduckgo.app.browser.logindetection.DOMLoginDetector
 import com.duckduckgo.app.browser.logindetection.WebNavigationEvent
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
-import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource.*
 import com.duckduckgo.app.globalprivacycontrol.GlobalPrivacyControl
@@ -45,7 +44,6 @@ import timber.log.Timber
 import java.net.URI
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
-
 
 class BrowserWebViewClient(
     private val webViewHttpAuthStore: WebViewHttpAuthStore,
@@ -74,15 +72,19 @@ class BrowserWebViewClient(
 
     override fun onReceivedClientCertRequest(view: WebView?, request: ClientCertRequest?) {
         val context = view!!.context as Activity
-        KeyChain.choosePrivateKeyAlias(context, { alias ->
-            try {
-                val changPrivateKey: PrivateKey? = KeyChain.getPrivateKey(context, alias!!)
-                val certificates: Array<X509Certificate>? = KeyChain.getCertificateChain(context, alias!!)
-                request!!.proceed(changPrivateKey, certificates)
-            } catch (e: KeyChainException) {
-            } catch (e: InterruptedException) {
-            }
-        }, arrayOf("RSA"), null, null, -1, null)
+        KeyChain.choosePrivateKeyAlias(
+            context,
+            { alias ->
+                try {
+                    val changPrivateKey: PrivateKey? = KeyChain.getPrivateKey(context, alias!!)
+                    val certificates: Array<X509Certificate>? = KeyChain.getCertificateChain(context, alias!!)
+                    request!!.proceed(changPrivateKey, certificates)
+                } catch (e: KeyChainException) {
+                } catch (e: InterruptedException) {
+                }
+            },
+            arrayOf("RSA"), null, null, -1, null
+        )
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -275,10 +275,10 @@ class BrowserWebViewClient(
     }
 
     private fun requestAuthentication(
-            view: WebView?,
-            handler: HttpAuthHandler,
-            host: String?,
-            realm: String?
+        view: WebView?,
+        handler: HttpAuthHandler,
+        host: String?,
+        realm: String?
     ) {
         webViewClientListener?.let {
             Timber.v("showAuthenticationDialog - $host, $realm")

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -48,17 +48,17 @@ import java.security.cert.X509Certificate
 
 
 class BrowserWebViewClient(
-        private val webViewHttpAuthStore: WebViewHttpAuthStore,
-        private val trustedCertificateStore: TrustedCertificateStore,
-        private val requestRewriter: RequestRewriter,
-        private val specialUrlDetector: SpecialUrlDetector,
-        private val requestInterceptor: RequestInterceptor,
-        private val offlinePixelCountDataStore: OfflinePixelCountDataStore,
-        private val uncaughtExceptionRepository: UncaughtExceptionRepository,
-        private val cookieManager: CookieManager,
-        private val loginDetector: DOMLoginDetector,
-        private val dosDetector: DosDetector,
-        private val globalPrivacyControl: GlobalPrivacyControl
+    private val webViewHttpAuthStore: WebViewHttpAuthStore,
+    private val trustedCertificateStore: TrustedCertificateStore,
+    private val requestRewriter: RequestRewriter,
+    private val specialUrlDetector: SpecialUrlDetector,
+    private val requestInterceptor: RequestInterceptor,
+    private val offlinePixelCountDataStore: OfflinePixelCountDataStore,
+    private val uncaughtExceptionRepository: UncaughtExceptionRepository,
+    private val cookieManager: CookieManager,
+    private val loginDetector: DOMLoginDetector,
+    private val dosDetector: DosDetector,
+    private val globalPrivacyControl: GlobalPrivacyControl
 ) : WebViewClient() {
 
     var webViewClientListener: WebViewClientListener? = null
@@ -286,10 +286,10 @@ class BrowserWebViewClient(
             val siteURL = if (view?.url != null) "${URI(view.url).scheme}://$host" else host.orEmpty()
 
             val request = BasicAuthenticationRequest(
-                    handler = handler,
-                    host = host.orEmpty(),
-                    realm = realm.orEmpty(),
-                    site = siteURL
+                handler = handler,
+                host = host.orEmpty(),
+                realm = realm.orEmpty(),
+                site = siteURL
             )
 
             it.requiresAuthentication(request)


### PR DESCRIPTION
Task/Issue URL:  https://github.com/duckduckgo/Android/issues/1063

**Description**:

Hi,

This code does the trick for our sites. It is important to note that RSA keys ONLY are requested by this pull request, I didn't test it with EC keys et al (see [choosePrivateKeyAlias](https://developer.android.com/reference/android/security/KeyChain#choosePrivateKeyAlias(android.app.Activity,%20android.security.KeyChainAliasCallback,%20java.lang.String[],%20java.security.Principal[],%20java.lang.String,%20int,%20java.lang.String)) field keyTypes

However RSA is the most common and if adding the rest to the String[] list still works, you may as well.

My apologies for proposing a change, I really want to you DuckDuckGo but without this I can't :)

This fix does not fix the certificate download but that is the easier part.

###### Internal references:
[From Issue](https://app.asana.com/0/414730916066338/1199561121099458/f)
