### PR TITLE
[BUG] Fixed toggle of Dark theme to Light theme causing the Settings activity to become unresponsive

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -75,7 +75,9 @@ class SettingsActivity :
 
     private val viewModel: SettingsViewModel by bindViewModel()
 
-    private val defaultBrowserChangeListener = OnCheckedChangeListener { _, _ -> launchDefaultAppScreen() }
+    private val defaultBrowserChangeListener = OnCheckedChangeListener { _, isChecked ->
+        viewModel.onDefaultBrowserChanged(isChecked)
+    }
 
     private val lightThemeToggleListener = OnCheckedChangeListener { _, isChecked ->
         viewModel.onLightThemeToggled(isChecked)
@@ -206,6 +208,7 @@ class SettingsActivity :
 
     private fun processCommand(it: Command?) {
         when (it) {
+            is Command.LaunchDefaultAppScreen -> launchDefaultAppScreen()
             is Command.LaunchFeedback -> launchFeedback()
             is Command.LaunchFireproofWebsites -> launchFireproofWebsites()
             is Command.LaunchLocation -> launchLocation()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
Tech Design URL: 
CC: 

**Description**:

Toggling from Dark to Light theme was causing the theme to toggle from Light to Dark in an infinite loop. This also caused the change default browser activity to launch on each theme change.

**Steps to test this PR**:
1. Open App and go to Settings.
2. Toggle from Dark to Light Theme
3. App should remain in Light Theme


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
