### PR TITLE
Update surrogates.txt file location

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/surrogates/api/ResourceSurrogateListService.kt
+++ b/app/src/main/java/com/duckduckgo/app/surrogates/api/ResourceSurrogateListService.kt
@@ -22,6 +22,6 @@ import retrofit2.http.GET
 
 interface ResourceSurrogateListService {
 
-    @GET("/contentblocking.js?l=surrogates")
+    @GET("https://staticcdn.duckduckgo.com/surrogates.txt")
     fun surrogates(): Call<ResponseBody>
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1200747843240362/f
Tech Design URL: 
CC: 

**Description**:
https://duckduckgo.com/contentblocking.js?l=surrogates is deprecated as it's bound to SERP releases, https://staticcdn.duckduckgo.com/surrogates.txt is the new recommended url.

**Steps to test this PR**:
1. Go to https://output.jsbin.com/sekeyeh/4
1. Make sure that the second message displayed on the page (after 5s since the first one), is equal to:

> answer: 42, typeof getAll(): "object", getAll() stringify: [null], getAll() isArray: true

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
