### PR TITLE
Make privacy grade clickable when grade is loading

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -823,9 +823,9 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenShowEmptyGradeIsTrueThenIsEnableIsFalse() {
+    fun whenShowEmptyGradeIsTrueThenIsEnableIsTrue() {
         val testee = BrowserTabViewModel.PrivacyGradeViewState(PrivacyGrade.A, shouldAnimate = false, showEmptyGrade = true)
-        assertFalse(testee.isEnabled)
+        assertTrue(testee.isEnabled)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -216,7 +216,7 @@ class BrowserTabViewModel(
         val shouldAnimate: Boolean = false,
         val showEmptyGrade: Boolean = true
     ) {
-        val isEnabled: Boolean = !showEmptyGrade && privacyGrade != PrivacyGrade.UNKNOWN
+        val isEnabled: Boolean = privacyGrade != PrivacyGrade.UNKNOWN
     }
 
     data class AutoCompleteViewState(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1191242003013179
Tech Design URL: 
CC: 

**Description**:
This PR makes the privacy grade clickable while the grade is loading.

**Steps to test this PR**:
1. Go to a site that takes a few seconds to load, a good example is the first time that `cnn.com` loads.
1. While loading (privacy grade is completely black) click on the privacy grade.
1. You should be taken to the privacy dashboard.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
