### PR TITLE
Replace location dialog subtitle copy in requests from our SERP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/location/ui/SiteLocationPermissionDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/location/ui/SiteLocationPermissionDialog.kt
@@ -99,40 +99,40 @@ class SiteLocationPermissionDialog : DialogFragment() {
         super.onDetach()
     }
 
+    private fun getOriginUrl(): String {
+        return requireArguments().getString(KEY_REQUEST_ORIGIN)!!
+    }
+
+    private fun getTabId(): String {
+        return requireArguments().getString(KEY_TAB_ID)!!
+    }
+
+    private fun isEditingPermissions(): Boolean {
+        return requireArguments().getBoolean(KEY_EDITING_PERMISSION)
+    }
+
     private fun populateTitle(title: TextView) {
-        arguments?.let { args ->
-            val originUrl = args.getString(KEY_REQUEST_ORIGIN)!!
-            val dialogTitle = getString(R.string.preciseLocationSiteDialogTitle, originUrl.websiteFromGeoLocationsApiOrigin())
-            title.text = dialogTitle
-        }
+        title.text = getString(R.string.preciseLocationSiteDialogTitle, getOriginUrl().websiteFromGeoLocationsApiOrigin())
     }
 
     private fun populateSubtitle(subtitle: TextView) {
-        arguments?.let { args ->
-            val originUrl = args.getString(KEY_REQUEST_ORIGIN)!!
-            val originDomain = originUrl.websiteFromGeoLocationsApiOrigin()
-            if (originDomain == DDG_DOMAIN) {
-                subtitle.text = getString(R.string.preciseLocationDDGDialogSubtitle)
-            } else {
-                subtitle.text = getString(R.string.preciseLocationSiteDialogSubtitle)
-            }
+        if (getOriginUrl().websiteFromGeoLocationsApiOrigin() == DDG_DOMAIN) {
+            subtitle.text = getString(R.string.preciseLocationDDGDialogSubtitle)
+        } else {
+            subtitle.text = getString(R.string.preciseLocationSiteDialogSubtitle)
         }
     }
 
     private fun populateFavicon(imageView: ImageView) {
-        arguments?.let { args ->
-            val originUrl = args.getString(KEY_REQUEST_ORIGIN)
-            val tabId = args.getString(KEY_TAB_ID, "")
+        val originUrl = getOriginUrl()
+        val tabId = getTabId()
 
-            originUrl?.let { url ->
-                faviconJob?.cancel()
-                faviconJob = this.lifecycleScope.launch {
-                    if (tabId.isNotBlank()) {
-                        faviconManager.loadToViewFromTemp(tabId, url, imageView)
-                    } else {
-                        faviconManager.loadToViewFromPersisted(url, imageView)
-                    }
-                }
+        faviconJob?.cancel()
+        faviconJob = this.lifecycleScope.launch {
+            if (tabId.isNotBlank()) {
+                faviconManager.loadToViewFromTemp(tabId, originUrl, imageView)
+            } else {
+                faviconManager.loadToViewFromPersisted(originUrl, imageView)
             }
         }
     }
@@ -143,25 +143,24 @@ class SiteLocationPermissionDialog : DialogFragment() {
         denyOnce: TextView,
         denyAlways: TextView
     ) {
-        arguments?.let { args ->
-            val originUrl = args.getString(KEY_REQUEST_ORIGIN)!!
-            allowAlways.setOnClickListener {
-                dismiss()
-                listener.onSiteLocationPermissionSelected(originUrl, LocationPermissionType.ALLOW_ALWAYS)
-            }
-            allowOnce.setOnClickListener {
-                dismiss()
-                listener.onSiteLocationPermissionSelected(originUrl, LocationPermissionType.ALLOW_ONCE)
-            }
-            denyOnce.setOnClickListener {
-                dismiss()
-                listener.onSiteLocationPermissionSelected(originUrl, LocationPermissionType.DENY_ONCE)
-            }
-            denyAlways.setOnClickListener {
-                dismiss()
-                listener.onSiteLocationPermissionSelected(originUrl, LocationPermissionType.DENY_ALWAYS)
-            }
+        val originUrl = getOriginUrl()
+        allowAlways.setOnClickListener {
+            dismiss()
+            listener.onSiteLocationPermissionSelected(originUrl, LocationPermissionType.ALLOW_ALWAYS)
         }
+        allowOnce.setOnClickListener {
+            dismiss()
+            listener.onSiteLocationPermissionSelected(originUrl, LocationPermissionType.ALLOW_ONCE)
+        }
+        denyOnce.setOnClickListener {
+            dismiss()
+            listener.onSiteLocationPermissionSelected(originUrl, LocationPermissionType.DENY_ONCE)
+        }
+        denyAlways.setOnClickListener {
+            dismiss()
+            listener.onSiteLocationPermissionSelected(originUrl, LocationPermissionType.DENY_ALWAYS)
+        }
+
     }
 
     private fun hideExtraViews(
@@ -170,23 +169,16 @@ class SiteLocationPermissionDialog : DialogFragment() {
         dividerOne: View,
         dividerTwo: View
     ) {
-        arguments?.let { args ->
-
-            val isEditing = args.getBoolean(KEY_EDITING_PERMISSION)
-            if (isEditing) {
-                dividerOne.gone()
-                dividerTwo.gone()
-                allowOnce.gone()
-                denyOnce.gone()
-            }
+        if (isEditingPermissions()) {
+            dividerOne.gone()
+            dividerTwo.gone()
+            allowOnce.gone()
+            denyOnce.gone()
         }
     }
 
     private fun makeCancellable() {
-        arguments?.let { args ->
-            val isEditing = args.getBoolean(KEY_EDITING_PERMISSION)
-            isCancelable = isEditing
-        }
+        isCancelable = isEditingPermissions()
     }
 
     private fun validateBundleArguments() {
@@ -194,6 +186,18 @@ class SiteLocationPermissionDialog : DialogFragment() {
         val args = requireArguments()
         if (!args.containsKey(KEY_REQUEST_ORIGIN)) {
             throw IllegalArgumentException("Bundle arguments required [KEY_REQUEST_ORIGIN")
+        }
+        if (args.getString(KEY_REQUEST_ORIGIN) == null) {
+            throw IllegalArgumentException("Bundle arguments can't be null [KEY_REQUEST_ORIGIN")
+        }
+        if (!args.containsKey(KEY_TAB_ID)) {
+            throw IllegalArgumentException("Bundle arguments required [KEY_TAB_ID")
+        }
+        if (args.getString(KEY_TAB_ID) == null) {
+            throw IllegalArgumentException("Bundle arguments can't be null [KEY_TAB_ID")
+        }
+        if (!args.containsKey(KEY_EDITING_PERMISSION)) {
+            throw IllegalArgumentException("Bundle arguments required [KEY_EDITING_PERMISSION")
         }
     }
 
@@ -203,6 +207,7 @@ class SiteLocationPermissionDialog : DialogFragment() {
         private const val KEY_REQUEST_ORIGIN = "KEY_REQUEST_ORIGIN"
         private const val KEY_EDITING_PERMISSION = "KEY_SCREEN_FROM"
         private const val KEY_TAB_ID = "TAB_ID"
+
         private const val DDG_DOMAIN = "duckduckgo.com"
 
         fun instance(origin: String, isEditingPermission: Boolean, tabId: String): SiteLocationPermissionDialog {

--- a/app/src/main/java/com/duckduckgo/app/location/ui/SiteLocationPermissionDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/location/ui/SiteLocationPermissionDialog.kt
@@ -41,7 +41,7 @@ class SiteLocationPermissionDialog : DialogFragment() {
     @Inject
     lateinit var faviconManager: FaviconManager
 
-    var faviconJob: Job? = null
+    private var faviconJob: Job? = null
 
     interface SiteLocationPermissionDialogListener {
         fun onSiteLocationPermissionSelected(domain: String, permission: LocationPermissionType)
@@ -71,6 +71,7 @@ class SiteLocationPermissionDialog : DialogFragment() {
         val rootView = layoutInflater.inflate(R.layout.content_site_location_permission_dialog, null)
 
         val title = rootView.find<TextView>(R.id.sitePermissionDialogTitle)
+        val subtitle = rootView.find<TextView>(R.id.sitePermissionDialogSubtitle)
         val favicon = rootView.find<ImageView>(R.id.sitePermissionDialogFavicon)
         val allowAlways = rootView.find<TextView>(R.id.siteAllowAlwaysLocationPermission)
         val allowOnce = rootView.find<TextView>(R.id.siteAllowOnceLocationPermission)
@@ -84,6 +85,7 @@ class SiteLocationPermissionDialog : DialogFragment() {
 
         validateBundleArguments()
         populateTitle(title)
+        populateSubtitle(subtitle)
         populateFavicon(favicon)
         configureListeners(allowAlways, allowOnce, denyOnce, denyAlways)
         hideExtraViews(allowOnce, denyOnce, extraDivider, anotherDivider)
@@ -102,6 +104,18 @@ class SiteLocationPermissionDialog : DialogFragment() {
             val originUrl = args.getString(KEY_REQUEST_ORIGIN)!!
             val dialogTitle = getString(R.string.preciseLocationSiteDialogTitle, originUrl.websiteFromGeoLocationsApiOrigin())
             title.text = dialogTitle
+        }
+    }
+
+    private fun populateSubtitle(subtitle: TextView) {
+        arguments?.let { args ->
+            val originUrl = args.getString(KEY_REQUEST_ORIGIN)!!
+            val originDomain = originUrl.websiteFromGeoLocationsApiOrigin()
+            if (originDomain == DDG_DOMAIN) {
+                subtitle.text = getString(R.string.preciseLocationDDGDialogSubtitle)
+            } else {
+                subtitle.text = getString(R.string.preciseLocationSiteDialogSubtitle)
+            }
         }
     }
 
@@ -189,6 +203,7 @@ class SiteLocationPermissionDialog : DialogFragment() {
         private const val KEY_REQUEST_ORIGIN = "KEY_REQUEST_ORIGIN"
         private const val KEY_EDITING_PERMISSION = "KEY_SCREEN_FROM"
         private const val KEY_TAB_ID = "TAB_ID"
+        private const val DDG_DOMAIN = "duckduckgo.com"
 
         fun instance(origin: String, isEditingPermission: Boolean, tabId: String): SiteLocationPermissionDialog {
             return SiteLocationPermissionDialog().also { fragment ->

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -47,4 +47,7 @@
     <string name="importBookmarksError">Couldn\'t import any bookmarks, something went wrong</string>
     <string name="importBookmarksEmpty">The file has no bookmarks to import</string>
     <string name="importBookmarksSuccess">Successfully imported %1$d bookmarks</string>
+
+    <!-- Precise Location Improvements -->
+    <string name="preciseLocationDDGDialogSubtitle">We only use your anonymous location to deliver better results, closer to you. You can always change your mind later.</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1174433894299346/1200197271421338

**Description**:
We would like to replace the text in the location dialog in our DDG Android app with the copy that was in the black notification tooltip that appears for other browsers.  

**Screenshots**:
| duckduckgo.com  | other sites |
| ------ | ----- | 
![Screenshot_20210506_211307](https://user-images.githubusercontent.com/531613/117353625-a1fb2500-aeb0-11eb-9f61-98f26f1fee08.png)|![Screenshot_20210506_211346](https://user-images.githubusercontent.com/531613/117353618-9f98cb00-aeb0-11eb-9bc7-6ad93bdb6411.png)|

**Steps to test this PR**:
***For duckduckgo.com***
1. Open app and search for restaurants near me
2. Enable Location Services
3. Allow system location permission
4. The site permission dialog should now be shown
5. Check that the message is "We only use your anonymous location to deliver better results, closer to you. You can always change your mind later."

***For other sites**
1. Open app and navigate to maps.google.com
2. Ask for current position
3. Allow system location permission
4. The site permission dialog should now be shown
5. Check that the message is "You can manage the location access permissions you’ve granted to individual sites in Settings."
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
