### PR TITLE
Enable gradle local build cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx1536m -XX:+UseParallelGC
+org.gradle.caching=true
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200284402862753/f
Tech Design URL: 
CC: 

**Description**:
Enable the gradle build local cache

Incidentally I have also enabled the parallel GC. I use JDK 14 to compile locally and I realised that parallel GC is not enabled for JDK 9 and above. [See docs for more info](https://developer.android.com/studio/build/optimize-your-build)


**Steps to test this PR**:
1. from `develop` branch
2. execute `./gradlew clean asesmblePlayDebug` twice
3. verify the build time is more or less the same

1. from this branch
2. execute `./gradlew clean asesmblePlayDebug` twice
3. verify the second time around, the build time is way smaller


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
