### PR TITLE
Add fire animation preview to settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -331,6 +331,10 @@
             android:name="com.duckduckgo.app.email.ui.EmailWebViewActivity"
             android:label="@string/emailProtectionWebViewActivityTitle"
             android:parentActivityName="com.duckduckgo.app.email.ui.EmailProtectionActivity" />
+        <activity
+            android:name="com.duckduckgo.app.settings.FireAnimationActivity"
+            android:theme="@style/Theme.AppCompat.Transparent.NoActionBar"
+            android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
 
         <activity
             android:name="com.duckduckgo.app.WidgetThemeConfiguration"

--- a/app/src/main/java/com/duckduckgo/app/di/component/FireAnimationActivityComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/FireAnimationActivityComponent.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.di.component
+
+import com.duckduckgo.app.di.ActivityScoped
+import com.duckduckgo.app.settings.FireAnimationActivity
+import com.duckduckgo.di.scopes.AppObjectGraph
+
+import com.duckduckgo.di.scopes.ActivityObjectGraph
+import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.anvil.annotations.MergeSubcomponent
+import dagger.Binds
+import dagger.Module
+import dagger.Subcomponent
+import dagger.android.AndroidInjector
+import dagger.multibindings.ClassKey
+import dagger.multibindings.IntoMap
+
+@ActivityScoped
+@MergeSubcomponent(
+    scope = ActivityObjectGraph::class
+)
+interface FireAnimationActivityComponent : AndroidInjector<FireAnimationActivity> {
+    @Subcomponent.Factory
+    interface Factory : AndroidInjector.Factory<FireAnimationActivity>
+}
+
+@ContributesTo(AppObjectGraph::class)
+interface FireAnimationActivityComponentProvider {
+    fun provideFireAnimationActivityComponentFactory(): FireAnimationActivityComponent.Factory
+}
+
+@Module
+@ContributesTo(AppObjectGraph::class)
+abstract class FireAnimationActivityBindingModule {
+    @Binds
+    @IntoMap
+    @ClassKey(FireAnimationActivity::class)
+    abstract fun bindFireAnimationActivityComponentFactory(factory: FireAnimationActivityComponent.Factory): AndroidInjector.Factory<*>
+}

