### PR TITLE
Fix bug (#1390)

### DIFF
--- a/app/src/main/res/layout/sheet_fire_clear_data.xml
+++ b/app/src/main/res/layout/sheet_fire_clear_data.xml
@@ -44,7 +44,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/white">
+            android:background="?dialogBgColor">
 
             <TextView
                 android:id="@+id/clearAllOption"


### PR DESCRIPTION
Task/Issue URL:  https://github.com/duckduckgo/Android/issues/1390
Tech Design URL: No, just pick the closest attribute as the background color.
CC: 

**Description**:
Burn menu dialog(FireDialog) items' background color should be styled because the color of items' text has been styled.
I pick the the closest attribute, _dialogBgColor_, from file [Android\common-ui\src\main\res\values\attrs.xml](https://github.com/duckduckgo/Android/blob/develop/common-ui/src/main/res/values/attrs.xml) as the background color.

**Steps to test this PR**:
1. Open FireDialog when Light Theme is on, nothing should be changed after this PR
1. Open FireDialog when Light Theme is off, before the PR cancel button is "invisible", after the PR it will be "visible"


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
