### PR TITLE
Issue/914/webview positioning

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -26,6 +26,8 @@ import android.webkit.WebView
 import androidx.core.view.NestedScrollingChild
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
+import kotlinx.android.synthetic.main.include_duckduckgo_browser_webview.*
+import kotlinx.android.synthetic.main.include_omnibar_toolbar.*
 
 /**
  * WebView subclass which allows the WebView to
@@ -76,6 +78,13 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild {
         }
         val eventY = event.y.toInt()
         event.offsetLocation(0f, nestedOffsetY.toFloat())
+
+        if (contentHeight <= height) {
+            hasGestureFinished = true
+            returnValue = super.onTouchEvent(event)
+            stopNestedScroll()
+            return returnValue
+        }
 
         when (action) {
             MotionEvent.ACTION_UP -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/ui/AppBarMarginCollapseBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/ui/AppBarMarginCollapseBehavior.kt
@@ -26,7 +26,7 @@ import com.google.android.material.appbar.AppBarLayout
 class AppBarMarginCollapseBehavior : AppBarLayout.ScrollingViewBehavior {
     constructor() : super()
 
-    constructor(context: Context, attrs: AttributeSet): super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
 
     override fun onMeasureChild(
         parent: CoordinatorLayout,
@@ -40,8 +40,8 @@ class AppBarMarginCollapseBehavior : AppBarLayout.ScrollingViewBehavior {
         // handling of measured header height and window insets here
 
         val childLpHeight = child.layoutParams.height
-        if (childLpHeight == ViewGroup.LayoutParams.MATCH_PARENT
-            || childLpHeight == ViewGroup.LayoutParams.WRAP_CONTENT
+        if (childLpHeight == ViewGroup.LayoutParams.MATCH_PARENT ||
+            childLpHeight == ViewGroup.LayoutParams.WRAP_CONTENT
         ) {
             // If the menu's height is set to match_parent/wrap_content then measure it
             // with the maximum visible height

--- a/app/src/main/java/com/duckduckgo/app/browser/ui/AppBarMarginCollapseBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/ui/AppBarMarginCollapseBehavior.kt
@@ -20,9 +20,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowInsets
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.view.ViewCompat
 import com.google.android.material.appbar.AppBarLayout
 
 class AppBarMarginCollapseBehavior : AppBarLayout.ScrollingViewBehavior {

--- a/app/src/main/java/com/duckduckgo/app/browser/ui/AppBarMarginCollapseBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/ui/AppBarMarginCollapseBehavior.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.appbar.AppBarLayout
+
+class AppBarMarginCollapseBehavior : AppBarLayout.ScrollingViewBehavior {
+    constructor() : super()
+
+    constructor(context: Context, attrs: AttributeSet): super(context, attrs)
+
+    override fun onDependentViewChanged(
+        parent: CoordinatorLayout,
+        child: View,
+        dependency: View
+    ): Boolean {
+        super.onDependentViewChanged(parent, child, dependency)
+        child.setPadding(0, 0, 0, dependency.y.toInt() + dependency.height)
+
+        return false
+    }
+}

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -69,7 +69,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:animateLayoutChanges="true"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        app:layout_behavior="com.duckduckgo.app.browser.ui.AppBarMarginCollapseBehavior"
         tools:context="com.duckduckgo.app.browser.BrowserActivity">
 
         <com.duckduckgo.app.browser.ui.ScrollAwareRefreshLayout

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -81,7 +81,6 @@
                 android:id="@+id/webViewContainer"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:layout_behavior="@string/appbar_scrolling_view_behavior"
                 tools:background="#4F00" />
 
         </com.duckduckgo.app.browser.ui.ScrollAwareRefreshLayout>

--- a/app/src/main/res/layout/include_duckduckgo_browser_webview.xml
+++ b/app/src/main/res/layout/include_duckduckgo_browser_webview.xml
@@ -15,7 +15,6 @@
   -->
 
 <com.duckduckgo.app.browser.DuckDuckGoWebView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/browserWebView"
     android:layout_width="match_parent"
@@ -31,7 +30,6 @@
     android:scrollbarTrackVertical="@color/webViewScrollbarTrackColor"
     android:overScrollMode="always"
     android:visibility="gone"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:visibility="visible">
 
 </com.duckduckgo.app.browser.DuckDuckGoWebView>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/914
Tech Design URL: 
CC: 

**Description**:
It appears there were a couple of things happening:

1. The Google provided `AppBarLayout.ScrollingViewBehavior` doesn't seem to fully support the layouts used here. It moves the `WebView`, but fails to resize it (or just doesn't handle resizing) based on what's visible of the `AppBarLayout`.
2. The custom `WebView` for nested scrolling needed to be able to handle disabling of the nested scrolling when the content height <= view height.

**Steps to test this PR**:
1. Load twitter.com. The page's header and footer should both be visible.
2. Scrolling up and down should show and hide the app toolbar appropriately.
3. Some amount of update delay in the footer updating position is normal and other Android browsers exhibit the same delay
4. Load sketch.io/sketchpad. The page should load full screen.
5. Drawing should not cause the page to scroll, nor should it cause the app bar to show and hide.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
