### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,17 @@ jobs:
         run: ./gradlew spotlessCheck --stacktrace
 
       - name: Unit Tests
-        run: ./gradlew testDebugUnitTest --stacktrace
+        run: ./gradlew app:testPlayDebugUnitTest --stacktrace
 
-      - name: (Fail-only) Bundle the Unit Test report
-        if: failure()
+      - name: Bundle the Unit Test report
+        if: always()
         run: find . -type d -name 'reports' | zip -@ -r unit-test-report.zip
 
-      - name: (Fail-only) Upload the Unit Test report
-        if: failure()
+      - name: Upload the Unit Test report
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: unit-test-error-report
+          name: unit-test-report
           path: unit-test-report.zip
 
   android_tests:
@@ -59,8 +59,7 @@ jobs:
     name: Android tests
     strategy:
       matrix:
-        api-level: [22, 26]
-        target: [google_apis]
+        api-level: [22, 29]
 
     steps:
       - name: Cancel previous
@@ -73,10 +72,10 @@ jobs:
           submodules: recursive
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-      - name: set up JDK 14
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '14'
+          java-version: '11'
           distribution: 'adopt'
       - name: Gradle cache
         uses: actions/cache@v2
@@ -93,7 +92,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-emu-${{ matrix.api-level }}
+          key: avd-emul-${{ matrix.api-level }}
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -101,7 +100,6 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           ndk: 21.0.6113669
-          target: ${{ matrix.target }}
           arch: x86_64
           profile: Nexus 5
           force-avd-creation: true
@@ -114,7 +112,6 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           ndk: 21.0.6113669
-          target: ${{ matrix.target }}
           arch: x86_64
           profile: Nexus 5
           force-avd-creation: false
@@ -122,13 +119,13 @@ jobs:
           disable-animations: true
           script: ./gradlew app:connectedPlayDebugAndroidTest --stacktrace
 
-      - name: (Fail-only) Bundle the Android Test report
-        if: failure()
+      - name: Bundle the Android Test report
+        if: always()
         run: find . -type d -name 'reports' | zip -@ -r android-test-report.zip
 
-      - name: (Fail-only) Upload the Android Test report
-        if: failure()
+      - name: Upload the Android Test report
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: android-test-error-report
+          name: android-test-report
           path: android-test-report.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,17 +34,17 @@ jobs:
         run: ./gradlew spotlessCheck --stacktrace
 
       - name: Unit Tests
-        run: ./gradlew testDebugUnitTest --stacktrace
+        run: ./gradlew app:testPlayDebugUnitTest --stacktrace
 
-      - name: (Fail-only) Bundle the Unit Test report
-        if: failure()
+      - name: Bundle the Unit Test report
+        if: always()
         run: find . -type d -name 'reports' | zip -@ -r unit-test-report.zip
 
-      - name: (Fail-only) Upload the Unit Test report
-        if: failure()
+      - name: Upload the Unit Test report
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: unit-test-error-report
+          name: unit-test-report
           path: unit-test-report.zip
 
   android_tests:
@@ -52,8 +52,7 @@ jobs:
     name: Android tests
     strategy:
       matrix:
-        api-level: [22, 26]
-        target: [google_apis]
+        api-level: [22, 29]
 
     steps:
       - name: Cancel previous
@@ -66,10 +65,10 @@ jobs:
           submodules: recursive
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-      - name: set up JDK 14
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '14'
+          java-version: '11'
           distribution: 'adopt'
       - name: Gradle cache
         uses: actions/cache@v2
@@ -86,7 +85,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-emu-${{ matrix.api-level }}
+          key: avd-emul-${{ matrix.api-level }}
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -94,7 +93,6 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           ndk: 21.0.6113669
-          target: ${{ matrix.target }}
           arch: x86_64
           profile: Nexus 5
           force-avd-creation: true
@@ -107,7 +105,6 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           ndk: 21.0.6113669
-          target: ${{ matrix.target }}
           arch: x86_64
           profile: Nexus 5
           force-avd-creation: false
@@ -115,13 +112,13 @@ jobs:
           disable-animations: true
           script: ./gradlew app:connectedPlayDebugAndroidTest --stacktrace
 
-      - name: (Fail-only) Bundle the Android Test report
-        if: failure()
+      - name: Bundle the Android Test report
+        if: always()
         run: find . -type d -name 'reports' | zip -@ -r android-test-report.zip
 
-      - name: (Fail-only) Upload the Android Test report
-        if: failure()
+      - name: Upload the Android Test report
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: android-test-error-report
+          name: android-test-report
           path: android-test-report.zip

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3177,7 +3177,7 @@ class BrowserTabViewModelTest {
 
         testee.onViewVisible()
 
-        advanceTimeBy(3_600_000)
+        advanceTimeBy(3_600_001)
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_FIRE_BUTTON))
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_FIRE_BUTTON_PULSE))
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -113,7 +113,9 @@ class BrowserViewModelTest {
 
     @After
     fun after() {
-        testee.command.removeObserver(mockCommandObserver)
+        if (this::testee.isInitialized) {
+            testee.command.removeObserver(mockCommandObserver)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/fire/DataClearerTimeKeeperTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/DataClearerTimeKeeperTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 DuckDuckGo
+ * Copyright (c) 2021 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1200914515606072
Tech Design URL: 
CC: 

**Description**:
This PR improves our CI a bit (nothing drastic). We now run our Android tests in APIs 22 and 29 (instead of 26) and always upload the test report. There are also a few tests that were a bit flaky in API 22 so this PR should either fix them or at least get us close to the reason of why they fail.

**Steps to test this PR**:
1. Make sure the workflow runs JVM tests and Android tests (22 and 29) and all of them are green


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
