### PR TITLE
Extensible PixelName API

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -86,6 +86,7 @@ import com.duckduckgo.app.notification.model.UseOurAppNotification
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.NetworkLeaderboardDao
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.privacy.model.PrivacyGrade
@@ -1095,7 +1096,7 @@ class BrowserTabViewModelTest {
         loadUrl("http://example.com")
         testee.onDesktopSiteModeToggled(true)
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        verify(mockPixel).fire(Pixel.AppPixelName.MENU_ACTION_DESKTOP_SITE_ENABLE_PRESSED)
+        verify(mockPixel).fire(AppPixelName.MENU_ACTION_DESKTOP_SITE_ENABLE_PRESSED)
         assertTrue(browserViewState().isDesktopBrowsingMode)
     }
 
@@ -1103,7 +1104,7 @@ class BrowserTabViewModelTest {
     fun whenUserSelectsMobileSiteThenMobileModeStateUpdated() {
         loadUrl("http://example.com")
         testee.onDesktopSiteModeToggled(false)
-        verify(mockPixel).fire(Pixel.AppPixelName.MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED)
+        verify(mockPixel).fire(AppPixelName.MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED)
         assertFalse(browserViewState().isDesktopBrowsingMode)
     }
 
@@ -1385,7 +1386,7 @@ class BrowserTabViewModelTest {
         loadUrl("http://www.example.com/home.html")
         testee.onWhitelistSelected()
         verify(mockUserWhitelistDao).insert(UserWhitelistedDomain("www.example.com"))
-        verify(mockPixel).fire(Pixel.AppPixelName.BROWSER_MENU_WHITELIST_ADD)
+        verify(mockPixel).fire(AppPixelName.BROWSER_MENU_WHITELIST_ADD)
         verify(mockCommandObserver).onChanged(Command.Refresh)
     }
 
@@ -1395,7 +1396,7 @@ class BrowserTabViewModelTest {
         loadUrl("http://www.example.com/home.html")
         testee.onWhitelistSelected()
         verify(mockUserWhitelistDao).delete(UserWhitelistedDomain("www.example.com"))
-        verify(mockPixel).fire(Pixel.AppPixelName.BROWSER_MENU_WHITELIST_REMOVE)
+        verify(mockPixel).fire(AppPixelName.BROWSER_MENU_WHITELIST_REMOVE)
         verify(mockCommandObserver).onChanged(Command.Refresh)
     }
 
@@ -1635,7 +1636,7 @@ class BrowserTabViewModelTest {
         val suggestion = AutoCompleteBookmarkSuggestion("example", "Example", "https://example.com")
         testee.autoCompleteViewState.value = autoCompleteViewState().copy(searchResults = AutoCompleteResult("", listOf(suggestion)))
         testee.fireAutocompletePixel(suggestion)
-        verify(mockPixel).fire(Pixel.AppPixelName.AUTOCOMPLETE_BOOKMARK_SELECTION, pixelParams(showedBookmarks = true, bookmarkCapable = true))
+        verify(mockPixel).fire(AppPixelName.AUTOCOMPLETE_BOOKMARK_SELECTION, pixelParams(showedBookmarks = true, bookmarkCapable = true))
     }
 
     @Test
@@ -1645,7 +1646,7 @@ class BrowserTabViewModelTest {
         testee.autoCompleteViewState.value = autoCompleteViewState().copy(searchResults = AutoCompleteResult("", suggestions))
         testee.fireAutocompletePixel(AutoCompleteSearchSuggestion("example", false))
 
-        verify(mockPixel).fire(Pixel.AppPixelName.AUTOCOMPLETE_SEARCH_SELECTION, pixelParams(showedBookmarks = true, bookmarkCapable = true))
+        verify(mockPixel).fire(AppPixelName.AUTOCOMPLETE_SEARCH_SELECTION, pixelParams(showedBookmarks = true, bookmarkCapable = true))
     }
 
     @Test
@@ -1654,7 +1655,7 @@ class BrowserTabViewModelTest {
         testee.autoCompleteViewState.value = autoCompleteViewState().copy(searchResults = AutoCompleteResult("", emptyList()))
         testee.fireAutocompletePixel(AutoCompleteSearchSuggestion("example", false))
 
-        verify(mockPixel).fire(Pixel.AppPixelName.AUTOCOMPLETE_SEARCH_SELECTION, pixelParams(showedBookmarks = false, bookmarkCapable = false))
+        verify(mockPixel).fire(AppPixelName.AUTOCOMPLETE_SEARCH_SELECTION, pixelParams(showedBookmarks = false, bookmarkCapable = false))
     }
 
     @Test
@@ -2061,7 +2062,7 @@ class BrowserTabViewModelTest {
     fun whenFireproofWebsiteAddedThenPixelSent() {
         loadUrl("http://example.com/", isBrowserShowing = true)
         testee.onFireproofWebsiteMenuClicked()
-        verify(mockPixel).fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_ADDED)
+        verify(mockPixel).fire(AppPixelName.FIREPROOF_WEBSITE_ADDED)
     }
 
     @Test
@@ -2077,7 +2078,7 @@ class BrowserTabViewModelTest {
         givenFireproofWebsiteDomain("mobile.example.com")
         loadUrl("http://mobile.example.com/", isBrowserShowing = true)
         testee.onFireproofWebsiteMenuClicked()
-        verify(mockPixel).fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_REMOVE)
+        verify(mockPixel).fire(AppPixelName.FIREPROOF_WEBSITE_REMOVE)
     }
 
     @Test
@@ -2098,7 +2099,7 @@ class BrowserTabViewModelTest {
         assertCommandIssued<Command.ShowFireproofWebSiteConfirmation> {
             testee.onFireproofWebsiteSnackbarUndoClicked(this.fireproofWebsiteEntity)
         }
-        verify(mockPixel).fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_UNDO)
+        verify(mockPixel).fire(AppPixelName.FIREPROOF_WEBSITE_UNDO)
     }
 
     @Test
@@ -2313,7 +2314,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
+        verify(mockPixel).fire(AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
     }
 
     @Test
@@ -2323,7 +2324,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
+        verify(mockPixel).fire(AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
     }
 
     @Test
@@ -2333,7 +2334,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
+        verify(mockPixel).fire(AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
     }
 
     @Test
@@ -2342,7 +2343,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED)
+        verify(mockPixel).fire(AppPixelName.UOA_VISITED)
     }
 
     @Test
@@ -2352,7 +2353,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
+        verify(mockPixel, never()).fire(AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
     }
 
     @Test
@@ -2362,7 +2363,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
+        verify(mockPixel, never()).fire(AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
     }
 
     @Test
@@ -2372,7 +2373,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
+        verify(mockPixel, never()).fire(AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
     }
 
     @Test
@@ -2381,7 +2382,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED)
+        verify(mockPixel, never()).fire(AppPixelName.UOA_VISITED)
     }
 
     @Test
@@ -2391,7 +2392,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
+        verify(mockPixel).fire(AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
     }
 
     @Test
@@ -2401,7 +2402,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
+        verify(mockPixel).fire(AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
     }
 
     @Test
@@ -2411,7 +2412,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
+        verify(mockPixel).fire(AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
     }
 
     @Test
@@ -2420,7 +2421,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED)
+        verify(mockPixel).fire(AppPixelName.UOA_VISITED)
     }
 
     @Test
@@ -2430,7 +2431,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
+        verify(mockPixel, never()).fire(AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
     }
 
     @Test
@@ -2441,7 +2442,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
+        verify(mockPixel, never()).fire(AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
     }
 
     @Test
@@ -2451,7 +2452,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
+        verify(mockPixel, never()).fire(AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
     }
 
     @Test
@@ -2460,7 +2461,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED)
+        verify(mockPixel, never()).fire(AppPixelName.UOA_VISITED)
     }
 
     @Test
@@ -2565,7 +2566,7 @@ class BrowserTabViewModelTest {
 
         testee.onSystemLocationPermissionDeniedOneTime()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE)
+        verify(mockPixel).fire(AppPixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE)
         verify(geoLocationPermissions).clear(domain)
     }
 
@@ -2592,7 +2593,7 @@ class BrowserTabViewModelTest {
 
         testee.onSystemLocationPermissionGranted()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_ENABLE)
+        verify(mockPixel).fire(AppPixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_ENABLE)
     }
 
     @Test
@@ -2674,7 +2675,7 @@ class BrowserTabViewModelTest {
 
         testee.onSystemLocationPermissionNotAllowed()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SYSTEM_DIALOG_LATER)
+        verify(mockPixel).fire(AppPixelName.PRECISE_LOCATION_SYSTEM_DIALOG_LATER)
         verify(geoLocationPermissions).clear(domain)
     }
 
@@ -2688,7 +2689,7 @@ class BrowserTabViewModelTest {
 
         testee.onSystemLocationPermissionNeverAllowed()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SYSTEM_DIALOG_NEVER)
+        verify(mockPixel).fire(AppPixelName.PRECISE_LOCATION_SYSTEM_DIALOG_NEVER)
         verify(geoLocationPermissions).clear(domain)
         assertEquals(locationPermissionsDao.getPermission(domain)!!.permission, LocationPermissionType.DENY_ALWAYS)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1095,7 +1095,7 @@ class BrowserTabViewModelTest {
         loadUrl("http://example.com")
         testee.onDesktopSiteModeToggled(true)
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        verify(mockPixel).fire(Pixel.PixelName.MENU_ACTION_DESKTOP_SITE_ENABLE_PRESSED)
+        verify(mockPixel).fire(Pixel.AppPixelName.MENU_ACTION_DESKTOP_SITE_ENABLE_PRESSED)
         assertTrue(browserViewState().isDesktopBrowsingMode)
     }
 
@@ -1103,7 +1103,7 @@ class BrowserTabViewModelTest {
     fun whenUserSelectsMobileSiteThenMobileModeStateUpdated() {
         loadUrl("http://example.com")
         testee.onDesktopSiteModeToggled(false)
-        verify(mockPixel).fire(Pixel.PixelName.MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED)
+        verify(mockPixel).fire(Pixel.AppPixelName.MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED)
         assertFalse(browserViewState().isDesktopBrowsingMode)
     }
 
@@ -1385,7 +1385,7 @@ class BrowserTabViewModelTest {
         loadUrl("http://www.example.com/home.html")
         testee.onWhitelistSelected()
         verify(mockUserWhitelistDao).insert(UserWhitelistedDomain("www.example.com"))
-        verify(mockPixel).fire(Pixel.PixelName.BROWSER_MENU_WHITELIST_ADD)
+        verify(mockPixel).fire(Pixel.AppPixelName.BROWSER_MENU_WHITELIST_ADD)
         verify(mockCommandObserver).onChanged(Command.Refresh)
     }
 
@@ -1395,7 +1395,7 @@ class BrowserTabViewModelTest {
         loadUrl("http://www.example.com/home.html")
         testee.onWhitelistSelected()
         verify(mockUserWhitelistDao).delete(UserWhitelistedDomain("www.example.com"))
-        verify(mockPixel).fire(Pixel.PixelName.BROWSER_MENU_WHITELIST_REMOVE)
+        verify(mockPixel).fire(Pixel.AppPixelName.BROWSER_MENU_WHITELIST_REMOVE)
         verify(mockCommandObserver).onChanged(Command.Refresh)
     }
 
@@ -1635,7 +1635,7 @@ class BrowserTabViewModelTest {
         val suggestion = AutoCompleteBookmarkSuggestion("example", "Example", "https://example.com")
         testee.autoCompleteViewState.value = autoCompleteViewState().copy(searchResults = AutoCompleteResult("", listOf(suggestion)))
         testee.fireAutocompletePixel(suggestion)
-        verify(mockPixel).fire(Pixel.PixelName.AUTOCOMPLETE_BOOKMARK_SELECTION, pixelParams(showedBookmarks = true, bookmarkCapable = true))
+        verify(mockPixel).fire(Pixel.AppPixelName.AUTOCOMPLETE_BOOKMARK_SELECTION, pixelParams(showedBookmarks = true, bookmarkCapable = true))
     }
 
     @Test
@@ -1645,7 +1645,7 @@ class BrowserTabViewModelTest {
         testee.autoCompleteViewState.value = autoCompleteViewState().copy(searchResults = AutoCompleteResult("", suggestions))
         testee.fireAutocompletePixel(AutoCompleteSearchSuggestion("example", false))
 
-        verify(mockPixel).fire(Pixel.PixelName.AUTOCOMPLETE_SEARCH_SELECTION, pixelParams(showedBookmarks = true, bookmarkCapable = true))
+        verify(mockPixel).fire(Pixel.AppPixelName.AUTOCOMPLETE_SEARCH_SELECTION, pixelParams(showedBookmarks = true, bookmarkCapable = true))
     }
 
     @Test
@@ -1654,7 +1654,7 @@ class BrowserTabViewModelTest {
         testee.autoCompleteViewState.value = autoCompleteViewState().copy(searchResults = AutoCompleteResult("", emptyList()))
         testee.fireAutocompletePixel(AutoCompleteSearchSuggestion("example", false))
 
-        verify(mockPixel).fire(Pixel.PixelName.AUTOCOMPLETE_SEARCH_SELECTION, pixelParams(showedBookmarks = false, bookmarkCapable = false))
+        verify(mockPixel).fire(Pixel.AppPixelName.AUTOCOMPLETE_SEARCH_SELECTION, pixelParams(showedBookmarks = false, bookmarkCapable = false))
     }
 
     @Test
@@ -2061,7 +2061,7 @@ class BrowserTabViewModelTest {
     fun whenFireproofWebsiteAddedThenPixelSent() {
         loadUrl("http://example.com/", isBrowserShowing = true)
         testee.onFireproofWebsiteMenuClicked()
-        verify(mockPixel).fire(Pixel.PixelName.FIREPROOF_WEBSITE_ADDED)
+        verify(mockPixel).fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_ADDED)
     }
 
     @Test
@@ -2077,7 +2077,7 @@ class BrowserTabViewModelTest {
         givenFireproofWebsiteDomain("mobile.example.com")
         loadUrl("http://mobile.example.com/", isBrowserShowing = true)
         testee.onFireproofWebsiteMenuClicked()
-        verify(mockPixel).fire(Pixel.PixelName.FIREPROOF_WEBSITE_REMOVE)
+        verify(mockPixel).fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_REMOVE)
     }
 
     @Test
@@ -2098,7 +2098,7 @@ class BrowserTabViewModelTest {
         assertCommandIssued<Command.ShowFireproofWebSiteConfirmation> {
             testee.onFireproofWebsiteSnackbarUndoClicked(this.fireproofWebsiteEntity)
         }
-        verify(mockPixel).fire(Pixel.PixelName.FIREPROOF_WEBSITE_UNDO)
+        verify(mockPixel).fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_UNDO)
     }
 
     @Test
@@ -2313,7 +2313,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED_AFTER_NOTIFICATION)
+        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
     }
 
     @Test
@@ -2323,7 +2323,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED_AFTER_SHORTCUT)
+        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
     }
 
     @Test
@@ -2333,7 +2333,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED_AFTER_DELETE_CTA)
+        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
     }
 
     @Test
@@ -2342,7 +2342,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED)
+        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED)
     }
 
     @Test
@@ -2352,7 +2352,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED_AFTER_NOTIFICATION)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
     }
 
     @Test
@@ -2362,7 +2362,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED_AFTER_SHORTCUT)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
     }
 
     @Test
@@ -2372,7 +2372,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED_AFTER_DELETE_CTA)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
     }
 
     @Test
@@ -2381,7 +2381,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewReady()
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED)
     }
 
     @Test
@@ -2391,7 +2391,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED_AFTER_NOTIFICATION)
+        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
     }
 
     @Test
@@ -2401,7 +2401,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED_AFTER_SHORTCUT)
+        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
     }
 
     @Test
@@ -2411,7 +2411,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED_AFTER_DELETE_CTA)
+        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
     }
 
     @Test
@@ -2420,7 +2420,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel).fire(Pixel.PixelName.UOA_VISITED)
+        verify(mockPixel).fire(Pixel.AppPixelName.UOA_VISITED)
     }
 
     @Test
@@ -2430,7 +2430,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED_AFTER_NOTIFICATION)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
     }
 
     @Test
@@ -2441,7 +2441,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED_AFTER_SHORTCUT)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
     }
 
     @Test
@@ -2451,7 +2451,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED_AFTER_DELETE_CTA)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
     }
 
     @Test
@@ -2460,7 +2460,7 @@ class BrowserTabViewModelTest {
 
         loadUrl(USE_OUR_APP_DOMAIN, isBrowserShowing = true)
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.UOA_VISITED)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.UOA_VISITED)
     }
 
     @Test
@@ -2565,7 +2565,7 @@ class BrowserTabViewModelTest {
 
         testee.onSystemLocationPermissionDeniedOneTime()
 
-        verify(mockPixel).fire(Pixel.PixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE)
+        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE)
         verify(geoLocationPermissions).clear(domain)
     }
 
@@ -2592,7 +2592,7 @@ class BrowserTabViewModelTest {
 
         testee.onSystemLocationPermissionGranted()
 
-        verify(mockPixel).fire(Pixel.PixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_ENABLE)
+        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_ENABLE)
     }
 
     @Test
@@ -2674,7 +2674,7 @@ class BrowserTabViewModelTest {
 
         testee.onSystemLocationPermissionNotAllowed()
 
-        verify(mockPixel).fire(Pixel.PixelName.PRECISE_LOCATION_SYSTEM_DIALOG_LATER)
+        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SYSTEM_DIALOG_LATER)
         verify(geoLocationPermissions).clear(domain)
     }
 
@@ -2688,7 +2688,7 @@ class BrowserTabViewModelTest {
 
         testee.onSystemLocationPermissionNeverAllowed()
 
-        verify(mockPixel).fire(Pixel.PixelName.PRECISE_LOCATION_SYSTEM_DIALOG_NEVER)
+        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SYSTEM_DIALOG_NEVER)
         verify(geoLocationPermissions).clear(domain)
         assertEquals(locationPermissionsDao.getPermission(domain)!!.permission, LocationPermissionType.DENY_ALWAYS)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -215,7 +215,7 @@ class BrowserViewModelTest {
         val url = "http://m.$USE_OUR_APP_DOMAIN"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenShortcut(url)
-        verify(mockPixel).fire(Pixel.PixelName.USE_OUR_APP_SHORTCUT_OPENED)
+        verify(mockPixel).fire(Pixel.AppPixelName.USE_OUR_APP_SHORTCUT_OPENED)
     }
 
     @Test
