### PR TITLE
Remote Config (V): Https

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -124,6 +124,7 @@ import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER_VALUE
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.nhaarman.mockitokotlin2.*
 import com.nhaarman.mockitokotlin2.any
@@ -290,6 +291,9 @@ class BrowserTabViewModelTest {
     @Mock
     private lateinit var mockGpcRepository: GpcRepository
 
+    @Mock
+    private lateinit var mockUnprotectedTemporary: UnprotectedTemporary
+
     private val lazyFaviconManager = Lazy { mockFaviconManager }
 
     private lateinit var mockAutoCompleteApi: AutoCompleteApi
@@ -426,7 +430,7 @@ class BrowserTabViewModelTest {
             navigationAwareLoginDetector = mockNavigationAwareLoginDetector,
             userEventsStore = mockUserEventsStore,
             fileDownloader = mockFileDownloader,
-            gpc = RealGpc(context, mockFeatureToggle, mockGpcRepository),
+            gpc = RealGpc(context, mockFeatureToggle, mockGpcRepository, mockUnprotectedTemporary),
             fireproofDialogsEventHandler = fireproofDialogsEventHandler,
             emailManager = mockEmailManager,
             favoritesRepository = mockFavoritesRepository,

--- a/common/src/main/java/com/duckduckgo/app/global/plugins/migrations/MigrationPlugin.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/plugins/migrations/MigrationPlugin.kt
@@ -29,7 +29,7 @@ interface MigrationPlugin {
 class MigrationPluginPoint @Inject constructor(
     private val injectorPlugins: Set<@JvmSuppressWildcards MigrationPlugin>
 ) : PluginPoint<MigrationPlugin> {
-    override fun getPlugins(): List<MigrationPlugin> {
-        return injectorPlugins.toList()
+    override fun getPlugins(): Collection<MigrationPlugin> {
+        return injectorPlugins
     }
 }

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Https.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Https.kt
@@ -17,6 +17,18 @@
 package com.duckduckgo.privacy.config.api
 
 /**
+ * Public interface for the Https (Smart Encryption) feature
+ */
+interface Https {
+    /**
+     * This method takes a [url] and returns `true` or `false` depending if the [url]
+     * is in the https exceptions list
+     * @return a `true` if the given [url] if the url is in the https exceptions list and `false` otherwise.
+     */
+    fun isAnException(url: String): Boolean
+}
+
+/**
  * Public data class for Https Exceptions
  */
 data class HttpsException(val domain: String, val reason: String)

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Https.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Https.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.api
+
+/**
+ * Public data class for Https Exceptions
+ */
+data class HttpsException(val domain: String, val reason: String)

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyConfig.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyConfig.kt
@@ -24,4 +24,5 @@ import com.duckduckgo.feature.toggles.api.FeatureName
 sealed class PrivacyFeatureName(override val value: String) : FeatureName {
     data class ContentBlockingFeatureName(override val value: String = "contentBlocking") : PrivacyFeatureName(value)
     data class GpcFeatureName(override val value: String = "gpc") : PrivacyFeatureName(value)
+    data class HttpsFeatureName(override val value: String = "https") : PrivacyFeatureName(value)
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.privacy.config.store.PrivacyConfig
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -39,6 +40,7 @@ interface PrivacyConfigPersister {
 class RealPrivacyConfigPersister @Inject constructor(
     private val privacyFeaturePluginPoint: PluginPoint<PrivacyFeaturePlugin>,
     private val privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository,
+    private val unprotectedTemporaryRepository: UnprotectedTemporaryRepository,
     private val privacyConfigRepository: PrivacyConfigRepository,
     private val database: PrivacyConfigDatabase
 ) : PrivacyConfigPersister {
@@ -52,6 +54,7 @@ class RealPrivacyConfigPersister @Inject constructor(
             database.runInTransaction {
                 privacyFeatureTogglesRepository.deleteAll()
                 privacyConfigRepository.insert(PrivacyConfig(version = jsonPrivacyConfig.version, readme = jsonPrivacyConfig.readme))
+                unprotectedTemporaryRepository.updateAll(jsonPrivacyConfig.unprotectedTemporary)
                 jsonPrivacyConfig.features.forEach { feature ->
                     privacyFeaturePluginPoint.getPlugins().forEach { plugin ->
                         plugin.store(feature.key, feature.value)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
@@ -40,6 +40,8 @@ import com.duckduckgo.privacy.config.store.features.gpc.GpcSharedPreferences
 import com.duckduckgo.privacy.config.store.features.gpc.RealGpcRepository
 import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
 import com.duckduckgo.privacy.config.store.features.https.RealHttpsRepository
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.RealUnprotectedTemporaryRepository
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.moshi.Moshi
 import dagger.Module
@@ -126,6 +128,12 @@ class DatabaseModule {
     @Provides
     fun provideHttpsRepository(database: PrivacyConfigDatabase, @AppCoroutineScope coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider): HttpsRepository {
         return RealHttpsRepository(database, coroutineScope, dispatcherProvider)
+    }
+
+    @Singleton
+    @Provides
+    fun provideUnprotectedTemporaryRepository(database: PrivacyConfigDatabase, @AppCoroutineScope coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider): UnprotectedTemporaryRepository {
+        return RealUnprotectedTemporaryRepository(database, coroutineScope, dispatcherProvider)
     }
 
     @Singleton

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
@@ -38,6 +38,8 @@ import com.duckduckgo.privacy.config.store.features.gpc.GpcDataStore
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.duckduckgo.privacy.config.store.features.gpc.GpcSharedPreferences
 import com.duckduckgo.privacy.config.store.features.gpc.RealGpcRepository
+import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
+import com.duckduckgo.privacy.config.store.features.https.RealHttpsRepository
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.moshi.Moshi
 import dagger.Module
@@ -104,7 +106,7 @@ class DatabaseModule {
 
     @Singleton
     @Provides
-    fun provideContentBLockingRepository(database: PrivacyConfigDatabase, @AppCoroutineScope coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider): ContentBlockingRepository {
+    fun provideContentBlockingRepository(database: PrivacyConfigDatabase, @AppCoroutineScope coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider): ContentBlockingRepository {
         return RealContentBlockingRepository(database, coroutineScope, dispatcherProvider)
     }
 
@@ -118,6 +120,12 @@ class DatabaseModule {
     @Provides
     fun provideGpcRepository(gpcDataStore: GpcDataStore, database: PrivacyConfigDatabase, @AppCoroutineScope coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider): GpcRepository {
         return RealGpcRepository(gpcDataStore, database, coroutineScope, dispatcherProvider)
+    }
+
+    @Singleton
+    @Provides
+    fun provideHttpsRepository(database: PrivacyConfigDatabase, @AppCoroutineScope coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider): HttpsRepository {
+        return RealHttpsRepository(database, coroutineScope, dispatcherProvider)
     }
 
     @Singleton

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlocking.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlocking.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.di.scopes.AppObjectGraph
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -28,11 +29,11 @@ import javax.inject.Singleton
 
 @ContributesBinding(AppObjectGraph::class)
 @Singleton
-class RealContentBlocking @Inject constructor(private val contentBlockingRepository: ContentBlockingRepository, private val featureToggle: FeatureToggle) : ContentBlocking {
+class RealContentBlocking @Inject constructor(private val contentBlockingRepository: ContentBlockingRepository, private val featureToggle: FeatureToggle, private val unprotectedTemporary: UnprotectedTemporary) : ContentBlocking {
 
     override fun isAnException(url: String): Boolean {
         return if (featureToggle.isFeatureEnabled(PrivacyFeatureName.ContentBlockingFeatureName(), true) == true) {
-            matches(url)
+            unprotectedTemporary.isAnException(url) || matches(url)
         } else {
             false
         }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.R
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -30,7 +31,7 @@ import javax.inject.Singleton
 
 @ContributesBinding(AppObjectGraph::class)
 @Singleton
-class RealGpc @Inject constructor(context: Context, private val featureToggle: FeatureToggle, val gpcRepository: GpcRepository) : Gpc {
+class RealGpc @Inject constructor(context: Context, private val featureToggle: FeatureToggle, val gpcRepository: GpcRepository, private val unprotectedTemporary: UnprotectedTemporary) : Gpc {
 
     private val gpcJsFunctions: String = context.resources.openRawResource(R.raw.gpc).bufferedReader().use { it.readText() }
 
@@ -79,7 +80,7 @@ class RealGpc @Inject constructor(context: Context, private val featureToggle: F
     }
 
     private fun isAnException(url: String): Boolean {
-        return matches(url)
+        return matches(url) || unprotectedTemporary.isAnException(url)
     }
 
     private fun matches(url: String): Boolean {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsFeature.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.https
+
+import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
+
+data class HttpsFeature(
+    val state: String,
+    val exceptions: List<HttpsExceptionEntity>
+)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
@@ -54,5 +54,5 @@ class HttpsPlugin @Inject constructor(
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.GpcFeatureName()
+    override val featureName: PrivacyFeatureName = PrivacyFeatureName.HttpsFeatureName()
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.https
+
+import com.duckduckgo.di.scopes.AppObjectGraph
+import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
+import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
+import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
+import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
+import com.squareup.anvil.annotations.ContributesMultibinding
+import org.json.JSONObject
+import javax.inject.Inject
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+
+@ContributesMultibinding(AppObjectGraph::class)
+class HttpsPlugin @Inject constructor(
+    private val httpsRepository: HttpsRepository,
+    private val privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository
+) : PrivacyFeaturePlugin {
+
+    override fun store(name: String, jsonObject: JSONObject?): Boolean {
+        if (name == featureName.value) {
+            val httpsExceptions = mutableListOf<HttpsExceptionEntity>()
+            val moshi = Moshi.Builder().build()
+            val jsonAdapter: JsonAdapter<HttpsFeature> =
+                moshi.adapter(HttpsFeature::class.java)
+
+            val httpsFeature: HttpsFeature? = jsonAdapter.fromJson(jsonObject.toString())
+            httpsFeature?.exceptions?.map {
+                httpsExceptions.add(HttpsExceptionEntity(it.domain, it.reason))
+            }
+            httpsRepository.updateAll(httpsExceptions)
+            val isEnabled = httpsFeature?.state == "enabled"
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled))
+            return true
+        }
+        return false
+    }
+
+    override val featureName: PrivacyFeatureName = PrivacyFeatureName.GpcFeatureName()
+}

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/RealHttps.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/RealHttps.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.https
+
+import com.duckduckgo.app.global.UriString.Companion.sameOrSubdomain
+import com.duckduckgo.di.scopes.AppObjectGraph
+import com.duckduckgo.privacy.config.api.Https
+import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@ContributesBinding(AppObjectGraph::class)
+@Singleton
+class RealHttps @Inject constructor(private val httpsRepository: HttpsRepository) : Https {
+
+    override fun isAnException(url: String): Boolean {
+        return matches(url)
+    }
+
+    private fun matches(url: String): Boolean {
+        return httpsRepository.exceptions.any { sameOrSubdomain(url, it.domain) }
+    }
+}

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/UnprotectedTemporary.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/UnprotectedTemporary.kt
@@ -14,26 +14,28 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.privacy.config.impl.features.https
+package com.duckduckgo.privacy.config.impl.features.unprotectedtemporary
 
-import com.duckduckgo.app.global.UriString.Companion.sameOrSubdomain
+import com.duckduckgo.app.global.UriString
 import com.duckduckgo.di.scopes.AppObjectGraph
-import com.duckduckgo.privacy.config.api.Https
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
-import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import javax.inject.Singleton
 
+interface UnprotectedTemporary {
+    fun isAnException(url: String): Boolean
+}
+
 @ContributesBinding(AppObjectGraph::class)
 @Singleton
-class RealHttps @Inject constructor(private val httpsRepository: HttpsRepository, private val unprotectedTemporary: UnprotectedTemporary) : Https {
+class RealUnprotectedTemporary @Inject constructor(private val unprotectedTemporaryRepository: UnprotectedTemporaryRepository) : UnprotectedTemporary {
 
     override fun isAnException(url: String): Boolean {
-        return unprotectedTemporary.isAnException(url) || matches(url)
+        return matches(url)
     }
 
     private fun matches(url: String): Boolean {
-        return httpsRepository.exceptions.any { sameOrSubdomain(url, it.domain) }
+        return unprotectedTemporaryRepository.exceptions.any { UriString.sameOrSubdomain(url, it.domain) }
     }
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/models/JsonPrivacyConfig.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/models/JsonPrivacyConfig.kt
@@ -16,10 +16,12 @@
 
 package com.duckduckgo.privacy.config.impl.models
 
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import org.json.JSONObject
 
 data class JsonPrivacyConfig(
     val version: Long,
     val readme: String,
-    val features: Map<String, JSONObject?>
+    val features: Map<String, JSONObject?>,
+    val unprotectedTemporary: List<UnprotectedTemporaryEntity>
 )

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.privacy.config.impl
 
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.impl.network.PrivacyConfigService
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -70,12 +71,13 @@ class RealPrivacyConfigDownloaderTest {
 
     class TestPrivacyConfigService : PrivacyConfigService {
         override suspend fun privacyConfig(): JsonPrivacyConfig {
-            return JsonPrivacyConfig(version = 1, readme = "readme", features = mapOf(FEATURE_NAME to JSONObject(FEATURE_JSON)))
+            return JsonPrivacyConfig(version = 1, readme = "readme", features = mapOf(FEATURE_NAME to JSONObject(FEATURE_JSON)), unprotectedTemporaryList)
         }
     }
 
     companion object {
         private const val FEATURE_NAME = "test"
         private const val FEATURE_JSON = "{\"state\": \"enabled\"}"
+        val unprotectedTemporaryList = listOf(UnprotectedTemporaryEntity("example.com", "reason"))
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.privacy.config.impl.features.contentblocking
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.ContentBlockingException
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingRepository
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -34,13 +35,14 @@ class RealContentBlockingTest {
     lateinit var testee: RealContentBlocking
 
     private val mockContentBlockingRepository: ContentBlockingRepository = mock()
+    private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
     private val mockFeatureToggle: FeatureToggle = mock()
 
     @Before
     fun before() {
         givenFeatureIsEnabled()
 
-        testee = RealContentBlocking(mockContentBlockingRepository, mockFeatureToggle)
+        testee = RealContentBlocking(mockContentBlockingRepository, mockFeatureToggle, mockUnprotectedTemporary)
     }
 
     @Test
@@ -62,6 +64,15 @@ class RealContentBlockingTest {
         whenever(mockContentBlockingRepository.exceptions).thenReturn(arrayListOf())
 
         assertFalse(testee.isAnException("http://test.example.com"))
+    }
+
+    @Test
+    fun whenIsAnExceptionAndDomainIsInTheUnprotectedTemporaryListThenReturnTrue() {
+        val url = "http://test.example.com"
+        whenever(mockUnprotectedTemporary.isAnException(url)).thenReturn(true)
+        whenever(mockContentBlockingRepository.exceptions).thenReturn(arrayListOf())
+
+        assertTrue(testee.isAnException(url))
     }
 
     @Test

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.R
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER_VALUE
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
@@ -40,6 +41,7 @@ import java.io.ByteArrayInputStream
 class RealGpcTest {
     private val mockGpcRepository: GpcRepository = mock()
     private val mockFeatureToggle: FeatureToggle = mock()
+    private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
     private val mockContext: Context = mock()
     private val mockResources: Resources = mock()
     lateinit var testee: RealGpc
@@ -50,7 +52,7 @@ class RealGpcTest {
         whenever(mockResources.openRawResource(any())).thenReturn(ByteArrayInputStream("".toByteArray()))
         whenever(mockGpcRepository.exceptions).thenReturn(arrayListOf(GpcException(EXCEPTION_URL)))
 
-        testee = RealGpc(mockContext, mockFeatureToggle, mockGpcRepository)
+        testee = RealGpc(mockContext, mockFeatureToggle, mockGpcRepository, mockUnprotectedTemporary)
     }
 
     @Test
@@ -190,6 +192,14 @@ class RealGpcTest {
         givenFeatureIsNotEnabledButGpcIsEnabled()
 
         assertFalse(testee.canGpcBeUsedByUrl("test.com"))
+    }
+
+    @Test
+    fun whenCanGpcBeUsedByUrlIfFeatureAndGpcAreEnabledAnUrlIsInUnprotectedTemporaryThenReturnFalse() {
+        givenFeatureAndGpcAreEnabled()
+        whenever(mockUnprotectedTemporary.isAnException(VALID_CONSUMER_URL)).thenReturn(true)
+
+        assertFalse(testee.canGpcBeUsedByUrl(VALID_CONSUMER_URL))
     }
 
     private fun givenFeatureAndGpcAreEnabled() {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPluginTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.https
+
+import com.duckduckgo.privacy.config.impl.FileUtilities
+import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
+import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
+import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HttpsPluginTest {
+    lateinit var testee: HttpsPlugin
+
+    private val mockFeatureTogglesRepository: PrivacyFeatureTogglesRepository = mock()
+    private val mockHttpsRepository: HttpsRepository = mock()
+
+    @Before
+    fun before() {
+        testee = HttpsPlugin(mockHttpsRepository, mockFeatureTogglesRepository)
+    }
+
+    @Test
+    fun whenFeatureNameDoesNotMatchHttpsThenReturnFalse() {
+        assertFalse(testee.store("test", null))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesContentBlockingThenReturnTrue() {
+        assertTrue(testee.store(FEATURE_NAME, null))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesHttpsAndIsEnabledThenStoreFeatureEnabled() {
+        val jsonObject = getJsonObjectFromFile("json/https.json")
+
+        testee.store(FEATURE_NAME, jsonObject)
+
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesHttpsAndIsNotEnabledThenStoreFeatureDisabled() {
+        val jsonObject = getJsonObjectFromFile("json/https_disabled.json")
+
+        testee.store(FEATURE_NAME, jsonObject)
+
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesHttpsThenUpdateAllExistingExceptions() {
+        val jsonObject = getJsonObjectFromFile("json/https.json")
+
+        testee.store(FEATURE_NAME, jsonObject)
+
+        verify(mockHttpsRepository).updateAll(ArgumentMatchers.anyList())
+    }
+
+    private fun getJsonObjectFromFile(filename: String): JSONObject {
+        val json = FileUtilities.loadText(filename)
+        return JSONObject(json)
+    }
+
+    companion object {
+        private const val FEATURE_NAME = "https"
+    }
+}

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/RealHttpsTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/RealHttpsTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.https
+
+import com.duckduckgo.privacy.config.api.HttpsException
+import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RealHttpsTest {
+    private val mockHttpsRepository: HttpsRepository = mock()
+    lateinit var testee: RealHttps
+
+    @Before
+    fun before() {
+        testee = RealHttps(mockHttpsRepository)
+    }
+
+    @Test
+    fun whenIsAnExceptionAndDomainIsListedInTheExceptionsListThenReturnTrue() {
+        givenThereAreExceptions()
+
+        assertTrue(testee.isAnException("http://www.example.com"))
+    }
+
+    @Test
+    fun whenIsAnExceptionWithSubdomainAndDomainIsListedInTheExceptionsListThenReturnTrue() {
+        givenThereAreExceptions()
+
+        assertTrue(testee.isAnException("http://test.example.com"))
+    }
+
+    @Test
+    fun whenIsAnExceptionAndDomainIsNotListedInTheExceptionsListThenReturnFalse() {
+        whenever(mockHttpsRepository.exceptions).thenReturn(arrayListOf())
+
+        assertFalse(testee.isAnException("http://test.example.com"))
+    }
+
+    private fun givenThereAreExceptions() {
+        whenever(mockHttpsRepository.exceptions).thenReturn(
+            arrayListOf(
+                HttpsException("example.com", "my reason here")
+            )
+        )
+    }
+}

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.privacy.config.impl.features.https
+package com.duckduckgo.privacy.config.impl.features.unprotectedtemporary
 
-import com.duckduckgo.privacy.config.api.HttpsException
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
-import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.*
@@ -26,16 +25,16 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CopyOnWriteArrayList
 
 @RunWith(RobolectricTestRunner::class)
-class RealHttpsTest {
-    private val mockHttpsRepository: HttpsRepository = mock()
-    private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
-    lateinit var testee: RealHttps
+class RealUnprotectedTemporaryTest {
+    private val mockUnprotectedTemporaryRepository: UnprotectedTemporaryRepository = mock()
+    lateinit var testee: RealUnprotectedTemporary
 
     @Before
     fun before() {
-        testee = RealHttps(mockHttpsRepository, mockUnprotectedTemporary)
+        testee = RealUnprotectedTemporary(mockUnprotectedTemporaryRepository)
     }
 
     @Test
@@ -54,25 +53,16 @@ class RealHttpsTest {
 
     @Test
     fun whenIsAnExceptionAndDomainIsNotListedInTheExceptionsListThenReturnFalse() {
-        whenever(mockHttpsRepository.exceptions).thenReturn(arrayListOf())
+        val exceptions = CopyOnWriteArrayList<UnprotectedTemporaryEntity>()
+        whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptions)
 
         assertFalse(testee.isAnException("http://test.example.com"))
     }
 
-    @Test
-    fun whenIsAnExceptionAndDomainIsListedInTheUnprotectedTemporaryListThenReturnTrue() {
-        val url = "http://example.com"
-        whenever(mockUnprotectedTemporary.isAnException(url)).thenReturn(true)
-        whenever(mockHttpsRepository.exceptions).thenReturn(arrayListOf())
-
-        assertTrue(testee.isAnException(url))
-    }
-
     private fun givenThereAreExceptions() {
-        whenever(mockHttpsRepository.exceptions).thenReturn(
-            arrayListOf(
-                HttpsException("example.com", "my reason here")
-            )
-        )
+        val exceptions = CopyOnWriteArrayList<UnprotectedTemporaryEntity>()
+        exceptions.add(UnprotectedTemporaryEntity("example.com", "my reason here"))
+
+        whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptions)
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/resources/json/https.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/https.json
@@ -1,0 +1,13 @@
+{
+  "state": "enabled",
+  "exceptions": [
+    {
+      "domain": "www.livenewsnow.com",
+      "reason": "Adblocker wall"
+    },
+    {
+      "domain": "weather.com",
+      "reason": "Broken videos"
+    }
+  ]
+}

--- a/privacy-config/privacy-config-impl/src/test/resources/json/https_disabled.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/https_disabled.json
@@ -1,0 +1,13 @@
+{
+  "state": "disabled",
+  "exceptions": [
+    {
+      "domain": "www.livenewsnow.com",
+      "reason": "Adblocker wall"
+    },
+    {
+      "domain": "weather.com",
+      "reason": "Broken videos"
+    }
+  ]
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
@@ -20,10 +20,12 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingDao
 import com.duckduckgo.privacy.config.store.features.gpc.GpcDao
+import com.duckduckgo.privacy.config.store.features.https.HttpsDao
 
 @Database(
     exportSchema = true, version = 1,
     entities = [
+        HttpsExceptionEntity::class,
         GpcExceptionEntity::class,
         ContentBlockingExceptionEntity::class,
         PrivacyFeatureToggles::class,
@@ -31,6 +33,7 @@ import com.duckduckgo.privacy.config.store.features.gpc.GpcDao
     ]
 )
 abstract class PrivacyConfigDatabase : RoomDatabase() {
+    abstract fun httpsDao(): HttpsDao
     abstract fun gpcDao(): GpcDao
     abstract fun contentBlockingDao(): ContentBlockingDao
     abstract fun privacyFeatureTogglesDao(): PrivacyFeatureTogglesDao

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
@@ -21,10 +21,12 @@ import androidx.room.RoomDatabase
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingDao
 import com.duckduckgo.privacy.config.store.features.gpc.GpcDao
 import com.duckduckgo.privacy.config.store.features.https.HttpsDao
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryDao
 
 @Database(
     exportSchema = true, version = 1,
     entities = [
+        UnprotectedTemporaryEntity::class,
         HttpsExceptionEntity::class,
         GpcExceptionEntity::class,
         ContentBlockingExceptionEntity::class,
@@ -33,6 +35,7 @@ import com.duckduckgo.privacy.config.store.features.https.HttpsDao
     ]
 )
 abstract class PrivacyConfigDatabase : RoomDatabase() {
+    abstract fun unprotectedTemporaryDao(): UnprotectedTemporaryDao
     abstract fun httpsDao(): HttpsDao
     abstract fun gpcDao(): GpcDao
     abstract fun contentBlockingDao(): ContentBlockingDao

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -22,6 +22,12 @@ import com.duckduckgo.privacy.config.api.ContentBlockingException
 import com.duckduckgo.privacy.config.api.GpcException
 import com.duckduckgo.privacy.config.api.HttpsException
 
+@Entity(tableName = "unprotected_temporary")
+data class UnprotectedTemporaryEntity(
+    @PrimaryKey val domain: String,
+    val reason: String
+)
+
 @Entity(tableName = "https_exceptions")
 data class HttpsExceptionEntity(
     @PrimaryKey val domain: String,

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -20,12 +20,17 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.duckduckgo.privacy.config.api.ContentBlockingException
 import com.duckduckgo.privacy.config.api.GpcException
+import com.duckduckgo.privacy.config.api.HttpsException
 
 @Entity(tableName = "https_exceptions")
 data class HttpsExceptionEntity(
     @PrimaryKey val domain: String,
     val reason: String
 )
+
+fun HttpsExceptionEntity.toHttpsException(): HttpsException {
+    return HttpsException(domain = this.domain, reason = this.reason)
+}
 
 @Entity(tableName = "gpc_exceptions")
 data class GpcExceptionEntity(

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -21,6 +21,12 @@ import androidx.room.PrimaryKey
 import com.duckduckgo.privacy.config.api.ContentBlockingException
 import com.duckduckgo.privacy.config.api.GpcException
 
+@Entity(tableName = "https_exceptions")
+data class HttpsExceptionEntity(
+    @PrimaryKey val domain: String,
+    val reason: String
+)
+
 @Entity(tableName = "gpc_exceptions")
 data class GpcExceptionEntity(
     @PrimaryKey val domain: String

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsDao.kt
@@ -16,4 +16,31 @@
 
 package com.duckduckgo.privacy.config.store.features.https
 
-interface HttpsDao
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
+
+@Dao
+abstract class HttpsDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertAll(domains: List<HttpsExceptionEntity>)
+
+    @Transaction
+    open fun updateAll(domains: List<HttpsExceptionEntity>) {
+        deleteAll()
+        insertAll(domains)
+    }
+
+    @Query("select * from https_exceptions where domain = :domain")
+    abstract fun get(domain: String): HttpsExceptionEntity
+
+    @Query("select * from https_exceptions")
+    abstract fun getAll(): List<HttpsExceptionEntity>
+
+    @Query("delete from https_exceptions")
+    abstract fun deleteAll()
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsDao.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.https
+
+interface HttpsDao

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
@@ -17,24 +17,23 @@
 package com.duckduckgo.privacy.config.store.features.https
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.privacy.config.api.GpcException
-import com.duckduckgo.privacy.config.store.GpcExceptionEntity
+import com.duckduckgo.privacy.config.api.HttpsException
 import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
-import com.duckduckgo.privacy.config.store.toGpcException
+import com.duckduckgo.privacy.config.store.toHttpsException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 interface HttpsRepository {
     fun updateAll(exceptions: List<HttpsExceptionEntity>)
-    val exceptions: ArrayList<GpcException>
+    val exceptions: ArrayList<HttpsException>
 }
 
-class RealGpcRepository(private val gpcDataStore: GpcDataStore, val database: PrivacyConfigDatabase, coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider) :
-    GpcRepository {
+class RealHttpsRepository(val database: PrivacyConfigDatabase, coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider) :
+    HttpsRepository {
 
-    private val gpcDao: GpcDao = database.gpcDao()
-    override val exceptions = ArrayList<GpcException>()
+    private val httpsDao: HttpsDao = database.httpsDao()
+    override val exceptions = ArrayList<HttpsException>()
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
@@ -42,25 +41,15 @@ class RealGpcRepository(private val gpcDataStore: GpcDataStore, val database: Pr
         }
     }
 
-    override fun updateAll(exceptions: List<GpcExceptionEntity>) {
-        gpcDao.updateAll(exceptions)
+    override fun updateAll(exceptions: List<HttpsExceptionEntity>) {
+        httpsDao.updateAll(exceptions)
         loadToMemory()
     }
 
-    override fun enableGpc() {
-        gpcDataStore.gpcEnabled = true
-    }
-
-    override fun disableGpc() {
-        gpcDataStore.gpcEnabled = false
-    }
-
-    override fun isGpcEnabled(): Boolean = gpcDataStore.gpcEnabled
-
     private fun loadToMemory() {
         exceptions.clear()
-        gpcDao.getAll().map {
-            exceptions.add(it.toGpcException())
+        httpsDao.getAll().map {
+            exceptions.add(it.toHttpsException())
         }
     }
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.https
+
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.privacy.config.api.GpcException
+import com.duckduckgo.privacy.config.store.GpcExceptionEntity
+import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
+import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
+import com.duckduckgo.privacy.config.store.toGpcException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+interface HttpsRepository {
+    fun updateAll(exceptions: List<HttpsExceptionEntity>)
+    val exceptions: ArrayList<GpcException>
+}
+
+class RealGpcRepository(private val gpcDataStore: GpcDataStore, val database: PrivacyConfigDatabase, coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider) :
+    GpcRepository {
+
+    private val gpcDao: GpcDao = database.gpcDao()
+    override val exceptions = ArrayList<GpcException>()
+
+    init {
+        coroutineScope.launch(dispatcherProvider.io()) {
+            loadToMemory()
+        }
+    }
+
+    override fun updateAll(exceptions: List<GpcExceptionEntity>) {
+        gpcDao.updateAll(exceptions)
+        loadToMemory()
+    }
+
+    override fun enableGpc() {
+        gpcDataStore.gpcEnabled = true
+    }
+
+    override fun disableGpc() {
+        gpcDataStore.gpcEnabled = false
+    }
+
+    override fun isGpcEnabled(): Boolean = gpcDataStore.gpcEnabled
+
+    private fun loadToMemory() {
+        exceptions.clear()
+        gpcDao.getAll().map {
+            exceptions.add(it.toGpcException())
+        }
+    }
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryDao.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+
+@Dao
+abstract class UnprotectedTemporaryDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertAll(domains: List<UnprotectedTemporaryEntity>)
+
+    @Transaction
+    open fun updateAll(domains: List<UnprotectedTemporaryEntity>) {
+        deleteAll()
+        insertAll(domains)
+    }
+
+    @Query("select * from unprotected_temporary where domain = :domain")
+    abstract fun get(domain: String): UnprotectedTemporaryEntity
+
+    @Query("select * from unprotected_temporary")
+    abstract fun getAll(): List<UnprotectedTemporaryEntity>
+
+    @Query("delete from unprotected_temporary")
+    abstract fun deleteAll()
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
+
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
+
+interface UnprotectedTemporaryRepository {
+    fun updateAll(exceptions: List<UnprotectedTemporaryEntity>)
+    val exceptions: CopyOnWriteArrayList<UnprotectedTemporaryEntity>
+}
+
+class RealUnprotectedTemporaryRepository(val database: PrivacyConfigDatabase, coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider) :
+    UnprotectedTemporaryRepository {
+
+    private val unprotectedTemporaryDao: UnprotectedTemporaryDao = database.unprotectedTemporaryDao()
+    override val exceptions = CopyOnWriteArrayList<UnprotectedTemporaryEntity>()
+
+    init {
+        coroutineScope.launch(dispatcherProvider.io()) {
+            loadToMemory()
+        }
+    }
+
+    override fun updateAll(exceptions: List<UnprotectedTemporaryEntity>) {
+        unprotectedTemporaryDao.updateAll(exceptions)
+        loadToMemory()
+    }
+
+    private fun loadToMemory() {
+        exceptions.clear()
+        unprotectedTemporaryDao.getAll().map {
+            exceptions.add(it)
+        }
+    }
+}

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/https/RealHttpsRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/https/RealHttpsRepositoryTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.https
+
+import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
+import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
+import com.duckduckgo.privacy.config.store.PrivacyStoreCoroutineTestRule
+import com.duckduckgo.privacy.config.store.runBlocking
+import com.duckduckgo.privacy.config.store.toHttpsException
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.reset
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+
+class RealHttpsRepositoryTest {
+
+    @get:Rule
+    var coroutineRule = PrivacyStoreCoroutineTestRule()
+
+    lateinit var testee: RealHttpsRepository
+
+    private val mockDatabase: PrivacyConfigDatabase = mock()
+    private val mockHttpsDao: HttpsDao = mock()
+
+    @Before
+    fun before() {
+        whenever(mockDatabase.httpsDao()).thenReturn(mockHttpsDao)
+        testee = RealHttpsRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+    }
+
+    @Test
+    fun whenRepositoryIsCreatedThenExceptionsLoadedIntoMemory() {
+        givenHttpsDaoContainsExceptions()
+
+        testee = RealHttpsRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+
+        assertEquals(httpException.toHttpsException(), testee.exceptions.first())
+    }
+
+    @Test
+    fun whenUpdateAllThenUpdateAllCalled() = coroutineRule.runBlocking {
+        testee = RealHttpsRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+
+        testee.updateAll(listOf())
+
+        verify(mockHttpsDao).updateAll(ArgumentMatchers.anyList())
+    }
+
+    @Test
+    fun whenUpdateAllThenPreviousExceptionsAreCleared() = coroutineRule.runBlocking {
+        givenHttpsDaoContainsExceptions()
+        testee = RealHttpsRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+        assertEquals(1, testee.exceptions.size)
+        reset(mockHttpsDao)
+
+        testee.updateAll(listOf())
+
+        assertEquals(0, testee.exceptions.size)
+    }
+
+    private fun givenHttpsDaoContainsExceptions() {
+        whenever(mockHttpsDao.getAll()).thenReturn(listOf(httpException))
+    }
+
+    companion object {
+        val httpException = HttpsExceptionEntity("example.com", "reason")
+    }
+}

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
+
+import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
+import com.duckduckgo.privacy.config.store.PrivacyStoreCoroutineTestRule
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+import com.duckduckgo.privacy.config.store.runBlocking
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.reset
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+
+class RealUnprotectedTemporaryRepositoryTest {
+
+    @get:Rule
+    var coroutineRule = PrivacyStoreCoroutineTestRule()
+
+    lateinit var testee: RealUnprotectedTemporaryRepository
+
+    private val mockDatabase: PrivacyConfigDatabase = mock()
+    private val mockUnprotectedTemporaryDao: UnprotectedTemporaryDao = mock()
+
+    @Before
+    fun before() {
+        whenever(mockDatabase.unprotectedTemporaryDao()).thenReturn(mockUnprotectedTemporaryDao)
+        testee = RealUnprotectedTemporaryRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+    }
+
+    @Test
+    fun whenRepositoryIsCreatedThenExceptionsLoadedIntoMemory() {
+        givenUnprotectedTemporaryDaoContainsExceptions()
+
+        testee = RealUnprotectedTemporaryRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+
+        assertEquals(unprotectedTemporaryException, testee.exceptions.first())
+    }
+
+    @Test
+    fun whenUpdateAllThenUpdateAllCalled() = coroutineRule.runBlocking {
+        testee = RealUnprotectedTemporaryRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+
+        testee.updateAll(listOf())
+
+        verify(mockUnprotectedTemporaryDao).updateAll(ArgumentMatchers.anyList())
+    }
+
+    @Test
+    fun whenUpdateAllThenPreviousExceptionsAreCleared() = coroutineRule.runBlocking {
+        givenUnprotectedTemporaryDaoContainsExceptions()
+        testee = RealUnprotectedTemporaryRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+        assertEquals(1, testee.exceptions.size)
+        reset(mockUnprotectedTemporaryDao)
+
+        testee.updateAll(listOf())
+
+        assertEquals(0, testee.exceptions.size)
+    }
+
+    private fun givenUnprotectedTemporaryDaoContainsExceptions() {
+        whenever(mockUnprotectedTemporaryDao.getAll()).thenReturn(listOf(unprotectedTemporaryException))
+    }
+
+    companion object {
+        val unprotectedTemporaryException = UnprotectedTemporaryEntity("example.com", "reason")
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1200856548100506

### Description
This PR adds the https remote feature. It doesn't move out of the app module anything related with smarted encryption and just parses the new remote config which is then used by the `HttpsUpgrader`

### Steps to test this PR

_Config parsed correctly and working as expected_
1. Install and launch the app from this branch.
1. Check the `toggles` table in the `privacy_config` database.
1. The https toggle should be enabled.
1. Filter the logcat by `upgradable`
1. Go to `http://quora.com`
1. In the logcat you should see `quora.com is upgradable`
1. In the `toggles` table in the `privacy_config` database, change the `https` toggle to `0`.
1. Go to `http://quora.com`
1. In the logcat you should see `https is disabled in the remote config and so quora.com is not upgradable`

_Exceptions_
1. In the PR task, you will find a `privacy-config.json` file to be used during these tests.
1. Using Charles, map the call to `/trackerblocking/config/v1/android-config.json` with the json file from the task.
1. Re-install and launch the app
1. Go to `http://quora.com`
1. In the logcat you should see `quora.com is in the remote exception list and so not upgradable`
