### PR TITLE
Enable non-transitive R files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 android.useAndroidX=true
+android.nonTransitiveRClass=true
 org.gradle.jvmargs=-Xmx1536m -XX:+UseParallelGC
 org.gradle.caching=true
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201118368747585/f

### Description
Currently our gradle is configured in such a way that all `R` resources are rechable from any module, without the need to specify them as a gradle dependency. This has the following cons:
* compilation times are higher, as aapt has to include references to all resources in all gradle modules
* incremental compilations are higher, as any resource change affects more modules than it should
* APK/AAB files are bigger than needed

See [asana task](https://app.asana.com/0/414730916066338/1201118368747585/f) for a more detailed description.


This PR enables the `android.nonTransitiveRClass=true` in the `gradle.properties` file so that modules can only reference resources in the current module, or in modules explicitly added as dependency

### Steps to test this PR

The app builds for all flavors

