### PR TITLE
Keyboard not showing up after coming back from fullscreen

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1964,6 +1964,7 @@ class BrowserTabFragment :
             webViewFullScreenContainer.removeAllViews()
             webViewFullScreenContainer.gone()
             activity?.toggleFullScreen()
+            focusDummy.requestFocus()
         }
 
         private fun shouldUpdateOmnibarTextInput(viewState: OmnibarViewState, omnibarInput: String?) =


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1199969297683315
Tech Design URL: 
CC: 

**Description**:
When you are watching a video or any content in fullscreen, after you come back from fullscreen if there is an edit/search field in the website the keyboard won't show anymore until you click on the omnibar to get the focus back. This PR requests the focus back when coming back from fullscreen.

**Steps to test this PR**:
1. Go to youtube.com
1. Start watching any video
1. Change the video so you watch it in fullscreen (click on the square on the bottom right side)
1. Go back to normal mode (click on the square on the bottom right side or the back button)
1. Click on the search icon
1. Keyboard should show up

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
