### PR TITLE
Swipe to refresh is too sensitive

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -991,6 +991,9 @@ class BrowserTabFragment :
     }
 
     private fun configureSwipeRefresh() {
+        val metrics = resources.displayMetrics
+        val distanceToTrigger = (DEFAULT_CIRCLE_TARGET_TIMES_1_5 * metrics.density).toInt()
+        swipeRefreshContainer.setDistanceToTriggerSync(distanceToTrigger)
         swipeRefreshContainer.setColorSchemeColors(ContextCompat.getColor(requireContext(), R.color.cornflowerBlue))
 
         swipeRefreshContainer.setOnRefreshListener {
@@ -1395,6 +1398,8 @@ class BrowserTabFragment :
         private const val MAX_PROGRESS = 100
         private const val TRACKERS_INI_DELAY = 500L
         private const val TRACKERS_SECONDARY_DELAY = 200L
+
+        private const val DEFAULT_CIRCLE_TARGET_TIMES_1_5 = 96
 
         fun newInstance(tabId: String, query: String? = null, skipHome: Boolean): BrowserTabFragment {
             val fragment = BrowserTabFragment()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1199888021167463
Tech Design URL: 
CC: 

**Description**:
This PR changes how we enable swipe to refresh so it only happens once a website is clamped at the top AND a new gesture begins. This should fix https://github.com/duckduckgo/Android/issues/1081

**Steps to test this PR**:
1. Go to any site with scrollable content, i.e. `https://m.xkcd.com/2425/`
1. When the page loads for the first time, pulling to refresh should be enabled.
1. Scroll down a bit, then up to reach the top and then back again all within the same gesture.
1. Pull to refresh should not be activated.
1. Pull to refresh is only enabled if the site is clamped at the top and you being a new gesture.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
