### PR TITLE
Only use CI build number when versionNameSuffix supplied

### DIFF
--- a/versioning.gradle
+++ b/versioning.gradle
@@ -33,10 +33,16 @@ ext {
     buildNumberCode = {
         filePath = "${CI_HOME_DIR}/build_number.properties"
         if(!new File(filePath).exists()) return 0
-        def props = new Properties()
-        props.load(new FileInputStream(filePath))
-        buildNumber = props["build"]
-        if (buildNumber == null) return 0 else return Integer.valueOf(buildNumber)
+
+        def suffix = getVersionNameSuffix()
+        if (suffix?.trim()) {
+            def props = new Properties()
+            props.load(new FileInputStream(filePath))
+            String buildNumber = props["build"]
+            if (buildNumber == null) return 0 else return Integer.valueOf(buildNumber)
+        } else {
+            return 0
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201155711458577/f

### Description
Tweaks the build script so that build number is only added to the version code when a build suffix is supplied

### Steps to test this PR

_Feature 1_
1. 
2.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
