### PR TITLE
Fix fire animation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -20,6 +20,8 @@ import android.animation.Animator
 import android.animation.ValueAnimator
 import android.content.Context
 import android.os.Bundle
+import android.provider.Settings
+import android.provider.Settings.Global.ANIMATOR_DURATION_SCALE
 import androidx.core.content.ContextCompat
 import androidx.core.view.doOnDetach
 import androidx.core.view.isVisible
@@ -140,7 +142,12 @@ class FireDialog(
         }
     }
 
-    private fun animationEnabled() = settingsDataStore.fireAnimationEnabled
+    private fun animationEnabled() = settingsDataStore.fireAnimationEnabled && animatorDurationEnabled()
+
+    private fun animatorDurationEnabled(): Boolean {
+        val animatorScale = Settings.Global.getFloat(context.contentResolver, ANIMATOR_DURATION_SCALE, 1.0f)
+        return animatorScale != 0.0f
+    }
 
     private fun playAnimation() {
         window?.navigationBarColor = ContextCompat.getColor(context, R.color.black)

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -145,7 +145,7 @@ class FireDialog(
     private fun animationEnabled() = settingsDataStore.fireAnimationEnabled && animatorDurationEnabled()
 
     private fun animatorDurationEnabled(): Boolean {
-        val animatorScale = Settings.Global.getFloat(context.contentResolver, ANIMATOR_DURATION_SCALE, 1.0f)
+        val animatorScale = Settings.Global.getFloat(context.contentResolver, ANIMATOR_DURATION_SCALE, 0.0f)
         return animatorScale != 0.0f
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/1159
Tech Design URL:
CC:

**Description**:
When we check that the animation is enabled we can also check that the animator duration scale is set, if it is set to 0 then we skip the animation.

**Steps to test this PR**:
1. Set `Animator duration scale` to `Animation off`
2. Select `Clear all tabs and data`. 
3. Now we skip the animation unlike previously where we would get stuck on a black screen.
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
