### PR TITLE
Replaced lifecycle-extensions by specific artifacts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -160,9 +160,9 @@ dependencies {
     implementation AndroidX.fragmentKtx
 
     // ViewModel and LiveData
-    implementation AndroidX.lifecycle.extensions
     implementation AndroidX.lifecycle.viewModelKtx
     implementation AndroidX.lifecycle.liveDataKtx
+    implementation AndroidX.lifecycle.process
 
     implementation  AndroidX.lifecycle.commonJava8
     testImplementation AndroidX.archCore.testing

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation KotlinX.coroutines.android
 
     implementation AndroidX.work.runtimeKtx
+    implementation AndroidX.lifecycle.viewModelKtx
 
     implementation Google.dagger
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200271718763060/f
Tech Design URL: 
CC: 

**Description**:
The `lifecycle-extensions` artifact is now deprecated, see [docs for more info](https://developer.android.com/jetpack/androidx/releases/lifecycle).

The `lifecycle-extensions` are no longer upgraded and until we don't remove them we wont be able to update the `lifecycle` artifacts.

This PR removes the artifact and, as suggested by the documentation, adds the specific artifacts for view models etc.

We are not updating any version in this PR

**Steps to test this PR**:
This change is safe a lons as the branch compiles, however also check the main features of the app

1. install/upgrade from this branch
2. vefiry navigation, bookmarks, fireproof sites and fire button work as expected

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
