### PR TITLE
Amend email pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3252,6 +3252,26 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenConsumeAliasAndCopyToClipboardThenSetNewLastUsedDateCalled() {
+        whenever(mockEmailManager.getAlias()).thenReturn("alias")
+
+        testee.consumeAliasAndCopyToClipboard()
+
+        verify(mockEmailManager).setNewLastUsedDate()
+    }
+
+    @Test
+    fun whenConsumeAliasAndCopyToClipboardThenPixelSent() {
+        whenever(mockEmailManager.getAlias()).thenReturn("alias")
+        whenever(mockEmailManager.getCohort()).thenReturn("cohort")
+        whenever(mockEmailManager.getLastUsedDate()).thenReturn("2021-01-01")
+
+        testee.consumeAlias()
+
+        verify(mockPixel).enqueueFire(AppPixelName.EMAIL_USE_ALIAS, mapOf(Pixel.PixelParameter.COHORT to "cohort", Pixel.PixelParameter.LAST_USED_DAY to "2021-01-01"))
+    }
+
+    @Test
     fun whenEmailIsSignedOutThenIsEmailSignedInReturnsFalse() = coroutineRule.runBlocking {
         emailStateFlow.emit(false)
 
@@ -3280,10 +3300,20 @@ class BrowserTabViewModelTest {
     fun whenConsumeAliasThenPixelSent() {
         whenever(mockEmailManager.getAlias()).thenReturn("alias")
         whenever(mockEmailManager.getCohort()).thenReturn("cohort")
+        whenever(mockEmailManager.getLastUsedDate()).thenReturn("2021-01-01")
 
         testee.consumeAlias()
 
-        verify(mockPixel).enqueueFire(AppPixelName.EMAIL_USE_ALIAS, mapOf(Pixel.PixelParameter.COHORT to "cohort"))
+        verify(mockPixel).enqueueFire(AppPixelName.EMAIL_USE_ALIAS, mapOf(Pixel.PixelParameter.COHORT to "cohort", Pixel.PixelParameter.LAST_USED_DAY to "2021-01-01"))
+    }
+
+    @Test
+    fun whenConsumeAliasThenSetNewLastUsedDateCalled() {
+        whenever(mockEmailManager.getAlias()).thenReturn("alias")
+
+        testee.consumeAlias()
+
+        verify(mockEmailManager).setNewLastUsedDate()
     }
 
     @Test
@@ -3311,10 +3341,20 @@ class BrowserTabViewModelTest {
     fun whenUseAddressThenPixelSent() {
         whenever(mockEmailManager.getEmailAddress()).thenReturn("address")
         whenever(mockEmailManager.getCohort()).thenReturn("cohort")
+        whenever(mockEmailManager.getLastUsedDate()).thenReturn("2021-01-01")
 
         testee.useAddress()
 
-        verify(mockPixel).enqueueFire(AppPixelName.EMAIL_USE_ADDRESS, mapOf(Pixel.PixelParameter.COHORT to "cohort"))
+        verify(mockPixel).enqueueFire(AppPixelName.EMAIL_USE_ADDRESS, mapOf(Pixel.PixelParameter.COHORT to "cohort", Pixel.PixelParameter.LAST_USED_DAY to "2021-01-01"))
+    }
+
+    @Test
+    fun whenUseAddressThenSetNewLastUsedDateCalled() {
+        whenever(mockEmailManager.getEmailAddress()).thenReturn("address")
+
+        testee.useAddress()
+
+        verify(mockEmailManager).setNewLastUsedDate()
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
@@ -363,6 +363,17 @@ class AppEmailManagerTest {
     }
 
     @Test
+    fun whenGetLastUsedDateIfNullThenReturnEmpty() {
+        assertEquals("", testee.getLastUsedDate())
+    }
+
+    @Test
+    fun whenGetLastUsedDateIfNotNullThenReturnValueFromStore() {
+        whenever(mockEmailDataStore.lastUsedDate).thenReturn("2021-01-01")
+        assertEquals("2021-01-01", testee.getLastUsedDate())
+    }
+
+    @Test
     fun whenIsEmailFeatureSupportedAndEncryptionCannotBeUsedThenReturnFalse() {
         whenever(mockEmailDataStore.canUseEncryption()).thenReturn(false)
 

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/PixelEmailRemovalInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/PixelEmailRemovalInterceptorTest.kt
@@ -21,22 +21,23 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
-class PixelAtbRemovalInterceptorTest {
-    private lateinit var pixelAtbRemovalInterceptor: PixelAtbRemovalInterceptor
+class PixelEmailRemovalInterceptorTest {
+    private lateinit var pixelEmailRemovalInterceptor: PixelEmailRemovalInterceptor
 
     @Before
     fun setup() {
-        pixelAtbRemovalInterceptor = PixelAtbRemovalInterceptor()
+        pixelEmailRemovalInterceptor = PixelEmailRemovalInterceptor()
     }
 
     @Test
     fun whenSendPixelTheRedactAtvInfoFromDefinedPixels() {
         AppPixelName.values().map { it.pixelName }.forEach { pixelName ->
             val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
-            val removalExpected = PixelAtbRemovalInterceptor.pixels.contains(pixelName)
+            val removalExpected = PixelEmailRemovalInterceptor.pixels.contains(pixelName)
 
-            val interceptedUrl = pixelAtbRemovalInterceptor.intercept(FakeChain(pixelUrl)).request.url
+            val interceptedUrl = pixelEmailRemovalInterceptor.intercept(FakeChain(pixelUrl)).request.url
             assertEquals(removalExpected, interceptedUrl.queryParameter("atb") == null)
+            assertEquals(removalExpected, interceptedUrl.queryParameter("appVersion") == null)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2030,20 +2030,42 @@ class BrowserTabViewModel(
     fun consumeAliasAndCopyToClipboard() {
         emailManager.getAlias()?.let {
             command.value = CopyAliasToClipboard(it)
+            pixel.enqueueFire(
+                AppPixelName.EMAIL_COPIED_TO_CLIPBOARD,
+                mapOf(
+                    PixelParameter.COHORT to emailManager.getCohort(),
+                    PixelParameter.LAST_USED_DAY to emailManager.getLastUsedDate()
+                )
+            )
+            emailManager.setNewLastUsedDate()
         }
     }
 
     fun consumeAlias() {
         emailManager.getAlias()?.let {
             command.postValue(InjectEmailAddress(it))
-            pixel.enqueueFire(AppPixelName.EMAIL_USE_ALIAS, mapOf(PixelParameter.COHORT to emailManager.getCohort()))
+            pixel.enqueueFire(
+                AppPixelName.EMAIL_USE_ALIAS,
+                mapOf(
+                    PixelParameter.COHORT to emailManager.getCohort(),
+                    PixelParameter.LAST_USED_DAY to emailManager.getLastUsedDate()
+                )
+            )
+            emailManager.setNewLastUsedDate()
         }
     }
 
     fun useAddress() {
         emailManager.getEmailAddress()?.let {
             command.postValue(InjectEmailAddress(it))
-            pixel.enqueueFire(AppPixelName.EMAIL_USE_ADDRESS, mapOf(PixelParameter.COHORT to emailManager.getCohort()))
+            pixel.enqueueFire(
+                AppPixelName.EMAIL_USE_ADDRESS,
+                mapOf(
+                    PixelParameter.COHORT to emailManager.getCohort(),
+                    PixelParameter.LAST_USED_DAY to emailManager.getLastUsedDate()
+                )
+            )
+            emailManager.setNewLastUsedDate()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
@@ -83,12 +83,12 @@ class NetworkModule {
     fun pixelOkHttpClient(
         apiRequestInterceptor: ApiRequestInterceptor,
         pixelReQueryInterceptor: PixelReQueryInterceptor,
-        pixelAtbRemovalInterceptor: PixelAtbRemovalInterceptor
+        pixelEmailRemovalInterceptor: PixelEmailRemovalInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(apiRequestInterceptor)
             .addInterceptor(pixelReQueryInterceptor)
-            .addInterceptor(pixelAtbRemovalInterceptor)
+            .addInterceptor(pixelEmailRemovalInterceptor)
             // shall be the last one as it is logging the pixel request url that goes out
             .addInterceptor { chain: Interceptor.Chain ->
                 Timber.v("Pixel url request: ${chain.request().url}")
@@ -136,8 +136,8 @@ class NetworkModule {
     }
 
     @Provides
-    fun pixelAtbRemovalInterceptor(): PixelAtbRemovalInterceptor {
-        return PixelAtbRemovalInterceptor()
+    fun pixelEmailRemovalInterceptor(): PixelEmailRemovalInterceptor {
+        return PixelEmailRemovalInterceptor()
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
@@ -27,6 +27,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 interface EmailManager : LifecycleObserver {
     fun signedInFlow(): StateFlow<Boolean>
@@ -43,6 +47,8 @@ interface EmailManager : LifecycleObserver {
     fun notifyOnJoinedWaitlist()
     fun getCohort(): String
     fun isEmailFeatureSupported(): Boolean
+    fun getLastUsedDate(): String
+    fun setNewLastUsedDate()
 }
 
 class AppEmailManager(
@@ -138,6 +144,16 @@ class AppEmailManager(
     }
 
     override fun isEmailFeatureSupported(): Boolean = emailDataStore.canUseEncryption()
+
+    override fun getLastUsedDate(): String = emailDataStore.lastUsedDate.orEmpty()
+
+    override fun setNewLastUsedDate() {
+        val formatter: SimpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("US/Eastern")
+        }
+        val date = formatter.format(Date())
+        emailDataStore.lastUsedDate = date
+    }
 
     private fun consumeAlias(): String? {
         val alias = nextAliasFlow.value

--- a/app/src/main/java/com/duckduckgo/app/email/db/EmailDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/db/EmailDataStore.kt
@@ -41,6 +41,7 @@ interface EmailDataStore {
     var waitlistToken: String?
     var sendNotification: Boolean
     var cohort: String?
+    var lastUsedDate: String?
     fun nextAliasFlow(): StateFlow<String?>
     fun canUseEncryption(): Boolean
 }
@@ -150,6 +151,15 @@ class EmailEncryptedSharedPreferences(
             }
         }
 
+    override var lastUsedDate: String?
+        get() = encryptedPreferences?.getString(KEY_LAST_USED_DATE, null)
+        set(value) {
+            encryptedPreferences?.edit(commit = true) {
+                if (value == null) remove(KEY_LAST_USED_DATE)
+                else putString(KEY_LAST_USED_DATE, value)
+            }
+        }
+
     override fun canUseEncryption(): Boolean = encryptedPreferences != null
 
     companion object {
@@ -162,5 +172,6 @@ class EmailEncryptedSharedPreferences(
         const val KEY_INVITE_CODE = "KEY_INVITE_CODE"
         const val KEY_SEND_NOTIFICATION = "KEY_SEND_NOTIFICATION"
         const val KEY_COHORT = "KEY_COHORT"
+        const val KEY_LAST_USED_DATE = "KEY_LAST_USED_DATE"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelEmailRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelEmailRemovalInterceptor.kt
@@ -19,15 +19,16 @@ package com.duckduckgo.app.global.api
 import androidx.annotation.VisibleForTesting
 import com.duckduckgo.app.global.AppUrl
 import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class PixelAtbRemovalInterceptor : Interceptor {
+class PixelEmailRemovalInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request().newBuilder()
         val pixel = chain.request().url.pathSegments.last()
         val url = if (pixels.contains(pixel.substringBefore("_android_"))) {
-            chain.request().url.newBuilder().removeAllQueryParameters(AppUrl.ParamKey.ATB).build()
+            chain.request().url.newBuilder().removeAllQueryParameters(AppUrl.ParamKey.ATB).removeAllQueryParameters(Pixel.PixelParameter.APP_VERSION).build()
         } else {
             chain.request().url.newBuilder().build()
         }
@@ -36,12 +37,13 @@ class PixelAtbRemovalInterceptor : Interceptor {
     }
 
     companion object {
-        // list of pixels for which we'll remove the ATB information
+        // list of pixels for which we'll remove the ATB and App version information
         @VisibleForTesting
         val pixels = listOf(
             AppPixelName.EMAIL_TOOLTIP_DISMISSED.pixelName,
             AppPixelName.EMAIL_USE_ALIAS.pixelName,
-            AppPixelName.EMAIL_USE_ADDRESS.pixelName
+            AppPixelName.EMAIL_USE_ADDRESS.pixelName,
+            AppPixelName.EMAIL_COPIED_TO_CLIPBOARD.pixelName
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -219,10 +219,10 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     FIRE_ANIMATION_SETTINGS_OPENED("m_fas_o"),
     FIRE_ANIMATION_NEW_SELECTED("m_fas_s"),
 
-    EMAIL_TOOLTIP_DISMISSED("m_e_t_d"),
-    EMAIL_USE_ALIAS("m_e_ua"),
-    EMAIL_USE_ADDRESS("m_e_uad"),
-    EMAIL_COPIED_TO_CLIPBOARD("m_e_cc"),
+    EMAIL_TOOLTIP_DISMISSED("email_tooltip_dismissed"),
+    EMAIL_USE_ALIAS("email_filled_random"),
+    EMAIL_USE_ADDRESS("email_filled_main"),
+    EMAIL_COPIED_TO_CLIPBOARD("email_generated_button"),
 
     BOOKMARK_IMPORT_SUCCESS("m_bi_s"),
     BOOKMARK_IMPORT_ERROR("m_bi_e"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -222,6 +222,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     EMAIL_TOOLTIP_DISMISSED("m_e_t_d"),
     EMAIL_USE_ALIAS("m_e_ua"),
     EMAIL_USE_ADDRESS("m_e_uad"),
+    EMAIL_COPIED_TO_CLIPBOARD("m_e_cc"),
 
     BOOKMARK_IMPORT_SUCCESS("m_bi_s"),
     BOOKMARK_IMPORT_ERROR("m_bi_e"),

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -73,6 +73,7 @@ interface Pixel {
         const val FIRE_EXECUTED = "fe"
         const val BOOKMARK_COUNT = "bco"
         const val COHORT = "cohort"
+        const val LAST_USED_DAY = "duck_address_last_used"
     }
 
     object PixelValues {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1200757676857895

### Description
This PR removes the `appVersion` parameter from the email pixels. Renames the Pixel interceptor to something specific to email since it is only used by email pixels. We have also introduced a new parameter with the date when autofill was used for the last time.

### Steps to test this PR

_Clipboard Pixel_
1. Install the app and sign in using your duck email address.
1. Use Charles to intercept the calls or filter the logcat by `pixel url request`
1. In the overflow menu click on `Create Duck Address`
1. Pixel `email_generated_button` should be sent with the following parameters: `test`, `cohort` and `duck_address_last_used`
1. Note that the `duck_address_last_used` parameter is empty
1. In the overflow menu click on `Create Duck Address`
1. Pixel `email_generated_button` should be sent with the following parameters: `test`, `cohort` and `duck_address_last_used`
1. This time the `duck_address_last_used` should have the current date as value

_Use private address pixel_
1. Without uninstalling the app
1. Use Charles to intercept the calls or filter the logcat by `pixel url request`
1. Go to `github.com` and click on dax in the email field.
1. Click in `Generate a Private Address`
1. Pixel `email_filled_random` should be sent with the following parameters: `test`, `cohort` and `duck_address_last_used`
1. The `duck_address_last_used` should have the current date as value

_Use personal address pixel_
1. Without uninstalling the app
1. Use Charles to intercept the calls or filter the logcat by `pixel url request`
1. Go to `github.com` and click on dax in the email field.
1. Click in `Generate a Private Address`
1. Pixel `email_filled_main` should be sent with the following parameters: `test`, `cohort` and `duck_address_last_used`
1. The `duck_address_last_used` should have the current date as value

_Last used time is stored in ET_
1. Without uninstalling the app
1. Change the date on your phone so ET time will be one day behind. For example, if you are in UTC, change the date to 20th September at 00:20.
1. In the overflow menu click on `Create Duck Address`
1. Pixel `email_generated_button` should be sent with the following parameters: `test`, `cohort` and `duck_address_last_used`
1. The `duck_address_last_used` should have `2021-09-19` as a value