### PR TITLE
Remote Config (VI): Unprotected Temporary

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -124,6 +124,7 @@ import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER_VALUE
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.nhaarman.mockitokotlin2.*
 import com.nhaarman.mockitokotlin2.any
@@ -290,6 +291,9 @@ class BrowserTabViewModelTest {
     @Mock
     private lateinit var mockGpcRepository: GpcRepository
 
+    @Mock
+    private lateinit var mockUnprotectedTemporary: UnprotectedTemporary
+
     private val lazyFaviconManager = Lazy { mockFaviconManager }
 
     private lateinit var mockAutoCompleteApi: AutoCompleteApi
@@ -426,7 +430,7 @@ class BrowserTabViewModelTest {
             navigationAwareLoginDetector = mockNavigationAwareLoginDetector,
             userEventsStore = mockUserEventsStore,
             fileDownloader = mockFileDownloader,
-            gpc = RealGpc(context, mockFeatureToggle, mockGpcRepository),
+            gpc = RealGpc(context, mockFeatureToggle, mockGpcRepository, mockUnprotectedTemporary),
             fireproofDialogsEventHandler = fireproofDialogsEventHandler,
             emailManager = mockEmailManager,
             favoritesRepository = mockFavoritesRepository,

--- a/common/src/main/java/com/duckduckgo/app/global/plugins/migrations/MigrationPlugin.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/plugins/migrations/MigrationPlugin.kt
@@ -29,7 +29,7 @@ interface MigrationPlugin {
 class MigrationPluginPoint @Inject constructor(
     private val injectorPlugins: Set<@JvmSuppressWildcards MigrationPlugin>
 ) : PluginPoint<MigrationPlugin> {
-    override fun getPlugins(): List<MigrationPlugin> {
-        return injectorPlugins.toList()
+    override fun getPlugins(): Collection<MigrationPlugin> {
+        return injectorPlugins
     }
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.privacy.config.store.PrivacyConfig
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -39,6 +40,7 @@ interface PrivacyConfigPersister {
 class RealPrivacyConfigPersister @Inject constructor(
     private val privacyFeaturePluginPoint: PluginPoint<PrivacyFeaturePlugin>,
     private val privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository,
+    private val unprotectedTemporaryRepository: UnprotectedTemporaryRepository,
     private val privacyConfigRepository: PrivacyConfigRepository,
     private val database: PrivacyConfigDatabase
 ) : PrivacyConfigPersister {
@@ -52,6 +54,7 @@ class RealPrivacyConfigPersister @Inject constructor(
             database.runInTransaction {
                 privacyFeatureTogglesRepository.deleteAll()
                 privacyConfigRepository.insert(PrivacyConfig(version = jsonPrivacyConfig.version, readme = jsonPrivacyConfig.readme))
+                unprotectedTemporaryRepository.updateAll(jsonPrivacyConfig.unprotectedTemporary)
                 jsonPrivacyConfig.features.forEach { feature ->
                     privacyFeaturePluginPoint.getPlugins().forEach { plugin ->
                         plugin.store(feature.key, feature.value)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
@@ -40,6 +40,8 @@ import com.duckduckgo.privacy.config.store.features.gpc.GpcSharedPreferences
 import com.duckduckgo.privacy.config.store.features.gpc.RealGpcRepository
 import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
 import com.duckduckgo.privacy.config.store.features.https.RealHttpsRepository
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.RealUnprotectedTemporaryRepository
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.moshi.Moshi
 import dagger.Module
@@ -126,6 +128,12 @@ class DatabaseModule {
     @Provides
     fun provideHttpsRepository(database: PrivacyConfigDatabase, @AppCoroutineScope coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider): HttpsRepository {
         return RealHttpsRepository(database, coroutineScope, dispatcherProvider)
+    }
+
+    @Singleton
+    @Provides
+    fun provideUnprotectedTemporaryRepository(database: PrivacyConfigDatabase, @AppCoroutineScope coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider): UnprotectedTemporaryRepository {
+        return RealUnprotectedTemporaryRepository(database, coroutineScope, dispatcherProvider)
     }
 
     @Singleton

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlocking.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlocking.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.di.scopes.AppObjectGraph
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -28,11 +29,11 @@ import javax.inject.Singleton
 
 @ContributesBinding(AppObjectGraph::class)
 @Singleton
-class RealContentBlocking @Inject constructor(private val contentBlockingRepository: ContentBlockingRepository, private val featureToggle: FeatureToggle) : ContentBlocking {
+class RealContentBlocking @Inject constructor(private val contentBlockingRepository: ContentBlockingRepository, private val featureToggle: FeatureToggle, private val unprotectedTemporary: UnprotectedTemporary) : ContentBlocking {
 
     override fun isAnException(url: String): Boolean {
         return if (featureToggle.isFeatureEnabled(PrivacyFeatureName.ContentBlockingFeatureName(), true) == true) {
-            matches(url)
+            unprotectedTemporary.isAnException(url) || matches(url)
         } else {
             false
         }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.R
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -30,7 +31,7 @@ import javax.inject.Singleton
 
 @ContributesBinding(AppObjectGraph::class)
 @Singleton
-class RealGpc @Inject constructor(context: Context, private val featureToggle: FeatureToggle, val gpcRepository: GpcRepository) : Gpc {
+class RealGpc @Inject constructor(context: Context, private val featureToggle: FeatureToggle, val gpcRepository: GpcRepository, private val unprotectedTemporary: UnprotectedTemporary) : Gpc {
 
     private val gpcJsFunctions: String = context.resources.openRawResource(R.raw.gpc).bufferedReader().use { it.readText() }
 
@@ -79,7 +80,7 @@ class RealGpc @Inject constructor(context: Context, private val featureToggle: F
     }
 
     private fun isAnException(url: String): Boolean {
-        return matches(url)
+        return matches(url) || unprotectedTemporary.isAnException(url)
     }
 
     private fun matches(url: String): Boolean {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/UnprotectedTemporary.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/UnprotectedTemporary.kt
@@ -14,26 +14,28 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.privacy.config.impl.features.https
+package com.duckduckgo.privacy.config.impl.features.unprotectedtemporary
 
-import com.duckduckgo.app.global.UriString.Companion.sameOrSubdomain
+import com.duckduckgo.app.global.UriString
 import com.duckduckgo.di.scopes.AppObjectGraph
-import com.duckduckgo.privacy.config.api.Https
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
-import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import javax.inject.Singleton
 
+interface UnprotectedTemporary {
+    fun isAnException(url: String): Boolean
+}
+
 @ContributesBinding(AppObjectGraph::class)
 @Singleton
-class RealHttps @Inject constructor(private val httpsRepository: HttpsRepository, private val unprotectedTemporary: UnprotectedTemporary) : Https {
+class RealUnprotectedTemporary @Inject constructor(private val unprotectedTemporaryRepository: UnprotectedTemporaryRepository) : UnprotectedTemporary {
 
     override fun isAnException(url: String): Boolean {
-        return unprotectedTemporary.isAnException(url) || matches(url)
+        return matches(url)
     }
 
     private fun matches(url: String): Boolean {
-        return httpsRepository.exceptions.any { sameOrSubdomain(url, it.domain) }
+        return unprotectedTemporaryRepository.exceptions.any { UriString.sameOrSubdomain(url, it.domain) }
     }
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/models/JsonPrivacyConfig.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/models/JsonPrivacyConfig.kt
@@ -16,10 +16,12 @@
 
 package com.duckduckgo.privacy.config.impl.models
 
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import org.json.JSONObject
 
 data class JsonPrivacyConfig(
     val version: Long,
     val readme: String,
-    val features: Map<String, JSONObject?>
+    val features: Map<String, JSONObject?>,
+    val unprotectedTemporary: List<UnprotectedTemporaryEntity>
 )

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.privacy.config.impl
 
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.impl.network.PrivacyConfigService
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -70,12 +71,13 @@ class RealPrivacyConfigDownloaderTest {
 
     class TestPrivacyConfigService : PrivacyConfigService {
         override suspend fun privacyConfig(): JsonPrivacyConfig {
-            return JsonPrivacyConfig(version = 1, readme = "readme", features = mapOf(FEATURE_NAME to JSONObject(FEATURE_JSON)))
+            return JsonPrivacyConfig(version = 1, readme = "readme", features = mapOf(FEATURE_NAME to JSONObject(FEATURE_JSON)), unprotectedTemporaryList)
         }
     }
 
     companion object {
         private const val FEATURE_NAME = "test"
         private const val FEATURE_JSON = "{\"state\": \"enabled\"}"
+        val unprotectedTemporaryList = listOf(UnprotectedTemporaryEntity("example.com", "reason"))
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.privacy.config.impl.features.contentblocking
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.ContentBlockingException
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingRepository
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -34,13 +35,14 @@ class RealContentBlockingTest {
     lateinit var testee: RealContentBlocking
 
     private val mockContentBlockingRepository: ContentBlockingRepository = mock()
+    private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
     private val mockFeatureToggle: FeatureToggle = mock()
 
     @Before
     fun before() {
         givenFeatureIsEnabled()
 
-        testee = RealContentBlocking(mockContentBlockingRepository, mockFeatureToggle)
+        testee = RealContentBlocking(mockContentBlockingRepository, mockFeatureToggle, mockUnprotectedTemporary)
     }
 
     @Test
@@ -62,6 +64,15 @@ class RealContentBlockingTest {
         whenever(mockContentBlockingRepository.exceptions).thenReturn(arrayListOf())
 
         assertFalse(testee.isAnException("http://test.example.com"))
+    }
+
+    @Test
+    fun whenIsAnExceptionAndDomainIsInTheUnprotectedTemporaryListThenReturnTrue() {
+        val url = "http://test.example.com"
+        whenever(mockUnprotectedTemporary.isAnException(url)).thenReturn(true)
+        whenever(mockContentBlockingRepository.exceptions).thenReturn(arrayListOf())
+
+        assertTrue(testee.isAnException(url))
     }
 
     @Test

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.R
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER_VALUE
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
@@ -40,6 +41,7 @@ import java.io.ByteArrayInputStream
 class RealGpcTest {
     private val mockGpcRepository: GpcRepository = mock()
     private val mockFeatureToggle: FeatureToggle = mock()
+    private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
     private val mockContext: Context = mock()
     private val mockResources: Resources = mock()
     lateinit var testee: RealGpc
@@ -50,7 +52,7 @@ class RealGpcTest {
         whenever(mockResources.openRawResource(any())).thenReturn(ByteArrayInputStream("".toByteArray()))
         whenever(mockGpcRepository.exceptions).thenReturn(arrayListOf(GpcException(EXCEPTION_URL)))
 
-        testee = RealGpc(mockContext, mockFeatureToggle, mockGpcRepository)
+        testee = RealGpc(mockContext, mockFeatureToggle, mockGpcRepository, mockUnprotectedTemporary)
     }
 
     @Test
@@ -190,6 +192,14 @@ class RealGpcTest {
         givenFeatureIsNotEnabledButGpcIsEnabled()
 
         assertFalse(testee.canGpcBeUsedByUrl("test.com"))
+    }
+
+    @Test
+    fun whenCanGpcBeUsedByUrlIfFeatureAndGpcAreEnabledAnUrlIsInUnprotectedTemporaryThenReturnFalse() {
+        givenFeatureAndGpcAreEnabled()
+        whenever(mockUnprotectedTemporary.isAnException(VALID_CONSUMER_URL)).thenReturn(true)
+
+        assertFalse(testee.canGpcBeUsedByUrl(VALID_CONSUMER_URL))
     }
 
     private fun givenFeatureAndGpcAreEnabled() {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.privacy.config.impl.features.https
+package com.duckduckgo.privacy.config.impl.features.unprotectedtemporary
 
-import com.duckduckgo.privacy.config.api.HttpsException
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
-import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.*
@@ -28,14 +27,13 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class RealHttpsTest {
-    private val mockHttpsRepository: HttpsRepository = mock()
-    private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
-    lateinit var testee: RealHttps
+class RealUnprotectedTemporaryTest {
+    private val mockUnprotectedTemporaryRepository: UnprotectedTemporaryRepository = mock()
+    lateinit var testee: RealUnprotectedTemporary
 
     @Before
     fun before() {
-        testee = RealHttps(mockHttpsRepository, mockUnprotectedTemporary)
+        testee = RealUnprotectedTemporary(mockUnprotectedTemporaryRepository)
     }
 
     @Test
@@ -54,24 +52,15 @@ class RealHttpsTest {
 
     @Test
     fun whenIsAnExceptionAndDomainIsNotListedInTheExceptionsListThenReturnFalse() {
-        whenever(mockHttpsRepository.exceptions).thenReturn(arrayListOf())
+        whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(arrayListOf())
 
         assertFalse(testee.isAnException("http://test.example.com"))
     }
 
-    @Test
-    fun whenIsAnExceptionAndDomainIsListedInTheUnprotectedTemporaryListThenReturnTrue() {
-        val url = "http://example.com"
-        whenever(mockUnprotectedTemporary.isAnException(url)).thenReturn(true)
-        whenever(mockHttpsRepository.exceptions).thenReturn(arrayListOf())
-
-        assertTrue(testee.isAnException(url))
-    }
-
     private fun givenThereAreExceptions() {
-        whenever(mockHttpsRepository.exceptions).thenReturn(
+        whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(
             arrayListOf(
-                HttpsException("example.com", "my reason here")
+                UnprotectedTemporaryEntity("example.com", "my reason here")
             )
         )
     }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
@@ -25,6 +25,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CopyOnWriteArrayList
 
 @RunWith(RobolectricTestRunner::class)
 class RealUnprotectedTemporaryTest {
@@ -52,16 +53,16 @@ class RealUnprotectedTemporaryTest {
 
     @Test
     fun whenIsAnExceptionAndDomainIsNotListedInTheExceptionsListThenReturnFalse() {
-        whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(arrayListOf())
+        val exceptions = CopyOnWriteArrayList<UnprotectedTemporaryEntity>()
+        whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptions)
 
         assertFalse(testee.isAnException("http://test.example.com"))
     }
 
     private fun givenThereAreExceptions() {
-        whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(
-            arrayListOf(
-                UnprotectedTemporaryEntity("example.com", "my reason here")
-            )
-        )
+        val exceptions = CopyOnWriteArrayList<UnprotectedTemporaryEntity>()
+        exceptions.add(UnprotectedTemporaryEntity("example.com", "my reason here"))
+
+        whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptions)
     }
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
@@ -21,10 +21,12 @@ import androidx.room.RoomDatabase
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingDao
 import com.duckduckgo.privacy.config.store.features.gpc.GpcDao
 import com.duckduckgo.privacy.config.store.features.https.HttpsDao
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryDao
 
 @Database(
     exportSchema = true, version = 1,
     entities = [
+        UnprotectedTemporaryEntity::class,
         HttpsExceptionEntity::class,
         GpcExceptionEntity::class,
         ContentBlockingExceptionEntity::class,
@@ -33,6 +35,7 @@ import com.duckduckgo.privacy.config.store.features.https.HttpsDao
     ]
 )
 abstract class PrivacyConfigDatabase : RoomDatabase() {
+    abstract fun unprotectedTemporaryDao(): UnprotectedTemporaryDao
     abstract fun httpsDao(): HttpsDao
     abstract fun gpcDao(): GpcDao
     abstract fun contentBlockingDao(): ContentBlockingDao

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -22,6 +22,12 @@ import com.duckduckgo.privacy.config.api.ContentBlockingException
 import com.duckduckgo.privacy.config.api.GpcException
 import com.duckduckgo.privacy.config.api.HttpsException
 
+@Entity(tableName = "unprotected_temporary")
+data class UnprotectedTemporaryEntity(
+    @PrimaryKey val domain: String,
+    val reason: String
+)
+
 @Entity(tableName = "https_exceptions")
 data class HttpsExceptionEntity(
     @PrimaryKey val domain: String,

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryDao.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+
+@Dao
+abstract class UnprotectedTemporaryDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertAll(domains: List<UnprotectedTemporaryEntity>)
+
+    @Transaction
+    open fun updateAll(domains: List<UnprotectedTemporaryEntity>) {
+        deleteAll()
+        insertAll(domains)
+    }
+
+    @Query("select * from unprotected_temporary where domain = :domain")
+    abstract fun get(domain: String): UnprotectedTemporaryEntity
+
+    @Query("select * from unprotected_temporary")
+    abstract fun getAll(): List<UnprotectedTemporaryEntity>
+
+    @Query("delete from unprotected_temporary")
+    abstract fun deleteAll()
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
+
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+interface UnprotectedTemporaryRepository {
+    fun updateAll(exceptions: List<UnprotectedTemporaryEntity>)
+    val exceptions: ArrayList<UnprotectedTemporaryEntity>
+}
+
+class RealUnprotectedTemporaryRepository(val database: PrivacyConfigDatabase, coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider) :
+    UnprotectedTemporaryRepository {
+
+    private val unprotectedTemporaryDao: UnprotectedTemporaryDao = database.unprotectedTemporaryDao()
+    override val exceptions = ArrayList<UnprotectedTemporaryEntity>()
+
+    init {
+        coroutineScope.launch(dispatcherProvider.io()) {
+            loadToMemory()
+        }
+    }
+
+    override fun updateAll(exceptions: List<UnprotectedTemporaryEntity>) {
+        unprotectedTemporaryDao.updateAll(exceptions)
+        loadToMemory()
+    }
+
+    private fun loadToMemory() {
+        exceptions.clear()
+        unprotectedTemporaryDao.getAll().map {
+            exceptions.add(it)
+        }
+    }
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
@@ -21,17 +21,18 @@ import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
 
 interface UnprotectedTemporaryRepository {
     fun updateAll(exceptions: List<UnprotectedTemporaryEntity>)
-    val exceptions: ArrayList<UnprotectedTemporaryEntity>
+    val exceptions: CopyOnWriteArrayList<UnprotectedTemporaryEntity>
 }
 
 class RealUnprotectedTemporaryRepository(val database: PrivacyConfigDatabase, coroutineScope: CoroutineScope, dispatcherProvider: DispatcherProvider) :
     UnprotectedTemporaryRepository {
 
     private val unprotectedTemporaryDao: UnprotectedTemporaryDao = database.unprotectedTemporaryDao()
-    override val exceptions = ArrayList<UnprotectedTemporaryEntity>()
+    override val exceptions = CopyOnWriteArrayList<UnprotectedTemporaryEntity>()
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
+
+import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
+import com.duckduckgo.privacy.config.store.PrivacyStoreCoroutineTestRule
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+import com.duckduckgo.privacy.config.store.runBlocking
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.reset
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+
+class RealUnprotectedTemporaryRepositoryTest {
+
+    @get:Rule
+    var coroutineRule = PrivacyStoreCoroutineTestRule()
+
+    lateinit var testee: RealUnprotectedTemporaryRepository
+
+    private val mockDatabase: PrivacyConfigDatabase = mock()
+    private val mockUnprotectedTemporaryDao: UnprotectedTemporaryDao = mock()
+
+    @Before
+    fun before() {
+        whenever(mockDatabase.unprotectedTemporaryDao()).thenReturn(mockUnprotectedTemporaryDao)
+        testee = RealUnprotectedTemporaryRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+    }
+
+    @Test
+    fun whenRepositoryIsCreatedThenExceptionsLoadedIntoMemory() {
+        givenUnprotectedTemporaryDaoContainsExceptions()
+
+        testee = RealUnprotectedTemporaryRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+
+        assertEquals(unprotectedTemporaryException, testee.exceptions.first())
+    }
+
+    @Test
+    fun whenUpdateAllThenUpdateAllCalled() = coroutineRule.runBlocking {
+        testee = RealUnprotectedTemporaryRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+
+        testee.updateAll(listOf())
+
+        verify(mockUnprotectedTemporaryDao).updateAll(ArgumentMatchers.anyList())
+    }
+
+    @Test
+    fun whenUpdateAllThenPreviousExceptionsAreCleared() = coroutineRule.runBlocking {
+        givenUnprotectedTemporaryDaoContainsExceptions()
+        testee = RealUnprotectedTemporaryRepository(
+            mockDatabase,
+            TestCoroutineScope(),
+            coroutineRule.testDispatcherProvider
+        )
+        assertEquals(1, testee.exceptions.size)
+        reset(mockUnprotectedTemporaryDao)
+
+        testee.updateAll(listOf())
+
+        assertEquals(0, testee.exceptions.size)
+    }
+
+    private fun givenUnprotectedTemporaryDaoContainsExceptions() {
+        whenever(mockUnprotectedTemporaryDao.getAll()).thenReturn(listOf(unprotectedTemporaryException))
+    }
+
+    companion object {
+        val unprotectedTemporaryException = UnprotectedTemporaryEntity("example.com", "reason")
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1200853087962160

### Description
This PR implements the unprotected temporary list which disables all privacy protections for specific domains to avoid breakages. 

### Steps to test this PR

_Config parsed correctly and unprotected works as expected_
1. In the PR task, you will find a `privacy-config.json` file to be used during these tests.
1. Using Charles, map the call to `/trackerblocking/config/v1/android-config.json` with the json file from the task.
1. Launch the app
1. Go to `global-privacy-control.glitch.me`
1. In the logcat if you filter by `upgradable` you should see `global-privacy-control.glitch.me is in the remote exception list and so not upgradable`
1. Both the header and DOM signals should not be present.
1. Privacy grade icon should be solid black.
1. Click in the privacy grade
1. You should see a message saying that we temporarily disabled Privacy Protection
1. Site Privacy Protection toggle should be disabled (you cannot change the state)
1. It should say unencrypted connection
1. Go to `53.com`
1. In the logcat if you filter by `upgradable` you should see `53.com is in the remote exception list and so not upgradable`
1. Privacy grade icon should be solid black.
1. Click in the privacy grade
1. You should see a message saying that we temporarily disabled Privacy Protection
1. Site Privacy Protection toggle should be disabled (you cannot change the state)
1. It should say encrypted connection (even though https is disabled the website still uses https)
1. Go to `http://quora.com`
1. In the logcat if you filter by `upgradable` you should see `quora.com is in the remote exception list and so not upgradable`
1. Privacy grade icon should be solid black.
1. Click in the privacy grade
1. You should see a message saying that we temporarily disabled Privacy Protection
1. Site Privacy Protection toggle should be disabled (you cannot change the state)
1. It should say encrypted connection (even though https is disabled the website still redirects to https)
