### PR TITLE
Fix typo on Form yaml file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,46 +1,50 @@
 name: Bug Report
-decription: Create a report to help us improve
+description: Create a report to help us improve
 title: "[Bug] <title>"
 labels: [bug, needs triage]
-assignees: ''
+assignees: []
 body:
-- type: textarea
-  attributes:
-    label: Describe the bug
-    description: A clear and concise description of what the bug is
-    placeholder: Tell us what do you see!
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: How to Reproduce
-    description: Steps to reproduce the behavior
-    placeholder: |
-      1. Go to '...'
-      2. Click on '....'
-      3. Scroll down to '....'
-      4. See error
-      
-      If applicable, please include information about any settings that may be relevant to this issue (e.g. selected theme, auto clear option, etc).
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Expected behavior
-    description: A clear and concise description of what you expected to happen
-    placeholder: Tell us what did you expect to happen!
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Environment
-    description: Give us information about the app and your device
-    placeholder: |
-      - DDG App Version: (e.g. 5.25.0) Version can be found:
-       - DDG App settings: Settings -> Version
-       - System settings: Settings -> Apps & notifications -> App Info
-      - Device: [e.g. Pixel 2, Samsung s10]
-      - OS: [e.g. Android 10]
-      - If applicable, add screenshots to help explain your problem.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is
+      placeholder: Tell us what do you see!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How to Reproduce
+      description: |
+        Steps to reproduce the behavior
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+
+        If applicable, please include information about any settings that may be relevant to this issue (e.g. selected theme, auto clear option, etc).
+
+        Tip: You can attach screenshots by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen
+      placeholder: Tell us what did you expect to happen!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        Give us information about the app and your device
+        - DDG App Version: (e.g. 5.25.0) Version can be found inside Settings -> Version
+        - Device: [e.g. Pixel 2, Samsung s10]
+        - OS: [e.g. Android 10]
+      value: |
+        - DDG App Version:
+        - Device:
+        - OS:
+      render: markdown
+    validations:
+      required: false


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200761020174190/f
Tech Design URL: 
CC: 

**Description**:
Fixes a typo on the yaml file. 

This should fix the problem and enable GitHub forms.

I’ve also noticed the placeholder attribute doesn’t support multiline, so changed the schema to show hint as description.

**Steps to test this PR**:
1. Nothing to test
1. 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
