### PR TITLE
Fix the bug that problem with File Names in Downloads #1312

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
@@ -37,6 +37,11 @@ class FilenameExtractor @Inject constructor(
 
         val firstGuess = guessFilename(url, contentDisposition, mimeType)
         val guesses = Guesses(bestGuess = null, latestGuess = firstGuess)
+
+        if (firstGuess.contains(".")) {
+            return bestGuess(guesses)
+        }
+
         val baseUrl = url.toUri().host ?: ""
         var pathSegments = pathSegments(url)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: [https://github.com/duckduckgo/Android/issues/1312](url)
Tech Design URL: 
CC: 

**Description**: return the file name if gussed name forms as "*.*"


**Steps to test this PR**:
1. launch app and open the test url [https://ddg-name-test-ubsgiobgibsdgsbklsdjgm.netlify.app/](url) in browser
2. click the file link to download file
![Screen Shot 2021-08-10 at 3 31 25 PM](https://user-images.githubusercontent.com/1295939/128985980-b7efd6ab-6ba3-4592-a05d-94d311fe7939.png)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
