### PR TITLE
Fixed Czech translation for two menu items

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -33,7 +33,7 @@
     <string name="clearButtonContentDescription">Vymazat vyhledávací vstup</string>
     <string name="no_compatible_third_party_app_installed">Nebyla nainstalována žádná kompatibilní aplikace</string>
     <string name="addBookmarkMenuTitle">Přidat záložku</string>
-    <string name="requestDesktopSiteMenuTitle">Stránka plochy</string>
+    <string name="requestDesktopSiteMenuTitle">Verze pro počítač</string>
 
     <!-- Downloading files -->
     <string name="downloadImage">Stáhnout obrázek</string>
@@ -468,7 +468,7 @@
     <!-- Fireproof websites -->
     <string name="fireproofWebsitesActivityTitle">Weby s ochranou</string>
     <string name="settingsFireproofWebsites">Weby s ochranou</string>
-    <string name="fireproofWebsiteMenuTitleAdd">Web s ochranou</string>
+    <string name="fireproofWebsiteMenuTitleAdd">Ochránit web</string>
     <string name="fireproofWebsiteSnackbarConfirmation">&lt;b&gt;%1$s&lt;/b&gt;je nyní chráněný! Pro správu navštivte Nastavení.</string>
     <string name="fireproofWebsiteSnackbarAction">Vrátit</string>
     <string name="fireproofWebsiteDeleteConfirmMessage">Opravdu chcete smazat &lt;b&gt;%1$s&lt;/b&gt;?</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

**Description**:
This PR improves/fixes the translation of two menu items in the Czech language. Namely:

- `requestDesktopSiteMenuTitle` - "Stránka plochy" means pretty much nothing and the purpose of this menu items is not clear at all. I've changed it to "Verze pro počítač". It is the same string firefox uses in it's mobile web browser and it is actually understandable.
- `fireproofWebsiteMenuTitleAdd` - "Web s ochranou" is good, but I also feel like it is not clear and doesn't describe an action (the English version does). That is why I've changed it to "Ochránit web" which is an action.

Initially I also wanted to fix `settingsLightTheme`, but someone was a bit quicker than me 😃 