### PR TITLE
Replace deprecated toLowerCase and toUpperCase

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksEntityQueryListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksEntityQueryListener.kt
@@ -20,6 +20,7 @@ import androidx.appcompat.widget.SearchView
 import com.duckduckgo.app.bookmarks.model.BookmarkFolder
 import com.duckduckgo.app.bookmarks.model.SavedSite
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.BookmarkFoldersAdapter
+import java.util.*
 
 class BookmarksEntityQueryListener(
     private val viewModel: BookmarksViewModel,
@@ -43,17 +44,17 @@ class BookmarksEntityQueryListener(
     }
 
     private fun filterBookmarks(query: String, bookmarks: List<SavedSite.Bookmark>): List<BookmarksAdapter.BookmarkItem> {
-        val lowercaseQuery = query.toLowerCase()
+        val lowercaseQuery = query.lowercase(Locale.getDefault())
         return bookmarks.filter {
-            val lowercaseTitle = it.title.toLowerCase()
+            val lowercaseTitle = it.title.lowercase(Locale.getDefault())
             lowercaseTitle.contains(lowercaseQuery) || it.url.contains(lowercaseQuery)
         }.map { BookmarksAdapter.BookmarkItem(it) }
     }
 
     private fun filterBookmarkFolders(query: String, bookmarkFolders: List<BookmarkFolder>): List<BookmarkFoldersAdapter.BookmarkFolderItem> {
-        val lowercaseQuery = query.toLowerCase()
+        val lowercaseQuery = query.lowercase(Locale.getDefault())
         return bookmarkFolders.filter {
-            val lowercaseTitle = it.name.toLowerCase()
+            val lowercaseTitle = it.name.lowercase(Locale.getDefault())
             lowercaseTitle.contains(lowercaseQuery)
         }.map { BookmarkFoldersAdapter.BookmarkFolderItem(it) }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/filechooser/FileChooserIntentBuilder.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/filechooser/FileChooserIntentBuilder.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.filechooser
 import android.content.Intent
 import android.net.Uri
 import timber.log.Timber
+import java.util.*
 import javax.inject.Inject
 
 class FileChooserIntentBuilder @Inject constructor() {
@@ -75,7 +76,7 @@ class FileChooserIntentBuilder @Inject constructor() {
 
         acceptTypes
             .filter { it.isNotBlank() }
-            .forEach { acceptedMimeTypes.add(it.toLowerCase()) }
+            .forEach { acceptedMimeTypes.add(it.lowercase(Locale.getDefault())) }
 
         if (acceptedMimeTypes.isNotEmpty()) {
             Timber.d("Selectable file types limited to $acceptedMimeTypes")

--- a/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
@@ -66,7 +66,7 @@ fun generateDefaultDrawable(context: Context, domain: String): Drawable {
         private val baseHost: String = domain.toUri().baseHost ?: ""
 
         private val letter
-            get() = baseHost.firstOrNull()?.toString()?.toUpperCase(Locale.getDefault()) ?: ""
+            get() = baseHost.firstOrNull()?.toString()?.uppercase(Locale.getDefault()) ?: ""
 
         private val faviconDefaultCornerRadius = context.resources.getDimension(R.dimen.savedSiteGridItemCornerRadiusFavicon)
         private val faviconDefaultSize = context.resources.getDimension(R.dimen.savedSiteGridItemFavicon)

--- a/app/src/main/java/com/duckduckgo/app/privacy/renderer/TrackersRenderer.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/renderer/TrackersRenderer.kt
@@ -59,7 +59,7 @@ class TrackersRenderer {
             .replace(" ", "_")
             .replace(".", "")
             .replace(",", "")
-            .toLowerCase(Locale.ROOT)
+            .lowercase(Locale.ROOT)
         val resource = context.resources.getIdentifier(drawable, "drawable", context.packageName)
         return if (resource != 0) resource else null
     }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/api/TdsJson.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/api/TdsJson.kt
@@ -70,6 +70,6 @@ class ActionJsonAdapter {
 
     @FromJson
     fun fromJson(actionName: String): Action? {
-        return Action.values().firstOrNull { it.name == actionName.toUpperCase(Locale.ROOT) }
+        return Action.values().firstOrNull { it.name == actionName.uppercase(Locale.ROOT) }
     }
 }


### PR DESCRIPTION
closes #1486 

Task/Issue URL: #1486 

### Description
`toLowerCase` and `toUpperCase` are deprecated. We can replace them with `.lowercase(Locale.getDefault())` and `uppercase(Locale.getDefault()`


