### PR TITLE
Add ScrollView to fix Dax being cutoff when keyboard appears

### DIFF
--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -20,6 +20,7 @@
     android:id="@+id/newTabLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fillViewport="true"
     tools:context="com.duckduckgo.app.browser.BrowserActivity"
     tools:showIn="@layout/fragment_browser_tab">
 

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -14,53 +14,58 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/newTabLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginTop="?attr/actionBarSize"
-    android:foreground="@android:color/transparent"
     tools:context="com.duckduckgo.app.browser.BrowserActivity"
     tools:showIn="@layout/fragment_browser_tab">
 
-    <ImageView
-        android:id="@+id/ddgLogo"
-        android:layout_width="0dp"
-        android:alpha="0"
-        android:layout_height="wrap_content"
-        android:contentDescription="@string/duckDuckGoLogoDescription"
-        android:src="@drawable/logo_full"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_max="180dp"
-        app:layout_constraintStart_toStartOf="parent"
-        android:layout_marginTop="@dimen/homeTabDdgLogoTopMargin"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_max="180dp"
-        android:visibility="gone"/>
-
-    <include
-        layout="@layout/include_dax_dialog_cta"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_max="600dp"
-        android:visibility="gone"/>
-
-    <LinearLayout
-        android:id="@+id/ctaContainer"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:visibility="gone"
-        android:elevation="12dp"
-        android:outlineProvider="paddedBounds"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize"
+        android:foreground="@android:color/transparent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageView
+            android:id="@+id/ddgLogo"
+            android:layout_width="0dp"
+            android:alpha="0"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/duckDuckGoLogoDescription"
+            android:src="@drawable/logo_full"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_max="180dp"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="@dimen/homeTabDdgLogoTopMargin"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintWidth_max="180dp"
+            android:visibility="gone"/>
+
+        <include
+            layout="@layout/include_dax_dialog_cta"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintWidth_max="600dp"
+            android:visibility="gone"/>
+
+        <LinearLayout
+            android:id="@+id/ctaContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:elevation="12dp"
+            android:outlineProvider="paddedBounds"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1199709896363266
Tech Design URL: 
CC: 

**Description**:
This PR adds a `ScrollView` around the logo and dialog to prevent Dax from being cutoff on some screen sizes.

| Without `ScrollView`  | With `ScrollView` |
| ------ | ----- | 
![Screenshot_20210517-083930_DuckDuckGo](https://user-images.githubusercontent.com/3471025/118443165-e033e800-b6eb-11eb-9828-039287ab6f08.jpg)|![Screenshot_20210517-084534_DuckDuckGo](https://user-images.githubusercontent.com/3471025/118443659-7700a480-b6ec-11eb-9bba-0318da810b5f.jpg)|

**Steps to test this PR**:
1. Launch a fresh version of the app on a S7 Edge/OnePlus 6T/480 x 800 | hdpi emulator
2. Wait for the keyboard to pop-up when the onboarding dialog with Dax appears
3. Check that Dax is not cut off (If there is not enough space for the whole dialog to appear, the dialog (including Dax) should be scrollable)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
