### PR TITLE
Delay setting scroll position until Recycler is ready for it

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -170,7 +170,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private fun scrollToShowCurrentTab() {
         val index = tabsAdapter.adapterPositionForTab(selectedTabId)
-        tabsRecycler.scrollToPosition(index)
+        tabsRecycler.post { tabsRecycler.scrollToPosition(index) }
     }
 
     private fun processCommand(command: Command?) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
  - Internal: https://app.asana.com/0/414730916066338/1200504463069262/f
  - Fixes https://github.com/duckduckgo/Android/issues/1273

**Description**:
Ensures the `RecyclerView` in the tab switcher doesn't have its scroll position set until it's ready to receive that

**Steps to test this PR**:

On `develop`
1. Open up 12 tabs (hint, wikipedia is a good site to use to find lots of links to open in background)
1. Switch to the tab in position 7 or 8
2. Open tab switcher again; you _might_ see the bug whereby it doesn't scroll (repeat a few times if you don't see it immediately)
3. Install this branch
4. Repeat the experiment; you should see it set scroll position correctly
5. Repeat for other elements in the list (first, last etc...) and confirm all work as expected


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
