### PR TITLE
Close correct tab when close window called

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -553,7 +553,7 @@ class BrowserTabViewModelTest {
         testee.onUserSubmittedQuery("foo")
 
         coroutineRule.runBlocking {
-            verify(mockTabsRepository).delete(selectedTabLiveData.value!!)
+            verify(mockTabsRepository).deleteCurrentTabAndSelectSource(selectedTabLiveData.value!!.tabId)
         }
     }
 
@@ -1218,7 +1218,7 @@ class BrowserTabViewModelTest {
         testee.onRefreshRequested()
 
         coroutineRule.runBlocking {
-            verify(mockTabsRepository).delete(selectedTabLiveData.value!!)
+            verify(mockTabsRepository).deleteCurrentTabAndSelectSource(selectedTabLiveData.value!!.tabId)
         }
     }
 
@@ -1519,7 +1519,7 @@ class BrowserTabViewModelTest {
         showErrorWithAction.action()
 
         coroutineRule.runBlocking {
-            verify(mockTabsRepository).delete(selectedTabLiveData.value!!)
+            verify(mockTabsRepository).deleteCurrentTabAndSelectSource(selectedTabLiveData.value!!.tabId)
         }
     }
 
@@ -1691,7 +1691,7 @@ class BrowserTabViewModelTest {
     fun whenCloseCurrentTabSelectedThenTabDeletedFromRepository() = runBlocking {
         givenOneActiveTabSelected()
         testee.closeCurrentTab()
-        verify(mockTabsRepository).delete(selectedTabLiveData.value!!)
+        verify(mockTabsRepository).deleteCurrentTabAndSelectSource(selectedTabLiveData.value!!.tabId)
     }
 
     @Test
@@ -1723,7 +1723,7 @@ class BrowserTabViewModelTest {
 
         testee.onUserPressedBack()
 
-        verify(mockTabsRepository).deleteCurrentTabAndSelectSource()
+        verify(mockTabsRepository).deleteCurrentTabAndSelectSource("TAB_ID")
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -553,7 +553,7 @@ class BrowserTabViewModelTest {
         testee.onUserSubmittedQuery("foo")
 
         coroutineRule.runBlocking {
-            verify(mockTabsRepository).deleteCurrentTabAndSelectSource(selectedTabLiveData.value!!.tabId)
+            verify(mockTabsRepository).deleteTabAndSelectSource(selectedTabLiveData.value!!.tabId)
         }
     }
 
@@ -1218,7 +1218,7 @@ class BrowserTabViewModelTest {
         testee.onRefreshRequested()
 
         coroutineRule.runBlocking {
-            verify(mockTabsRepository).deleteCurrentTabAndSelectSource(selectedTabLiveData.value!!.tabId)
+            verify(mockTabsRepository).deleteTabAndSelectSource(selectedTabLiveData.value!!.tabId)
         }
     }
 
@@ -1519,7 +1519,7 @@ class BrowserTabViewModelTest {
         showErrorWithAction.action()
 
         coroutineRule.runBlocking {
-            verify(mockTabsRepository).deleteCurrentTabAndSelectSource(selectedTabLiveData.value!!.tabId)
+            verify(mockTabsRepository).deleteTabAndSelectSource(selectedTabLiveData.value!!.tabId)
         }
     }
 
@@ -1691,7 +1691,7 @@ class BrowserTabViewModelTest {
     fun whenCloseCurrentTabSelectedThenTabDeletedFromRepository() = runBlocking {
         givenOneActiveTabSelected()
         testee.closeCurrentTab()
-        verify(mockTabsRepository).deleteCurrentTabAndSelectSource(selectedTabLiveData.value!!.tabId)
+        verify(mockTabsRepository).deleteTabAndSelectSource(selectedTabLiveData.value!!.tabId)
     }
 
     @Test
@@ -1723,7 +1723,7 @@ class BrowserTabViewModelTest {
 
         testee.onUserPressedBack()
 
-        verify(mockTabsRepository).deleteCurrentTabAndSelectSource("TAB_ID")
+        verify(mockTabsRepository).deleteTabAndSelectSource("TAB_ID")
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -320,7 +320,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenDeleteCurrentTabAndSelectSourceLiveSelectedTabReturnsToSourceTab() = runBlocking<Unit> {
+    fun whenDeleteTabAndSelectSourceLiveSelectedTabReturnsToSourceTab() = runBlocking<Unit> {
         val db = createDatabase()
         val dao = db.tabsDao()
         val sourceTab = TabEntity(tabId = "sourceId", url = "http://www.example.com", position = 0)
@@ -331,7 +331,7 @@ class TabDataRepositoryTest {
         var currentSelectedTabId = testee.liveSelectedTab.blockingObserve()?.tabId
         assertEquals(currentSelectedTabId, tabToDelete.tabId)
 
-        testee.deleteCurrentTabAndSelectSource("tabToDeleteId")
+        testee.deleteTabAndSelectSource("tabToDeleteId")
 
         currentSelectedTabId = testee.liveSelectedTab.blockingObserve()?.tabId
         assertEquals(currentSelectedTabId, sourceTab.tabId)

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -331,7 +331,7 @@ class TabDataRepositoryTest {
         var currentSelectedTabId = testee.liveSelectedTab.blockingObserve()?.tabId
         assertEquals(currentSelectedTabId, tabToDelete.tabId)
 
-        testee.deleteCurrentTabAndSelectSource()
+        testee.deleteCurrentTabAndSelectSource("tabToDeleteId")
 
         currentSelectedTabId = testee.liveSelectedTab.blockingObserve()?.tabId
         assertEquals(currentSelectedTabId, sourceTab.tabId)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -586,7 +586,7 @@ class BrowserTabViewModel(
     private suspend fun removeCurrentTabFromRepository() {
         val currentTab = tabRepository.liveSelectedTab.value
         currentTab?.let {
-            tabRepository.deleteCurrentTabAndSelectSource(it.tabId)
+            tabRepository.deleteTabAndSelectSource(it.tabId)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -586,7 +586,7 @@ class BrowserTabViewModel(
     private suspend fun removeCurrentTabFromRepository() {
         val currentTab = tabRepository.liveSelectedTab.value
         currentTab?.let {
-            tabRepository.delete(currentTab)
+            tabRepository.deleteCurrentTabAndSelectSource(it.tabId)
         }
     }
 
@@ -636,7 +636,7 @@ class BrowserTabViewModel(
     }
 
     private suspend fun removeAndSelectTabFromRepository() {
-        tabRepository.deleteCurrentTabAndSelectSource()
+        removeCurrentTabFromRepository()
     }
 
     fun onUserPressedForward() {
@@ -688,7 +688,7 @@ class BrowserTabViewModel(
             return true
         } else if (hasSourceTab) {
             viewModelScope.launch {
-                tabRepository.deleteCurrentTabAndSelectSource()
+                removeCurrentTabFromRepository()
             }
             return true
         } else if (!skipHome) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -216,9 +216,9 @@ class TabDataRepository @Inject constructor(
         }.join()
     }
 
-    override suspend fun deleteCurrentTabAndSelectSource() {
+    override suspend fun deleteCurrentTabAndSelectSource(tabId: String) {
         databaseExecutor().scheduleDirect {
-            val tabToDelete = tabsDao.selectedTab() ?: return@scheduleDirect
+            val tabToDelete = tabsDao.tab(tabId) ?: return@scheduleDirect
 
             deleteOldPreviewImages(tabToDelete.tabId)
             val tabToSelect = tabToDelete.sourceTabId

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -216,7 +216,7 @@ class TabDataRepository @Inject constructor(
         }.join()
     }
 
-    override suspend fun deleteCurrentTabAndSelectSource(tabId: String) {
+    override suspend fun deleteTabAndSelectSource(tabId: String) {
         databaseExecutor().scheduleDirect {
             val tabToDelete = tabsDao.tab(tabId) ?: return@scheduleDirect
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -66,7 +66,7 @@ interface TabRepository {
      */
     suspend fun purgeDeletableTabs()
 
-    suspend fun deleteCurrentTabAndSelectSource(tabId: String)
+    suspend fun deleteTabAndSelectSource(tabId: String)
 
     suspend fun deleteAll()
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -66,7 +66,7 @@ interface TabRepository {
      */
     suspend fun purgeDeletableTabs()
 
-    suspend fun deleteCurrentTabAndSelectSource()
+    suspend fun deleteCurrentTabAndSelectSource(tabId: String)
 
     suspend fun deleteAll()
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1199674134590488
Tech Design URL: 
CC: 

**Description**:
This PR fixes a bug where we close the wrong tab after receiving a close window event.

**Steps to test this PR**:

**Google Sign in**
1. Install the app
1. Open a tab and go to SERP
1. Open another tab and go to a site with a google login like `etsy.com`
1. Sign in with your google account, once the flow has finished you should be returned to the tab which initiated the flow
1. Some sites require us to enable 3p cookies for the login with Google to work, in those cases you will not be signed in but you should still be returned to the correct tab.

**Facebook Sign in**
1. Install the app
1. Open a tab and go to SERP
1. Open another tab and go to a site with a Facebook login like `pinterest.com`
1. Sign in with your facebook account, once the flow has finished you should be returned to the tab which initiated the flow.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
