### PR TITLE
Made navigation bar transparent for devices with API23

### DIFF
--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -19,13 +19,13 @@
 <resources>
 
     <style name="AppTheme.Dark" parent="AppTheme.BaseDark">
-		<item name="android:windowLightStatusBar">false</item>
-		<item name="android:navigationBarColor">@android:color/transparent</item>
+	<item name="android:windowLightStatusBar">false</item>
+	<item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
     <style name="AppTheme.Light" parent="AppTheme.BaseLight">
-		<item name="android:windowLightStatusBar">true</item>
-		<item name="android:navigationBarColor">@android:color/transparent</item>
+	<item name="android:windowLightStatusBar">true</item>
+	<item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -19,11 +19,13 @@
 <resources>
 
     <style name="AppTheme.Dark" parent="AppTheme.BaseDark">
-        <item name="android:windowLightStatusBar">false</item>
+		<item name="android:windowLightStatusBar">false</item>
+		<item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
     <style name="AppTheme.Light" parent="AppTheme.BaseLight">
-        <item name="android:windowLightStatusBar">true</item>
+		<item name="android:windowLightStatusBar">true</item>
+		<item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
Tech Design URL: 
CC: 

**Description**:
Hello!
I made some changes to the app's design for devices with API23. The problem was that navigation bar remained black even if the light theme was enabled. This should fix it by making the whole navigation bar transparent

**Steps to test this PR**:
1. Install the app on device/emulator with API23/Android 7.0 
2. Launch the app
3. The navigation bar should have the same colour as the app's theme


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
