### PR TITLE
Return to previous tab for back navigation after "Web search" on a new tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -231,7 +231,15 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
                 launch { viewModel.onOpenShortcut(sharedText) }
             } else {
                 Timber.w("opening in new tab requested for $sharedText")
-                launch { viewModel.onOpenInNewTabRequested(query = sharedText, skipHome = true) }
+                val sourceTabId =
+                    if (intent.action == null && currentTab?.tabUrl != null)
+                        currentTab?.tabId
+                    else
+                    // Do not set sourceTabId for external intents which usually has
+                    // non-null action, or for empty current tab which will be removed
+                    // before the new tab is added.
+                        null
+                launch { viewModel.onOpenInNewTabRequested(query = sharedText, sourceTabId = sourceTabId, skipHome = true) }
                 return
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -192,6 +192,8 @@ class BrowserTabFragment :
 
     val tabId get() = requireArguments()[TAB_ID_ARG] as String
 
+    val tabUrl get() = viewModel.url
+
     @Inject
     lateinit var userAgentProvider: UserAgentProvider
 


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL: 
CC: 

**Description**:
Pass the current tab id to onOpenInNewTabRequested function when performing web search on a new tab.
- Does not set sourceTabId if the current tab url is null. This is to prevent failure on opening the new tab when the sourceTab is empty and removed before the new tab is added.
- Does not set sourceTabId if the intent has non-null action. This is to differentiate opening external link, which should not have a sourceTabId.

**Steps to test this PR**:
For external links:
1. Open the browser.
2. Open a new tab.
3. Exit the browser by pressing home.
4. Click on an external link.
5. Browser loads the new site.

For "Web search" in browser:
1. Open a webpage and perform "Web search" on this tab, consider this as tab 1.
2. On the new tab created by "Web search", press back.
3. The current tab should close. The user will be seeing the tab1.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
