### PR TITLE
Sanitize Intent in BrowserActivity.onCreate(), same as in onNewIntent()

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -104,6 +104,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
     @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.daggerInject()
+        intent?.sanitize()
         Timber.i("onCreate called. freshAppLaunch: ${dataClearer.isFreshAppLaunch}, savedInstanceState: $savedInstanceState")
         dataClearerForegroundAppRestartPixel.registerIntent(intent)
         renderer = BrowserStateRenderer()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1184175637619353/f
Tech Design URL: 
CC: 

**Description**:
Adds call to sanitise `Intent` in the `BrowserActivity.onCreate()` function

**Steps to test this PR**:
1. Same steps to test as in #953, use the snippet provided [here](https://github.com/duckduckgo/Android/issues/953#issuecomment-712151654) and verify no crash happens


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
