### PR TITLE
Privacy Dashboard toggle bug

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardActivity.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.CompoundButton
 import androidx.core.content.ContextCompat
 import com.duckduckgo.app.brokensite.BrokenSiteActivity
 import com.duckduckgo.app.brokensite.BrokenSiteData
@@ -41,6 +42,7 @@ import com.duckduckgo.app.privacy.ui.PrivacyDashboardViewModel.ViewState
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
+import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
 
@@ -96,6 +98,10 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
         )
     }
 
+    private val privacyToggleListener = CompoundButton.OnCheckedChangeListener { _, enabled ->
+        viewModel.onPrivacyToggled(enabled)
+    }
+
     private fun setupClickListeners() {
         with(contentPrivacyDashboard) {
             privacyDashboardHeader.privacyHeader.setOnClickListener {
@@ -110,9 +116,7 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
                 viewModel.onReportBrokenSiteSelected()
             }
 
-            privacyToggle.setOnCheckedChangeListener { _, enabled ->
-                viewModel.onPrivacyToggled(enabled)
-            }
+            privacyToggle.setOnCheckedChangeListener(privacyToggleListener)
         }
     }
 
@@ -190,9 +194,9 @@ class PrivacyDashboardActivity : DuckDuckGoActivity() {
     }
 
     private fun renderToggle(enabled: Boolean, isSiteIntTempAllowedList: Boolean) {
-        val backgroundColor = if (enabled) R.color.midGreen else R.color.warmerGray
+        val backgroundColor = if (enabled && !isSiteIntTempAllowedList) R.color.midGreen else R.color.warmerGray
         contentPrivacyDashboard.privacyToggleContainer.setBackgroundColor(ContextCompat.getColor(this, backgroundColor))
-        contentPrivacyDashboard.privacyToggle.isChecked = enabled && !isSiteIntTempAllowedList
+        contentPrivacyDashboard.privacyToggle.quietlySetIsChecked(enabled && !isSiteIntTempAllowedList, privacyToggleListener)
         contentPrivacyDashboard.privacyToggle.isEnabled = !isSiteIntTempAllowedList
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200853087962147
Tech Design URL: 
CC: 

**Description**:
This PR fixes a bug where we automatically add sites to the user's allow list when the user visits the Privacy Dashboard after going to a site from our temporary allowed list.

**Steps to test this PR**:
1. Go to `53.com` or any other site from `https://staticcdn.duckduckgo.com/trackerblocking/config/v1/android-config.json`
1. Go to the Privacy Dashboard (click on the privacy grade)
1. The toggle should be disabled and colored in grey and you should not be able to click on the toggle.
1. Go to settings and  Unprotected Sites
1. The site you visited should not show up there.
1. Go to `test.com`
1. Click on the privacy grade to go to the Privacy Dashboard
1. The toggle should be enabled and colored in green
1. Click on the toggle to remove the site protection.
1. Toggle should be colored in grey
1. Go to settings and  Unprotected Sites
1. `test.com` should show up in the list


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
