### PR TITLE
Add view binding delegate and use it in custom views

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/TabSwitcherButton.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/TabSwitcherButton.kt
@@ -20,9 +20,9 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.widget.RelativeLayout
 import com.duckduckgo.app.browser.databinding.ViewTabSwitcherButtonBinding
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class TabSwitcherButton @JvmOverloads constructor(
     context: Context,
@@ -30,8 +30,7 @@ class TabSwitcherButton @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : RelativeLayout(context, attrs, defStyleAttr) {
 
-    private var _binding: ViewTabSwitcherButtonBinding? = null
-    private val binding get() = _binding!!
+    private val binding: ViewTabSwitcherButtonBinding by viewBinding()
 
     var count = 0
         set(value) {
@@ -41,11 +40,6 @@ class TabSwitcherButton @JvmOverloads constructor(
         }
 
     var hasUnread = false
-
-    override fun onFinishInflate() {
-        super.onFinishInflate()
-        _binding = ViewTabSwitcherButtonBinding.inflate(LayoutInflater.from(context), this)
-    }
 
     fun increment(callback: () -> Unit) {
         fadeOutCount {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsOptionWithSubtitle.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsOptionWithSubtitle.kt
@@ -20,27 +20,21 @@ package com.duckduckgo.app.settings
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.children
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.SettingsOptionWithSubtitleBinding
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class SettingsOptionWithSubtitle : ConstraintLayout {
 
-    private var root: View
-    private var titleView: TextView
-    private var subtitleView: TextView
+    private val binding: SettingsOptionWithSubtitleBinding by viewBinding()
 
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, R.style.SettingsItem)
     constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle) {
-
-        root = LayoutInflater.from(context).inflate(R.layout.settings_option_with_subtitle, this, true)
-        titleView = root.findViewById(R.id.title)
-        subtitleView = root.findViewById(R.id.subtitle)
 
         val attributes = context.obtainStyledAttributes(attrs, R.styleable.SettingsOptionWithSubtitle)
         setTitle(attributes.getString(R.styleable.SettingsOptionWithSubtitle_title) ?: "")
@@ -49,11 +43,11 @@ class SettingsOptionWithSubtitle : ConstraintLayout {
     }
 
     fun setTitle(title: String) {
-        titleView.text = title
+        binding.title.text = title
     }
 
     fun setSubtitle(subtitle: String) {
-        subtitleView.text = subtitle
+        binding.subtitle.text = subtitle
     }
 
     override fun setEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsPillWithSubtitle.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsPillWithSubtitle.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 DuckDuckGo
+ * Copyright (c) 2021 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,54 +16,45 @@
 
 @file:Suppress("MemberVisibilityCanBePrivate")
 
-package com.duckduckgo.app.settings.db
+package com.duckduckgo.app.settings
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.core.view.children
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.SettingsPillWithSubtitleBinding
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class SettingsPillWithSubtitle : LinearLayout {
 
-    private var root: View
-    private var titleView: TextView
-    private var subtitleView: TextView
-    private var pillView: ImageView
+    private val binding: SettingsPillWithSubtitleBinding by viewBinding()
 
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, R.style.SettingsItem)
     constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle) {
 
-        root = LayoutInflater.from(context).inflate(R.layout.settings_pill_with_subtitle, this, true)
-        titleView = root.findViewById(R.id.title)
-        subtitleView = root.findViewById(R.id.subtitle)
-        pillView = root.findViewById(R.id.pill)
-
-        val attributes = context.obtainStyledAttributes(attrs, R.styleable.SettingsOptionWithPill)
-        setTitle(attributes.getString(R.styleable.SettingsOptionWithPill_pillTitle) ?: "")
-        setSubtitle(attributes.getString(R.styleable.SettingsOptionWithPill_pillSubtitle) ?: "")
-        setPill(attributes.getResourceId(R.styleable.SettingsOptionWithPill_pillDrawable, R.drawable.ic_beta_pill))
+        val attributes = context.obtainStyledAttributes(attrs, R.styleable.SettingsPillWithSubtitle)
+        setTitle(attributes.getString(R.styleable.SettingsPillWithSubtitle_pillTitle) ?: "")
+        setSubtitle(attributes.getString(R.styleable.SettingsPillWithSubtitle_pillSubtitle) ?: "")
+        setPill(attributes.getResourceId(R.styleable.SettingsPillWithSubtitle_pillDrawable, R.drawable.ic_beta_pill))
         attributes.recycle()
     }
 
     fun setTitle(title: String) {
-        titleView.text = title
+        binding.title.text = title
     }
 
     fun setSubtitle(subtitle: String) {
-        subtitleView.text = subtitle
+        binding.subtitle.text = subtitle
     }
 
     fun setPill(idRes: Int) {
         val drawable = VectorDrawableCompat.create(resources, idRes, null)
-        pillView.setImageDrawable(drawable)
+        binding.pill.setImageDrawable(drawable)
     }
 
     override fun setEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsToggleOptionWithSubtitle.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsToggleOptionWithSubtitle.kt
@@ -18,20 +18,17 @@ package com.duckduckgo.app.settings
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
-import android.view.View
 import android.widget.CompoundButton
 import android.widget.FrameLayout
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.SettingsToggleOptionWithSubtitleBinding
 import com.duckduckgo.app.global.view.childrenRecursiveSequence
 import com.duckduckgo.app.global.view.quietlySetIsChecked
-import kotlinx.android.synthetic.main.settings_toggle_option_with_subtitle.view.*
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class SettingsToggleOptionWithSubtitle : FrameLayout {
 
-    private val root: View by lazy {
-        LayoutInflater.from(context).inflate(R.layout.settings_toggle_option_with_subtitle, this, true)
-    }
+    private val binding: SettingsToggleOptionWithSubtitleBinding by viewBinding()
 
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, R.style.SettingsItem)
@@ -47,32 +44,32 @@ class SettingsToggleOptionWithSubtitle : FrameLayout {
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         setOnClickListener {
-            root.toggle.performClick()
+            binding.toggle.performClick()
         }
     }
 
     var title: String
-        get() { return root.title.text.toString() }
-        set(value) { root.title.text = value }
+        get() { return binding.title.text.toString() }
+        set(value) { binding.title.text = value }
 
     var subtitle: String
-        get() { return root.subtitle.text.toString() }
-        set(value) { root.subtitle.text = value }
+        get() { return binding.subtitle.text.toString() }
+        set(value) { binding.subtitle.text = value }
 
     var isChecked: Boolean
-        get() { return root.toggle.isChecked }
-        set(value) { root.toggle.isChecked = value }
+        get() { return binding.toggle.isChecked }
+        set(value) { binding.toggle.isChecked = value }
 
     override fun setEnabled(enabled: Boolean) {
-        root.childrenRecursiveSequence().forEach { it.isEnabled = enabled }
+        binding.root.childrenRecursiveSequence().forEach { it.isEnabled = enabled }
         super.setEnabled(enabled)
     }
 
     fun setOnCheckedChangeListener(listener: CompoundButton.OnCheckedChangeListener) {
-        root.toggle.setOnCheckedChangeListener(listener)
+        binding.toggle.setOnCheckedChangeListener(listener)
     }
 
     fun quietlySetIsChecked(newCheckedState: Boolean, changeListener: CompoundButton.OnCheckedChangeListener?) {
-        root.toggle.quietlySetIsChecked(newCheckedState, changeListener)
+        binding.toggle.quietlySetIsChecked(newCheckedState, changeListener)
     }
 }

--- a/app/src/main/res/layout/content_settings_privacy.xml
+++ b/app/src/main/res/layout/content_settings_privacy.xml
@@ -90,7 +90,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/whitelist" />
 
-    <com.duckduckgo.app.settings.db.SettingsPillWithSubtitle
+    <com.duckduckgo.app.settings.SettingsPillWithSubtitle
         android:id="@+id/emailSetting"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/ViewBindingDelegate.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/ViewBindingDelegate.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.viewbinding
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.viewbinding.ViewBinding
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+inline fun <reified T : ViewBinding> ViewGroup.viewBinding() = ViewBindingDelegate(T::class.java, this)
+
+class ViewBindingDelegate<T : ViewBinding>(
+  bindingClass: Class<T>,
+  view: ViewGroup
+) : ReadOnlyProperty<ViewGroup, T> {
+  private val binding: T = try {
+    val inflateMethod = bindingClass.getMethod("inflate", LayoutInflater::class.java, ViewGroup::class.java, Boolean::class.javaPrimitiveType)
+    inflateMethod.invoke(null, LayoutInflater.from(view.context), view, true).cast<T>()
+  } catch (e: NoSuchMethodException) {
+    val inflateMethod = bindingClass.getMethod("inflate", LayoutInflater::class.java, ViewGroup::class.java)
+    inflateMethod.invoke(null, LayoutInflater.from(view.context), view).cast<T>()
+  }
+
+  override fun getValue(thisRef: ViewGroup, property: KProperty<*>): T {
+    return binding
+  }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> Any.cast(): T = this as T

--- a/common-ui/src/main/res/values/attrs-settings-item-with-subtitle-and-pill.xml
+++ b/common-ui/src/main/res/values/attrs-settings-item-with-subtitle-and-pill.xml
@@ -15,7 +15,7 @@
   -->
 
 <resources>
-    <declare-styleable name="SettingsOptionWithPill">
+    <declare-styleable name="SettingsPillWithSubtitle">
         <attr name="pillTitle" format="string" />
         <attr name="pillSubtitle" format="string" />
         <attr name="pillDrawable" format="reference" />


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1200640982441046/f
Tech Design URL: 
CC: 

**Description**:
This PR adds a view binding delegate for `Views` and migrates some of the following custom views to use view binding
* SettingsOptionWithSubtitle
* SettingsToggleOptionWithSubtitle
* TabSwitcherButton (it was already using view binding but now it uses the delegate)


**Steps to test this PR**:
1. install from this branch
1. verify the tab switcher button in top right of the browser works properly
1. go to settings
1. verify all toggle views veriry properly


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
