### PR TITLE
Fix text size for titles in settings activity

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -86,7 +86,7 @@
         <item name="android:paddingEnd">@dimen/settingsItemHorizontalPadding</item>
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:textColor">@color/cornflowerBlue</item>
-        <item name="android:textSize">12sp</item>
+        <item name="android:textSize">14sp</item>
         <item name="android:textStyle">normal</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:selectable">false</item>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200353412494330/f
Tech Design URL: 
CC: 

**Description**:
Fixes text size for titles in the Settings screen.

Before:
![image](https://user-images.githubusercontent.com/4747865/118816784-d3adbc00-b8b2-11eb-8ae6-363af155e8ba.png)

After:
![image](https://user-images.githubusercontent.com/4747865/118816738-c55fa000-b8b2-11eb-9523-ba196d318c78.png)


**Steps to test this PR**:
1. 
1. 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
