### PR TITLE
Add nav parameter to autocomplete

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -105,10 +105,10 @@ class AutoCompleteApiTest {
         whenever(mockAutoCompleteService.autoComplete("title")).thenReturn(
             Observable.just(
                 listOf(
-                    AutoCompleteServiceRawResult("example.com"),
-                    AutoCompleteServiceRawResult("foo.com"),
-                    AutoCompleteServiceRawResult("bar.com"),
-                    AutoCompleteServiceRawResult("baz.com")
+                    AutoCompleteServiceRawResult("example.com", false),
+                    AutoCompleteServiceRawResult("foo.com", true),
+                    AutoCompleteServiceRawResult("bar.com", true),
+                    AutoCompleteServiceRawResult("baz.com", true)
                 )
             )
         )
@@ -143,10 +143,10 @@ class AutoCompleteApiTest {
         whenever(mockAutoCompleteService.autoComplete("title")).thenReturn(
             Observable.just(
                 listOf(
-                    AutoCompleteServiceRawResult("example.com"),
-                    AutoCompleteServiceRawResult("foo.com"),
-                    AutoCompleteServiceRawResult("bar.com"),
-                    AutoCompleteServiceRawResult("baz.com")
+                    AutoCompleteServiceRawResult("example.com", false),
+                    AutoCompleteServiceRawResult("foo.com", true),
+                    AutoCompleteServiceRawResult("bar.com", true),
+                    AutoCompleteServiceRawResult("baz.com", true)
                 )
             )
         )
@@ -167,7 +167,7 @@ class AutoCompleteApiTest {
             listOf(
                 AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "foo.com?key=value", "title foo", "https://foo.com?key=value"),
                 AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion(phrase = "foo.com", "title foo", "https://foo.com"),
-                AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion(phrase = "example.com", true),
+                AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion(phrase = "example.com", false),
                 AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion(phrase = "bar.com", true),
                 AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion(phrase = "baz.com", true)
             ),

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -329,7 +329,7 @@ class BrowserTabViewModelTest {
 
         val siteFactory = SiteFactory(mockPrivacyPractices, mockEntityLookup)
 
-        whenever(mockOmnibarConverter.convertQueryToUrl(any(), any())).thenReturn("duckduckgo.com")
+        whenever(mockOmnibarConverter.convertQueryToUrl(any(), any(), any())).thenReturn("duckduckgo.com")
         whenever(mockVariantManager.getVariant()).thenReturn(DEFAULT_VARIANT)
         whenever(mockTabRepository.liveSelectedTab).thenReturn(selectedTabLiveData)
         whenever(mockNavigationAwareLoginDetector.loginEventLiveData).thenReturn(loginEventLiveData)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -111,7 +111,7 @@ class BrowserViewModelTest {
 
         runBlocking<Unit> {
             whenever(mockTabRepository.add()).thenReturn(TAB_ID)
-            whenever(mockOmnibarEntryConverter.convertQueryToUrl(any(), any())).then { it.arguments.first() }
+            whenever(mockOmnibarEntryConverter.convertQueryToUrl(any(), any(), any())).then { it.arguments.first() }
         }
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -96,30 +96,30 @@ class QueryUrlConverterTest {
     }
 
     @Test
-    fun whenQueryOriginIsFromAutocompleteAndNavIsFalseThenSearchQueryBuilt() {
+    fun whenQueryOriginIsFromAutocompleteAndIsNavIsFalseThenSearchQueryBuilt() {
         val input = "example.com"
-        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(nav = false))
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(isNav = false))
         assertDuckDuckGoSearchQuery("example.com", result)
     }
 
     @Test
-    fun whenQueryOriginIsFromAutocompleteAndNavIsTrueThenUrlReturned() {
+    fun whenQueryOriginIsFromAutocompleteAndIsNavIsTrueThenUrlReturned() {
         val input = "http://example.com"
-        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(nav = true))
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(isNav = true))
         assertEquals(input, result)
     }
 
     @Test
-    fun whenQueryOriginIsFromAutocompleteAndNavIsNullAndIsUrlThenUrlReturned() {
+    fun whenQueryOriginIsFromAutocompleteAndIsNavIsNullAndIsUrlThenUrlReturned() {
         val input = "http://example.com"
-        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(nav = null))
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(isNav = null))
         assertEquals(input, result)
     }
 
     @Test
-    fun whenQueryOriginIsFromAutocompleteAndNavIsNullAndIsNotUrlThenSearchQueryBuilt() {
+    fun whenQueryOriginIsFromAutocompleteAndIsNavIsNullAndIsNotUrlThenSearchQueryBuilt() {
         val input = "foo"
-        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(nav = null))
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(isNav = null))
         assertDuckDuckGoSearchQuery("foo", result)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -110,13 +110,6 @@ class QueryUrlConverterTest {
     }
 
     @Test
-    fun whenQueryOriginIsFromAutocompleteAndIsNavIsNullAndIsUrlThenUrlReturned() {
-        val input = "http://example.com"
-        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(isNav = null))
-        assertEquals(input, result)
-    }
-
-    @Test
     fun whenQueryOriginIsFromAutocompleteAndIsNavIsNullAndIsNotUrlThenSearchQueryBuilt() {
         val input = "foo"
         val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(isNav = null))

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser
 
 import android.net.Uri
