### PR TITLE
Sanitize intents in BrowserActivity

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.app.fire.DataClearerForegroundAppRestartPixel
 import com.duckduckgo.app.global.ApplicationClearDataState
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.intentText
+import com.duckduckgo.app.global.sanitize
 import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.location.ui.LocationPermissionsActivity
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPage
@@ -127,6 +128,9 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         Timber.i("onNewIntent: $intent")
+
+        intent?.sanitize()
+
         dataClearerForegroundAppRestartPixel.registerIntent(intent)
 
         if (dataClearer.dataClearerState.value == ApplicationClearDataState.FINISHED) {

--- a/app/src/main/java/com/duckduckgo/app/global/IntentExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/IntentExtension.kt
@@ -17,8 +17,27 @@
 package com.duckduckgo.app.global
 
 import android.content.Intent
+import android.os.BadParcelableException
+import android.os.Bundle
+import timber.log.Timber
 
 val Intent.intentText: String?
     get() {
         return data?.toString() ?: getStringExtra(Intent.EXTRA_TEXT)
     }
+
+fun Intent.sanitize() {
+
+    try {
+        // The strings are empty to force unparcel() call in BaseBundle
+        getStringExtra("")
+        getBooleanExtra("", false)
+    } catch (e: BadParcelableException) {
+        Timber.e(e, "Failed to read Parcelable from intent")
+        replaceExtras(Bundle())
+
+    } catch (e: RuntimeException) {
+        Timber.e(e, "Failed to receive extras from intent")
+        replaceExtras(Bundle())
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/953
Tech Design URL: 
CC: 

**Description**:
This issue happened because every time an intent.getX (X being string, bool, etc) was called, internally it would eventually call unparcel() on BaseBundle, and if there is a class that was passed somewhere on the intent that duckduckgo can't unserialize (either by Serializable or Parcelable) it would throw an exception and close the app. One thing to note is that I tracked all current calls of where the app received intents that were not under the app control, and it seems that this point is in BrowserActivity in onNewIntent. So before any call could be made to any intent `getSomething` call I called sanitize, which is the preferred design that duckduckgo team mentioned on the original issue URL.

I think it seems safe but may require further tests since the app is quite big and there may be corner cases, one design issue though is that every new addition to the app that handle intents would have to be checked (say if for some reason another Activity that handles outside intents would be added, someone will need to remember to add `sanitize()` in there). If you guys want extra control and futureproofing then maybe creating an extension method that gets extras and uses generics. So instead of using getBoolean, getString, getShort we could create a getSafe with generics and inside the method handle each case. This seems safer but it would require to refactor the entire app, but it could be enforced on future development to only use this extension method. Idk what's the best solution, it would be interesting to hear what you guys think about it.

**Steps to test this PR**:
1. Create another application that sends a bundle with a serializable or parcelable class. On the original Issue URL there's a code snippet that shows this https://github.com/duckduckgo/Android/issues/953#issuecomment-712151654
2. Send it to duckduckgo.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
