### PR TITLE
Add fragment viewBinding delegate and migrate current fragments

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionFragment.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.email.ui
 import android.content.Context
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -26,7 +27,7 @@ import com.duckduckgo.app.global.ViewModelFactory
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
 
-abstract class EmailProtectionFragment : Fragment() {
+abstract class EmailProtectionFragment(@LayoutRes contentLayoutId: Int = 0) : Fragment(contentLayoutId) {
 
     @Inject
     lateinit var viewModelFactory: ViewModelFactory

--- a/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignInFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignInFragment.kt
@@ -16,13 +16,10 @@
 
 package com.duckduckgo.app.email.ui
 
-import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.Toast
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -35,16 +32,16 @@ import com.duckduckgo.app.global.view.NonUnderlinedClickableSpan
 import com.duckduckgo.app.global.view.gone
 import com.duckduckgo.app.global.view.html
 import com.duckduckgo.app.global.view.show
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.google.android.material.textview.MaterialTextView
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-class EmailProtectionSignInFragment : EmailProtectionFragment() {
+class EmailProtectionSignInFragment : EmailProtectionFragment(R.layout.fragment_email_protection_sign_in) {
 
     private val viewModel by bindViewModel<EmailProtectionSignInViewModel>()
 
-    private var _binding: FragmentEmailProtectionSignInBinding? = null
-    private val binding get() = _binding!!
+    private val binding: FragmentEmailProtectionSignInBinding by viewBinding()
 
     private val getNotificationSpan = object : NonUnderlinedClickableSpan() {
         override fun onClick(widget: View) {
@@ -62,16 +59,6 @@ class EmailProtectionSignInFragment : EmailProtectionFragment() {
         override fun onClick(widget: View) {
             viewModel.readPrivacyGuarantees()
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentEmailProtectionSignInBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     override fun configureViewModelObservers() {

--- a/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignOutFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignOutFragment.kt
@@ -18,13 +18,10 @@ package com.duckduckgo.app.email.ui
 
 import android.content.Intent
 import android.net.Uri
-import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.flowWithLifecycle
@@ -32,15 +29,15 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.FragmentEmailProtectionSignOutBinding
 import com.duckduckgo.app.global.view.NonUnderlinedClickableSpan
 import com.duckduckgo.app.global.view.html
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-class EmailProtectionSignOutFragment(val emailAddress: String) : EmailProtectionFragment() {
+class EmailProtectionSignOutFragment(val emailAddress: String) : EmailProtectionFragment(R.layout.fragment_email_protection_sign_out) {
 
     private val viewModel by bindViewModel<EmailProtectionSignOutViewModel>()
 
-    private var _binding: FragmentEmailProtectionSignOutBinding? = null
-    private val binding get() = _binding!!
+    private val binding: FragmentEmailProtectionSignOutBinding by viewBinding()
 
     private val contactUsSpan = object : NonUnderlinedClickableSpan() {
         override fun onClick(widget: View) {
@@ -48,16 +45,6 @@ class EmailProtectionSignOutFragment(val emailAddress: String) : EmailProtection
             intent.data = Uri.parse("mailto:support@duck.com")
             openExternalApp(intent)
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentEmailProtectionSignOutBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     override fun configureViewModelObservers() {

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/common/FeedbackFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/common/FeedbackFragment.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.feedback.ui.common
 
 import android.content.Context
 import android.os.Bundle
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -25,7 +26,7 @@ import com.duckduckgo.app.global.ViewModelFactory
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
 
-abstract class FeedbackFragment : Fragment() {
+abstract class FeedbackFragment(@LayoutRes contentLayoutId: Int = 0) : Fragment(contentLayoutId) {
 
     @Inject
     lateinit var viewModelFactory: ViewModelFactory

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/initial/InitialFeedbackFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/initial/InitialFeedbackFragment.kt
@@ -17,9 +17,6 @@
 package com.duckduckgo.app.feedback.ui.initial
 
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ContentFeedbackBinding
@@ -27,9 +24,10 @@ import com.duckduckgo.app.feedback.ui.common.FeedbackFragment
 import com.duckduckgo.app.feedback.ui.initial.InitialFeedbackFragmentViewModel.Command.*
 import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.store.ThemingDataStore
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
-class InitialFeedbackFragment : FeedbackFragment() {
+class InitialFeedbackFragment : FeedbackFragment(R.layout.content_feedback) {
 
     interface InitialFeedbackListener {
         fun userSelectedPositiveFeedback()
@@ -40,18 +38,12 @@ class InitialFeedbackFragment : FeedbackFragment() {
     @Inject
     lateinit var themingDataStore: ThemingDataStore
 
-    private var _binding: ContentFeedbackBinding? = null
-    private val binding get() = _binding!!
+    private val binding: ContentFeedbackBinding by viewBinding()
 
     private val viewModel by bindViewModel<InitialFeedbackFragmentViewModel>()
 
     private val listener: InitialFeedbackListener?
         get() = activity as InitialFeedbackListener
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = ContentFeedbackBinding.inflate(inflater, container, false)
-        return binding.root
-    }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
@@ -63,11 +55,6 @@ class InitialFeedbackFragment : FeedbackFragment() {
             binding.positiveFeedbackButton.setImageResource(R.drawable.button_happy_dark_theme)
             binding.negativeFeedbackButton.setImageResource(R.drawable.button_sad_dark_theme)
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     override fun configureViewModelObservers() {

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/brokensite/BrokenSiteNegativeFeedbackFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/brokensite/BrokenSiteNegativeFeedbackFragment.kt
@@ -16,40 +16,27 @@
 
 package com.duckduckgo.app.feedback.ui.negative.brokensite
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.doOnNextLayout
 import androidx.lifecycle.Observer
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ContentFeedbackNegativeBrokenSiteFeedbackBinding
 import com.duckduckgo.app.feedback.ui.common.FeedbackFragment
 import com.duckduckgo.app.feedback.ui.common.LayoutScrollingTouchListener
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
-class BrokenSiteNegativeFeedbackFragment : FeedbackFragment() {
+class BrokenSiteNegativeFeedbackFragment : FeedbackFragment(R.layout.content_feedback_negative_broken_site_feedback) {
 
     interface BrokenSiteFeedbackListener {
         fun onProvidedBrokenSiteFeedback(feedback: String, url: String?)
         fun userCancelled()
     }
 
-    private var _binding: ContentFeedbackNegativeBrokenSiteFeedbackBinding? = null
-    private val binding get() = _binding!!
+    private val binding: ContentFeedbackNegativeBrokenSiteFeedbackBinding by viewBinding()
 
     private val viewModel by bindViewModel<BrokenSiteNegativeFeedbackViewModel>()
 
     private val listener: BrokenSiteFeedbackListener?
         get() = activity as BrokenSiteFeedbackListener
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = ContentFeedbackNegativeBrokenSiteFeedbackBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
 
     override fun configureViewModelObservers() {
         viewModel.command.observe(

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/mainreason/MainReasonNegativeFeedbackFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/mainreason/MainReasonNegativeFeedbackFragment.kt
@@ -29,8 +29,9 @@ import com.duckduckgo.app.feedback.ui.common.FeedbackItemDecoration
 import com.duckduckgo.app.feedback.ui.negative.FeedbackType.MainReason
 import com.duckduckgo.app.feedback.ui.negative.FeedbackTypeDisplay
 import com.duckduckgo.app.feedback.ui.negative.FeedbackTypeDisplay.FeedbackTypeMainReasonDisplay
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
-class MainReasonNegativeFeedbackFragment : FeedbackFragment() {
+class MainReasonNegativeFeedbackFragment : FeedbackFragment(R.layout.content_feedback_negative_disambiguation_main_reason) {
     private lateinit var recyclerAdapter: MainReasonAdapter
 
     interface MainReasonNegativeFeedbackListener {
@@ -38,15 +39,12 @@ class MainReasonNegativeFeedbackFragment : FeedbackFragment() {
         fun userSelectedNegativeFeedbackMainReason(type: MainReason)
     }
 
-    private var _binding: ContentFeedbackNegativeDisambiguationMainReasonBinding? = null
-    private val binding get() = _binding!!
+    private val binding: ContentFeedbackNegativeDisambiguationMainReasonBinding by viewBinding()
 
     private val listener: MainReasonNegativeFeedbackListener?
         get() = activity as MainReasonNegativeFeedbackListener
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = ContentFeedbackNegativeDisambiguationMainReasonBinding.inflate(inflater, container, false)
-
         recyclerAdapter = MainReasonAdapter(object : (FeedbackTypeMainReasonDisplay) -> Unit {
             override fun invoke(reason: FeedbackTypeMainReasonDisplay) {
                 listener?.userSelectedNegativeFeedbackMainReason(reason.mainReason)
@@ -67,11 +65,6 @@ class MainReasonNegativeFeedbackFragment : FeedbackFragment() {
             val listValues = getMainReasonsDisplayText()
             recyclerAdapter.submitList(listValues)
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     private fun getMainReasonsDisplayText(): List<FeedbackTypeMainReasonDisplay> {

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/openended/ShareOpenEndedFeedbackFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/openended/ShareOpenEndedFeedbackFragment.kt
@@ -17,9 +17,6 @@
 package com.duckduckgo.app.feedback.ui.negative.openended
 
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.doOnNextLayout
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.browser.R
@@ -31,8 +28,9 @@ import com.duckduckgo.app.feedback.ui.negative.FeedbackType.SubReason
 import com.duckduckgo.app.feedback.ui.negative.FeedbackTypeDisplay.Companion.mainReasons
 import com.duckduckgo.app.feedback.ui.negative.FeedbackTypeDisplay.Companion.subReasons
 import com.duckduckgo.app.feedback.ui.negative.openended.ShareOpenEndedNegativeFeedbackViewModel.Command
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
-class ShareOpenEndedFeedbackFragment : FeedbackFragment() {
+class ShareOpenEndedFeedbackFragment : FeedbackFragment(R.layout.content_feedback_open_ended_feedback) {
 
     interface OpenEndedFeedbackListener {
         fun userProvidedNegativeOpenEndedFeedback(mainReason: MainReason, subReason: SubReason?, feedback: String)
@@ -40,8 +38,7 @@ class ShareOpenEndedFeedbackFragment : FeedbackFragment() {
         fun userCancelled()
     }
 
-    private var _binding: ContentFeedbackOpenEndedFeedbackBinding? = null
-    private val binding get() = _binding!!
+    private val binding: ContentFeedbackOpenEndedFeedbackBinding by viewBinding()
 
     private val viewModel by bindViewModel<ShareOpenEndedNegativeFeedbackViewModel>()
 
@@ -52,16 +49,6 @@ class ShareOpenEndedFeedbackFragment : FeedbackFragment() {
 
     private var mainReason: MainReason? = null
     private var subReason: SubReason? = null
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = ContentFeedbackOpenEndedFeedbackBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
 
     override fun configureViewModelObservers() {
         viewModel.command.observe(

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/subreason/SubReasonNegativeFeedbackFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/subreason/SubReasonNegativeFeedbackFragment.kt
@@ -31,9 +31,10 @@ import com.duckduckgo.app.feedback.ui.negative.FeedbackType.MainReason.*
 import com.duckduckgo.app.feedback.ui.negative.FeedbackTypeDisplay
 import com.duckduckgo.app.feedback.ui.negative.FeedbackTypeDisplay.FeedbackTypeSubReasonDisplay
 import com.duckduckgo.app.feedback.ui.negative.displayText
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import timber.log.Timber
 
-class SubReasonNegativeFeedbackFragment : FeedbackFragment() {
+class SubReasonNegativeFeedbackFragment : FeedbackFragment(R.layout.content_feedback_negative_disambiguation_sub_reason) {
 
     private lateinit var recyclerAdapter: SubReasonAdapter
 
@@ -44,8 +45,7 @@ class SubReasonNegativeFeedbackFragment : FeedbackFragment() {
         fun userSelectedSubReasonAppIsSlowOrBuggy(mainReason: MainReason, subReason: PerformanceSubReasons)
     }
 
-    private var _binding: ContentFeedbackNegativeDisambiguationSubReasonBinding? = null
-    private val binding get() = _binding!!
+    private val binding: ContentFeedbackNegativeDisambiguationSubReasonBinding by viewBinding()
 
     private val listener: DisambiguationNegativeFeedbackListener?
         get() = activity as DisambiguationNegativeFeedbackListener
@@ -53,8 +53,6 @@ class SubReasonNegativeFeedbackFragment : FeedbackFragment() {
     private lateinit var mainReason: MainReason
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = ContentFeedbackNegativeDisambiguationSubReasonBinding.inflate(inflater, container, false)
-
         recyclerAdapter = SubReasonAdapter(object : (FeedbackTypeSubReasonDisplay) -> Unit {
             override fun invoke(reason: FeedbackTypeSubReasonDisplay) {
                 when (reason.subReason) {
@@ -98,11 +96,6 @@ class SubReasonNegativeFeedbackFragment : FeedbackFragment() {
                 recyclerAdapter.submitList(subReasons)
             }
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     private fun getDisplayTextForReasonType(mainReason: MainReason): List<FeedbackTypeSubReasonDisplay> {

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/positive/initial/PositiveFeedbackLandingFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/positive/initial/PositiveFeedbackLandingFragment.kt
@@ -16,17 +16,15 @@
 
 package com.duckduckgo.app.feedback.ui.positive.initial
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.lifecycle.Observer
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ContentFeedbackPositiveLandingBinding
 import com.duckduckgo.app.feedback.ui.common.FeedbackFragment
 import com.duckduckgo.app.playstore.PlayStoreUtils
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
-class PositiveFeedbackLandingFragment : FeedbackFragment() {
+class PositiveFeedbackLandingFragment : FeedbackFragment(R.layout.content_feedback_positive_landing) {
 
     interface PositiveFeedbackLandingListener {
         fun userSelectedToRateApp()
@@ -34,8 +32,7 @@ class PositiveFeedbackLandingFragment : FeedbackFragment() {
         fun userGavePositiveFeedbackNoDetails()
     }
 
-    private var _binding: ContentFeedbackPositiveLandingBinding? = null
-    private val binding get() = _binding!!
+    private val binding: ContentFeedbackPositiveLandingBinding by viewBinding()
 
     private val viewModel by bindViewModel<PositiveFeedbackLandingViewModel>()
 
@@ -44,11 +41,6 @@ class PositiveFeedbackLandingFragment : FeedbackFragment() {
 
     @Inject
     lateinit var playStoreUtils: PlayStoreUtils
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = ContentFeedbackPositiveLandingBinding.inflate(inflater, container, false)
-        return binding.root
-    }
 
     override fun configureViewModelObservers() {
         viewModel.command.observe(
@@ -68,11 +60,6 @@ class PositiveFeedbackLandingFragment : FeedbackFragment() {
                 }
             }
         )
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     override fun configureListeners() {

--- a/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/DaxDialog.kt
@@ -22,13 +22,13 @@ import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.Gravity
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat.getColor
 import androidx.fragment.app.DialogFragment
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ContentDaxDialogBinding
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 interface DaxDialog {
     fun setDaxText(daxText: String)
@@ -45,10 +45,9 @@ interface DaxDialogListener {
     fun onDaxDialogHideClick()
 }
 
-class TypewriterDaxDialog : DialogFragment(), DaxDialog {
+class TypewriterDaxDialog : DialogFragment(R.layout.content_dax_dialog), DaxDialog {
 
-    private var _binding: ContentDaxDialogBinding? = null
-    private val binding get() = _binding!!
+    private val binding: ContentDaxDialogBinding by viewBinding()
 
     private var daxText: String = ""
     private var primaryButtonText: String = ""
@@ -62,11 +61,6 @@ class TypewriterDaxDialog : DialogFragment(), DaxDialog {
 
     override fun setDaxDialogListener(listener: DaxDialogListener) {
         daxDialogListener = listener
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = ContentDaxDialogBinding.inflate(inflater, container, false)
-        return binding.root
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -107,11 +101,6 @@ class TypewriterDaxDialog : DialogFragment(), DaxDialog {
         }
     }
 
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
-    }
-
     override fun getTheme(): Int {
         return R.style.DaxDialogFragment
     }
@@ -128,7 +117,7 @@ class TypewriterDaxDialog : DialogFragment(), DaxDialog {
     }
 
     override fun onDismiss(dialog: DialogInterface) {
-        if (activity != null && _binding != null) {
+        if (activity != null) {
             binding.dialogText.cancelAnimation()
             daxDialogListener?.onDaxDialogDismiss()
         }

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/FragmentViewBindingDelegate.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/FragmentViewBindingDelegate.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.viewbinding
+
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import androidx.viewbinding.ViewBinding
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+inline fun <reified T : ViewBinding> Fragment.viewBinding() = FragmentViewBindingDelegate(T::class.java, this)
+
+class FragmentViewBindingDelegate<T : ViewBinding>(
+  bindingClass: Class<T>,
+  private val fragment: Fragment
+) : ReadOnlyProperty<Fragment, T> {
+
+  // LazyThreadSafetyMode.NONE because it will never be initialised from ore than one thread
+  private val nullifyBindingHandler by lazy(LazyThreadSafetyMode.NONE) { Handler(Looper.getMainLooper()) }
+  private var binding: T? = null
+
+  private val bindMethod = bindingClass.getMethod("bind", View::class.java)
+
+  init {
+    fragment.viewLifecycleOwnerLiveData.observe(fragment) { lifecycleOwner ->
+      lifecycleOwner.lifecycle.addObserver(object : LifecycleObserver {
+        @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        fun onDestroy() {
+          nullifyBindingHandler.post { binding = null }
+        }
+      })
+    }
+  }
+
+  override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
+
+    // onCreateView maybe be called between the onDestroyView and the next Main thread run-loop.
+    // Because nullifyBindingHandler has to post to null the binding, it may happen that [binding]
+    // refers to the previous fragment view. When that happens, ie. bindings's root view does not match
+    // the current fragment, we just null the [binding] here too
+    if (binding != null && binding?.root !== thisRef.view) {
+      binding = null
+    }
+
+    binding?.let { return it }
+
+    val lifecycle = thisRef.viewLifecycleOwner.lifecycle
+    if(!lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)) {
+      error("Cannot access view bindings, View lifecycle is ${lifecycle.currentState}")
+    }
+
+    binding = bindMethod.invoke(null, thisRef.requireView()).cast<T>()
+
+    return binding!!
+  }
+
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> Any.cast(): T = this as T


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1200640982441041/f
Tech Design URL: 
CC: 

**Description**:
Some of the Fragments were already using view binding. This PR:
* adds a fragment viewbinding delegate to make viewbinding in fragments easier
* uses the delegate in all fragments that were using viewbinding already

With the delegate the viewbinding for fragments will be done as follows

```kotlin
class MyNewFragment : Fragment(R.layout.my_new_fragment) {
    // This will create/null the binding
    private val binding: MyNewFragmentBinding by viewBinding()
  
  ...
}
```


**Steps to test this PR**:
1. fresh install from this branch and run the app
1. verify the dax dialog during onboarding works properly
1. verify the broken site works
1. verify the feedback feature works
1. verify the email protection feature works


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