+import com.duckduckgo.app.browser.omnibar.QueryOrigin
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
 import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.VariantManager
@@ -78,6 +79,48 @@ class QueryUrlConverterTest {
         val expected = "http://$input"
         val result = testee.convertQueryToUrl(input)
         assertEquals(expected, result)
+    }
+
+    @Test
+    fun whenQueryOriginIsFromUserAndIsQueryThenSearchQueryBuilt() {
+        val input = "foo"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromUser)
+        assertDuckDuckGoSearchQuery("foo", result)
+    }
+
+    @Test
+    fun whenQueryOriginIsFromUserAndIsUrlThenUrlReturned() {
+        val input = "http://example.com"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromUser)
+        assertEquals(input, result)
+    }
+
+    @Test
+    fun whenQueryOriginIsFromAutocompleteAndNavIsFalseThenSearchQueryBuilt() {
+        val input = "example.com"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(nav = false))
+        assertDuckDuckGoSearchQuery("example.com", result)
+    }
+
+    @Test
+    fun whenQueryOriginIsFromAutocompleteAndNavIsTrueThenUrlReturned() {
+        val input = "http://example.com"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(nav = true))
+        assertEquals(input, result)
+    }
+
+    @Test
+    fun whenQueryOriginIsFromAutocompleteAndNavIsNullAndIsUrlThenUrlReturned() {
+        val input = "http://example.com"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(nav = null))
+        assertEquals(input, result)
+    }
+
+    @Test
+    fun whenQueryOriginIsFromAutocompleteAndNavIsNullAndIsNotUrlThenSearchQueryBuilt() {
+        val input = "foo"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(nav = null))
+        assertDuckDuckGoSearchQuery("foo", result)
     }
 
     private fun assertDuckDuckGoSearchQuery(query: String, url: String) {

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -71,7 +71,7 @@ class AutoCompleteApi @Inject constructor(
         autoCompleteService.autoComplete(query)
             .flatMapIterable { it }
             .map {
-                AutoCompleteSearchSuggestion(phrase = it.phrase, isUrl = (it.nav ?: UriString.isWebUrl(it.phrase)))
+                AutoCompleteSearchSuggestion(phrase = it.phrase, isUrl = (it.isNav ?: UriString.isWebUrl(it.phrase)))
             }
             .toList()
             .onErrorReturn { emptyList() }

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.app.global.UriString
 import com.duckduckgo.app.global.baseHost
 import com.duckduckgo.app.global.toStringDropScheme
 import io.reactivex.Observable
-import io.reactivex.functions.BiFunction
 import javax.inject.Inject
 
 interface AutoComplete {
@@ -59,7 +58,7 @@ class AutoCompleteApi @Inject constructor(
 
         return getAutoCompleteBookmarkResults(query).zipWith(
             getAutoCompleteSearchResults(query),
-            BiFunction { bookmarksResults, searchResults ->
+            { bookmarksResults, searchResults ->
                 AutoCompleteResult(
                     query = query,
                     suggestions = (bookmarksResults + searchResults).distinctBy { it.phrase }
@@ -72,7 +71,7 @@ class AutoCompleteApi @Inject constructor(
         autoCompleteService.autoComplete(query)
             .flatMapIterable { it }
             .map {
-                AutoCompleteSearchSuggestion(phrase = it.phrase, isUrl = UriString.isWebUrl(it.phrase))
+                AutoCompleteSearchSuggestion(phrase = it.phrase, isUrl = (it.nav ?: UriString.isWebUrl(it.phrase)))
             }
             .toList()
             .onErrorReturn { emptyList() }

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteService.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteService.kt
@@ -27,8 +27,9 @@ interface AutoCompleteService {
     @GET("${AppUrl.Url.API}/ac/")
     fun autoComplete(
         @Query("q") query: String,
-        @Query("kl") languageCode: String = Locale.getDefault().language
+        @Query("kl") languageCode: String = Locale.getDefault().language,
+        @Query("nav") nav: String = "1"
     ): Observable<List<AutoCompleteServiceRawResult>>
 }
 
-data class AutoCompleteServiceRawResult(val phrase: String)
+data class AutoCompleteServiceRawResult(val phrase: String, val nav: Boolean?)

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteService.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteService.kt
@@ -28,8 +28,8 @@ interface AutoCompleteService {
     fun autoComplete(
         @Query("q") query: String,
         @Query("kl") languageCode: String = Locale.getDefault().language,
-        @Query("nav") nav: String = "1"
+        @Query("is_nav") nav: String = "1"
     ): Observable<List<AutoCompleteServiceRawResult>>
 }
 
-data class AutoCompleteServiceRawResult(val phrase: String, val nav: Boolean?)
+data class AutoCompleteServiceRawResult(val phrase: String, val isNav: Boolean?)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -971,8 +971,8 @@ class BrowserTabFragment :
             viewModel.fireAutocompletePixel(suggestion)
             withContext(Dispatchers.Main) {
                 val origin = when (suggestion) {
-                    is AutoCompleteBookmarkSuggestion -> FromAutocomplete(nav = null)
-                    is AutoCompleteSearchSuggestion -> FromAutocomplete(nav = suggestion.isUrl)
+                    is AutoCompleteBookmarkSuggestion -> FromAutocomplete(isNav = null)
+                    is AutoCompleteSearchSuggestion -> FromAutocomplete(isNav = suggestion.isUrl)
                 }
                 viewModel.onUserSubmittedQuery(suggestion.phrase, origin)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -79,6 +79,7 @@ import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.browser.omnibar.KeyboardAwareEditText
 import com.duckduckgo.app.browser.omnibar.OmnibarScrolling
+import com.duckduckgo.app.browser.omnibar.QueryOrigin
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewGenerator
@@ -968,7 +969,11 @@ class BrowserTabFragment :
         GlobalScope.launch {
             viewModel.fireAutocompletePixel(suggestion)
             withContext(Dispatchers.Main) {
-                viewModel.onUserSubmittedQuery(suggestion.phrase)
+                val origin = when (suggestion) {
+                    is AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion -> QueryOrigin.FromAutocomplete(nav = null)
+                    is AutoCompleteSuggestion.AutoCompleteSearchSuggestion -> QueryOrigin.FromAutocomplete(nav = suggestion.isUrl)
+                }
+                viewModel.onUserSubmittedQuery(suggestion.phrase, origin)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -971,7 +971,7 @@ class BrowserTabFragment :
             viewModel.fireAutocompletePixel(suggestion)
             withContext(Dispatchers.Main) {
                 val origin = when (suggestion) {
-                    is AutoCompleteBookmarkSuggestion -> FromAutocomplete(isNav = null)
+                    is AutoCompleteBookmarkSuggestion -> FromAutocomplete(isNav = true)
                     is AutoCompleteSearchSuggestion -> FromAutocomplete(isNav = suggestion.isUrl)
                 }
                 viewModel.onUserSubmittedQuery(suggestion.phrase, origin)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -58,6 +58,7 @@ import androidx.fragment.app.transaction
 import androidx.lifecycle.*
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion
+import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.*
 import com.duckduckgo.app.bookmarks.ui.EditBookmarkDialogFragment
 import com.duckduckgo.app.brokensite.BrokenSiteActivity
 import com.duckduckgo.app.brokensite.BrokenSiteData
@@ -79,7 +80,7 @@ import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.browser.omnibar.KeyboardAwareEditText
 import com.duckduckgo.app.browser.omnibar.OmnibarScrolling
-import com.duckduckgo.app.browser.omnibar.QueryOrigin
+import com.duckduckgo.app.browser.omnibar.QueryOrigin.*
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewGenerator
@@ -970,8 +971,8 @@ class BrowserTabFragment :
             viewModel.fireAutocompletePixel(suggestion)
             withContext(Dispatchers.Main) {
                 val origin = when (suggestion) {
-                    is AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion -> QueryOrigin.FromAutocomplete(nav = null)
-                    is AutoCompleteSuggestion.AutoCompleteSearchSuggestion -> QueryOrigin.FromAutocomplete(nav = suggestion.isUrl)
+                    is AutoCompleteBookmarkSuggestion -> FromAutocomplete(nav = null)
+                    is AutoCompleteSearchSuggestion -> FromAutocomplete(nav = suggestion.isUrl)
                 }
                 viewModel.onUserSubmittedQuery(suggestion.phrase, origin)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -62,6 +62,7 @@ import com.duckduckgo.app.browser.model.BasicAuthenticationCredentials
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
+import com.duckduckgo.app.browser.omnibar.QueryOrigin
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.ui.HttpAuthenticationDialogFragment.HttpAuthenticationListener
@@ -531,7 +532,7 @@ class BrowserTabViewModel(
         pixel.fire(pixelName, params)
     }
 
-    fun onUserSubmittedQuery(query: String) {
+    fun onUserSubmittedQuery(query: String, queryOrigin: QueryOrigin = QueryOrigin.FromUser) {
         navigationAwareLoginDetector.onEvent(NavigationEvent.UserAction.NewQuerySubmitted)
 
         if (query.isBlank()) {
@@ -551,7 +552,7 @@ class BrowserTabViewModel(
         }
 
         val verticalParameter = extractVerticalParameter(url)
-        val urlToNavigate = queryUrlConverter.convertQueryToUrl(trimmedInput, verticalParameter)
+        val urlToNavigate = queryUrlConverter.convertQueryToUrl(trimmedInput, verticalParameter, queryOrigin)
 
         val type = specialUrlDetector.determineType(trimmedInput)
         if (type is IntentType) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarEntryConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarEntryConverter.kt
@@ -23,5 +23,5 @@ interface OmnibarEntryConverter {
 
 sealed class QueryOrigin {
     object FromUser : QueryOrigin()
-    data class FromAutocomplete(val nav: Boolean?) : QueryOrigin()
+    data class FromAutocomplete(val isNav: Boolean?) : QueryOrigin()
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarEntryConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarEntryConverter.kt
@@ -18,5 +18,10 @@ package com.duckduckgo.app.browser.omnibar
 
 interface OmnibarEntryConverter {
 
-    fun convertQueryToUrl(searchQuery: String, vertical: String? = null): String
+    fun convertQueryToUrl(searchQuery: String, vertical: String? = null, queryOrigin: QueryOrigin = QueryOrigin.FromUser): String
+}
+
+sealed class QueryOrigin {
+    object FromUser : QueryOrigin()
+    data class FromAutocomplete(val nav: Boolean?) : QueryOrigin()
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
@@ -30,7 +30,7 @@ class QueryUrlConverter @Inject constructor(private val requestRewriter: Request
 
     override fun convertQueryToUrl(searchQuery: String, vertical: String?, queryOrigin: QueryOrigin): String {
         val isUrl = when (queryOrigin) {
-            is QueryOrigin.FromAutocomplete -> queryOrigin.nav
+            is QueryOrigin.FromAutocomplete -> queryOrigin.isNav
             is QueryOrigin.FromUser -> UriString.isWebUrl(searchQuery)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
@@ -28,8 +28,13 @@ import javax.inject.Inject
 
 class QueryUrlConverter @Inject constructor(private val requestRewriter: RequestRewriter) : OmnibarEntryConverter {
 
-    override fun convertQueryToUrl(searchQuery: String, vertical: String?): String {
-        if (UriString.isWebUrl(searchQuery)) {
+    override fun convertQueryToUrl(searchQuery: String, vertical: String?, queryOrigin: QueryOrigin): String {
+        val isUrl = when (queryOrigin) {
+            is QueryOrigin.FromAutocomplete -> queryOrigin.nav ?: UriString.isWebUrl(searchQuery)
+            is QueryOrigin.FromUser -> UriString.isWebUrl(searchQuery)
+        }
+
+        if (isUrl) {
             return convertUri(searchQuery)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
@@ -30,11 +30,11 @@ class QueryUrlConverter @Inject constructor(private val requestRewriter: Request
 
     override fun convertQueryToUrl(searchQuery: String, vertical: String?, queryOrigin: QueryOrigin): String {
         val isUrl = when (queryOrigin) {
-            is QueryOrigin.FromAutocomplete -> queryOrigin.nav ?: UriString.isWebUrl(searchQuery)
+            is QueryOrigin.FromAutocomplete -> queryOrigin.nav
             is QueryOrigin.FromUser -> UriString.isWebUrl(searchQuery)
         }
 
-        if (isUrl) {
+        if (isUrl == true) {
             return convertUri(searchQuery)
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1200343978632902
Tech Design URL: 
CC: 

**Description**:
This PR introduces the new autocomplete parameter `is_nav`. The extra `isNav=true` field will then be used as a navigation query (meaning when the user clicks that autocomplete suggestion we load that URL). Results where this is `false` should be treated as searches (even if they look like a URL).

This PR also handles the case where `nav=null` in which case we default to the old way.

**Steps to test this PR**:
**Previous steps, setting up Charles**
1. Connect your device to charles and use the `autocomplete.json` response provided in the task.
1. Install and launch the app.
1. Add a bookmark to `http://m.youtube.com`
1. Do a search (i.e. `you`) and in Charles map the response to the `autocomplete.json` file.

**Test cases**
1. The bookmark result should take you to the URL.
1. The first autocomplete result has `isNav=false`, clicking on it should do a search.
1. The second autocomplete result has `isNav=false` and is a URL, clicking on it should do a search.
1. The third autocomplete result has `isNav=true`, clicking on it should load the URL.
1. The fourth autocomplete result doesn't have the nav attribute and is a URL, clicking on it should load the URL.
1. The fifth autocomplete result doesn't have the nav attribute and is a search term, clicking on it should do a search.
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
