### PR TITLE
[BUG] Fix crash when accidentally returning binding.root in onCreateView

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/mainreason/MainReasonNegativeFeedbackFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/mainreason/MainReasonNegativeFeedbackFragment.kt
@@ -17,9 +17,6 @@
 package com.duckduckgo.app.feedback.ui.negative.mainreason
 
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.app.browser.R
@@ -44,18 +41,14 @@ class MainReasonNegativeFeedbackFragment : FeedbackFragment(R.layout.content_fee
     private val listener: MainReasonNegativeFeedbackListener?
         get() = activity as MainReasonNegativeFeedbackListener
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
         recyclerAdapter = MainReasonAdapter(object : (FeedbackTypeMainReasonDisplay) -> Unit {
             override fun invoke(reason: FeedbackTypeMainReasonDisplay) {
                 listener?.userSelectedNegativeFeedbackMainReason(reason.mainReason)
             }
         })
-
-        return binding.root
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
 
         activity?.let {
             binding.recyclerView.layoutManager = LinearLayoutManager(it)

--- a/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/subreason/SubReasonNegativeFeedbackFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/ui/negative/subreason/SubReasonNegativeFeedbackFragment.kt
@@ -17,9 +17,6 @@
 package com.duckduckgo.app.feedback.ui.negative.subreason
 
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.app.browser.R
@@ -52,7 +49,9 @@ class SubReasonNegativeFeedbackFragment : FeedbackFragment(R.layout.content_feed
 
     private lateinit var mainReason: MainReason
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
         recyclerAdapter = SubReasonAdapter(object : (FeedbackTypeSubReasonDisplay) -> Unit {
             override fun invoke(reason: FeedbackTypeSubReasonDisplay) {
                 when (reason.subReason) {
@@ -71,12 +70,6 @@ class SubReasonNegativeFeedbackFragment : FeedbackFragment(R.layout.content_feed
                 }
             }
         })
-
-        return binding.root
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
 
         activity?.let {
             binding.recyclerView.layoutManager = LinearLayoutManager(it)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200701185339109/f
Tech Design URL: 
CC: 

**Description**:
This PR fixes a crash that happened when submitting negative feedback.
In `MainReasonNegativeFeedbackFragment` and `SubReasonNegativeFeedbackFragment` we were doing some logic in `onCreateView` and then returning `binding.root`. But Android does not allow to use view binding inside `onCreateView` that should return an inflated view, which at that point it is not.

This PR moves the logic performed in the `onCreateView` method to the `onActivityCreated` method--which is the next lifecycle method to be called--so that we can continue using view binding


**Steps to test this PR**:
1. install from develop and launch the app
1. go to settings -> share feedback
1. click in sad face
1. BOOM! app crashes
1. install from this branch and launch the app
1. go to settings -> share feedback
1. click in sad face
1. verify app does not crash
1. select a sub-reason
1. verify app does not crash
1. complete the feedback and submit
1. verify app does not crash


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
