### PR TITLE
fix: convert clip data into plain text before pasting to omnibar

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
@@ -85,12 +85,14 @@ class KeyboardAwareEditText : AppCompatEditText {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 super.onTextContextMenuItem(android.R.id.pasteAsPlainText)
             } else {
-                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                clipboard.convertClipToPlainText()
+                context.getClipboardManager().convertClipToPlainText()
                 super.onTextContextMenuItem(id)
             }
         else -> super.onTextContextMenuItem(id)
     }
+
+    private fun Context.getClipboardManager(): ClipboardManager =
+        getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
     private fun ClipboardManager.convertClipToPlainText() {
         val clip = primaryClip ?: return

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
@@ -81,13 +81,14 @@ class KeyboardAwareEditText : AppCompatEditText {
      * Overrides to paste clip data without rich text formatting.
      */
     override fun onTextContextMenuItem(id: Int): Boolean = when (id) {
-        android.R.id.paste -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            super.onTextContextMenuItem(android.R.id.pasteAsPlainText)
-        } else {
-            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            clipboard.convertClipToPlainText()
-            super.onTextContextMenuItem(id)
-        }
+        android.R.id.paste ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                super.onTextContextMenuItem(android.R.id.pasteAsPlainText)
+            } else {
+                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                clipboard.convertClipToPlainText()
+                super.onTextContextMenuItem(id)
+            }
         else -> super.onTextContextMenuItem(id)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/1074

**Description**:

- This PR modifies `KeyboardAwareEditText` to be aware of pasting text from the clipboard and clear its style beforehand.
  - If API level >= M, we can just use [R.id.pasteAsPlainText](https://developer.android.com/reference/android/R.id#pasteAsPlainText)
  - If API level < M, we need to manually clear and set the data to primary clip again(see `ClipboardManager.convertClipToPlainText`)

#### Discussion

- Now `KeyboardAwareEditText` has kind of two responsibilities and I was thinking I should rename the class as `OmniToolbarEditText` or something, but since this is my 1st PR as an external contributor I'd like to keep the diff smaller as much as I can. Let me know your thoughts around here🙏


**Steps to test this PR**:

1. API level >= M
  - Launch the emulator with API Level M
  - Open https://www.theverge.com/2018/1/23/16922508/private-search-engine-duckduckgo-browser-extension-app
  - Copy bold "DuckDuckGo" from the title
  - Paste the clipboard clip to omnibar search input area
  - Confirm there's no rich text formatting
 
2. API level < M
  - Launch the emulator with API Level M
  - Open https://www.theverge.com/2018/1/23/16922508/private-search-engine-duckduckgo-browser-extension-app
  - Copy bold "DuckDuckGo" from the title
  - Paste the clipboard clip to omnibar search input area
  - Confirm there's no rich text formatting

#### Screenshots

##### API level >= M

| Before |  After |
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/471318/108139870-54b6b500-7104-11eb-9bfe-2ed337b4419f.gif" width="300" />|<img src="https://user-images.githubusercontent.com/471318/108139901-626c3a80-7104-11eb-9792-76a0d2fe90c4.gif" width="300" />

##### API level < M

| Before |  After |
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/471318/108140543-a0b62980-7105-11eb-90e5-bacfdd2983d2.gif" width="300" />|<img src="https://user-images.githubusercontent.com/471318/108140452-72384e80-7105-11eb-9a87-04508020fad7.gif" width="300" />
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
