### PR TITLE
Increase clickable area of favorite quick access item

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/favorites/FavoritesQuickAccessAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favorites/FavoritesQuickAccessAdapter.kt
@@ -144,6 +144,7 @@ class FavoritesQuickAccessAdapter(
                 false
             }
             itemView.quickAccessFaviconCard.setOnClickListener { onItemSelected(item) }
+            itemView.quickAccessTitle.setOnClickListener { onItemSelected(item) }
         }
 
         private fun showOverFlowMenu(layoutInflater: LayoutInflater, anchor: View, item: QuickAccessFavorite) {

--- a/app/src/main/java/com/duckduckgo/app/browser/favorites/FavoritesQuickAccessAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favorites/FavoritesQuickAccessAdapter.kt
@@ -101,7 +101,7 @@ class FavoritesQuickAccessAdapter(
 
         @SuppressLint("ClickableViewAccessibility")
         private fun configureTouchListener() {
-            itemView.quickAccessFaviconCard.setOnTouchListener { v, event ->
+            itemView.setOnTouchListener { _, event ->
                 when (event.actionMasked) {
                     MotionEvent.ACTION_MOVE -> {
                         if (itemState != ItemState.LongPress) return@setOnTouchListener false
@@ -137,14 +137,13 @@ class FavoritesQuickAccessAdapter(
         }
 
         private fun configureClickListeners(item: QuickAccessFavorite) {
-            itemView.quickAccessFaviconCard.setOnLongClickListener {
+            itemView.setOnLongClickListener {
                 itemState = ItemState.LongPress
                 scaleUpFavicon()
-                showOverFlowMenu(inflater, it, item)
+                showOverFlowMenu(inflater, itemView.quickAccessFaviconCard, item)
                 false
             }
-            itemView.quickAccessFaviconCard.setOnClickListener { onItemSelected(item) }
-            itemView.quickAccessTitle.setOnClickListener { onItemSelected(item) }
+            itemView.setOnClickListener { onItemSelected(item) }
         }
 
         private fun showOverFlowMenu(layoutInflater: LayoutInflater, anchor: View, item: QuickAccessFavorite) {

--- a/app/src/main/res/layout/view_quick_access_item.xml
+++ b/app/src/main/res/layout/view_quick_access_item.xml
@@ -22,16 +22,15 @@
     android:orientation="vertical"
     android:paddingTop="15dp"
     android:paddingBottom="15dp"
-    android:clipToPadding="false">
+    android:clipToPadding="false"
+    android:clickable="true"
+    android:focusable="true">
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/quickAccessFaviconCard"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:background="?android:attr/selectableItemBackground"
-        android:clickable="true"
-        android:focusable="true"
         android:paddingStart="15dp"
         android:paddingEnd="15dp"
         app:cardBackgroundColor="?attr/colorPrimary"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1200841231124618/f

### Description
This PR increases the clickable area of the favorites quick access item to include the whole item and not just the card.

### Steps to test this PR
1. Add a favorite
2. Open a new tab
3. Test that a favorite is still clickable and long-clickable

### UI changes
| Clickable area before | Clickable area after|
| ------ | ----- |
|![clickable_area_before](https://user-images.githubusercontent.com/3471025/132759311-828817ca-08f9-4b95-b869-be368736d999.jpg)|![clickable_area_after](https://user-images.githubusercontent.com/3471025/132759322-eb489776-9612-4657-9c55-051b9ca3a010.jpg)|
