### PR TITLE
Remove bookmarksDao from BrowserTabViewModel

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/model/BookmarksDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/model/BookmarksDataRepositoryTest.kt
@@ -75,6 +75,12 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
+    fun whenInsertBookmarkByTitleAndUrlThenPopulateDB() = runBlocking {
+        repository.insert(title = bookmark.title, url = bookmark.url, parentId = bookmark.parentId)
+        assertEquals(listOf(bookmarkEntity), bookmarksDao.getBookmarks().first())
+    }
+
+    @Test
     fun whenUpdateBookmarkThenUpdateBookmarkInDB() = runBlocking {
         repository.insert(bookmark)
 
@@ -300,5 +306,21 @@ class BookmarksDataRepositoryTest {
         val bookmark = repository.getBookmark("www.test.com")
 
         assertNull(bookmark)
+    }
+
+    @Test
+    fun whenHasBookmarksRequestedAndNoBookmarksAvailableThenReturnFalse() = runBlocking {
+        val result = repository.hasBookmarks()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenHasBookmarksRequestedAndBookmarksAvailableThenReturnTrue() = runBlocking {
+        repository.insert(SavedSite.Bookmark(id = 1, title = "title", url = "www.website.com", parentId = 0))
+
+        val result = repository.hasBookmarks()
+
+        assertTrue(result)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -552,7 +552,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenBookmarkEditedThenRepositoryIsUpdated() = coroutineRule.runBlocking {
-        val bookmark = Bookmark(0, "A title", "www.example.com", 0)
+        val bookmark = Bookmark(id = 0, title = "A title", url = "www.example.com", parentId = 0)
         testee.onSavedSiteEdited(bookmark)
         verify(mockBookmarksRepository).update(bookmark)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -566,10 +566,14 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenBookmarkAddedThenRepositoryIsUpdatedAndUserNotified() = coroutineRule.runBlocking {
-        loadUrl("www.example.com", "A title")
+        val url = "http://www.example.com"
+        val title = "A title"
+        val bookmark = Bookmark(id = 0, title = title, url = url, parentId = 0)
+        whenever(mockBookmarksRepository.insert(title = anyString(), url = anyString(), parentId = anyLong())).thenReturn(bookmark)
+        loadUrl(url = url, title = title)
 
         testee.onBookmarkMenuClicked()
-        verify(mockBookmarksRepository).insert(title = "A title", url = "www.example.com")
+        verify(mockBookmarksRepository).insert(title = title, url = url)
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertTrue(commandCaptor.lastValue is Command.ShowSavedSiteAddedConfirmation)
     }
@@ -1492,12 +1496,16 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSiteLoadedAndUserSelectsToAddBookmarkThenAddBookmarkCommandSentWithUrlAndTitle() = coroutineRule.runBlocking {
-        loadUrl("foo.com")
-        testee.titleReceived("Foo Title")
+        val url = "http://foo.com"
+        val title = "Foo Title"
+        val bookmark = Bookmark(id = 0, title = title, url = url, parentId = 0)
+        whenever(mockBookmarksRepository.insert(title = anyString(), url = anyString(), parentId = anyLong())).thenReturn(bookmark)
+        loadUrl(url = url)
+        testee.titleReceived(newTitle = title)
         testee.onBookmarkMenuClicked()
         val command = captureCommands().value as Command.ShowSavedSiteAddedConfirmation
-        assertEquals("foo.com", command.savedSite.url)
-        assertEquals("Foo Title", command.savedSite.title)
+        assertEquals(url, command.savedSite.url)
+        assertEquals(title, command.savedSite.title)
     }
 
     @Test
@@ -2968,7 +2976,10 @@ class BrowserTabViewModelTest {
     @Test
     fun whenBookmarkAddedThenPersistFavicon() = coroutineRule.runBlocking {
         val url = "http://example.com"
-        loadUrl(url, "A title")
+        val title = "A title"
+        val bookmark = Bookmark(id = 0, title = title, url = url, parentId = 0)
+        whenever(mockBookmarksRepository.insert(title = anyString(), url = anyString(), parentId = anyLong())).thenReturn(bookmark)
+        loadUrl(url = url, title = title)
 
         testee.onBookmarkMenuClicked()
 
@@ -3428,12 +3439,13 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenEditBookmarkRequestedThenRepositoryIsNotUpdated() = coroutineRule.runBlocking {
-        val bookmark = Bookmark(id = 1L, title = "", url = "www.example.com", parentId = 0L)
-        whenever(mockBookmarksRepository.getBookmark("www.example.com")).thenReturn(bookmark)
+        val url = "http://www.example.com"
+        val bookmark = Bookmark(id = 1L, title = "", url = url, parentId = 0L)
+        whenever(mockBookmarksRepository.getBookmark(url = url)).thenReturn(bookmark)
         bookmarksListFlow.send(listOf(bookmark))
-        loadUrl("www.example.com", isBrowserShowing = true)
+        loadUrl(url = url, isBrowserShowing = true)
         testee.onBookmarkMenuClicked()
-        verify(mockBookmarksRepository, never()).insert(anyString(), anyString())
+        verify(mockBookmarksRepository, never()).insert(title = anyString(), url = anyString(), parentId = anyLong())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1502,7 +1502,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenNoSiteAndUserSelectsToAddBookmarkThenBookmarkIsNotAdded() = coroutineRule.runBlocking {
-        val bookmark = Bookmark(0, "A title", "www.example.com", 0)
+        val bookmark = Bookmark(id = 0, title = "A title", url = "www.example.com", parentId = 0)
         whenever(mockBookmarksRepository.insert(anyString(), anyString(), anyLong())).thenReturn(bookmark)
 
         testee.onBookmarkMenuClicked()

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -37,7 +37,6 @@ import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.A
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoCompleteApi
 import com.duckduckgo.app.autocomplete.api.AutoCompleteService
-import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.bookmarks.model.BookmarksRepository
 import com.duckduckgo.app.bookmarks.model.FavoritesRepository
@@ -127,7 +126,6 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import dagger.Lazy
 import io.reactivex.Observable
-import io.reactivex.Single
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
@@ -382,7 +380,6 @@ class BrowserTabViewModelTest {
             networkLeaderboardDao = mockNetworkLeaderboardDao,
             autoComplete = mockAutoCompleteApi,
             appSettingsPreferencesStore = mockSettingsStore,
-            bookmarksDao = mockBookmarksDao,
             bookmarksRepository = mockBookmarksRepository,
             longPressHandler = mockLongPressHandler,
             webViewSessionStorage = webViewSessionStorage,
@@ -554,9 +551,10 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenBookmarkEditedThenDaoIsUpdated() = coroutineRule.runBlocking {
-        testee.onSavedSiteEdited(Bookmark(0, "A title", "www.example.com", 0))
-        verify(mockBookmarksDao).update(BookmarkEntity(title = "A title", url = "www.example.com", parentId = 0))
+    fun whenBookmarkEditedThenRepositoryIsUpdated() = coroutineRule.runBlocking {
+        val bookmark = Bookmark(0, "A title", "www.example.com", 0)
+        testee.onSavedSiteEdited(bookmark)
+        verify(mockBookmarksRepository).update(bookmark)
     }
 
     @Test
@@ -567,11 +565,11 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenBookmarkAddedThenDaoIsUpdatedAndUserNotified() = coroutineRule.runBlocking {
+    fun whenBookmarkAddedThenRepositoryIsUpdatedAndUserNotified() = coroutineRule.runBlocking {
         loadUrl("www.example.com", "A title")
 
         testee.onBookmarkMenuClicked()
-        verify(mockBookmarksDao).insert(BookmarkEntity(title = "A title", url = "www.example.com", parentId = 0))
+        verify(mockBookmarksRepository).insert(title = "A title", url = "www.example.com")
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertTrue(commandCaptor.lastValue is Command.ShowSavedSiteAddedConfirmation)
     }
@@ -1092,7 +1090,6 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenEnteringQueryWithAutoCompleteEnabledThenAutoCompleteSuggestionsShown() {
-        whenever(mockBookmarksDao.bookmarksObservable()).thenReturn(Single.just(emptyList()))
         whenever(mockAutoCompleteService.autoComplete("foo")).thenReturn(Observable.just(emptyList()))
         doReturn(true).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
         testee.onOmnibarInputStateChanged("foo", true, hasQueryChanged = true)
@@ -1505,11 +1502,12 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenNoSiteAndUserSelectsToAddBookmarkThenBookmarkIsNotAdded() = coroutineRule.runBlocking {
-        whenever(mockBookmarksDao.insert(any<BookmarkEntity>())).thenReturn(1)
+        val bookmark = Bookmark(0, "A title", "www.example.com", 0)
+        whenever(mockBookmarksRepository.insert(anyString(), anyString(), anyLong())).thenReturn(bookmark)
 
         testee.onBookmarkMenuClicked()
 
-        verify(mockBookmarksDao, times(0)).insert(any<BookmarkEntity>())
+        verify(mockBookmarksRepository, times(0)).insert(bookmark)
     }
 
     @Test
@@ -1803,7 +1801,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenBookmarkSuggestionSubmittedThenAutoCompleteBookmarkSelectionPixelSent() = runBlocking {
-        whenever(mockBookmarksDao.hasBookmarks()).thenReturn(true)
+        whenever(mockBookmarksRepository.hasBookmarks()).thenReturn(true)
         val suggestion = AutoCompleteBookmarkSuggestion("example", "Example", "https://example.com")
         testee.autoCompleteViewState.value = autoCompleteViewState().copy(searchResults = AutoCompleteResult("", listOf(suggestion)))
         testee.fireAutocompletePixel(suggestion)
@@ -1812,7 +1810,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSearchSuggestionSubmittedWithBookmarksThenAutoCompleteSearchSelectionPixelSent() = runBlocking {
-        whenever(mockBookmarksDao.hasBookmarks()).thenReturn(true)
+        whenever(mockBookmarksRepository.hasBookmarks()).thenReturn(true)
         val suggestions = listOf(AutoCompleteSearchSuggestion("", false), AutoCompleteBookmarkSuggestion("", "", ""))
         testee.autoCompleteViewState.value = autoCompleteViewState().copy(searchResults = AutoCompleteResult("", suggestions))
         testee.fireAutocompletePixel(AutoCompleteSearchSuggestion("example", false))
@@ -1822,7 +1820,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSearchSuggestionSubmittedWithoutBookmarksThenAutoCompleteSearchSelectionPixelSent() = runBlocking {
-        whenever(mockBookmarksDao.hasBookmarks()).thenReturn(false)
+        whenever(mockBookmarksRepository.hasBookmarks()).thenReturn(false)
         testee.autoCompleteViewState.value = autoCompleteViewState().copy(searchResults = AutoCompleteResult("", emptyList()))
         testee.fireAutocompletePixel(AutoCompleteSearchSuggestion("example", false))
 
@@ -3429,13 +3427,13 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenEditBookmarkRequestedThenDaoIsNotUpdated() = coroutineRule.runBlocking {
+    fun whenEditBookmarkRequestedThenRepositoryIsNotUpdated() = coroutineRule.runBlocking {
         val bookmark = Bookmark(id = 1L, title = "", url = "www.example.com", parentId = 0L)
         whenever(mockBookmarksRepository.getBookmark("www.example.com")).thenReturn(bookmark)
         bookmarksListFlow.send(listOf(bookmark))
         loadUrl("www.example.com", isBrowserShowing = true)
         testee.onBookmarkMenuClicked()
-        verify(mockBookmarksDao, never()).insert(any())
+        verify(mockBookmarksRepository, never()).insert(anyString(), anyString())
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/model/BookmarksRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/model/BookmarksRepository.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.map
 interface BookmarksRepository {
     suspend fun insert(bookmarkFolder: BookmarkFolder): Long
     suspend fun insert(bookmark: Bookmark)
+    suspend fun insert(title: String, url: String, parentId: Long = 0): Bookmark
     suspend fun update(bookmarkFolder: BookmarkFolder)
     suspend fun update(bookmark: Bookmark)
     suspend fun delete(bookmark: Bookmark)
@@ -39,6 +40,7 @@ interface BookmarksRepository {
     suspend fun fetchBookmarksAndFolders(parentId: Long?): Flow<Pair<List<Bookmark>, List<BookmarkFolder>>>
     fun bookmarks(): Flow<List<Bookmark>>
     fun getBookmark(url: String): Bookmark?
+    suspend fun hasBookmarks(): Boolean
 }
 
 class BookmarksDataRepository(
@@ -53,6 +55,11 @@ class BookmarksDataRepository(
 
     override suspend fun insert(bookmark: Bookmark) {
         bookmarksDao.insert(BookmarkEntity(title = bookmark.title, url = bookmark.url, parentId = bookmark.parentId))
+    }
+
+    override suspend fun insert(title: String, url: String, parentId: Long): Bookmark {
+        val id = bookmarksDao.insert(BookmarkEntity(title = title, url = url, parentId = 0))
+        return Bookmark(id = id, title = title, url = url, parentId = parentId)
     }
 
     override suspend fun update(bookmarkFolder: BookmarkFolder) {
@@ -81,6 +88,10 @@ class BookmarksDataRepository(
 
     override fun getBookmark(url: String): Bookmark? {
         return bookmarksDao.getBookmarkByUrl(url)?.mapToSavedSite()
+    }
+
+    override suspend fun hasBookmarks(): Boolean {
+        return bookmarksDao.hasBookmarks()
     }
 
     @VisibleForTesting

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -39,8 +39,6 @@ import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoCompleteApi
-import com.duckduckgo.app.bookmarks.db.BookmarkEntity
-import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.bookmarks.model.BookmarksRepository
 import com.duckduckgo.app.bookmarks.model.FavoritesRepository
 import com.duckduckgo.app.bookmarks.model.SavedSite
@@ -136,7 +134,6 @@ class BrowserTabViewModel(
     private val userWhitelistDao: UserWhitelistDao,
     private val contentBlocking: ContentBlocking,
     private val networkLeaderboardDao: NetworkLeaderboardDao,
-    private val bookmarksDao: BookmarksDao,
     private val bookmarksRepository: BookmarksRepository,
     private val favoritesRepository: FavoritesRepository,
     private val fireproofWebsiteRepository: FireproofWebsiteRepository,
@@ -574,7 +571,7 @@ class BrowserTabViewModel(
     suspend fun fireAutocompletePixel(suggestion: AutoCompleteSuggestion) {
         val currentViewState = currentAutoCompleteViewState()
         val hasBookmarks = withContext(dispatchers.io()) {
-            bookmarksDao.hasBookmarks()
+            bookmarksRepository.hasBookmarks()
         }
         val hasBookmarkResults = currentViewState.searchResults.suggestions.any { it is AutoCompleteBookmarkSuggestion }
         val params = mapOf(
@@ -1420,9 +1417,7 @@ class BrowserTabViewModel(
             if (url.isNotBlank()) {
                 faviconManager.persistCachedFavicon(tabId, url)
             }
-            val bookmarkEntity = BookmarkEntity(title = title, url = url, parentId = 0)
-            val id = bookmarksDao.insert(bookmarkEntity)
-            SavedSite.Bookmark(id, title, url, 0)
+            bookmarksRepository.insert(title, url)
         }
         withContext(dispatchers.main()) {
             command.value = ShowSavedSiteAddedConfirmation(savedBookmark)
@@ -1556,7 +1551,7 @@ class BrowserTabViewModel(
 
     private suspend fun editBookmark(bookmark: SavedSite.Bookmark) {
         withContext(dispatchers.io()) {
-            bookmarksDao.update(BookmarkEntity(bookmark.id, bookmark.title, bookmark.url, bookmark.parentId))
+            bookmarksRepository.update(bookmark)
         }
     }
 
@@ -2152,7 +2147,6 @@ class BrowserTabViewModelFactory @Inject constructor(
     private val userWhitelistDao: Provider<UserWhitelistDao>,
     private val contentBlocking: Provider<ContentBlocking>,
     private val networkLeaderboardDao: Provider<NetworkLeaderboardDao>,
-    private val bookmarksDao: Provider<BookmarksDao>,
     private val bookmarksRepository: Provider<BookmarksRepository>,
     private val favoritesRepository: Provider<FavoritesRepository>,
     private val fireproofWebsiteRepository: Provider<FireproofWebsiteRepository>,
@@ -2181,7 +2175,7 @@ class BrowserTabViewModelFactory @Inject constructor(
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(BrowserTabViewModel::class.java) -> BrowserTabViewModel(statisticsUpdater.get(), queryUrlConverter.get(), duckDuckGoUrlDetector.get(), siteFactory.get(), tabRepository.get(), userWhitelistDao.get(), contentBlocking.get(), networkLeaderboardDao.get(), bookmarksDao.get(), bookmarksRepository.get(), favoritesRepository.get(), fireproofWebsiteRepository.get(), locationPermissionsRepository.get(), geoLocationPermissions.get(), navigationAwareLoginDetector.get(), autoComplete.get(), appSettingsPreferencesStore.get(), longPressHandler.get(), webViewSessionStorage.get(), specialUrlDetector.get(), faviconManager.get(), addToHomeCapabilityDetector.get(), ctaViewModel.get(), searchCountDao.get(), pixel.get(), dispatchers, userEventsStore.get(), fileDownloader.get(), gpc.get(), fireproofDialogsEventHandler.get(), emailManager.get(), appCoroutineScope.get(), appLinksHandler.get()) as T
+                isAssignableFrom(BrowserTabViewModel::class.java) -> BrowserTabViewModel(statisticsUpdater.get(), queryUrlConverter.get(), duckDuckGoUrlDetector.get(), siteFactory.get(), tabRepository.get(), userWhitelistDao.get(), contentBlocking.get(), networkLeaderboardDao.get(), bookmarksRepository.get(), favoritesRepository.get(), fireproofWebsiteRepository.get(), locationPermissionsRepository.get(), geoLocationPermissions.get(), navigationAwareLoginDetector.get(), autoComplete.get(), appSettingsPreferencesStore.get(), longPressHandler.get(), webViewSessionStorage.get(), specialUrlDetector.get(), faviconManager.get(), addToHomeCapabilityDetector.get(), ctaViewModel.get(), searchCountDao.get(), pixel.get(), dispatchers, userEventsStore.get(), fileDownloader.get(), gpc.get(), fireproofDialogsEventHandler.get(), emailManager.get(), appCoroutineScope.get(), appLinksHandler.get()) as T
                 else -> null
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200996756744658/f

### Description

Replaced the usage of bookmarksDao with bookmarksRepository in BrowserTabViewModel and updated BookmarksDataRepository with the needed functions.

### Steps to test this PR

Regression testing for the bookmark feature (add / edit / remove).