@@ -223,7 +223,7 @@ class BrowserViewModelTest {
         val url = "example.com"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenShortcut(url)
-        verify(mockPixel).fire(Pixel.PixelName.SHORTCUT_OPENED)
+        verify(mockPixel).fire(Pixel.AppPixelName.SHORTCUT_OPENED)
     }
 
     companion object {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
 import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.global.useourapp.UseOurAppDetector
 import com.duckduckgo.app.global.useourapp.UseOurAppDetector.Companion.USE_OUR_APP_DOMAIN
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -215,7 +216,7 @@ class BrowserViewModelTest {
         val url = "http://m.$USE_OUR_APP_DOMAIN"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenShortcut(url)
-        verify(mockPixel).fire(Pixel.AppPixelName.USE_OUR_APP_SHORTCUT_OPENED)
+        verify(mockPixel).fire(AppPixelName.USE_OUR_APP_SHORTCUT_OPENED)
     }
 
     @Test
@@ -223,7 +224,7 @@ class BrowserViewModelTest {
         val url = "example.com"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenShortcut(url)
-        verify(mockPixel).fire(Pixel.AppPixelName.SHORTCUT_OPENED)
+        verify(mockPixel).fire(AppPixelName.SHORTCUT_OPENED)
     }
 
     companion object {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
@@ -21,6 +21,7 @@ import android.view.MenuItem
 import android.webkit.WebView.HitTestResult
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.model.LongPressTarget
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.never
@@ -62,19 +63,19 @@ class WebViewLongPressHandlerTest {
     @Test
     fun whenUserLongPressesWithImageTypeThenPixelFired() {
         testee.handleLongPress(HitTestResult.IMAGE_TYPE, HTTPS_IMAGE_URL, mockMenu)
-        verify(mockPixel).fire(Pixel.AppPixelName.LONG_PRESS)
+        verify(mockPixel).fire(AppPixelName.LONG_PRESS)
     }
 
     @Test
     fun whenUserLongPressesWithAnchorImageTypeThenPixelFired() {
         testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, HTTPS_IMAGE_URL, mockMenu)
-        verify(mockPixel).fire(Pixel.AppPixelName.LONG_PRESS)
+        verify(mockPixel).fire(AppPixelName.LONG_PRESS)
     }
 
     @Test
     fun whenUserLongPressesWithUnknownTypeThenPixelNotFired() {
         testee.handleLongPress(HitTestResult.UNKNOWN_TYPE, HTTPS_IMAGE_URL, mockMenu)
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.LONG_PRESS)
+        verify(mockPixel, never()).fire(AppPixelName.LONG_PRESS)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
@@ -62,19 +62,19 @@ class WebViewLongPressHandlerTest {
     @Test
     fun whenUserLongPressesWithImageTypeThenPixelFired() {
         testee.handleLongPress(HitTestResult.IMAGE_TYPE, HTTPS_IMAGE_URL, mockMenu)
-        verify(mockPixel).fire(Pixel.PixelName.LONG_PRESS)
+        verify(mockPixel).fire(Pixel.AppPixelName.LONG_PRESS)
     }
 
     @Test
     fun whenUserLongPressesWithAnchorImageTypeThenPixelFired() {
         testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, HTTPS_IMAGE_URL, mockMenu)
-        verify(mockPixel).fire(Pixel.PixelName.LONG_PRESS)
+        verify(mockPixel).fire(Pixel.AppPixelName.LONG_PRESS)
     }
 
     @Test
     fun whenUserLongPressesWithUnknownTypeThenPixelNotFired() {
         testee.handleLongPress(HitTestResult.UNKNOWN_TYPE, HTTPS_IMAGE_URL, mockMenu)
-        verify(mockPixel, never()).fire(Pixel.PixelName.LONG_PRESS)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.LONG_PRESS)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
@@ -53,7 +53,7 @@ class DefaultBrowserObserverTest {
 
         testee.onApplicationResumed()
 
-        verify(mockPixel).fire(Pixel.PixelName.DEFAULT_BROWSER_SET, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
     }
 
     @Test
@@ -63,7 +63,7 @@ class DefaultBrowserObserverTest {
 
         testee.onApplicationResumed()
 
-        verify(mockPixel, never()).fire(eq(Pixel.PixelName.DEFAULT_BROWSER_SET), any(), any())
+        verify(mockPixel, never()).fire(eq(Pixel.AppPixelName.DEFAULT_BROWSER_SET), any(), any())
     }
 
     @Test
@@ -73,7 +73,7 @@ class DefaultBrowserObserverTest {
 
         testee.onApplicationResumed()
 
-        verify(mockPixel, never()).fire(eq(Pixel.PixelName.DEFAULT_BROWSER_SET), any(), any())
+        verify(mockPixel, never()).fire(eq(Pixel.AppPixelName.DEFAULT_BROWSER_SET), any(), any())
     }
 
     @Test
@@ -83,6 +83,6 @@ class DefaultBrowserObserverTest {
 
         testee.onApplicationResumed()
 
-        verify(mockPixel).fire(Pixel.PixelName.DEFAULT_BROWSER_UNSET)
+        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_UNSET)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.defaultbrowsing
 
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.*
 import org.junit.Before
@@ -53,7 +54,7 @@ class DefaultBrowserObserverTest {
 
         testee.onApplicationResumed()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
+        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_SET, params)
     }
 
     @Test
@@ -63,7 +64,7 @@ class DefaultBrowserObserverTest {
 
         testee.onApplicationResumed()
 
-        verify(mockPixel, never()).fire(eq(Pixel.AppPixelName.DEFAULT_BROWSER_SET), any(), any())
+        verify(mockPixel, never()).fire(eq(AppPixelName.DEFAULT_BROWSER_SET), any(), any())
     }
 
     @Test
@@ -73,7 +74,7 @@ class DefaultBrowserObserverTest {
 
         testee.onApplicationResumed()
 
-        verify(mockPixel, never()).fire(eq(Pixel.AppPixelName.DEFAULT_BROWSER_SET), any(), any())
+        verify(mockPixel, never()).fire(eq(AppPixelName.DEFAULT_BROWSER_SET), any(), any())
     }
 
     @Test
@@ -83,6 +84,6 @@ class DefaultBrowserObserverTest {
 
         testee.onApplicationResumed()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_UNSET)
+        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_UNSET)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.browser.downloader
 
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -159,7 +160,7 @@ class UriUtilsFilenameExtractorTest {
         val mimeType: String? = null
         val contentDisposition: String? = null
         val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
-        verify(mockedPixel).fire(Pixel.AppPixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
+        verify(mockedPixel).fire(AppPixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
     }
 
     private fun buildPendingDownload(url: String, contentDisposition: String?, mimeType: String?): FileDownloader.PendingFileDownload {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -159,7 +159,7 @@ class UriUtilsFilenameExtractorTest {
         val mimeType: String? = null
         val contentDisposition: String? = null
         val extracted = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
-        verify(mockedPixel).fire(Pixel.PixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
+        verify(mockedPixel).fire(Pixel.AppPixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
     }
 
     private fun buildPendingDownload(url: String, contentDisposition: String?, mimeType: String?): FileDownloader.PendingFileDownload {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/BrowserTabFireproofDialogsEventHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/BrowserTabFireproofDialogsEventHandlerTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.events.db.UserEventEntity
 import com.duckduckgo.app.global.events.db.UserEventKey.*
 import com.duckduckgo.app.global.events.db.UserEventsStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.Variant
@@ -91,7 +92,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onFireproofLoginDialogShown()
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
+            pixel = AppPixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -103,7 +104,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onFireproofLoginDialogShown()
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
+            pixel = AppPixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }
@@ -113,7 +114,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserConfirmedFireproofDialog("twitter.com")
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_ADDED,
+            pixel = AppPixelName.FIREPROOF_WEBSITE_LOGIN_ADDED,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -125,7 +126,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserConfirmedFireproofDialog("twitter.com")
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_ADDED,
+            pixel = AppPixelName.FIREPROOF_WEBSITE_LOGIN_ADDED,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }
@@ -150,7 +151,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserDismissedFireproofLoginDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS,
+            pixel = AppPixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -161,7 +162,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserDismissedFireproofLoginDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS,
+            pixel = AppPixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }
@@ -215,7 +216,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onDisableLoginDetectionDialogShown()
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN,
+            pixel = AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -225,7 +226,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserConfirmedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
+            pixel = AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -237,7 +238,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserConfirmedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
+            pixel = AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }
@@ -254,7 +255,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserDismissedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL,
+            pixel = AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -266,7 +267,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserDismissedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL,
+            pixel = AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/BrowserTabFireproofDialogsEventHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/BrowserTabFireproofDialogsEventHandlerTest.kt
@@ -91,7 +91,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onFireproofLoginDialogShown()
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
+            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -103,7 +103,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onFireproofLoginDialogShown()
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
+            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }
@@ -113,7 +113,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserConfirmedFireproofDialog("twitter.com")
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_WEBSITE_LOGIN_ADDED,
+            pixel = Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_ADDED,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -125,7 +125,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserConfirmedFireproofDialog("twitter.com")
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_WEBSITE_LOGIN_ADDED,
+            pixel = Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_ADDED,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }
@@ -150,7 +150,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserDismissedFireproofLoginDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS,
+            pixel = Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -161,7 +161,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserDismissedFireproofLoginDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS,
+            pixel = Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }
@@ -215,7 +215,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onDisableLoginDetectionDialogShown()
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN,
+            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -225,7 +225,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserConfirmedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
+            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -237,7 +237,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserConfirmedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
+            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }
@@ -254,7 +254,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserDismissedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL,
+            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "false")
         )
     }
@@ -266,7 +266,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
         testee.onUserDismissedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
-            pixel = Pixel.PixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL,
+            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to "true")
         )
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiverTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.shortcut
 import android.content.Intent
 import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.useourapp.UseOurAppDetector
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -43,7 +44,7 @@ class ShortcutReceiverTest {
         intent.putExtra(ShortcutBuilder.SHORTCUT_TITLE_ARG, "Title")
         testee.onReceive(null, intent)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.USE_OUR_APP_SHORTCUT_ADDED)
+        verify(mockPixel).fire(AppPixelName.USE_OUR_APP_SHORTCUT_ADDED)
     }
 
     @Test
@@ -53,7 +54,7 @@ class ShortcutReceiverTest {
         intent.putExtra(ShortcutBuilder.SHORTCUT_TITLE_ARG, "Title")
         testee.onReceive(null, intent)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.SHORTCUT_ADDED)
+        verify(mockPixel).fire(AppPixelName.SHORTCUT_ADDED)
     }
 
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiverTest.kt
@@ -43,7 +43,7 @@ class ShortcutReceiverTest {
         intent.putExtra(ShortcutBuilder.SHORTCUT_TITLE_ARG, "Title")
         testee.onReceive(null, intent)
 
-        verify(mockPixel).fire(Pixel.PixelName.USE_OUR_APP_SHORTCUT_ADDED)
+        verify(mockPixel).fire(Pixel.AppPixelName.USE_OUR_APP_SHORTCUT_ADDED)
     }
 
     @Test
@@ -53,7 +53,7 @@ class ShortcutReceiverTest {
         intent.putExtra(ShortcutBuilder.SHORTCUT_TITLE_ARG, "Title")
         testee.onReceive(null, intent)
 
-        verify(mockPixel).fire(Pixel.PixelName.SHORTCUT_ADDED)
+        verify(mockPixel).fire(Pixel.AppPixelName.SHORTCUT_ADDED)
     }
 
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -47,7 +47,7 @@ import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.model.Survey.Status.SCHEDULED

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -47,7 +47,7 @@ import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.model.Survey.Status.SCHEDULED

--- a/app/src/androidTest/java/com/duckduckgo/app/feedback/ui/BrokenSiteViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/feedback/ui/BrokenSiteViewModelTest.kt
@@ -7,6 +7,7 @@ import com.duckduckgo.app.brokensite.BrokenSiteViewModel
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel.Command
 import com.duckduckgo.app.brokensite.api.BrokenSiteSender
 import com.duckduckgo.app.brokensite.model.BrokenSite
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -115,7 +116,7 @@ class BrokenSiteViewModelTest {
             siteType = BrokenSiteViewModel.DESKTOP_SITE
         )
 
-        verify(mockPixel).fire(Pixel.AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
+        verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
         verify(mockBrokenSiteSender).submitBrokenSiteFeedback(brokenSiteExpected)
         verify(mockCommandObserver).onChanged(Command.ConfirmAndFinish)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/feedback/ui/BrokenSiteViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/feedback/ui/BrokenSiteViewModelTest.kt
@@ -115,7 +115,7 @@ class BrokenSiteViewModelTest {
             siteType = BrokenSiteViewModel.DESKTOP_SITE
         )
 
-        verify(mockPixel).fire(Pixel.PixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
+        verify(mockPixel).fire(Pixel.AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
         verify(mockBrokenSiteSender).submitBrokenSiteFeedback(brokenSiteExpected)
         verify(mockCommandObserver).onChanged(Command.ConfirmAndFinish)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixelTest.kt
@@ -40,7 +40,7 @@ class DataClearerForegroundAppRestartPixelTest {
 
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.PixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
+        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
     }
 
     @Test
@@ -51,7 +51,7 @@ class DataClearerForegroundAppRestartPixelTest {
 
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.PixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
+        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
     }
 
     @Test
@@ -62,7 +62,7 @@ class DataClearerForegroundAppRestartPixelTest {
 
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.PixelName.FORGET_ALL_AUTO_RESTART)
+        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART)
     }
 
     @Test
@@ -74,7 +74,7 @@ class DataClearerForegroundAppRestartPixelTest {
         testee.firePendingPixels()
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.PixelName.FORGET_ALL_AUTO_RESTART)
+        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART)
     }
 
     @Test
@@ -86,7 +86,7 @@ class DataClearerForegroundAppRestartPixelTest {
 
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.PixelName.FORGET_ALL_AUTO_RESTART)
+        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART)
     }
 
     private fun givenEmptyIntent(): Intent = Intent(context, BrowserActivity::class.java)

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixelTest.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchActivity
 import com.nhaarman.mockitokotlin2.mock
@@ -40,7 +41,7 @@ class DataClearerForegroundAppRestartPixelTest {
 
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
+        verify(pixel).fire(AppPixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
     }
 
     @Test
@@ -51,7 +52,7 @@ class DataClearerForegroundAppRestartPixelTest {
 
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
+        verify(pixel).fire(AppPixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
     }
 
     @Test
@@ -62,7 +63,7 @@ class DataClearerForegroundAppRestartPixelTest {
 
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART)
+        verify(pixel).fire(AppPixelName.FORGET_ALL_AUTO_RESTART)
     }
 
     @Test
@@ -74,7 +75,7 @@ class DataClearerForegroundAppRestartPixelTest {
         testee.firePendingPixels()
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART)
+        verify(pixel).fire(AppPixelName.FORGET_ALL_AUTO_RESTART)
     }
 
     @Test
@@ -86,7 +87,7 @@ class DataClearerForegroundAppRestartPixelTest {
 
         testee.firePendingPixels()
 
-        verify(pixel).fire(Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART)
+        verify(pixel).fire(AppPixelName.FORGET_ALL_AUTO_RESTART)
     }
 
     private fun givenEmptyIntent(): Intent = Intent(context, BrowserActivity::class.java)

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/SQLCookieRemoverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/SQLCookieRemoverTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.global.DefaultDispatcherProvider
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.exception.RootExceptionFinder
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.ExceptionPixel
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
@@ -106,7 +107,7 @@ class SQLCookieRemoverTest {
         sqlCookieRemover.removeCookies()
 
         verify(mockOfflinePixelCountDataStore).cookieDatabaseOpenErrorCount = 1
-        verify(mockPixel).fire(eq(Pixel.AppPixelName.COOKIE_DATABASE_EXCEPTION_OPEN_ERROR), any(), any())
+        verify(mockPixel).fire(eq(AppPixelName.COOKIE_DATABASE_EXCEPTION_OPEN_ERROR), any(), any())
     }
 
     private fun givenFireproofWebsitesStored() {

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/SQLCookieRemoverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/SQLCookieRemoverTest.kt
@@ -106,7 +106,7 @@ class SQLCookieRemoverTest {
         sqlCookieRemover.removeCookies()
 
         verify(mockOfflinePixelCountDataStore).cookieDatabaseOpenErrorCount = 1
-        verify(mockPixel).fire(eq(Pixel.PixelName.COOKIE_DATABASE_EXCEPTION_OPEN_ERROR), any(), any())
+        verify(mockPixel).fire(eq(Pixel.AppPixelName.COOKIE_DATABASE_EXCEPTION_OPEN_ERROR), any(), any())
     }
 
     private fun givenFireproofWebsitesStored() {

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModelTest.kt
@@ -30,10 +30,11 @@ import com.duckduckgo.app.fire.fireproofwebsite.ui.FireproofWebsitesViewModel.Co
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.events.db.UserEventKey
 import com.duckduckgo.app.global.events.db.UserEventsStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.FIREPROOF_LOGIN_TOGGLE_ENABLED
+import com.duckduckgo.app.pixels.AppPixelName.FIREPROOF_LOGIN_TOGGLE_ENABLED
 import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.mock
 import dagger.Lazy
@@ -140,7 +141,7 @@ class FireproofWebsitesViewModelTest {
 
         viewModel.delete(FireproofWebsiteEntity("domain.com"))
 
-        verify(mockPixel).fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_DELETED)
+        verify(mockPixel).fire(AppPixelName.FIREPROOF_WEBSITE_DELETED)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModelTest.kt
@@ -33,7 +33,7 @@ import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.FIREPROOF_LOGIN_TOGGLE_ENABLED
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.FIREPROOF_LOGIN_TOGGLE_ENABLED
 import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.mock
 import dagger.Lazy
@@ -140,7 +140,7 @@ class FireproofWebsitesViewModelTest {
 
         viewModel.delete(FireproofWebsiteEntity("domain.com"))
 
-        verify(mockPixel).fire(Pixel.PixelName.FIREPROOF_WEBSITE_DELETED)
+        verify(mockPixel).fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_DELETED)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModelTest.kt
@@ -20,6 +20,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.globalprivacycontrol.ui.GlobalPrivacyControlViewModel.Companion.LEARN_MORE_URL
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.atLeastOnce
@@ -71,7 +72,7 @@ class GlobalPrivacyControlViewModelTest {
 
     @Test
     fun whenViewModelCreateThenPixelSent() {
-        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_DO_NOT_SELL_SHOWN)
+        verify(mockPixel).fire(AppPixelName.SETTINGS_DO_NOT_SELL_SHOWN)
     }
 
     @Test
@@ -88,14 +89,14 @@ class GlobalPrivacyControlViewModelTest {
     fun whenOnUserToggleGlobalPrivacyControlThenDoNotSellOnPixelSent() {
         testee.onUserToggleGlobalPrivacyControl(true)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_DO_NOT_SELL_ON)
+        verify(mockPixel).fire(AppPixelName.SETTINGS_DO_NOT_SELL_ON)
     }
 
     @Test
     fun whenOnUserToggleGlobalPrivacyControlThenDoNotSellOffPixelSent() {
         testee.onUserToggleGlobalPrivacyControl(false)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_DO_NOT_SELL_OFF)
+        verify(mockPixel).fire(AppPixelName.SETTINGS_DO_NOT_SELL_OFF)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModelTest.kt
@@ -71,7 +71,7 @@ class GlobalPrivacyControlViewModelTest {
 
     @Test
     fun whenViewModelCreateThenPixelSent() {
-        verify(mockPixel).fire(Pixel.PixelName.SETTINGS_DO_NOT_SELL_SHOWN)
+        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_DO_NOT_SELL_SHOWN)
     }
 
     @Test
@@ -88,14 +88,14 @@ class GlobalPrivacyControlViewModelTest {
     fun whenOnUserToggleGlobalPrivacyControlThenDoNotSellOnPixelSent() {
         testee.onUserToggleGlobalPrivacyControl(true)
 
-        verify(mockPixel).fire(Pixel.PixelName.SETTINGS_DO_NOT_SELL_ON)
+        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_DO_NOT_SELL_ON)
     }
 
     @Test
     fun whenOnUserToggleGlobalPrivacyControlThenDoNotSellOffPixelSent() {
         testee.onUserToggleGlobalPrivacyControl(false)
 
-        verify(mockPixel).fire(Pixel.PixelName.SETTINGS_DO_NOT_SELL_OFF)
+        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_DO_NOT_SELL_OFF)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
@@ -51,28 +51,28 @@ class HttpsUpgraderTest {
     fun whenHttpUriIsInBloomThenShouldUpgrade() {
         bloomFilter.add("www.local.url")
         assertTrue(testee.shouldUpgrade(Uri.parse("http://www.local.url")))
-        mockPixel.fire(Pixel.PixelName.HTTPS_LOCAL_UPGRADE)
+        mockPixel.fire(Pixel.AppPixelName.HTTPS_LOCAL_UPGRADE)
     }
 
     @Test
     fun whenHttpUriIsNotInBloomThenShouldNotUpgrade() {
         bloomFilter.add("www.local.url")
         assertFalse(testee.shouldUpgrade(Uri.parse("http://www.differentlocal.url")))
-        mockPixel.fire(Pixel.PixelName.HTTPS_NO_UPGRADE)
+        mockPixel.fire(Pixel.AppPixelName.HTTPS_NO_UPGRADE)
     }
 
     @Test
     fun whenHttpsUriThenShouldNotUpgrade() {
         bloomFilter.add("www.local.url")
         assertFalse(testee.shouldUpgrade(Uri.parse("https://www.local.url")))
-        mockPixel.fire(Pixel.PixelName.HTTPS_NO_UPGRADE)
+        mockPixel.fire(Pixel.AppPixelName.HTTPS_NO_UPGRADE)
     }
 
     @Test
     fun whenHttpUriHasOnlyPartDomainInLocalListThenShouldNotUpgrade() {
         bloomFilter.add("local.url")
         assertFalse(testee.shouldUpgrade(Uri.parse("http://www.local.url")))
-        mockPixel.fire(Pixel.PixelName.HTTPS_NO_LOOKUP)
+        mockPixel.fire(Pixel.AppPixelName.HTTPS_NO_LOOKUP)
     }
 
     @Test
@@ -80,6 +80,6 @@ class HttpsUpgraderTest {
         bloomFilter.add("www.local.url")
         whenever(mockUserAllowlistDao.contains("www.local.url")).thenReturn(true)
         assertFalse(testee.shouldUpgrade(Uri.parse("http://www.local.url")))
-        mockPixel.fire(Pixel.PixelName.HTTPS_NO_LOOKUP)
+        mockPixel.fire(Pixel.AppPixelName.HTTPS_NO_LOOKUP)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.httpsupgrade
 
 import android.net.Uri
 import com.duckduckgo.app.httpsupgrade.store.HttpsFalsePositivesDao
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.mock
@@ -51,28 +52,28 @@ class HttpsUpgraderTest {
     fun whenHttpUriIsInBloomThenShouldUpgrade() {
         bloomFilter.add("www.local.url")
         assertTrue(testee.shouldUpgrade(Uri.parse("http://www.local.url")))
-        mockPixel.fire(Pixel.AppPixelName.HTTPS_LOCAL_UPGRADE)
+        mockPixel.fire(AppPixelName.HTTPS_LOCAL_UPGRADE)
     }
 
     @Test
     fun whenHttpUriIsNotInBloomThenShouldNotUpgrade() {
         bloomFilter.add("www.local.url")
         assertFalse(testee.shouldUpgrade(Uri.parse("http://www.differentlocal.url")))
-        mockPixel.fire(Pixel.AppPixelName.HTTPS_NO_UPGRADE)
+        mockPixel.fire(AppPixelName.HTTPS_NO_UPGRADE)
     }
 
     @Test
     fun whenHttpsUriThenShouldNotUpgrade() {
         bloomFilter.add("www.local.url")
         assertFalse(testee.shouldUpgrade(Uri.parse("https://www.local.url")))
-        mockPixel.fire(Pixel.AppPixelName.HTTPS_NO_UPGRADE)
+        mockPixel.fire(AppPixelName.HTTPS_NO_UPGRADE)
     }
 
     @Test
     fun whenHttpUriHasOnlyPartDomainInLocalListThenShouldNotUpgrade() {
         bloomFilter.add("local.url")
         assertFalse(testee.shouldUpgrade(Uri.parse("http://www.local.url")))
-        mockPixel.fire(Pixel.AppPixelName.HTTPS_NO_LOOKUP)
+        mockPixel.fire(AppPixelName.HTTPS_NO_LOOKUP)
     }
 
     @Test
@@ -80,6 +81,6 @@ class HttpsUpgraderTest {
         bloomFilter.add("www.local.url")
         whenever(mockUserAllowlistDao.contains("www.local.url")).thenReturn(true)
         assertFalse(testee.shouldUpgrade(Uri.parse("http://www.local.url")))
-        mockPixel.fire(Pixel.AppPixelName.HTTPS_NO_LOOKUP)
+        mockPixel.fire(AppPixelName.HTTPS_NO_LOOKUP)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/icon/ui/ChangeIconViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/icon/ui/ChangeIconViewModelTest.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.Observer
 import com.duckduckgo.app.ValueCaptorObserver
 import com.duckduckgo.app.icon.api.AppIcon
 import com.duckduckgo.app.icon.api.IconModifier
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.mock
@@ -65,7 +66,7 @@ class ChangeIconViewModelTest {
 
         testee.start()
 
-        Mockito.verify(mockPixel).fire(Pixel.AppPixelName.CHANGE_APP_ICON_OPENED)
+        Mockito.verify(mockPixel).fire(AppPixelName.CHANGE_APP_ICON_OPENED)
 
         val viewState = testee.viewState.value!!
         assertTrue(viewState.appIcons.isNotEmpty())

--- a/app/src/androidTest/java/com/duckduckgo/app/icon/ui/ChangeIconViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/icon/ui/ChangeIconViewModelTest.kt
@@ -65,7 +65,7 @@ class ChangeIconViewModelTest {
 
         testee.start()
 
-        Mockito.verify(mockPixel).fire(Pixel.PixelName.CHANGE_APP_ICON_OPENED)
+        Mockito.verify(mockPixel).fire(Pixel.AppPixelName.CHANGE_APP_ICON_OPENED)
 
         val viewState = testee.viewState.value!!
         assertTrue(viewState.appIcons.isNotEmpty())

--- a/app/src/androidTest/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModelTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.location.data.LocationPermissionEntity
 import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.location.data.LocationPermissionsDao
 import com.duckduckgo.app.location.data.LocationPermissionsRepository
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -223,7 +224,7 @@ class LocationPermissionsViewModelTest {
 
         viewModel.onSiteLocationPermissionSelected("domain.com", LocationPermissionType.DENY_ALWAYS)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
+        verify(mockPixel).fire(AppPixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
         Mockito.verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
         assertTrue(viewStateCaptor.lastValue.locationPermissionEntities.size == 1)
 
@@ -237,7 +238,7 @@ class LocationPermissionsViewModelTest {
 
         viewModel.onSiteLocationPermissionSelected(domain, LocationPermissionType.ALLOW_ALWAYS)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
+        verify(mockPixel).fire(AppPixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
         verify(mockGeoLocationPermissions).allow(domain)
         assertEquals(locationPermissionsDao.getPermission(domain)!!.permission, LocationPermissionType.ALLOW_ALWAYS)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModelTest.kt
@@ -223,7 +223,7 @@ class LocationPermissionsViewModelTest {
 
         viewModel.onSiteLocationPermissionSelected("domain.com", LocationPermissionType.DENY_ALWAYS)
 
-        verify(mockPixel).fire(Pixel.PixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
+        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
         Mockito.verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
         assertTrue(viewStateCaptor.lastValue.locationPermissionEntities.size == 1)
 
@@ -237,7 +237,7 @@ class LocationPermissionsViewModelTest {
 
         viewModel.onSiteLocationPermissionSelected(domain, LocationPermissionType.ALLOW_ALWAYS)
 
-        verify(mockPixel).fire(Pixel.PixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
+        verify(mockPixel).fire(Pixel.AppPixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
         verify(mockGeoLocationPermissions).allow(domain)
         assertEquals(locationPermissionsDao.getPermission(domain)!!.permission, LocationPermissionType.ALLOW_ALWAYS)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
@@ -56,7 +56,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOffAndNowOnThenPixelIsFiredAndSettingsUpdated() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(false)
         testee.updateStatus(true)
-        verify(mockPixel).fire(eq(Pixel.PixelName.NOTIFICATIONS_ENABLED), any(), any())
+        verify(mockPixel).fire(eq(Pixel.AppPixelName.NOTIFICATIONS_ENABLED), any(), any())
         verify(mockSettingsDataStore).appNotificationsEnabled = true
     }
 
@@ -80,7 +80,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOnAndNowOffPixelIsFiredAndSettingsUpdated() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(true)
         testee.updateStatus(false)
-        verify(mockPixel).fire(eq(Pixel.PixelName.NOTIFICATIONS_DISABLED), any(), any())
+        verify(mockPixel).fire(eq(Pixel.AppPixelName.NOTIFICATIONS_DISABLED), any(), any())
         verify(mockSettingsDataStore).appNotificationsEnabled = false
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
@@ -20,6 +20,7 @@ import android.app.NotificationManager
 import android.content.Context.NOTIFICATION_SERVICE
 import androidx.core.app.NotificationManagerCompat
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
@@ -56,7 +57,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOffAndNowOnThenPixelIsFiredAndSettingsUpdated() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(false)
         testee.updateStatus(true)
-        verify(mockPixel).fire(eq(Pixel.AppPixelName.NOTIFICATIONS_ENABLED), any(), any())
+        verify(mockPixel).fire(eq(AppPixelName.NOTIFICATIONS_ENABLED), any(), any())
         verify(mockSettingsDataStore).appNotificationsEnabled = true
     }
 
@@ -80,7 +81,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOnAndNowOffPixelIsFiredAndSettingsUpdated() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(true)
         testee.updateStatus(false)
-        verify(mockPixel).fire(eq(Pixel.AppPixelName.NOTIFICATIONS_DISABLED), any(), any())
+        verify(mockPixel).fire(eq(AppPixelName.NOTIFICATIONS_DISABLED), any(), any())
         verify(mockSettingsDataStore).appNotificationsEnabled = false
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
@@ -76,14 +76,14 @@ class DefaultBrowserPageViewModelTest {
     @Test
     fun whenPageBecomesVisibleThenPixelSent() {
         testee.pageBecameVisible()
-        verify(mockPixel, times(1)).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+        verify(mockPixel, times(1)).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
     }
 
     @Test
     fun whenPageBecomesVisibleSubsequentTimeThenAdditionalPixelNotSent() {
         testee.pageBecameVisible()
         testee.pageBecameVisible()
-        verify(mockPixel, times(1)).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+        verify(mockPixel, times(1)).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
     }
 
     @Test
@@ -141,7 +141,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onContinueToBrowser(false)
 
-        verify(mockPixel).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+        verify(mockPixel).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
     }
 
@@ -152,7 +152,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onContinueToBrowser(false)
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
     }
 
@@ -163,7 +163,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onContinueToBrowser(true)
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
     }
 
@@ -174,7 +174,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onContinueToBrowser(true)
 
-        verify(mockPixel, never()).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+        verify(mockPixel, never()).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
     }
 
@@ -189,7 +189,7 @@ class DefaultBrowserPageViewModelTest {
         testee.onDefaultBrowserClicked()
 
         assertTrue(captureCommands().lastValue is Command.OpenSettings)
-        verify(mockPixel).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
     }
 
     @Test
@@ -213,7 +213,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onDefaultBrowserClicked()
 
-        verify(mockPixel).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
     }
 
     @Test
@@ -229,7 +229,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.InternalBrowser)
 
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
-        verify(mockPixel).fire(Pixel.PixelName.DEFAULT_BROWSER_SET, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
     }
 
     @Test
@@ -243,7 +243,7 @@ class DefaultBrowserPageViewModelTest {
         assertEquals(viewState(), DefaultBrowserDialogUI(showInstructionsCard = true))
         assertTrue(captureCommands().lastValue is Command.OpenDialog)
         assertEquals(2, testee.timesPressedJustOnce)
-        verify(mockPixel).fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE)
+        verify(mockPixel).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE)
     }
 
     @Test
@@ -259,7 +259,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.InternalBrowser)
 
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
-        verify(mockPixel).fire(Pixel.PixelName.DEFAULT_BROWSER_NOT_SET, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
     }
 
     @Test
@@ -275,7 +275,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.DialogDismissed)
 
         assertEquals(viewState(), DefaultBrowserDialogUI(showInstructionsCard = false))
-        verify(mockPixel).fire(Pixel.PixelName.DEFAULT_BROWSER_NOT_SET, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
     }
 
     @Test
@@ -291,7 +291,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.ExternalBrowser)
 
         assertTrue(viewState() is DefaultBrowserSettingsUI)
-        verify(mockPixel).fire(Pixel.PixelName.DEFAULT_BROWSER_NOT_SET, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
     }
 
     @Test
@@ -308,7 +308,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.ExternalBrowser)
 
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
-        verify(mockPixel).fire(Pixel.PixelName.DEFAULT_BROWSER_SET, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
     }
 
     @Test
@@ -349,7 +349,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.handleResult(Origin.Settings)
 
-        verify(mockPixel).fire(Pixel.PixelName.DEFAULT_BROWSER_SET, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
     }
 
     @Test
@@ -364,7 +364,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.handleResult(Origin.Settings)
 
-        verify(mockPixel).fire(Pixel.PixelName.DEFAULT_BROWSER_NOT_SET, params)
+        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPageViewModel.Command
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPageViewModel.Companion.MAX_DIALOG_ATTEMPTS
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPageViewModel.Origin
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPageViewModel.ViewState.*
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DEFAULT_BROWSER_DIALOG
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DEFAULT_BROWSER_SETTINGS
@@ -76,14 +77,14 @@ class DefaultBrowserPageViewModelTest {
     @Test
     fun whenPageBecomesVisibleThenPixelSent() {
         testee.pageBecameVisible()
-        verify(mockPixel, times(1)).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+        verify(mockPixel, times(1)).fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
     }
 
     @Test
     fun whenPageBecomesVisibleSubsequentTimeThenAdditionalPixelNotSent() {
         testee.pageBecameVisible()
         testee.pageBecameVisible()
-        verify(mockPixel, times(1)).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+        verify(mockPixel, times(1)).fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
     }
 
     @Test
@@ -141,7 +142,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onContinueToBrowser(false)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+        verify(mockPixel).fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
     }
 
@@ -152,7 +153,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onContinueToBrowser(false)
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+        verify(mockPixel, never()).fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
     }
 
@@ -163,7 +164,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onContinueToBrowser(true)
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+        verify(mockPixel, never()).fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
     }
 
@@ -174,7 +175,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onContinueToBrowser(true)
 
-        verify(mockPixel, never()).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+        verify(mockPixel, never()).fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
     }
 
@@ -189,7 +190,7 @@ class DefaultBrowserPageViewModelTest {
         testee.onDefaultBrowserClicked()
 
         assertTrue(captureCommands().lastValue is Command.OpenSettings)
-        verify(mockPixel).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
+        verify(mockPixel).fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
     }
 
     @Test
@@ -213,7 +214,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.onDefaultBrowserClicked()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
+        verify(mockPixel).fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
     }
 
     @Test
