### PR TITLE
Better Slovak translations of download confirmation

### DIFF
--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -460,10 +460,10 @@
     <string name="daxMainNetworkOwnedCtaText">Hlavu hore! Keďže spoločnosť %1$s vlastní službu %2$s, nemôžem jej zabrániť v tom, aby videla vašu aktivitu.&lt;br/&gt;&lt;br/&gt;Prehliadajte so mnou a môžem obmedziť to, čo o vás %3$s celkovo vie, zablokovaním jej sledovacích zariadení na mnohých ďalších stránkach.</string>
 
     <!-- Download Confirmation -->
-    <string name="downloadConfirmationContinue">Ďalej</string>
-    <string name="downloadConfirmationSaveFileTitle">Ušetrite %1$s</string>
+    <string name="downloadConfirmationContinue">Pokračovať</string>
+    <string name="downloadConfirmationSaveFileTitle">Uložiť %1$s</string>
     <string name="downloadConfirmationKeepBothFilesText">Nechať si oboje</string>
-    <string name="downloadConfirmationReplaceOldFileText">Vymeniť</string>
+    <string name="downloadConfirmationReplaceOldFileText">Nahradiť</string>
     <string name="downloadConfirmationOpenFileText">Otvoriť</string>
     <string name="downloadConfirmationUnableToOpenFileText">Súbor sa nepodarilo otvoriť</string>
     <string name="downloadConfirmationUnableToDeleteFileText">Starý súbor sa nepodarilo odstrániť</string>


### PR DESCRIPTION
Updated download confirmation dialog translations, so they have correct meaning:

**Continue** -> ~~Ďalej~~ **Pokračovať** ("ďalej" means further or so, "continue" as "continue doing something (saving file)" is translated as "pokračovať", [see dictionary](https://slovniky.lingea.sk/anglicko-slovensky/continue))
**Save** -> ~~Ušetrite~~ **Uložiť** (In English, "save" is used for different things, like "save file" or "save money / resources", but in Slovak, "ušetriť" can be used in sentences like "save resources / money / ..." or "protect sth" or so, but in sentences like "save file", "uložiť" is used)
**Replace** -> ~~Vymeniť~~ **Nahradiť** ("vymeniť" is translated more as "swap" than "replace" and is definitely not used to replace file(s), "replace" as "replace file" is translated as "nahradiť")
