### PR TITLE
System default theme added Fixes #1397

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -143,7 +143,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenThemeSettingsClickedThenPixelSent(){
+    fun whenThemeSettingsClickedThenPixelSent() {
         testee.userRequestedToChangeTheme()
         verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_OPENED)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -143,28 +143,28 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenLightThemeToggledOnThenDataStoreIsUpdatedAndUpdateThemeCommandIsSent() = coroutineTestRule.runBlocking {
+    fun whenThemeSettingsClickedThenPixelSent(){
+        testee.userRequestedToChangeTheme()
+        verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_OPENED)
+    }
+
+    @Test
+    fun whenThemeSettingsClickedThenCommandIsLaunchThemeSettingsIsSent() = coroutineTestRule.runBlocking {
         testee.commands().test {
-            testee.onLightThemeToggled(true)
-            verify(mockThemeSettingsDataStore).theme = DuckDuckGoTheme.LIGHT
+            testee.userRequestedToChangeTheme()
 
-            assertEquals(Command.UpdateTheme, expectItem())
+            assertEquals(Command.LaunchThemeSettings(DuckDuckGoTheme.LIGHT), expectItem())
 
-            cancelAndConsumeRemainingEvents()
+            cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun whenLightThemeToggledOnThenLightThemePixelIsSent() {
-        testee.onLightThemeToggled(true)
-        verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_TOGGLED_LIGHT)
-    }
-
-    @Test
-    fun whenLightThemeTogglesOffThenDataStoreIsUpdatedAndUpdateThemeCommandIsSent() = coroutineTestRule.runBlocking {
+    fun whenThemeChangedThenDataStoreIsUpdatedAndUpdateThemeCommandIsSent() = coroutineTestRule.runBlocking {
         testee.commands().test {
             givenThemeSelected(DuckDuckGoTheme.LIGHT)
-            testee.onLightThemeToggled(false)
+            testee.onThemeSelected(DuckDuckGoTheme.DARK)
+
             verify(mockThemeSettingsDataStore).theme = DuckDuckGoTheme.DARK
 
             assertEquals(Command.UpdateTheme, expectItem())
@@ -174,17 +174,31 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenLightThemeToggledOffThenDarkThemePixelIsSent() {
+    fun whenThemeChangedToLightThenLightThemePixelIsSent() {
+        givenThemeSelected(DuckDuckGoTheme.DARK)
+        testee.onThemeSelected(DuckDuckGoTheme.LIGHT)
+        verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_TOGGLED_LIGHT)
+    }
+
+    @Test
+    fun whenThemeChangedToDarkThenDarkThemePixelIsSent() {
         givenThemeSelected(DuckDuckGoTheme.LIGHT)
-        testee.onLightThemeToggled(false)
+        testee.onThemeSelected(DuckDuckGoTheme.DARK)
         verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_TOGGLED_DARK)
     }
 
     @Test
-    fun whenLightThemeToggledButThemeWasAlreadySetThenDoNothing() = coroutineTestRule.runBlocking {
+    fun whenThemeChangedToSystemDefaultThenSystemDefaultThemePixelIsSent() {
+        givenThemeSelected(DuckDuckGoTheme.LIGHT)
+        testee.onThemeSelected(DuckDuckGoTheme.SYSTEM_DEFAULT)
+        verify(mockPixel).fire(AppPixelName.SETTINGS_THEME_TOGGLED_SYSTEM_DEFAULT)
+    }
+
+    @Test
+    fun whenThemeChangedButThemeWasAlreadySetThenDoNothing() = coroutineTestRule.runBlocking {
         testee.commands().test {
             givenThemeSelected(DuckDuckGoTheme.LIGHT)
-            testee.onLightThemeToggled(true)
+            testee.onThemeSelected(DuckDuckGoTheme.LIGHT)
 
             verify(mockPixel, never()).fire(AppPixelName.SETTINGS_THEME_TOGGLED_LIGHT)
             verify(mockThemeSettingsDataStore, never()).theme = DuckDuckGoTheme.LIGHT

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -109,6 +109,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     DOWNLOAD_FILE_DEFAULT_GUESSED_NAME("m_df_dgn"),
 
     SETTINGS_OPENED("ms"),
+    SETTINGS_THEME_OPENED("ms_t_o"),
     SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),
     SETTINGS_THEME_TOGGLED_DARK("ms_td"),
     SETTINGS_THEME_TOGGLED_SYSTEM_DEFAULT("ms_tsd"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -111,6 +111,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_OPENED("ms"),
     SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),
     SETTINGS_THEME_TOGGLED_DARK("ms_td"),
+    SETTINGS_THEME_TOGGLED_SYSTEM_DEFAULT("ms_tsd"), // confirm? the code here for statistics
     SETTINGS_MANAGE_WHITELIST("ms_mw"),
     SETTINGS_DO_NOT_SELL_SHOWN("ms_dns"),
     SETTINGS_DO_NOT_SELL_ON("ms_dns_on"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -111,7 +111,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_OPENED("ms"),
     SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),
     SETTINGS_THEME_TOGGLED_DARK("ms_td"),
-    SETTINGS_THEME_TOGGLED_SYSTEM_DEFAULT("ms_tsd"), // confirm? the code here for statistics
+    SETTINGS_THEME_TOGGLED_SYSTEM_DEFAULT("ms_tsd"),
     SETTINGS_MANAGE_WHITELIST("ms_mw"),
     SETTINGS_DO_NOT_SELL_SHOWN("ms_dns"),
     SETTINGS_DO_NOT_SELL_ON("ms_dns_on"),

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -114,7 +114,7 @@ class SettingsActivity :
         locationPermissions.setOnClickListener { viewModel.onLocationClicked() }
         globalPrivacyControlSetting.setOnClickListener { viewModel.onGlobalPrivacyControlClicked() }
 
-        selectedThemeSetting.setOnClickListener{ viewModel.userRequestedToChangeTheme() }
+        selectedThemeSetting.setOnClickListener { viewModel.userRequestedToChangeTheme() }
         autocompleteToggle.setOnCheckedChangeListener(autocompleteToggleListener)
         setAsDefaultBrowserSetting.setOnCheckedChangeListener(defaultBrowserChangeListener)
         automaticallyClearWhatSetting.setOnClickListener { viewModel.onAutomaticallyClearWhatClicked() }
@@ -182,11 +182,13 @@ class SettingsActivity :
     }
 
     private fun updateSelectedTheme(selectedTheme: DuckDuckGoTheme) {
-        val subtitle =  getString(when (selectedTheme){
-            DuckDuckGoTheme.DARK-> R.string.settingsDarkTheme
-            DuckDuckGoTheme.LIGHT-> R.string.settingsLightTheme
-            DuckDuckGoTheme.SYSTEM_DEFAULT-> R.string.settingsSystemTheme
-        })
+        val subtitle = getString(
+            when (selectedTheme) {
+                DuckDuckGoTheme.DARK -> R.string.settingsDarkTheme
+                DuckDuckGoTheme.LIGHT -> R.string.settingsLightTheme
+                DuckDuckGoTheme.SYSTEM_DEFAULT -> R.string.settingsSystemTheme
+            }
+        )
         selectedThemeSetting.setSubtitle(subtitle)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -37,20 +37,21 @@ import com.duckduckgo.app.fire.fireproofwebsite.ui.FireproofWebsitesActivity
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.global.view.launchDefaultAppActivity
-import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import com.duckduckgo.app.globalprivacycontrol.ui.GlobalPrivacyControlActivity
 import com.duckduckgo.app.icon.ui.ChangeIconActivity
 import com.duckduckgo.app.location.ui.LocationPermissionsActivity
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.ui.WhitelistActivity
 import com.duckduckgo.app.settings.SettingsViewModel.AutomaticallyClearData
 import com.duckduckgo.app.settings.SettingsViewModel.Command
 import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.clear.ClearWhenOption
 import com.duckduckgo.app.settings.clear.FireAnimation
-import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.extension.InternalFeaturePlugin
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.sendThemeChangedBroadcast
+import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import kotlinx.android.synthetic.main.content_settings_general.*
 import kotlinx.android.synthetic.main.content_settings_internal.*
 import kotlinx.android.synthetic.main.content_settings_other.*
@@ -65,6 +66,7 @@ class SettingsActivity :
     DuckDuckGoActivity(),
     SettingsAutomaticallyClearWhatFragment.Listener,
     SettingsAutomaticallyClearWhenFragment.Listener,
+    SettingsThemeSelectorFragment.Listener,
     SettingsFireAnimationSelectorFragment.Listener {
 
     @Inject
@@ -77,10 +79,6 @@ class SettingsActivity :
 
     private val defaultBrowserChangeListener = OnCheckedChangeListener { _, isChecked ->
         viewModel.onDefaultBrowserToggled(isChecked)
-    }
-
-    private val lightThemeToggleListener = OnCheckedChangeListener { _, isChecked ->
-        viewModel.onLightThemeToggled(isChecked)
     }
 
     private val autocompleteToggleListener = OnCheckedChangeListener { _, isChecked ->
@@ -116,7 +114,7 @@ class SettingsActivity :
         locationPermissions.setOnClickListener { viewModel.onLocationClicked() }
         globalPrivacyControlSetting.setOnClickListener { viewModel.onGlobalPrivacyControlClicked() }
 
-        lightThemeToggle.setOnCheckedChangeListener(lightThemeToggleListener)
+        themeToggle.setOnClickListener{ viewModel.userRequestedToChangeTheme() }
         autocompleteToggle.setOnCheckedChangeListener(autocompleteToggleListener)
         setAsDefaultBrowserSetting.setOnCheckedChangeListener(defaultBrowserChangeListener)
         automaticallyClearWhatSetting.setOnClickListener { viewModel.onAutomaticallyClearWhatClicked() }
@@ -152,7 +150,7 @@ class SettingsActivity :
             .onEach { viewState ->
                 viewState.let {
                     version.setSubtitle(it.version)
-                    lightThemeToggle.quietlySetIsChecked(it.lightThemeEnabled, lightThemeToggleListener)
+                    updateSelectedTheme(it.theme)
                     autocompleteToggle.quietlySetIsChecked(it.autoCompleteSuggestionsEnabled, autocompleteToggleListener)
                     updateDefaultBrowserViewVisibility(it)
                     updateAutomaticClearDataOptions(it.automaticallyClearData)
@@ -181,6 +179,15 @@ class SettingsActivity :
     private fun updateSelectedFireAnimation(fireAnimation: FireAnimation) {
         val subtitle = getString(fireAnimation.nameResId)
         selectedFireAnimationSetting.setSubtitle(subtitle)
+    }
+
+    private fun updateSelectedTheme(selectedTheme: DuckDuckGoTheme) {
+        val subtitle =  getString(when (selectedTheme){
+            DuckDuckGoTheme.DARK-> R.string.settingsDarkTheme
+            DuckDuckGoTheme.LIGHT-> R.string.settingsLightTheme
+            DuckDuckGoTheme.SYSTEM_DEFAULT-> R.string.settingsSystemTheme
+        })
+        themeToggle.setSubtitle(subtitle)
     }
 
     private fun updateAutomaticClearDataOptions(automaticallyClearData: AutomaticallyClearData) {
@@ -217,6 +224,7 @@ class SettingsActivity :
             is Command.LaunchGlobalPrivacyControl -> launchGlobalPrivacyControl()
             is Command.UpdateTheme -> sendThemeChangedBroadcast()
             is Command.LaunchEmailProtection -> launchEmailProtectionScreen()
+            is Command.LaunchThemeSettings -> launchThemeSelector(it.theme)
             is Command.LaunchFireAnimationSettings -> launchFireAnimationSelector(it.animation)
             is Command.ShowClearWhatDialog -> launchAutomaticallyClearWhatDialog(it.option)
             is Command.ShowClearWhenDialog -> launchAutomaticallyClearWhenDialog(it.option)
@@ -271,6 +279,11 @@ class SettingsActivity :
         dialog.show(supportFragmentManager, FIRE_ANIMATION_SELECTOR_TAG)
     }
 
+    private fun launchThemeSelector(theme: DuckDuckGoTheme) {
+        val dialog = SettingsThemeSelectorFragment.create(theme)
+        dialog.show(supportFragmentManager, THEME_SELECTOR_TAG)
+    }
+
     private fun launchGlobalPrivacyControl() {
         val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
         startActivity(GlobalPrivacyControlActivity.intent(this), options)
@@ -279,6 +292,10 @@ class SettingsActivity :
     private fun launchEmailProtectionScreen() {
         val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
         startActivity(EmailProtectionActivity.intent(this), options)
+    }
+
+    override fun onThemeSelected(selectedTheme: DuckDuckGoTheme) {
+        viewModel.onThemeSelected(selectedTheme)
     }
 
     override fun onAutomaticallyClearWhatOptionSelected(clearWhatSetting: ClearWhatOption) {
@@ -329,6 +346,7 @@ class SettingsActivity :
 
     companion object {
         private const val FIRE_ANIMATION_SELECTOR_TAG = "FIRE_ANIMATION_SELECTOR_DIALOG_FRAGMENT"
+        private const val THEME_SELECTOR_TAG = "THEME_SELECTOR_DIALOG_FRAGMENT"
         private const val CLEAR_WHAT_DIALOG_TAG = "CLEAR_WHAT_DIALOG_FRAGMENT"
         private const val CLEAR_WHEN_DIALOG_TAG = "CLEAR_WHEN_DIALOG_FRAGMENT"
         private const val FEEDBACK_REQUEST_CODE = 100

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -114,7 +114,7 @@ class SettingsActivity :
         locationPermissions.setOnClickListener { viewModel.onLocationClicked() }
         globalPrivacyControlSetting.setOnClickListener { viewModel.onGlobalPrivacyControlClicked() }
 
-        themeToggle.setOnClickListener{ viewModel.userRequestedToChangeTheme() }
+        selectedThemeSetting.setOnClickListener{ viewModel.userRequestedToChangeTheme() }
         autocompleteToggle.setOnCheckedChangeListener(autocompleteToggleListener)
         setAsDefaultBrowserSetting.setOnCheckedChangeListener(defaultBrowserChangeListener)
         automaticallyClearWhatSetting.setOnClickListener { viewModel.onAutomaticallyClearWhatClicked() }
@@ -187,7 +187,7 @@ class SettingsActivity :
             DuckDuckGoTheme.LIGHT-> R.string.settingsLightTheme
             DuckDuckGoTheme.SYSTEM_DEFAULT-> R.string.settingsSystemTheme
         })
-        themeToggle.setSubtitle(subtitle)
+        selectedThemeSetting.setSubtitle(subtitle)
     }
 
     private fun updateAutomaticClearDataOptions(automaticallyClearData: AutomaticallyClearData) {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsThemeSelectorFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsThemeSelectorFragment.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.settings
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.View
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import androidx.annotation.IdRes
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
+import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme.*
+
+class SettingsThemeSelectorFragment : DialogFragment() {
+
+    interface Listener {
+        fun onThemeSelected(selectedTheme: DuckDuckGoTheme)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
+        val currentOption: DuckDuckGoTheme =
+            arguments?.getSerializable(DEFAULT_OPTION_EXTRA) as DuckDuckGoTheme? ?: SYSTEM_DEFAULT
+
+        val rootView =
+            View.inflate(activity, R.layout.settings_theme_selector_fragment, null)
+
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            rootView.findViewById<RadioButton>(R.id.themeSelectorSystemDefault).visibility =
+                View.VISIBLE
+        }
+        updateCurrentSelect(currentOption, rootView.findViewById(R.id.themeSelectorGroup))
+
+        val alertBuilder = AlertDialog.Builder(requireActivity())
+            .setView(rootView)
+            .setTitle(R.string.settingsTheme)
+            .setPositiveButton(R.string.settingsThemeDialogSave) { _, _ ->
+                dialog?.let {
+                    val radioGroup = it.findViewById(R.id.themeSelectorGroup) as RadioGroup
+                    val selectedOption = when (radioGroup.checkedRadioButtonId) {
+                        R.id.themeSelectorLight -> LIGHT
+                        R.id.themeSelectorDark -> DARK
+                        R.id.themeSelectorSystemDefault -> SYSTEM_DEFAULT
+                        else -> LIGHT
+                    }
+                    val listener = activity as Listener?
+                    listener?.onThemeSelected(selectedOption)
+                }
+            }
+            .setNegativeButton(android.R.string.cancel) { _, _ -> }
+
+        return alertBuilder.create()
+    }
+
+    private fun updateCurrentSelect(currentOption: DuckDuckGoTheme, radioGroup: RadioGroup) {
+        val selectedId = currentOption.radioButtonId()
+        radioGroup.check(selectedId)
+    }
+
+    @IdRes
+    private fun DuckDuckGoTheme.radioButtonId(): Int {
+        return when (this) {
+            LIGHT -> R.id.themeSelectorLight
+            DARK -> R.id.themeSelectorDark
+            SYSTEM_DEFAULT -> R.id.themeSelectorSystemDefault
+        }
+    }
+
+    companion object {
+
+        private const val DEFAULT_OPTION_EXTRA = "DEFAULT_OPTION"
+
+        fun create(selectedFireAnimation: DuckDuckGoTheme?): SettingsThemeSelectorFragment {
+            val fragment = SettingsThemeSelectorFragment()
+
+            fragment.arguments = Bundle().also {
+                it.putSerializable(DEFAULT_OPTION_EXTRA, selectedFireAnimation)
+            }
+            return fragment
+        }
+    }
+
+}

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsThemeSelectorFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsThemeSelectorFragment.kt
@@ -37,7 +37,7 @@ class SettingsThemeSelectorFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
 
         val currentOption: DuckDuckGoTheme =
-            arguments?.getSerializable(DEFAULT_OPTION_EXTRA) as DuckDuckGoTheme? ?: SYSTEM_DEFAULT
+            arguments?.getSerializable(DEFAULT_OPTION_EXTRA) as DuckDuckGoTheme? ?: LIGHT
 
         val rootView =
             View.inflate(activity, R.layout.settings_theme_selector_fragment, null)

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -39,7 +39,10 @@ import com.duckduckgo.mobile.android.ui.store.ThemingDataStore
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -57,7 +60,7 @@ class SettingsViewModel @Inject constructor(
     data class ViewState(
         val loading: Boolean = true,
         val version: String = "",
-        val lightThemeEnabled: Boolean = false,
+        val theme: DuckDuckGoTheme = DuckDuckGoTheme.LIGHT,
         val autoCompleteSuggestionsEnabled: Boolean = true,
         val showDefaultBrowserSetting: Boolean = false,
         val isAppDefaultBrowser: Boolean = false,
@@ -83,6 +86,7 @@ class SettingsViewModel @Inject constructor(
         object LaunchWhitelist : Command()
         object LaunchAppIcon : Command()
         data class LaunchFireAnimationSettings(val animation: FireAnimation) : Command()
+        data class LaunchThemeSettings(val theme: DuckDuckGoTheme) : Command()
         object LaunchGlobalPrivacyControl : Command()
         object UpdateTheme : Command()
         data class ShowClearWhatDialog(val option: ClearWhatOption) : Command()
@@ -100,7 +104,7 @@ class SettingsViewModel @Inject constructor(
     fun start() {
         val defaultBrowserAlready = defaultWebBrowserCapability.isDefaultBrowser()
         val variant = variantManager.getVariant()
-        val isLightTheme = themingDataStore.theme == DuckDuckGoTheme.LIGHT
+        val savedTheme = themingDataStore.theme
         val automaticallyClearWhat = settingsDataStore.automaticallyClearWhatOption
         val automaticallyClearWhen = settingsDataStore.automaticallyClearWhenOption
         val automaticallyClearWhenEnabled = isAutomaticallyClearingDataWhenSettingEnabled(automaticallyClearWhat)
@@ -109,7 +113,7 @@ class SettingsViewModel @Inject constructor(
             viewState.emit(
                 currentViewState().copy(
                     loading = false,
-                    lightThemeEnabled = isLightTheme,
+                    theme = savedTheme,
                     autoCompleteSuggestionsEnabled = settingsDataStore.autoCompleteSuggestionsEnabled,
                     isAppDefaultBrowser = defaultBrowserAlready,
                     showDefaultBrowserSetting = defaultWebBrowserCapability.deviceSupportsDefaultBrowserConfiguration(),
@@ -145,6 +149,10 @@ class SettingsViewModel @Inject constructor(
         pixel.fire(FIRE_ANIMATION_SETTINGS_OPENED)
     }
 
+    fun userRequestedToChangeTheme(){
+        viewModelScope.launch { command.send(Command.LaunchThemeSettings(viewState.value.theme)) }
+    }
+
     fun onFireproofWebsitesClicked() {
         viewModelScope.launch { command.send(Command.LaunchFireproofWebsites) }
     }
@@ -177,21 +185,6 @@ class SettingsViewModel @Inject constructor(
             viewState.emit(currentViewState().copy(isAppDefaultBrowser = enabled))
             command.send(Command.LaunchDefaultBrowser)
         }
-    }
-
-    fun onLightThemeToggled(enabled: Boolean) {
-        Timber.i("User toggled light theme, is now enabled: $enabled")
-        val lightThemeSelected = themingDataStore.theme == DuckDuckGoTheme.LIGHT
-        if (enabled && lightThemeSelected) return
-        themingDataStore.theme = if (enabled) DuckDuckGoTheme.LIGHT else DuckDuckGoTheme.DARK
-        viewModelScope.launch {
-            viewState.emit(currentViewState().copy(lightThemeEnabled = enabled))
-            command.send(Command.UpdateTheme)
-        }
-
-        val pixelName =
-            if (enabled) SETTINGS_THEME_TOGGLED_LIGHT else SETTINGS_THEME_TOGGLED_DARK
-        pixel.fire(pixelName)
     }
 
     fun onAutocompleteSettingChanged(enabled: Boolean) {
@@ -259,6 +252,27 @@ class SettingsViewModel @Inject constructor(
                 )
             )
         }
+    }
+
+    fun onThemeSelected(selectedTheme : DuckDuckGoTheme){
+        Timber.d("User toggled theme, theme to set: $selectedTheme")
+        if (themingDataStore.isCurrentlySelected(selectedTheme)){
+            Timber.d("User selected same theme they've already set: $selectedTheme; no need to do anything else")
+            return
+        }
+        themingDataStore.theme = selectedTheme
+        viewModelScope.launch {
+            viewState.emit(currentViewState().copy(theme = selectedTheme))
+            command.send(Command.UpdateTheme)
+        }
+
+        val pixelName =
+            when(selectedTheme){
+                DuckDuckGoTheme.LIGHT -> SETTINGS_THEME_TOGGLED_LIGHT
+                DuckDuckGoTheme.DARK -> SETTINGS_THEME_TOGGLED_DARK
+                DuckDuckGoTheme.SYSTEM_DEFAULT -> SETTINGS_THEME_TOGGLED_SYSTEM_DEFAULT
+            }
+        pixel.fire(pixelName)
     }
 
     fun onFireAnimationSelected(selectedFireAnimation: FireAnimation) {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -151,6 +151,7 @@ class SettingsViewModel @Inject constructor(
 
     fun userRequestedToChangeTheme(){
         viewModelScope.launch { command.send(Command.LaunchThemeSettings(viewState.value.theme)) }
+        pixel.fire(SETTINGS_THEME_OPENED)
     }
 
     fun onFireproofWebsitesClicked() {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -149,7 +149,7 @@ class SettingsViewModel @Inject constructor(
         pixel.fire(FIRE_ANIMATION_SETTINGS_OPENED)
     }
 
-    fun userRequestedToChangeTheme(){
+    fun userRequestedToChangeTheme() {
         viewModelScope.launch { command.send(Command.LaunchThemeSettings(viewState.value.theme)) }
         pixel.fire(SETTINGS_THEME_OPENED)
     }
@@ -255,9 +255,9 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    fun onThemeSelected(selectedTheme : DuckDuckGoTheme){
+    fun onThemeSelected(selectedTheme: DuckDuckGoTheme) {
         Timber.d("User toggled theme, theme to set: $selectedTheme")
-        if (themingDataStore.isCurrentlySelected(selectedTheme)){
+        if (themingDataStore.isCurrentlySelected(selectedTheme)) {
             Timber.d("User selected same theme they've already set: $selectedTheme; no need to do anything else")
             return
         }
@@ -268,7 +268,7 @@ class SettingsViewModel @Inject constructor(
         }
 
         val pixelName =
-            when(selectedTheme){
+            when (selectedTheme) {
                 DuckDuckGoTheme.LIGHT -> SETTINGS_THEME_TOGGLED_LIGHT
                 DuckDuckGoTheme.DARK -> SETTINGS_THEME_TOGGLED_DARK
                 DuckDuckGoTheme.SYSTEM_DEFAULT -> SETTINGS_THEME_TOGGLED_SYSTEM_DEFAULT

--- a/app/src/main/res/layout/content_settings_general.xml
+++ b/app/src/main/res/layout/content_settings_general.xml
@@ -30,7 +30,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <com.duckduckgo.app.settings.SettingsOptionWithSubtitle
-        android:id="@+id/themeToggle"
+        android:id="@+id/selectedThemeSetting"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
@@ -46,7 +46,7 @@
         android:theme="@style/SettingsSwitchTheme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/themeToggle" />
+        app:layout_constraintTop_toBottomOf="@id/selectedThemeSetting" />
 
     <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/setAsDefaultBrowserSetting"

--- a/app/src/main/res/layout/content_settings_general.xml
+++ b/app/src/main/res/layout/content_settings_general.xml
@@ -29,14 +29,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/lightThemeToggle"
-        style="@style/SettingsSwitch"
-        android:text="@string/settingsLightTheme"
-        android:theme="@style/SettingsSwitchTheme"
+    <com.duckduckgo.app.settings.SettingsOptionWithSubtitle
+        android:id="@+id/themeToggle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/settingsGeneralTitle" />
+        app:layout_constraintTop_toBottomOf="@id/settingsGeneralTitle"
+        app:subtitle="@string/settingsSystemTheme"
+        app:title="@string/settingsTheme" />
 
     <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/autocompleteToggle"
@@ -45,7 +46,7 @@
         android:theme="@style/SettingsSwitchTheme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/lightThemeToggle" />
+        app:layout_constraintTop_toBottomOf="@id/themeToggle" />
 
     <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/setAsDefaultBrowserSetting"

--- a/app/src/main/res/layout/settings_theme_selector_fragment.xml
+++ b/app/src/main/res/layout/settings_theme_selector_fragment.xml
@@ -17,12 +17,12 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:background="@color/white"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingStart="20dp"
     android:paddingTop="10dp"
-    android:paddingEnd="20dp">
+    android:paddingEnd="20dp"
+    tools:background="@color/white">
 
     <RadioGroup
         android:id="@+id/themeSelectorGroup"
@@ -31,6 +31,18 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
+
+        <RadioButton
+            android:id="@+id/themeSelectorSystemDefault"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:padding="10dp"
+            android:paddingStart="10dp"
+            android:paddingEnd="10dp"
+            android:text="@string/settingsSystemTheme"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <RadioButton
             android:id="@+id/themeSelectorLight"
@@ -50,18 +62,7 @@
             android:padding="10dp"
             android:paddingStart="10dp"
             android:paddingEnd="10dp"
-            android:text="@string/settingsDarkTheme"/>
-
-        <RadioButton
-            android:id="@+id/themeSelectorSystemDefault"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:padding="10dp"
-            android:visibility="gone"
-            android:paddingStart="10dp"
-            android:paddingEnd="10dp"
-            android:text="@string/settingsSystemTheme" />
+            android:text="@string/settingsDarkTheme" />
 
     </RadioGroup>
 

--- a/app/src/main/res/layout/settings_theme_selector_fragment.xml
+++ b/app/src/main/res/layout/settings_theme_selector_fragment.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2018 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:background="@color/white"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="20dp"
+    android:paddingTop="10dp"
+    android:paddingEnd="20dp">
+
+    <RadioGroup
+        android:id="@+id/themeSelectorGroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <RadioButton
+            android:id="@+id/themeSelectorLight"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:padding="10dp"
+            android:paddingStart="10dp"
+            android:paddingEnd="10dp"
+            android:text="@string/settingsLightTheme" />
+
+        <RadioButton
+            android:id="@+id/themeSelectorDark"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:padding="10dp"
+            android:paddingStart="10dp"
+            android:paddingEnd="10dp"
+            android:text="@string/settingsDarkTheme"/>
+
+        <RadioButton
+            android:id="@+id/themeSelectorSystemDefault"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:padding="10dp"
+            android:visibility="gone"
+            android:paddingStart="10dp"
+            android:paddingEnd="10dp"
+            android:text="@string/settingsSystemTheme" />
+
+    </RadioGroup>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -151,10 +151,6 @@
     <string name="settingsHeadingGeneral">Обща информация</string>
     <string name="settingsHeadingOther">Други</string>
     <string name="settingsHeadingPrivacy">Поверителност</string>
-    <string name="settingsTheme">Тема</string>
-    <string name="settingsLightTheme">Светла тема</string>
-    <string name="settingsDarkTheme">Тъмна тема</string>
-    <string name="settingsSystemTheme">Система по подразбиране</string>
     <string name="settingsAboutDuckduckgo">За DuckDuckGo</string>
     <string name="settingsVersion">Версия</string>
     <string name="leaveFeedback">Споделяне на отзив</string>
@@ -494,9 +490,6 @@
     <string name="disableLoginDetectionDialogPositive">ЗАБРАНИ</string>
     <string name="disableLoginDetectionDialogNegative">ОТМЕНИ</string>
     <string name="fireproofWebsiteRemovalConfirmation">Премахната огнеустойчивост за &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Задаване на тема</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Анимация на огнения бутон</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -151,7 +151,10 @@
     <string name="settingsHeadingGeneral">Обща информация</string>
     <string name="settingsHeadingOther">Други</string>
     <string name="settingsHeadingPrivacy">Поверителност</string>
+    <string name="settingsTheme">Тема</string>
     <string name="settingsLightTheme">Светла тема</string>
+    <string name="settingsDarkTheme">Тъмна тема</string>
+    <string name="settingsSystemTheme">Система по подразбиране</string>
     <string name="settingsAboutDuckduckgo">За DuckDuckGo</string>
     <string name="settingsVersion">Версия</string>
     <string name="leaveFeedback">Споделяне на отзив</string>
@@ -491,6 +494,9 @@
     <string name="disableLoginDetectionDialogPositive">ЗАБРАНИ</string>
     <string name="disableLoginDetectionDialogNegative">ОТМЕНИ</string>
     <string name="fireproofWebsiteRemovalConfirmation">Премахната огнеустойчивост за &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Задаване на тема</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Анимация на огнения бутон</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -160,6 +160,9 @@
     <string name="settingsHeadingOther">Jiné</string>
     <string name="settingsHeadingPrivacy">Soukromí</string>
     <string name="settingsLightTheme">Světlý motiv</string>
+    <string name="settingsTheme">Téma</string>
+    <string name="settingsDarkTheme">Tmavé téma</string>
+    <string name="settingsSystemTheme">Výchozí nastavení systému</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGo</string>
     <string name="settingsVersion">Verze</string>
     <string name="leaveFeedback">Podělte se o zpětnou vazbu</string>
@@ -503,6 +506,9 @@
     <string name="disableLoginDetectionDialogPositive">VYPNOUT</string>
     <string name="disableLoginDetectionDialogNegative">ZRUŠIT</string>
     <string name="fireproofWebsiteRemovalConfirmation">Ochrana odstraněna pro &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Nastavit téma</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animace tlačítka pro mazání</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -159,10 +159,6 @@
     <string name="settingsHeadingGeneral">Obecné</string>
     <string name="settingsHeadingOther">Jiné</string>
     <string name="settingsHeadingPrivacy">Soukromí</string>
-    <string name="settingsLightTheme">Světlý motiv</string>
-    <string name="settingsTheme">Téma</string>
-    <string name="settingsDarkTheme">Tmavé téma</string>
-    <string name="settingsSystemTheme">Výchozí nastavení systému</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGo</string>
     <string name="settingsVersion">Verze</string>
     <string name="leaveFeedback">Podělte se o zpětnou vazbu</string>
@@ -506,9 +502,6 @@
     <string name="disableLoginDetectionDialogPositive">VYPNOUT</string>
     <string name="disableLoginDetectionDialogNegative">ZRUŠIT</string>
     <string name="fireproofWebsiteRemovalConfirmation">Ochrana odstraněna pro &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Nastavit téma</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animace tlačítka pro mazání</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Generelt</string>
     <string name="settingsHeadingOther">Andet</string>
     <string name="settingsHeadingPrivacy">Privatliv</string>
-    <string name="settingsLightTheme">Lystema</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Mørkt tema</string>
-    <string name="settingsSystemTheme">System Standard</string>
     <string name="settingsAboutDuckduckgo">Om DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Del feedback</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">Deaktiver</string>
     <string name="disableLoginDetectionDialogNegative">Afbestil</string>
     <string name="fireproofWebsiteRemovalConfirmation">Brandsikring fjernet for &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Indstil tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Ildknap-animation</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Andet</string>
     <string name="settingsHeadingPrivacy">Privatliv</string>
     <string name="settingsLightTheme">Lystema</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Mørkt tema</string>
+    <string name="settingsSystemTheme">System Standard</string>
     <string name="settingsAboutDuckduckgo">Om DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Del feedback</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">Deaktiver</string>
     <string name="disableLoginDetectionDialogNegative">Afbestil</string>
     <string name="fireproofWebsiteRemovalConfirmation">Brandsikring fjernet for &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Indstil tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Ildknap-animation</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Allgemeines</string>
     <string name="settingsHeadingOther">Sonstiges</string>
     <string name="settingsHeadingPrivacy">Privatsphäre</string>
-    <string name="settingsLightTheme">Helles Design</string>
-    <string name="settingsTheme">Thema</string>
-    <string name="settingsDarkTheme">Dunkles Thema</string>
-    <string name="settingsSystemTheme">Systemfehler</string>
     <string name="settingsAboutDuckduckgo">Über DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Feedback teilen</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">DEAKTIVIEREN</string>
     <string name="disableLoginDetectionDialogNegative">ABBRECHEN</string>
     <string name="fireproofWebsiteRemovalConfirmation">Feuerfest-Einstellung für &lt;b&gt;%1$s&lt;/b&gt; deaktiviert</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Ορισμός θέματος</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animation der Schaltfläche „Feuer“</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Sonstiges</string>
     <string name="settingsHeadingPrivacy">Privatsphäre</string>
     <string name="settingsLightTheme">Helles Design</string>
+    <string name="settingsTheme">Thema</string>
+    <string name="settingsDarkTheme">Dunkles Thema</string>
+    <string name="settingsSystemTheme">Systemfehler</string>
     <string name="settingsAboutDuckduckgo">Über DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Feedback teilen</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">DEAKTIVIEREN</string>
     <string name="disableLoginDetectionDialogNegative">ABBRECHEN</string>
     <string name="fireproofWebsiteRemovalConfirmation">Feuerfest-Einstellung für &lt;b&gt;%1$s&lt;/b&gt; deaktiviert</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Ορισμός θέματος</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animation der Schaltfläche „Feuer“</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Άλλα</string>
     <string name="settingsHeadingPrivacy">Ιδιωτικότητα</string>
     <string name="settingsLightTheme">Ανοιχτόχρωμο θέμα</string>
+    <string name="settingsTheme">Θέμα</string>
+    <string name="settingsDarkTheme">Σκούρο Θέμα</string>
+    <string name="settingsSystemTheme">Προεπιλογή συστήματος</string>
     <string name="settingsAboutDuckduckgo">Πληροφορίες για το DuckDuckGo</string>
     <string name="settingsVersion">Έκδοση</string>
     <string name="leaveFeedback">Κοινοποίηση σχολίου</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">ΑΠΕΝΕΡΓΟΠΟΙΗΣΗ</string>
     <string name="disableLoginDetectionDialogNegative">ΑΚΥΡΩΣΗ</string>
     <string name="fireproofWebsiteRemovalConfirmation">Η διαγραφή δραστηριότητας αφαιρέθηκε για το &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Ορισμός θέματος</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Κινούμενο κουμπί φωτιάς</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Γενικά</string>
     <string name="settingsHeadingOther">Άλλα</string>
     <string name="settingsHeadingPrivacy">Ιδιωτικότητα</string>
-    <string name="settingsLightTheme">Ανοιχτόχρωμο θέμα</string>
-    <string name="settingsTheme">Θέμα</string>
-    <string name="settingsDarkTheme">Σκούρο Θέμα</string>
-    <string name="settingsSystemTheme">Προεπιλογή συστήματος</string>
     <string name="settingsAboutDuckduckgo">Πληροφορίες για το DuckDuckGo</string>
     <string name="settingsVersion">Έκδοση</string>
     <string name="leaveFeedback">Κοινοποίηση σχολίου</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">ΑΠΕΝΕΡΓΟΠΟΙΗΣΗ</string>
     <string name="disableLoginDetectionDialogNegative">ΑΚΥΡΩΣΗ</string>
     <string name="fireproofWebsiteRemovalConfirmation">Η διαγραφή δραστηριότητας αφαιρέθηκε για το &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Ορισμός θέματος</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Κινούμενο κουμπί φωτιάς</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ~ Copyright (c) 2021 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,6 +167,9 @@
     <string name="settingsHeadingOther">Otros</string>
     <string name="settingsHeadingPrivacy">Privacidad</string>
     <string name="settingsLightTheme">Tema claro</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Tema oscuro</string>
+    <string name="settingsSystemTheme">Sistema por defecto</string>
     <string name="settingsAboutDuckduckgo">Acerca de DuckDuckGo</string>
     <string name="settingsVersion">Versión</string>
     <string name="leaveFeedback">Compartir opiniones</string>
@@ -507,6 +509,9 @@
     <string name="disableLoginDetectionDialogPositive">DESHABILITAR</string>
     <string name="disableLoginDetectionDialogNegative">CANCELAR</string>
     <string name="fireproofWebsiteRemovalConfirmation">A prueba de fuego desactivado para &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Establecer tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animación del botón Fuego</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2021 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -166,10 +167,6 @@
     <string name="settingsHeadingGeneral">General</string>
     <string name="settingsHeadingOther">Otros</string>
     <string name="settingsHeadingPrivacy">Privacidad</string>
-    <string name="settingsLightTheme">Tema claro</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Tema oscuro</string>
-    <string name="settingsSystemTheme">Sistema por defecto</string>
     <string name="settingsAboutDuckduckgo">Acerca de DuckDuckGo</string>
     <string name="settingsVersion">Versión</string>
     <string name="leaveFeedback">Compartir opiniones</string>
@@ -509,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">DESHABILITAR</string>
     <string name="disableLoginDetectionDialogNegative">CANCELAR</string>
     <string name="fireproofWebsiteRemovalConfirmation">A prueba de fuego desactivado para &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Establecer tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animación del botón Fuego</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Üldine</string>
     <string name="settingsHeadingOther">Muu</string>
     <string name="settingsHeadingPrivacy">Privaatsus</string>
-    <string name="settingsLightTheme">Kerge teema</string>
-    <string name="settingsTheme">Teema</string>
-    <string name="settingsDarkTheme">Tume teema</string>
-    <string name="settingsSystemTheme">Süsteemi vaikeseade</string>
     <string name="settingsAboutDuckduckgo">DuckDuckGo teave</string>
     <string name="settingsVersion">Versioon</string>
     <string name="leaveFeedback">Jaga tagasisidet</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">KEELA</string>
     <string name="disableLoginDetectionDialogNegative">TÜHISTA</string>
     <string name="fireproofWebsiteRemovalConfirmation">&lt;b&gt;%1$s&lt;/b&gt; tulekindlus on eemaldatud</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Määra teema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Tulenupu animatsioon</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Muu</string>
     <string name="settingsHeadingPrivacy">Privaatsus</string>
     <string name="settingsLightTheme">Kerge teema</string>
+    <string name="settingsTheme">Teema</string>
+    <string name="settingsDarkTheme">Tume teema</string>
+    <string name="settingsSystemTheme">Süsteemi vaikeseade</string>
     <string name="settingsAboutDuckduckgo">DuckDuckGo teave</string>
     <string name="settingsVersion">Versioon</string>
     <string name="leaveFeedback">Jaga tagasisidet</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">KEELA</string>
     <string name="disableLoginDetectionDialogNegative">TÜHISTA</string>
     <string name="fireproofWebsiteRemovalConfirmation">&lt;b&gt;%1$s&lt;/b&gt; tulekindlus on eemaldatud</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Määra teema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Tulenupu animatsioon</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Muu</string>
     <string name="settingsHeadingPrivacy">Tietosuoja</string>
     <string name="settingsLightTheme">Vaalea teema</string>
+    <string name="settingsTheme">Teema</string>
+    <string name="settingsDarkTheme">Tumma teema</string>
+    <string name="settingsSystemTheme">Järjestelmän oletusarvo</string>
     <string name="settingsAboutDuckduckgo">Tietoa DuckDuckGosta</string>
     <string name="settingsVersion">Versio</string>
     <string name="leaveFeedback">Jaa palaute</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">POISTA KÄYTÖSTÄ</string>
     <string name="disableLoginDetectionDialogNegative">PERUUTA</string>
     <string name="fireproofWebsiteRemovalConfirmation">Palonkestävyys poistettu sivustolta &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Aseta teema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Liekki-painikkeen animaatio</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Yleistä</string>
     <string name="settingsHeadingOther">Muu</string>
     <string name="settingsHeadingPrivacy">Tietosuoja</string>
-    <string name="settingsLightTheme">Vaalea teema</string>
-    <string name="settingsTheme">Teema</string>
-    <string name="settingsDarkTheme">Tumma teema</string>
-    <string name="settingsSystemTheme">Järjestelmän oletusarvo</string>
     <string name="settingsAboutDuckduckgo">Tietoa DuckDuckGosta</string>
     <string name="settingsVersion">Versio</string>
     <string name="leaveFeedback">Jaa palaute</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">POISTA KÄYTÖSTÄ</string>
     <string name="disableLoginDetectionDialogNegative">PERUUTA</string>
     <string name="fireproofWebsiteRemovalConfirmation">Palonkestävyys poistettu sivustolta &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Aseta teema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Liekki-painikkeen animaatio</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Autre</string>
     <string name="settingsHeadingPrivacy">Confidentialité</string>
     <string name="settingsLightTheme">Thème clair</string>
+    <string name="settingsTheme">Thème</string>
+    <string name="settingsDarkTheme">Thème sombre</string>
+    <string name="settingsSystemTheme">Défaillance du système</string>
     <string name="settingsAboutDuckduckgo">À propos de DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Partagez vos commentaires</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">DÉSACTIVER</string>
     <string name="disableLoginDetectionDialogNegative">ANNULER</string>
     <string name="fireproofWebsiteRemovalConfirmation">Mode coupe-feu désactivé pour &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Définir le thème</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animation du bouton en forme de flamme</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Général</string>
     <string name="settingsHeadingOther">Autre</string>
     <string name="settingsHeadingPrivacy">Confidentialité</string>
-    <string name="settingsLightTheme">Thème clair</string>
-    <string name="settingsTheme">Thème</string>
-    <string name="settingsDarkTheme">Thème sombre</string>
-    <string name="settingsSystemTheme">Défaillance du système</string>
     <string name="settingsAboutDuckduckgo">À propos de DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Partagez vos commentaires</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">DÉSACTIVER</string>
     <string name="disableLoginDetectionDialogNegative">ANNULER</string>
     <string name="fireproofWebsiteRemovalConfirmation">Mode coupe-feu désactivé pour &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Définir le thème</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animation du bouton en forme de flamme</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -175,10 +175,6 @@
     <string name="settingsHeadingGeneral">Općenito</string>
     <string name="settingsHeadingOther">Ostalo</string>
     <string name="settingsHeadingPrivacy">Zaštita privatnosti</string>
-    <string name="settingsLightTheme">Svijetla tema</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Tamna tema</string>
-    <string name="settingsSystemTheme">Zadani sistem</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGou</string>
     <string name="settingsVersion">Verzija</string>
     <string name="leaveFeedback">Podijeli povratne informacije</string>
@@ -522,9 +518,6 @@
     <string name="disableLoginDetectionDialogPositive">ONEMOGUĆI</string>
     <string name="disableLoginDetectionDialogNegative">ODUSTANI</string>
     <string name="fireproofWebsiteRemovalConfirmation">Oznaka sigurnog web-mjesta uklonjena je za &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Postavi temu</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animacija gumba Vatre</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -176,6 +176,9 @@
     <string name="settingsHeadingOther">Ostalo</string>
     <string name="settingsHeadingPrivacy">Zaštita privatnosti</string>
     <string name="settingsLightTheme">Svijetla tema</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Tamna tema</string>
+    <string name="settingsSystemTheme">Zadani sistem</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGou</string>
     <string name="settingsVersion">Verzija</string>
     <string name="leaveFeedback">Podijeli povratne informacije</string>
@@ -519,6 +522,9 @@
     <string name="disableLoginDetectionDialogPositive">ONEMOGUĆI</string>
     <string name="disableLoginDetectionDialogNegative">ODUSTANI</string>
     <string name="fireproofWebsiteRemovalConfirmation">Oznaka sigurnog web-mjesta uklonjena je za &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Postavi temu</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animacija gumba Vatre</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ~ Copyright (c) 2021 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,6 +167,9 @@
     <string name="settingsHeadingOther">Egyéb</string>
     <string name="settingsHeadingPrivacy">Adatvédelem</string>
     <string name="settingsLightTheme">Világos felület</string>
+    <string name="settingsTheme">Téma</string>
+    <string name="settingsDarkTheme">Sötét téma</string>
+    <string name="settingsSystemTheme">Rendszer alapértelmezett</string>
     <string name="settingsAboutDuckduckgo">A DuckDuckGo névjegye</string>
     <string name="settingsVersion">Változat</string>
     <string name="leaveFeedback">Visszajelzés megosztása</string>
@@ -507,6 +509,9 @@
     <string name="disableLoginDetectionDialogPositive">LETILT</string>
     <string name="disableLoginDetectionDialogNegative">MÉGSEM</string>
     <string name="fireproofWebsiteRemovalConfirmation">Tűzállóvá tétel törölve a következőhöz: &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Állítsa be a témát</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Tűz gomb animáció</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2021 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -166,10 +167,6 @@
     <string name="settingsHeadingGeneral">Általános</string>
     <string name="settingsHeadingOther">Egyéb</string>
     <string name="settingsHeadingPrivacy">Adatvédelem</string>
-    <string name="settingsLightTheme">Világos felület</string>
-    <string name="settingsTheme">Téma</string>
-    <string name="settingsDarkTheme">Sötét téma</string>
-    <string name="settingsSystemTheme">Rendszer alapértelmezett</string>
     <string name="settingsAboutDuckduckgo">A DuckDuckGo névjegye</string>
     <string name="settingsVersion">Változat</string>
     <string name="leaveFeedback">Visszajelzés megosztása</string>
@@ -509,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">LETILT</string>
     <string name="disableLoginDetectionDialogNegative">MÉGSEM</string>
     <string name="fireproofWebsiteRemovalConfirmation">Tűzállóvá tétel törölve a következőhöz: &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Állítsa be a témát</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Tűz gomb animáció</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Generale</string>
     <string name="settingsHeadingOther">Altro</string>
     <string name="settingsHeadingPrivacy">Privacy</string>
-    <string name="settingsLightTheme">Tema chiaro</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Tema scuro</string>
-    <string name="settingsSystemTheme">Default del sistema</string>
     <string name="settingsAboutDuckduckgo">Informazioni su DuckDuckGo</string>
     <string name="settingsVersion">Versione</string>
     <string name="leaveFeedback">Condividi feedback</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">DISABILITA</string>
     <string name="disableLoginDetectionDialogNegative">ANNULLA</string>
     <string name="fireproofWebsiteRemovalConfirmation">Protezione rimossa per &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Imposta tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animazione pulsante fuoco</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Altro</string>
     <string name="settingsHeadingPrivacy">Privacy</string>
     <string name="settingsLightTheme">Tema chiaro</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Tema scuro</string>
+    <string name="settingsSystemTheme">Default del sistema</string>
     <string name="settingsAboutDuckduckgo">Informazioni su DuckDuckGo</string>
     <string name="settingsVersion">Versione</string>
     <string name="leaveFeedback">Condividi feedback</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">DISABILITA</string>
     <string name="disableLoginDetectionDialogNegative">ANNULLA</string>
     <string name="fireproofWebsiteRemovalConfirmation">Protezione rimossa per &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Imposta tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animazione pulsante fuoco</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -176,6 +176,9 @@
     <string name="settingsHeadingOther">Kiti</string>
     <string name="settingsHeadingPrivacy">Privatumas</string>
     <string name="settingsLightTheme">Šviesus apipavidalinimas</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Tamsi tema</string>
+    <string name="settingsSystemTheme">Sistemos numatytasis</string>
     <string name="settingsAboutDuckduckgo">Apie „DuckDuckGo“</string>
     <string name="settingsVersion">Versija</string>
     <string name="leaveFeedback">Bendrinti atsiliepimą</string>
@@ -519,6 +522,9 @@
     <string name="disableLoginDetectionDialogPositive">IŠJUNGTI</string>
     <string name="disableLoginDetectionDialogNegative">ATŠAUKTI</string>
     <string name="fireproofWebsiteRemovalConfirmation">&lt;b&gt;%1$s&lt;/b&gt; apsauga pašalinta</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Nustatykite temą</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Mygtuko „Fire“ animacija</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -175,10 +175,6 @@
     <string name="settingsHeadingGeneral">Bendrieji</string>
     <string name="settingsHeadingOther">Kiti</string>
     <string name="settingsHeadingPrivacy">Privatumas</string>
-    <string name="settingsLightTheme">Šviesus apipavidalinimas</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Tamsi tema</string>
-    <string name="settingsSystemTheme">Sistemos numatytasis</string>
     <string name="settingsAboutDuckduckgo">Apie „DuckDuckGo“</string>
     <string name="settingsVersion">Versija</string>
     <string name="leaveFeedback">Bendrinti atsiliepimą</string>
@@ -522,9 +518,6 @@
     <string name="disableLoginDetectionDialogPositive">IŠJUNGTI</string>
     <string name="disableLoginDetectionDialogNegative">ATŠAUKTI</string>
     <string name="fireproofWebsiteRemovalConfirmation">&lt;b&gt;%1$s&lt;/b&gt; apsauga pašalinta</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Nustatykite temą</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Mygtuko „Fire“ animacija</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -171,10 +171,6 @@
     <string name="settingsHeadingGeneral">Vispārīgi</string>
     <string name="settingsHeadingOther">Cits</string>
     <string name="settingsHeadingPrivacy">Privātums</string>
-    <string name="settingsLightTheme">Gaišs motīvs</string>
-    <string name="settingsTheme">Tēma</string>
-    <string name="settingsDarkTheme">Tumša tēma</string>
-    <string name="settingsSystemTheme">Sistēmas noklusējums</string>
     <string name="settingsAboutDuckduckgo">Par DuckDuckGo</string>
     <string name="settingsVersion">Versija</string>
     <string name="leaveFeedback">Kopīgot atsauksmi</string>
@@ -516,9 +512,6 @@
     <string name="disableLoginDetectionDialogPositive">ATSPĒJOT</string>
     <string name="disableLoginDetectionDialogNegative">ATCELT</string>
     <string name="fireproofWebsiteRemovalConfirmation">&lt;b&gt;%1$s&lt;/b&gt; ir noņemta ugunsdrošība</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Iestatiet motīvu</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Uguns pogas animācija</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -172,6 +172,9 @@
     <string name="settingsHeadingOther">Cits</string>
     <string name="settingsHeadingPrivacy">Privātums</string>
     <string name="settingsLightTheme">Gaišs motīvs</string>
+    <string name="settingsTheme">Tēma</string>
+    <string name="settingsDarkTheme">Tumša tēma</string>
+    <string name="settingsSystemTheme">Sistēmas noklusējums</string>
     <string name="settingsAboutDuckduckgo">Par DuckDuckGo</string>
     <string name="settingsVersion">Versija</string>
     <string name="leaveFeedback">Kopīgot atsauksmi</string>
@@ -513,6 +516,9 @@
     <string name="disableLoginDetectionDialogPositive">ATSPĒJOT</string>
     <string name="disableLoginDetectionDialogNegative">ATCELT</string>
     <string name="fireproofWebsiteRemovalConfirmation">&lt;b&gt;%1$s&lt;/b&gt; ir noņemta ugunsdrošība</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Iestatiet motīvu</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Uguns pogas animācija</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Annet</string>
     <string name="settingsHeadingPrivacy">Personvern</string>
     <string name="settingsLightTheme">Lyst utseende</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Mørkt tema</string>
+    <string name="settingsSystemTheme">System standard</string>
     <string name="settingsAboutDuckduckgo">Om DuckDuckGo</string>
     <string name="settingsVersion">Versjon</string>
     <string name="leaveFeedback">Del tilbakemelding</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">DEAKTIVER</string>
     <string name="disableLoginDetectionDialogNegative">AVBRYT</string>
     <string name="fireproofWebsiteRemovalConfirmation">Brannsikring fjernet for &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Angi tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animasjon for brannknappen</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Generelt</string>
     <string name="settingsHeadingOther">Annet</string>
     <string name="settingsHeadingPrivacy">Personvern</string>
-    <string name="settingsLightTheme">Lyst utseende</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Mørkt tema</string>
-    <string name="settingsSystemTheme">System standard</string>
     <string name="settingsAboutDuckduckgo">Om DuckDuckGo</string>
     <string name="settingsVersion">Versjon</string>
     <string name="leaveFeedback">Del tilbakemelding</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">DEAKTIVER</string>
     <string name="disableLoginDetectionDialogNegative">AVBRYT</string>
     <string name="fireproofWebsiteRemovalConfirmation">Brannsikring fjernet for &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Angi tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animasjon for brannknappen</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Algemeen</string>
     <string name="settingsHeadingOther">Anders</string>
     <string name="settingsHeadingPrivacy">Privacy</string>
-    <string name="settingsLightTheme">Licht thema</string>
-    <string name="settingsTheme">Thema</string>
-    <string name="settingsDarkTheme">Donker thema</string>
-    <string name="settingsSystemTheme">Systeemfout</string>
     <string name="settingsAboutDuckduckgo">Over DuckDuckGo</string>
     <string name="settingsVersion">Versie</string>
     <string name="leaveFeedback">Feedback delen</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">UITSCHAKELEN</string>
     <string name="disableLoginDetectionDialogNegative">ANNULEREN</string>
     <string name="fireproofWebsiteRemovalConfirmation">Brandveiligheid verwijderd voor &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Thema instellen</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animatie vuurknop</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Anders</string>
     <string name="settingsHeadingPrivacy">Privacy</string>
     <string name="settingsLightTheme">Licht thema</string>
+    <string name="settingsTheme">Thema</string>
+    <string name="settingsDarkTheme">Donker thema</string>
+    <string name="settingsSystemTheme">Systeemfout</string>
     <string name="settingsAboutDuckduckgo">Over DuckDuckGo</string>
     <string name="settingsVersion">Versie</string>
     <string name="leaveFeedback">Feedback delen</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">UITSCHAKELEN</string>
     <string name="disableLoginDetectionDialogNegative">ANNULEREN</string>
     <string name="fireproofWebsiteRemovalConfirmation">Brandveiligheid verwijderd voor &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Thema instellen</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animatie vuurknop</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -176,6 +176,9 @@
     <string name="settingsHeadingOther">Inne</string>
     <string name="settingsHeadingPrivacy">Prywatność</string>
     <string name="settingsLightTheme">Jasny motyw</string>
+    <string name="settingsTheme">Temat</string>
+    <string name="settingsDarkTheme">Ciemny schemat</string>
+    <string name="settingsSystemTheme">Domyślne ustawienie systemowe</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGo</string>
     <string name="settingsVersion">Wersja</string>
     <string name="leaveFeedback">Podziel się opinią</string>
@@ -519,6 +522,9 @@
     <string name="disableLoginDetectionDialogPositive">WYŁĄCZ</string>
     <string name="disableLoginDetectionDialogNegative">ANULUJ</string>
     <string name="fireproofWebsiteRemovalConfirmation">Usunięto zabezpieczenie dla &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Ustaw motyw</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animacja przycisku ognia</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -175,10 +175,6 @@
     <string name="settingsHeadingGeneral">Ogólne</string>
     <string name="settingsHeadingOther">Inne</string>
     <string name="settingsHeadingPrivacy">Prywatność</string>
-    <string name="settingsLightTheme">Jasny motyw</string>
-    <string name="settingsTheme">Temat</string>
-    <string name="settingsDarkTheme">Ciemny schemat</string>
-    <string name="settingsSystemTheme">Domyślne ustawienie systemowe</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGo</string>
     <string name="settingsVersion">Wersja</string>
     <string name="leaveFeedback">Podziel się opinią</string>
@@ -522,9 +518,6 @@
     <string name="disableLoginDetectionDialogPositive">WYŁĄCZ</string>
     <string name="disableLoginDetectionDialogNegative">ANULUJ</string>
     <string name="fireproofWebsiteRemovalConfirmation">Usunięto zabezpieczenie dla &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Ustaw motyw</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animacja przycisku ognia</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Outros</string>
     <string name="settingsHeadingPrivacy">Privacidade</string>
     <string name="settingsLightTheme">Tema claro</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Tema escuro</string>
+    <string name="settingsSystemTheme">Sistema padrão</string>
     <string name="settingsAboutDuckduckgo">Sobre o DuckDuckGo</string>
     <string name="settingsVersion">Versão</string>
     <string name="leaveFeedback">Partilhar comentários</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">DESATIVAR</string>
     <string name="disableLoginDetectionDialogNegative">CANCELAR</string>
     <string name="fireproofWebsiteRemovalConfirmation">Barreira de segurança removida para &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Definir tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animação do Botão de Fogo</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Gerais</string>
     <string name="settingsHeadingOther">Outros</string>
     <string name="settingsHeadingPrivacy">Privacidade</string>
-    <string name="settingsLightTheme">Tema claro</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Tema escuro</string>
-    <string name="settingsSystemTheme">Sistema padrão</string>
     <string name="settingsAboutDuckduckgo">Sobre o DuckDuckGo</string>
     <string name="settingsVersion">Versão</string>
     <string name="leaveFeedback">Partilhar comentários</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">DESATIVAR</string>
     <string name="disableLoginDetectionDialogNegative">CANCELAR</string>
     <string name="fireproofWebsiteRemovalConfirmation">Barreira de segurança removida para &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Definir tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animação do Botão de Fogo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -172,6 +172,9 @@
     <string name="settingsHeadingOther">Altele</string>
     <string name="settingsHeadingPrivacy">Confidențialitate</string>
     <string name="settingsLightTheme">Temă luminoasă</string>
+    <string name="settingsTheme">Temă</string>
+    <string name="settingsDarkTheme">Tema întunecată</string>
+    <string name="settingsSystemTheme">Defectiune de sistem</string>
     <string name="settingsAboutDuckduckgo">Despre DuckDuckGo</string>
     <string name="settingsVersion">Versiune</string>
     <string name="leaveFeedback">Partajează feedback</string>
@@ -513,6 +516,9 @@
     <string name="disableLoginDetectionDialogPositive">DEZACTIVARE</string>
     <string name="disableLoginDetectionDialogNegative">ANULARE</string>
     <string name="fireproofWebsiteRemovalConfirmation">Ștergerea activității și istoricului a fost eliminată pentru &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Setează Tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animație buton Foc</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -171,10 +171,6 @@
     <string name="settingsHeadingGeneral">Generalități</string>
     <string name="settingsHeadingOther">Altele</string>
     <string name="settingsHeadingPrivacy">Confidențialitate</string>
-    <string name="settingsLightTheme">Temă luminoasă</string>
-    <string name="settingsTheme">Temă</string>
-    <string name="settingsDarkTheme">Tema întunecată</string>
-    <string name="settingsSystemTheme">Defectiune de sistem</string>
     <string name="settingsAboutDuckduckgo">Despre DuckDuckGo</string>
     <string name="settingsVersion">Versiune</string>
     <string name="leaveFeedback">Partajează feedback</string>
@@ -516,9 +512,6 @@
     <string name="disableLoginDetectionDialogPositive">DEZACTIVARE</string>
     <string name="disableLoginDetectionDialogNegative">ANULARE</string>
     <string name="fireproofWebsiteRemovalConfirmation">Ștergerea activității și istoricului a fost eliminată pentru &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Setează Tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animație buton Foc</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -175,10 +175,6 @@
     <string name="settingsHeadingGeneral">Общие настройки</string>
     <string name="settingsHeadingOther">Дополнительные настройки</string>
     <string name="settingsHeadingPrivacy">Конфиденциальность</string>
-    <string name="settingsLightTheme">Светлая тема</string>
-    <string name="settingsTheme">Тема</string>
-    <string name="settingsDarkTheme">Темная тема</string>
-    <string name="settingsSystemTheme">Системные установки по умолчанию</string>
     <string name="settingsAboutDuckduckgo">Несколько слов о DuckDuckGo</string>
     <string name="settingsVersion">Версия</string>
     <string name="leaveFeedback">Оставьте нам отзыв</string>
@@ -522,9 +518,6 @@
     <string name="disableLoginDetectionDialogPositive">Выключить</string>
     <string name="disableLoginDetectionDialogNegative">Отменить</string>
     <string name="fireproofWebsiteRemovalConfirmation">С сайта &lt;b&gt;%1$s&lt;/b&gt; снята огнеупорность</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Установить тему</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Анимация кнопки «Пожар»</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -176,6 +176,9 @@
     <string name="settingsHeadingOther">Дополнительные настройки</string>
     <string name="settingsHeadingPrivacy">Конфиденциальность</string>
     <string name="settingsLightTheme">Светлая тема</string>
+    <string name="settingsTheme">Тема</string>
+    <string name="settingsDarkTheme">Темная тема</string>
+    <string name="settingsSystemTheme">Системные установки по умолчанию</string>
     <string name="settingsAboutDuckduckgo">Несколько слов о DuckDuckGo</string>
     <string name="settingsVersion">Версия</string>
     <string name="leaveFeedback">Оставьте нам отзыв</string>
@@ -519,6 +522,9 @@
     <string name="disableLoginDetectionDialogPositive">Выключить</string>
     <string name="disableLoginDetectionDialogNegative">Отменить</string>
     <string name="fireproofWebsiteRemovalConfirmation">С сайта &lt;b&gt;%1$s&lt;/b&gt; снята огнеупорность</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Установить тему</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Анимация кнопки «Пожар»</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -176,6 +176,9 @@
     <string name="settingsHeadingOther">Iné</string>
     <string name="settingsHeadingPrivacy">Súkromie</string>
     <string name="settingsLightTheme">Svetlý motív</string>
+    <string name="settingsTheme">Téma</string>
+    <string name="settingsDarkTheme">Temná téma</string>
+    <string name="settingsSystemTheme">Predvolený systém</string>
     <string name="settingsAboutDuckduckgo">Informácie o DuckDuckGo</string>
     <string name="settingsVersion">Verzia</string>
     <string name="leaveFeedback">Zdieľať spätnú väzbu</string>
@@ -519,6 +522,9 @@
     <string name="disableLoginDetectionDialogPositive">VYPNÚŤ</string>
     <string name="disableLoginDetectionDialogNegative">ZRUŠIŤ</string>
     <string name="fireproofWebsiteRemovalConfirmation">Odstránilo sa zabezpečenie pre &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Nastaviť tému</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animácia tlačidla ohňa</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -175,10 +175,6 @@
     <string name="settingsHeadingGeneral">Všeobecné</string>
     <string name="settingsHeadingOther">Iné</string>
     <string name="settingsHeadingPrivacy">Súkromie</string>
-    <string name="settingsLightTheme">Svetlý motív</string>
-    <string name="settingsTheme">Téma</string>
-    <string name="settingsDarkTheme">Temná téma</string>
-    <string name="settingsSystemTheme">Predvolený systém</string>
     <string name="settingsAboutDuckduckgo">Informácie o DuckDuckGo</string>
     <string name="settingsVersion">Verzia</string>
     <string name="leaveFeedback">Zdieľať spätnú väzbu</string>
@@ -522,9 +518,6 @@
     <string name="disableLoginDetectionDialogPositive">VYPNÚŤ</string>
     <string name="disableLoginDetectionDialogNegative">ZRUŠIŤ</string>
     <string name="fireproofWebsiteRemovalConfirmation">Odstránilo sa zabezpečenie pre &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Nastaviť tému</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animácia tlačidla ohňa</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -176,6 +176,9 @@
     <string name="settingsHeadingOther">Drugo</string>
     <string name="settingsHeadingPrivacy">Zasebnost</string>
     <string name="settingsLightTheme">Svetli način</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Temna tema</string>
+    <string name="settingsSystemTheme">Sistemska privzeta vrednost</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGo</string>
     <string name="settingsVersion">Različica</string>
     <string name="leaveFeedback">Delite povratne informacije</string>
@@ -519,6 +522,9 @@
     <string name="disableLoginDetectionDialogPositive">ONEMOGOČI</string>
     <string name="disableLoginDetectionDialogNegative">PREKLIČI</string>
     <string name="fireproofWebsiteRemovalConfirmation">Požarna zaščita odstranjena za &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Nastavi temo</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animacija za gumb ogenj</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -175,10 +175,6 @@
     <string name="settingsHeadingGeneral">Splošno</string>
     <string name="settingsHeadingOther">Drugo</string>
     <string name="settingsHeadingPrivacy">Zasebnost</string>
-    <string name="settingsLightTheme">Svetli način</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Temna tema</string>
-    <string name="settingsSystemTheme">Sistemska privzeta vrednost</string>
     <string name="settingsAboutDuckduckgo">O DuckDuckGo</string>
     <string name="settingsVersion">Različica</string>
     <string name="leaveFeedback">Delite povratne informacije</string>
@@ -522,9 +518,6 @@
     <string name="disableLoginDetectionDialogPositive">ONEMOGOČI</string>
     <string name="disableLoginDetectionDialogNegative">PREKLIČI</string>
     <string name="fireproofWebsiteRemovalConfirmation">Požarna zaščita odstranjena za &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Nastavi temo</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animacija za gumb ogenj</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -167,10 +167,6 @@
     <string name="settingsHeadingGeneral">Allmänt</string>
     <string name="settingsHeadingOther">Annat</string>
     <string name="settingsHeadingPrivacy">Sekretess</string>
-    <string name="settingsLightTheme">Ljust</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Mörkt tema</string>
-    <string name="settingsSystemTheme">Systemfel</string>
     <string name="settingsAboutDuckduckgo">Om DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Berätta vad du tycker</string>
@@ -510,9 +506,6 @@
     <string name="disableLoginDetectionDialogPositive">INAKTIVERA</string>
     <string name="disableLoginDetectionDialogNegative">AVBRYT</string>
     <string name="fireproofWebsiteRemovalConfirmation">Brandsäkring har tagits bort för &lt;b&gt;%1$s&lt;/b&gt;</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Ange tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animation för brännarknapp</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -168,6 +168,9 @@
     <string name="settingsHeadingOther">Annat</string>
     <string name="settingsHeadingPrivacy">Sekretess</string>
     <string name="settingsLightTheme">Ljust</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Mörkt tema</string>
+    <string name="settingsSystemTheme">Systemfel</string>
     <string name="settingsAboutDuckduckgo">Om DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Berätta vad du tycker</string>
@@ -507,6 +510,9 @@
     <string name="disableLoginDetectionDialogPositive">INAKTIVERA</string>
     <string name="disableLoginDetectionDialogNegative">AVBRYT</string>
     <string name="fireproofWebsiteRemovalConfirmation">Brandsäkring har tagits bort för &lt;b&gt;%1$s&lt;/b&gt;</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Ange tema</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animation för brännarknapp</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -151,10 +151,6 @@
     <string name="settingsHeadingGeneral">Genel</string>
     <string name="settingsHeadingOther">Diğer</string>
     <string name="settingsHeadingPrivacy">Gizlilik</string>
-    <string name="settingsLightTheme">Açık Tema</string>
-    <string name="settingsTheme">Tema</string>
-    <string name="settingsDarkTheme">Sistem varsayılanı</string>
-    <string name="settingsSystemTheme">Systemfel</string>
     <string name="settingsAboutDuckduckgo">DuckDuckGo Hakkında</string>
     <string name="settingsVersion">Versiyon</string>
     <string name="leaveFeedback">Geri Bildirim Paylaş</string>
@@ -494,9 +490,6 @@
     <string name="disableLoginDetectionDialogPositive">DEVRE DIŞI BIRAK</string>
     <string name="disableLoginDetectionDialogNegative">İPTAL</string>
     <string name="fireproofWebsiteRemovalConfirmation">&lt;b&gt;%1$s&lt;/b&gt; için Koruma kaldırıldı</string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Tema Ayarla</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Yangın Düğmesi Animasyonu</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -152,6 +152,9 @@
     <string name="settingsHeadingOther">Diğer</string>
     <string name="settingsHeadingPrivacy">Gizlilik</string>
     <string name="settingsLightTheme">Açık Tema</string>
+    <string name="settingsTheme">Tema</string>
+    <string name="settingsDarkTheme">Sistem varsayılanı</string>
+    <string name="settingsSystemTheme">Systemfel</string>
     <string name="settingsAboutDuckduckgo">DuckDuckGo Hakkında</string>
     <string name="settingsVersion">Versiyon</string>
     <string name="leaveFeedback">Geri Bildirim Paylaş</string>
@@ -491,6 +494,9 @@
     <string name="disableLoginDetectionDialogPositive">DEVRE DIŞI BIRAK</string>
     <string name="disableLoginDetectionDialogNegative">İPTAL</string>
     <string name="fireproofWebsiteRemovalConfirmation">&lt;b&gt;%1$s&lt;/b&gt; için Koruma kaldırıldı</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Tema Ayarla</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Yangın Düğmesi Animasyonu</string>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -40,4 +40,13 @@
     <!-- Email -->
     <string name="emailNotSupported">Device not supported</string>
     <string name="emailNotSupportedExplanation">Email Protection allows you to create private email addresses that remove email trackers. We need to encrypt and store these addresses you create locally on your device. Because your device does not support encrypted storage, Email Protection is unavailable.</string>
+
+    <!-- Settings Activity -->
+    <string name="settingsLightTheme">Light</string>
+    <string name="settingsTheme">Theme</string>
+    <string name="settingsDarkTheme">Dark </string>
+    <string name="settingsSystemTheme">System Default</string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave">Set Theme</string>
 </resources>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -47,9 +47,9 @@
     <string name="settingsDarkTheme">Dark</string>
     <string name="settingsSystemTheme">System Default</string>
 
-    <!--    Theme Settings-->
+    <!-- Theme Settings -->
     <string name="settingsThemeDialogSave">Set Theme</string>
-  
+
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Edit Bookmark</string>
     <string name="favoriteDialogTitleEdit">Edit Favorite</string>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -44,7 +44,7 @@
     <!-- Settings Activity -->
     <string name="settingsLightTheme">Light</string>
     <string name="settingsTheme">Theme</string>
-    <string name="settingsDarkTheme">Dark </string>
+    <string name="settingsDarkTheme">Dark</string>
     <string name="settingsSystemTheme">System Default</string>
 
     <!--    Theme Settings-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,7 +150,10 @@
     <string name="settingsHeadingGeneral">General</string>
     <string name="settingsHeadingOther">Other</string>
     <string name="settingsHeadingPrivacy">Privacy</string>
+    <string name="settingsTheme" translatable="false">Theme</string>
     <string name="settingsLightTheme">Light Theme</string>
+    <string name="settingsDarkTheme" translatable="false">Dark Theme</string>
+    <string name="settingsSystemTheme" translatable="false">System Default</string>
     <string name="settingsAboutDuckduckgo">About DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Share Feedback</string>
@@ -492,6 +495,9 @@
     <string name="disableLoginDetectionDialogPositive">DISABLE</string>
     <string name="disableLoginDetectionDialogNegative">CANCEL</string>
     <string name="fireproofWebsiteRemovalConfirmation">Fireproofing removed for &lt;b>%s&lt;/b></string>
+
+    <!--    Theme Settings-->
+    <string name="settingsThemeDialogSave" translatable="false">Set Theme</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Fire Button Animation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,10 +150,10 @@
     <string name="settingsHeadingGeneral">General</string>
     <string name="settingsHeadingOther">Other</string>
     <string name="settingsHeadingPrivacy">Privacy</string>
-    <string name="settingsTheme" translatable="false">Theme</string>
     <string name="settingsLightTheme">Light Theme</string>
-    <string name="settingsDarkTheme" translatable="false">Dark Theme</string>
-    <string name="settingsSystemTheme" translatable="false">System Default</string>
+    <string name="settingsTheme">Theme</string>
+    <string name="settingsDarkTheme">Dark Theme</string>
+    <string name="settingsSystemTheme">System Default</string>
     <string name="settingsAboutDuckduckgo">About DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Share Feedback</string>
@@ -497,7 +497,7 @@
     <string name="fireproofWebsiteRemovalConfirmation">Fireproofing removed for &lt;b>%s&lt;/b></string>
 
     <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave" translatable="false">Set Theme</string>
+    <string name="settingsThemeDialogSave">Set Theme</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Fire Button Animation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,10 +150,6 @@
     <string name="settingsHeadingGeneral">General</string>
     <string name="settingsHeadingOther">Other</string>
     <string name="settingsHeadingPrivacy">Privacy</string>
-    <string name="settingsLightTheme">Light Theme</string>
-    <string name="settingsTheme">Theme</string>
-    <string name="settingsDarkTheme">Dark Theme</string>
-    <string name="settingsSystemTheme">System Default</string>
     <string name="settingsAboutDuckduckgo">About DuckDuckGo</string>
     <string name="settingsVersion">Version</string>
     <string name="leaveFeedback">Share Feedback</string>
@@ -495,9 +491,6 @@
     <string name="disableLoginDetectionDialogPositive">DISABLE</string>
     <string name="disableLoginDetectionDialogNegative">CANCEL</string>
     <string name="fireproofWebsiteRemovalConfirmation">Fireproofing removed for &lt;b>%s&lt;/b></string>
-
-    <!--    Theme Settings-->
-    <string name="settingsThemeDialogSave">Set Theme</string>
 
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Fire Button Animation</string>

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
@@ -32,9 +32,9 @@ import com.duckduckgo.mobile.android.ui.Theming.Constants.BROADCAST_THEME_CHANGE
 import com.duckduckgo.mobile.android.ui.Theming.Constants.THEME_MAP
 
 enum class DuckDuckGoTheme {
+    SYSTEM_DEFAULT,
     DARK,
-    LIGHT,
-    SYSTEM_DEFAULT;
+    LIGHT;
 }
 
 object Theming {

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.mobile.android.ui
 
+import android.app.UiModeManager
+import android.app.UiModeManager.MODE_NIGHT_NO
+import android.app.UiModeManager.MODE_NIGHT_YES
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -30,7 +33,8 @@ import com.duckduckgo.mobile.android.ui.Theming.Constants.THEME_MAP
 
 enum class DuckDuckGoTheme {
     DARK,
-    LIGHT;
+    LIGHT,
+    SYSTEM_DEFAULT;
 }
 
 object Theming {
@@ -60,8 +64,18 @@ private fun AppCompatActivity.manifestThemeId(): Int {
 }
 
 fun AppCompatActivity.applyTheme(theme: DuckDuckGoTheme): BroadcastReceiver? {
-    val themeId = THEME_MAP[Pair(manifestThemeId(), theme)] ?: return null
-    setTheme(themeId)
+    if (theme == DuckDuckGoTheme.SYSTEM_DEFAULT) {
+        val uiManager = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
+        val themeId = when (uiManager.nightMode) {
+            MODE_NIGHT_YES -> THEME_MAP[Pair(manifestThemeId(), DuckDuckGoTheme.DARK)]
+            MODE_NIGHT_NO -> THEME_MAP[Pair(manifestThemeId(), DuckDuckGoTheme.LIGHT)]
+            else -> THEME_MAP[Pair(manifestThemeId(), DuckDuckGoTheme.LIGHT)]
+        }
+        if (themeId != null) setTheme(themeId)
+    } else {
+        val themeId = THEME_MAP[Pair(manifestThemeId(), theme)] ?: return null
+        setTheme(themeId)
+    }
     return registerForThemeChangeBroadcast()
 }
 

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/store/ThemingDataStore.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/store/ThemingDataStore.kt
@@ -22,4 +22,5 @@ interface ThemingDataStore {
 
     var theme: DuckDuckGoTheme
 
+    fun isCurrentlySelected(theme: DuckDuckGoTheme): Boolean
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: #1397

**Description**:
Added system default theme option for supporting devices Android 10 onwards

**Steps to test this PR**:
1. Open Settings
2. Open theme group
3. Devices above 10 and above will have an option to set the System Default theme option.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