@@ -229,7 +230,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.InternalBrowser)
 
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
-        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
+        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_SET, params)
     }
 
     @Test
@@ -243,7 +244,7 @@ class DefaultBrowserPageViewModelTest {
         assertEquals(viewState(), DefaultBrowserDialogUI(showInstructionsCard = true))
         assertTrue(captureCommands().lastValue is Command.OpenDialog)
         assertEquals(2, testee.timesPressedJustOnce)
-        verify(mockPixel).fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE)
+        verify(mockPixel).fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE)
     }
 
     @Test
@@ -259,7 +260,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.InternalBrowser)
 
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
-        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
+        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
     }
 
     @Test
@@ -275,7 +276,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.DialogDismissed)
 
         assertEquals(viewState(), DefaultBrowserDialogUI(showInstructionsCard = false))
-        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
+        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
     }
 
     @Test
@@ -291,7 +292,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.ExternalBrowser)
 
         assertTrue(viewState() is DefaultBrowserSettingsUI)
-        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
+        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
     }
 
     @Test
@@ -308,7 +309,7 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.ExternalBrowser)
 
         assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
-        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
+        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_SET, params)
     }
 
     @Test
@@ -349,7 +350,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.handleResult(Origin.Settings)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
+        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_SET, params)
     }
 
     @Test
@@ -364,7 +365,7 @@ class DefaultBrowserPageViewModelTest {
 
         testee.handleResult(Origin.Settings)
 
-        verify(mockPixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
+        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -126,7 +126,7 @@ class WelcomePageViewModelTest {
         }
         events.send(WelcomePageView.Event.OnPrimaryCtaClicked)
 
-        verify(pixel).fire(Pixel.PixelName.DEFAULT_BROWSER_DIALOG_NOT_SHOWN)
+        verify(pixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_DIALOG_NOT_SHOWN)
 
         launch.cancel()
     }
@@ -142,7 +142,7 @@ class WelcomePageViewModelTest {
 
         verify(defaultRoleBrowserDialog).dialogShown()
         verify(pixel).fire(
-            Pixel.PixelName.DEFAULT_BROWSER_SET,
+            Pixel.AppPixelName.DEFAULT_BROWSER_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())
         )
 
@@ -160,7 +160,7 @@ class WelcomePageViewModelTest {
 
         verify(defaultRoleBrowserDialog).dialogShown()
         verify(pixel).fire(
-            Pixel.PixelName.DEFAULT_BROWSER_NOT_SET,
+            Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())
         )
 

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -22,6 +22,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.any
@@ -126,7 +127,7 @@ class WelcomePageViewModelTest {
         }
         events.send(WelcomePageView.Event.OnPrimaryCtaClicked)
 
-        verify(pixel).fire(Pixel.AppPixelName.DEFAULT_BROWSER_DIALOG_NOT_SHOWN)
+        verify(pixel).fire(AppPixelName.DEFAULT_BROWSER_DIALOG_NOT_SHOWN)
 
         launch.cancel()
     }
@@ -142,7 +143,7 @@ class WelcomePageViewModelTest {
 
         verify(defaultRoleBrowserDialog).dialogShown()
         verify(pixel).fire(
-            Pixel.AppPixelName.DEFAULT_BROWSER_SET,
+            AppPixelName.DEFAULT_BROWSER_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())
         )
 
@@ -160,7 +161,7 @@ class WelcomePageViewModelTest {
 
         verify(defaultRoleBrowserDialog).dialogShown()
         verify(pixel).fire(
-            Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET,
+            AppPixelName.DEFAULT_BROWSER_NOT_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())
         )
 

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
@@ -34,7 +34,7 @@ import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchManageWhitelist
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchReportBrokenSite
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
@@ -34,7 +34,7 @@ import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchManageWhitelist
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchReportBrokenSite
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -93,7 +93,7 @@ class SettingsViewModelTest {
     @Test
     fun whenViewModelInitialisedThenPixelIsFired() {
         testee // init
-        verify(mockPixel).fire(Pixel.PixelName.SETTINGS_OPENED)
+        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_OPENED)
     }
 
     @Test
@@ -136,7 +136,7 @@ class SettingsViewModelTest {
     @Test
     fun whenLightThemeToggledOnThenLighThemePixelIsSent() {
         testee.onLightThemeToggled(true)
-        verify(mockPixel).fire(Pixel.PixelName.SETTINGS_THEME_TOGGLED_LIGHT)
+        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_THEME_TOGGLED_LIGHT)
     }
 
     @Test
@@ -152,7 +152,7 @@ class SettingsViewModelTest {
     @Test
     fun whenLightThemeToggledOffThenDarkThemePixelIsSent() {
         testee.onLightThemeToggled(false)
-        verify(mockPixel).fire(Pixel.PixelName.SETTINGS_THEME_TOGGLED_DARK)
+        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_THEME_TOGGLED_DARK)
     }
 
     @Test
@@ -208,7 +208,7 @@ class SettingsViewModelTest {
     @Test
     fun whenWhitelistSelectedThenPixelIsSentAndWhitelistLaunched() {
         testee.onManageWhitelistSelected()
-        verify(mockPixel).fire(Pixel.PixelName.SETTINGS_MANAGE_WHITELIST)
+        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_MANAGE_WHITELIST)
         verify(commandObserver).onChanged(Command.LaunchWhitelist)
     }
 
@@ -247,7 +247,7 @@ class SettingsViewModelTest {
     fun whenFireAnimationSettingClickedThenPixelSent() {
         testee.userRequestedToChangeFireAnimation()
 
-        verify(mockPixel).fire(Pixel.PixelName.FIRE_ANIMATION_SETTINGS_OPENED)
+        verify(mockPixel).fire(Pixel.AppPixelName.FIRE_ANIMATION_SETTINGS_OPENED)
     }
 
     @Test
@@ -276,7 +276,7 @@ class SettingsViewModelTest {
         testee.onFireAnimationSelected(FireAnimation.HeroWater)
 
         verify(mockPixel).fire(
-            Pixel.PixelName.FIRE_ANIMATION_NEW_SELECTED,
+            Pixel.AppPixelName.FIRE_ANIMATION_NEW_SELECTED,
             mapOf(Pixel.PixelParameter.FIRE_ANIMATION to Pixel.PixelValues.FIRE_ANIMATION_WHIRLPOOL)
         )
     }
@@ -288,7 +288,7 @@ class SettingsViewModelTest {
         testee.onFireAnimationSelected(FireAnimation.HeroFire)
 
         verify(mockPixel, times(0)).fire(
-            Pixel.PixelName.FIRE_ANIMATION_NEW_SELECTED,
+            Pixel.AppPixelName.FIRE_ANIMATION_NEW_SELECTED,
             mapOf(Pixel.PixelParameter.FIRE_ANIMATION to Pixel.PixelValues.FIRE_ANIMATION_INFERNO)
         )
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.fire.FireAnimationLoader
 import com.duckduckgo.app.global.DuckDuckGoTheme
 import com.duckduckgo.app.icon.api.AppIcon
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.SettingsViewModel.Command
 import com.duckduckgo.app.settings.clear.ClearWhatOption.CLEAR_NONE
 import com.duckduckgo.app.settings.clear.ClearWhenOption.APP_EXIT_ONLY
@@ -93,7 +94,7 @@ class SettingsViewModelTest {
     @Test
     fun whenViewModelInitialisedThenPixelIsFired() {
         testee // init
-        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_OPENED)
+        verify(mockPixel).fire(AppPixelName.SETTINGS_OPENED)
     }
 
     @Test
@@ -136,7 +137,7 @@ class SettingsViewModelTest {
     @Test
     fun whenLightThemeToggledOnThenLighThemePixelIsSent() {
         testee.onLightThemeToggled(true)
-        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_THEME_TOGGLED_LIGHT)
+        verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_TOGGLED_LIGHT)
     }
 
     @Test
@@ -152,7 +153,7 @@ class SettingsViewModelTest {
     @Test
     fun whenLightThemeToggledOffThenDarkThemePixelIsSent() {
         testee.onLightThemeToggled(false)
-        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_THEME_TOGGLED_DARK)
+        verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_TOGGLED_DARK)
     }
 
     @Test
