### PR TITLE
Fix: nav history not cleared when favorite clicked

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -571,17 +571,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenQuickAccessItemClickedThenSubmitNewQuery() {
-        val savedSite = Favorite(1, "title", "http://example.com", 0)
-
-        testee.onQuickAccesItemClicked(savedSite)
-
-        assertCommandIssued<Command.SubmitQuery> {
-            assertEquals("http://example.com", this.url)
-        }
-    }
-
-    @Test
     fun whenQuickAccessDeletedThenRepositoryUpdated() = coroutineRule.runBlocking {
         val savedSite = Favorite(1, "title", "http://example.com", 0)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -656,7 +656,6 @@ class BrowserTabFragment :
             is Command.ConvertBlobToDataUri -> convertBlobToDataUri(it)
             is Command.RequestFileDownload -> requestFileDownload(it.url, it.contentDisposition, it.mimeType, it.requestUserConfirmation)
             is Command.ChildTabClosed -> processUriForThirdPartyCookies()
-            is Command.SubmitQuery -> submitQuery(it.url)
             is Command.CopyAliasToClipboard -> copyAliasToClipboard(it.alias)
             is Command.InjectEmailAddress -> injectEmailAddress(it.address)
             is Command.ShowEmailTooltip -> showEmailTooltip(it.address)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1033,7 +1033,7 @@ class BrowserTabFragment :
     private fun createQuickAccessAdapter(onMoveListener: (RecyclerView.ViewHolder) -> Unit): FavoritesQuickAccessAdapter {
         return FavoritesQuickAccessAdapter(
             this, faviconManager, onMoveListener,
-            { viewModel.onQuickAccesItemClicked(it.favorite) },
+            { viewModel.onUserSubmittedQuery(it.favorite.url) },
             { viewModel.onEditSavedSiteRequested(it.favorite) },
             { viewModel.onDeleteQuickAccessItemRequested(it.favorite) }
         )

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1945,10 +1945,6 @@ class BrowserTabViewModel(
         }
     }
 
-    fun onQuickAccesItemClicked(it: SavedSite) {
-        command.value = SubmitQuery(it.url)
-    }
-
     fun deleteQuickAccessItem(savedSite: SavedSite) {
         val favorite = savedSite as? SavedSite.Favorite ?: return
         viewModelScope.launch(dispatchers.io() + NonCancellable) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -277,7 +277,6 @@ class BrowserTabViewModel(
         class AskToFireproofWebsite(val fireproofWebsite: FireproofWebsiteEntity) : Command()
         class ShareLink(val url: String) : Command()
         class CopyLink(val url: String) : Command()
-        class SubmitQuery(val url: String) : Command()
         class FindInPageCommand(val searchTerm: String) : Command()
         class BrokenSiteFeedback(val data: BrokenSiteData) : Command()
         object DismissFindInPage : Command()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200484661445644/f
Tech Design URL: 
CC: 

**Description**:

Follow up of https://github.com/duckduckgo/Android/pull/1284

We fixed clearing the navigation when the user submits a new query from the home tab, however, when the user clicks on a favorite the issue was still present.

We detected that `ResetHistory` was emitted from the viewmodel but not received in the fragment, and we don't know why that happens.

Bug behavior:
-> quickAccessAdapter item clicked -> `viewModel.onQuickAccesItemClicked` -> `Command.SubmitQuery` -> `viewModel.onUserSubmittedQuery`-> `Command.ResetHistory` and `Command.Navigate` -> ❌ `ResetHistory` command not received, ✅`Navigate` command received

Fix:
-> quickAccessAdapter item clicked -> `viewModel.onUserSubmittedQuery` -> `Command.ResetHistory` and `Command.Navigate` -> ✅ `ResetHistory` command not received, ✅`Navigate` command received


**Steps to test this PR**:
1. Run the app with at least 1 favorite
1. Open a new tab
1. Go to as.com (site A)
1. Press back → going back to home tab
1. Click on a favorite
1. Site A doesn't load
1. Press back
1. You should now be on the home screen


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
