### PR TITLE
Handle user-entered app link redirects

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3233,7 +3233,7 @@ class BrowserTabViewModelTest {
         whenever(mockOmnibarConverter.convertQueryToUrl("foo", null)).thenReturn("foo.com")
         whenever(mockSpecialUrlDetector.determineType(anyString())).thenReturn(SpecialUrlDetector.UrlType.AppLink(uriString = "http://foo.com"))
         testee.onUserSubmittedQuery("foo")
-        verify(mockAppLinksHandler).enterBrowserState()
+        verify(mockAppLinksHandler).userEnteredBrowserState()
         assertCommandIssued<Navigate>()
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksHandlerTest.kt
@@ -143,9 +143,18 @@ class DuckDuckGoAppLinksHandlerTest {
     }
 
     @Test
-    fun whenResetCalledThenSetAppLinkOpenedInBrowserToFalse() {
+    fun whenUserEntersBrowserStateThenSetUserEnteredLinkToTrue() {
+        assertFalse(testee.userEnteredLink)
+        testee.userEnteredBrowserState()
+        assertTrue(testee.userEnteredLink)
+    }
+
+    @Test
+    fun whenResetCalledThenResetAppLinkState() {
         testee.appLinkOpenedInBrowser = true
+        testee.userEnteredLink = true
         testee.reset()
         assertFalse(testee.appLinkOpenedInBrowser)
+        assertFalse(testee.userEnteredLink)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -858,6 +858,7 @@ class BrowserTabFragment :
                 }
             }
         }
+        viewModel.resetAppLinkState()
     }
 
     private fun askToFireproofWebsite(context: Context, fireproofWebsite: FireproofWebsiteEntity) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -581,7 +581,7 @@ class BrowserTabViewModel(
 
             fireQueryChangedPixel(trimmedInput)
 
-            appLinksHandler.enterBrowserState()
+            appLinksHandler.userEnteredBrowserState()
             command.value = Navigate(urlToNavigate, getUrlHeaders())
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
@@ -23,12 +23,14 @@ interface AppLinksHandler {
     fun handleAppLink(isRedirect: Boolean, isForMainFrame: Boolean, launchAppLink: () -> Unit): Boolean
     fun handleNonHttpAppLink(isRedirect: Boolean, launchNonHttpAppLink: () -> Unit): Boolean
     fun enterBrowserState()
+    fun userEnteredBrowserState()
     fun reset()
 }
 
 class DuckDuckGoAppLinksHandler @Inject constructor() : AppLinksHandler {
 
     var appLinkOpenedInBrowser = false
+    var userEnteredLink = false
 
     override fun handleAppLink(isRedirect: Boolean, isForMainFrame: Boolean, launchAppLink: () -> Unit): Boolean {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N || isRedirect && appLinkOpenedInBrowser || !isForMainFrame) {
@@ -39,7 +41,7 @@ class DuckDuckGoAppLinksHandler @Inject constructor() : AppLinksHandler {
     }
 
     override fun handleNonHttpAppLink(isRedirect: Boolean, launchNonHttpAppLink: () -> Unit): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isRedirect && appLinkOpenedInBrowser) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isRedirect && appLinkOpenedInBrowser && !userEnteredLink) {
             return true
         }
         launchNonHttpAppLink()
@@ -50,7 +52,13 @@ class DuckDuckGoAppLinksHandler @Inject constructor() : AppLinksHandler {
         appLinkOpenedInBrowser = true
     }
 
+    override fun userEnteredBrowserState() {
+        userEnteredLink = true
+        enterBrowserState()
+    }
+
     override fun reset() {
         appLinkOpenedInBrowser = false
+        userEnteredLink = false
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1200571376274550/f
Tech Design URL: 
CC: 

**Description**:
User-entered app links that redirect to intent:// links are not being handled after adding the app links feature.
This PR handles those cases.

**Steps to test this PR**:
1. Paste https://photoprints.page.link/t-mobile into the search bar
2. Verify that the "Open in another app" dialog is shown
3. Verify that clicking open, opens the Google Play app page
4. (Ensure that DuckDuckGo is the default browser)
5. Using a physical device, scan the QR code for the same link: https://duckduckgo.com/?q=qrcode+https%3A%2F%2Fphotoprints.page.link%2Ft-mobile
5. Verify that the "Open in another app" dialog is shown
6. Verify that clicking open, opens the Google Play app page

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
