### PR TITLE
Allow empty commits, for when version and release notes are unchanged

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -163,7 +163,12 @@ platform :android do
 
           if UI.confirm(text:"If you have any other changes to make to the release branch, do them now. Enter `y` when ready to create and push tags")
 
-            git_commit(path: "*", message: "Updated release notes and version number for new release - #{newVersion}")
+            git_commit(
+                message: "Updated release notes and version number for new release - #{newVersion}",
+                path: "*",
+                allow_nothing_to_commit: true,
+                skip_git_hooks: true
+            )
             
             sh "git flow release finish -mnFS '#{newVersion}' '#{newVersion}'"
             push_git_tags


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1200390729242552/f
Tech Design URL: 
CC: 

**Description**:
Updates fastlane release script to allow empty commits. This is handy when both release number and release notes are unchanged.

**Steps to test this PR**:
1. Confirm new parameters match https://docs.fastlane.tools/actions/git_commit/#parameters


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
