### PR TITLE
Change weight in serp variants to 1.0

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -45,14 +45,14 @@ class VariantManagerTest {
     @Test
     fun serpGxControlVariantHasExpectedWeightAndNoFeatures() {
         val variant = variants.first { it.key == "gx" }
-        assertEqualsDouble(0.1, variant.weight)
+        assertEqualsDouble(1.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 
     @Test
     fun serpGyExperimentalVariantHasExpectedWeightAndNoFeatures() {
         val variant = variants.first { it.key == "gy" }
-        assertEqualsDouble(0.1, variant.weight)
+        assertEqualsDouble(1.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -41,8 +41,8 @@ interface VariantManager {
             // the future if we can filter by app version
             Variant(key = "sc", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
             Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
-            Variant(key = "gx", weight = 0.1, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "gy", weight = 0.1, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "gx", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "gy", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
         )
 
         val REFERRER_VARIANTS = listOf(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200765651134621/f
Tech Design URL: 
CC: 

**Description**:
This PR changes the weight in the new SERP variants to 1.0

**Steps to test this PR**:
1. Make sure new weight for the variant matches 1.0 and you can be allocated to them


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
