### PR TITLE
Fix bug (#1391)

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -193,14 +193,11 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUsersUpdatesWithAutoCompleteDisabledThenAutoCompleteSuggestionsIsEmpty() = coroutineRule.runBlocking {
+    fun whenUsersUpdatesWithAutoCompleteDisabledThenViewStateReset() = coroutineRule.runBlocking {
         doReturn(false).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
         testee.userUpdatedQuery(QUERY)
 
-        val newViewState = testee.resultsViewState.value as SystemSearchResultsViewState
-        assertNotNull(newViewState)
-        assertEquals(appQueryResult, newViewState.appResults)
-        assertEquals(autocompleteQueryEmptyResult, newViewState.autocompleteResults)
+        assertTrue(testee.resultsViewState.value is SystemSearchViewModel.Suggestions.QuickAccessItems)
     }
 
     @Test
@@ -405,7 +402,6 @@ class SystemSearchViewModelTest {
         const val AUTOCOMPLETE_RESULT = "autocomplete result"
         val deviceApp = DeviceApp("", "", Intent())
         val autocompleteQueryResult = AutoCompleteResult(QUERY, listOf(AutoCompleteSearchSuggestion(QUERY, false)))
-        val autocompleteQueryEmptyResult = AutoCompleteResult(QUERY, emptyList())
         val autocompleteBlankResult = AutoCompleteResult(BLANK_QUERY, emptyList())
         val appQueryResult = listOf(deviceApp)
         val appBlankResult = emptyList<DeviceApp>()

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -195,8 +195,10 @@ class SystemSearchViewModel(
             return
         }
 
-        val trimmedQuery = query.trim()
-        resultsPublishSubject.accept(trimmedQuery)
+        if (appSettingsPreferencesStore.autoCompleteSuggestionsEnabled) {
+            val trimmedQuery = query.trim()
+            resultsPublishSubject.accept(trimmedQuery)
+        }
     }
 
     private fun updateResults(results: SystemSearchResult) {
@@ -204,17 +206,9 @@ class SystemSearchViewModel(
 
         val suggestions = results.autocomplete.suggestions
         val appResults = results.deviceApps
+        val hasMultiResults = suggestions.isNotEmpty() && appResults.isNotEmpty()
 
-        val autoCompleteSuggestionsEnabled = appSettingsPreferencesStore.autoCompleteSuggestionsEnabled
-        val hasMultiResults = (autoCompleteSuggestionsEnabled && suggestions.isNotEmpty()) && appResults.isNotEmpty()
-
-        val updatedSuggestions = if (hasMultiResults) suggestions.take(RESULTS_MAX_RESULTS_PER_GROUP) else {
-            if (autoCompleteSuggestionsEnabled) {
-                suggestions
-            } else {
-                emptyList()
-            }
-        }
+        val updatedSuggestions = if (hasMultiResults) suggestions.take(RESULTS_MAX_RESULTS_PER_GROUP) else suggestions
         val updatedApps = if (hasMultiResults) appResults.take(RESULTS_MAX_RESULTS_PER_GROUP) else appResults
         resultsViewState.postValue(
             when (val currentResultsState = currentResultsState()) {
@@ -233,7 +227,9 @@ class SystemSearchViewModel(
     }
 
     private fun inputCleared() {
-        resultsPublishSubject.accept("")
+        if (appSettingsPreferencesStore.autoCompleteSuggestionsEnabled) {
+            resultsPublishSubject.accept("")
+        }
         resetResultsState()
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/Android/issues/1391
Tech Design URL: Following the logic pattern in [BrowserTabViewModel](https://github.com/duckduckgo/Android/blob/develop/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt)
CC: 

**Description**:
When user open DuckDuckGo as an assist app, SystemSearchActivity is the landing page. User can perform search in this activity.
However, currently autocomplete-setting-status is only applied to the _BrowserTabViewModel_, which is different from the _SystemSearchViewModel_ used in SystemSearchActivity.
The logic in _SystemSearchViewModel_ doesn't take autocomplete-setting-status into account so that even user has disabled autocomplete in settings, SystemSearchActivity still shows autocomplete results.
In this PR, I changed the final autocomplete results to an empty list when user has disabled autocomplete in settings.
Like _BrowserTabViewModel_, the filter logic is in the last step before actually update the viewState.
But the code is not elegant enough, as you can see that the var _autoCompleteSuggestionsEnabled_ has been used twice.
If you have better idea, plz let me know.
I also make autocomplete is enabled as default in _SystemSearchViewModelTest_ so that previous test cases can pass.
And I add two new test cases.

**Steps to test this PR**:
1. Disable autocomplete in settings
2. Set DuckDuckGo as the default assist app in SystemSettings
3. Open DuckDuckGo as assist app, for example long pressed home in an Android10 AVD
4. Type any char in omnibarTextInput
5. You should only see apps result and "No Suggestions" text


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
