### PR TITLE
migrate settings activity to viewbinding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
+import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.statistics.VariantManager
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -65,6 +66,7 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
 
     private fun showOnboarding() {
         startActivity(OnboardingActivity.intent(this))
+        startActivity(SettingsActivity.intent(this))
         finish()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
-import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.statistics.VariantManager
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -66,7 +66,6 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
 
     private fun showOnboarding() {
         startActivity(OnboardingActivity.intent(this))
-        startActivity(SettingsActivity.intent(this))
         finish()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.about.AboutDuckDuckGoActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ActivitySettingsBinding
 import com.duckduckgo.app.email.ui.EmailProtectionActivity
 import com.duckduckgo.app.feedback.ui.common.FeedbackActivity
 import com.duckduckgo.app.fire.fireproofwebsite.ui.FireproofWebsitesActivity
@@ -52,11 +53,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.sendThemeChangedBroadcast
 import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
-import kotlinx.android.synthetic.main.content_settings_general.*
-import kotlinx.android.synthetic.main.content_settings_internal.*
-import kotlinx.android.synthetic.main.content_settings_other.*
-import kotlinx.android.synthetic.main.content_settings_privacy.*
-import kotlinx.android.synthetic.main.include_toolbar.*
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
@@ -69,13 +66,14 @@ class SettingsActivity :
     SettingsThemeSelectorFragment.Listener,
     SettingsFireAnimationSelectorFragment.Listener {
 
+    private val viewModel: SettingsViewModel by bindViewModel()
+    private val binding: ActivitySettingsBinding by viewBinding()
+
     @Inject
     lateinit var pixel: Pixel
 
     @Inject
     lateinit var internalFeaturePlugins: PluginPoint<InternalFeaturePlugin>
-
-    private val viewModel: SettingsViewModel by bindViewModel()
 
     private val defaultBrowserChangeListener = OnCheckedChangeListener { _, isChecked ->
         viewModel.onDefaultBrowserToggled(isChecked)
@@ -85,14 +83,26 @@ class SettingsActivity :
         viewModel.onAutocompleteSettingChanged(isChecked)
     }
 
+    private val viewsGeneral
+        get() = binding.includeSettings.contentSettingsGeneral
+
+    private val viewsPrivacy
+        get() = binding.includeSettings.contentSettingsPrivacy
+
+    private val viewsInternal
+        get() = binding.includeSettings.contentSettingsInternal
+
+    private val viewsOther
+        get() = binding.includeSettings.contentSettingsOther
+
     private val appLinksToggleListener = OnCheckedChangeListener { _, isChecked ->
         viewModel.onAppLinksSettingChanged(isChecked)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_settings)
-        setupToolbar(toolbar)
+        setContentView(binding.root)
+        setupToolbar(binding.includeToolbar.toolbar)
 
         configureUiEventHandlers()
         configureInternalFeatures()
@@ -106,41 +116,49 @@ class SettingsActivity :
     }
 
     private fun configureUiEventHandlers() {
-        changeAppIconLabel.setOnClickListener { viewModel.userRequestedToChangeIcon() }
-        selectedFireAnimationSetting.setOnClickListener { viewModel.userRequestedToChangeFireAnimation() }
-        about.setOnClickListener { startActivity(AboutDuckDuckGoActivity.intent(this)) }
-        provideFeedback.setOnClickListener { viewModel.userRequestedToSendFeedback() }
-        fireproofWebsites.setOnClickListener { viewModel.onFireproofWebsitesClicked() }
-        locationPermissions.setOnClickListener { viewModel.onLocationClicked() }
-        globalPrivacyControlSetting.setOnClickListener { viewModel.onGlobalPrivacyControlClicked() }
+        with(viewsGeneral) {
+            selectedThemeSetting.setOnClickListener { viewModel.userRequestedToChangeTheme() }
+            autocompleteToggle.setOnCheckedChangeListener(autocompleteToggleListener)
+            setAsDefaultBrowserSetting.setOnCheckedChangeListener(defaultBrowserChangeListener)
+            changeAppIconLabel.setOnClickListener { viewModel.userRequestedToChangeIcon() }
+            selectedFireAnimationSetting.setOnClickListener { viewModel.userRequestedToChangeFireAnimation() }
+        }
 
-        selectedThemeSetting.setOnClickListener { viewModel.userRequestedToChangeTheme() }
-        autocompleteToggle.setOnCheckedChangeListener(autocompleteToggleListener)
-        setAsDefaultBrowserSetting.setOnCheckedChangeListener(defaultBrowserChangeListener)
-        automaticallyClearWhatSetting.setOnClickListener { viewModel.onAutomaticallyClearWhatClicked() }
-        automaticallyClearWhenSetting.setOnClickListener { viewModel.onAutomaticallyClearWhenClicked() }
-        whitelist.setOnClickListener { viewModel.onManageWhitelistSelected() }
-        emailSetting.setOnClickListener { viewModel.onEmailProtectionSettingClicked() }
+        with(viewsPrivacy) {
+            globalPrivacyControlSetting.setOnClickListener { viewModel.onGlobalPrivacyControlClicked() }
+            fireproofWebsites.setOnClickListener { viewModel.onFireproofWebsitesClicked() }
+            locationPermissions.setOnClickListener { viewModel.onLocationClicked() }
+            automaticallyClearWhatSetting.setOnClickListener { viewModel.onAutomaticallyClearWhatClicked() }
+            automaticallyClearWhenSetting.setOnClickListener { viewModel.onAutomaticallyClearWhenClicked() }
+            whitelist.setOnClickListener { viewModel.onManageWhitelistSelected() }
+            emailSetting.setOnClickListener { viewModel.onEmailProtectionSettingClicked() }
+        }
+
+        with(viewsOther) {
+            provideFeedback.setOnClickListener { viewModel.userRequestedToSendFeedback() }
+            about.setOnClickListener { startActivity(AboutDuckDuckGoActivity.intent(this@SettingsActivity)) }
+        }
+
     }
 
     private fun configureInternalFeatures() {
-        settingsSectionInternal.visibility = if (internalFeaturePlugins.getPlugins().isEmpty()) View.GONE else View.VISIBLE
+        viewsInternal.settingsSectionInternal.visibility = if (internalFeaturePlugins.getPlugins().isEmpty()) View.GONE else View.VISIBLE
         internalFeaturePlugins.getPlugins().forEach { feature ->
             Timber.v("Adding internal feature ${feature.internalFeatureTitle()}")
             val view = SettingsOptionWithSubtitle(this).apply {
                 setTitle(feature.internalFeatureTitle())
                 this.setSubtitle(feature.internalFeatureSubtitle())
             }
-            settingsInternalFeaturesContainer.addView(view)
+            viewsInternal.settingsInternalFeaturesContainer.addView(view)
             view.setOnClickListener { feature.onInternalFeatureClicked(this) }
         }
     }
 
     private fun configureAppLinksToggle() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            appLinksToggle.setOnCheckedChangeListener(appLinksToggleListener)
+            viewsPrivacy.appLinksToggle.setOnCheckedChangeListener(appLinksToggleListener)
         } else {
-            appLinksToggle.visibility = View.GONE
+            viewsPrivacy.appLinksToggle.visibility = View.GONE
         }
     }
 