@@ -208,7 +209,7 @@ class SettingsViewModelTest {
     @Test
     fun whenWhitelistSelectedThenPixelIsSentAndWhitelistLaunched() {
         testee.onManageWhitelistSelected()
-        verify(mockPixel).fire(Pixel.AppPixelName.SETTINGS_MANAGE_WHITELIST)
+        verify(mockPixel).fire(AppPixelName.SETTINGS_MANAGE_WHITELIST)
         verify(commandObserver).onChanged(Command.LaunchWhitelist)
     }
 
@@ -247,7 +248,7 @@ class SettingsViewModelTest {
     fun whenFireAnimationSettingClickedThenPixelSent() {
         testee.userRequestedToChangeFireAnimation()
 
-        verify(mockPixel).fire(Pixel.AppPixelName.FIRE_ANIMATION_SETTINGS_OPENED)
+        verify(mockPixel).fire(AppPixelName.FIRE_ANIMATION_SETTINGS_OPENED)
     }
 
     @Test
@@ -276,7 +277,7 @@ class SettingsViewModelTest {
         testee.onFireAnimationSelected(FireAnimation.HeroWater)
 
         verify(mockPixel).fire(
-            Pixel.AppPixelName.FIRE_ANIMATION_NEW_SELECTED,
+            AppPixelName.FIRE_ANIMATION_NEW_SELECTED,
             mapOf(Pixel.PixelParameter.FIRE_ANIMATION to Pixel.PixelValues.FIRE_ANIMATION_WHIRLPOOL)
         )
     }
@@ -288,7 +289,7 @@ class SettingsViewModelTest {
         testee.onFireAnimationSelected(FireAnimation.HeroFire)
 
         verify(mockPixel, times(0)).fire(
-            Pixel.AppPixelName.FIRE_ANIMATION_NEW_SELECTED,
+            AppPixelName.FIRE_ANIMATION_NEW_SELECTED,
             mapOf(Pixel.PixelParameter.FIRE_ANIMATION to Pixel.PixelValues.FIRE_ANIMATION_INFERNO)
         )
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/OfflinePixelSenderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/OfflinePixelSenderTest.kt
@@ -70,6 +70,6 @@ class OfflinePixelSenderTest {
 
         testee.sendOfflinePixels().blockingAwait()
 
-        verify(mockPixel).sendPixel(Pixel.AppPixelName.APPLICATION_CRASH_GLOBAL.pixelName, params, emptyMap())
+        verify(mockPixel).sendPixel(Pixel.StatisticsPixelName.APPLICATION_CRASH_GLOBAL.pixelName, params, emptyMap())
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/OfflinePixelSenderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/OfflinePixelSenderTest.kt
@@ -70,6 +70,6 @@ class OfflinePixelSenderTest {
 
         testee.sendOfflinePixels().blockingAwait()
 
-        verify(mockPixel).sendPixel(Pixel.PixelName.APPLICATION_CRASH_GLOBAL.pixelName, params, emptyMap())
+        verify(mockPixel).sendPixel(Pixel.AppPixelName.APPLICATION_CRASH_GLOBAL.pixelName, params, emptyMap())
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
@@ -26,7 +26,7 @@ import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.model.PixelEntity
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.PRIVACY_DASHBOARD_OPENED
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.PRIVACY_DASHBOARD_OPENED
 import com.duckduckgo.app.statistics.store.PendingPixelDao
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.nhaarman.mockitokotlin2.*

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
@@ -26,7 +26,7 @@ import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.model.PixelEntity
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.PRIVACY_DASHBOARD_OPENED
+import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_DASHBOARD_OPENED
 import com.duckduckgo.app.statistics.store.PendingPixelDao
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.nhaarman.mockitokotlin2.*

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
@@ -24,7 +24,7 @@ class PixelNameTest {
     @Test
     fun verifyNoDuplicatePixelNames() {
         val existingNames = mutableSetOf<String>()
-        Pixel.PixelName.values().forEach {
+        Pixel.AppPixelName.values().forEach {
             if (!existingNames.add(it.pixelName)) {
                 fail("Duplicate pixel name found: ${it.pixelName}")
             }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
@@ -27,12 +27,12 @@ class PixelNameTest {
         val existingNames = mutableSetOf<String>()
         AppPixelName.values().forEach {
             if (!existingNames.add(it.pixelName)) {
-                fail("Duplicate pixel name found: ${it.pixelName}")
+                fail("Duplicate pixel name in AppPixelName: ${it.pixelName}")
             }
         }
         Pixel.StatisticsPixelName.values().forEach {
             if (!existingNames.add(it.pixelName)) {
-                fail("Duplicate pixel name found: ${it.pixelName}")
+                fail("Duplicate pixel name in StatisticsPixelName: ${it.pixelName}")
             }
         }
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.statistics.pixels
 
+import com.duckduckgo.app.pixels.AppPixelName
 import org.junit.Assert.fail
 import org.junit.Test
 
@@ -24,7 +25,7 @@ class PixelNameTest {
     @Test
     fun verifyNoDuplicatePixelNames() {
         val existingNames = mutableSetOf<String>()
-        Pixel.AppPixelName.values().forEach {
+        AppPixelName.values().forEach {
             if (!existingNames.add(it.pixelName)) {
                 fail("Duplicate pixel name found: ${it.pixelName}")
             }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
@@ -30,6 +30,10 @@ class PixelNameTest {
                 fail("Duplicate pixel name found: ${it.pixelName}")
             }
         }
+        Pixel.StatisticsPixelName.values().forEach {
+            if (!existingNames.add(it.pixelName)) {
+                fail("Duplicate pixel name found: ${it.pixelName}")
+            }
+        }
     }
-
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/RxBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/RxBasedPixelTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.app.statistics.pixels
 
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.statistics.api.PixelSender
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.PRIVACY_DASHBOARD_OPENED
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.PRIVACY_DASHBOARD_OPENED
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/RxBasedPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/pixels/RxBasedPixelTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.app.statistics.pixels
 
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.statistics.api.PixelSender
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.PRIVACY_DASHBOARD_OPENED
+import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_DASHBOARD_OPENED
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify

--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.A
 import com.duckduckgo.app.onboarding.store.*
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckDuckGo
 import com.nhaarman.mockitokotlin2.*

--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.A
 import com.duckduckgo.app.onboarding.store.*
 import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckDuckGo
 import com.nhaarman.mockitokotlin2.*

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -98,7 +98,7 @@ class BrokenSiteViewModel(private val pixel: Pixel, private val brokenSiteSender
     fun onSubmitPressed(webViewVersion: String) {
         val brokenSite = getBrokenSite(url, webViewVersion)
         brokenSiteSender.submitBrokenSiteFeedback(brokenSite)
-        pixel.fire(Pixel.PixelName.BROKEN_SITE_REPORTED, mapOf(Pixel.PixelParameter.URL to brokenSite.siteUrl))
+        pixel.fire(Pixel.AppPixelName.BROKEN_SITE_REPORTED, mapOf(Pixel.PixelParameter.URL to brokenSite.siteUrl))
         command.value = Command.ConfirmAndFinish
     }
 

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.global.absoluteString
 import com.duckduckgo.app.global.isMobileSite
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo
@@ -98,7 +99,7 @@ class BrokenSiteViewModel(private val pixel: Pixel, private val brokenSiteSender
     fun onSubmitPressed(webViewVersion: String) {
         val brokenSite = getBrokenSite(url, webViewVersion)
         brokenSiteSender.submitBrokenSiteFeedback(brokenSite)
-        pixel.fire(Pixel.AppPixelName.BROKEN_SITE_REPORTED, mapOf(Pixel.PixelParameter.URL to brokenSite.siteUrl))
+        pixel.fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf(Pixel.PixelParameter.URL to brokenSite.siteUrl))
         command.value = Command.ConfirmAndFinish
     }
 

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -20,6 +20,7 @@ import android.os.Build
 import com.duckduckgo.app.brokensite.model.BrokenSite
 import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.globalprivacycontrol.GlobalPrivacyControl
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -62,7 +63,7 @@ class BrokenSiteSubmitter(
                 SURROGATES_KEY to brokenSite.surrogates
             )
             runCatching {
-                pixel.fire(Pixel.AppPixelName.BROKEN_SITE_REPORT.pixelName, params, encodedParams)
+                pixel.fire(AppPixelName.BROKEN_SITE_REPORT.pixelName, params, encodedParams)
             }
                 .onSuccess { Timber.v("Feedback submission succeeded") }
                 .onFailure { Timber.w(it, "Feedback submission failed") }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -62,7 +62,7 @@ class BrokenSiteSubmitter(
                 SURROGATES_KEY to brokenSite.surrogates
             )
             runCatching {
-                pixel.fire(Pixel.PixelName.BROKEN_SITE_REPORT.pixelName, params, encodedParams)
+                pixel.fire(Pixel.AppPixelName.BROKEN_SITE_REPORT.pixelName, params, encodedParams)
             }
                 .onSuccess { Timber.v("Feedback submission succeeded") }
                 .onFailure { Timber.w(it, "Feedback submission failed") }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -50,8 +50,8 @@ import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.FIRE_DIALOG_CANCEL
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.FIRE_DIALOG_PROMOTED_CANCEL
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.FIRE_DIALOG_CANCEL
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.FIRE_DIALOG_PROMOTED_CANCEL
 import com.duckduckgo.app.tabs.model.TabEntity
 import kotlinx.android.synthetic.main.activity_browser.*
 import kotlinx.android.synthetic.main.include_omnibar_toolbar_mockup.*
@@ -302,7 +302,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
     }
 
     fun launchFire() {
-        pixel.fire(Pixel.PixelName.FORGET_ALL_PRESSED_BROWSING)
+        pixel.fire(Pixel.AppPixelName.FORGET_ALL_PRESSED_BROWSING)
         val dialog = FireDialog(
             context = this,
             clearPersonalDataAction = clearPersonalDataAction,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -45,13 +45,14 @@ import com.duckduckgo.app.global.intentText
 import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.location.ui.LocationPermissionsActivity
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPage
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.FIRE_DIALOG_CANCEL
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.FIRE_DIALOG_PROMOTED_CANCEL
+import com.duckduckgo.app.pixels.AppPixelName.FIRE_DIALOG_CANCEL
+import com.duckduckgo.app.pixels.AppPixelName.FIRE_DIALOG_PROMOTED_CANCEL
 import com.duckduckgo.app.tabs.model.TabEntity
 import kotlinx.android.synthetic.main.activity_browser.*
 import kotlinx.android.synthetic.main.include_omnibar_toolbar_mockup.*
@@ -302,7 +303,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
     }
 
     fun launchFire() {
-        pixel.fire(Pixel.AppPixelName.FORGET_ALL_PRESSED_BROWSING)
+        pixel.fire(AppPixelName.FORGET_ALL_PRESSED_BROWSING)
         val dialog = FireDialog(
             context = this,
             clearPersonalDataAction = clearPersonalDataAction,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1452,7 +1452,7 @@ class BrowserTabFragment :
             fireMenuButton?.setOnClickListener {
                 browserActivity?.launchFire()
                 pixel.fire(
-                    Pixel.PixelName.MENU_ACTION_FIRE_PRESSED.pixelName,
+                    Pixel.AppPixelName.MENU_ACTION_FIRE_PRESSED.pixelName,
                     mapOf(FIRE_BUTTON_STATE to pulseAnimation.isActive.toString())
                 )
             }
@@ -1465,54 +1465,54 @@ class BrowserTabFragment :
             val view = popupMenu.contentView
             popupMenu.apply {
                 onMenuItemClicked(view.forwardPopupMenuItem) {
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_NAVIGATE_FORWARD_PRESSED)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_NAVIGATE_FORWARD_PRESSED)
                     viewModel.onUserPressedForward()
                 }
                 onMenuItemClicked(view.backPopupMenuItem) {
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_NAVIGATE_BACK_PRESSED)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_NAVIGATE_BACK_PRESSED)
                     activity?.onBackPressed()
                 }
                 onMenuItemClicked(view.refreshPopupMenuItem) {
                     viewModel.onRefreshRequested()
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_REFRESH_PRESSED.pixelName)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName)
                 }
                 onMenuItemClicked(view.newTabPopupMenuItem) {
                     viewModel.userRequestedOpeningNewTab()
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_NEW_TAB_PRESSED.pixelName)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_NEW_TAB_PRESSED.pixelName)
                 }
                 onMenuItemClicked(view.bookmarksPopupMenuItem) {
                     browserActivity?.launchBookmarks()
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_BOOKMARKS_PRESSED.pixelName)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_BOOKMARKS_PRESSED.pixelName)
                 }
                 onMenuItemClicked(view.fireproofWebsitePopupMenuItem) { launch { viewModel.onFireproofWebsiteMenuClicked() } }
                 onMenuItemClicked(view.addBookmarksPopupMenuItem) {
                     launch {
-                        pixel.fire(Pixel.PixelName.MENU_ACTION_ADD_BOOKMARK_PRESSED.pixelName)
+                        pixel.fire(Pixel.AppPixelName.MENU_ACTION_ADD_BOOKMARK_PRESSED.pixelName)
                         viewModel.onBookmarkAddRequested()
                     }
                 }
                 onMenuItemClicked(view.findInPageMenuItem) {
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_FIND_IN_PAGE_PRESSED)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_FIND_IN_PAGE_PRESSED)
                     viewModel.onFindInPageSelected()
                 }
                 onMenuItemClicked(view.whitelistPopupMenuItem) { viewModel.onWhitelistSelected() }
                 onMenuItemClicked(view.brokenSitePopupMenuItem) {
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_REPORT_BROKEN_SITE_PRESSED)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_REPORT_BROKEN_SITE_PRESSED)
                     viewModel.onBrokenSiteSelected()
                 }
                 onMenuItemClicked(view.settingsPopupMenuItem) {
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_SETTINGS_PRESSED)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_SETTINGS_PRESSED)
                     browserActivity?.launchSettings()
                 }
                 onMenuItemClicked(view.requestDesktopSiteCheckMenuItem) {
                     viewModel.onDesktopSiteModeToggled(view.requestDesktopSiteCheckMenuItem.isChecked)
                 }
                 onMenuItemClicked(view.sharePageMenuItem) {
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_SHARE_PRESSED)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_SHARE_PRESSED)
                     viewModel.onShareSelected()
                 }
                 onMenuItemClicked(view.addToHome) {
-                    pixel.fire(Pixel.PixelName.MENU_ACTION_ADD_TO_HOME_PRESSED)
+                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_ADD_TO_HOME_PRESSED)
                     viewModel.onPinPageToHomeSelected()
                 }
             }
@@ -1524,7 +1524,7 @@ class BrowserTabFragment :
 
         private fun launchTopAnchoredPopupMenu() {
             popupMenu.show(rootView, toolbar)
-            pixel.fire(Pixel.PixelName.MENU_ACTION_POPUP_OPENED.pixelName)
+            pixel.fire(Pixel.AppPixelName.MENU_ACTION_POPUP_OPENED.pixelName)
         }
 
         private fun configureShowTabSwitcherListener() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -93,6 +93,7 @@ import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.location.ui.SiteLocationPermissionDialog
 import com.duckduckgo.app.location.ui.SystemLocationPermissionDialog
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.renderer.icon
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -1452,7 +1453,7 @@ class BrowserTabFragment :
             fireMenuButton?.setOnClickListener {
                 browserActivity?.launchFire()
                 pixel.fire(
-                    Pixel.AppPixelName.MENU_ACTION_FIRE_PRESSED.pixelName,
+                    AppPixelName.MENU_ACTION_FIRE_PRESSED.pixelName,
                     mapOf(FIRE_BUTTON_STATE to pulseAnimation.isActive.toString())
                 )
             }
@@ -1465,54 +1466,54 @@ class BrowserTabFragment :
             val view = popupMenu.contentView
             popupMenu.apply {
                 onMenuItemClicked(view.forwardPopupMenuItem) {
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_NAVIGATE_FORWARD_PRESSED)
+                    pixel.fire(AppPixelName.MENU_ACTION_NAVIGATE_FORWARD_PRESSED)
                     viewModel.onUserPressedForward()
                 }
                 onMenuItemClicked(view.backPopupMenuItem) {
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_NAVIGATE_BACK_PRESSED)
+                    pixel.fire(AppPixelName.MENU_ACTION_NAVIGATE_BACK_PRESSED)
                     activity?.onBackPressed()
                 }
                 onMenuItemClicked(view.refreshPopupMenuItem) {
                     viewModel.onRefreshRequested()
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName)
+                    pixel.fire(AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName)
                 }
                 onMenuItemClicked(view.newTabPopupMenuItem) {
                     viewModel.userRequestedOpeningNewTab()
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_NEW_TAB_PRESSED.pixelName)
+                    pixel.fire(AppPixelName.MENU_ACTION_NEW_TAB_PRESSED.pixelName)
                 }
                 onMenuItemClicked(view.bookmarksPopupMenuItem) {
                     browserActivity?.launchBookmarks()
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_BOOKMARKS_PRESSED.pixelName)
+                    pixel.fire(AppPixelName.MENU_ACTION_BOOKMARKS_PRESSED.pixelName)
                 }
                 onMenuItemClicked(view.fireproofWebsitePopupMenuItem) { launch { viewModel.onFireproofWebsiteMenuClicked() } }
                 onMenuItemClicked(view.addBookmarksPopupMenuItem) {
                     launch {
-                        pixel.fire(Pixel.AppPixelName.MENU_ACTION_ADD_BOOKMARK_PRESSED.pixelName)
+                        pixel.fire(AppPixelName.MENU_ACTION_ADD_BOOKMARK_PRESSED.pixelName)
                         viewModel.onBookmarkAddRequested()
                     }
                 }
                 onMenuItemClicked(view.findInPageMenuItem) {
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_FIND_IN_PAGE_PRESSED)
+                    pixel.fire(AppPixelName.MENU_ACTION_FIND_IN_PAGE_PRESSED)
                     viewModel.onFindInPageSelected()
                 }
                 onMenuItemClicked(view.whitelistPopupMenuItem) { viewModel.onWhitelistSelected() }
                 onMenuItemClicked(view.brokenSitePopupMenuItem) {
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_REPORT_BROKEN_SITE_PRESSED)
+                    pixel.fire(AppPixelName.MENU_ACTION_REPORT_BROKEN_SITE_PRESSED)
                     viewModel.onBrokenSiteSelected()
                 }
                 onMenuItemClicked(view.settingsPopupMenuItem) {
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_SETTINGS_PRESSED)
+                    pixel.fire(AppPixelName.MENU_ACTION_SETTINGS_PRESSED)
                     browserActivity?.launchSettings()
                 }
                 onMenuItemClicked(view.requestDesktopSiteCheckMenuItem) {
                     viewModel.onDesktopSiteModeToggled(view.requestDesktopSiteCheckMenuItem.isChecked)
                 }
                 onMenuItemClicked(view.sharePageMenuItem) {
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_SHARE_PRESSED)
+                    pixel.fire(AppPixelName.MENU_ACTION_SHARE_PRESSED)
                     viewModel.onShareSelected()
                 }
                 onMenuItemClicked(view.addToHome) {
-                    pixel.fire(Pixel.AppPixelName.MENU_ACTION_ADD_TO_HOME_PRESSED)
+                    pixel.fire(AppPixelName.MENU_ACTION_ADD_TO_HOME_PRESSED)
                     viewModel.onPinPageToHomeSelected()
                 }
             }
@@ -1524,7 +1525,7 @@ class BrowserTabFragment :
 
         private fun launchTopAnchoredPopupMenu() {
             popupMenu.show(rootView, toolbar)
-            pixel.fire(Pixel.AppPixelName.MENU_ACTION_POPUP_OPENED.pixelName)
+            pixel.fire(AppPixelName.MENU_ACTION_POPUP_OPENED.pixelName)
         }
 
         private fun configureShowTabSwitcherListener() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -95,7 +95,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.survey.model.Survey
@@ -505,8 +505,8 @@ class BrowserTabViewModel(
             PixelParameter.BOOKMARK_CAPABLE to hasBookmarks.toString()
         )
         val pixelName = when (suggestion) {
-            is AutoCompleteBookmarkSuggestion -> PixelName.AUTOCOMPLETE_BOOKMARK_SELECTION
-            is AutoCompleteSearchSuggestion -> PixelName.AUTOCOMPLETE_SEARCH_SELECTION
+            is AutoCompleteBookmarkSuggestion -> AppPixelName.AUTOCOMPLETE_BOOKMARK_SELECTION
+            is AutoCompleteSearchSuggestion -> AppPixelName.AUTOCOMPLETE_SEARCH_SELECTION
         }
 
         pixel.fire(pixelName, params)
@@ -572,9 +572,9 @@ class BrowserTabViewModel(
         if (Patterns.WEB_URL.matcher(oldQuery.toString()).matches()) return
 
         if (oldQuery == newQuery) {
-            pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_NOT_CHANGED))
+            pixel.fire(String.format(Locale.US, AppPixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_NOT_CHANGED))
         } else if (oldQuery.toString().isNotBlank()) { // blank means no previous search, don't send pixel
-            pixel.fire(String.format(Locale.US, PixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_CHANGED))
+            pixel.fire(String.format(Locale.US, AppPixelName.SERP_REQUERY.pixelName, PixelParameter.SERP_QUERY_CHANGED))
         }
     }
 
@@ -838,10 +838,10 @@ class BrowserTabViewModel(
             val deleteCtaShown = ctaViewModel.useOurAppDeletionDialogShown()
 
             when {
-                deleteCtaShown -> pixel.fire(PixelName.UOA_VISITED_AFTER_DELETE_CTA)
-                isShortcutAdded != null -> pixel.fire(PixelName.UOA_VISITED_AFTER_SHORTCUT)
-                isUseOurAppNotificationSeen -> pixel.fire(PixelName.UOA_VISITED_AFTER_NOTIFICATION)
-                else -> pixel.fire(PixelName.UOA_VISITED)
+                deleteCtaShown -> pixel.fire(AppPixelName.UOA_VISITED_AFTER_DELETE_CTA)
+                isShortcutAdded != null -> pixel.fire(AppPixelName.UOA_VISITED_AFTER_SHORTCUT)
+                isUseOurAppNotificationSeen -> pixel.fire(AppPixelName.UOA_VISITED_AFTER_NOTIFICATION)
+                else -> pixel.fire(AppPixelName.UOA_VISITED)
             }
         }
     }
