### PR TITLE
Fixed search bar selection behavior

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.omnibar
 import android.content.Context
 import android.graphics.Rect
 import android.text.Editable
+import android.text.Selection
 import android.util.AttributeSet
 import android.util.Patterns
 import android.view.KeyEvent
@@ -50,9 +51,13 @@ class KeyboardAwareEditText : AppCompatEditText {
                 text = text
                 // cursor at the end of the word
                 setSelection(text!!.length)
+            } else if (text?.isWebUrl() == true) {
+                // We always want URLs to be selected
+                // we need to post for the selectAll to take effect. The wonders of Android layout !
+                post { Selection.selectAll(text) }
             }
             showKeyboard()
-            didFocusAlready = true
+            didFocusAlready = text?.isWebUrl() == false
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
@@ -36,17 +36,14 @@ class KeyboardAwareEditText : AppCompatEditText {
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
-    private var didFocusAlready = false
-
     private fun Editable.isWebUrl(): Boolean {
         return Patterns.WEB_URL.matcher(this.toString()).matches()
     }
 
     override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
         super.onFocusChanged(focused, direction, previouslyFocusedRect)
-        setSelectAllOnFocus(!didFocusAlready)
         if (focused) {
-            if (didFocusAlready && text != null && text?.isWebUrl() == false) {
+            if (text != null && text?.isWebUrl() == false) {
                 // trigger the text change listener so that we can show autocomplete
                 text = text
                 // cursor at the end of the word
@@ -57,7 +54,6 @@ class KeyboardAwareEditText : AppCompatEditText {
                 post { Selection.selectAll(text) }
             }
             showKeyboard()
-            didFocusAlready = text?.isWebUrl() == false
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1199931182139250/f
Tech Design URL: 
CC: 

**Description**:
When we fixed the requery pixels (https://github.com/duckduckgo/Android/pull/1065) we also had to tune the search bar behavior, causing a side effect where URLs in thee search bar would never be selected when the user taps on the search bar.

This PR fixes that issue


**Steps to test this PR**:

1. install/update from this branch
2. Ensure tests in https://app.asana.com/0/0/1199922227966104/f pass (to see when rq pixels are sent, filter by `rq_` in logcat)


1. install/update from this branch
2. open app and tap on search bar
3. search for "reddit"
4. select "🔎 reddit"
5. tap on the search bar
6. verify text is not selected and autocomplete results show up
7. open the first URL in the SERP
8. tap on the search bar
9. verify URL text is selected


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
