### PR TITLE
Restrict iar parameters to major verticals

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
@@ -47,7 +47,7 @@ class QueryUrlConverter @Inject constructor(private val requestRewriter: Request
             .appendQueryParameter(AppUrl.ParamKey.QUERY, searchQuery)
             .authority(Url.HOST)
 
-        vertical?.let {
+        if (vertical != null && majorVerticals.contains(vertical)) {
             uriBuilder.appendQueryParameter(AppUrl.ParamKey.VERTICAL_REWRITE, vertical)
         }
 
@@ -63,6 +63,10 @@ class QueryUrlConverter @Inject constructor(private val requestRewriter: Request
         }
 
         return uri.toString()
+    }
+
+    companion object {
+        val majorVerticals = listOf("images", "videos", "news", "shopping")
     }
 
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 DuckDuckGo
+ * Copyright (c) 2021 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser
 
 import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.omnibar.QueryOrigin
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
 import com.duckduckgo.app.referral.AppReferrerDataStore
@@ -28,7 +29,9 @@ import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class QueryUrlConverterTest {
 
     private var mockStatisticsStore: StatisticsDataStore = mock()
@@ -114,6 +117,22 @@ class QueryUrlConverterTest {
         val input = "foo"
         val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromAutocomplete(isNav = null))
         assertDuckDuckGoSearchQuery("foo", result)
+    }
+
+    @Test
+    fun whenConvertQueryToUrlContainsAMajorVerticalThenVerticalAddedToUrl() {
+        val input = "foo"
+        val vertical = QueryUrlConverter.majorVerticals.random()
+        val result = testee.convertQueryToUrl(input, vertical = vertical, queryOrigin = QueryOrigin.FromUser)
+        assertTrue(result.contains("iar=$vertical"))
+    }
+
+    @Test
+    fun whenConvertQueryToUrlContainsANonMajorVerticalThenVerticalNotAddedToUrl() {
+        val input = "foo"
+        val vertical = "nonMajor"
+        val result = testee.convertQueryToUrl(input, vertical = vertical, queryOrigin = QueryOrigin.FromUser)
+        assertFalse(result.contains("iar=$vertical"))
     }
 
     private fun assertDuckDuckGoSearchQuery(query: String, url: String) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1200465880706413

### Description
This PR validates that a vertical is a major vertical before being added to the iar parameter

### Steps to test this PR

_IAR added only if major_
1. Search for lol
1. Click on the videos tab
1. In the logcat filter by `iar=videos`, nothing should show up.
1. Select the search bar and search for `test`
1. The logcat should now show results
1. Filter the logcat by `ia=currency`
1. Search `usd to gbp`
1. The logcat should return several results
1. Filter the logcat by `iar=currency`
1. Select the search bar and search for `test`
1. The logcat should not show any results