### PR TITLE
Minor tweak to how GPC DOM property is set

### DIFF
--- a/privacy-config/privacy-config-impl/src/main/res/raw/gpc.js
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/gpc.js
@@ -19,10 +19,10 @@
 
 (function() {
     if (navigator.globalPrivacyControl === undefined) {
-        Object.defineProperty(navigator, 'globalPrivacyControl', {
-            value: true,
-            writable: false,
-            configurable: false
+        Object.defineProperty(Navigator.prototype, 'globalPrivacyControl', {
+            get: () => true,
+            configurable: true,
+            enumerable: true
         });
     } else {
         try {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201168853446394/f

### Description
Set GPC DOM signal on `Navigator.prototype` rather than `navigator`. Existing tests should still pass after this change--calling `navigator.globalPrivacyControl` will still return the signal value.

### Steps to test this PR
1. Visit test page and ensure that Client-side detection is passing: https://global-privacy-control.glitch.me/
2. Toggle GPC off and check that Client-side detection is no longer passing.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
