### PR TITLE
Remove unused listener clearComplete

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.browser.BrowserViewModel.Command
-import com.duckduckgo.app.browser.BrowserViewModel.Command.DisplayMessage
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.global.events.db.UserEventsStore
@@ -175,13 +174,6 @@ class BrowserViewModelTest {
     fun whenUnknownDashboardResultReceivedThenNoCommandTriggered() {
         testee.receivedDashboardResult(1111)
         verify(mockCommandObserver, never()).onChanged(any())
-    }
-
-    @Test
-    fun whenClearCompleteThenMessageDisplayed() {
-        testee.onClearComplete()
-        verify(mockCommandObserver).onChanged(commandCaptor.capture())
-        assertEquals(DisplayMessage(R.string.fireDataCleared), commandCaptor.lastValue)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -21,7 +21,6 @@ package com.duckduckgo.app.tabs.ui
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -103,14 +102,6 @@ class TabSwitcherViewModelTest {
         val entity = TabEntity("abc", "", "", position = 0)
         testee.onTabDeleted(entity)
         verify(mockTabRepository).delete(entity)
-    }
-
-    @Test
-    fun whenClearCompleteThenMessageDisplayedAndSwitcherClosed() {
-        testee.onClearComplete()
-        verify(mockCommandObserver, times(2)).onChanged(commandCaptor.capture())
-        assertEquals(Command.DisplayMessage(R.string.fireDataCleared), commandCaptor.allValues[0])
-        assertEquals(Command.Close, commandCaptor.allValues[1])
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -288,7 +288,6 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
         when (command) {
             is Query -> currentTab?.submitQuery(command.query)
             is Refresh -> currentTab?.onRefreshRequested()
-            is Command.DisplayMessage -> Toast.makeText(applicationContext, command.messageId, Toast.LENGTH_LONG).show()
             is Command.LaunchPlayStore -> launchPlayStore()
             is Command.ShowAppEnjoymentPrompt -> showAppEnjoymentPrompt(AppEnjoymentDialogFragment.create(command.promptCount, viewModel))
             is Command.ShowAppRatingPrompt -> showAppEnjoymentPrompt(RateAppDialogFragment.create(command.promptCount, viewModel))
@@ -320,7 +319,6 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
         dialog.clearStarted = {
             removeObservers()
         }
-        dialog.clearComplete = { viewModel.onClearComplete() }
         dialog.setOnShowListener { currentTab?.onFireDialogVisibilityChanged(isVisible = true) }
         dialog.setOnCancelListener {
             pixel.fire(if (dialog.ctaVisible) FIRE_DIALOG_PROMOTED_CANCEL else FIRE_DIALOG_CANCEL)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -16,12 +16,10 @@
 
 package com.duckduckgo.app.browser
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
-import com.duckduckgo.app.browser.BrowserViewModel.Command.DisplayMessage
 import com.duckduckgo.app.browser.BrowserViewModel.Command.Refresh
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
@@ -79,7 +77,6 @@ class BrowserViewModel(
     sealed class Command {
         object Refresh : Command()
         data class Query(val query: String) : Command()
-        data class DisplayMessage(@StringRes val messageId: Int) : Command()
         object LaunchPlayStore : Command()
         object LaunchFeedbackView : Command()
         data class ShowAppEnjoymentPrompt(val promptCount: PromptCount) : Command()
@@ -166,10 +163,6 @@ class BrowserViewModel(
 
     fun receivedDashboardResult(resultCode: Int) {
         if (resultCode == RELOAD_RESULT_CODE) command.value = Refresh
-    }
-
-    fun onClearComplete() {
-        command.value = DisplayMessage(R.string.fireDataCleared)
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -60,7 +60,6 @@ class FireDialog(
 ) : BottomSheetDialog(context, R.style.FireDialog), CoroutineScope by MainScope() {
 
     var clearStarted: (() -> Unit) = {}
-    var clearComplete: (() -> Unit) = {}
     val ctaVisible: Boolean
         get() = daxCtaContainer?.isVisible == true
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -22,7 +22,6 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.TextView
-import android.widget.Toast
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.GridLayoutManager
@@ -42,7 +41,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.Close
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.DisplayMessage
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
@@ -172,7 +170,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private fun processCommand(command: Command?) {
         when (command) {
-            is DisplayMessage -> Toast.makeText(applicationContext, command.messageId, Toast.LENGTH_LONG).show()
             is Close -> finishAfterTransition()
         }
     }
@@ -202,7 +199,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             settingsDataStore = settingsDataStore,
             userEventsStore = userEventsStore
         )
-        dialog.clearComplete = { viewModel.onClearComplete() }
         dialog.show()
     }
 
@@ -240,7 +236,8 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                         BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_SWIPE,
                         BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_TIMEOUT -> launch { viewModel.purgeDeletableTabs() }
                         BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_CONSECUTIVE,
-                        BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_MANUAL -> { /* noop */ }
+                        BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_MANUAL -> { /* noop */
+                        }
                     }
                 }
             })

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -16,12 +16,10 @@
 
 package com.duckduckgo.app.tabs.ui
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
@@ -41,7 +39,6 @@ class TabSwitcherViewModel(private val tabRepository: TabRepository, private val
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
     sealed class Command {
-        data class DisplayMessage(@StringRes val messageId: Int) : Command()
         object Close : Command()
     }
 
@@ -70,11 +67,6 @@ class TabSwitcherViewModel(private val tabRepository: TabRepository, private val
 
     suspend fun purgeDeletableTabs() {
         tabRepository.purgeDeletableTabs()
-    }
-
-    fun onClearComplete() {
-        command.value = Command.DisplayMessage(R.string.fireDataCleared)
-        command.value = Command.Close
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200308959421574/f
Tech Design URL: 
CC: 

**Description**:
Removes unused listener inside FireDialog.


**Steps to test this PR**:
Nothing should have changed with this PR. The removed callback method was not being called, so removed logic was never executed.
However, as a smoke test:
1. Run the app
2. Clear all data (from browser / from tab screen)
1. Ensure fire animations runs, process restarts, and nothing crashes


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