@@ -149,15 +167,15 @@ class SettingsActivity :
             .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
             .onEach { viewState ->
                 viewState.let {
-                    version.setSubtitle(it.version)
+                    viewsOther.version.setSubtitle(it.version)
                     updateSelectedTheme(it.theme)
-                    autocompleteToggle.quietlySetIsChecked(it.autoCompleteSuggestionsEnabled, autocompleteToggleListener)
+                    viewsGeneral.autocompleteToggle.quietlySetIsChecked(it.autoCompleteSuggestionsEnabled, autocompleteToggleListener)
                     updateDefaultBrowserViewVisibility(it)
                     updateAutomaticClearDataOptions(it.automaticallyClearData)
                     setGlobalPrivacyControlSetting(it.globalPrivacyControlEnabled)
-                    changeAppIcon.setImageResource(it.appIcon.icon)
+                    viewsGeneral.changeAppIcon.setImageResource(it.appIcon.icon)
                     updateSelectedFireAnimation(it.selectedFireAnimation)
-                    appLinksToggle.quietlySetIsChecked(it.appLinksEnabled, appLinksToggleListener)
+                    viewsPrivacy.appLinksToggle.quietlySetIsChecked(it.appLinksEnabled, appLinksToggleListener)
                 }
             }.launchIn(lifecycleScope)
 
@@ -173,12 +191,12 @@ class SettingsActivity :
         } else {
             getString(R.string.disabled)
         }
