### PR TITLE
Move the app lifecycle observers to be plugins

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubCoroutinesModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubCoroutinesModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 DuckDuckGo
+ * Copyright (c) 2020 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,34 +16,24 @@
 
 package com.duckduckgo.app.di
 
-import android.content.Context
-import android.webkit.WebViewDatabase
-import androidx.room.Room
-import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
 
-@Module(includes = [DaoModule::class])
+@Module
 @ContributesTo(
     scope = AppObjectGraph::class,
-    replaces = [DatabaseModule::class]
+    replaces = [CoroutinesModule::class]
 )
-class StubDatabaseModule {
+class StubCoroutinesModule {
 
     @Provides
     @Singleton
-    fun provideWebviewDatabase(context: Context): WebViewDatabase {
-        return WebViewDatabase.getInstance(context)
-    }
-
-    @Provides
-    @Singleton
-    fun provideDatabase(context: Context): AppDatabase {
-        return Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .allowMainThreadQueries()
-            .build()
+    fun providesDispatcherProvider(): DispatcherProvider {
+        return CoroutineTestRule().testDispatcherProvider
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -20,6 +20,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.webkit.CookieManager
 import android.webkit.WebSettings
+import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.browser.*
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.addtohome.AddToHomeSystemCapabilityDetector
@@ -71,6 +72,7 @@ import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
 import com.duckduckgo.app.trackerdetection.TrackerDetector
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Named
 import javax.inject.Singleton
@@ -136,11 +138,13 @@ class BrowserModule {
     }
 
     @Provides
+    @Singleton
+    @IntoSet
     fun defaultBrowserObserver(
         defaultBrowserDetector: DefaultBrowserDetector,
         appInstallStore: AppInstallStore,
         pixel: Pixel
-    ): DefaultBrowserObserver {
+    ): LifecycleObserver {
         return DefaultBrowserObserver(defaultBrowserDetector, appInstallStore, pixel)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.rating.di
 
 import android.content.Context
+import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.browser.rating.db.AppEnjoymentDao
 import com.duckduckgo.app.browser.rating.db.AppEnjoymentDatabaseRepository
 import com.duckduckgo.app.browser.rating.db.AppEnjoymentRepository
@@ -28,6 +29,7 @@ import com.duckduckgo.app.usage.app.AppDaysUsedRepository
 import com.duckduckgo.app.usage.search.SearchCountDao
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -36,10 +38,11 @@ class RatingModule {
 
     @Singleton
     @Provides
-    fun appEnjoymentManager(
+    @IntoSet
+    fun appEnjoymentManagerObserver(
         appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
         promptTypeDecider: PromptTypeDecider
-    ): AppEnjoymentLifecycleObserver {
+    ): LifecycleObserver {
         return AppEnjoymentAppCreationObserver(appEnjoymentPromptEmitter, promptTypeDecider)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.app.browser.rating.di.RatingModule
 import com.duckduckgo.app.email.di.EmailModule
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.global.exception.UncaughtExceptionModule
-import com.duckduckgo.app.global.plugin.LifecycleObserverPluginProviderModule
 import com.duckduckgo.app.httpsupgrade.di.HttpsUpgraderModule
 import com.duckduckgo.app.onboarding.di.OnboardingModule
 import com.duckduckgo.app.onboarding.di.WelcomePageModule
@@ -80,8 +79,7 @@ import javax.inject.Singleton
         CertificateTrustedStoreModule::class,
         WelcomePageModule::class,
         HttpsPersisterModule::class,
-        EmailModule::class,
-        LifecycleObserverPluginProviderModule::class,
+        EmailModule::class
     ]
 )
 interface AppComponent : AndroidInjector<DuckDuckGoApplication> {

--- a/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppComponent.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.browser.rating.di.RatingModule
 import com.duckduckgo.app.email.di.EmailModule
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.global.exception.UncaughtExceptionModule
+import com.duckduckgo.app.global.plugin.LifecycleObserverPluginProviderModule
 import com.duckduckgo.app.httpsupgrade.di.HttpsUpgraderModule
 import com.duckduckgo.app.onboarding.di.OnboardingModule
 import com.duckduckgo.app.onboarding.di.WelcomePageModule
@@ -79,7 +80,8 @@ import javax.inject.Singleton
         CertificateTrustedStoreModule::class,
         WelcomePageModule::class,
         HttpsPersisterModule::class,
-        EmailModule::class
+        EmailModule::class,
+        LifecycleObserverPluginProviderModule::class,
     ]
 )
 interface AppComponent : AndroidInjector<DuckDuckGoApplication> {

--- a/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
@@ -21,17 +21,11 @@ import android.webkit.WebViewDatabase
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
-import com.duckduckgo.app.browser.httpauth.RealWebViewHttpAuthStore
-import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
-import com.duckduckgo.app.fire.DatabaseCleaner
-import com.duckduckgo.app.fire.DatabaseLocator
-import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.db.MigrationsProvider
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import dagger.Module
 import dagger.Provides
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Module(includes = [DaoModule::class])
@@ -39,13 +33,8 @@ class DatabaseModule {
 
     @Provides
     @Singleton
-    fun provideWebViewHttpAuthStore(
-        context: Context,
-        databaseCleaner: DatabaseCleaner,
-        @Named("authDbLocator") authDatabaseLocator: DatabaseLocator,
-        dispatcherProvider: DispatcherProvider
-    ): WebViewHttpAuthStore {
-        return RealWebViewHttpAuthStore(WebViewDatabase.getInstance(context), databaseCleaner, authDatabaseLocator, dispatcherProvider)
+    fun provideWebviewDatabase(context: Context): WebViewDatabase {
+        return WebViewDatabase.getInstance(context)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.di
 
 import android.content.Context
-import androidx.work.WorkManager
 import com.duckduckgo.app.autocomplete.api.AutoCompleteService
 import com.duckduckgo.app.brokensite.api.BrokenSiteSender
 import com.duckduckgo.app.brokensite.api.BrokenSiteSubmitter
@@ -29,11 +28,8 @@ import com.duckduckgo.app.feedback.api.FireAndForgetFeedbackSubmitter
 import com.duckduckgo.app.feedback.api.SubReasonApiMapper
 import com.duckduckgo.app.global.AppUrl.Url
 import com.duckduckgo.app.global.api.*
-import com.duckduckgo.app.global.job.AppConfigurationSyncWorkRequestBuilder
 import com.duckduckgo.app.globalprivacycontrol.GlobalPrivacyControl
 import com.duckduckgo.app.httpsupgrade.api.HttpsUpgradeService
-import com.duckduckgo.app.job.AppConfigurationSyncer
-import com.duckduckgo.app.job.ConfigurationDownloader
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -167,16 +163,6 @@ class NetworkModule {
     @Provides
     fun feedbackService(@Named("api") retrofit: Retrofit): FeedbackService =
         retrofit.create(FeedbackService::class.java)
-
-    @Provides
-    @Singleton
-    fun appConfigurationSyncer(
-        appConfigurationSyncWorkRequestBuilder: AppConfigurationSyncWorkRequestBuilder,
-        workManager: WorkManager,
-        appConfigurationDownloader: ConfigurationDownloader
-    ): AppConfigurationSyncer {
-        return AppConfigurationSyncer(appConfigurationSyncWorkRequestBuilder, workManager, appConfigurationDownloader)
-    }
 
     companion object {
         private const val CACHE_SIZE: Long = 10 * 1024 * 1024 // 10MB

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.di
 
 import android.content.Context
+import androidx.lifecycle.LifecycleObserver
 import androidx.work.WorkManager
 import com.duckduckgo.app.browser.WebDataManager
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
@@ -40,6 +41,7 @@ import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import javax.inject.Singleton
 
 @Module
@@ -96,6 +98,18 @@ class PrivacyModule {
     ): DataClearer {
         return AutomaticDataClearer(workManager, settingsDataStore, clearDataAction, dataClearerTimeKeeper, dataClearerForegroundAppRestartPixel)
     }
+
+    @Provides
+    @Singleton
+    @IntoSet
+    fun dataClearerLifecycleObserver(dataClearer: DataClearer): LifecycleObserver = dataClearer
+
+    @Provides
+    @Singleton
+    @IntoSet
+    fun dataClearerForegroundAppRestartPixelObserver(
+        dataClearerForegroundAppRestartPixel: DataClearerForegroundAppRestartPixel
+    ): LifecycleObserver = dataClearerForegroundAppRestartPixel
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.di
 
 import android.content.Context
+import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.device.ContextDeviceInfo
 import com.duckduckgo.app.global.device.DeviceInfo
@@ -32,6 +33,7 @@ import com.duckduckgo.app.statistics.store.PendingPixelDao
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import retrofit2.Retrofit
 import javax.inject.Named
 import javax.inject.Singleton
@@ -62,6 +64,7 @@ class StatisticsModule {
         RxBasedPixel(pixelSender)
 
     @Provides
+    @Singleton
     fun pixelSender(
         pixelService: PixelService,
         statisticsDataStore: StatisticsDataStore,
@@ -70,6 +73,11 @@ class StatisticsModule {
         pendingPixelDao: PendingPixelDao
     ): PixelSender =
         RxPixelSender(pixelService, pendingPixelDao, statisticsDataStore, variantManager, deviceInfo)
+
+    @Provides
+    @Singleton
+    @IntoSet
+    fun pixelSenderObserver(pixelSender: PixelSender): LifecycleObserver = pixelSender
 
     @Provides
     fun offlinePixelSender(

--- a/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
@@ -59,6 +59,10 @@ abstract class StoreModule {
     abstract fun bindAppInstallStore(store: AppInstallSharedPreferences): AppInstallStore
 
     @Binds
+    @IntoSet
+    abstract fun bindAppInstallStoreObserver(appInstallStore: AppInstallStore): LifecycleObserver
+
+    @Binds
     abstract fun bindDataClearingStore(store: UnsentForgetAllPixelStoreSharedPreferences): UnsentForgetAllPixelStore
 
     @Binds

--- a/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.di
 
+import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStoreSharedPreferences
 import com.duckduckgo.app.global.install.AppInstallSharedPreferences
@@ -32,10 +33,12 @@ import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
 import com.duckduckgo.app.statistics.store.OfflinePixelCountSharedPreferences
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.statistics.store.StatisticsSharedPreferences
+import com.duckduckgo.app.tabs.db.TabsDbSanitizer
 import com.duckduckgo.app.tabs.model.TabDataRepository
 import com.duckduckgo.app.tabs.model.TabRepository
 import dagger.Binds
 import dagger.Module
+import dagger.multibindings.IntoSet
 
 @Module
 abstract class StoreModule {
@@ -65,5 +68,13 @@ abstract class StoreModule {
     abstract fun bindUserStageStore(userStageStore: AppUserStageStore): UserStageStore
 
     @Binds
+    @IntoSet
+    abstract fun bindUserStageStoreObserver(userStageStore: UserStageStore): LifecycleObserver
+
+    @Binds
     abstract fun bindUserEventsStore(userEventsStore: AppUserEventsStore): UserEventsStore
+
+    @Binds
+    @IntoSet
+    abstract fun bindTabsDbSanitizerObserver(tabsDbSanitizer: TabsDbSanitizer): LifecycleObserver
 }

--- a/app/src/main/java/com/duckduckgo/app/di/SystemComponentsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/SystemComponentsModule.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.di
 
 import android.content.Context
 import android.content.pm.PackageManager
+import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.fire.FireAnimationLoader
 import com.duckduckgo.app.fire.LottieFireAnimationLoader
 import com.duckduckgo.app.global.DispatcherProvider
@@ -29,12 +30,16 @@ import com.duckduckgo.app.systemsearch.DeviceAppListProvider
 import com.duckduckgo.app.systemsearch.DeviceAppLookup
 import com.duckduckgo.app.systemsearch.InstalledDeviceAppListProvider
 import com.duckduckgo.app.systemsearch.InstalledDeviceAppLookup
+import com.duckduckgo.di.scopes.AppObjectGraph
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import javax.inject.Singleton
 
 @Module
-open class SystemComponentsModule {
+class SystemComponentsModule {
 
     @Singleton
     @Provides
@@ -56,4 +61,12 @@ open class SystemComponentsModule {
     fun animatorLoader(context: Context, settingsDataStore: SettingsDataStore, dispatcherProvider: DispatcherProvider): FireAnimationLoader {
         return LottieFireAnimationLoader(context, settingsDataStore, dispatcherProvider)
     }
+}
+
+@Module
+@ContributesTo(AppObjectGraph::class)
+abstract class SystemComponentsModuleBindings {
+    @Binds
+    @IntoSet
+    abstract fun animatorLoaderObserver(fireAnimationLoader: FireAnimationLoader): LifecycleObserver
 }

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
@@ -53,6 +53,13 @@ class DataClearerForegroundAppRestartPixel @Inject constructor(
         get() = preferences.getInt(KEY_UNSENT_CLEAR_APP_RESTARTED_WITH_INTENT_PIXELS, 0)
 
     @UiThread
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    fun onAppCreated() {
+        Timber.i("onAppCreated firePendingPixels")
+        firePendingPixels()
+    }
+
+    @UiThread
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun onAppBackgrounded() {
         Timber.i("Registered App on_stop")

--- a/app/src/main/java/com/duckduckgo/app/fire/LottieFireAnimationLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/LottieFireAnimationLoader.kt
@@ -26,13 +26,12 @@ import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 interface FireAnimationLoader : LifecycleObserver {
     fun preloadSelectedAnimation()
 }
 
-class LottieFireAnimationLoader @Inject constructor(
+class LottieFireAnimationLoader constructor(
     private val context: Context,
     private val settingsDataStore: SettingsDataStore,
     private val dispatchers: DispatcherProvider

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -23,7 +23,6 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.duckduckgo.app.browser.BuildConfig
-import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
 import com.duckduckgo.app.browser.shortcut.ShortcutReceiver
 import com.duckduckgo.app.di.AppComponent
@@ -109,9 +108,6 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
     @Inject
     lateinit var lifecycleObserverPluginPoint: PluginPoint<LifecycleObserver>
 
-    @Inject
-    lateinit var webViewHttpAuthStore: WebViewHttpAuthStore
-
     private var launchedByFireAction: Boolean = false
 
     private val applicationCoroutineScope = CoroutineScope(SupervisorJob())
@@ -132,9 +128,8 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
         ProcessLifecycleOwner.get().lifecycle.apply {
             addObserver(this@DuckDuckGoApplication)
             lifecycleObserverPluginPoint.getPlugins().forEach {
+                Timber.d("Registering application lifecycle observer: ${it.javaClass.canonicalName}")
                 addObserver(it)
-                Need to add this here
-                it.addObserver(webViewHttpAuthStore)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.global
 
 import android.app.Application
 import android.content.IntentFilter
-import android.os.Build
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
@@ -34,7 +33,6 @@ import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.global.Theming.initializeTheme
 import com.duckduckgo.app.global.initialization.AppDataLoader
 import com.duckduckgo.app.global.plugins.PluginPoint
-import com.duckduckgo.app.global.shortcut.AppShortcutCreator
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.job.WorkScheduler
 import com.duckduckgo.app.notification.NotificationRegistrar
@@ -80,9 +78,6 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
 
     @Inject
     lateinit var pixel: Pixel
-
-    @Inject
-    lateinit var appShortcutCreator: AppShortcutCreator
 
     @Inject
     lateinit var httpsUpgrader: HttpsUpgrader
@@ -141,10 +136,6 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
                 Need to add this here
                 it.addObserver(webViewHttpAuthStore)
             }
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            appShortcutCreator.configureAppShortcuts(this)
         }
 
         initializeTheme(settingsDataStore)

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -33,7 +33,6 @@ import com.duckduckgo.app.fire.FireActivity
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.global.Theming.initializeTheme
 import com.duckduckgo.app.global.initialization.AppDataLoader
-import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.global.shortcut.AppShortcutCreator
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
@@ -72,9 +71,6 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
 
     @Inject
     lateinit var resourceSurrogateLoader: ResourceSurrogateLoader
-
-    @Inject
-    lateinit var appInstallStore: AppInstallStore
 
     @Inject
     lateinit var settingsDataStore: SettingsDataStore
@@ -151,7 +147,6 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
             appShortcutCreator.configureAppShortcuts(this)
         }
 
-        recordInstallationTimestamp()
         initializeTheme(settingsDataStore)
         loadTrackerData()
         scheduleOfflinePixels()
@@ -176,12 +171,6 @@ open class DuckDuckGoApplication : HasAndroidInjector, Application(), LifecycleO
             } else {
                 alertingUncaughtExceptionHandler.uncaughtException(Thread.currentThread(), throwable)
             }
-        }
-    }
-
-    private fun recordInstallationTimestamp() {
-        if (!appInstallStore.hasInstallTimestampRecorded()) {
-            appInstallStore.installTimestamp = System.currentTimeMillis()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
@@ -18,12 +18,17 @@ package com.duckduckgo.app.global.install
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-interface AppInstallStore {
+interface AppInstallStore : LifecycleObserver {
     var installTimestamp: Long
 
     var widgetInstalled: Boolean
@@ -60,6 +65,15 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
 
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+
+    @UiThread
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    fun recordInstallationTimestamp() {
+        Timber.i("recording installation timestamp")
+        if (!hasInstallTimestampRecorded()) {
+            installTimestamp = System.currentTimeMillis()
+        }
+    }
 
     companion object {
         @VisibleForTesting

--- a/app/src/main/java/com/duckduckgo/app/global/plugin/LifecycleObserverPluginPoint.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/plugin/LifecycleObserverPluginPoint.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.plugin
+
+import androidx.lifecycle.LifecycleObserver
+import com.duckduckgo.app.global.plugins.PluginPoint
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.Multibinds
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Module
+abstract class LifecycleObserverPluginProviderModule {
+    // we use multibinds as the list of plugins can be empty
+    @Multibinds
+    abstract fun provideLifecycleObserverPlugins(): Set<@JvmSuppressWildcards LifecycleObserver>
+
+    @Binds
+    @Singleton
+    abstract fun provideLifecycleObserverPluginProvider(
+        lifecycleObserverPluginPoint: LifecycleObserverPluginPoint
+    ): PluginPoint<LifecycleObserver>
+}
+
+@Singleton
+class LifecycleObserverPluginPoint @Inject constructor(
+    private val plugins: Set<@JvmSuppressWildcards LifecycleObserver>
+) : PluginPoint<LifecycleObserver> {
+    override fun getPlugins(): Set<LifecycleObserver> {
+        return plugins
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/plugin/LifecycleObserverPluginPoint.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/plugin/LifecycleObserverPluginPoint.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.app.global.plugin
 
 import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.di.scopes.AppObjectGraph
+import com.squareup.anvil.annotations.ContributesTo
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.Multibinds
@@ -25,6 +27,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Module
+@ContributesTo(AppObjectGraph::class)
 abstract class LifecycleObserverPluginProviderModule {
     // we use multibinds as the list of plugins can be empty
     @Multibinds

--- a/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentLifecycleObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentLifecycleObserver.kt
@@ -24,13 +24,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
-interface AppEnjoymentLifecycleObserver : LifecycleObserver
-
 class AppEnjoymentAppCreationObserver(
     private val appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
     private val promptTypeDecider: PromptTypeDecider
-) :
-    AppEnjoymentLifecycleObserver {
+) : LifecycleObserver {
 
     @UiThread
     @OnLifecycleEvent(Lifecycle.Event.ON_START)

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -23,17 +23,52 @@ import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.annotation.UiThread
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.graphics.drawable.IconCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.duckduckgo.app.bookmarks.ui.BookmarksActivity
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.di.scopes.AppObjectGraph
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoSet
+import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Singleton
 
-class AppShortcutCreator @Inject constructor() {
+@Module
+@ContributesTo(AppObjectGraph::class)
+class AppShortcutCreatorModule {
+    @Provides
+    @IntoSet
+    fun provideAppShortcutCreatorObserver(appShortcutCreator: AppShortcutCreator): LifecycleObserver {
+        return AppShortcutCreatorLifecycleObserver(appShortcutCreator)
+    }
+}
+
+class AppShortcutCreatorLifecycleObserver(
+    private val appShortcutCreator: AppShortcutCreator
+) : LifecycleObserver {
+    @UiThread
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    fun configureAppShortcuts() {
+        Timber.i("Configure app shortcuts")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            appShortcutCreator.configureAppShortcuts()
+        }
+    }
+}
+
+@Singleton
+class AppShortcutCreator @Inject constructor(private val context: Context) {
 
     @RequiresApi(Build.VERSION_CODES.N_MR1)
-    fun configureAppShortcuts(context: Context) {
+    fun configureAppShortcuts() {
         val shortcutList = mutableListOf<ShortcutInfo>()
 
         shortcutList.add(buildNewTabShortcut(context))

--- a/app/src/main/java/com/duckduckgo/app/icon/api/AppIconModifier.kt
+++ b/app/src/main/java/com/duckduckgo/app/icon/api/AppIconModifier.kt
@@ -86,7 +86,7 @@ class AppIconModifier @Inject constructor(
         enable(context, newIcon)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            appShortcutCreator.configureAppShortcuts(context)
+            appShortcutCreator.configureAppShortcuts()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -25,7 +25,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class TabsDbSanitizer @Inject constructor(
     private val tabRepository: TabRepository
 ) : LifecycleObserver {

--- a/app/src/main/java/com/duckduckgo/app/usage/di/AppUsageModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/usage/di/AppUsageModule.kt
@@ -16,19 +16,23 @@
 
 package com.duckduckgo.app.usage.di
 
+import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.usage.app.AppDaysUsedDao
 import com.duckduckgo.app.usage.app.AppDaysUsedDatabaseRepository
 import com.duckduckgo.app.usage.app.AppDaysUsedRecorder
 import com.duckduckgo.app.usage.app.AppDaysUsedRepository
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import javax.inject.Singleton
 
 @Module
 class AppUsageModule {
 
     @Provides
-    fun appDaysUsedRecorder(appDaysUsedRepository: AppDaysUsedRepository): AppDaysUsedRecorder {
+    @Singleton
+    @IntoSet
+    fun appDaysUsedRecorderObserver(appDaysUsedRepository: AppDaysUsedRepository): LifecycleObserver {
         return AppDaysUsedRecorder(appDaysUsedRepository)
     }
 

--- a/common/src/main/java/com/duckduckgo/app/global/plugins/PluginPoint.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/plugins/PluginPoint.kt
@@ -23,5 +23,5 @@ interface PluginPoint<T> {
     /**
      * @return the list of plugins of type <T>
      */
-    fun getPlugins(): List<T>
+    fun getPlugins(): Collection<T>
 }

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelSender.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelSender.kt
@@ -29,14 +29,13 @@ import io.reactivex.Completable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
-import javax.inject.Inject
 
 interface PixelSender : LifecycleObserver {
     fun sendPixel(pixelName: String, parameters: Map<String, String>, encodedParameters: Map<String, String>): Completable
     fun enqueuePixel(pixelName: String, parameters: Map<String, String>, encodedParameters: Map<String, String>): Completable
 }
 
-class RxPixelSender @Inject constructor(
+class RxPixelSender constructor(
     private val api: PixelService,
     private val pendingPixelDao: PendingPixelDao,
     private val statisticsDataStore: StatisticsDataStore,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200284402862810/f
Tech Design URL: 
CC: 

**Description**:
The `DuckDuckGoAppliation` adds all application observers manually, like so:

```kotlin
ProcessLifecycleOwner.get().lifecycle.also {
  it.addObserver(this)
  it.addObserver(dataClearer)
  it.addObserver(appDaysUsedRecorder)
  it.addObserver(defaultBrowserObserver)
  it.addObserver(appEnjoymentLifecycleObserver)
  it.addObserver(dataClearerForegroundAppRestartPixel)
  it.addObserver(userStageStore)
  it.addObserver(pixelSender)
  it.addObserver(fireFireAnimationLoader)
  it.addObserver(tabsDbSanitizer)
  it.addObserver(webViewHttpAuthStore)
}
```

The main drawback is that the appliation has to depend on all the observer types, and every time we add/remove one observer we need to touch the applicaton.

We'd like to move that to use the plugin pattern, when the appliation will just get a set of `LifecycleObserver` plugins and add them. Liek so:

```kotlin
ProcessLifecycleOwner.get().lifecycle.also {
  it.addObserver(this)
  appLifecycleObserverPlugins.forEach { plugin ->
    it.addObserver(plugin)
  }
}
```

The `DuckDuckGoApplication` also manually initialised some other classes in lifecycle methods. I have also moved those to be a lifecycle observer. These are the classes:
* `appShortcutCreator.configureAppShortcuts()` was called in `onCreate` method. I moved that to the `AppShortcutCreatorLifecycleObserver` observer
* `appInstallStore` was initialised during `onCreate`. The `AppInstallStore` is also a lifecycle observer
* The `AppConfigurationSyncer` was initialised during `onCreate`. The `AppConfigurationSyncer` is also now a lifecycle observer

**Steps to test this PR**:
1. install/upgrade from this branch
2. For every observer listed above, add timbers in their methods annotated with `OnLifecycleEvent`
3. open the app
4. verify the methods are executed in the correct app lifecycle event

The DuckDuckApplication logs all registered observers, this should be the list:
```
com.duckduckgo.app.fire.AutomaticDataClearer
com.duckduckgo.app.global.shortcut.AppShortcutCreatorLifecycleObserver
com.duckduckgo.app.browser.httpauth.RealWebViewHttpAuthStore
com.duckduckgo.app.fire.LottieFireAnimationLoader
com.duckduckgo.app.global.install.AppInstallSharedPreferences
com.duckduckgo.app.global.rating.AppEnjoymentAppCreationObserver 
com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserObserver
com.duckduckgo.app.job.AppConfigurationSyncer
com.duckduckgo.app.statistics.api.RxPixelSender
com.duckduckgo.app.onboarding.store.AppUserStageStore
com.duckduckgo.app.usage.app.AppDaysUsedRecorder
com.duckduckgo.app.tabs.db.TabsDbSanitizer
com.duckduckgo.app.fire.DataClearerForegroundAppRestartPixel
```

1. instal/upgrade from this branch
2. ensure the core features of the app work as usual, bookmarks, fireproof sites, fire button, browsing


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
