### PR TITLE
Fix service worker crash

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/serviceworker/ServiceWorkerLifecycleObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/serviceworker/ServiceWorkerLifecycleObserver.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import com.duckduckgo.app.browser.RequestInterceptor
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -35,9 +36,13 @@ class ServiceWorkerLifecycleObserver @Inject constructor(
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
     fun setServiceWorkerClient() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            ServiceWorkerController.getInstance().setServiceWorkerClient(
-                BrowserServiceWorkerClient(requestInterceptor, uncaughtExceptionRepository)
-            )
+            try {
+                ServiceWorkerController.getInstance().setServiceWorkerClient(
+                    BrowserServiceWorkerClient(requestInterceptor, uncaughtExceptionRepository)
+                )
+            } catch (e: Exception) {
+                Timber.w(e.localizedMessage)
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200407932131592
Tech Design URL: 
CC: 

**Description**:
This PR wraps the `getInstance()` call from the Service Worker to avoid crashing the app.

**Steps to test this PR**:
1. Build the app and make sure it doesn't crash!


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