-        globalPrivacyControlSetting.setSubtitle(stateText)
+        viewsPrivacy.globalPrivacyControlSetting.setSubtitle(stateText)
     }
 
     private fun updateSelectedFireAnimation(fireAnimation: FireAnimation) {
         val subtitle = getString(fireAnimation.nameResId)
-        selectedFireAnimationSetting.setSubtitle(subtitle)
+        viewsGeneral.selectedFireAnimationSetting.setSubtitle(subtitle)
     }
 
     private fun updateSelectedTheme(selectedTheme: DuckDuckGoTheme) {
@@ -189,18 +207,18 @@ class SettingsActivity :
                 DuckDuckGoTheme.SYSTEM_DEFAULT -> R.string.settingsSystemTheme
             }
         )
-        selectedThemeSetting.setSubtitle(subtitle)
+        viewsGeneral.selectedThemeSetting.setSubtitle(subtitle)
     }
 
     private fun updateAutomaticClearDataOptions(automaticallyClearData: AutomaticallyClearData) {
         val clearWhatSubtitle = getString(automaticallyClearData.clearWhatOption.nameStringResourceId())
-        automaticallyClearWhatSetting.setSubtitle(clearWhatSubtitle)
+        viewsPrivacy.automaticallyClearWhatSetting.setSubtitle(clearWhatSubtitle)
 
         val clearWhenSubtitle = getString(automaticallyClearData.clearWhenOption.nameStringResourceId())
-        automaticallyClearWhenSetting.setSubtitle(clearWhenSubtitle)
+        viewsPrivacy.automaticallyClearWhenSetting.setSubtitle(clearWhenSubtitle)
 
         val whenOptionEnabled = automaticallyClearData.clearWhenOptionEnabled
-        automaticallyClearWhenSetting.isEnabled = whenOptionEnabled
+        viewsPrivacy.automaticallyClearWhenSetting.isEnabled = whenOptionEnabled
     }
 
     private fun launchAutomaticallyClearWhatDialog(option: ClearWhatOption) {
@@ -235,11 +253,13 @@ class SettingsActivity :
     }
 
     private fun updateDefaultBrowserViewVisibility(it: SettingsViewModel.ViewState) {
-        if (it.showDefaultBrowserSetting) {
-            setAsDefaultBrowserSetting.quietlySetIsChecked(it.isAppDefaultBrowser, defaultBrowserChangeListener)
-            setAsDefaultBrowserSetting.visibility = View.VISIBLE
-        } else {
-            setAsDefaultBrowserSetting.visibility = View.GONE
+        with(viewsGeneral.setAsDefaultBrowserSetting) {
+            if (it.showDefaultBrowserSetting) {
+                quietlySetIsChecked(it.isAppDefaultBrowser, defaultBrowserChangeListener)
+                visibility = View.VISIBLE
+            } else {
+                visibility = View.GONE
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -20,8 +20,12 @@
     android:layout_height="match_parent"
     tools:context="com.duckduckgo.app.settings.SettingsActivity">
 
-    <include layout="@layout/include_toolbar" />
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_toolbar" />
 
-    <include layout="@layout/content_settings" />
+    <include
+        android:id="@+id/includeSettings"
+        layout="@layout/content_settings" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_settings.xml
+++ b/app/src/main/res/layout/content_settings.xml
@@ -29,6 +29,7 @@
         android:paddingBottom="20dp">
 
         <include
+            android:id="@+id/contentSettingsGeneral"
             layout="@layout/content_settings_general"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -40,9 +41,10 @@
             style="@style/SettingsGroupDivider"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/settingsSectionGeneral" />
+            app:layout_constraintTop_toBottomOf="@id/contentSettingsGeneral" />
 
         <include
+            android:id="@+id/contentSettingsPrivacy"
             layout="@layout/content_settings_privacy"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -53,20 +55,21 @@
             style="@style/SettingsGroupDivider"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/settingsSectionPrivacy" />
+            app:layout_constraintTop_toBottomOf="@id/contentSettingsPrivacy" />
 
         <include
-            android:id="@+id/settingsSectionOtherBottomDivider"
+            android:id="@+id/contentSettingsOther"
             layout="@layout/content_settings_other"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@id/settingsSectionPrivacyBottomDivider" />
 
         <include
+            android:id="@+id/contentSettingsInternal"
             layout="@layout/content_settings_internal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/settingsSectionOtherBottomDivider" />
+            app:layout_constraintTop_toBottomOf="@id/contentSettingsOther" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1200998021794668/f

### Description
Updates `SettingsActivity` to use `ViewBinding` instead of Kotlin synthetics

### Steps to test this PR

1. Launch the app and visit settings; verify everything looks as expected
2. Change **every** setting on the page, and verify the setting is applied correctly and any visual states are updated (subtitles, toggles etc...)
3. Repeat for the opposite theme color
