### PR TITLE
Pull to refresh sensitivity fix

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1674,7 +1674,6 @@ class BrowserTabFragment :
 
                 if (!viewState.isLoading && lastSeenBrowserViewState?.browserShowing == true) {
                     swipeRefreshContainer.isRefreshing = false
-                    webView?.detectOverscrollBehavior()
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -105,7 +105,7 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild {
 
                 if (canSwipeToRefresh && scrollY == 0 && lastClampedTopY && nestedOffsetY == 0) {
                     // we are on a new gesture, have reached the top, are clamped vertically and nestedScrollY is done too -> enable swipeRefresh (by default always disabled)
-                    enableSwipeRefresh(true)
+                    //enableSwipeRefresh(true)
                 }
 
                 lastDeltaY = deltaY

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -103,11 +103,6 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild {
                     lastY -= scrollOffset[1]
                 }
 
-                if (canSwipeToRefresh && scrollY == 0 && lastClampedTopY && nestedOffsetY == 0) {
-                    // we are on a new gesture, have reached the top, are clamped vertically and nestedScrollY is done too -> enable swipeRefresh (by default always disabled)
-                    //enableSwipeRefresh(true)
-                }
-
                 lastDeltaY = deltaY
             }
 
@@ -174,16 +169,6 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild {
 
     fun setEnableSwipeRefreshCallback(callback: (Boolean) -> Unit) {
         enableSwipeRefreshCallback = callback
-    }
-
-    /**
-     * Allows us to determine whether to (de)activate Swipe to Refresh behavior for the current page content, e.g. if page implements a swipe behavior of its
-     * own already (see twitter.com).
-     */
-    fun detectOverscrollBehavior() {
-        evaluateJavascript("(function() { return getComputedStyle(document.querySelector('body')).overscrollBehaviorY; })();") { behavior ->
-            setContentAllowsSwipeToRefresh(behavior.replace("\"", "") == "auto")
-        }
     }
 
     private fun enableSwipeRefresh(enable: Boolean) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1125189844075764/1200092328111314/1200200821708976
Tech Design URL: 
CC: 

**Description**:
This PR fixes some bug reports where pull to refresh is triggered incorrectly while scrolling on a map or some other interactive content. This also can happen if the site has its own toolbar. This PR fixes https://github.com/duckduckgo/Android/issues/1132

**Steps to test this PR**:
1. Visit some of the following problematic sites. With the prod app pull to refresh should be triggered very easily whereas with this branch that should not happen:
- SERP with a map search.
- https://makecode.microbit.org/projects/guitar/displaybuttons
- https://www.openstreetmap.org/
- https://tiktok.com
- https://www.walmart.com/grocery/


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
