### PR TITLE
Re-add api 30 changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,11 +5,12 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
 
     <application
         android:name="com.duckduckgo.app.global.DuckDuckGoApplication"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext.anvil_version = "2.3.3"
 
     ext.min_sdk = 21
-    ext.target_sdk = 29
+    ext.target_sdk = 30
     ext.compile_sdk = 30
     ext.tools_build_version = "30.0.3"
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200094754307600
Tech Design URL: 
CC: 

**Description**:
This PR changes the target SDK to API 30

**Steps to test this PR**:

**Query permissions**:
1. Install the app and add the search widget
1. Click on the widget and try to search for one of the apps you have installed in your phone (not the stock ones)
1. The app should show up in the autocomplete results
1. Click on the app and make sure it opens correctly

**Download images**:
1. Search for any images in SERP
1. Long click in one of the images and press `Download Image`
1. The image should be saved correctly

**Download blobs**:
1. Go to `https://eligrey.com/demos/FileSaver.js`
1. Try to save the some files from the site
1. All the files should be saved correctly

**Download files**:
1. Go to `https://github.com/duckduckgo/Android/releases`
1. Try to download one of our APKs
1. File should be saved correctly
1. Go to `https://file-examples.com/index.php/sample-documents-download/sample-pdf-download/`
1. Click on any PDF.
1. If you select to not open with another app the document should be correctly saved.
1. If you select to open with another app the document should be opened in that app.

**Favicons and preview images**
1. Go to `github.com`
1. Go to the tab swticher
1. Make sure you can see the favicon and the preview image.
1. Add the site to your bookmarks
1. Go to bookmarks
1. Make sure the favicon shows up correctly

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)