### PR TITLE
Screen freezes after changing theme

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -155,7 +155,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenLightThemeToggledOnThenLighThemePixelIsSent() {
+    fun whenLightThemeToggledOnThenLightThemePixelIsSent() {
         testee.onLightThemeToggled(true)
         verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_TOGGLED_LIGHT)
     }
@@ -163,6 +163,7 @@ class SettingsViewModelTest {
     @Test
     fun whenLightThemeTogglesOffThenDataStoreIsUpdatedAndUpdateThemeCommandIsSent() = coroutineTestRule.runBlocking {
         testee.commands().test {
+            givenThemeSelected(DuckDuckGoTheme.LIGHT)
             testee.onLightThemeToggled(false)
             verify(mockThemeSettingsDataStore).theme = DuckDuckGoTheme.DARK
 
@@ -174,8 +175,24 @@ class SettingsViewModelTest {
 
     @Test
     fun whenLightThemeToggledOffThenDarkThemePixelIsSent() {
+        givenThemeSelected(DuckDuckGoTheme.LIGHT)
         testee.onLightThemeToggled(false)
         verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_TOGGLED_DARK)
+    }
+
+    @Test
+    fun whenLightThemeToggledButThemeWasAlreadySetThenDoNothing() = coroutineTestRule.runBlocking {
+        testee.commands().test {
+            givenThemeSelected(DuckDuckGoTheme.LIGHT)
+            testee.onLightThemeToggled(true)
+
+            verify(mockPixel, never()).fire(AppPixelName.SETTINGS_THEME_TOGGLED_LIGHT)
+            verify(mockThemeSettingsDataStore, never()).theme = DuckDuckGoTheme.LIGHT
+
+            expectNoEvents()
+
+            cancelAndConsumeRemainingEvents()
+        }
     }
 
     @Test
@@ -421,5 +438,9 @@ class SettingsViewModelTest {
     private fun givenSelectedFireAnimation(fireAnimation: FireAnimation) {
         whenever(mockAppSettingsDataStore.selectedFireAnimation).thenReturn(fireAnimation)
         whenever(mockAppSettingsDataStore.isCurrentlySelected(fireAnimation)).thenReturn(true)
+    }
+
+    private fun givenThemeSelected(theme: DuckDuckGoTheme) {
+        whenever(mockThemeSettingsDataStore.theme).thenReturn(theme)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -196,6 +196,42 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun whenDefaultBrowserTogglesOffThenLaunchDefaultBrowserCommandIsSent() = coroutineTestRule.runBlocking {
+        testee.commands().test {
+            whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
+            testee.onDefaultBrowserToggled(false)
+
+            assertEquals(Command.LaunchDefaultBrowser, expectItem())
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenDefaultBrowserTogglesOnThenLaunchDefaultBrowserCommandIsSent() = coroutineTestRule.runBlocking {
+        testee.commands().test {
+            whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
+            testee.onDefaultBrowserToggled(true)
+
+            assertEquals(Command.LaunchDefaultBrowser, expectItem())
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenDefaultBrowserTogglesOnAndBrowserWasAlreadyDefaultThenLaunchDefaultBrowserCommandIsNotSent() = coroutineTestRule.runBlocking {
+        testee.commands().test {
+            whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
+            testee.onDefaultBrowserToggled(true)
+
+            expectNoEvents()
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenAutocompleteSwitchedOnThenDataStoreIsUpdated() {
         testee.onAutocompleteSettingChanged(true)
         verify(mockAppSettingsDataStore).autoCompleteSuggestionsEnabled = true

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -75,7 +75,9 @@ class SettingsActivity :
 
     private val viewModel: SettingsViewModel by bindViewModel()
 
-    private val defaultBrowserChangeListener = OnCheckedChangeListener { _, _ -> launchDefaultAppScreen() }
+    private val defaultBrowserChangeListener = OnCheckedChangeListener { _, isChecked ->
+        viewModel.onDefaultBrowserToggled(isChecked)
+    }
 
     private val lightThemeToggleListener = OnCheckedChangeListener { _, isChecked ->
         viewModel.onLightThemeToggled(isChecked)
@@ -206,6 +208,7 @@ class SettingsActivity :
 
     private fun processCommand(it: Command?) {
         when (it) {
+            is Command.LaunchDefaultBrowser -> launchDefaultAppScreen()
             is Command.LaunchFeedback -> launchFeedback()
             is Command.LaunchFireproofWebsites -> launchFireproofWebsites()
             is Command.LaunchLocation -> launchLocation()

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -170,14 +170,18 @@ class SettingsViewModel @Inject constructor(
 
     fun onLightThemeToggled(enabled: Boolean) {
         Timber.i("User toggled light theme, is now enabled: $enabled")
-        themingDataStore.theme = if (enabled) DuckDuckGoTheme.LIGHT else DuckDuckGoTheme.DARK
-        viewModelScope.launch {
-            viewState.emit(currentViewState().copy(lightThemeEnabled = enabled))
-            command.send(Command.UpdateTheme)
-        }
+        val currentValue = themingDataStore.theme == DuckDuckGoTheme.LIGHT
+        if (enabled != currentValue) {
+            themingDataStore.theme = if (enabled) DuckDuckGoTheme.LIGHT else DuckDuckGoTheme.DARK
+            viewModelScope.launch {
+                viewState.emit(currentViewState().copy(lightThemeEnabled = enabled))
+                command.send(Command.UpdateTheme)
+            }
 
-        val pixelName = if (enabled) SETTINGS_THEME_TOGGLED_LIGHT else SETTINGS_THEME_TOGGLED_DARK
-        pixel.fire(pixelName)
+            val pixelName =
+                if (enabled) SETTINGS_THEME_TOGGLED_LIGHT else SETTINGS_THEME_TOGGLED_DARK
+            pixel.fire(pixelName)
+        }
     }
 
     fun onAutocompleteSettingChanged(enabled: Boolean) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200757594616707
Tech Design URL: 
CC: 

**Description**:
This PR fixes a bug where the screen starts a party of its own after changing the theme in the settings screen. It checks if the toggle state has changed before emitting the command which causes the "party"

**Steps to test this PR**:
1. Go to settings
1. Change the theme to dark
1. App should now have our dark theme
1. Change the theme to light
1. App should now have our light theme

**Default browser toggle**
I could only reproduce with a Samsung device
1. Go to settings
1. Select DDG as the default browser
1. Go back to settings
1. Change the theme to dark
1. Default browser screen should not show up


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
