### PR TITLE
Czech - Fixed translation of 'Light Theme'

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -155,7 +155,7 @@
     <string name="settingsHeadingGeneral">Obecné</string>
     <string name="settingsHeadingOther">Jiné</string>
     <string name="settingsHeadingPrivacy">Soukromí</string>
-    <string name="settingsLightTheme">Lehký motiv</string>
+    <string name="settingsLightTheme">Světlý motiv</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGo</string>
     <string name="settingsVersion">Verze</string>
     <string name="leaveFeedback">Podělte se o zpětnou vazbu</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->
**Description**:
Czech translation of "Light theme" is wrong. The word "Lehký" is being used when something is not heavy (it's related to weight and not to brightness). The proper translation is "Světlý".
