### PR TITLE
Leak after responding to Rate dialog

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -92,8 +92,6 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
 
     private var lastIntent: Intent? = null
 
-    private var currentAppEnjoymentFragment: DialogFragment? = null
-
     private lateinit var renderer: BrowserStateRenderer
 
     private var openMessageInNewTabJob: Job? = null
@@ -433,9 +431,8 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
         get() = (flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
 
     private fun showAppEnjoymentPrompt(prompt: DialogFragment) {
-        currentAppEnjoymentFragment?.dismiss()
+        (supportFragmentManager.findFragmentByTag(APP_ENJOYMENT_DIALOG_TAG) as? DialogFragment)?.dismiss()
         prompt.show(supportFragmentManager, APP_ENJOYMENT_DIALOG_TAG)
-        currentAppEnjoymentFragment = prompt
     }
 
     private fun hideWebContent() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1199921546480466/1199948623134658/f
Tech Design URL: 
CC: 

**Description**:
Fixes reported memory leak when any AppEnjoyment dismissed in our app.

**Steps to test this PR**:
To reproduce:
1. Using develop, force any AppEnjoyment dialog (you can hardcode a value in `InitialPromptTypeDecider`) to displayed
2. Dismiss dialog
3. Wait until leakcanary reports the leak, or dump heap manually 

To test:
1. Using this branch, force any AppEnjoyment dialog (you can hardcode a value in `InitialPromptTypeDecider`) to be displayed
2. Dismiss dialog
3. Dump heap manually 
4. Ensure no memory leaks (use leak canary) when any AppEnjoyment dialog displayed and dismissed.
(see report in https://app.asana.com/0/1199921546480466/1199948623134658/f)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
