### PR TITLE
Do not send rq.1 when the user is NOT in the SERP

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1259,6 +1259,17 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserSubmittedDifferentQueryAndOldQueryIsUrlThenDoNotSendQueryChangePixel() {
+        whenever(mockOmnibarConverter.convertQueryToUrl("another query", null)).thenReturn("another query")
+        loadUrl("www.foo.com")
+
+        testee.onUserSubmittedQuery("another query")
+
+        verify(mockPixel, never()).fire("rq_0")
+        verify(mockPixel, never()).fire("rq_1")
+    }
+
+    @Test
     fun whenUserBrowsingPressesBackAndBrowserCanGoBackThenNavigatesToPreviousPageAndHandledTrue() {
         setupNavigation(isBrowsing = true, canGoBack = true, stepsToPreviousPage = 2)
         assertTrue(testee.onUserPressedBack())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -545,6 +545,8 @@ class BrowserTabViewModel(
         val oldQuery = currentOmnibarViewState().omnibarText.toUri()
         val newQuery = omnibarText.toUri()
 
+        if (Patterns.WEB_URL.matcher(oldQuery.toString()).matches()) return
+
         if (oldQuery == newQuery) {
             pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_NOT_CHANGED))
         } else if (oldQuery.toString().isNotBlank()) { // blank means no previous search, don't send pixel


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1199905759163742/f
Tech Design URL: 
CC: 

**Description**:
We should not send rq.1 pixels when the user is in NOT in the SERP, ie. the search bar contains a valid URL

Repro steps of the bug
* open browser
* load website, eg. http://example.com
* tap on search bar
* search for "reddit"
* select "🔎 reddit"
* verify rq.1 pixel is wrongly fired ❌


**Steps to test this PR**:
(to see when rq pixels are sent, filter logcat with `rq_`)


Verify the following test flow
* open app and search reddit
* Verify `rq.x` pixels are NOT sent
* pull to refresh
* verify `rq.0` pixel is sent
* overflow menu -> refresh
* verify `rq.0` is sent
* tap on search bar 
* select "🔎 reddit" from autocomplete
* verify `rq.0` is sent
* tap on search bar and select "🔎 reddit politics" (or any other reddit xxx autocomplete result)
* Verify `rq.1` pixel is sent
* click on a link in SERP, open it in a new tab and wait for it to load
* verify `rq.x` pixels are NOT sent
* tap on the search bar and search for "reddit"
* select "🔎 reddit"
* verify `rq.x` pixels are NOT sent
* tap on search bar and select "🔎 reddit politics" (or any other reddit xxx autocomplete result)
* Verify `rq.1` pixel is sent
* close the app and re-open
* Verify `rq.x` pixels are not sent

also verify the test scenario in https://app.asana.com/0/0/1199922227966104/f

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
