### PR TITLE
Grant DRM permissions when requested

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -23,6 +23,7 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Message
 import android.view.View
+import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
@@ -187,6 +188,28 @@ class BrowserChromeClientTest {
         assertTrue(testee.onShowFileChooser(webView, mockFilePathCallback, mockFileChooserParams))
         verify(mockUncaughtExceptionRepository).recordUncaughtException(exception, UncaughtExceptionSource.SHOW_FILE_CHOOSER)
         verify(mockFilePathCallback).onReceiveValue(null)
+    }
+
+    @Test
+    fun whenOnPermissionRequestIfProtectedMediaIdIsRequestedThenPermissionIsGranted() {
+        val permissions = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
+        val mockPermission: PermissionRequest = mock()
+        whenever(mockPermission.resources).thenReturn(permissions)
+
+        testee.onPermissionRequest(mockPermission)
+
+        verify(mockPermission).grant(permissions)
+    }
+
+    @Test
+    fun whenOnPermissionRequestIfProtectedMediaIdIsNotRequestedThenNoPermissionsAreGranted() {
+        val permissions = arrayOf(PermissionRequest.RESOURCE_MIDI_SYSEX, PermissionRequest.RESOURCE_VIDEO_CAPTURE, PermissionRequest.RESOURCE_AUDIO_CAPTURE)
+        val mockPermission: PermissionRequest = mock()
+        whenever(mockPermission.resources).thenReturn(permissions)
+
+        testee.onPermissionRequest(mockPermission)
+
+        verify(mockPermission).grant(arrayOf())
     }
 
     private val mockMsg = Message().apply {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -197,7 +197,7 @@ class BrowserChromeClientTest {
         val permissions = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
         val mockPermission: PermissionRequest = mock()
         whenever(mockPermission.resources).thenReturn(permissions)
-        whenever(mockPermission.origin).thenReturn("https://www.spotify.com".toUri())
+        whenever(mockPermission.origin).thenReturn("https://open.spotify.com".toUri())
 
         testee.onPermissionRequest(mockPermission)
 

--- a/app/src/androidTest/java/com/duckduckgo/app/drm/DrmRequestManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/drm/DrmRequestManagerTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.drm
+
+import android.webkit.PermissionRequest
+import androidx.core.net.toUri
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DrmRequestManagerTest {
+
+    val testee: DrmRequestManager = DrmRequestManager()
+
+    @Test
+    fun whenOnPermissionRequestIfProtectedMediaIdIsRequestedThenPermissionIsReturned() {
+        val permissions = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
+        val mockPermission: PermissionRequest = mock()
+        whenever(mockPermission.resources).thenReturn(permissions)
+        whenever(mockPermission.origin).thenReturn("https://www.spotify.com".toUri())
+
+        val value = testee.drmPermissionsForRequest(mockPermission)
+
+        assertEquals(1, value.size)
+        assertEquals(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID, value.first())
+    }
+
+    @Test
+    fun whenOnPermissionRequestIfProtectedMediaIdIsNotRequestedThenNoPermissionsAreReturned() {
+        val permissions = arrayOf(PermissionRequest.RESOURCE_MIDI_SYSEX, PermissionRequest.RESOURCE_VIDEO_CAPTURE, PermissionRequest.RESOURCE_AUDIO_CAPTURE)
+        val mockPermission: PermissionRequest = mock()
+        whenever(mockPermission.resources).thenReturn(permissions)
+        whenever(mockPermission.origin).thenReturn("https://www.spotify.com".toUri())
+
+        val value = testee.drmPermissionsForRequest(mockPermission)
+
+        assertEquals(0, value.size)
+    }
+
+    @Test
+    fun whenOnPermissionRequestIfDomainIsNotInListThenNoPermissionsAreReturned() {
+        val permissions = arrayOf(PermissionRequest.RESOURCE_MIDI_SYSEX, PermissionRequest.RESOURCE_VIDEO_CAPTURE, PermissionRequest.RESOURCE_AUDIO_CAPTURE)
+        val mockPermission: PermissionRequest = mock()
+        whenever(mockPermission.resources).thenReturn(permissions)
+        whenever(mockPermission.origin).thenReturn("https://www.spotify.com".toUri())
+
+        val value = testee.drmPermissionsForRequest(mockPermission)
+
+        assertEquals(0, value.size)
+    }
+
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/drm/DrmRequestManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/drm/DrmRequestManagerTest.kt
@@ -32,7 +32,7 @@ class DrmRequestManagerTest {
         val permissions = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
         val mockPermission: PermissionRequest = mock()
         whenever(mockPermission.resources).thenReturn(permissions)
-        whenever(mockPermission.origin).thenReturn("https://www.spotify.com".toUri())
+        whenever(mockPermission.origin).thenReturn("https://open.spotify.com".toUri())
 
         val value = testee.drmPermissionsForRequest(mockPermission)
 
@@ -45,7 +45,7 @@ class DrmRequestManagerTest {
         val permissions = arrayOf(PermissionRequest.RESOURCE_MIDI_SYSEX, PermissionRequest.RESOURCE_VIDEO_CAPTURE, PermissionRequest.RESOURCE_AUDIO_CAPTURE)
         val mockPermission: PermissionRequest = mock()
         whenever(mockPermission.resources).thenReturn(permissions)
-        whenever(mockPermission.origin).thenReturn("https://www.spotify.com".toUri())
+        whenever(mockPermission.origin).thenReturn("https://open.spotify.com".toUri())
 
         val value = testee.drmPermissionsForRequest(mockPermission)
 
@@ -57,7 +57,7 @@ class DrmRequestManagerTest {
         val permissions = arrayOf(PermissionRequest.RESOURCE_MIDI_SYSEX, PermissionRequest.RESOURCE_VIDEO_CAPTURE, PermissionRequest.RESOURCE_AUDIO_CAPTURE)
         val mockPermission: PermissionRequest = mock()
         whenever(mockPermission.resources).thenReturn(permissions)
-        whenever(mockPermission.origin).thenReturn("https://www.spotify.com".toUri())
+        whenever(mockPermission.origin).thenReturn("https://open.spotify.com".toUri())
 
         val value = testee.drmPermissionsForRequest(mockPermission)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -21,6 +21,7 @@ import android.net.Uri
 import android.os.Message
 import android.view.View
 import android.webkit.GeolocationPermissions
+import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
@@ -136,6 +137,15 @@ class BrowserChromeClient @Inject constructor(
             return true
         }
         return false
+    }
+
+    override fun onPermissionRequest(request: PermissionRequest) {
+        val resources = request.resources
+        val perms = mutableSetOf<String>()
+        resources.find { (it == PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID) }?.let {
+            perms.add(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
+        }
+        request.grant(perms.toTypedArray())
     }
 
     override fun onCloseWindow(window: WebView?) {

--- a/app/src/main/java/com/duckduckgo/app/drm/DrmRequestManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/drm/DrmRequestManager.kt
@@ -40,7 +40,7 @@ class DrmRequestManager @Inject constructor() {
 
     companion object {
         val domainsThatAllowDrm = listOf(
-            "spotify.com",
+            "open.spotify.com",
             "netflix.com"
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/drm/DrmRequestManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/drm/DrmRequestManager.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.drm
+
+import android.net.Uri
+import android.webkit.PermissionRequest
+import com.duckduckgo.app.global.baseHost
+import javax.inject.Inject
+
+class DrmRequestManager @Inject constructor() {
+
+    fun drmPermissionsForRequest(request: PermissionRequest): Array<String> {
+        val perms = mutableSetOf<String>()
+        if (shouldEnableDrmForUri(request.origin)) {
+            val resources = request.resources
+            resources.find { (it == PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID) }?.let {
+                perms.add(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
+            }
+        }
+        return perms.toTypedArray()
+    }
+
+    private fun shouldEnableDrmForUri(uri: Uri): Boolean {
+        return domainsThatAllowDrm.contains(uri.baseHost)
+    }
+
+    companion object {
+        val domainsThatAllowDrm = listOf(
+            "spotify.com",
+            "netflix.com"
+        )
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1200498850561025
Tech Design URL: 
CC: 

**Description**:
This PR grants DRM permissions when requested so protected media content can be played. We only grant `RESOURCE_PROTECTED_MEDIA_ID` and ignore any other media permissions.

**Steps to test this PR**:
1. Go to spotify.com
1. Log in with your account
1. The player should successfully show up and you should be able to play songs, etc.
1. If you try the same in `develop` you will see a `Not supported` message after logging in and/or opening the web player.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
