### PR TITLE
Fixed the back navigation after web search

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -225,7 +225,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
                 launch { viewModel.onOpenShortcut(sharedText) }
             } else {
                 Timber.w("opening in new tab requested for $sharedText")
-                launch { viewModel.onOpenInNewTabRequested(query = sharedText, skipHome = true) }
+                launch { viewModel.onOpenInNewTabRequested(query = sharedText, sourceTabId = currentTab?.tabId, skipHome = true) }
                 return
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/1070
Tech Design URL: 
CC: https://app.asana.com/0/414730916066338/1199905075709368/f

Fixed the issue by passing the current tab id to onOpenInNewTabRequested function while performing web search


**Steps to test this PR**:
1. Perfrom "Web search" on a tab. Consider this as tab 1.
2. The user will be in a new tab, Now press back button
3. The current tab should close. The user will be seeing the tab1.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
