### PR TITLE
Remove ATB params from email pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/PixelAtbRemovalInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/PixelAtbRemovalInterceptorTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import com.duckduckgo.app.pixels.AppPixelName
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class PixelAtbRemovalInterceptorTest {
+    private lateinit var pixelAtbRemovalInterceptor: PixelAtbRemovalInterceptor
+
+    @Before
+    fun setup() {
+        pixelAtbRemovalInterceptor = PixelAtbRemovalInterceptor()
+    }
+
+    @Test
+    fun whenSendPixelTheRedactAtvInfoFromDefinedPixels() {
+        AppPixelName.values().map { it.pixelName }.forEach { pixelName ->
+            val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
+            val removalExpected = PixelAtbRemovalInterceptor.pixels.contains(pixelName)
+
+            val interceptedUrl = pixelAtbRemovalInterceptor.intercept(FakeChain(pixelUrl)).request.url
+            assertEquals(removalExpected, interceptedUrl.queryParameter("atb") == null)
+        }
+    }
+
+    companion object {
+        private const val PIXEL_TEMPLATE = "https://improving.duckduckgo.com/t/%s_android_phone?atb=v255-7zu&appVersion=5.74.0&test=1"
+    }
+
+}

--- a/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
@@ -42,11 +42,13 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
 import okhttp3.Cache
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
+import timber.log.Timber
 import java.io.File
 import javax.inject.Named
 import javax.inject.Singleton
@@ -72,10 +74,17 @@ class NetworkModule {
     fun pixelOkHttpClient(
         apiRequestInterceptor: ApiRequestInterceptor,
         pixelReQueryInterceptor: PixelReQueryInterceptor,
+        pixelAtbRemovalInterceptor: PixelAtbRemovalInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(apiRequestInterceptor)
             .addInterceptor(pixelReQueryInterceptor)
+            .addInterceptor(pixelAtbRemovalInterceptor)
+            // shall be the last one as it is logging the pixel request url that goes out
+            .addInterceptor { chain: Interceptor.Chain ->
+                Timber.v("Pixel url request: ${chain.request().url}")
+                return@addInterceptor chain.proceed(chain.request())
+            }
             .build()
     }
 
@@ -115,6 +124,11 @@ class NetworkModule {
     @Provides
     fun pixelReQueryInterceptor(): PixelReQueryInterceptor {
         return PixelReQueryInterceptor()
+    }
+
+    @Provides
+    fun pixelAtbRemovalInterceptor(): PixelAtbRemovalInterceptor {
+        return PixelAtbRemovalInterceptor()
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelAtbRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelAtbRemovalInterceptor.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import androidx.annotation.VisibleForTesting
+import com.duckduckgo.app.global.AppUrl
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class PixelAtbRemovalInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+        val pixel = chain.request().url.pathSegments.last()
+        val url = if (pixels.contains(pixel.substringBefore("_android_"))) {
+            chain.request().url.newBuilder().removeAllQueryParameters(AppUrl.ParamKey.ATB).build()
+        } else {
+            chain.request().url.newBuilder().build()
+        }
+
+        return chain.proceed(request.url(url).build())
+    }
+
+    companion object {
+        // list of pixels for which we'll remove the ATB information
+        @VisibleForTesting
+        val pixels = listOf(
+            "m_e_t_d",
+            "m_e_ua",
+            "m_e_uad"
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelAtbRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelAtbRemovalInterceptor.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.global.api
 
 import androidx.annotation.VisibleForTesting
 import com.duckduckgo.app.global.AppUrl
+import com.duckduckgo.app.pixels.AppPixelName
 import okhttp3.Interceptor
 import okhttp3.Response
 
@@ -38,9 +39,9 @@ class PixelAtbRemovalInterceptor : Interceptor {
         // list of pixels for which we'll remove the ATB information
         @VisibleForTesting
         val pixels = listOf(
-            "m_e_t_d",
-            "m_e_ua",
-            "m_e_uad"
+            AppPixelName.EMAIL_TOOLTIP_DISMISSED.pixelName,
+            AppPixelName.EMAIL_USE_ALIAS.pixelName,
+            AppPixelName.EMAIL_USE_ADDRESS.pixelName
         )
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200714585958657/f
Tech Design URL: 
CC: 

**Description**:
All our pixels currently send the ATB as a parameter but some pixels should not send such information, for instance `EMAIL_TOOLTIP_DISMISSED`, `EMAIL_USE_ALIAS`, `, EMAIL_USE_ADDRESS`.

This PR:
* Adds a `PixelAtbRemovalInterceptor` that is added to the pixel `okHttp` instance that will redact the `atb` parameter from the pixel if necessary
* Adds an inline interceptor to the pixel `okHttp` instance that just logs the final `request` url that is sent so that we can easily check in the console in debug builds
 * we already had some `timbers` that logged the pixel params etc, but as we are modifying the request using an interceptor, those timber may not contain the request params that are actually going out
* Adds `PixelAtbRemovalInterceptorTest` that verifies that for all pixels in `AppPixelName` only contain the `atb` param those which are supposse to


**Steps to test this PR**:
1. install from this branch
1. filter logcat by `Pixel url request:`
1. add your personal duck address in settings -> Email Protection
1. navigate to github.com
1. in the email address input field dax should appear
1. click on dax
1. dismiss the dialog that appears
1. verify that `Pixel url request: https://improving.duckduckgo.com/t/m_e_t_d_android_phone?appVersion=5.92.1&cohort=internal_beta&test=1` appears in logcat
 * the important thing is that pixel should be `m_e_t_d` and `atb` param is not in url
1. click on dax
1. click on `User yourEmail@duck.com`
1. verify that `Pixel url request: https://improving.duckduckgo.com/t/m_e_uad_android_phone?appVersion=5.92.1&cohort=internal_beta&test=1` appears in logcat
 * the important thing is that pixel should be `m_e_uad` and `atb` param is not in url
1. click on dax
1. click on `Generate private address`
1. verify that `Pixel url request: https://improving.duckduckgo.com/t/m_e_ua_android_phone?appVersion=5.92.1&cohort=internal_beta&test=1` appears in logcat
 * the important thing is that pixel should be `m_e_ua` and `atb` param is not in url


If you remove the `PixelAtbRemovalInterceptor` form the okHttp instance and perform the test steps above, all three pixels should have the `atb` param

The `PixelAtbRemovalInterceptorTest` should ensure that no other pixel is affected by this change

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
