### PR TITLE
Activity view binding delegate

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/about/AboutDuckDuckGoActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/about/AboutDuckDuckGoActivity.kt
@@ -23,12 +23,14 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.databinding.ActivityAboutDuckDuckGoBinding
 import com.duckduckgo.app.global.AppUrl.Url
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class AboutDuckDuckGoActivity : DuckDuckGoActivity() {
 
+    private val binding: ActivityAboutDuckDuckGoBinding by viewBinding()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = ActivityAboutDuckDuckGoBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
 

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
@@ -28,11 +28,12 @@ import com.duckduckgo.app.brokensite.BrokenSiteViewModel.ViewState
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityBrokenSiteBinding
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class BrokenSiteActivity : DuckDuckGoActivity() {
 
-    private lateinit var binding: ActivityBrokenSiteBinding
+    private val binding: ActivityBrokenSiteBinding by viewBinding()
     private val viewModel: BrokenSiteViewModel by bindViewModel()
 
     private val toolbar
@@ -43,7 +44,6 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityBrokenSiteBinding.inflate(layoutInflater)
         setContentView(binding.root)
         configureListeners()
         configureObservers()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -60,6 +60,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
@@ -110,7 +111,7 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
 
     private lateinit var renderer: BrowserStateRenderer
 
-    private lateinit var binding: ActivityBrowserBinding
+    private val binding: ActivityBrowserBinding by viewBinding()
 
     private lateinit var toolbarMockupBinding: IncludeOmnibarToolbarMockupBinding
 
@@ -127,7 +128,6 @@ class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
         instanceStateBundles = CombinedInstanceState(originalInstanceState = savedInstanceState, newInstanceState = newInstanceState)
 
         super.onCreate(savedInstanceState = newInstanceState, daggerInject = false)
-        binding = ActivityBrowserBinding.inflate(layoutInflater)
         toolbarMockupBinding = IncludeOmnibarToolbarMockupBinding.bind(binding.root)
         setContentView(binding.root)
         viewModel.viewState.observe(

--- a/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionActivity.kt
@@ -26,20 +26,20 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityFragmentWithToolbarBinding
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 class EmailProtectionActivity : DuckDuckGoActivity() {
 
     private val viewModel: EmailProtectionViewModel by bindViewModel()
-    private lateinit var binding: ActivityFragmentWithToolbarBinding
+    private val binding: ActivityFragmentWithToolbarBinding by viewBinding()
 
     private val toolbar
         get() = binding.includeToolbar.toolbar
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityFragmentWithToolbarBinding.inflate(layoutInflater)
 
         viewModel.viewState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).onEach { render(it) }.launchIn(lifecycleScope)
         setContentView(binding.root)

--- a/app/src/main/java/com/duckduckgo/app/email/ui/EmailWebViewActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/ui/EmailWebViewActivity.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.browser.databinding.ActivityEmailWebviewBinding
 import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.email.EmailInjector
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
 class EmailWebViewActivity : DuckDuckGoActivity() {
@@ -40,7 +41,7 @@ class EmailWebViewActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var emailInjector: EmailInjector
 
-    private lateinit var binding: ActivityEmailWebviewBinding
+    private val binding: ActivityEmailWebviewBinding by viewBinding()
 
     private val toolbar
         get() = binding.includeToolbar.toolbar
@@ -48,7 +49,6 @@ class EmailWebViewActivity : DuckDuckGoActivity() {
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityEmailWebviewBinding.inflate(layoutInflater)
 
         setContentView(binding.root)
         setupToolbar(toolbar)

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/common/FeedbackActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/common/FeedbackActivity.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.app.feedback.ui.negative.subreason.SubReasonNegativeFeedba
 import com.duckduckgo.app.feedback.ui.positive.initial.PositiveFeedbackLandingFragment
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.hideKeyboard
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import timber.log.Timber
 
 class FeedbackActivity :
@@ -48,14 +49,13 @@ class FeedbackActivity :
 
     private val viewModel: FeedbackViewModel by bindViewModel()
 
-    private lateinit var binding: ActivityFragmentWithToolbarBinding
+    private val binding: ActivityFragmentWithToolbarBinding by viewBinding()
 
     private val toolbar
         get() = binding.includeToolbar.toolbar
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityFragmentWithToolbarBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
         configureObservers()

--- a/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesActivity.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteEntity
 import com.duckduckgo.app.fire.fireproofwebsite.data.website
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
 
@@ -38,7 +39,7 @@ class FireproofWebsitesActivity : DuckDuckGoActivity() {
 
     lateinit var adapter: FireproofWebsiteAdapter
 
-    private lateinit var binding: ActivityFireproofWebsitesBinding
+    private val binding: ActivityFireproofWebsitesBinding by viewBinding()
 
     private var deleteDialog: AlertDialog? = null
 
@@ -49,7 +50,6 @@ class FireproofWebsitesActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityFireproofWebsitesBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
         setupFireproofWebsiteRecycler()

--- a/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlActivity.kt
@@ -31,10 +31,11 @@ import com.duckduckgo.app.browser.databinding.ActivityGlobalPrivacyControlBindin
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.view.html
 import com.duckduckgo.app.global.view.quietlySetIsChecked
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class GlobalPrivacyControlActivity : DuckDuckGoActivity() {
 
-    private lateinit var binding: ActivityGlobalPrivacyControlBinding
+    private val binding: ActivityGlobalPrivacyControlBinding by viewBinding()
 
     private val viewModel: GlobalPrivacyControlViewModel by bindViewModel()
 
@@ -53,7 +54,6 @@ class GlobalPrivacyControlActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityGlobalPrivacyControlBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
         configureUiEventHandlers()

--- a/app/src/main/java/com/duckduckgo/app/icon/ui/ChangeIconActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/icon/ui/ChangeIconActivity.kt
@@ -25,10 +25,11 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityAppIconsBinding
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class ChangeIconActivity : DuckDuckGoActivity() {
 
-    private lateinit var binding: ActivityAppIconsBinding
+    private val binding: ActivityAppIconsBinding by viewBinding()
     private val viewModel: ChangeIconViewModel by bindViewModel()
     private val iconsAdapter: AppIconsAdapter = AppIconsAdapter { icon ->
         viewModel.onIconSelected(icon)
@@ -39,7 +40,6 @@ class ChangeIconActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityAppIconsBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
         configureRecycler()

--- a/app/src/main/java/com/duckduckgo/app/location/ui/LocationPermissionsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/location/ui/LocationPermissionsActivity.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.global.view.show
 import com.duckduckgo.app.global.view.websiteFromGeoLocationsApiOrigin
 import com.duckduckgo.app.location.data.LocationPermissionEntity
 import com.duckduckgo.app.location.data.LocationPermissionType
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
 class LocationPermissionsActivity : DuckDuckGoActivity(), SiteLocationPermissionDialog.SiteLocationPermissionDialogListener {
@@ -41,7 +42,7 @@ class LocationPermissionsActivity : DuckDuckGoActivity(), SiteLocationPermission
     @Inject
     lateinit var faviconManager: FaviconManager
 
-    private lateinit var binding: ActivityLocationPermissionsBinding
+    private val binding: ActivityLocationPermissionsBinding by viewBinding()
     lateinit var adapter: LocationPermissionsAdapter
     private var deleteDialog: AlertDialog? = null
 
@@ -52,7 +53,6 @@ class LocationPermissionsActivity : DuckDuckGoActivity(), SiteLocationPermission
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityLocationPermissionsBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
         setupRecyclerView()

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.databinding.ActivityOnboardingBinding
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class OnboardingActivity : DuckDuckGoActivity() {
 
@@ -29,14 +30,13 @@ class OnboardingActivity : DuckDuckGoActivity() {
 
     private val viewModel: OnboardingViewModel by bindViewModel()
 
-    private lateinit var binding: ActivityOnboardingBinding
+    private val binding: ActivityOnboardingBinding by viewBinding()
 
     private val viewPager
         get() = binding.viewPager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityOnboardingBinding.inflate(layoutInflater)
         setContentView(binding.root)
         configurePager()
     }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.ViewState
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
 class PrivacyDashboardActivity : DuckDuckGoActivity() {
@@ -51,7 +52,7 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var pixel: Pixel
 
-    private lateinit var binding: ActivityPrivacyDashboardBinding
+    private val binding: ActivityPrivacyDashboardBinding by viewBinding()
     private val trackersRenderer = TrackersRenderer()
     private val upgradeRenderer = PrivacyUpgradeRenderer()
 
@@ -68,7 +69,6 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityPrivacyDashboardBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
         setupObservers()

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesActivity.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.privacy.renderer.banner
 import com.duckduckgo.app.privacy.renderer.text
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
 class PrivacyPracticesActivity : DuckDuckGoActivity() {
@@ -38,7 +39,7 @@ class PrivacyPracticesActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var repository: TabRepository
 
-    private lateinit var binding: ActivityPrivacyPracticesBinding
+    private val binding: ActivityPrivacyPracticesBinding by viewBinding()
 
     private val practicesAdapter = PrivacyPracticesAdapter()
 
@@ -52,7 +53,6 @@ class PrivacyPracticesActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityPrivacyPracticesBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
         configureRecycler()

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardActivity.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.global.view.show
 import com.duckduckgo.app.privacy.renderer.*
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
 class ScorecardActivity : DuckDuckGoActivity() {
@@ -37,7 +38,7 @@ class ScorecardActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var repository: TabRepository
 
-    private lateinit var binding: ActivityPrivacyScorecardBinding
+    private val binding: ActivityPrivacyScorecardBinding by viewBinding()
     private val trackersRenderer = TrackersRenderer()
     private val upgradeRenderer = PrivacyUpgradeRenderer()
 
@@ -54,7 +55,6 @@ class ScorecardActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityPrivacyScorecardBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
 

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksActivity.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.privacy.renderer.TrackersRenderer
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
 class TrackerNetworksActivity : DuckDuckGoActivity() {
@@ -34,7 +35,7 @@ class TrackerNetworksActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var repository: TabRepository
 
-    private lateinit var binding: ActivityTrackerNetworksBinding
+    private val binding: ActivityTrackerNetworksBinding by viewBinding()
 
     private val trackersRenderer = TrackersRenderer()
     private val networksAdapter = TrackerNetworksAdapter()
@@ -49,7 +50,6 @@ class TrackerNetworksActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityTrackerNetworksBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
         configureRecycler()

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/WhitelistActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/WhitelistActivity.kt
@@ -40,12 +40,13 @@ import com.duckduckgo.app.global.view.html
 import com.duckduckgo.app.global.view.show
 import com.duckduckgo.app.privacy.model.UserWhitelistedDomain
 import com.duckduckgo.app.privacy.ui.WhitelistViewModel.Command.*
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class WhitelistActivity : DuckDuckGoActivity() {
 
     private lateinit var adapter: WhitelistAdapter
 
-    private lateinit var binding: ActivityWhitelistBinding
+    private val binding: ActivityWhitelistBinding by viewBinding()
 
     private var dialog: AlertDialog? = null
     private val viewModel: WhitelistViewModel by bindViewModel()
@@ -58,7 +59,6 @@ class WhitelistActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityWhitelistBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(toolbar)
         setupRecycler()

--- a/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.ui.SurveyViewModel.Command
 import com.duckduckgo.app.survey.ui.SurveyViewModel.Command.*
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
 class SurveyActivity : DuckDuckGoActivity() {
@@ -42,7 +43,7 @@ class SurveyActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var pixel: Pixel
 
-    private lateinit var binding: ActivityUserSurveyBinding
+    private val binding: ActivityUserSurveyBinding by viewBinding()
 
     private val webView
         get() = binding.webView
@@ -50,7 +51,6 @@ class SurveyActivity : DuckDuckGoActivity() {
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityUserSurveyBinding.inflate(layoutInflater)
         setContentView(binding.root)
         configureListeners()
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.*
 import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
 
@@ -71,7 +72,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
     lateinit var gridViewColumnCalculator: GridViewColumnCalculator
 
     private val viewModel: SystemSearchViewModel by bindViewModel()
-    private lateinit var binding: ActivitySystemSearchBinding
+    private val binding: ActivitySystemSearchBinding by viewBinding()
     private lateinit var quickAccessItemsBinding: IncludeQuickAccessItemsBinding
     private lateinit var autocompleteSuggestionsAdapter: BrowserAutoCompleteSuggestionsAdapter
     private lateinit var deviceAppSuggestionsAdapter: DeviceAppSuggestionsAdapter
@@ -94,7 +95,6 @@ class SystemSearchActivity : DuckDuckGoActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         dataClearerForegroundAppRestartPixel.registerIntent(intent)
-        binding = ActivitySystemSearchBinding.inflate(layoutInflater)
         quickAccessItemsBinding = IncludeQuickAccessItemsBinding.bind(binding.root)
         setContentView(binding.root)
         configureObservers()

--- a/app/src/main/java/com/duckduckgo/app/widget/ui/AddWidgetInstructionsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/ui/AddWidgetInstructionsActivity.kt
@@ -24,10 +24,11 @@ import com.duckduckgo.app.browser.databinding.ActivityAddWidgetInstructionsBindi
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.widget.ui.AddWidgetInstructionsViewModel.Command.Close
 import com.duckduckgo.app.widget.ui.AddWidgetInstructionsViewModel.Command.ShowHome
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class AddWidgetInstructionsActivity : DuckDuckGoActivity() {
 
-    private lateinit var binding: ActivityAddWidgetInstructionsBinding
+    private val binding: ActivityAddWidgetInstructionsBinding by viewBinding()
 
     private val viewModel: AddWidgetInstructionsViewModel by bindViewModel()
 
@@ -36,7 +37,6 @@ class AddWidgetInstructionsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityAddWidgetInstructionsBinding.inflate(layoutInflater)
         setContentView(binding.root)
         configureListeners()
         configureCommandObserver()

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/ActivityViewBindingDelegate.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/ActivityViewBindingDelegate.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.viewbinding
+
+import android.view.LayoutInflater
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.viewbinding.ViewBinding
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+inline fun <reified T : ViewBinding> AppCompatActivity.viewBinding() = ActivityViewBindingDelegate(T::class.java, this)
+
+class ActivityViewBindingDelegate<T : ViewBinding>(
+  bindingClass: Class<T>,
+  val activity: AppCompatActivity
+) : ReadOnlyProperty<AppCompatActivity, T> {
+
+  private var binding: T? = null
+  private val bindMethod = bindingClass.getMethod("inflate", LayoutInflater::class.java)
+
+  override fun getValue(thisRef: AppCompatActivity, property: KProperty<*>): T {
+    binding?.let { return it }
+
+    val lifecycle = thisRef.lifecycle
+    if (!lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)) {
+      error("Cannot access viewBinding activity lifecycle is ${lifecycle.currentState}")
+    }
+
+    binding = bindMethod.invoke(null, thisRef.layoutInflater).cast<T>()
+
+    return binding!!
+  }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> Any.cast(): T = this as T

--- a/gradle/android-library.gradle
+++ b/gradle/android-library.gradle
@@ -41,4 +41,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    buildFeatures {
+        viewBinding = true
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200552671375508/f
Tech Design URL: 
CC: 

**Description**:
In PR https://github.com/duckduckgo/Android/pull/1302 we migrated some of the activities to use view binding. This PR creates an activity view binding delegate that makes viewbinding a bit simpler for activities.

The idea is to do the same for views and fragments. Fragments will be the ones that benefit the most out of using a delegate because we won't need to remember to `null` the `binding` in `onDestroy`


**Steps to test this PR**:
1. repeat tests from https://github.com/duckduckgo/Android/pull/1302

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
