### PR TITLE
Use providers in the VM factories to respect the dep di semantics

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -37,6 +37,7 @@ import dagger.multibindings.IntoSet
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class BookmarksViewModel(
@@ -127,23 +128,23 @@ class BookmarksViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideBookmarksViewModelFactory(
-        dao: BookmarksDao,
-        faviconManager: FaviconManager,
-        dispatcherProvider: DispatcherProvider
+        dao: Provider<BookmarksDao>,
+        faviconManager: Provider<FaviconManager>,
+        dispatcherProvider: Provider<DispatcherProvider>
     ): ViewModelFactoryPlugin {
         return BookmarksViewModelFactory(dao, faviconManager, dispatcherProvider)
     }
 }
 
 private class BookmarksViewModelFactory(
-    private val dao: BookmarksDao,
-    private val faviconManager: FaviconManager,
-    private val dispatcherProvider: DispatcherProvider
+    private val dao: Provider<BookmarksDao>,
+    private val faviconManager: Provider<FaviconManager>,
+    private val dispatcherProvider: Provider<DispatcherProvider>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(BookmarksViewModel::class.java) -> (BookmarksViewModel(dao, faviconManager, dispatcherProvider) as T)
+                isAssignableFrom(BookmarksViewModel::class.java) -> (BookmarksViewModel(dao.get(), faviconManager.get(), dispatcherProvider.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -35,6 +35,7 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class BrokenSiteViewModel(private val pixel: Pixel, private val brokenSiteSender: BrokenSiteSender) : ViewModel() {
@@ -134,21 +135,21 @@ class BrokenSiteViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideBrokenSiteViewModelFactory(
-        pixel: Pixel,
-        brokenSiteSender: BrokenSiteSender
+        pixel: Provider<Pixel>,
+        brokenSiteSender: Provider<BrokenSiteSender>
     ): ViewModelFactoryPlugin {
         return BrokenSiteViewModelFactory(pixel, brokenSiteSender)
     }
 }
 
 private class BrokenSiteViewModelFactory(
-    private val pixel: Pixel,
-    private val brokenSiteSender: BrokenSiteSender
+    private val pixel: Provider<Pixel>,
+    private val brokenSiteSender: Provider<BrokenSiteSender>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(BrokenSiteViewModel::class.java) -> (BrokenSiteViewModel(pixel, brokenSiteSender) as T)
+                isAssignableFrom(BrokenSiteViewModel::class.java) -> (BrokenSiteViewModel(pixel.get(), brokenSiteSender.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -117,6 +117,7 @@ import timber.log.Timber
 import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class BrowserTabViewModel(
@@ -1843,36 +1844,36 @@ class BrowserTabViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideBrowserTabViewModelFactory(
-        statisticsUpdater: StatisticsUpdater,
-        queryUrlConverter: QueryUrlConverter,
-        duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
-        siteFactory: SiteFactory,
-        tabRepository: TabRepository,
-        userWhitelistDao: UserWhitelistDao,
-        networkLeaderboardDao: NetworkLeaderboardDao,
-        bookmarksDao: BookmarksDao,
-        fireproofWebsiteRepository: FireproofWebsiteRepository,
-        locationPermissionsRepository: LocationPermissionsRepository,
-        geoLocationPermissions: GeoLocationPermissions,
-        navigationAwareLoginDetector: NavigationAwareLoginDetector,
-        autoCompleteApi: AutoCompleteApi,
-        appSettingsPreferencesStore: SettingsDataStore,
-        longPressHandler: LongPressHandler,
-        webViewSessionStorage: WebViewSessionStorage,
-        specialUrlDetector: SpecialUrlDetector,
-        faviconManager: FaviconManager,
-        addToHomeCapabilityDetector: AddToHomeCapabilityDetector,
-        ctaViewModel: CtaViewModel,
-        searchCountDao: SearchCountDao,
-        pixel: Pixel,
+        statisticsUpdater: Provider<StatisticsUpdater>,
+        queryUrlConverter: Provider<QueryUrlConverter>,
+        duckDuckGoUrlDetector: Provider<DuckDuckGoUrlDetector>,
+        siteFactory: Provider<SiteFactory>,
+        tabRepository: Provider<TabRepository>,
+        userWhitelistDao: Provider<UserWhitelistDao>,
+        networkLeaderboardDao: Provider<NetworkLeaderboardDao>,
+        bookmarksDao: Provider<BookmarksDao>,
+        fireproofWebsiteRepository: Provider<FireproofWebsiteRepository>,
+        locationPermissionsRepository: Provider<LocationPermissionsRepository>,
+        geoLocationPermissions: Provider<GeoLocationPermissions>,
+        navigationAwareLoginDetector: Provider<NavigationAwareLoginDetector>,
+        autoCompleteApi: Provider<AutoCompleteApi>,
+        appSettingsPreferencesStore: Provider<SettingsDataStore>,
+        longPressHandler: Provider<LongPressHandler>,
+        webViewSessionStorage: Provider<WebViewSessionStorage>,
+        specialUrlDetector: Provider<SpecialUrlDetector>,
+        faviconManager: Provider<FaviconManager>,
+        addToHomeCapabilityDetector: Provider<AddToHomeCapabilityDetector>,
+        ctaViewModel: Provider<CtaViewModel>,
+        searchCountDao: Provider<SearchCountDao>,
+        pixel: Provider<Pixel>,
         dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
-        userEventsStore: UserEventsStore,
-        notificationDao: NotificationDao,
-        useOurAppDetector: UseOurAppDetector,
-        variantManager: VariantManager,
-        fileDownloader: FileDownloader,
-        globalPrivacyControl: GlobalPrivacyControl,
-        fireproofDialogsEventHandler: FireproofDialogsEventHandler
+        userEventsStore: Provider<UserEventsStore>,
+        notificationDao: Provider<NotificationDao>,
+        useOurAppDetector: Provider<UseOurAppDetector>,
+        variantManager: Provider<VariantManager>,
+        fileDownloader: Provider<FileDownloader>,
+        globalPrivacyControl: Provider<GlobalPrivacyControl>,
+        fireproofDialogsEventHandler: Provider<FireproofDialogsEventHandler>
     ): ViewModelFactoryPlugin {
         return BrowserTabViewModelFactory(
             statisticsUpdater,
@@ -1910,41 +1911,41 @@ class BrowserTabViewModelFactoryModule {
 }
 
 private class BrowserTabViewModelFactory(
-    private val statisticsUpdater: StatisticsUpdater,
-    private val queryUrlConverter: OmnibarEntryConverter,
-    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
-    private val siteFactory: SiteFactory,
-    private val tabRepository: TabRepository,
-    private val userWhitelistDao: UserWhitelistDao,
-    private val networkLeaderboardDao: NetworkLeaderboardDao,
-    private val bookmarksDao: BookmarksDao,
-    private val fireproofWebsiteRepository: FireproofWebsiteRepository,
-    private val locationPermissionsRepository: LocationPermissionsRepository,
-    private val geoLocationPermissions: GeoLocationPermissions,
-    private val navigationAwareLoginDetector: NavigationAwareLoginDetector,
-    private val autoComplete: AutoComplete,
-    private val appSettingsPreferencesStore: SettingsDataStore,
-    private val longPressHandler: LongPressHandler,
-    private val webViewSessionStorage: WebViewSessionStorage,
-    private val specialUrlDetector: SpecialUrlDetector,
-    private val faviconManager: FaviconManager,
-    private val addToHomeCapabilityDetector: AddToHomeCapabilityDetector,
-    private val ctaViewModel: CtaViewModel,
-    private val searchCountDao: SearchCountDao,
-    private val pixel: Pixel,
+    private val statisticsUpdater: Provider<StatisticsUpdater>,
+    private val queryUrlConverter: Provider<QueryUrlConverter>,
+    private val duckDuckGoUrlDetector: Provider<DuckDuckGoUrlDetector>,
+    private val siteFactory: Provider<SiteFactory>,
+    private val tabRepository: Provider<TabRepository>,
+    private val userWhitelistDao: Provider<UserWhitelistDao>,
+    private val networkLeaderboardDao: Provider<NetworkLeaderboardDao>,
+    private val bookmarksDao: Provider<BookmarksDao>,
+    private val fireproofWebsiteRepository: Provider<FireproofWebsiteRepository>,
+    private val locationPermissionsRepository: Provider<LocationPermissionsRepository>,
+    private val geoLocationPermissions: Provider<GeoLocationPermissions>,
+    private val navigationAwareLoginDetector: Provider<NavigationAwareLoginDetector>,
+    private val autoComplete: Provider<AutoCompleteApi>,
+    private val appSettingsPreferencesStore: Provider<SettingsDataStore>,
+    private val longPressHandler: Provider<LongPressHandler>,
+    private val webViewSessionStorage: Provider<WebViewSessionStorage>,
+    private val specialUrlDetector: Provider<SpecialUrlDetector>,
+    private val faviconManager: Provider<FaviconManager>,
+    private val addToHomeCapabilityDetector: Provider<AddToHomeCapabilityDetector>,
+    private val ctaViewModel: Provider<CtaViewModel>,
+    private val searchCountDao: Provider<SearchCountDao>,
+    private val pixel: Provider<Pixel>,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
-    private val userEventsStore: UserEventsStore,
-    private val notificationDao: NotificationDao,
-    private val useOurAppDetector: UseOurAppDetector,
-    private val variantManager: VariantManager,
-    private val fileDownloader: FileDownloader,
-    private val globalPrivacyControl: GlobalPrivacyControl,
-    private val fireproofDialogsEventHandler: FireproofDialogsEventHandler
+    private val userEventsStore: Provider<UserEventsStore>,
+    private val notificationDao: Provider<NotificationDao>,
+    private val useOurAppDetector: Provider<UseOurAppDetector>,
+    private val variantManager: Provider<VariantManager>,
+    private val fileDownloader: Provider<FileDownloader>,
+    private val globalPrivacyControl: Provider<GlobalPrivacyControl>,
+    private val fireproofDialogsEventHandler: Provider<FireproofDialogsEventHandler>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(BrowserTabViewModel::class.java) -> BrowserTabViewModel(statisticsUpdater, queryUrlConverter, duckDuckGoUrlDetector, siteFactory, tabRepository, userWhitelistDao, networkLeaderboardDao, bookmarksDao, fireproofWebsiteRepository, locationPermissionsRepository, geoLocationPermissions, navigationAwareLoginDetector, autoComplete, appSettingsPreferencesStore, longPressHandler, webViewSessionStorage, specialUrlDetector, faviconManager, addToHomeCapabilityDetector, ctaViewModel, searchCountDao, pixel, dispatchers, userEventsStore, notificationDao, useOurAppDetector, variantManager, fileDownloader, globalPrivacyControl, fireproofDialogsEventHandler) as T
+                isAssignableFrom(BrowserTabViewModel::class.java) -> BrowserTabViewModel(statisticsUpdater.get(), queryUrlConverter.get(), duckDuckGoUrlDetector.get(), siteFactory.get(), tabRepository.get(), userWhitelistDao.get(), networkLeaderboardDao.get(), bookmarksDao.get(), fireproofWebsiteRepository.get(), locationPermissionsRepository.get(), geoLocationPermissions.get(), navigationAwareLoginDetector.get(), autoComplete.get(), appSettingsPreferencesStore.get(), longPressHandler.get(), webViewSessionStorage.get(), specialUrlDetector.get(), faviconManager.get(), addToHomeCapabilityDetector.get(), ctaViewModel.get(), searchCountDao.get(), pixel.get(), dispatchers, userEventsStore.get(), notificationDao.get(), useOurAppDetector.get(), variantManager.get(), fileDownloader.get(), globalPrivacyControl.get(), fireproofDialogsEventHandler.get()) as T
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -248,33 +249,33 @@ class BrowserViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideBrowserViewModelFactory(
-        tabRepository: TabRepository,
-        queryUrlConverter: QueryUrlConverter,
-        dataClearer: DataClearer,
-        appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
-        appEnjoymentUserEventRecorder: AppEnjoymentUserEventRecorder,
+        tabRepository: Provider<TabRepository>,
+        queryUrlConverter: Provider<QueryUrlConverter>,
+        dataClearer: Provider<DataClearer>,
+        appEnjoymentPromptEmitter: Provider<AppEnjoymentPromptEmitter>,
+        appEnjoymentUserEventRecorder: Provider<AppEnjoymentUserEventRecorder>,
         dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
-        pixel: Pixel,
-        useOurAppDetector: UseOurAppDetector
+        pixel: Provider<Pixel>,
+        useOurAppDetector: Provider<UseOurAppDetector>
     ): ViewModelFactoryPlugin {
         return BrowserViewModelFactory(tabRepository, queryUrlConverter, dataClearer, appEnjoymentPromptEmitter, appEnjoymentUserEventRecorder, dispatchers, pixel, useOurAppDetector)
     }
 }
 
 private class BrowserViewModelFactory(
-    val tabRepository: TabRepository,
-    val queryUrlConverter: OmnibarEntryConverter,
-    val dataClearer: DataClearer,
-    val appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
-    val appEnjoymentUserEventRecorder: AppEnjoymentUserEventRecorder,
+    val tabRepository: Provider<TabRepository>,
+    val queryUrlConverter: Provider<QueryUrlConverter>,
+    val dataClearer: Provider<DataClearer>,
+    val appEnjoymentPromptEmitter: Provider<AppEnjoymentPromptEmitter>,
+    val appEnjoymentUserEventRecorder: Provider<AppEnjoymentUserEventRecorder>,
     val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
-    val pixel: Pixel,
-    val useOurAppDetector: UseOurAppDetector
+    val pixel: Provider<Pixel>,
+    val useOurAppDetector: Provider<UseOurAppDetector>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(BrowserViewModel::class.java) -> BrowserViewModel(tabRepository, queryUrlConverter, dataClearer, appEnjoymentPromptEmitter, appEnjoymentUserEventRecorder, dispatchers, pixel, useOurAppDetector) as T
+                isAssignableFrom(BrowserViewModel::class.java) -> BrowserViewModel(tabRepository.get(), queryUrlConverter.get(), dataClearer.get(), appEnjoymentPromptEmitter.get(), appEnjoymentUserEventRecorder.get(), dispatchers, pixel.get(), useOurAppDetector.get()) as T
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/common/FeedbackViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/common/FeedbackViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class FeedbackViewModel(private val playStoreUtils: PlayStoreUtils, private val feedbackSubmitter: FeedbackSubmitter) : ViewModel() {
@@ -297,21 +298,21 @@ class FeedbackViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideFeedbackViewModelFactory(
-        playStoreUtils: PlayStoreUtils,
-        feedbackSubmitter: FeedbackSubmitter
+        playStoreUtils: Provider<PlayStoreUtils>,
+        feedbackSubmitter: Provider<FeedbackSubmitter>
     ): ViewModelFactoryPlugin {
         return FeedbackViewModelFactory(playStoreUtils, feedbackSubmitter)
     }
 }
 
 private class FeedbackViewModelFactory(
-    private val playStoreUtils: PlayStoreUtils,
-    private val feedbackSubmitter: FeedbackSubmitter
+    private val playStoreUtils: Provider<PlayStoreUtils>,
+    private val feedbackSubmitter: Provider<FeedbackSubmitter>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(FeedbackViewModel::class.java) -> (FeedbackViewModel(playStoreUtils, feedbackSubmitter) as T)
+                isAssignableFrom(FeedbackViewModel::class.java) -> (FeedbackViewModel(playStoreUtils.get(), feedbackSubmitter.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/initial/InitialFeedbackFragmentViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/initial/InitialFeedbackFragmentViewModel.kt
@@ -58,7 +58,7 @@ class InitialFeedbackFragmentViewModelFactoryModule {
     }
 }
 
-private class InitialFeedbackFragmentViewModelFactory() : ViewModelFactoryPlugin {
+private class InitialFeedbackFragmentViewModelFactory : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/brokensite/BrokenSiteNegativeFeedbackViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/brokensite/BrokenSiteNegativeFeedbackViewModel.kt
@@ -51,7 +51,7 @@ class BrokenSiteNegativeFeedbackViewModelFactoryModule {
     }
 }
 
-private class BrokenSiteNegativeFeedbackViewModelFactory() : ViewModelFactoryPlugin {
+private class BrokenSiteNegativeFeedbackViewModelFactory : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/openended/ShareOpenEndedNegativeFeedbackViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/openended/ShareOpenEndedNegativeFeedbackViewModel.kt
@@ -58,7 +58,7 @@ class ShareOpenEndedNegativeFeedbackViewModelFactoryModule {
     }
 }
 
-private class ShareOpenEndedNegativeFeedbackViewModelFactory() : ViewModelFactoryPlugin {
+private class ShareOpenEndedNegativeFeedbackViewModelFactory : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/positive/initial/PositiveFeedbackLandingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/positive/initial/PositiveFeedbackLandingViewModel.kt
@@ -62,7 +62,7 @@ class PositiveFeedbackLandingViewModelFactoryModule {
     }
 }
 
-private class PositiveFeedbackLandingViewModelFactory() : ViewModelFactoryPlugin {
+private class PositiveFeedbackLandingViewModelFactory : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {

--- a/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModel.kt
@@ -35,6 +35,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
 import kotlinx.coroutines.launch
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class FireproofWebsitesViewModel(
@@ -118,27 +119,27 @@ class FireproofWebsitesViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideFireproofWebsitesViewModelFactory(
-        fireproofWebsiteRepository: FireproofWebsiteRepository,
-        dispatcherProvider: DispatcherProvider,
-        pixel: Pixel,
-        settingsDataStore: SettingsDataStore,
-        userEventsStore: UserEventsStore
+        fireproofWebsiteRepository: Provider<FireproofWebsiteRepository>,
+        dispatcherProvider: Provider<DispatcherProvider>,
+        pixel: Provider<Pixel>,
+        settingsDataStore: Provider<SettingsDataStore>,
+        userEventsStore: Provider<UserEventsStore>
     ): ViewModelFactoryPlugin {
         return FireproofWebsitesViewModelFactory(fireproofWebsiteRepository, dispatcherProvider, pixel, settingsDataStore, userEventsStore)
     }
 }
 
 private class FireproofWebsitesViewModelFactory(
-    private val fireproofWebsiteRepository: FireproofWebsiteRepository,
-    private val dispatcherProvider: DispatcherProvider,
-    private val pixel: Pixel,
-    private val settingsDataStore: SettingsDataStore,
-    private val userEventsStore: UserEventsStore
+    private val fireproofWebsiteRepository: Provider<FireproofWebsiteRepository>,
+    private val dispatcherProvider: Provider<DispatcherProvider>,
+    private val pixel: Provider<Pixel>,
+    private val settingsDataStore: Provider<SettingsDataStore>,
+    private val userEventsStore: Provider<UserEventsStore>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(FireproofWebsitesViewModel::class.java) -> (FireproofWebsitesViewModel(fireproofWebsiteRepository, dispatcherProvider, pixel, settingsDataStore, userEventsStore) as T)
+                isAssignableFrom(FireproofWebsitesViewModel::class.java) -> (FireproofWebsitesViewModel(fireproofWebsiteRepository.get(), dispatcherProvider.get(), pixel.get(), settingsDataStore.get(), userEventsStore.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModel.kt
@@ -27,6 +27,7 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class GlobalPrivacyControlViewModel(
@@ -76,21 +77,21 @@ class GlobalPrivacyControlViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideGlobalPrivacyControlViewModelFactory(
-        pixel: Pixel,
-        settingsDataStore: SettingsDataStore
+        pixel: Provider<Pixel>,
+        settingsDataStore: Provider<SettingsDataStore>
     ): ViewModelFactoryPlugin {
         return GlobalPrivacyControlViewModelFactory(pixel, settingsDataStore)
     }
 }
 
 private class GlobalPrivacyControlViewModelFactory(
-    private val pixel: Pixel,
-    private val settingsDataStore: SettingsDataStore
+    private val pixel: Provider<Pixel>,
+    private val settingsDataStore: Provider<SettingsDataStore>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(GlobalPrivacyControlViewModel::class.java) -> (GlobalPrivacyControlViewModel(pixel, settingsDataStore) as T)
+                isAssignableFrom(GlobalPrivacyControlViewModel::class.java) -> (GlobalPrivacyControlViewModel(pixel.get(), settingsDataStore.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/icon/ui/ChangeIconViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/icon/ui/ChangeIconViewModel.kt
@@ -31,6 +31,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class ChangeIconViewModel @Inject constructor(
@@ -89,23 +90,23 @@ class ChangeIconViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideChangeIconViewModelFactory(
-        settingsDataStore: SettingsDataStore,
-        appIconModifier: IconModifier,
-        pixel: Pixel
+        settingsDataStore: Provider<SettingsDataStore>,
+        appIconModifier: Provider<IconModifier>,
+        pixel: Provider<Pixel>
     ): ViewModelFactoryPlugin {
         return ChangeIconViewModelFactory(settingsDataStore, appIconModifier, pixel)
     }
 }
 
 private class ChangeIconViewModelFactory(
-    private val settingsDataStore: SettingsDataStore,
-    private val appIconModifier: IconModifier,
-    private val pixel: Pixel
+    private val settingsDataStore: Provider<SettingsDataStore>,
+    private val appIconModifier: Provider<IconModifier>,
+    private val pixel: Provider<Pixel>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(ChangeIconViewModel::class.java) -> (ChangeIconViewModel(settingsDataStore, appIconModifier, pixel) as T)
+                isAssignableFrom(ChangeIconViewModel::class.java) -> (ChangeIconViewModel(settingsDataStore.get(), appIconModifier.get(), pixel.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
@@ -30,6 +30,7 @@ import dagger.Provides
 import dagger.multibindings.IntoSet
 import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class LaunchViewModel(
@@ -74,21 +75,21 @@ class LaunchViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideLaunchViewModelFactory(
-        userStageStore: UserStageStore,
-        appInstallationReferrerStateListener: AppInstallationReferrerStateListener
+        userStageStore: Provider<UserStageStore>,
+        appInstallationReferrerStateListener: Provider<AppInstallationReferrerStateListener>
     ): ViewModelFactoryPlugin {
         return LaunchViewModelFactory(userStageStore, appInstallationReferrerStateListener)
     }
 }
 
 private class LaunchViewModelFactory(
-    private val userStageStore: UserStageStore,
-    private val appInstallationReferrerStateListener: AppInstallationReferrerStateListener
+    private val userStageStore: Provider<UserStageStore>,
+    private val appInstallationReferrerStateListener: Provider<AppInstallationReferrerStateListener>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(LaunchViewModel::class.java) -> (LaunchViewModel(userStageStore, appInstallationReferrerStateListener) as T)
+                isAssignableFrom(LaunchViewModel::class.java) -> (LaunchViewModel(userStageStore.get(), appInstallationReferrerStateListener.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModel.kt
@@ -34,6 +34,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
 import kotlinx.coroutines.launch
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class LocationPermissionsViewModel(
@@ -145,27 +146,27 @@ class LocationPermissionsViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideLocationPermissionsViewModelFactory(
-        locationPermissionsRepository: LocationPermissionsRepository,
-        geoLocationPermissions: GeoLocationPermissions,
-        dispatcherProvider: DispatcherProvider,
-        settingsDataStore: SettingsDataStore,
-        pixel: Pixel
+        locationPermissionsRepository: Provider<LocationPermissionsRepository>,
+        geoLocationPermissions: Provider<GeoLocationPermissions>,
+        dispatcherProvider: Provider<DispatcherProvider>,
+        settingsDataStore: Provider<SettingsDataStore>,
+        pixel: Provider<Pixel>
     ): ViewModelFactoryPlugin {
         return LocationPermissionsViewModelFactory(locationPermissionsRepository, geoLocationPermissions, dispatcherProvider, settingsDataStore, pixel)
     }
 }
 
 private class LocationPermissionsViewModelFactory(
-    private val locationPermissionsRepository: LocationPermissionsRepository,
-    private val geoLocationPermissions: GeoLocationPermissions,
-    private val dispatcherProvider: DispatcherProvider,
-    private val settingsDataStore: SettingsDataStore,
-    private val pixel: Pixel
+    private val locationPermissionsRepository: Provider<LocationPermissionsRepository>,
+    private val geoLocationPermissions: Provider<GeoLocationPermissions>,
+    private val dispatcherProvider: Provider<DispatcherProvider>,
+    private val settingsDataStore: Provider<SettingsDataStore>,
+    private val pixel: Provider<Pixel>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(LocationPermissionsViewModel::class.java) -> (LocationPermissionsViewModel(locationPermissionsRepository, geoLocationPermissions, dispatcherProvider, settingsDataStore, pixel) as T)
+                isAssignableFrom(LocationPermissionsViewModel::class.java) -> (LocationPermissionsViewModel(locationPermissionsRepository.get(), geoLocationPermissions.get(), dispatcherProvider.get(), settingsDataStore.get(), pixel.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
@@ -29,6 +29,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
 import kotlinx.coroutines.launch
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class OnboardingViewModel(
@@ -64,23 +65,23 @@ class OnboardingViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideOnboardingViewModelFactory(
-        userStageStore: UserStageStore,
-        pageLayoutManager: OnboardingPageManager,
-        dispatchers: DispatcherProvider
+        userStageStore: Provider<UserStageStore>,
+        pageLayoutManager: Provider<OnboardingPageManager>,
+        dispatchers: Provider<DispatcherProvider>
     ): ViewModelFactoryPlugin {
         return OnboardingViewModelFactory(userStageStore, pageLayoutManager, dispatchers)
     }
 }
 
 private class OnboardingViewModelFactory(
-    private val userStageStore: UserStageStore,
-    private val pageLayoutManager: OnboardingPageManager,
-    private val dispatchers: DispatcherProvider
+    private val userStageStore: Provider<UserStageStore>,
+    private val pageLayoutManager: Provider<OnboardingPageManager>,
+    private val dispatchers: Provider<DispatcherProvider>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(OnboardingViewModel::class.java) -> (OnboardingViewModel(userStageStore, pageLayoutManager, dispatchers) as T)
+                isAssignableFrom(OnboardingViewModel::class.java) -> (OnboardingViewModel(userStageStore.get(), pageLayoutManager.get(), dispatchers.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
@@ -29,6 +29,7 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class DefaultBrowserPageViewModel(
@@ -209,23 +210,23 @@ class DefaultBrowserPageViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideDefaultBrowserPageViewModelFactory(
-        defaultBrowserDetector: DefaultBrowserDetector,
-        pixel: Pixel,
-        installStore: AppInstallStore
+        defaultBrowserDetector: Provider<DefaultBrowserDetector>,
+        pixel: Provider<Pixel>,
+        installStore: Provider<AppInstallStore>
     ): ViewModelFactoryPlugin {
         return DefaultBrowserPageViewModelFactory(defaultBrowserDetector, pixel, installStore)
     }
 }
 
 private class DefaultBrowserPageViewModelFactory(
-    private val defaultBrowserDetector: DefaultBrowserDetector,
-    private val pixel: Pixel,
-    private val installStore: AppInstallStore
+    private val defaultBrowserDetector: Provider<DefaultBrowserDetector>,
+    private val pixel: Provider<Pixel>,
+    private val installStore: Provider<AppInstallStore>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(DefaultBrowserPageViewModel::class.java) -> (DefaultBrowserPageViewModel(defaultBrowserDetector, pixel, installStore) as T)
+                isAssignableFrom(DefaultBrowserPageViewModel::class.java) -> (DefaultBrowserPageViewModel(defaultBrowserDetector.get(), pixel.get(), installStore.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
@@ -44,6 +44,7 @@ import dagger.multibindings.IntoSet
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class PrivacyDashboardViewModel(
@@ -212,23 +213,23 @@ class PrivacyDashboardViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun providePrivacyDashboardViewModelFactory(
-        userWhitelistDao: UserWhitelistDao,
-        networkLeaderboardDao: NetworkLeaderboardDao,
-        pixel: Pixel
+        userWhitelistDao: Provider<UserWhitelistDao>,
+        networkLeaderboardDao: Provider<NetworkLeaderboardDao>,
+        pixel: Provider<Pixel>
     ): ViewModelFactoryPlugin {
         return PrivacyDashboardViewModelFactory(userWhitelistDao, networkLeaderboardDao, pixel)
     }
 }
 
 private class PrivacyDashboardViewModelFactory(
-    private val userWhitelistDao: UserWhitelistDao,
-    private val networkLeaderboardDao: NetworkLeaderboardDao,
-    private val pixel: Pixel
+    private val userWhitelistDao: Provider<UserWhitelistDao>,
+    private val networkLeaderboardDao: Provider<NetworkLeaderboardDao>,
+    private val pixel: Provider<Pixel>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(PrivacyDashboardViewModel::class.java) -> PrivacyDashboardViewModel(userWhitelistDao, networkLeaderboardDao, pixel) as T
+                isAssignableFrom(PrivacyDashboardViewModel::class.java) -> PrivacyDashboardViewModel(userWhitelistDao.get(), networkLeaderboardDao.get(), pixel.get()) as T
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesViewModel.kt
@@ -79,7 +79,7 @@ class PrivacyPracticesViewModelFactoryModule {
     }
 }
 
-private class PrivacyPracticesViewModelFactory() : ViewModelFactoryPlugin {
+private class PrivacyPracticesViewModelFactory : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardViewModel.kt
@@ -36,6 +36,7 @@ import dagger.Provides
 import dagger.multibindings.IntoSet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class ScorecardViewModel(
@@ -121,18 +122,18 @@ class ScorecardViewModelFactoryModule {
     @Provides
     @Singleton
     @IntoSet
-    fun provideScorecardViewModelFactory(userWhitelistDao: UserWhitelistDao): ViewModelFactoryPlugin {
+    fun provideScorecardViewModelFactory(userWhitelistDao: Provider<UserWhitelistDao>): ViewModelFactoryPlugin {
         return ScorecardViewModelFactory(userWhitelistDao)
     }
 }
 
 private class ScorecardViewModelFactory(
-    private val userWhitelistDao: UserWhitelistDao,
+    private val userWhitelistDao: Provider<UserWhitelistDao>,
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(ScorecardViewModel::class.java) -> ScorecardViewModel(userWhitelistDao) as T
+                isAssignableFrom(ScorecardViewModel::class.java) -> ScorecardViewModel(userWhitelistDao.get()) as T
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksViewModel.kt
@@ -104,7 +104,7 @@ class TrackerNetworksViewModelFactoryModule {
     }
 }
 
-private class TrackerNetworksViewModelFactory() : ViewModelFactoryPlugin {
+private class TrackerNetworksViewModelFactory : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/WhitelistViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/WhitelistViewModel.kt
@@ -36,6 +36,7 @@ import dagger.multibindings.IntoSet
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class WhitelistViewModel(
@@ -133,19 +134,19 @@ class WhitelistViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideWhitelistViewModelFactory(
-        dao: UserWhitelistDao
+        dao: Provider<UserWhitelistDao>
     ): ViewModelFactoryPlugin {
         return WhitelistViewModelFactory(dao)
     }
 }
 
 private class WhitelistViewModelFactory(
-    private val dao: UserWhitelistDao
+    private val dao: Provider<UserWhitelistDao>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(WhitelistViewModel::class.java) -> (WhitelistViewModel(dao) as T)
+                isAssignableFrom(WhitelistViewModel::class.java) -> (WhitelistViewModel(dao.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -42,6 +42,7 @@ import dagger.Provides
 import dagger.multibindings.IntoSet
 import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class SettingsViewModel @Inject constructor(
@@ -251,27 +252,27 @@ class SettingsViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideSettingsViewModelFactory(
-        settingsDataStore: SettingsDataStore,
-        defaultWebBrowserCapability: DefaultBrowserDetector,
-        variantManager: VariantManager,
-        fireAnimationLoader: FireAnimationLoader,
-        pixel: Pixel
+        settingsDataStore: Provider<SettingsDataStore>,
+        defaultWebBrowserCapability: Provider<DefaultBrowserDetector>,
+        variantManager: Provider<VariantManager>,
+        fireAnimationLoader: Provider<FireAnimationLoader>,
+        pixel: Provider<Pixel>
     ): ViewModelFactoryPlugin {
         return SettingsViewModelFactory(settingsDataStore, defaultWebBrowserCapability, variantManager, fireAnimationLoader, pixel)
     }
 }
 
 private class SettingsViewModelFactory(
-    private val settingsDataStore: SettingsDataStore,
-    private val defaultWebBrowserCapability: DefaultBrowserDetector,
-    private val variantManager: VariantManager,
-    private val fireAnimationLoader: FireAnimationLoader,
-    private val pixel: Pixel
+    private val settingsDataStore: Provider<SettingsDataStore>,
+    private val defaultWebBrowserCapability: Provider<DefaultBrowserDetector>,
+    private val variantManager: Provider<VariantManager>,
+    private val fireAnimationLoader: Provider<FireAnimationLoader>,
+    private val pixel: Provider<Pixel>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(SettingsViewModel::class.java) -> (SettingsViewModel(settingsDataStore, defaultWebBrowserCapability, variantManager, fireAnimationLoader, pixel) as T)
+                isAssignableFrom(SettingsViewModel::class.java) -> (SettingsViewModel(settingsDataStore.get(), defaultWebBrowserCapability.get(), variantManager.get(), fireAnimationLoader.get(), pixel.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyViewModel.kt
@@ -38,6 +38,7 @@ import dagger.multibindings.IntoSet
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class SurveyViewModel(
@@ -123,23 +124,23 @@ class SurveyViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideSurveyViewModelFactory(
-        surveyDao: SurveyDao,
-        statisticsStore: StatisticsDataStore,
-        appInstallStore: AppInstallStore,
+        surveyDao: Provider<SurveyDao>,
+        statisticsStore: Provider<StatisticsDataStore>,
+        appInstallStore: Provider<AppInstallStore>
     ): ViewModelFactoryPlugin {
         return SurveyViewModelFactory(surveyDao, statisticsStore, appInstallStore)
     }
 }
 
 private class SurveyViewModelFactory(
-    private val surveyDao: SurveyDao,
-    private val statisticsStore: StatisticsDataStore,
-    private val appInstallStore: AppInstallStore
+    private val surveyDao: Provider<SurveyDao>,
+    private val statisticsStore: Provider<StatisticsDataStore>,
+    private val appInstallStore: Provider<AppInstallStore>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(SurveyViewModel::class.java) -> (SurveyViewModel(surveyDao, statisticsStore, appInstallStore) as T)
+                isAssignableFrom(SurveyViewModel::class.java) -> (SurveyViewModel(surveyDao.get(), statisticsStore.get(), appInstallStore.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
+import javax.inject.Provider
 import javax.inject.Singleton
 
 data class SystemSearchResult(val autocomplete: AutoCompleteResult, val deviceApps: List<DeviceApp>)
@@ -266,25 +267,25 @@ class SystemSearchViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideSystemSearchViewModelFactory(
-        userStageStore: UserStageStore,
-        autoCompleteApi: AutoCompleteApi,
-        deviceAppLookup: DeviceAppLookup,
-        pixel: Pixel,
+        userStageStore: Provider<UserStageStore>,
+        autoCompleteApi: Provider<AutoCompleteApi>,
+        deviceAppLookup: Provider<DeviceAppLookup>,
+        pixel: Provider<Pixel>
     ): ViewModelFactoryPlugin {
         return SystemSearchViewModelFactory(userStageStore, autoCompleteApi, deviceAppLookup, pixel)
     }
 }
 
 private class SystemSearchViewModelFactory(
-    private val userStageStore: UserStageStore,
-    private val autoComplete: AutoComplete,
-    private val deviceAppLookup: DeviceAppLookup,
-    private val pixel: Pixel
+    private val userStageStore: Provider<UserStageStore>,
+    private val autoComplete: Provider<AutoCompleteApi>,
+    private val deviceAppLookup: Provider<DeviceAppLookup>,
+    private val pixel: Provider<Pixel>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(SystemSearchViewModel::class.java) -> (SystemSearchViewModel(userStageStore, autoComplete, deviceAppLookup, pixel) as T)
+                isAssignableFrom(SystemSearchViewModel::class.java) -> (SystemSearchViewModel(userStageStore.get(), autoComplete.get(), deviceAppLookup.get(), pixel.get()) as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -32,6 +32,7 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
+import javax.inject.Provider
 import javax.inject.Singleton
 
 class TabSwitcherViewModel(private val tabRepository: TabRepository, private val webViewSessionStorage: WebViewSessionStorage) : ViewModel() {
@@ -87,21 +88,21 @@ class TabSwitcherViewModelFactoryModule {
     @Singleton
     @IntoSet
     fun provideTabSwitcherViewModelFactory(
-        tabRepository: TabRepository,
-        webViewSessionStorage: WebViewSessionStorage
+        tabRepository: Provider<TabRepository>,
+        webViewSessionStorage: Provider<WebViewSessionStorage>
     ): ViewModelFactoryPlugin {
         return TabSwitcherViewModelFactory(tabRepository, webViewSessionStorage)
     }
 }
 
 private class TabSwitcherViewModelFactory(
-    private val tabRepository: TabRepository,
-    private val webViewSessionStorage: WebViewSessionStorage
+    private val tabRepository: Provider<TabRepository>,
+    private val webViewSessionStorage: Provider<WebViewSessionStorage>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(TabSwitcherViewModel::class.java) -> TabSwitcherViewModel(tabRepository, webViewSessionStorage) as T
+                isAssignableFrom(TabSwitcherViewModel::class.java) -> TabSwitcherViewModel(tabRepository.get(), webViewSessionStorage.get()) as T
                 else -> null
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/30173902528854/1200098175084894/f
Tech Design URL: 
CC: 

**Description**:
https://github.com/duckduckgo/Android/pull/1123 introduced a bug that was detected by our pixels.

* That pull request delegated the creation of the view models (VMs) to its own factory
* The VM factories are `singleton` -- as they should be
* The VM factories create the VMs and inject their dependencies
* Because the VM factories are `singleton` that effectively makes all VM dependencies `singleton`. Regardless of whether they are actually declare as such or not
* This is not desired, VM factories thouls be singleton, but it should respect the di semantics of its deps

This PR makes all the factories to provide `providers` of the dependencies, rather than the actual instance. So that they respect how the instances declare themselves when injected, ie. `singleton` or multiple instances.


In particular, the effects can be seen with the `fw_` pixels. They are fired multiple times (one per fragment) when they should fire only once.

**Steps to test this PR**:
1. App compiles
2. install/upgrade the app from this branch
3. use the SERP to perform searches
4. form the SERP, open several tabs
5. add/remove bookmarks
6. add/remove fireproof sites
7. navigate to settings screen
8. use fire button
10. clear app data and go through onboarding UX
11. for all above, verify app works as expected


1. install/upgrade from this branch
2. open several tabs and ensure they are active
3. ensure `Ask When Signing In` is enabled inside `settings -> fireproof sites`
4. open a new tab and log into facebook.com (or any other login you may want)
5. verify the dialog to fireproof the site appears
6. navigate to any other of the active tabs
7. verify no dialog appears
8. verify `m_fw_xx` are only shown once



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
