### PR TITLE
UOA experiment 2nd iteration

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -47,14 +47,14 @@ class VariantManagerTest {
     @Test
     fun inBrowserControlVariantHasExpectedWeightAndNoFeatures() {
         val variant = variants.first { it.key == "ma" }
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
     fun inBrowserSecondControlVariantHasExpectedWeightAndRemoveDay1And3NotificationsAndKillOnboardingFeatures() {
         val variant = variants.first { it.key == "mb" }
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(2, variant.features.size)
         assertTrue(variant.hasFeature(KillOnboarding))
         assertTrue(variant.hasFeature(RemoveDay1AndDay3Notifications))
@@ -63,10 +63,26 @@ class VariantManagerTest {
     @Test
     fun inBrowserInAppUsageVariantHasExpectedWeightAndRemoveDay1And3NotificationsAndKillOnboardingAndInAppUsageFeatures() {
         val variant = variants.first { it.key == "mc" }
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(3, variant.features.size)
         assertTrue(variant.hasFeature(KillOnboarding))
         assertTrue(variant.hasFeature(RemoveDay1AndDay3Notifications))
+        assertTrue(variant.hasFeature(InAppUsage))
+    }
+
+    @Test
+    fun newInBrowserControlVariantHasExpectedWeightAndNoFeatures() {
+        val variant = variants.first { it.key == "zx" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(0, variant.features.size)
+    }
+
+    @Test
+    fun newInBrowserInAppUsageVariantHasExpectedWeightAndKillOnboardingAndInAppUsageFeatures() {
+        val variant = variants.first { it.key == "zy" }
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(2, variant.features.size)
+        assertTrue(variant.hasFeature(KillOnboarding))
         assertTrue(variant.hasFeature(InAppUsage))
     }
 

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -22,6 +22,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.work.WorkManager
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
+import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.duckduckgo.app.notification.NotificationFactory
 import com.duckduckgo.app.notification.NotificationScheduler
@@ -92,14 +93,16 @@ class NotificationModule {
         clearDataNotification: ClearDataNotification,
         privacyProtectionNotification: PrivacyProtectionNotification,
         useOurAppNotification: UseOurAppNotification,
-        variantManager: VariantManager
+        variantManager: VariantManager,
+        appInstallStore: AppInstallStore
     ): AndroidNotificationScheduler {
         return NotificationScheduler(
             workManager,
             clearDataNotification,
             privacyProtectionNotification,
             useOurAppNotification,
-            variantManager
+            variantManager,
+            appInstallStore
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -64,7 +64,7 @@ class NotificationScheduler(
         if (variant().hasFeature(VariantManager.VariantFeature.InAppUsage) && useOurAppNotification.canShow()) {
             val operation = scheduleUniqueNotification(
                 OneTimeWorkRequestBuilder<UseOurAppNotificationWorker>(),
-                UOA_DURATION,
+                UOA_DELAY_DURATION_IN_DAYS,
                 TimeUnit.DAYS,
                 USE_OUR_APP_WORK_REQUEST_TAG
             )
@@ -81,11 +81,11 @@ class NotificationScheduler(
 
         when {
             (!variant().hasFeature(VariantManager.VariantFeature.RemoveDay1AndDay3Notifications) && privacyNotification.canShow()) -> {
-                val duration = getDurationForInactiveNotification(PRIVACY_DURATION)
+                val duration = getDurationForInactiveNotification(PRIVACY_DELAY_DURATION_IN_DAYS)
                 scheduleNotification(OneTimeWorkRequestBuilder<PrivacyNotificationWorker>(), duration, TimeUnit.DAYS, UNUSED_APP_WORK_REQUEST_TAG)
             }
             (!variant().hasFeature(VariantManager.VariantFeature.RemoveDay1AndDay3Notifications) && clearDataNotification.canShow()) -> {
-                val duration = getDurationForInactiveNotification(CLEAR_DATA_DURATION)
+                val duration = getDurationForInactiveNotification(CLEAR_DATA_DELAY_DURATION_IN_DAYS)
                 scheduleNotification(OneTimeWorkRequestBuilder<ClearDataNotificationWorker>(), duration, TimeUnit.DAYS, UNUSED_APP_WORK_REQUEST_TAG)
             }
             else -> Timber.v("Notifications not enabled for this variant")
@@ -96,7 +96,7 @@ class NotificationScheduler(
     fun getDurationForInactiveNotification(day: Long): Long {
         Timber.d("Inactive notification days installed is ${appInstallStore.daysInstalled()} day is $day")
         var duration = day
-        if (variantHasInAppUsage() && (appInstallStore.daysInstalled() + day) == UOA_DURATION) {
+        if (variantHasInAppUsage() && (appInstallStore.daysInstalled() + day) == UOA_DELAY_DURATION_IN_DAYS) {
             duration += 1
         }
         return duration
@@ -164,9 +164,9 @@ class NotificationScheduler(
     companion object {
         const val UNUSED_APP_WORK_REQUEST_TAG = "com.duckduckgo.notification.schedule"
         const val USE_OUR_APP_WORK_REQUEST_TAG = "com.duckduckgo.notification.useOurApp"
-        const val UOA_DURATION = 3L
-        const val CLEAR_DATA_DURATION = 3L
-        const val PRIVACY_DURATION = 1L
+        const val UOA_DELAY_DURATION_IN_DAYS = 3L
+        const val CLEAR_DATA_DELAY_DURATION_IN_DAYS = 3L
+        const val PRIVACY_DELAY_DURATION_IN_DAYS = 1L
     }
 }
 

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -47,9 +47,12 @@ interface VariantManager {
             Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
 
             // InAppUsage Experiments
-            Variant(key = "ma", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),
-            Variant(key = "mb", weight = 1.0, features = listOf(VariantFeature.KillOnboarding, VariantFeature.RemoveDay1AndDay3Notifications), filterBy = { isEnglishLocale() }),
-            Variant(key = "mc", weight = 1.0, features = listOf(VariantFeature.KillOnboarding, VariantFeature.InAppUsage, VariantFeature.RemoveDay1AndDay3Notifications), filterBy = { isEnglishLocale() })
+            Variant(key = "ma", weight = 0.0, features = emptyList(), filterBy = { isEnglishLocale() }),
+            Variant(key = "mb", weight = 0.0, features = listOf(VariantFeature.KillOnboarding, VariantFeature.RemoveDay1AndDay3Notifications), filterBy = { isEnglishLocale() }),
+            Variant(key = "mc", weight = 0.0, features = listOf(VariantFeature.KillOnboarding, VariantFeature.InAppUsage, VariantFeature.RemoveDay1AndDay3Notifications), filterBy = { isEnglishLocale() }),
+
+            Variant(key = "zx", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),
+            Variant(key = "zy", weight = 1.0, features = listOf(VariantFeature.KillOnboarding, VariantFeature.InAppUsage), filterBy = { isEnglishLocale() })
         )
 
         val REFERRER_VARIANTS = listOf(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1125189844075764/1200252649107473/1200229532781040
Tech Design URL: 
CC: 

**Description**:
This PR disabled the previous experiment and creates two new variants. The experimental variant now enables all the inactive notification as long as the don't clash with the UOA notification. If that's the case we delay the inactive notification by one day.

**Before testing**
In the `AndroidNotificationScheduler` change lines `85` and `89` so they pass `TimeUnit.SECONDS` instead of days.
 
In the `AndroidNotificationScheduler` change line 102 to `return duration * 10` to give the notification more than 1 second to be sent.

**Steps to test this PR**:
**ZY experimental variant**
Change the variant to always use `zy`

**Day 0**
1. Before installing the app change the line 39 in `AppInstallStore` to return 0
1. Install the app and launch it
1. In the logcat, if you filter by `notification`you should see
1. `Inactive notification days installed is 0 day is 1`
1. `Scheduling notification for 10` -> scheduled for 1 day later
1. After 10 seconds the notification should show up
1. Dismiss the notification and bring the app to the foreground
1. Bring the app back to the foreground
1. In the logcat, if you filter by `notification`you should see
1. `Inactive notification days installed is 0 day is 3`
1. `Scheduling notification for 40` -> scheduled for 4 days later
1. After 40 seconds the notification should show up

**Day 2**
1. Before installing the app change the line 39 in `AppInstallStore` to return 2
1. Install the app and launch it
1. In the logcat, if you filter by `notification`you should see
1. `Inactive notification days installed is 2 day is 1`
1. `Scheduling notification for 20` -> scheduled for 2 days later
1. After 20 seconds the notification should show up
1. Dismiss the notification and bring the app to the foreground
1. Bring the app back to the foreground
1. In the logcat, if you filter by `notification`you should see
1. `Inactive notification days installed is 2 day is 3`
1. `Scheduling notification for 30` -> scheduled for 3 days later
1. After 30 seconds the notification should show up

Testing any other days (step 1) should always return 10 for the privacy notification and 30 for the clear data notification since those notification cannot clash with the UOA notification out of day 0 and 2.

**ZX experimental variant**
Change the variant to always use `zx`

**Day 0**
1. Before installing the app change the line 39 in `AppInstallStore` to return 0
1. Install the app and launch it
1. In the logcat, if you filter by `notification`you should see
1. `Inactive notification days installed is 0 day is 1`
1. `Scheduling notification for 10` -> scheduled for 1 day later
1. After 10 seconds the notification should show up
1. Dismiss the notification and bring the app to the foreground
1. Bring the app back to the foreground
1. In the logcat, if you filter by `notification`you should see
1. `Inactive notification days installed is 0 day is 3`
1. `Scheduling notification for 30` -> scheduled for 3 days later 
1. After 40 seconds the notification should show up

**Day 2**
1. Before installing the app change the line 39 in `AppInstallStore` to return 2
1. Install the app and launch it
1. In the logcat, if you filter by `notification`you should see
1. `Inactive notification days installed is 2 day is 1`
1. `Scheduling notification for 10` -> scheduled for 1 day later
1. After 20 seconds the notification should show up
1. Dismiss the notification and bring the app to the foreground
1. Bring the app back to the foreground
1. In the logcat, if you filter by `notification`you should see
1. `Inactive notification days installed is 2 day is 3`
1. `Scheduling notification for 30` -> scheduled for 3 days later
1. After 30 seconds the notification should show up

Testing any other days (step 1) should always return 10 for the privacy notification and 30 for the clear data notification since those notification cannot clash with the UOA notification out of day 0 and 2.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
