### PR TITLE
Fix glide exception in some edge cases

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
@@ -38,13 +38,15 @@ class GlideFaviconDownloader @Inject constructor(
 
     override suspend fun getFaviconFromDisk(file: File): Bitmap? {
         return withContext(dispatcherProvider.io()) {
-            Glide.with(context)
-                .asBitmap()
-                .load(file)
-                .diskCacheStrategy(DiskCacheStrategy.NONE)
-                .skipMemoryCache(true)
-                .submit()
-                .get()
+            return@withContext runCatching {
+                Glide.with(context)
+                    .asBitmap()
+                    .load(file)
+                    .diskCacheStrategy(DiskCacheStrategy.NONE)
+                    .skipMemoryCache(true)
+                    .submit()
+                    .get()
+            }.getOrNull()
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200403069635810/f
Tech Design URL: 
CC: 

**Description**:
This PR tries to bring a fix for GlideExceptions crash reports.
We have not being able to reproduce the exception so this workaround only addresses one of the areas where exceptions from Glide are not captured.

**Steps to test this PR**:
This change should not affect current app behavior.

However, we could try to force a crash in that part of the code by trying to read a non existing file:
1. checkout the code
1. add `val file = File(file.path+"err")` in line 40 file `GlideFaviconDownloader`
1. Install the app
1. Add a few favorites or bookmarks
3. Go to bookmarks screen
4. Ensure all bookmarks or favorites show the placeholder and the app did not crash (some sites may show a real favicon but most of them should show the generated one)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
