### PR TITLE
Switching from JCenter to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
@@ -30,7 +29,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
**_Details / rationale_:**
- JCenter repository sunset is announced for a May 01st 2021 (and hence Jcenter references must be changed to a Maven Central)
- `'com.android.tools.build:gradle'` plugin version is bumped: 4.1.0-->> 4.1.2 

ℹ️ Please note that bump to an upcoming Android Studio/android gradle plugin version **4.1.3** is required in order to solve issues with gradle dependency refresh/project sync (after `jcenter()` repository references are removed, that is... see pending issue here: https://issuetracker.google.com/issues/179291081)

**_Related links:_**
- https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter
- https://www.infoq.com/news/2021/02/jfrog-jcenter-bintray-closure
- https://blog.sonatype.com/dear-bintray-and-jcenter-users-heres-what-you-need-to-know-about-the-central-repository