### PR TITLE
Fix: avoid disabling animation if no value provided

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -145,7 +145,7 @@ class FireDialog(
     private fun animationEnabled() = settingsDataStore.fireAnimationEnabled && animatorDurationEnabled()
 
     private fun animatorDurationEnabled(): Boolean {
-        val animatorScale = Settings.Global.getFloat(context.contentResolver, ANIMATOR_DURATION_SCALE, 0.0f)
+        val animatorScale = Settings.Global.getFloat(context.contentResolver, ANIMATOR_DURATION_SCALE, 1.0f)
         return animatorScale != 0.0f
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200266002668723/f
Tech Design URL: 
CC: 

**Description**:
This PR avoids disabling fire animations if no value provided from global settings. In that case we will assume is active.


**Steps to test this PR**:
1. Disable scale animation on dev settings
1. Fire Animation should not be triggered when clearing data
2. Enable scale animation on dev settings
3. Fire Animation should be triggered when clearing data


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
