### PR TITLE
fix: null pointer when trying to hide omnibar when activity is restored

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.Intent.EXTRA_TEXT
 import android.os.Bundle
+import android.os.Handler
 import android.os.Message
 import android.view.View
 import android.widget.Toast
@@ -373,7 +374,13 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
     }
 
     private fun hideMockupOmnibar() {
-        appBarLayoutMockup.visibility = View.GONE
+        // Delaying this code to avoid race condition when fragment and activity recreated
+        Handler().postDelayed(
+            {
+                appBarLayoutMockup?.visibility = View.GONE
+            },
+            300
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -482,7 +482,6 @@ class BrowserTabFragment :
         appBarLayout.setExpanded(true)
         webView?.onPause()
         webView?.hide()
-        omnibarScrolling.disableOmnibarScrolling(toolbarContainer)
         homeBackgroundLogo.showLogo()
     }
 
@@ -490,7 +489,6 @@ class BrowserTabFragment :
         newTabLayout.gone()
         webView?.show()
         webView?.onResume()
-        omnibarScrolling.enableOmnibarScrolling(toolbarContainer)
         homeBackgroundLogo.hideLogo()
     }
 
@@ -1431,12 +1429,14 @@ class BrowserTabFragment :
             fireMenuButton?.isVisible = viewState.fireButton is FireButton.Visible
             menuButton?.isVisible = viewState.showMenuButton
 
+            // omnibar only scrollable when browser showing and the fire button is not promoted
             if (viewState.fireButton.playPulseAnimation()) {
-                appBarLayout.setExpanded(true, true)
                 omnibarScrolling.disableOmnibarScrolling(toolbarContainer)
                 playPulseAnimation()
             } else {
-                omnibarScrolling.enableOmnibarScrolling(toolbarContainer)
+                if (viewState.browserShowing) {
+                    omnibarScrolling.enableOmnibarScrolling(toolbarContainer)
+                }
                 pulseAnimation.stop()
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200072845922531/f
Tech Design URL: 
CC: 

**Description**:
PR fixes:
- Being able to scroll omnibar on home screen
- Nullpointer exception when hiding mockup onminbar when activity is recreated

**Steps to test this PR**:
1. Install this branch
1. Enable "Don't keep activities" inside developer settings
2. Go to the browser
3. Go into settings
4. Press back
5. Ensure Browser shown (no runtime exception)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
