### PR TITLE
Fix Swipe To Refresh On NTP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -487,6 +487,7 @@ class BrowserTabFragment :
         appBarLayout.setExpanded(true)
         webView?.onPause()
         webView?.hide()
+        swipeRefreshContainer.isEnabled = false
         homeBackgroundLogo.showLogo()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/1162


**Description**:
Fixed by disabling swipeRefreshContainer at home

Resolves: #1162


**Steps to test this PR**:
1. Open new tab 
2. Visit any site
3. Press back (this will go back to the home tab)
4. Now user will not be able to pull to refresh


