### PR TITLE
Changed tabs count from `~` (tilde)  to first two numbers ending with for tabs>99

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/TabSwitcherButton.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/TabSwitcherButton.kt
@@ -36,7 +36,7 @@ class TabSwitcherButton @JvmOverloads constructor(
     var count = 0
         set(value) {
             field = value
-            val text = if (count < 100) "$count" else "~"
+            val text = if (count < 100) "$count" else "${(count.toString().subSequence(0,2))}."
             binding.tabCount.text = text
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/1331
Tech Design URL: 
CC: 

**Description**:
When the tabs count exceeds 99, the app shows a `~`  (Tilde) sign signifying problems as addressed in issue #1331.
This PR proposed changes as shown below:
* Changed tabs from `~` to the first two digits of the number of tabs opened ending with a ` .` (dot) where `.` signifying a short form of  `....` (too many dots).

#### Points to be considered:
- [x] It is more human-understandable.
- [x] It won't look ugly even in screenshots.


Example: 
* 1000 can be shown as `10.` 
*  5555 can be shown as `55.`


**Steps to test this PR**:
1. Install App.
2. Keep opening tabs until the tabs count is greater than 99.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