@@ -1013,19 +1013,19 @@ class BrowserTabViewModel(
                 LocationPermissionType.ALLOW_ALWAYS -> {
                     onSiteLocationPermissionAlwaysAllowed()
                     setDomainHasLocationPermissionShown(domain)
-                    pixel.fire(PixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
+                    pixel.fire(AppPixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
                     viewModelScope.launch {
                         locationPermissionsRepository.savePermission(domain, permission)
                         faviconManager.persistFavicon(tabId, domain)
                     }
                 }
                 LocationPermissionType.ALLOW_ONCE -> {
-                    pixel.fire(PixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ONCE)
+                    pixel.fire(AppPixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ONCE)
                     locationPermissionSession[domain] = permission
                     locationPermission.callback.invoke(locationPermission.origin, true, false)
                 }
                 LocationPermissionType.DENY_ALWAYS -> {
-                    pixel.fire(PixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
+                    pixel.fire(AppPixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
                     onSiteLocationPermissionAlwaysDenied()
                     viewModelScope.launch {
                         locationPermissionsRepository.savePermission(domain, permission)
@@ -1033,7 +1033,7 @@ class BrowserTabViewModel(
                     }
                 }
                 LocationPermissionType.DENY_ONCE -> {
-                    pixel.fire(PixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ONCE)
+                    pixel.fire(AppPixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ONCE)
                     locationPermissionSession[domain] = permission
                     locationPermission.callback.invoke(locationPermission.origin, false, false)
                 }
@@ -1091,19 +1091,19 @@ class BrowserTabViewModel(
     }
 
     override fun onSystemLocationPermissionAllowed() {
-        pixel.fire(PixelName.PRECISE_LOCATION_SYSTEM_DIALOG_ENABLE)
+        pixel.fire(AppPixelName.PRECISE_LOCATION_SYSTEM_DIALOG_ENABLE)
         command.postValue(RequestSystemLocationPermission)
     }
 
     override fun onSystemLocationPermissionNotAllowed() {
-        pixel.fire(PixelName.PRECISE_LOCATION_SYSTEM_DIALOG_LATER)
+        pixel.fire(AppPixelName.PRECISE_LOCATION_SYSTEM_DIALOG_LATER)
         onSiteLocationPermissionAlwaysDenied()
     }
 
     override fun onSystemLocationPermissionNeverAllowed() {
         locationPermission?.let { locationPermission ->
             onSiteLocationPermissionSelected(locationPermission.origin, LocationPermissionType.DENY_ALWAYS)
-            pixel.fire(PixelName.PRECISE_LOCATION_SYSTEM_DIALOG_NEVER)
+            pixel.fire(AppPixelName.PRECISE_LOCATION_SYSTEM_DIALOG_NEVER)
         }
     }
 
@@ -1111,7 +1111,7 @@ class BrowserTabViewModel(
         locationPermission?.let { locationPermission ->
             appSettingsPreferencesStore.appLocationPermissionDeniedForever = false
             appSettingsPreferencesStore.appLocationPermission = true
-            pixel.fire(PixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_ENABLE)
+            pixel.fire(AppPixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_ENABLE)
             viewModelScope.launch {
                 val permissionEntity = locationPermissionsRepository.getDomainPermission(locationPermission.origin)
                 if (permissionEntity == null) {
@@ -1124,7 +1124,7 @@ class BrowserTabViewModel(
     }
 
     fun onSystemLocationPermissionDeniedOneTime() {
-        pixel.fire(PixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE)
+        pixel.fire(AppPixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE)
         onSiteLocationPermissionAlwaysDenied()
     }
 
@@ -1298,10 +1298,10 @@ class BrowserTabViewModel(
         viewModelScope.launch {
             if (currentBrowserViewState().isFireproofWebsite) {
                 fireproofWebsiteRepository.removeFireproofWebsite(FireproofWebsiteEntity(domain))
-                pixel.fire(PixelName.FIREPROOF_WEBSITE_REMOVE)
+                pixel.fire(AppPixelName.FIREPROOF_WEBSITE_REMOVE)
             } else {
                 fireproofWebsiteRepository.fireproofWebsite(domain)?.let {
-                    pixel.fire(PixelName.FIREPROOF_WEBSITE_ADDED)
+                    pixel.fire(AppPixelName.FIREPROOF_WEBSITE_ADDED)
                     command.value = ShowFireproofWebSiteConfirmation(fireproofWebsiteEntity = it)
                     faviconManager.persistFavicon(tabId, url = domain)
                 }
@@ -1348,7 +1348,7 @@ class BrowserTabViewModel(
     fun onFireproofWebsiteSnackbarUndoClicked(fireproofWebsiteEntity: FireproofWebsiteEntity) {
         viewModelScope.launch(dispatchers.io()) {
             fireproofWebsiteRepository.removeFireproofWebsite(fireproofWebsiteEntity)
-            pixel.fire(PixelName.FIREPROOF_WEBSITE_UNDO)
+            pixel.fire(AppPixelName.FIREPROOF_WEBSITE_UNDO)
         }
     }
 
@@ -1381,7 +1381,7 @@ class BrowserTabViewModel(
     }
 
     private suspend fun addToWhitelist(domain: String) {
-        pixel.fire(PixelName.BROWSER_MENU_WHITELIST_ADD)
+        pixel.fire(AppPixelName.BROWSER_MENU_WHITELIST_ADD)
         withContext(dispatchers.io()) {
             userWhitelistDao.insert(domain)
         }
@@ -1391,7 +1391,7 @@ class BrowserTabViewModel(
     }
 
     private suspend fun removeFromWhitelist(domain: String) {
-        pixel.fire(PixelName.BROWSER_MENU_WHITELIST_REMOVE)
+        pixel.fire(AppPixelName.BROWSER_MENU_WHITELIST_REMOVE)
         withContext(dispatchers.io()) {
             userWhitelistDao.delete(domain)
         }
@@ -1490,8 +1490,8 @@ class BrowserTabViewModel(
         val uri = site?.uri ?: return
 
         pixel.fire(
-            if (desktopSiteRequested) PixelName.MENU_ACTION_DESKTOP_SITE_ENABLE_PRESSED
-            else PixelName.MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED
+            if (desktopSiteRequested) AppPixelName.MENU_ACTION_DESKTOP_SITE_ENABLE_PRESSED
+            else AppPixelName.MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED
         )
 
         if (desktopSiteRequested && uri.isMobileSite) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -95,7 +95,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.survey.model.Survey

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions
 import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
 import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.global.useourapp.UseOurAppDetector
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity.Companion.RELOAD_RESULT_CODE
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -232,9 +233,9 @@ class BrowserViewModel(
         launch(dispatchers.io()) {
             tabRepository.selectByUrlOrNewTab(queryUrlConverter.convertQueryToUrl(url))
             if (useOurAppDetector.isUseOurAppUrl(url)) {
-                pixel.fire(Pixel.AppPixelName.USE_OUR_APP_SHORTCUT_OPENED)
+                pixel.fire(AppPixelName.USE_OUR_APP_SHORTCUT_OPENED)
             } else {
-                pixel.fire(Pixel.AppPixelName.SHORTCUT_OPENED)
+                pixel.fire(AppPixelName.SHORTCUT_OPENED)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -232,9 +232,9 @@ class BrowserViewModel(
         launch(dispatchers.io()) {
             tabRepository.selectByUrlOrNewTab(queryUrlConverter.convertQueryToUrl(url))
             if (useOurAppDetector.isUseOurAppUrl(url)) {
-                pixel.fire(Pixel.PixelName.USE_OUR_APP_SHORTCUT_OPENED)
+                pixel.fire(Pixel.AppPixelName.USE_OUR_APP_SHORTCUT_OPENED)
             } else {
-                pixel.fire(Pixel.PixelName.SHORTCUT_OPENED)
+                pixel.fire(Pixel.AppPixelName.SHORTCUT_OPENED)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.*
 import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import timber.log.Timber
 import javax.inject.Inject
 

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.*
 import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import timber.log.Timber
 import javax.inject.Inject
 

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 
 class DefaultBrowserObserver(

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 
 class DefaultBrowserObserver(
@@ -40,9 +40,9 @@ class DefaultBrowserObserver(
                     val params = mapOf(
                         PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to false.toString()
                     )
-                    pixel.fire(PixelName.DEFAULT_BROWSER_SET, params)
+                    pixel.fire(AppPixelName.DEFAULT_BROWSER_SET, params)
                 }
-                else -> pixel.fire(PixelName.DEFAULT_BROWSER_UNSET)
+                else -> pixel.fire(AppPixelName.DEFAULT_BROWSER_UNSET)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
@@ -21,6 +21,7 @@ import androidx.core.net.toUri
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import com.duckduckgo.app.browser.downloader.FilenameExtractor.GuessQuality.NotGoodEnough
 import com.duckduckgo.app.browser.downloader.FilenameExtractor.GuessQuality.TriedAllOptions
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import timber.log.Timber
 import javax.inject.Inject
@@ -76,7 +77,7 @@ class FilenameExtractor @Inject constructor(
     private fun bestGuess(guesses: Guesses): String {
         val guess = guesses.bestGuess ?: guesses.latestGuess
         if (!guess.contains(".")) {
-            pixel.fire(Pixel.AppPixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
+            pixel.fire(AppPixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
             return guess + DEFAULT_FILE_TYPE
         }
         return guess

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
@@ -76,7 +76,7 @@ class FilenameExtractor @Inject constructor(
     private fun bestGuess(guesses: Guesses): String {
         val guess = guesses.bestGuess ?: guesses.latestGuess
         if (!guess.contains(".")) {
-            pixel.fire(Pixel.PixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
+            pixel.fire(Pixel.AppPixelName.DOWNLOAD_FILE_DEFAULT_GUESSED_NAME)
             return guess + DEFAULT_FILE_TYPE
         }
         return guess

--- a/app/src/main/java/com/duckduckgo/app/browser/logindetection/FireproofDialogsEventHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/logindetection/FireproofDialogsEventHandler.kt
@@ -58,7 +58,7 @@ class BrowserTabFireproofDialogsEventHandler constructor(
 
     override suspend fun onFireproofLoginDialogShown() {
         pixel.fire(
-            pixel = Pixel.PixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
+            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString())
         )
     }
@@ -67,14 +67,14 @@ class BrowserTabFireproofDialogsEventHandler constructor(
         withContext(dispatchers.io()) {
             userEventsStore.removeUserEvent(UserEventKey.FIREPROOF_LOGIN_DIALOG_DISMISSED)
             fireproofWebsiteRepository.fireproofWebsite(domain)?.let {
-                pixel.fire(Pixel.PixelName.FIREPROOF_WEBSITE_LOGIN_ADDED, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
+                pixel.fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_ADDED, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
                 emitEvent(Event.FireproofWebSiteSuccess(fireproofWebsiteEntity = it))
             }
         }
     }
 
     override suspend fun onUserDismissedFireproofLoginDialog() {
-        pixel.fire(Pixel.PixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
+        pixel.fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
         if (allowUserToDisableFireproofLoginActive()) {
             if (shouldAskToDisableFireproofLogin()) {
                 event.value = Event.AskToDisableLoginDetection
@@ -86,7 +86,7 @@ class BrowserTabFireproofDialogsEventHandler constructor(
 
     override suspend fun onDisableLoginDetectionDialogShown() {
         pixel.fire(
-            Pixel.PixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN,
+            Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN,
             mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString())
         )
     }
@@ -94,7 +94,7 @@ class BrowserTabFireproofDialogsEventHandler constructor(
     override suspend fun onUserConfirmedDisableLoginDetectionDialog() {
         appSettingsPreferencesStore.appLoginDetection = false
         pixel.fire(
-            Pixel.PixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
+            Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
             mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString())
         )
     }
@@ -103,7 +103,7 @@ class BrowserTabFireproofDialogsEventHandler constructor(
         appSettingsPreferencesStore.appLoginDetection = true
         userEventsStore.removeUserEvent(UserEventKey.FIREPROOF_LOGIN_DIALOG_DISMISSED)
         userEventsStore.registerUserEvent(UserEventKey.FIREPROOF_DISABLE_DIALOG_DISMISSED)
-        pixel.fire(Pixel.PixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
+        pixel.fire(Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
     }
 
     private suspend fun userTriedFireButton() = userEventsStore.getUserEvent(UserEventKey.FIRE_BUTTON_EXECUTED) != null

--- a/app/src/main/java/com/duckduckgo/app/browser/logindetection/FireproofDialogsEventHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/logindetection/FireproofDialogsEventHandler.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.events.db.UserEventKey
 import com.duckduckgo.app.global.events.db.UserEventsStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.loginDetectionExperimentEnabled
@@ -58,7 +59,7 @@ class BrowserTabFireproofDialogsEventHandler constructor(
 
     override suspend fun onFireproofLoginDialogShown() {
         pixel.fire(
-            pixel = Pixel.AppPixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
+            pixel = AppPixelName.FIREPROOF_LOGIN_DIALOG_SHOWN,
             parameters = mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString())
         )
     }
@@ -67,14 +68,14 @@ class BrowserTabFireproofDialogsEventHandler constructor(
         withContext(dispatchers.io()) {
             userEventsStore.removeUserEvent(UserEventKey.FIREPROOF_LOGIN_DIALOG_DISMISSED)
             fireproofWebsiteRepository.fireproofWebsite(domain)?.let {
-                pixel.fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_ADDED, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
+                pixel.fire(AppPixelName.FIREPROOF_WEBSITE_LOGIN_ADDED, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
                 emitEvent(Event.FireproofWebSiteSuccess(fireproofWebsiteEntity = it))
             }
         }
     }
 
     override suspend fun onUserDismissedFireproofLoginDialog() {
-        pixel.fire(Pixel.AppPixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
+        pixel.fire(AppPixelName.FIREPROOF_WEBSITE_LOGIN_DISMISS, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
         if (allowUserToDisableFireproofLoginActive()) {
             if (shouldAskToDisableFireproofLogin()) {
                 event.value = Event.AskToDisableLoginDetection
@@ -86,7 +87,7 @@ class BrowserTabFireproofDialogsEventHandler constructor(
 
     override suspend fun onDisableLoginDetectionDialogShown() {
         pixel.fire(
-            Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN,
+            AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN,
             mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString())
         )
     }
@@ -94,7 +95,7 @@ class BrowserTabFireproofDialogsEventHandler constructor(
     override suspend fun onUserConfirmedDisableLoginDetectionDialog() {
         appSettingsPreferencesStore.appLoginDetection = false
         pixel.fire(
-            Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
+            AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE,
             mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString())
         )
     }
@@ -103,7 +104,7 @@ class BrowserTabFireproofDialogsEventHandler constructor(
         appSettingsPreferencesStore.appLoginDetection = true
         userEventsStore.removeUserEvent(UserEventKey.FIREPROOF_LOGIN_DIALOG_DISMISSED)
         userEventsStore.registerUserEvent(UserEventKey.FIREPROOF_DISABLE_DIALOG_DISMISSED)
-        pixel.fire(Pixel.AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
+        pixel.fire(AppPixelName.FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL, mapOf(Pixel.PixelParameter.FIRE_EXECUTED to userTriedFireButton().toString()))
     }
 
     private suspend fun userTriedFireButton() = userEventsStore.getUserEvent(UserEventKey.FIRE_BUTTON_EXECUTED) != null

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/AppEnjoymentDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/AppEnjoymentDialogFragment.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AlertDialog
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.dialog.BackKeyListener
 import com.duckduckgo.app.global.rating.PromptCount
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 
 class AppEnjoymentDialogFragment : EnjoymentDialog() {
 

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/AppEnjoymentDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/AppEnjoymentDialogFragment.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AlertDialog
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.dialog.BackKeyListener
 import com.duckduckgo.app.global.rating.PromptCount
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 
 class AppEnjoymentDialogFragment : EnjoymentDialog() {
 

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/GiveFeedbackDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/GiveFeedbackDialogFragment.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AlertDialog
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.dialog.BackKeyListener
 import com.duckduckgo.app.global.rating.PromptCount
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 
 class GiveFeedbackDialogFragment : EnjoymentDialog() {
 

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/GiveFeedbackDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/GiveFeedbackDialogFragment.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AlertDialog
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.dialog.BackKeyListener
 import com.duckduckgo.app.global.rating.PromptCount
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 
 class GiveFeedbackDialogFragment : EnjoymentDialog() {
 

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/RateAppDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/RateAppDialogFragment.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AlertDialog
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.dialog.BackKeyListener
 import com.duckduckgo.app.global.rating.PromptCount
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 
 class RateAppDialogFragment : EnjoymentDialog() {
 

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/ui/RateAppDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/ui/RateAppDialogFragment.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AlertDialog
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.dialog.BackKeyListener
 import com.duckduckgo.app.global.rating.PromptCount
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 
 class RateAppDialogFragment : EnjoymentDialog() {
 

--- a/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiver.kt
@@ -45,9 +45,9 @@ class ShortcutReceiver @Inject constructor(
         }
 
         if (useOurAppDetector.isUseOurAppUrl(originUrl)) {
-            pixel.fire(Pixel.PixelName.USE_OUR_APP_SHORTCUT_ADDED)
+            pixel.fire(Pixel.AppPixelName.USE_OUR_APP_SHORTCUT_ADDED)
         } else {
-            pixel.fire(Pixel.PixelName.SHORTCUT_ADDED)
+            pixel.fire(Pixel.AppPixelName.SHORTCUT_ADDED)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiver.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder.Companion.SHORTCUT_TITLE_ARG
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder.Companion.SHORTCUT_URL_ARG
 import com.duckduckgo.app.global.useourapp.UseOurAppDetector
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import javax.inject.Inject
 
@@ -45,9 +46,9 @@ class ShortcutReceiver @Inject constructor(
         }
 
         if (useOurAppDetector.isUseOurAppUrl(originUrl)) {
-            pixel.fire(Pixel.AppPixelName.USE_OUR_APP_SHORTCUT_ADDED)
+            pixel.fire(AppPixelName.USE_OUR_APP_SHORTCUT_ADDED)
         } else {
-            pixel.fire(Pixel.AppPixelName.SHORTCUT_ADDED)
+            pixel.fire(AppPixelName.SHORTCUT_ADDED)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -72,8 +72,8 @@ class UseOurAppCta(
     @StringRes val okButton: Int = R.string.useOurAppDialogButtonText,
     @StringRes val cancelButton: Int = R.string.useOurAppDialogCancelButtonText,
     override val ctaId: CtaId = CtaId.USE_OUR_APP,
-    override val shownPixel: Pixel.PixelName? = Pixel.PixelName.USE_OUR_APP_DIALOG_SHOWN,
-    override val okPixel: Pixel.PixelName? = Pixel.PixelName.USE_OUR_APP_DIALOG_OK,
+    override val shownPixel: Pixel.PixelName? = Pixel.AppPixelName.USE_OUR_APP_DIALOG_SHOWN,
+    override val okPixel: Pixel.PixelName? = Pixel.AppPixelName.USE_OUR_APP_DIALOG_OK,
     override val cancelPixel: Pixel.PixelName? = null
 ) : Cta, DialogCta {
 
@@ -97,7 +97,7 @@ class UseOurAppDeletionCta(
     @StringRes val text: Int = R.string.useOurAppDeletionDialogText,
     @StringRes val okButton: Int = R.string.daxDialogGotIt,
     override val ctaId: CtaId = CtaId.USE_OUR_APP_DELETION,
-    override val shownPixel: Pixel.PixelName? = Pixel.PixelName.USE_OUR_APP_DIALOG_DELETE_SHOWN,
+    override val shownPixel: Pixel.PixelName? = Pixel.AppPixelName.USE_OUR_APP_DIALOG_DELETE_SHOWN,
     override val okPixel: Pixel.PixelName? = null,
     override val cancelPixel: Pixel.PixelName? = null
 ) : Cta, DialogCta {
@@ -144,8 +144,8 @@ sealed class DaxDialogCta(
         CtaId.DAX_DIALOG_SERP,
         R.string.daxSerpCtaText,
         R.string.daxDialogPhew,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_SERP_CTA,
         onboardingStore,
@@ -161,8 +161,8 @@ sealed class DaxDialogCta(
         CtaId.DAX_DIALOG_TRACKERS_FOUND,
         R.plurals.daxTrackersBlockedCtaText,
         R.string.daxDialogHighFive,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_TRACKERS_BLOCKED_CTA,
         onboardingStore,
@@ -203,8 +203,8 @@ sealed class DaxDialogCta(
         CtaId.DAX_DIALOG_NETWORK,
         R.string.daxMainNetworkCtaText,
         R.string.daxDialogGotIt,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_NETWORK_CTA_1,
         onboardingStore,
@@ -238,8 +238,8 @@ sealed class DaxDialogCta(
         CtaId.DAX_DIALOG_OTHER,
         R.string.daxNonSerpCtaText,
         R.string.daxDialogGotIt,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_NO_TRACKERS_CTA,
         onboardingStore,
@@ -286,8 +286,8 @@ sealed class DaxBubbleCta(
     class DaxIntroCta(override val onboardingStore: OnboardingStore, override val appInstallStore: AppInstallStore) : DaxBubbleCta(
         CtaId.DAX_INTRO,
         R.string.daxIntroCtaText,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_INITIAL_CTA,
         onboardingStore,
@@ -297,8 +297,8 @@ sealed class DaxBubbleCta(
     class DaxEndCta(override val onboardingStore: OnboardingStore, override val appInstallStore: AppInstallStore) : DaxBubbleCta(
         CtaId.DAX_END,
         R.string.daxEndCtaText,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.PixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_END_CTA,
         onboardingStore,
@@ -335,7 +335,7 @@ sealed class DaxFireDialogCta(
     class TryClearDataCta(override val onboardingStore: OnboardingStore, override val appInstallStore: AppInstallStore) : DaxFireDialogCta(
         ctaId = CtaId.DAX_FIRE_BUTTON,
         description = R.string.daxClearDataCtaText,
-        shownPixel = Pixel.PixelName.ONBOARDING_DAX_CTA_SHOWN,
+        shownPixel = Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
         okPixel = null,
         cancelPixel = null,
         ctaPixelParam = DAX_FIRE_DIALOG_CTA,
@@ -378,9 +378,9 @@ sealed class HomePanelCta(
         R.string.surveyCtaDescription,
         R.string.surveyCtaLaunchButton,
         R.string.surveyCtaDismissButton,
-        Pixel.PixelName.SURVEY_CTA_SHOWN,
-        Pixel.PixelName.SURVEY_CTA_LAUNCHED,
-        Pixel.PixelName.SURVEY_CTA_DISMISSED
+        Pixel.AppPixelName.SURVEY_CTA_SHOWN,
+        Pixel.AppPixelName.SURVEY_CTA_LAUNCHED,
+        Pixel.AppPixelName.SURVEY_CTA_DISMISSED
     )
 
     object AddWidgetAuto : HomePanelCta(
@@ -390,9 +390,9 @@ sealed class HomePanelCta(
         R.string.addWidgetCtaDescription,
         R.string.addWidgetCtaAutoLaunchButton,
         R.string.addWidgetCtaDismissButton,
-        Pixel.PixelName.WIDGET_CTA_SHOWN,
-        Pixel.PixelName.WIDGET_CTA_LAUNCHED,
-        Pixel.PixelName.WIDGET_CTA_DISMISSED
+        Pixel.AppPixelName.WIDGET_CTA_SHOWN,
+        Pixel.AppPixelName.WIDGET_CTA_LAUNCHED,
+        Pixel.AppPixelName.WIDGET_CTA_DISMISSED
     )
 
     object AddWidgetInstructions : HomePanelCta(
@@ -402,9 +402,9 @@ sealed class HomePanelCta(
         R.string.addWidgetCtaDescription,
         R.string.addWidgetCtaInstructionsLaunchButton,
         R.string.addWidgetCtaDismissButton,
-        Pixel.PixelName.WIDGET_LEGACY_CTA_SHOWN,
-        Pixel.PixelName.WIDGET_LEGACY_CTA_LAUNCHED,
-        Pixel.PixelName.WIDGET_LEGACY_CTA_DISMISSED
+        Pixel.AppPixelName.WIDGET_LEGACY_CTA_SHOWN,
+        Pixel.AppPixelName.WIDGET_LEGACY_CTA_LAUNCHED,
+        Pixel.AppPixelName.WIDGET_LEGACY_CTA_DISMISSED
     )
 }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.install.daysInstalled
 import com.duckduckgo.app.global.view.*
 import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_FIRE_DIALOG_CTA
 import com.duckduckgo.app.trackerdetection.model.Entity
@@ -72,8 +73,8 @@ class UseOurAppCta(
     @StringRes val okButton: Int = R.string.useOurAppDialogButtonText,
     @StringRes val cancelButton: Int = R.string.useOurAppDialogCancelButtonText,
     override val ctaId: CtaId = CtaId.USE_OUR_APP,
-    override val shownPixel: Pixel.PixelName? = Pixel.AppPixelName.USE_OUR_APP_DIALOG_SHOWN,
-    override val okPixel: Pixel.PixelName? = Pixel.AppPixelName.USE_OUR_APP_DIALOG_OK,
+    override val shownPixel: Pixel.PixelName? = AppPixelName.USE_OUR_APP_DIALOG_SHOWN,
+    override val okPixel: Pixel.PixelName? = AppPixelName.USE_OUR_APP_DIALOG_OK,
     override val cancelPixel: Pixel.PixelName? = null
 ) : Cta, DialogCta {
 
@@ -97,7 +98,7 @@ class UseOurAppDeletionCta(
     @StringRes val text: Int = R.string.useOurAppDeletionDialogText,
     @StringRes val okButton: Int = R.string.daxDialogGotIt,
     override val ctaId: CtaId = CtaId.USE_OUR_APP_DELETION,
-    override val shownPixel: Pixel.PixelName? = Pixel.AppPixelName.USE_OUR_APP_DIALOG_DELETE_SHOWN,
+    override val shownPixel: Pixel.PixelName? = AppPixelName.USE_OUR_APP_DIALOG_DELETE_SHOWN,
     override val okPixel: Pixel.PixelName? = null,
     override val cancelPixel: Pixel.PixelName? = null
 ) : Cta, DialogCta {
@@ -144,8 +145,8 @@ sealed class DaxDialogCta(
         CtaId.DAX_DIALOG_SERP,
         R.string.daxSerpCtaText,
         R.string.daxDialogPhew,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_SERP_CTA,
         onboardingStore,
@@ -161,8 +162,8 @@ sealed class DaxDialogCta(
         CtaId.DAX_DIALOG_TRACKERS_FOUND,
         R.plurals.daxTrackersBlockedCtaText,
         R.string.daxDialogHighFive,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_TRACKERS_BLOCKED_CTA,
         onboardingStore,
@@ -203,8 +204,8 @@ sealed class DaxDialogCta(
         CtaId.DAX_DIALOG_NETWORK,
         R.string.daxMainNetworkCtaText,
         R.string.daxDialogGotIt,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_NETWORK_CTA_1,
         onboardingStore,
@@ -238,8 +239,8 @@ sealed class DaxDialogCta(
         CtaId.DAX_DIALOG_OTHER,
         R.string.daxNonSerpCtaText,
         R.string.daxDialogGotIt,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_NO_TRACKERS_CTA,
         onboardingStore,
@@ -286,8 +287,8 @@ sealed class DaxBubbleCta(
     class DaxIntroCta(override val onboardingStore: OnboardingStore, override val appInstallStore: AppInstallStore) : DaxBubbleCta(
         CtaId.DAX_INTRO,
         R.string.daxIntroCtaText,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_INITIAL_CTA,
         onboardingStore,
@@ -297,8 +298,8 @@ sealed class DaxBubbleCta(
     class DaxEndCta(override val onboardingStore: OnboardingStore, override val appInstallStore: AppInstallStore) : DaxBubbleCta(
         CtaId.DAX_END,
         R.string.daxEndCtaText,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
-        Pixel.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
         Pixel.PixelValues.DAX_END_CTA,
         onboardingStore,
@@ -335,7 +336,7 @@ sealed class DaxFireDialogCta(
     class TryClearDataCta(override val onboardingStore: OnboardingStore, override val appInstallStore: AppInstallStore) : DaxFireDialogCta(
         ctaId = CtaId.DAX_FIRE_BUTTON,
         description = R.string.daxClearDataCtaText,
-        shownPixel = Pixel.AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
         okPixel = null,
         cancelPixel = null,
         ctaPixelParam = DAX_FIRE_DIALOG_CTA,
@@ -378,9 +379,9 @@ sealed class HomePanelCta(
         R.string.surveyCtaDescription,
         R.string.surveyCtaLaunchButton,
         R.string.surveyCtaDismissButton,
-        Pixel.AppPixelName.SURVEY_CTA_SHOWN,
-        Pixel.AppPixelName.SURVEY_CTA_LAUNCHED,
-        Pixel.AppPixelName.SURVEY_CTA_DISMISSED
+        AppPixelName.SURVEY_CTA_SHOWN,
+        AppPixelName.SURVEY_CTA_LAUNCHED,
+        AppPixelName.SURVEY_CTA_DISMISSED
     )
 
     object AddWidgetAuto : HomePanelCta(
@@ -390,9 +391,9 @@ sealed class HomePanelCta(
         R.string.addWidgetCtaDescription,
         R.string.addWidgetCtaAutoLaunchButton,
         R.string.addWidgetCtaDismissButton,
-        Pixel.AppPixelName.WIDGET_CTA_SHOWN,
-        Pixel.AppPixelName.WIDGET_CTA_LAUNCHED,
-        Pixel.AppPixelName.WIDGET_CTA_DISMISSED
+        AppPixelName.WIDGET_CTA_SHOWN,
+        AppPixelName.WIDGET_CTA_LAUNCHED,
+        AppPixelName.WIDGET_CTA_DISMISSED
     )
 
     object AddWidgetInstructions : HomePanelCta(
@@ -402,9 +403,9 @@ sealed class HomePanelCta(
         R.string.addWidgetCtaDescription,
         R.string.addWidgetCtaInstructionsLaunchButton,
         R.string.addWidgetCtaDismissButton,
-        Pixel.AppPixelName.WIDGET_LEGACY_CTA_SHOWN,
-        Pixel.AppPixelName.WIDGET_LEGACY_CTA_LAUNCHED,
-        Pixel.AppPixelName.WIDGET_LEGACY_CTA_DISMISSED
+        AppPixelName.WIDGET_LEGACY_CTA_SHOWN,
+        AppPixelName.WIDGET_LEGACY_CTA_LAUNCHED,
+        AppPixelName.WIDGET_LEGACY_CTA_DISMISSED
     )
 }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.global.model.orderedTrackingEntities
 import com.duckduckgo.app.global.useourapp.UseOurAppDetector
 import com.duckduckgo.app.onboarding.store.*
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
@@ -115,7 +116,7 @@ class CtaViewModel @Inject constructor(
 
     suspend fun hideTipsForever(cta: Cta) {
         settingsDataStore.hideTips = true
-        pixel.fire(Pixel.AppPixelName.ONBOARDING_DAX_ALL_CTA_HIDDEN, cta.pixelCancelParameters())
+        pixel.fire(AppPixelName.ONBOARDING_DAX_ALL_CTA_HIDDEN, cta.pixelCancelParameters())
         userStageStore.stageCompleted(AppStage.DAX_ONBOARDING)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -115,7 +115,7 @@ class CtaViewModel @Inject constructor(
 
     suspend fun hideTipsForever(cta: Cta) {
         settingsDataStore.hideTips = true
-        pixel.fire(Pixel.PixelName.ONBOARDING_DAX_ALL_CTA_HIDDEN, cta.pixelCancelParameters())
+        pixel.fire(Pixel.AppPixelName.ONBOARDING_DAX_ALL_CTA_HIDDEN, cta.pixelCancelParameters())
         userStageStore.stageCompleted(AppStage.DAX_ONBOARDING)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
@@ -21,9 +21,10 @@ import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.feedback.ui.negative.FeedbackType.MainReason
 import com.duckduckgo.app.feedback.ui.negative.FeedbackType.MainReason.*
 import com.duckduckgo.app.feedback.ui.negative.FeedbackType.SubReason
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.FEEDBACK_NEGATIVE_SUBMISSION
+import com.duckduckgo.app.pixels.AppPixelName.FEEDBACK_NEGATIVE_SUBMISSION
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -151,7 +152,7 @@ class FireAndForgetFeedbackSubmitter(
     }
 
     private fun pixelForPositiveFeedback(): String {
-        return String.format(Locale.US, Pixel.AppPixelName.FEEDBACK_POSITIVE_SUBMISSION.pixelName, POSITIVE_FEEDBACK)
+        return String.format(Locale.US, AppPixelName.FEEDBACK_POSITIVE_SUBMISSION.pixelName, POSITIVE_FEEDBACK)
     }
 
     private fun version(): String {

--- a/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.app.feedback.ui.negative.FeedbackType.MainReason.*
 import com.duckduckgo.app.feedback.ui.negative.FeedbackType.SubReason
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.FEEDBACK_NEGATIVE_SUBMISSION
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.FEEDBACK_NEGATIVE_SUBMISSION
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -151,7 +151,7 @@ class FireAndForgetFeedbackSubmitter(
     }
 
     private fun pixelForPositiveFeedback(): String {
-        return String.format(Locale.US, Pixel.PixelName.FEEDBACK_POSITIVE_SUBMISSION.pixelName, POSITIVE_FEEDBACK)
+        return String.format(Locale.US, Pixel.AppPixelName.FEEDBACK_POSITIVE_SUBMISSION.pixelName, POSITIVE_FEEDBACK)
     }
 
     private fun version(): String {

--- a/app/src/main/java/com/duckduckgo/app/fire/CookieRemover.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/CookieRemover.kt
@@ -73,7 +73,7 @@ class SQLCookieRemover(
             SQLiteDatabase.openDatabase(databasePath, null, SQLiteDatabase.OPEN_READWRITE, databaseErrorHandler)
         } catch (exception: Exception) {
             offlinePixelCountDataStore.cookieDatabaseOpenErrorCount += 1
-            exceptionPixel.sendExceptionPixel(Pixel.PixelName.COOKIE_DATABASE_EXCEPTION_OPEN_ERROR, exception)
+            exceptionPixel.sendExceptionPixel(Pixel.AppPixelName.COOKIE_DATABASE_EXCEPTION_OPEN_ERROR, exception)
             null
         }
     }
@@ -89,7 +89,7 @@ class SQLCookieRemover(
             } catch (exception: Exception) {
                 Timber.e(exception)
                 offlinePixelCountDataStore.cookieDatabaseDeleteErrorCount += 1
-                exceptionPixel.sendExceptionPixel(Pixel.PixelName.COOKIE_DATABASE_EXCEPTION_DELETE_ERROR, exception)
+                exceptionPixel.sendExceptionPixel(Pixel.AppPixelName.COOKIE_DATABASE_EXCEPTION_DELETE_ERROR, exception)
             } finally {
                 close()
             }

--- a/app/src/main/java/com/duckduckgo/app/fire/CookieRemover.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/CookieRemover.kt
@@ -21,8 +21,8 @@ import android.database.DefaultDatabaseErrorHandler
 import android.database.sqlite.SQLiteDatabase
 import android.webkit.CookieManager
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.ExceptionPixel
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -73,7 +73,7 @@ class SQLCookieRemover(
             SQLiteDatabase.openDatabase(databasePath, null, SQLiteDatabase.OPEN_READWRITE, databaseErrorHandler)
         } catch (exception: Exception) {
             offlinePixelCountDataStore.cookieDatabaseOpenErrorCount += 1
-            exceptionPixel.sendExceptionPixel(Pixel.AppPixelName.COOKIE_DATABASE_EXCEPTION_OPEN_ERROR, exception)
+            exceptionPixel.sendExceptionPixel(AppPixelName.COOKIE_DATABASE_EXCEPTION_OPEN_ERROR, exception)
             null
         }
     }
@@ -89,7 +89,7 @@ class SQLCookieRemover(
             } catch (exception: Exception) {
                 Timber.e(exception)
                 offlinePixelCountDataStore.cookieDatabaseDeleteErrorCount += 1
-                exceptionPixel.sendExceptionPixel(Pixel.AppPixelName.COOKIE_DATABASE_EXCEPTION_DELETE_ERROR, exception)
+                exceptionPixel.sendExceptionPixel(AppPixelName.COOKIE_DATABASE_EXCEPTION_DELETE_ERROR, exception)
             } finally {
                 close()
             }

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import com.duckduckgo.app.global.intentText
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchActivity
 import timber.log.Timber
@@ -73,8 +74,8 @@ class DataClearerForegroundAppRestartPixel @Inject constructor(
     }
 
     fun firePendingPixels() {
-        firePendingPixels(pendingAppForegroundRestart, Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART)
-        firePendingPixels(pendingAppForegroundRestartWithIntent, Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
+        firePendingPixels(pendingAppForegroundRestart, AppPixelName.FORGET_ALL_AUTO_RESTART)
+        firePendingPixels(pendingAppForegroundRestartWithIntent, AppPixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
         resetCount()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
@@ -73,8 +73,8 @@ class DataClearerForegroundAppRestartPixel @Inject constructor(
     }
 
     fun firePendingPixels() {
-        firePendingPixels(pendingAppForegroundRestart, Pixel.PixelName.FORGET_ALL_AUTO_RESTART)
-        firePendingPixels(pendingAppForegroundRestartWithIntent, Pixel.PixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
+        firePendingPixels(pendingAppForegroundRestart, Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART)
+        firePendingPixels(pendingAppForegroundRestartWithIntent, Pixel.AppPixelName.FORGET_ALL_AUTO_RESTART_WITH_INTENT)
         resetCount()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModel.kt
@@ -28,7 +28,7 @@ import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module

--- a/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModel.kt
@@ -28,7 +28,7 @@ import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -46,7 +46,7 @@ import com.duckduckgo.app.statistics.AtbInitializer
 import com.duckduckgo.app.statistics.api.OfflinePixelScheduler
 import com.duckduckgo.app.statistics.api.PixelSender
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.APP_LAUNCH
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.APP_LAUNCH
 import com.duckduckgo.app.surrogates.ResourceSurrogateLoader
 import com.duckduckgo.app.tabs.db.TabsDbSanitizer
 import com.duckduckgo.app.trackerdetection.TrackerDataLoader
@@ -259,7 +259,7 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
                 launchedByFireAction = true
             }
             for (i in 1..count) {
-                pixel.fire(Pixel.PixelName.FORGET_ALL_EXECUTED)
+                pixel.fire(Pixel.AppPixelName.FORGET_ALL_EXECUTED)
             }
             unsentForgetAllPixelStore.resetCount()
         }

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -40,13 +40,14 @@ import com.duckduckgo.app.job.AppConfigurationSyncer
 import com.duckduckgo.app.job.WorkScheduler
 import com.duckduckgo.app.notification.NotificationRegistrar
 import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.referral.AppInstallationReferrerStateListener
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.AtbInitializer
 import com.duckduckgo.app.statistics.api.OfflinePixelScheduler
 import com.duckduckgo.app.statistics.api.PixelSender
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.APP_LAUNCH
+import com.duckduckgo.app.pixels.AppPixelName.APP_LAUNCH
 import com.duckduckgo.app.surrogates.ResourceSurrogateLoader
 import com.duckduckgo.app.tabs.db.TabsDbSanitizer
 import com.duckduckgo.app.trackerdetection.TrackerDataLoader
@@ -259,7 +260,7 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
                 launchedByFireAction = true
             }
             for (i in 1..count) {
-                pixel.fire(Pixel.AppPixelName.FORGET_ALL_EXECUTED)
+                pixel.fire(AppPixelName.FORGET_ALL_EXECUTED)
             }
             unsentForgetAllPixelStore.resetCount()
         }

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -34,7 +34,7 @@ import com.duckduckgo.app.global.view.FireDialog.FireDialogClearAllEvent.ClearAl
 import com.duckduckgo.app.settings.clear.getPixelValue
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_ANIMATION
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -34,7 +34,7 @@ import com.duckduckgo.app.global.view.FireDialog.FireDialogClearAllEvent.ClearAl
 import com.duckduckgo.app.settings.clear.getPixelValue
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_ANIMATION
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog

--- a/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModel.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module

--- a/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModel.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.app.global.toHttps
 import com.duckduckgo.app.httpsupgrade.store.HttpsFalsePositivesDao
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import timber.log.Timber
 import java.util.concurrent.locks.ReentrantLock
 

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.app.global.toHttps
 import com.duckduckgo.app.httpsupgrade.store.HttpsFalsePositivesDao
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import timber.log.Timber
 import java.util.concurrent.locks.ReentrantLock
 

--- a/app/src/main/java/com/duckduckgo/app/icon/ui/ChangeIconViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/icon/ui/ChangeIconViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
 import com.duckduckgo.app.icon.api.AppIcon
 import com.duckduckgo.app.icon.api.IconModifier
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppObjectGraph
@@ -63,7 +64,7 @@ class ChangeIconViewModel @Inject constructor(
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
     fun start() {
-        pixel.fire(Pixel.AppPixelName.CHANGE_APP_ICON_OPENED)
+        pixel.fire(AppPixelName.CHANGE_APP_ICON_OPENED)
         val selectedIcon = settingsDataStore.appIcon
         viewState.value = ViewState(AppIcon.values().map { IconViewData.from(it, selectedIcon) })
     }

--- a/app/src/main/java/com/duckduckgo/app/icon/ui/ChangeIconViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/icon/ui/ChangeIconViewModel.kt
@@ -63,7 +63,7 @@ class ChangeIconViewModel @Inject constructor(
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
     fun start() {
-        pixel.fire(Pixel.PixelName.CHANGE_APP_ICON_OPENED)
+        pixel.fire(Pixel.AppPixelName.CHANGE_APP_ICON_OPENED)
         val selectedIcon = settingsDataStore.appIcon
         viewState.value = ViewState(AppIcon.values().map { IconViewData.from(it, selectedIcon) })
     }

--- a/app/src/main/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModel.kt
@@ -114,7 +114,7 @@ class LocationPermissionsViewModel(
     override fun onSiteLocationPermissionSelected(domain: String, permission: LocationPermissionType) {
         when (permission) {
             LocationPermissionType.ALLOW_ALWAYS -> {
-                pixel.fire(Pixel.PixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
+                pixel.fire(Pixel.AppPixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
                 geoLocationPermissions.allow(domain)
                 viewModelScope.launch {
                     locationPermissionsRepository.savePermission(domain, permission)
@@ -122,7 +122,7 @@ class LocationPermissionsViewModel(
             }
             LocationPermissionType.DENY_ALWAYS -> {
                 geoLocationPermissions.clear(domain)
-                pixel.fire(Pixel.PixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
+                pixel.fire(Pixel.AppPixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
                 viewModelScope.launch {
                     locationPermissionsRepository.savePermission(domain, permission)
                 }

--- a/app/src/main/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModel.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.location.GeoLocationPermissions
 import com.duckduckgo.app.location.data.LocationPermissionEntity
 import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.location.data.LocationPermissionsRepository
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppObjectGraph
@@ -114,7 +115,7 @@ class LocationPermissionsViewModel(
     override fun onSiteLocationPermissionSelected(domain: String, permission: LocationPermissionType) {
         when (permission) {
             LocationPermissionType.ALLOW_ALWAYS -> {
-                pixel.fire(Pixel.AppPixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
+                pixel.fire(AppPixelName.PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS)
                 geoLocationPermissions.allow(domain)
                 viewModelScope.launch {
                     locationPermissionsRepository.savePermission(domain, permission)
@@ -122,7 +123,7 @@ class LocationPermissionsViewModel(
             }
             LocationPermissionType.DENY_ALWAYS -> {
                 geoLocationPermissions.clear(domain)
-                pixel.fire(Pixel.AppPixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
+                pixel.fire(AppPixelName.PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS)
                 viewModelScope.launch {
                     locationPermissionsRepository.savePermission(domain, permission)
                 }

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.app.notification.model.Notification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.NOTIFICATION_SHOWN
+import com.duckduckgo.app.pixels.AppPixelName.NOTIFICATION_SHOWN
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.app.notification.model.Notification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.NOTIFICATION_SHOWN
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.NOTIFICATION_SHOWN
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationHandlerService.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationHandlerService.kt
@@ -39,8 +39,8 @@ import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.NOTIFICATION_CANCELLED
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.NOTIFICATION_LAUNCHED
+import com.duckduckgo.app.pixels.AppPixelName.NOTIFICATION_CANCELLED
+import com.duckduckgo.app.pixels.AppPixelName.NOTIFICATION_LAUNCHED
 import dagger.android.AndroidInjection
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationHandlerService.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationHandlerService.kt
@@ -39,8 +39,8 @@ import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.NOTIFICATION_CANCELLED
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.NOTIFICATION_LAUNCHED
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.NOTIFICATION_CANCELLED
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.NOTIFICATION_LAUNCHED
 import dagger.android.AndroidInjection
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
@@ -105,7 +105,7 @@ class NotificationRegistrar @Inject constructor(
 
     fun updateStatus(enabled: Boolean) {
         if (settingsDataStore.appNotificationsEnabled != enabled) {
-            pixel.fire(if (enabled) Pixel.PixelName.NOTIFICATIONS_ENABLED else Pixel.PixelName.NOTIFICATIONS_DISABLED)
+            pixel.fire(if (enabled) Pixel.AppPixelName.NOTIFICATIONS_ENABLED else Pixel.AppPixelName.NOTIFICATIONS_DISABLED)
             settingsDataStore.appNotificationsEnabled = enabled
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
@@ -26,6 +26,7 @@ import android.os.Build.VERSION_CODES.O
 import androidx.annotation.StringRes
 import androidx.core.app.NotificationManagerCompat
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import timber.log.Timber
@@ -105,7 +106,7 @@ class NotificationRegistrar @Inject constructor(
 
     fun updateStatus(enabled: Boolean) {
         if (settingsDataStore.appNotificationsEnabled != enabled) {
-            pixel.fire(if (enabled) Pixel.AppPixelName.NOTIFICATIONS_ENABLED else Pixel.AppPixelName.NOTIFICATIONS_DISABLED)
+            pixel.fire(if (enabled) AppPixelName.NOTIFICATIONS_ENABLED else AppPixelName.NOTIFICATIONS_DISABLED)
             settingsDataStore.appNotificationsEnabled = enabled
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/notification/model/UseOurAppNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/UseOurAppNotification.kt
@@ -66,7 +66,7 @@ class UseOurAppSpecification(context: Context) : NotificationSpec {
     override val description: String = context.getString(R.string.useOurAppNotificationDescription)
     override val launchButton: String? = null
     override val closeButton: String? = null
-    override val pixelSuffix = Pixel.PixelName.USE_OUR_APP_NOTIFICATION_SUFFIX.pixelName
+    override val pixelSuffix = Pixel.AppPixelName.USE_OUR_APP_NOTIFICATION_SUFFIX.pixelName
     override val autoCancel = true
     override val bundle: Bundle = Bundle()
     override val color: Int = R.color.ic_launcher_red_background

--- a/app/src/main/java/com/duckduckgo/app/notification/model/UseOurAppNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/UseOurAppNotification.kt
@@ -24,8 +24,8 @@ import com.duckduckgo.app.notification.NotificationHandlerService
 import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.CANCEL
 import com.duckduckgo.app.notification.NotificationRegistrar
 import com.duckduckgo.app.notification.db.NotificationDao
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.app.statistics.pixels.Pixel
 import timber.log.Timber
 
 class UseOurAppNotification(
@@ -66,7 +66,7 @@ class UseOurAppSpecification(context: Context) : NotificationSpec {
     override val description: String = context.getString(R.string.useOurAppNotificationDescription)
     override val launchButton: String? = null
     override val closeButton: String? = null
-    override val pixelSuffix = Pixel.AppPixelName.USE_OUR_APP_NOTIFICATION_SUFFIX.pixelName
+    override val pixelSuffix = AppPixelName.USE_OUR_APP_NOTIFICATION_SUFFIX.pixelName
     override val autoCancel = true
     override val bundle: Bundle = Bundle()
     override val color: Int = R.color.ic_launcher_red_background

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo
@@ -68,7 +69,7 @@ class DefaultBrowserPageViewModel(
     fun pageBecameVisible() {
         if (!viewHasShown) {
             viewHasShown = true
-            pixel.fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+            pixel.fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
         }
     }
 
@@ -80,7 +81,7 @@ class DefaultBrowserPageViewModel(
 
     fun onContinueToBrowser(userTriedToSetDDGAsDefault: Boolean) {
         if (!userTriedToSetDDGAsDefault && !defaultBrowserDetector.isDefaultBrowser()) {
-            pixel.fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+            pixel.fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         }
         command.value = Command.ContinueToBrowser
     }
@@ -99,7 +100,7 @@ class DefaultBrowserPageViewModel(
         val params = mapOf(
             Pixel.PixelParameter.DEFAULT_BROWSER_BEHAVIOUR_TRIGGERED to behaviourTriggered
         )
-        pixel.fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
+        pixel.fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
     }
 
     fun handleResult(origin: Origin) {
@@ -154,7 +155,7 @@ class DefaultBrowserPageViewModel(
             if (timesPressedJustOnce < MAX_DIALOG_ATTEMPTS) {
                 timesPressedJustOnce++
                 command.value = Command.OpenDialog()
-                pixel.fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE)
+                pixel.fire(AppPixelName.ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE)
             } else {
                 fireDefaultBrowserPixelAndResetTimesPressedJustOnce(originValue = Pixel.PixelValues.DEFAULT_BROWSER_JUST_ONCE_MAX)
                 navigateToBrowser = true
@@ -171,13 +172,13 @@ class DefaultBrowserPageViewModel(
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to originValue
             )
-            pixel.fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
+            pixel.fire(AppPixelName.DEFAULT_BROWSER_SET, params)
         } else {
             installStore.defaultBrowser = false
             val params = mapOf(
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to originValue
             )
-            pixel.fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
+            pixel.fire(AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
@@ -68,7 +68,7 @@ class DefaultBrowserPageViewModel(
     fun pageBecameVisible() {
         if (!viewHasShown) {
             viewHasShown = true
-            pixel.fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
+            pixel.fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_VISUALIZED)
         }
     }
 
@@ -80,7 +80,7 @@ class DefaultBrowserPageViewModel(
 
     fun onContinueToBrowser(userTriedToSetDDGAsDefault: Boolean) {
         if (!userTriedToSetDDGAsDefault && !defaultBrowserDetector.isDefaultBrowser()) {
-            pixel.fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
+            pixel.fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SKIPPED)
         }
         command.value = Command.ContinueToBrowser
     }
@@ -99,7 +99,7 @@ class DefaultBrowserPageViewModel(
         val params = mapOf(
             Pixel.PixelParameter.DEFAULT_BROWSER_BEHAVIOUR_TRIGGERED to behaviourTriggered
         )
-        pixel.fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
+        pixel.fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_LAUNCHED, params)
     }
 
     fun handleResult(origin: Origin) {
@@ -154,7 +154,7 @@ class DefaultBrowserPageViewModel(
             if (timesPressedJustOnce < MAX_DIALOG_ATTEMPTS) {
                 timesPressedJustOnce++
                 command.value = Command.OpenDialog()
-                pixel.fire(Pixel.PixelName.ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE)
+                pixel.fire(Pixel.AppPixelName.ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE)
             } else {
                 fireDefaultBrowserPixelAndResetTimesPressedJustOnce(originValue = Pixel.PixelValues.DEFAULT_BROWSER_JUST_ONCE_MAX)
                 navigateToBrowser = true
@@ -171,13 +171,13 @@ class DefaultBrowserPageViewModel(
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to originValue
             )
-            pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_SET, params)
+            pixel.fire(Pixel.AppPixelName.DEFAULT_BROWSER_SET, params)
         } else {
             installStore.defaultBrowser = false
             val params = mapOf(
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to originValue
             )
-            pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_NOT_SET, params)
+            pixel.fire(Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET, params)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -46,7 +47,7 @@ class WelcomePageViewModel(
             if (intent != null) {
                 emit(WelcomePageView.State.ShowDefaultBrowserDialog(intent))
             } else {
-                pixel.fire(Pixel.AppPixelName.DEFAULT_BROWSER_DIALOG_NOT_SHOWN)
+                pixel.fire(AppPixelName.DEFAULT_BROWSER_DIALOG_NOT_SHOWN)
                 emit(WelcomePageView.State.Finish)
             }
         } else {
@@ -60,7 +61,7 @@ class WelcomePageViewModel(
         appInstallStore.defaultBrowser = true
 
         pixel.fire(
-            Pixel.AppPixelName.DEFAULT_BROWSER_SET,
+            AppPixelName.DEFAULT_BROWSER_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())
         )
 
@@ -73,7 +74,7 @@ class WelcomePageViewModel(
         appInstallStore.defaultBrowser = false
 
         pixel.fire(
-            Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET,
+            AppPixelName.DEFAULT_BROWSER_NOT_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())
         )
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -46,7 +46,7 @@ class WelcomePageViewModel(
             if (intent != null) {
                 emit(WelcomePageView.State.ShowDefaultBrowserDialog(intent))
             } else {
-                pixel.fire(Pixel.PixelName.DEFAULT_BROWSER_DIALOG_NOT_SHOWN)
+                pixel.fire(Pixel.AppPixelName.DEFAULT_BROWSER_DIALOG_NOT_SHOWN)
                 emit(WelcomePageView.State.Finish)
             }
         } else {
@@ -60,7 +60,7 @@ class WelcomePageViewModel(
         appInstallStore.defaultBrowser = true
 
         pixel.fire(
-            Pixel.PixelName.DEFAULT_BROWSER_SET,
+            Pixel.AppPixelName.DEFAULT_BROWSER_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())
         )
 
@@ -73,7 +73,7 @@ class WelcomePageViewModel(
         appInstallStore.defaultBrowser = false
 
         pixel.fire(
-            Pixel.PixelName.DEFAULT_BROWSER_NOT_SET,
+            Pixel.AppPixelName.DEFAULT_BROWSER_NOT_SET,
             mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString())
         )
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.pixels
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
+    APP_LAUNCH("ml"),
+
+    FORGET_ALL_PRESSED_BROWSING("mf_bp"),
+    FORGET_ALL_PRESSED_TABSWITCHING("mf_tp"),
+    FORGET_ALL_EXECUTED("mf"),
+    FORGET_ALL_AUTO_RESTART("m_f_r"),
+    FORGET_ALL_AUTO_RESTART_WITH_INTENT("m_f_ri"),
+
+    BROKEN_SITE_REPORTED("m_bsr"),
+    BROKEN_SITE_REPORT("epbf"),
+
+    ONBOARDING_DEFAULT_BROWSER_VISUALIZED("m_odb_v"),
+    ONBOARDING_DEFAULT_BROWSER_LAUNCHED("m_odb_l"),
+    ONBOARDING_DEFAULT_BROWSER_SKIPPED("m_odb_s"),
+    ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE("m_odb_jo"),
+
+    ONBOARDING_DAX_CTA_SHOWN("m_odc_s"),
+    ONBOARDING_DAX_ALL_CTA_HIDDEN("m_odc_h"),
+    ONBOARDING_DAX_CTA_OK_BUTTON("m_odc_ok"),
+
+    PRIVACY_DASHBOARD_OPENED("mp"),
+    PRIVACY_DASHBOARD_SCORECARD("mp_c"),
+    PRIVACY_DASHBOARD_ENCRYPTION("mp_e"),
+    PRIVACY_DASHBOARD_GLOBAL_STATS("mp_s"),
+    PRIVACY_DASHBOARD_PRIVACY_PRACTICES("mp_p"),
+    PRIVACY_DASHBOARD_NETWORKS("mp_n"),
+    PRIVACY_DASHBOARD_WHITELIST_ADD("mp_wla"),
+    PRIVACY_DASHBOARD_WHITELIST_REMOVE("mp_wlr"),
+    PRIVACY_DASHBOARD_MANAGE_WHITELIST("mp_mw"),
+    PRIVACY_DASHBOARD_REPORT_BROKEN_SITE("mp_rb"),
+
+    BROWSER_MENU_WHITELIST_ADD("mb_wla"),
+    BROWSER_MENU_WHITELIST_REMOVE("mb_wlr"),
+
+    HTTPS_NO_LOOKUP("m_https_nl"),
+    HTTPS_LOCAL_UPGRADE("m_https_lu"),
+    HTTPS_NO_UPGRADE("m_https_nu"),
+
+    DEFAULT_BROWSER_SET("m_db_s"),
+    DEFAULT_BROWSER_NOT_SET("m_db_ns"),
+    DEFAULT_BROWSER_UNSET("m_db_u"),
+    DEFAULT_BROWSER_DIALOG_NOT_SHOWN("m_dbd_ns"),
+
+    WIDGET_CTA_SHOWN("m_wc_s"),
+    WIDGET_CTA_LAUNCHED("m_wc_l"),
+    WIDGET_CTA_DISMISSED("m_wc_d"),
+    WIDGET_LEGACY_CTA_SHOWN("m_wlc_s"),
+    WIDGET_LEGACY_CTA_LAUNCHED("m_wlc_l"),
+    WIDGET_LEGACY_CTA_DISMISSED("m_wlc_d"),
+    WIDGETS_ADDED(pixelName = "m_w_a"),
+    WIDGETS_DELETED(pixelName = "m_w_d"),
+
+    APP_NOTIFICATION_LAUNCH(pixelName = "m_n_l"),
+    APP_WIDGET_LAUNCH(pixelName = "m_w_l"),
+    APP_ASSIST_LAUNCH(pixelName = "m_a_l"),
+    APP_SYSTEM_SEARCH_BOX_LAUNCH(pixelName = "m_ssb_l"),
+    INTERSTITIAL_LAUNCH_BROWSER_QUERY(pixelName = "m_i_lbq"),
+    INTERSTITIAL_LAUNCH_DEVICE_APP(pixelName = "m_i_sda"),
+    INTERSTITIAL_LAUNCH_DAX(pixelName = "m_i_ld"),
+    INTERSTITIAL_ONBOARDING_SHOWN(pixelName = "m_io_s"),
+    INTERSTITIAL_ONBOARDING_DISMISSED(pixelName = "m_io_d"),
+    INTERSTITIAL_ONBOARDING_LESS_PRESSED(pixelName = "m_io_l"),
+    INTERSTITIAL_ONBOARDING_MORE_PRESSED(pixelName = "m_io_m"),
+
+    LONG_PRESS("mlp"),
+    LONG_PRESS_DOWNLOAD_IMAGE("mlp_i"),
+    LONG_PRESS_NEW_TAB("mlp_t"),
+    LONG_PRESS_NEW_BACKGROUND_TAB("mlp_b"),
+    LONG_PRESS_SHARE("mlp_s"),
+    LONG_PRESS_COPY_URL("mlp_c"),
+    LONG_PRESS_OPEN_IMAGE_IN_BACKGROUND_TAB("mlp_ibt"),
+
+    DOWNLOAD_FILE_DEFAULT_GUESSED_NAME("m_df_dgn"),
+
+    SETTINGS_OPENED("ms"),
+    SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),
+    SETTINGS_THEME_TOGGLED_DARK("ms_td"),
+    SETTINGS_MANAGE_WHITELIST("ms_mw"),
+    SETTINGS_DO_NOT_SELL_SHOWN("ms_dns"),
+    SETTINGS_DO_NOT_SELL_ON("ms_dns_on"),
+    SETTINGS_DO_NOT_SELL_OFF("ms_dns_off"),
+
+    SURVEY_CTA_SHOWN(pixelName = "mus_cs"),
+    SURVEY_CTA_DISMISSED(pixelName = "mus_cd"),
+    SURVEY_CTA_LAUNCHED(pixelName = "mus_cl"),
+    SURVEY_SURVEY_DISMISSED(pixelName = "mus_sd"),
+
+    NOTIFICATION_SHOWN("mnot_s"),
+    NOTIFICATION_LAUNCHED("mnot_l"),
+    NOTIFICATION_CANCELLED("mnot_c"),
+    NOTIFICATIONS_ENABLED("mnot_e"),
+    NOTIFICATIONS_DISABLED("mnot_d"),
+
+    AUTOMATIC_CLEAR_DATA_WHAT_SHOWN("macwhat_s"),
+    AUTOMATIC_CLEAR_DATA_WHAT_OPTION_NONE("macwhat_n"),
+    AUTOMATIC_CLEAR_DATA_WHAT_OPTION_TABS("macwhat_t"),
+    AUTOMATIC_CLEAR_DATA_WHAT_OPTION_TABS_AND_DATA("macwhat_d"),
+
+    AUTOMATIC_CLEAR_DATA_WHEN_SHOWN("macwhen_s"),
+    AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_ONLY("macwhen_x"),
+    AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_5_MINS("macwhen_5"),
+    AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_15_MINS("macwhen_15"),
+    AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_30_MINS("macwhen_30"),
+    AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_60_MINS("macwhen_60"),
+
+    APP_ENJOYMENT_DIALOG_SHOWN("mrp_e_d%d_ds"),
+    APP_ENJOYMENT_DIALOG_USER_ENJOYING("mrp_e_d%d_y"),
+    APP_ENJOYMENT_DIALOG_USER_NOT_ENJOYING("mrp_e_d%d_n"),
+    APP_ENJOYMENT_DIALOG_USER_CANCELLED("mrp_e_d%d_c"),
+
+    APP_RATING_DIALOG_SHOWN("mrp_r_d%d_ds"),
+    APP_RATING_DIALOG_USER_GAVE_RATING("mrp_r_d%d_y"),
+    APP_RATING_DIALOG_USER_DECLINED_RATING("mrp_r_d%d_n"),
+    APP_RATING_DIALOG_USER_CANCELLED("mrp_r_d%d_c"),
+
+    APP_FEEDBACK_DIALOG_SHOWN("mrp_f_d%d_ds"),
+    APP_FEEDBACK_DIALOG_USER_GAVE_FEEDBACK("mrp_f_d%d_y"),
+    APP_FEEDBACK_DIALOG_USER_DECLINED_FEEDBACK("mrp_f_d%d_n"),
+    APP_FEEDBACK_DIALOG_USER_CANCELLED("mrp_f_d%d_c"),
+
+    FEEDBACK_POSITIVE_SUBMISSION("mfbs_%s_submit"),
+    FEEDBACK_NEGATIVE_SUBMISSION("mfbs_%s_%s_%s"),
+
+    AUTOCOMPLETE_BOOKMARK_SELECTION("m_aut_s_b"),
+    AUTOCOMPLETE_SEARCH_SELECTION("m_aut_s_s"),
+
+    SERP_REQUERY("rq_%s"),
+
+    CHANGE_APP_ICON_OPENED("m_ic"),
+
+    MENU_ACTION_POPUP_OPENED("m_nav_pm_o"),
+    MENU_ACTION_FIRE_PRESSED("m_nav_f_p"),
+    MENU_ACTION_REFRESH_PRESSED("m_nav_r_p"),
+    MENU_ACTION_NEW_TAB_PRESSED("m_nav_nt_p"),
+    MENU_ACTION_BOOKMARKS_PRESSED("m_nav_b_p"),
+    MENU_ACTION_NAVIGATE_FORWARD_PRESSED("m_nav_nf_p"),
+    MENU_ACTION_NAVIGATE_BACK_PRESSED("m_nav_nb_p"),
+    MENU_ACTION_ADD_BOOKMARK_PRESSED("m_nav_ab_p"),
+    MENU_ACTION_SHARE_PRESSED("m_nav_sh_p"),
+    MENU_ACTION_FIND_IN_PAGE_PRESSED("m_nav_fip_p"),
+    MENU_ACTION_ADD_TO_HOME_PRESSED("m_nav_ath_p"),
+    MENU_ACTION_DESKTOP_SITE_ENABLE_PRESSED("m_nav_dse_p"),
+    MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED("m_nav_dsd_p"),
+    MENU_ACTION_REPORT_BROKEN_SITE_PRESSED("m_nav_rbs_p"),
+    MENU_ACTION_SETTINGS_PRESSED("m_nav_s_p"),
+
+    COOKIE_DATABASE_EXCEPTION_OPEN_ERROR("m_cdb_e_oe"),
+    COOKIE_DATABASE_EXCEPTION_DELETE_ERROR("m_cdb_e_de"),
+
+    FIREPROOF_WEBSITE_ADDED("m_fw_a"),
+    FIREPROOF_WEBSITE_REMOVE("m_fw_r"),
+    FIREPROOF_LOGIN_DIALOG_SHOWN("m_fw_ld_s"),
+    FIREPROOF_WEBSITE_LOGIN_ADDED("m_fw_l_a"),
+    FIREPROOF_WEBSITE_LOGIN_DISMISS("m_fw_l_d"),
+    FIREPROOF_WEBSITE_DELETED("m_fw_d"),
+    FIREPROOF_LOGIN_TOGGLE_ENABLED("m_fw_d_e"),
+    FIREPROOF_LOGIN_TOGGLE_DISABLED("m_fw_d_d"),
+    FIREPROOF_WEBSITE_UNDO("m_fw_u"),
+    FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN("m_fw_dd_s"),
+    FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE("m_fw_dd_d"),
+    FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL("m_fw_dd_c"),
+
+    USE_OUR_APP_NOTIFICATION_SUFFIX("uoa"),
+    USE_OUR_APP_DIALOG_SHOWN("m_uoa_d"),
+    USE_OUR_APP_DIALOG_OK("m_uoa_d_ok"),
+    USE_OUR_APP_SHORTCUT_ADDED("m_uoa_s_a"),
+    USE_OUR_APP_DIALOG_DELETE_SHOWN("m_uoa_dd"),
+    UOA_VISITED_AFTER_SHORTCUT("m_uoa_vas"),
+    UOA_VISITED_AFTER_NOTIFICATION("m_uoa_van"),
+    UOA_VISITED_AFTER_DELETE_CTA("m_uoa_vad"),
+    UOA_VISITED("m_uoa_v"),
+
+    USE_OUR_APP_SHORTCUT_OPENED("m_sho_uoa_o"),
+    SHORTCUT_ADDED("m_sho_a"),
+    SHORTCUT_OPENED("m_sho_o"),
+
+    PRECISE_LOCATION_SYSTEM_DIALOG_ENABLE("m_pc_syd_e"),
+    PRECISE_LOCATION_SYSTEM_DIALOG_LATER("m_pc_syd_l"),
+    PRECISE_LOCATION_SYSTEM_DIALOG_NEVER("m_pc_syd_n"),
+    PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_ENABLE("m_pc_s_l_e"),
+    PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE("m_pc_s_l_d"),
+    PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS("m_pc_sd_aa"),
+    PRECISE_LOCATION_SITE_DIALOG_ALLOW_ONCE("m_pc_sd_ao"),
+    PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS("m_pc_sd_da"),
+    PRECISE_LOCATION_SITE_DIALOG_DENY_ONCE("m_pc_sd_do"),
+
+    FIRE_DIALOG_PROMOTED_CLEAR_PRESSED("m_fdp_p"),
+    FIRE_DIALOG_CLEAR_PRESSED("m_fd_p"),
+    FIRE_DIALOG_PROMOTED_CANCEL("m_fdp_c"),
+    FIRE_DIALOG_CANCEL("m_fd_c"),
+    FIRE_DIALOG_ANIMATION("m_fd_a"),
+
+    FIRE_ANIMATION_SETTINGS_OPENED("m_fas_o"),
+    FIRE_ANIMATION_NEW_SELECTED("m_fas_s"),
+}

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchMan
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchReportBrokenSite
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.ViewState
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
 import kotlinx.android.synthetic.main.content_privacy_dashboard.*

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchMan
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchReportBrokenSite
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.ViewState
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
 import kotlinx.android.synthetic.main.content_privacy_dashboard.*

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
@@ -35,7 +35,7 @@ import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.UNKNOWN
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchManageWhitelist
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchReportBrokenSite
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
@@ -35,7 +35,7 @@ import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.UNKNOWN
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchManageWhitelist
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchReportBrokenSite
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -45,7 +45,7 @@ import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.clear.ClearWhenOption
 import com.duckduckgo.app.settings.clear.FireAnimation
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
+import com.duckduckgo.app.pixels.AppPixelName
 import kotlinx.android.synthetic.main.content_settings_general.*
 import kotlinx.android.synthetic.main.content_settings_other.*
 import kotlinx.android.synthetic.main.content_settings_privacy.*

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -45,7 +45,7 @@ import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.clear.ClearWhenOption
 import com.duckduckgo.app.settings.clear.FireAnimation
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
 import kotlinx.android.synthetic.main.content_settings_general.*
 import kotlinx.android.synthetic.main.content_settings_other.*
 import kotlinx.android.synthetic.main.content_settings_privacy.*
@@ -157,13 +157,13 @@ class SettingsActivity :
     private fun launchAutomaticallyClearWhatDialog() {
         val dialog = SettingsAutomaticallyClearWhatFragment.create(viewModel.viewState.value?.automaticallyClearData?.clearWhatOption)
         dialog.show(supportFragmentManager, CLEAR_WHAT_DIALOG_TAG)
-        pixel.fire(PixelName.AUTOMATIC_CLEAR_DATA_WHAT_SHOWN)
+        pixel.fire(AppPixelName.AUTOMATIC_CLEAR_DATA_WHAT_SHOWN)
     }
 
     private fun launchAutomaticallyClearWhenDialog() {
         val dialog = SettingsAutomaticallyClearWhenFragment.create(viewModel.viewState.value?.automaticallyClearData?.clearWhenOption)
         dialog.show(supportFragmentManager, CLEAR_WHEN_DIALOG_TAG)
-        pixel.fire(PixelName.AUTOMATIC_CLEAR_DATA_WHEN_SHOWN)
+        pixel.fire(AppPixelName.AUTOMATIC_CLEAR_DATA_WHEN_SHOWN)
     }
 
     private fun processCommand(it: Command?) {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -33,7 +33,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_ANIMATION
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -33,7 +33,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_ANIMATION
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo

--- a/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
@@ -28,7 +28,7 @@ import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.gone
 import com.duckduckgo.app.global.view.show
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.SURVEY_SURVEY_DISMISSED
+import com.duckduckgo.app.pixels.AppPixelName.SURVEY_SURVEY_DISMISSED
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.ui.SurveyViewModel.Command
 import com.duckduckgo.app.survey.ui.SurveyViewModel.Command.*

--- a/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
@@ -28,7 +28,7 @@ import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.gone
 import com.duckduckgo.app.global.view.show
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.SURVEY_SURVEY_DISMISSED
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.SURVEY_SURVEY_DISMISSED
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.ui.SurveyViewModel.Command
 import com.duckduckgo.app.survey.ui.SurveyViewModel.Command.*

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -39,7 +39,7 @@ import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.TextChangedWatcher
 import com.duckduckgo.app.global.view.hideKeyboard
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.*
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.SystemSearchResultsViewState
 import kotlinx.android.synthetic.main.activity_system_search.*

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -39,7 +39,7 @@ import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.TextChangedWatcher
 import com.duckduckgo.app.global.view.hideKeyboard
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.*
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.SystemSearchResultsViewState
 import kotlinx.android.synthetic.main.activity_system_search.*
@@ -94,10 +94,10 @@ class SystemSearchActivity : DuckDuckGoActivity() {
 
     private fun sendLaunchPixels(intent: Intent) {
         when {
-            launchedFromAssist(intent) -> pixel.fire(PixelName.APP_ASSIST_LAUNCH)
-            launchedFromWidget(intent) -> pixel.fire(PixelName.APP_WIDGET_LAUNCH)
-            launchedFromNotification(intent) -> pixel.fire(PixelName.APP_NOTIFICATION_LAUNCH)
-            launchedFromSystemSearchBox(intent) -> pixel.fire(PixelName.APP_SYSTEM_SEARCH_BOX_LAUNCH)
+            launchedFromAssist(intent) -> pixel.fire(AppPixelName.APP_ASSIST_LAUNCH)
+            launchedFromWidget(intent) -> pixel.fire(AppPixelName.APP_WIDGET_LAUNCH)
+            launchedFromNotification(intent) -> pixel.fire(AppPixelName.APP_NOTIFICATION_LAUNCH)
+            launchedFromSystemSearchBox(intent) -> pixel.fire(AppPixelName.APP_SYSTEM_SEARCH_BOX_LAUNCH)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -30,7 +30,7 @@ import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.store.isNewUser
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.jakewharton.rxrelay2.PublishRelay
 import com.squareup.anvil.annotations.ContributesTo

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -30,7 +30,7 @@ import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.store.isNewUser
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.jakewharton.rxrelay2.PublishRelay
 import com.squareup.anvil.annotations.ContributesTo

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -193,7 +193,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun onFire() {
-        pixel.fire(Pixel.PixelName.FORGET_ALL_PRESSED_TABSWITCHING)
+        pixel.fire(Pixel.AppPixelName.FORGET_ALL_PRESSED_TABSWITCHING)
         val dialog = FireDialog(
             context = this,
             clearPersonalDataAction = clearPersonalDataAction,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
 import com.duckduckgo.app.global.view.FireDialog
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -193,7 +194,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun onFire() {
-        pixel.fire(Pixel.AppPixelName.FORGET_ALL_PRESSED_TABSWITCHING)
+        pixel.fire(AppPixelName.FORGET_ALL_PRESSED_TABSWITCHING)
         val dialog = FireDialog(
             context = this,
             clearPersonalDataAction = clearPersonalDataAction,

--- a/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
@@ -26,8 +26,8 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.WIDGETS_ADDED
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.WIDGETS_DELETED
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.WIDGETS_ADDED
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.WIDGETS_DELETED
 import com.duckduckgo.app.systemsearch.SystemSearchActivity
 import com.duckduckgo.app.widget.ui.AppWidgetCapabilities
 import javax.inject.Inject

--- a/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchWidget.kt
@@ -26,8 +26,8 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.WIDGETS_ADDED
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.WIDGETS_DELETED
+import com.duckduckgo.app.pixels.AppPixelName.WIDGETS_ADDED
+import com.duckduckgo.app.pixels.AppPixelName.WIDGETS_DELETED
 import com.duckduckgo.app.systemsearch.SystemSearchActivity
 import com.duckduckgo.app.widget.ui.AppWidgetCapabilities
 import javax.inject.Inject

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
@@ -20,7 +20,7 @@ import com.duckduckgo.app.global.exception.UncaughtExceptionEntity
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource.*
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.StatisticsPixelName.*
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.COUNT
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.EXCEPTION_APP_VERSION
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.EXCEPTION_MESSAGE

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelSender.kt
@@ -20,7 +20,7 @@ import com.duckduckgo.app.global.exception.UncaughtExceptionEntity
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource.*
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName.*
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName.*
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.COUNT
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.EXCEPTION_APP_VERSION
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.EXCEPTION_MESSAGE

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -18,15 +18,18 @@ package com.duckduckgo.app.statistics.pixels
 
 import android.annotation.SuppressLint
 import com.duckduckgo.app.statistics.api.PixelSender
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
 import javax.inject.Inject
 
 interface Pixel {
 
-    enum class PixelName(val pixelName: String) {
+    interface PixelName {
+        val pixelName: String
+    }
 
+    enum class AppPixelName(override val pixelName: String) : PixelName {
         APP_LAUNCH("ml"),
 
         FORGET_ALL_PRESSED_BROWSING("mf_bp"),
@@ -293,7 +296,7 @@ class RxBasedPixel @Inject constructor(
     private val pixelSender: PixelSender
 ) : Pixel {
 
-    override fun fire(pixel: PixelName, parameters: Map<String, String>, encodedParameters: Map<String, String>) {
+    override fun fire(pixel: Pixel.PixelName, parameters: Map<String, String>, encodedParameters: Map<String, String>) {
         fire(pixel.pixelName, parameters, encodedParameters)
     }
 
@@ -316,7 +319,7 @@ class RxBasedPixel @Inject constructor(
      * As this method stores the pixel to disk until successful delivery, check with privacy triage if the pixel has additional parameters
      * that they would want to validate.
      */
-    override fun enqueueFire(pixel: PixelName, parameters: Map<String, String>, encodedParameters: Map<String, String>) {
+    override fun enqueueFire(pixel: Pixel.PixelName, parameters: Map<String, String>, encodedParameters: Map<String, String>) {
         enqueueFire(pixel.pixelName, parameters, encodedParameters)
     }
 

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.statistics.pixels
 
 import android.annotation.SuppressLint
 import com.duckduckgo.app.statistics.api.PixelSender
-import com.duckduckgo.app.statistics.pixels.Pixel.AppPixelName
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
 import javax.inject.Inject
@@ -29,14 +28,15 @@ interface Pixel {
         val pixelName: String
     }
 
-    enum class AppPixelName(override val pixelName: String) : PixelName {
-        APP_LAUNCH("ml"),
+    enum class StatisticsPixelName(override val pixelName: String) : PixelName {
+        WEB_RENDERER_GONE_CRASH("m_d_wrg_c"),
+        WEB_RENDERER_GONE_KILLED("m_d_wrg_k"),
 
-        FORGET_ALL_PRESSED_BROWSING("mf_bp"),
-        FORGET_ALL_PRESSED_TABSWITCHING("mf_tp"),
-        FORGET_ALL_EXECUTED("mf"),
-        FORGET_ALL_AUTO_RESTART("m_f_r"),
-        FORGET_ALL_AUTO_RESTART_WITH_INTENT("m_f_ri"),
+
+        COOKIE_DATABASE_NOT_FOUND("m_cdb_nf"),
+        COOKIE_DATABASE_OPEN_ERROR("m_cdb_oe"),
+        COOKIE_DATABASE_DELETE_ERROR("m_cdb_de"),
+        COOKIE_DATABASE_CORRUPTED_ERROR("m_cdb_ce"),
 
         APPLICATION_CRASH("m_d_ac"),
         APPLICATION_CRASH_GLOBAL("m_d_ac_g"),
@@ -50,199 +50,6 @@ interface Pixel {
         APPLICATION_CRASH_WEBVIEW_ON_PROGRESS_CHANGED("m_d_ac_wpc"),
         APPLICATION_CRASH_WEBVIEW_RECEIVED_PAGE_TITLE("m_d_ac_wpt"),
         APPLICATION_CRASH_WEBVIEW_SHOW_FILE_CHOOSER("m_d_ac_wfc"),
-
-        WEB_RENDERER_GONE_CRASH("m_d_wrg_c"),
-        WEB_RENDERER_GONE_KILLED("m_d_wrg_k"),
-        BROKEN_SITE_REPORTED("m_bsr"),
-        BROKEN_SITE_REPORT("epbf"),
-
-        ONBOARDING_DEFAULT_BROWSER_VISUALIZED("m_odb_v"),
-        ONBOARDING_DEFAULT_BROWSER_LAUNCHED("m_odb_l"),
-        ONBOARDING_DEFAULT_BROWSER_SKIPPED("m_odb_s"),
-        ONBOARDING_DEFAULT_BROWSER_SELECTED_JUST_ONCE("m_odb_jo"),
-
-        ONBOARDING_DAX_CTA_SHOWN("m_odc_s"),
-        ONBOARDING_DAX_ALL_CTA_HIDDEN("m_odc_h"),
-        ONBOARDING_DAX_CTA_OK_BUTTON("m_odc_ok"),
-
-        PRIVACY_DASHBOARD_OPENED("mp"),
-        PRIVACY_DASHBOARD_SCORECARD("mp_c"),
-        PRIVACY_DASHBOARD_ENCRYPTION("mp_e"),
-        PRIVACY_DASHBOARD_GLOBAL_STATS("mp_s"),
-        PRIVACY_DASHBOARD_PRIVACY_PRACTICES("mp_p"),
-        PRIVACY_DASHBOARD_NETWORKS("mp_n"),
-        PRIVACY_DASHBOARD_WHITELIST_ADD("mp_wla"),
-        PRIVACY_DASHBOARD_WHITELIST_REMOVE("mp_wlr"),
-        PRIVACY_DASHBOARD_MANAGE_WHITELIST("mp_mw"),
-        PRIVACY_DASHBOARD_REPORT_BROKEN_SITE("mp_rb"),
-
-        BROWSER_MENU_WHITELIST_ADD("mb_wla"),
-        BROWSER_MENU_WHITELIST_REMOVE("mb_wlr"),
-
-        HTTPS_NO_LOOKUP("m_https_nl"),
-        HTTPS_LOCAL_UPGRADE("m_https_lu"),
-        HTTPS_NO_UPGRADE("m_https_nu"),
-
-        DEFAULT_BROWSER_SET("m_db_s"),
-        DEFAULT_BROWSER_NOT_SET("m_db_ns"),
-        DEFAULT_BROWSER_UNSET("m_db_u"),
-        DEFAULT_BROWSER_DIALOG_NOT_SHOWN("m_dbd_ns"),
-
-        WIDGET_CTA_SHOWN("m_wc_s"),
-        WIDGET_CTA_LAUNCHED("m_wc_l"),
-        WIDGET_CTA_DISMISSED("m_wc_d"),
-        WIDGET_LEGACY_CTA_SHOWN("m_wlc_s"),
-        WIDGET_LEGACY_CTA_LAUNCHED("m_wlc_l"),
-        WIDGET_LEGACY_CTA_DISMISSED("m_wlc_d"),
-        WIDGETS_ADDED(pixelName = "m_w_a"),
-        WIDGETS_DELETED(pixelName = "m_w_d"),
-
-        APP_NOTIFICATION_LAUNCH(pixelName = "m_n_l"),
-        APP_WIDGET_LAUNCH(pixelName = "m_w_l"),
-        APP_ASSIST_LAUNCH(pixelName = "m_a_l"),
-        APP_SYSTEM_SEARCH_BOX_LAUNCH(pixelName = "m_ssb_l"),
-        INTERSTITIAL_LAUNCH_BROWSER_QUERY(pixelName = "m_i_lbq"),
-        INTERSTITIAL_LAUNCH_DEVICE_APP(pixelName = "m_i_sda"),
-        INTERSTITIAL_LAUNCH_DAX(pixelName = "m_i_ld"),
-        INTERSTITIAL_ONBOARDING_SHOWN(pixelName = "m_io_s"),
-        INTERSTITIAL_ONBOARDING_DISMISSED(pixelName = "m_io_d"),
-        INTERSTITIAL_ONBOARDING_LESS_PRESSED(pixelName = "m_io_l"),
-        INTERSTITIAL_ONBOARDING_MORE_PRESSED(pixelName = "m_io_m"),
-
-        LONG_PRESS("mlp"),
-        LONG_PRESS_DOWNLOAD_IMAGE("mlp_i"),
-        LONG_PRESS_NEW_TAB("mlp_t"),
-        LONG_PRESS_NEW_BACKGROUND_TAB("mlp_b"),
-        LONG_PRESS_SHARE("mlp_s"),
-        LONG_PRESS_COPY_URL("mlp_c"),
-        LONG_PRESS_OPEN_IMAGE_IN_BACKGROUND_TAB("mlp_ibt"),
-
-        DOWNLOAD_FILE_DEFAULT_GUESSED_NAME("m_df_dgn"),
-
-        SETTINGS_OPENED("ms"),
-        SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),
-        SETTINGS_THEME_TOGGLED_DARK("ms_td"),
-        SETTINGS_MANAGE_WHITELIST("ms_mw"),
-        SETTINGS_DO_NOT_SELL_SHOWN("ms_dns"),
-        SETTINGS_DO_NOT_SELL_ON("ms_dns_on"),
-        SETTINGS_DO_NOT_SELL_OFF("ms_dns_off"),
-
-        SURVEY_CTA_SHOWN(pixelName = "mus_cs"),
-        SURVEY_CTA_DISMISSED(pixelName = "mus_cd"),
-        SURVEY_CTA_LAUNCHED(pixelName = "mus_cl"),
-        SURVEY_SURVEY_DISMISSED(pixelName = "mus_sd"),
-
-        NOTIFICATION_SHOWN("mnot_s"),
-        NOTIFICATION_LAUNCHED("mnot_l"),
-        NOTIFICATION_CANCELLED("mnot_c"),
-        NOTIFICATIONS_ENABLED("mnot_e"),
-        NOTIFICATIONS_DISABLED("mnot_d"),
-
-        AUTOMATIC_CLEAR_DATA_WHAT_SHOWN("macwhat_s"),
-        AUTOMATIC_CLEAR_DATA_WHAT_OPTION_NONE("macwhat_n"),
-        AUTOMATIC_CLEAR_DATA_WHAT_OPTION_TABS("macwhat_t"),
-        AUTOMATIC_CLEAR_DATA_WHAT_OPTION_TABS_AND_DATA("macwhat_d"),
-
-        AUTOMATIC_CLEAR_DATA_WHEN_SHOWN("macwhen_s"),
-        AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_ONLY("macwhen_x"),
-        AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_5_MINS("macwhen_5"),
-        AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_15_MINS("macwhen_15"),
-        AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_30_MINS("macwhen_30"),
-        AUTOMATIC_CLEAR_DATA_WHEN_OPTION_APP_EXIT_OR_60_MINS("macwhen_60"),
-
-        APP_ENJOYMENT_DIALOG_SHOWN("mrp_e_d%d_ds"),
-        APP_ENJOYMENT_DIALOG_USER_ENJOYING("mrp_e_d%d_y"),
-        APP_ENJOYMENT_DIALOG_USER_NOT_ENJOYING("mrp_e_d%d_n"),
-        APP_ENJOYMENT_DIALOG_USER_CANCELLED("mrp_e_d%d_c"),
-
-        APP_RATING_DIALOG_SHOWN("mrp_r_d%d_ds"),
-        APP_RATING_DIALOG_USER_GAVE_RATING("mrp_r_d%d_y"),
-        APP_RATING_DIALOG_USER_DECLINED_RATING("mrp_r_d%d_n"),
-        APP_RATING_DIALOG_USER_CANCELLED("mrp_r_d%d_c"),
-
-        APP_FEEDBACK_DIALOG_SHOWN("mrp_f_d%d_ds"),
-        APP_FEEDBACK_DIALOG_USER_GAVE_FEEDBACK("mrp_f_d%d_y"),
-        APP_FEEDBACK_DIALOG_USER_DECLINED_FEEDBACK("mrp_f_d%d_n"),
-        APP_FEEDBACK_DIALOG_USER_CANCELLED("mrp_f_d%d_c"),
-
-        FEEDBACK_POSITIVE_SUBMISSION("mfbs_%s_submit"),
-        FEEDBACK_NEGATIVE_SUBMISSION("mfbs_%s_%s_%s"),
-
-        AUTOCOMPLETE_BOOKMARK_SELECTION("m_aut_s_b"),
-        AUTOCOMPLETE_SEARCH_SELECTION("m_aut_s_s"),
-
-        SERP_REQUERY("rq_%s"),
-
-        CHANGE_APP_ICON_OPENED("m_ic"),
-
-        MENU_ACTION_POPUP_OPENED("m_nav_pm_o"),
-        MENU_ACTION_FIRE_PRESSED("m_nav_f_p"),
-        MENU_ACTION_REFRESH_PRESSED("m_nav_r_p"),
-        MENU_ACTION_NEW_TAB_PRESSED("m_nav_nt_p"),
-        MENU_ACTION_BOOKMARKS_PRESSED("m_nav_b_p"),
-        MENU_ACTION_NAVIGATE_FORWARD_PRESSED("m_nav_nf_p"),
-        MENU_ACTION_NAVIGATE_BACK_PRESSED("m_nav_nb_p"),
-        MENU_ACTION_ADD_BOOKMARK_PRESSED("m_nav_ab_p"),
-        MENU_ACTION_SHARE_PRESSED("m_nav_sh_p"),
-        MENU_ACTION_FIND_IN_PAGE_PRESSED("m_nav_fip_p"),
-        MENU_ACTION_ADD_TO_HOME_PRESSED("m_nav_ath_p"),
-        MENU_ACTION_DESKTOP_SITE_ENABLE_PRESSED("m_nav_dse_p"),
-        MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED("m_nav_dsd_p"),
-        MENU_ACTION_REPORT_BROKEN_SITE_PRESSED("m_nav_rbs_p"),
-        MENU_ACTION_SETTINGS_PRESSED("m_nav_s_p"),
-
-        COOKIE_DATABASE_NOT_FOUND("m_cdb_nf"),
-        COOKIE_DATABASE_OPEN_ERROR("m_cdb_oe"),
-        COOKIE_DATABASE_DELETE_ERROR("m_cdb_de"),
-        COOKIE_DATABASE_CORRUPTED_ERROR("m_cdb_ce"),
-        COOKIE_DATABASE_EXCEPTION_OPEN_ERROR("m_cdb_e_oe"),
-        COOKIE_DATABASE_EXCEPTION_DELETE_ERROR("m_cdb_e_de"),
-
-        FIREPROOF_WEBSITE_ADDED("m_fw_a"),
-        FIREPROOF_WEBSITE_REMOVE("m_fw_r"),
-        FIREPROOF_LOGIN_DIALOG_SHOWN("m_fw_ld_s"),
-        FIREPROOF_WEBSITE_LOGIN_ADDED("m_fw_l_a"),
-        FIREPROOF_WEBSITE_LOGIN_DISMISS("m_fw_l_d"),
-        FIREPROOF_WEBSITE_DELETED("m_fw_d"),
-        FIREPROOF_LOGIN_TOGGLE_ENABLED("m_fw_d_e"),
-        FIREPROOF_LOGIN_TOGGLE_DISABLED("m_fw_d_d"),
-        FIREPROOF_WEBSITE_UNDO("m_fw_u"),
-        FIREPROOF_LOGIN_DISABLE_DIALOG_SHOWN("m_fw_dd_s"),
-        FIREPROOF_LOGIN_DISABLE_DIALOG_DISABLE("m_fw_dd_d"),
-        FIREPROOF_LOGIN_DISABLE_DIALOG_CANCEL("m_fw_dd_c"),
-
-        USE_OUR_APP_NOTIFICATION_SUFFIX("uoa"),
-        USE_OUR_APP_DIALOG_SHOWN("m_uoa_d"),
-        USE_OUR_APP_DIALOG_OK("m_uoa_d_ok"),
-        USE_OUR_APP_SHORTCUT_ADDED("m_uoa_s_a"),
-        USE_OUR_APP_DIALOG_DELETE_SHOWN("m_uoa_dd"),
-        UOA_VISITED_AFTER_SHORTCUT("m_uoa_vas"),
-        UOA_VISITED_AFTER_NOTIFICATION("m_uoa_van"),
-        UOA_VISITED_AFTER_DELETE_CTA("m_uoa_vad"),
-        UOA_VISITED("m_uoa_v"),
-
-        USE_OUR_APP_SHORTCUT_OPENED("m_sho_uoa_o"),
-        SHORTCUT_ADDED("m_sho_a"),
-        SHORTCUT_OPENED("m_sho_o"),
-
-        PRECISE_LOCATION_SYSTEM_DIALOG_ENABLE("m_pc_syd_e"),
-        PRECISE_LOCATION_SYSTEM_DIALOG_LATER("m_pc_syd_l"),
-        PRECISE_LOCATION_SYSTEM_DIALOG_NEVER("m_pc_syd_n"),
-        PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_ENABLE("m_pc_s_l_e"),
-        PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE("m_pc_s_l_d"),
-        PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS("m_pc_sd_aa"),
-        PRECISE_LOCATION_SITE_DIALOG_ALLOW_ONCE("m_pc_sd_ao"),
-        PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS("m_pc_sd_da"),
-        PRECISE_LOCATION_SITE_DIALOG_DENY_ONCE("m_pc_sd_do"),
-
-        FIRE_DIALOG_PROMOTED_CLEAR_PRESSED("m_fdp_p"),
-        FIRE_DIALOG_CLEAR_PRESSED("m_fd_p"),
-        FIRE_DIALOG_PROMOTED_CANCEL("m_fdp_c"),
-        FIRE_DIALOG_CANCEL("m_fd_c"),
-        FIRE_DIALOG_ANIMATION("m_fd_a"),
-
-        FIRE_ANIMATION_SETTINGS_OPENED("m_fas_o"),
-        FIRE_ANIMATION_NEW_SELECTED("m_fas_s"),
     }
 
     object PixelParameter {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1200049149472987/f
Tech Design URL: https://app.asana.com/0/715106103902962/1200043236683507/f
CC: 

**Description**:
This PR
* abstracts the `PixelName` as an interface so that it can be extended
* pixel definitions can thus be kept private to the gradle module that uses them


**Steps to test this PR**:
1. App should comile

(it is not extrictly necessary to perform any test as all issues should be detected at compile time)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
