### PR TITLE
Fixed regression query selection on search bar

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/KeyboardAwareEditText.kt
@@ -39,6 +39,8 @@ class KeyboardAwareEditText : AppCompatEditText {
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
+    private var didSelectQueryFirstTime = false
+
     private fun Editable.isWebUrl(): Boolean {
         return Patterns.WEB_URL.matcher(this.toString()).matches()
     }
@@ -47,10 +49,15 @@ class KeyboardAwareEditText : AppCompatEditText {
         super.onFocusChanged(focused, direction, previouslyFocusedRect)
         if (focused) {
             if (text != null && text?.isWebUrl() == false) {
-                // trigger the text change listener so that we can show autocomplete
-                text = text
-                // cursor at the end of the word
-                setSelection(text!!.length)
+                if (didSelectQueryFirstTime) {
+                    // trigger the text change listener so that we can show autocomplete
+                    text = text
+                    // cursor at the end of the word
+                    setSelection(text!!.length)
+                } else {
+                    didSelectQueryFirstTime = true
+                    post { Selection.selectAll(text) }
+                }
             } else if (text?.isWebUrl() == true) {
                 // We always want URLs to be selected
                 // we need to post for the selectAll to take effect. The wonders of Android layout !


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1200004870762512/f
Tech Design URL: 
CC: 

**Description**:
The search bar shall behave as follows when we open the app and have a tab with a search query:
* first time the user taps on the search bar → query shall be selected so that the user can start typing a new query
 * no AC results shall show in this case
* any subsequent taps on the search bar will not select the query but rather show AC results

This behavior regressed in 5.77.x and now we always don't select the query in the search bar and show AC results.

Repro steps

1. open the app and open a new tab
2. search for anything and wait for SERP results
3. close and re-open the app
4. tap on search bar
 * expected → the query text is selected and AC results don't show
 * actual →  the query text is not selected and AC results do show


**Steps to test this PR**:
1. install/update from this branch
2. open the app and search for anything
3. close and re-open the app
4. tap on search bar
5. verify query text should be selected and AC results not shown
6. dismiss the keyboard
7. tap on search bar again
8. verify query text should NOT be selected and AC results did show
9. open any link in a new tab and switch to it
10. close and re-open the app
11. tap on the search bar
12. verify URL should be selected
12. switch to tab with query search
13. tap on search bar
14. verify query text should be selected
15. dismiss keyboard
16. tab on search bar again
17. verify query text should NOT be selected and AC results show


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
