### PR TITLE
Fix UI when a site is in temp allowed list

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -111,6 +111,7 @@ import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.EntityLookup
+import com.duckduckgo.app.trackerdetection.db.TemporaryTrackingWhitelistDao
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
@@ -239,6 +240,9 @@ class BrowserTabViewModelTest {
 
     @Mock
     private lateinit var mockUserWhitelistDao: UserWhitelistDao
+
+    @Mock
+    private lateinit var mockTemporaryTrackingWhitelistDao: TemporaryTrackingWhitelistDao
 
     @Mock
     private lateinit var mockNavigationAwareLoginDetector: NavigationAwareLoginDetector
@@ -385,7 +389,8 @@ class BrowserTabViewModelTest {
             emailManager = mockEmailManager,
             favoritesRepository = mockFavoritesRepository,
             appCoroutineScope = TestCoroutineScope(),
-            appLinksHandler = mockAppLinksHandler
+            appLinksHandler = mockAppLinksHandler,
+            temporaryTrackingWhitelistDao = mockTemporaryTrackingWhitelistDao
         )
 
         testee.loadData("abc", null, false)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -350,6 +350,7 @@ class BrowserTabViewModelTest {
         whenever(mockPrivacyPractices.privacyPracticesFor(any())).thenReturn(PrivacyPractices.UNKNOWN)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserWhitelistDao.contains(anyString())).thenReturn(false)
+        whenever(mockTemporaryTrackingWhitelistDao.contains(anyString())).thenReturn(false)
         whenever(fireproofDialogsEventHandler.event).thenReturn(fireproofDialogsEventHandlerLiveData)
 
         testee = BrowserTabViewModel(
@@ -3255,6 +3256,20 @@ class BrowserTabViewModelTest {
         whenever(mockOmnibarConverter.convertQueryToUrl("nytimes.com", null)).thenReturn("nytimes.com")
         testee.onUserSubmittedQuery("nytimes.com")
         assertCommandNotIssued<Command.ResetHistory>()
+    }
+
+    @Test
+    fun whenLoadUrlAndUrlIsInTempAllowListThenIsWhitelistedIsTrue() {
+        whenever(mockTemporaryTrackingWhitelistDao.contains("example.com")).thenReturn(true)
+        loadUrl("https://example.com")
+        assertTrue(browserViewState().isWhitelisted)
+    }
+
+    @Test
+    fun whenLoadUrlAndUrlIsInTempAllowListThenPrivacyOnIsFalse() {
+        whenever(mockTemporaryTrackingWhitelistDao.contains("example.com")).thenReturn(true)
+        loadUrl("https://example.com")
+        assertFalse(loadingViewState().privacyOn)
     }
 
     private suspend fun givenFireButtonPulsing() {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -909,6 +909,15 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenProgressChangesAndPrivacyIsOnAndSiteIsInTempAllowListAndSiteIsFullyLoadedThenShowLoadingGradeIsFalse() {
+        whenever(mockTemporaryTrackingWhitelistDao.contains(any())).thenReturn(true)
+        setBrowserShowing(true)
+        testee.loadingViewState.value = loadingViewState().copy(privacyOn = true)
+        testee.progressChanged(100)
+        assertTrue(privacyGradeState().showEmptyGrade)
+    }
+
+    @Test
     fun whenProgressChangesButIsTheSameAsBeforeThenDoNotUpdateState() {
         setBrowserShowing(true)
         testee.progressChanged(100)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -909,15 +909,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenProgressChangesAndPrivacyIsOnAndSiteIsInTempAllowListAndSiteIsFullyLoadedThenShowLoadingGradeIsFalse() {
-        whenever(mockTemporaryTrackingWhitelistDao.contains(any())).thenReturn(true)
-        setBrowserShowing(true)
-        testee.loadingViewState.value = loadingViewState().copy(privacyOn = true)
-        testee.progressChanged(100)
-        assertTrue(privacyGradeState().showEmptyGrade)
-    }
-
-    @Test
     fun whenProgressChangesButIsTheSameAsBeforeThenDoNotUpdateState() {
         setBrowserShowing(true)
         testee.progressChanged(100)
@@ -3279,6 +3270,13 @@ class BrowserTabViewModelTest {
         whenever(mockTemporaryTrackingWhitelistDao.contains("example.com")).thenReturn(true)
         loadUrl("https://example.com")
         assertFalse(loadingViewState().privacyOn)
+    }
+
+    @Test
+    fun whenLoadUrlAndSiteIsInTempAllowListThenDoNotChangePrivacyGrade() {
+        whenever(mockTemporaryTrackingWhitelistDao.contains(any())).thenReturn(true)
+        loadUrl("https://example.com")
+        assertNull(privacyGradeState().privacyGrade)
     }
 
     private suspend fun givenFireButtonPulsing() {

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
@@ -103,7 +103,8 @@ class PrivacyDashboardViewModelTest {
         assertEquals(PrivacyGrade.UNKNOWN, viewState.afterGrade)
         assertEquals(HttpsStatus.SECURE, viewState.httpsStatus)
         assertTrue(viewState.allTrackersBlocked)
-        assertEquals(UNKNOWN, testee.viewState.value!!.practices)
+        assertEquals(UNKNOWN, viewState.practices)
+        assertFalse(viewState.isSiteInTempAllowedList)
     }
 
     @Test
@@ -235,6 +236,14 @@ class PrivacyDashboardViewModelTest {
         verify(mockPixel).fire(PRIVACY_DASHBOARD_REPORT_BROKEN_SITE)
         verify(commandObserver).onChanged(commandCaptor.capture())
         assertTrue(commandCaptor.lastValue is LaunchReportBrokenSite)
+    }
+
+    @Test
+    fun whenOnSiteChangedAndSiteIsInTempAllowListThenReturnTrue() {
+        whenever(mockTemporaryTrackingWhitelistDao.contains(any())).thenReturn(true)
+        val site = site(grade = PrivacyGrade.D, improvedGrade = PrivacyGrade.B)
+        testee.onSiteChanged(site)
+        assertTrue(testee.viewState.value!!.isSiteInTempAllowedList)
     }
 
     private fun givenSiteWithPrivacyOn() {

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchMan
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchReportBrokenSite
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.pixels.AppPixelName.*
+import com.duckduckgo.app.trackerdetection.db.TemporaryTrackingWhitelistDao
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -56,6 +57,7 @@ class PrivacyDashboardViewModelTest {
 
     private var viewStateObserver: Observer<PrivacyDashboardViewModel.ViewState> = mock()
     private var mockUserWhitelistDao: UserWhitelistDao = mock()
+    private var mockTemporaryTrackingWhitelistDao: TemporaryTrackingWhitelistDao = mock()
     private var networkLeaderboardDao: NetworkLeaderboardDao = mock()
     private var networkLeaderboardLiveData: LiveData<List<NetworkLeaderboardEntry>> = mock()
     private var sitesVisitedLiveData: LiveData<Int> = mock()
@@ -66,7 +68,7 @@ class PrivacyDashboardViewModelTest {
 
     @ExperimentalCoroutinesApi
     private val testee: PrivacyDashboardViewModel by lazy {
-        val model = PrivacyDashboardViewModel(mockUserWhitelistDao, networkLeaderboardDao, mockPixel, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+        val model = PrivacyDashboardViewModel(mockUserWhitelistDao, mockTemporaryTrackingWhitelistDao, networkLeaderboardDao, mockPixel, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
         model.viewState.observeForever(viewStateObserver)
         model.command.observeForever(commandObserver)
         model

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/ScorecardViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/ScorecardViewModelTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.model.PrivacyPractices.Practices
 import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.GOOD
 import com.duckduckgo.app.privacy.model.TestEntity
+import com.duckduckgo.app.trackerdetection.db.TemporaryTrackingWhitelistDao
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
@@ -51,9 +52,10 @@ class ScorecardViewModelTest {
 
     private var viewStateObserver: Observer<ScorecardViewModel.ViewState> = mock()
     private var userWhitelistDao: UserWhitelistDao = mock()
+    private var temporaryTrackingWhitelistDao: TemporaryTrackingWhitelistDao = mock()
 
     private val testee: ScorecardViewModel by lazy {
-        val model = ScorecardViewModel(userWhitelistDao, coroutineRule.testDispatcherProvider)
+        val model = ScorecardViewModel(userWhitelistDao, temporaryTrackingWhitelistDao, coroutineRule.testDispatcherProvider)
         model.viewState.observeForever(viewStateObserver)
         model
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/TrackerDetectorClientTypeTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/TrackerDetectorClientTypeTest.kt
@@ -71,7 +71,8 @@ class TrackerDetectorClientTypeTest {
     @Test
     fun whenUrlMatchesInBlockingAndWhitelistedClientThenEvaluateReturnsNull() {
         val url = Url.BLOCKED_AND_WHITELISTED
-        assertNull(testee.evaluate(url, documentUrl))
+        val expected = TrackingEvent(documentUrl, url, null, null, false, null)
+        assertEquals(expected, testee.evaluate(url, documentUrl))
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/db/TemporaryTrackingWhitelistDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/db/TemporaryTrackingWhitelistDaoTest.kt
@@ -114,6 +114,13 @@ class TemporaryTrackingWhitelistDaoTest {
         Assert.assertFalse(dao.contains(domain))
     }
 
+    @Test
+    fun whenElementAddedAndSubdomainCheckedThenContainsIsTrue() {
+        val entity = createEntity("test.com")
+        dao.insertAll(listOf(entity))
+        assertTrue(dao.contains("subdomain.test.com"))
+    }
+
     private fun createEntity(domain: String): TemporaryTrackingWhitelistedDomain {
         return TemporaryTrackingWhitelistedDomain(domain)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/db/TemporaryTrackingWhitelistDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/db/TemporaryTrackingWhitelistDaoTest.kt
@@ -21,6 +21,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.trackerdetection.model.TemporaryTrackingWhitelistedDomain
 import org.junit.After
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -91,6 +92,26 @@ class TemporaryTrackingWhitelistDaoTest {
         dao.insertAll(listOf(entity))
         dao.deleteAll()
         assertEquals(0, dao.count())
+    }
+
+    @Test
+    fun whenElementAddedThenContainsIsTrue() {
+        val entity = createEntity(domain)
+        dao.insertAll(listOf(entity))
+        assertTrue(dao.contains(domain))
+    }
+
+    @Test
+    fun wheElementDeletedThenContainsIsFalse() {
+        val entity = createEntity(domain)
+        dao.insertAll(listOf(entity))
+        dao.deleteAll()
+        Assert.assertFalse(dao.contains(domain))
+    }
+
+    @Test
+    fun whenElementDoesNotExistThenContainsIsFalse() {
+        Assert.assertFalse(dao.contains(domain))
     }
 
     private fun createEntity(domain: String): TemporaryTrackingWhitelistedDomain {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -996,7 +996,7 @@ class BrowserTabViewModel(
 
         loadingViewState.value = progress.copy(isLoading = isLoading, progress = visualProgress)
 
-        val showLoadingGrade = progress.privacyOn || isLoading
+        val showLoadingGrade = (progress.privacyOn && !currentBrowserViewState().isWhitelisted) || isLoading
         privacyGradeViewState.value = currentPrivacyGradeState().copy(shouldAnimate = isLoading, showEmptyGrade = showLoadingGrade)
 
         if (newProgress == 100) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -996,7 +996,7 @@ class BrowserTabViewModel(
 
         loadingViewState.value = progress.copy(isLoading = isLoading, progress = visualProgress)
 
-        val showLoadingGrade = (progress.privacyOn && !currentBrowserViewState().isWhitelisted) || isLoading
+        val showLoadingGrade = progress.privacyOn || isLoading
         privacyGradeViewState.value = currentPrivacyGradeState().copy(shouldAnimate = isLoading, showEmptyGrade = showLoadingGrade)
 
         if (newProgress == 100) {
@@ -1241,7 +1241,10 @@ class BrowserTabViewModel(
 
             withContext(dispatchers.main()) {
                 siteLiveData.value = site
-                privacyGradeViewState.value = currentPrivacyGradeState().copy(privacyGrade = improvedGrade)
+                val isWhiteListed: Boolean = site?.domain?.let { isWhitelisted(it) } ?: false
+                if (!isWhiteListed) {
+                    privacyGradeViewState.value = currentPrivacyGradeState().copy(privacyGrade = improvedGrade)
+                }
             }
 
             withContext(dispatchers.io()) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -108,6 +108,7 @@ import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.trackerdetection.db.TemporaryTrackingWhitelistDao
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.di.scopes.AppObjectGraph
@@ -133,6 +134,7 @@ class BrowserTabViewModel(
     private val siteFactory: SiteFactory,
     private val tabRepository: TabRepository,
     private val userWhitelistDao: UserWhitelistDao,
+    private val temporaryTrackingWhitelistDao: TemporaryTrackingWhitelistDao,
     private val networkLeaderboardDao: NetworkLeaderboardDao,
     private val bookmarksDao: BookmarksDao,
     private val favoritesRepository: FavoritesRepository,
@@ -899,7 +901,9 @@ class BrowserTabViewModel(
     }
 
     private suspend fun isWhitelisted(domain: String): Boolean {
-        return withContext(dispatchers.io()) { userWhitelistDao.contains(domain) }
+        return withContext(dispatchers.io()) {
+            userWhitelistDao.contains(domain) || temporaryTrackingWhitelistDao.contains(domain)
+        }
     }
 
     private suspend fun notifyPermanentLocationPermission(domain: String) {
@@ -1984,6 +1988,7 @@ class BrowserTabViewModelFactory @Inject constructor(
     private val siteFactory: Provider<SiteFactory>,
     private val tabRepository: Provider<TabRepository>,
     private val userWhitelistDao: Provider<UserWhitelistDao>,
+    private val temporaryTrackingWhitelistDao: Provider<TemporaryTrackingWhitelistDao>,
     private val networkLeaderboardDao: Provider<NetworkLeaderboardDao>,
     private val bookmarksDao: Provider<BookmarksDao>,
     private val favoritesRepository: Provider<FavoritesRepository>,
@@ -2015,7 +2020,7 @@ class BrowserTabViewModelFactory @Inject constructor(
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(BrowserTabViewModel::class.java) -> BrowserTabViewModel(statisticsUpdater.get(), queryUrlConverter.get(), duckDuckGoUrlDetector.get(), siteFactory.get(), tabRepository.get(), userWhitelistDao.get(), networkLeaderboardDao.get(), bookmarksDao.get(), favoritesRepository.get(), fireproofWebsiteRepository.get(), locationPermissionsRepository.get(), geoLocationPermissions.get(), navigationAwareLoginDetector.get(), autoComplete.get(), appSettingsPreferencesStore.get(), longPressHandler.get(), webViewSessionStorage.get(), specialUrlDetector.get(), faviconManager.get(), addToHomeCapabilityDetector.get(), ctaViewModel.get(), searchCountDao.get(), pixel.get(), dispatchers, userEventsStore.get(), notificationDao.get(), variantManager.get(), fileDownloader.get(), globalPrivacyControl.get(), fireproofDialogsEventHandler.get(), emailManager.get(), appCoroutineScope.get(), appLinksHandler.get()) as T
+                isAssignableFrom(BrowserTabViewModel::class.java) -> BrowserTabViewModel(statisticsUpdater.get(), queryUrlConverter.get(), duckDuckGoUrlDetector.get(), siteFactory.get(), tabRepository.get(), userWhitelistDao.get(), temporaryTrackingWhitelistDao.get(), networkLeaderboardDao.get(), bookmarksDao.get(), favoritesRepository.get(), fireproofWebsiteRepository.get(), locationPermissionsRepository.get(), geoLocationPermissions.get(), navigationAwareLoginDetector.get(), autoComplete.get(), appSettingsPreferencesStore.get(), longPressHandler.get(), webViewSessionStorage.get(), specialUrlDetector.get(), faviconManager.get(), addToHomeCapabilityDetector.get(), ctaViewModel.get(), searchCountDao.get(), pixel.get(), dispatchers, userEventsStore.get(), notificationDao.get(), variantManager.get(), fileDownloader.get(), globalPrivacyControl.get(), fireproofDialogsEventHandler.get(), emailManager.get(), appCoroutineScope.get(), appLinksHandler.get()) as T
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
@@ -110,6 +110,7 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
             return
         }
         val toggle = viewState.toggleEnabled ?: true
+        val privacyProtectionEnabled = viewState.privacyProtectionEnabled
         privacyBanner.setImageResource(viewState.afterGrade.banner(toggle))
         domain.text = viewState.domain
         heading.text = upgradeRenderer.heading(this, viewState.beforeGrade, viewState.afterGrade, toggle).html(this)
@@ -119,7 +120,7 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
         networksText.text = trackersRenderer.trackersText(this, viewState.trackerCount, viewState.allTrackersBlocked)
         practicesIcon.setImageResource(viewState.practices.icon())
         practicesText.text = viewState.practices.text(this)
-        renderToggle(toggle)
+        renderToggle(toggle, privacyProtectionEnabled)
         renderTrackerNetworkLeaderboard(viewState)
         updateActivityResult(viewState.shouldReloadPage)
     }
@@ -153,10 +154,11 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
         trackerNetworkLeaderboardNotReady.show()
     }
 
-    private fun renderToggle(enabled: Boolean) {
+    private fun renderToggle(enabled: Boolean, privacyProtectionEnabled: Boolean) {
         val backgroundColor = if (enabled) R.color.midGreen else R.color.warmerGray
         privacyToggleContainer.setBackgroundColor(ContextCompat.getColor(this, backgroundColor))
         privacyToggle.isChecked = enabled
+        privacyToggle.isEnabled = privacyProtectionEnabled
     }
 
     private fun processCommand(command: Command) {

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
@@ -111,29 +111,45 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
             return
         }
         val toggle = viewState.toggleEnabled ?: true
-        val isSiteIntTempAllowedList = viewState.isSiteOnTempAllowedList
-        val isPrivacyOn = toggle && !isSiteIntTempAllowedList
         privacyBanner.setImageResource(viewState.afterGrade.banner(toggle))
         domain.text = viewState.domain
-        heading.text = upgradeRenderer.heading(this, viewState.beforeGrade, viewState.afterGrade, isPrivacyOn).html(this)
+        renderHeading(viewState, toggle)
         httpsIcon.setImageResource(viewState.httpsStatus.icon())
         httpsText.text = viewState.httpsStatus.text(this)
         networksIcon.setImageResource(trackersRenderer.networksIcon(viewState.allTrackersBlocked))
         networksText.text = trackersRenderer.trackersText(this, viewState.trackerCount, viewState.allTrackersBlocked)
         practicesIcon.setImageResource(viewState.practices.icon())
         practicesText.text = viewState.practices.text(this)
-        renderToggle(toggle, isSiteIntTempAllowedList)
+        renderToggle(toggle, viewState.isSiteInTempAllowedList)
         renderTrackerNetworkLeaderboard(viewState)
+        renderButtonContainer(viewState.isSiteInTempAllowedList)
         updateActivityResult(viewState.shouldReloadPage)
     }
 
-    private fun renderTrackerNetworkLeaderboard(viewState: ViewState) {
+    private fun renderButtonContainer(isSiteIntTempAllowedList: Boolean) {
+        if (isSiteIntTempAllowedList) {
+            buttonContainer.gone()
+        } else {
+            buttonContainer.show()
+        }
+    }
 
+    private fun renderHeading(viewState: ViewState, isPrivacyOn: Boolean) {
+        if (viewState.isSiteInTempAllowedList) {
+            heading.gone()
+            protectionsTemporarilyDisabled.show()
+        } else {
+            protectionsTemporarilyDisabled.gone()
+            heading.show()
+            heading.text = upgradeRenderer.heading(this, viewState.beforeGrade, viewState.afterGrade, isPrivacyOn).html(this)
+        }
+    }
+
+    private fun renderTrackerNetworkLeaderboard(viewState: ViewState) {
         if (!viewState.shouldShowTrackerNetworkLeaderboard) {
             hideTrackerNetworkLeaderboard()
             return
         }
-
         trackerNetworkPill1.render(viewState.trackerNetworkEntries.elementAtOrNull(0), viewState.sitesVisited)
         trackerNetworkPill2.render(viewState.trackerNetworkEntries.elementAtOrNull(1), viewState.sitesVisited)
         trackerNetworkPill3.render(viewState.trackerNetworkEntries.elementAtOrNull(2), viewState.sitesVisited)
@@ -157,16 +173,10 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
     }
 
     private fun renderToggle(enabled: Boolean, isSiteIntTempAllowedList: Boolean) {
-        val backgroundColor = if (enabled && !isSiteIntTempAllowedList) R.color.midGreen else R.color.warmerGray
+        val backgroundColor = if (enabled) R.color.midGreen else R.color.warmerGray
         privacyToggleContainer.setBackgroundColor(ContextCompat.getColor(this, backgroundColor))
-        privacyToggle.isChecked = enabled
-        if (isSiteIntTempAllowedList) {
-            privacyToggle.gone()
-            privacyToggleText.text = getString(R.string.privacyProtectionToggleDisabled)
-        } else {
-            privacyToggle.show()
-            privacyToggleText.text = getString(R.string.privacyProtectionToggle)
-        }
+        privacyToggle.isChecked = enabled && !isSiteIntTempAllowedList
+        privacyToggle.isEnabled = !isSiteIntTempAllowedList
     }
 
     private fun processCommand(command: Command) {

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
@@ -22,12 +22,10 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.Observer
 import com.duckduckgo.app.brokensite.BrokenSiteActivity
 import com.duckduckgo.app.brokensite.BrokenSiteData
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.view.gone
 import com.duckduckgo.app.global.view.hide
 import com.duckduckgo.app.global.view.html

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
@@ -152,7 +152,7 @@ class PrivacyDashboardViewModel(
         val grades = site.calculateGrades()
         val domain = site.domain ?: ""
         val toggleEnabled = withContext(dispatchers.io()) { !userWhitelistDao.contains(domain) }
-        val isInTemporaryWhitelist = withContext(dispatchers.io()) {
+        val isInTemporaryAllowlist = withContext(dispatchers.io()) {
             temporaryTrackingWhitelistDao.contains(domain)
         }
 
@@ -166,7 +166,7 @@ class PrivacyDashboardViewModel(
                 allTrackersBlocked = site.allTrackersBlocked,
                 toggleEnabled = toggleEnabled,
                 practices = site.privacyPractices.summary,
-                isSiteInTempAllowedList = isInTemporaryWhitelist
+                isSiteInTempAllowedList = isInTemporaryAllowlist
             )
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
@@ -68,7 +68,7 @@ class PrivacyDashboardViewModel(
         val sitesVisited: Int,
         val trackerNetworkEntries: List<NetworkLeaderboardEntry>,
         val shouldReloadPage: Boolean,
-        val isSiteOnTempAllowedList: Boolean
+        val isSiteInTempAllowedList: Boolean
     )
 
     sealed class Command {
@@ -144,7 +144,7 @@ class PrivacyDashboardViewModel(
             sitesVisited = 0,
             trackerNetworkEntries = emptyList(),
             shouldReloadPage = false,
-            isSiteOnTempAllowedList = false
+            isSiteInTempAllowedList = false
         )
     }
 
@@ -166,7 +166,7 @@ class PrivacyDashboardViewModel(
                 allTrackersBlocked = site.allTrackersBlocked,
                 toggleEnabled = toggleEnabled,
                 practices = site.privacyPractices.summary,
-                isSiteOnTempAllowedList = isInTemporaryWhitelist
+                isSiteInTempAllowedList = isInTemporaryWhitelist
             )
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModel.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.UNKNOWN
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchManageWhitelist
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.Command.LaunchReportBrokenSite
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.trackerdetection.db.TemporaryTrackingWhitelistDao
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
@@ -47,6 +48,7 @@ import javax.inject.Provider
 
 class PrivacyDashboardViewModel(
     private val userWhitelistDao: UserWhitelistDao,
+    private val temporaryTrackingWhitelistDao: TemporaryTrackingWhitelistDao,
     networkLeaderboardDao: NetworkLeaderboardDao,
     private val pixel: Pixel,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
@@ -65,7 +67,8 @@ class PrivacyDashboardViewModel(
         val shouldShowTrackerNetworkLeaderboard: Boolean,
         val sitesVisited: Int,
         val trackerNetworkEntries: List<NetworkLeaderboardEntry>,
-        val shouldReloadPage: Boolean
+        val shouldReloadPage: Boolean,
+        val privacyProtectionEnabled: Boolean
     )
 
     sealed class Command {
@@ -140,14 +143,22 @@ class PrivacyDashboardViewModel(
             shouldShowTrackerNetworkLeaderboard = false,
             sitesVisited = 0,
             trackerNetworkEntries = emptyList(),
-            shouldReloadPage = false
+            shouldReloadPage = false,
+            privacyProtectionEnabled = true
         )
     }
 
     private suspend fun updateSite(site: Site) {
         val grades = site.calculateGrades()
         val domain = site.domain ?: ""
-        val toggleEnabled = withContext(dispatchers.io()) { !userWhitelistDao.contains(domain) }
+        val isInUserWhitelist = withContext(dispatchers.io()) {
+            userWhitelistDao.contains(domain)
+        }
+        val isInTemporaryWhitelist = withContext(dispatchers.io()) {
+            temporaryTrackingWhitelistDao.contains(domain)
+        }
+
+        val toggleEnabled = !(isInTemporaryWhitelist || isInUserWhitelist)
 
         withContext(dispatchers.main()) {
             viewState.value = viewState.value?.copy(
@@ -158,7 +169,8 @@ class PrivacyDashboardViewModel(
                 trackerCount = site.trackerCount,
                 allTrackersBlocked = site.allTrackersBlocked,
                 toggleEnabled = toggleEnabled,
-                practices = site.privacyPractices.summary
+                practices = site.privacyPractices.summary,
+                privacyProtectionEnabled = !isInTemporaryWhitelist
             )
         }
     }
@@ -208,6 +220,7 @@ class PrivacyDashboardViewModel(
 @ContributesMultibinding(AppObjectGraph::class)
 class PrivacyDashboardViewModelFactory @Inject constructor(
     private val userWhitelistDao: Provider<UserWhitelistDao>,
+    private val temporaryTrackingWhitelistDao: Provider<TemporaryTrackingWhitelistDao>,
     private val networkLeaderboardDao: Provider<NetworkLeaderboardDao>,
     private val pixel: Provider<Pixel>,
     private val appCoroutineScope: Provider<CoroutineScope>
@@ -215,7 +228,7 @@ class PrivacyDashboardViewModelFactory @Inject constructor(
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(PrivacyDashboardViewModel::class.java) -> PrivacyDashboardViewModel(userWhitelistDao.get(), networkLeaderboardDao.get(), pixel.get(), appCoroutineScope.get()) as T
+                isAssignableFrom(PrivacyDashboardViewModel::class.java) -> PrivacyDashboardViewModel(userWhitelistDao.get(), temporaryTrackingWhitelistDao.get(), networkLeaderboardDao.get(), pixel.get(), appCoroutineScope.get()) as T
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardActivity.kt
@@ -22,10 +22,8 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.DrawableRes
-import androidx.lifecycle.Observer
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.view.gone
 import com.duckduckgo.app.global.view.html
 import com.duckduckgo.app.global.view.show

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardActivity.kt
@@ -26,7 +26,9 @@ import androidx.lifecycle.Observer
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.app.global.view.gone
 import com.duckduckgo.app.global.view.html
+import com.duckduckgo.app.global.view.show
 import com.duckduckgo.app.privacy.renderer.*
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
@@ -51,14 +53,14 @@ class ScorecardActivity : DuckDuckGoActivity() {
 
         viewModel.viewState.observe(
             this,
-            Observer<ScorecardViewModel.ViewState> {
+            {
                 it?.let { render(it) }
             }
         )
 
         repository.retrieveSiteData(intent.tabId!!).observe(
             this,
-            Observer<Site> {
+            {
                 viewModel.onSiteChanged(it)
             }
         )
@@ -67,7 +69,7 @@ class ScorecardActivity : DuckDuckGoActivity() {
     private fun render(viewState: ScorecardViewModel.ViewState) {
         privacyBanner.setImageResource(viewState.afterGrade.banner(viewState.privacyOn))
         domain.text = viewState.domain
-        heading.text = upgradeRenderer.heading(this, viewState.beforeGrade, viewState.afterGrade, viewState.privacyOn).html(this)
+        renderHeading(viewState)
         https.text = viewState.httpsStatus.text(this)
         https.setDrawableEnd(viewState.httpsStatus.successFailureIcon())
         practices.text = viewState.practices.text(this)
@@ -80,6 +82,17 @@ class ScorecardActivity : DuckDuckGoActivity() {
         majorNetworks.setDrawableEnd(trackersRenderer.successFailureIcon(viewState.majorNetworkCount))
         showIsMemberOfMajorNetwork(viewState.showIsMemberOfMajorNetwork)
         showEnhancedGrade(viewState.showEnhancedGrade)
+    }
+
+    private fun renderHeading(viewState: ScorecardViewModel.ViewState) {
+        if (viewState.isSiteInTempAllowedList) {
+            heading.gone()
+            protectionsTemporarilyDisabled.show()
+        } else {
+            protectionsTemporarilyDisabled.gone()
+            heading.show()
+            heading.text = upgradeRenderer.heading(this, viewState.beforeGrade, viewState.afterGrade, viewState.privacyOn).html(this)
+        }
     }
 
     private fun showIsMemberOfMajorNetwork(show: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardViewModel.kt
@@ -54,7 +54,8 @@ class ScorecardViewModel(
         val practices: PrivacyPractices.Summary,
         val privacyOn: Boolean,
         val showIsMemberOfMajorNetwork: Boolean,
-        val showEnhancedGrade: Boolean
+        val showEnhancedGrade: Boolean,
+        val isSiteInTempAllowedList: Boolean
     )
 
     val viewState: MutableLiveData<ViewState> = MutableLiveData()
@@ -85,7 +86,8 @@ class ScorecardViewModel(
             practices = UNKNOWN,
             privacyOn = true,
             showIsMemberOfMajorNetwork = false,
-            showEnhancedGrade = false
+            showEnhancedGrade = false,
+            isSiteInTempAllowedList = false
         )
     }
 
@@ -110,7 +112,8 @@ class ScorecardViewModel(
                 practices = site.privacyPractices.summary,
                 privacyOn = !isWhitelisted && !isSiteInTempList,
                 showIsMemberOfMajorNetwork = site.entity?.isMajor ?: false,
-                showEnhancedGrade = grade != improvedGrade
+                showEnhancedGrade = grade != improvedGrade,
+                isSiteInTempAllowedList = isSiteInTempList
             )
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/db/TemporaryTrackingWhitelistDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/db/TemporaryTrackingWhitelistDao.kt
@@ -48,6 +48,6 @@ abstract class TemporaryTrackingWhitelistDao {
     @Query("delete from temporary_tracking_whitelist")
     abstract fun deleteAll()
 
-    @Query("select count(1) > 0 from temporary_tracking_whitelist where domain = :domain")
+    @Query("select count(1) > 0 from temporary_tracking_whitelist where :domain LIKE '%'||domain||'%'")
     abstract fun contains(domain: String): Boolean
 }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/db/TemporaryTrackingWhitelistDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/db/TemporaryTrackingWhitelistDao.kt
@@ -47,4 +47,7 @@ abstract class TemporaryTrackingWhitelistDao {
 
     @Query("delete from temporary_tracking_whitelist")
     abstract fun deleteAll()
+
+    @Query("select count(1) > 0 from temporary_tracking_whitelist where domain = :domain")
+    abstract fun contains(domain: String): Boolean
 }

--- a/app/src/main/res/layout/include_privacy_dashboard_header.xml
+++ b/app/src/main/res/layout/include_privacy_dashboard_header.xml
@@ -18,7 +18,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="212dp"
+    android:layout_height="wrap_content"
     android:background="@color/subtleGray"
     tools:showIn="@layout/content_privacy_dashboard">
 
@@ -30,6 +30,7 @@
         android:paddingTop="20dp"
         android:paddingBottom="12dp"
         android:src="@drawable/privacygrade_banner_unknown"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent" />
 
@@ -52,7 +53,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp"
-        android:layout_marginBottom="16dp"
+        android:layout_marginBottom="14dp"
         android:fontFamily="sans-serif"
         android:gravity="center"
         android:letterSpacing="0.14"
@@ -63,6 +64,29 @@
         android:textAlignment="gravity"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/domain" />
+
+    <TextView
+        android:id="@+id/protectionsTemporarilyDisabled"
+        android:layout_width="0dp"
+        android:layout_height="60dp"
+        android:layout_marginTop="10dp"
+        android:paddingEnd="19dp"
+        android:paddingStart="19dp"
+        android:fontFamily="sans-serif"
+        android:gravity="center"
+        android:visibility="visible"
+        android:text="@string/privacyProtectionTemporarilyDisabled"
+        android:textColor="@color/black"
+        android:textSize="14sp"
+        android:textStyle="bold"
+
+        android:background="@color/yellow_10"
+        android:textAlignment="gravity"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/domain" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -53,5 +53,5 @@
     <string name="appLinkDialogTitle">Open in another app?</string>
 
     <!-- Privacy Protection Dashboard -->
-    <string name="privacyProtectionToggleDisabled">Protections are temporarily disabled due to this site being broken.</string>
+    <string name="privacyProtectionTemporarilyDisabled">Privacy Protection is temporarily disabled due to breakage of site</string>
 </resources>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -53,5 +53,5 @@
     <string name="appLinkDialogTitle">Open in another app?</string>
 
     <!-- Privacy Protection Dashboard -->
-    <string name="privacyProtectionTemporarilyDisabled">Privacy Protection is temporarily disabled due to breakage of site</string>
+    <string name="privacyProtectionTemporarilyDisabled">We temporarily disabled Privacy Protection as it appears to be breaking this site.</string>
 </resources>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -52,4 +52,6 @@
     <string name="settingSubtitleOpenLinksInAssociatedApps">Disable to prevent links from automatically opening in other installed apps.</string>
     <string name="appLinkDialogTitle">Open in another app?</string>
 
+    <!-- Privacy Protection Dashboard -->
+    <string name="privacyProtectionToggleDisabled">Protections are temporarily disabled due to this site being broken.</string>
 </resources>

--- a/common-ui/src/main/res/values/colors.xml
+++ b/common-ui/src/main/res/values/colors.xml
@@ -111,5 +111,6 @@
     <color name="blue">#1A73E9</color>
     <color name="grey">#F3F5F9</color>
     <color name="light_blue">#F2F5F9</color>
+    <color name="yellow_10">#FFF2BF</color>
 
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/1125189844075764/1200517965702749/1200538500897521
Tech Design URL: 
CC: 

**Description**:
This PR changes the privacy dashboard UI when a visited site is in the temporary allowed list to correctly show that Privacy Protections are disabled.

**Steps to test this PR**:
1. Launch the app
1. Go to `vanguard.com` and wait until the site loads
1. The privacy grade should be black
1. Click in the privacy grade
1. The privacy dashboard should have the toggle disabled (as in non changeable)
1. The privacy dashboard should show trackers found rather than blocked.
1. The privacy dashboard should show a warning saying the protections is disabled due to a breakage
1. The privacy dashboard should not show the Unprotected Sites and the Report Broken Site buttons
1. Click on the header of the dashboard, the privacy grade should open
1. Same warning message as before should show
1. Go to `cnn.com` and in the options menu disable privacy protection. Let the site load.
1. The privacy grade should be black
1. Click in the privacy grade
1. The privacy dashboard should have the toggle OFF but you should be able to turn it on.
1. The privacy dashboard doesn't show the prior warning message.
1. The privacy dashboard shows the Unprotected Sites and the Report Broken Site buttons
1. Go to `as.com` and let it load
1. The privacy grade should show a grade.
1. Click on the privacy grade, the privacy dashboard should have privacy protection enabled.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
