### PR TITLE
Config in settings.gradle for local build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ bitrise.yml
 
 # NDK files
 **/.cxx
+
+# Local build cache
+build-cache

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,3 +19,12 @@ project(':privacy-config-api').projectDir = new File('privacy-config/privacy-con
 project(':privacy-config-impl').projectDir = new File('privacy-config/privacy-config-impl')
 project(':privacy-config-store').projectDir = new File('privacy-config/privacy-config-store')
 include ':common-test'
+
+
+buildCache {
+    local {
+        enabled = true
+        directory = new File(rootDir, 'build-cache')
+        removeUnusedEntriesAfterDays = 7
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201114482844091/f

### Description
* We have the gradle local build cache enable in gradle.properties
* the local cache are local to the machine and speeds up the builds during development
* the local cache if otherwise specified is placed under the user local directory, ie. ~/.gradle/caches/build-cache-1
* which makes it a bit hard to find
  * gradle has issues with kotlin + annotation processors + incremental compiation and so sometimes happens that adding a new Dagger module, binding, provider etc.  
  * is not picked up by gradle and not compiled
* an easy solution at that point is just to remove the local cache to force the rebuild


This PR configures the local cache to be in the `build-cache` folder under the project root directory.
This way devs can just remove the `build-cache` folder right from AS when problems arise

### Steps to test this PR
1. build from this branch
1. verify the `build-cache` directory is created and visible under AS


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