--- a/app/src/main/java/com/duckduckgo/app/settings/FireAnimationActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/FireAnimationActivity.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.app.settings.clear.FireAnimation
 import com.duckduckgo.mobile.android.ui.view.setAndPropagateUpFitsSystemWindows
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
-import kotlinx.android.synthetic.main.sheet_fire_clear_data.*
 
 class FireAnimationActivity : DuckDuckGoActivity() {
 
@@ -67,9 +66,9 @@ class FireAnimationActivity : DuckDuckGoActivity() {
 
     private val accelerateAnimatorUpdateListener = object : ValueAnimator.AnimatorUpdateListener {
         override fun onAnimationUpdate(animation: ValueAnimator?) {
-            fireAnimationView.speed += ANIMATION_SPEED_INCREMENT
-            if (fireAnimationView.speed > ANIMATION_MAX_SPEED) {
-                fireAnimationView.removeUpdateListener(this)
+            binding.fireAnimationView.speed += ANIMATION_SPEED_INCREMENT
+            if (binding.fireAnimationView.speed > ANIMATION_MAX_SPEED) {
+                binding.fireAnimationView.removeUpdateListener(this)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/settings/FireAnimationActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/FireAnimationActivity.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.settings
+
+import android.animation.Animator
+import android.animation.ValueAnimator
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import com.airbnb.lottie.LottieAnimationView
+import com.airbnb.lottie.RenderMode
+import com.duckduckgo.app.browser.databinding.ActivityFireAnimationBinding
+import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.app.settings.clear.FireAnimation
+import com.duckduckgo.mobile.android.ui.view.setAndPropagateUpFitsSystemWindows
+import com.duckduckgo.mobile.android.ui.view.show
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import kotlinx.android.synthetic.main.sheet_fire_clear_data.*
+
+class FireAnimationActivity : DuckDuckGoActivity() {
+
+    private val binding: ActivityFireAnimationBinding by viewBinding()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        val fireAnimationSerializable = intent.getSerializableExtra(FIRE_ANIMATION_EXTRA)
+
+        if (fireAnimationSerializable == null) finish()
+
+        configureFireAnimationView(fireAnimationSerializable as FireAnimation, binding.fireAnimationView)
+
+        binding.fireAnimationView.show()
+        binding.fireAnimationView.playAnimation()
+    }
+
+    private fun configureFireAnimationView(fireAnimation: FireAnimation, fireAnimationView: LottieAnimationView) {
+        fireAnimationView.setAnimation(fireAnimation.resId)
+        fireAnimationView.setRenderMode(RenderMode.SOFTWARE)
+        fireAnimationView.enableMergePathsForKitKatAndAbove(true)
+        fireAnimationView.setAndPropagateUpFitsSystemWindows(false)
+        fireAnimationView.addAnimatorUpdateListener(accelerateAnimatorUpdateListener)
+        fireAnimationView.addAnimatorListener(object : Animator.AnimatorListener {
+            override fun onAnimationRepeat(animation: Animator?) {}
+            override fun onAnimationCancel(animation: Animator?) {}
+            override fun onAnimationStart(animation: Animator?) {}
+            override fun onAnimationEnd(animation: Animator?) {
+                finish()
+            }
+        })
+    }
+
+    private val accelerateAnimatorUpdateListener = object : ValueAnimator.AnimatorUpdateListener {
+        override fun onAnimationUpdate(animation: ValueAnimator?) {
+            fireAnimationView.speed += ANIMATION_SPEED_INCREMENT
+            if (fireAnimationView.speed > ANIMATION_MAX_SPEED) {
+                fireAnimationView.removeUpdateListener(this)
+            }
+        }
+    }
+
+    companion object {
+        const val FIRE_ANIMATION_EXTRA = "FIRE_ANIMATION_EXTRA"
+
+        private const val ANIMATION_MAX_SPEED = 1.4f
+        private const val ANIMATION_SPEED_INCREMENT = 0.15f
+
+        fun intent(context: Context, fireAnimation: FireAnimation): Intent {
+            val intent = Intent(context, FireAnimationActivity::class.java)
+            intent.putExtra(FIRE_ANIMATION_EXTRA, fireAnimation)
+            return intent
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsFireAnimationSelectorFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsFireAnimationSelectorFragment.kt
@@ -41,12 +41,27 @@ class SettingsFireAnimationSelectorFragment : DialogFragment() {
 
         updateCurrentSelect(currentOption, rootView.findViewById(R.id.fireAnimationSelectorGroup))
 
+        val radioGroup = rootView.findViewById(R.id.fireAnimationSelectorGroup) as RadioGroup
+
+        radioGroup.setOnCheckedChangeListener { group, _ ->
+            val fireAnimation = when (group.checkedRadioButtonId) {
+                R.id.fireAnimationFire -> HeroFire
+                R.id.fireAnimationWater -> HeroWater
+                R.id.fireAnimationAbstract -> HeroAbstract
+                R.id.fireAnimationDisabled -> None
+                else -> HeroFire
+            }
+
+            if (fireAnimation != None) {
+                startActivity(FireAnimationActivity.intent(requireContext(), fireAnimation))
+            }
+        }
+
         val alertBuilder = AlertDialog.Builder(requireActivity())
             .setView(rootView)
             .setTitle(R.string.settingsSelectFireAnimationDialog)
             .setPositiveButton(R.string.settingsSelectFireAnimationDialogSave) { _, _ ->
                 dialog?.let {
-                    val radioGroup = it.findViewById(R.id.fireAnimationSelectorGroup) as RadioGroup
                     val selectedOption = when (radioGroup.checkedRadioButtonId) {
                         R.id.fireAnimationFire -> HeroFire
                         R.id.fireAnimationWater -> HeroWater
@@ -91,5 +106,4 @@ class SettingsFireAnimationSelectorFragment : DialogFragment() {
             return fragment
         }
     }
-
 }

--- a/app/src/main/res/layout/activity_fire_animation.xml
+++ b/app/src/main/res/layout/activity_fire_animation.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2021 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.airbnb.lottie.LottieAnimationView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/fireAnimationView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:importantForAccessibility="no"
+    android:scaleType="centerCrop"
+    android:visibility="gone"
+    app:lottie_loop="false" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -572,4 +572,12 @@
         <item name="android:backgroundTint">?attr/savedSiteEditTextUnderlineColor</item>
     </style>
 
+    <style name="Theme.AppCompat.Transparent.NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/42792087274227/1200315340580172/f

### Description
This PR adds fire animation previews to the selection dialog in settings.

### Steps to test this PR

1. Go settings and tap "Fire Button animation"
2. Verify that the different options show the corresponding animation when tapped

### UI changes

https://user-images.githubusercontent.com/3471025/132840907-b9dd5ac7-b075-440c-b970-192e2ba4f597.mp4


