### PR TITLE
Migrate fragments to view binding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/SavedSiteDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/SavedSiteDialogFragment.kt
@@ -38,15 +38,14 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.DialogFragmentSavedSiteBinding
 import com.duckduckgo.app.global.view.TextChangedWatcher
 import com.duckduckgo.mobile.android.ui.view.showKeyboard
-import kotlinx.android.synthetic.main.include_find_in_page.*
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 abstract class SavedSiteDialogFragment : DialogFragment() {
 
     abstract fun onConfirmation()
     abstract fun configureUI()
 
-    private var _binding: DialogFragmentSavedSiteBinding? = null
-    protected val binding get() = _binding!!
+    protected val binding: DialogFragmentSavedSiteBinding by viewBinding()
 
     private var initialTitle: String? = null
     private var titleState = ValidationState.UNCHANGED
@@ -80,7 +79,11 @@ abstract class SavedSiteDialogFragment : DialogFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        _binding = DialogFragmentSavedSiteBinding.inflate(inflater, container, false)
+        return inflater.inflate(R.layout.dialog_fragment_saved_site, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         configureClickListeners()
         arguments?.getString(KEY_BOOKMARK_FOLDER_NAME)?.let { name ->
             binding.savedSiteLocation.setText(name)
@@ -91,7 +94,6 @@ abstract class SavedSiteDialogFragment : DialogFragment() {
         initialParentFolderId = arguments?.getLong(EditBookmarkFolderDialogFragment.KEY_PARENT_FOLDER_ID)
         addTextWatchers()
         showKeyboard(binding.titleInput)
-        return binding.root
     }
 
     private fun addTextWatchers() {
@@ -124,11 +126,6 @@ abstract class SavedSiteDialogFragment : DialogFragment() {
     override fun onPause() {
         super.onPause()
         dialog?.window?.setWindowAnimations(android.R.style.Animation)
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     private fun configureUpNavigation(toolbar: Toolbar) {

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/SavedSiteDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/SavedSiteDialogFragment.kt
@@ -20,9 +20,7 @@ import android.app.Dialog
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.EditText
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
@@ -40,7 +38,7 @@ import com.duckduckgo.app.global.view.TextChangedWatcher
 import com.duckduckgo.mobile.android.ui.view.showKeyboard
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
-abstract class SavedSiteDialogFragment : DialogFragment() {
+abstract class SavedSiteDialogFragment : DialogFragment(R.layout.dialog_fragment_saved_site) {
 
     abstract fun onConfirmation()
     abstract fun configureUI()
@@ -76,10 +74,6 @@ abstract class SavedSiteDialogFragment : DialogFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(STYLE_NO_TITLE, R.style.SavedSiteFullScreenDialog)
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.dialog_fragment_saved_site, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/duckduckgo/app/browser/DownloadConfirmationFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DownloadConfirmationFragment.kt
@@ -21,15 +21,16 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import com.duckduckgo.app.browser.databinding.DownloadConfirmationBinding
 import com.duckduckgo.app.browser.downloader.FileDownloader.PendingFileDownload
 import com.duckduckgo.app.browser.downloader.FilenameExtractor
 import com.duckduckgo.app.browser.downloader.isDataUrl
 import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.app.global.view.leftDrawable
 import com.duckduckgo.mobile.android.ui.view.show
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.download_confirmation.view.*
 import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
@@ -41,6 +42,8 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
 
     @Inject
     lateinit var filenameExtractor: FilenameExtractor
+
+    private val binding: DownloadConfirmationBinding by viewBinding()
 
     private var file: File? = null
 
@@ -72,35 +75,35 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupViews(view: View) {
-        view.downloadMessage.text = getString(R.string.downloadConfirmationSaveFileTitle, file?.name ?: "")
-        view.replace.setOnClickListener {
+        binding.downloadMessage.text = getString(R.string.downloadConfirmationSaveFileTitle, file?.name ?: "")
+        binding.replace.setOnClickListener {
             listener.replaceExistingFile(file, pendingDownload)
             dismiss()
         }
-        view.continueDownload.setOnClickListener {
+        binding.continueDownload.setOnClickListener {
             listener.continueDownload(pendingDownload)
             dismiss()
         }
-        view.openWith.setOnClickListener {
+        binding.openWith.setOnClickListener {
             listener.openExistingFile(file)
             dismiss()
         }
-        view.cancel.setOnClickListener {
+        binding.cancel.setOnClickListener {
             Timber.i("Cancelled download for url ${pendingDownload.url}")
             listener.cancelDownload()
             dismiss()
         }
 
         if (file?.exists() == true) {
-            view.openWith.show()
-            view.replace.show()
-            view.continueDownload.text = getString(R.string.downloadConfirmationKeepBothFilesText)
-            view.continueDownload.leftDrawable(R.drawable.ic_keepboth_brownish_24dp)
+            binding.openWith.show()
+            binding.replace.show()
+            binding.continueDownload.text = getString(R.string.downloadConfirmationKeepBothFilesText)
+            binding.continueDownload.leftDrawable(R.drawable.ic_keepboth_brownish_24dp)
         } else {
-            view.openWith.gone()
-            view.replace.gone()
-            view.continueDownload.text = getString(R.string.downloadConfirmationContinue)
-            view.continueDownload.leftDrawable(R.drawable.ic_file_brownish_24dp)
+            binding.openWith.gone()
+            binding.replace.gone()
+            binding.continueDownload.text = getString(R.string.downloadConfirmationContinue)
+            binding.continueDownload.leftDrawable(R.drawable.ic_file_brownish_24dp)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/email/EmailAutofillTooltipFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailAutofillTooltipFragment.kt
@@ -19,10 +19,11 @@ package com.duckduckgo.app.email
 import android.content.Context
 import android.os.Bundle
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ContentAutofillTooltipBinding
 import com.duckduckgo.app.global.view.html
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import kotlinx.android.synthetic.main.content_autofill_tooltip.*
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 
 class EmailAutofillTooltipFragment(
     context: Context,
@@ -32,8 +33,10 @@ class EmailAutofillTooltipFragment(
     var useAddress: (() -> Unit) = {}
     var usePrivateAlias: (() -> Unit) = {}
 
+    private val binding: ContentAutofillTooltipBinding by viewBinding()
+
     init {
-        setContentView(R.layout.content_autofill_tooltip)
+        setContentView(binding.root)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,14 +47,14 @@ class EmailAutofillTooltipFragment(
     private fun setDialog() {
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
         val addressFormatted = context.getString(R.string.autofillTooltipUseYourAlias, address)
-        tooltipPrimaryCtaTitle.text = addressFormatted.html(context)
+        binding.tooltipPrimaryCtaTitle.text = addressFormatted.html(context)
 
-        secondaryCta.setOnClickListener {
+        binding.secondaryCta.setOnClickListener {
             usePrivateAlias()
             dismiss()
         }
 
-        primaryCta.setOnClickListener {
+        binding.primaryCta.setOnClickListener {
             useAddress()
             dismiss()
         }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
@@ -34,23 +34,27 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ContentOnboardingDefaultBrowserBinding
+import com.duckduckgo.app.browser.databinding.IncludeDefaultBrowserButtonsBinding
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserSystemSettings
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.content_onboarding_default_browser.*
-import kotlinx.android.synthetic.main.include_default_browser_buttons.*
 import timber.log.Timber
 import javax.inject.Inject
 
-class DefaultBrowserPage : OnboardingPageFragment() {
+class DefaultBrowserPage : OnboardingPageFragment(R.layout.content_onboarding_default_browser) {
 
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
     @Inject
     lateinit var variantManager: VariantManager
+
+    private val binding: ContentOnboardingDefaultBrowserBinding by viewBinding()
+    private val browserDefaultButtonBinding: IncludeDefaultBrowserButtonsBinding by viewBinding()
 
     private var userTriedToSetDDGAsDefault = false
     private var userSelectedExternalBrowser = false
@@ -60,8 +64,6 @@ class DefaultBrowserPage : OnboardingPageFragment() {
     private val viewModel: DefaultBrowserPageViewModel by lazy {
         ViewModelProvider(this, viewModelFactory).get(DefaultBrowserPageViewModel::class.java)
     }
-
-    override fun layoutResource(): Int = R.layout.content_onboarding_default_browser
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -113,7 +115,7 @@ class DefaultBrowserPage : OnboardingPageFragment() {
             }
             statusBarColor = Color.WHITE
         }
-        requestApplyInsets(longDescriptionContainer)
+        requestApplyInsets(binding.longDescriptionContainer)
     }
 
     private fun observeViewModel() {
@@ -155,26 +157,26 @@ class DefaultBrowserPage : OnboardingPageFragment() {
     }
 
     private fun setUiForDialog() {
-        defaultBrowserImage.setImageResource(R.drawable.set_as_default_browser_illustration_dialog)
-        browserProtectionSubtitle.setText(R.string.defaultBrowserDescriptionNoDefault)
-        browserProtectionTitle.setText(R.string.onboardingDefaultBrowserTitle)
-        launchSettingsButton.setText(R.string.defaultBrowserLetsDoIt)
+        binding.defaultBrowserImage.setImageResource(R.drawable.set_as_default_browser_illustration_dialog)
+        binding.browserProtectionSubtitle.setText(R.string.defaultBrowserDescriptionNoDefault)
+        binding.browserProtectionTitle.setText(R.string.onboardingDefaultBrowserTitle)
+        browserDefaultButtonBinding.launchSettingsButton.setText(R.string.defaultBrowserLetsDoIt)
         setButtonsBehaviour()
     }
 
     private fun setUiForSettings() {
-        defaultBrowserImage.setImageResource(R.drawable.set_as_default_browser_illustration_settings)
-        browserProtectionSubtitle.setText(R.string.onboardingDefaultBrowserDescription)
-        browserProtectionTitle.setText(R.string.onboardingDefaultBrowserTitle)
-        launchSettingsButton.setText(R.string.defaultBrowserLetsDoIt)
+        binding.defaultBrowserImage.setImageResource(R.drawable.set_as_default_browser_illustration_settings)
+        binding.browserProtectionSubtitle.setText(R.string.onboardingDefaultBrowserDescription)
+        binding.browserProtectionTitle.setText(R.string.onboardingDefaultBrowserTitle)
+        browserDefaultButtonBinding.launchSettingsButton.setText(R.string.defaultBrowserLetsDoIt)
         setButtonsBehaviour()
     }
 
     private fun setButtonsBehaviour() {
-        launchSettingsButton.setOnClickListener {
+        browserDefaultButtonBinding.launchSettingsButton.setOnClickListener {
             viewModel.onDefaultBrowserClicked()
         }
-        continueButton.setOnClickListener {
+        browserDefaultButtonBinding.continueButton.setOnClickListener {
             viewModel.onContinueToBrowser(userTriedToSetDDGAsDefault)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
@@ -54,7 +54,9 @@ class DefaultBrowserPage : OnboardingPageFragment(R.layout.content_onboarding_de
     lateinit var variantManager: VariantManager
 
     private val binding: ContentOnboardingDefaultBrowserBinding by viewBinding()
-    private val browserDefaultButtonBinding: IncludeDefaultBrowserButtonsBinding by viewBinding()
+    private val browserDefaultButtonBinding: IncludeDefaultBrowserButtonsBinding by lazy {
+        binding.defaultBrowserButtons!!
+    }
 
     private var userTriedToSetDDGAsDefault = false
     private var userSelectedExternalBrowser = false

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPageFragment.kt
@@ -16,21 +16,10 @@
 
 package com.duckduckgo.app.onboarding.ui.page
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 
-abstract class OnboardingPageFragment : Fragment() {
-
-    @LayoutRes
-    abstract fun layoutResource(): Int
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-        inflater.inflate(layoutResource(), container, false)
+abstract class OnboardingPageFragment(layoutResId: Int) : Fragment(layoutResId) {
 
     fun onContinuePressed() {
         when (activity) {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -49,9 +49,6 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
     @Inject
     lateinit var viewModelFactory: WelcomePageViewModelFactory
 
-    private val binding: ContentOnboardingWelcomeBinding by viewBinding()
-    private val includeDaxDialogBinding: IncludeDaxDialogCtaBinding by viewBinding()
-
     private var ctaText: String = ""
     private var welcomeAnimation: ViewPropertyAnimatorCompat? = null
     private var typingAnimation: ViewPropertyAnimatorCompat? = null
@@ -59,6 +56,11 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
 
     // we use a BroadcastChannel because we don't want to emit the last value upon subscription
     private val events = BroadcastChannel<WelcomePageView.Event>(1)
+
+    private val binding: ContentOnboardingWelcomeBinding by viewBinding()
+    private val daxDialogCtaBinding: IncludeDaxDialogCtaBinding by lazy {
+        binding.includeDaxDialogCta!!
+    }
 
     private val welcomePageViewModel: WelcomePageViewModel by lazy {
         ViewModelProvider(this, viewModelFactory).get(WelcomePageViewModel::class.java)
@@ -148,17 +150,17 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
     private fun configureDaxCta() {
         context?.let {
             ctaText = it.getString(R.string.onboardingDaxText)
-            includeDaxDialogBinding.hiddenTextCta.text = ctaText.html(it)
-            includeDaxDialogBinding.dialogTextCta.textInDialog = ctaText.html(it)
-            includeDaxDialogBinding.dialogTextCta.setTextColor(ContextCompat.getColor(it, R.color.grayishBrown))
-            includeDaxDialogBinding.cardView.backgroundTintList = ContextCompat.getColorStateList(it, R.color.white)
+            daxDialogCtaBinding.hiddenTextCta.text = ctaText.html(it)
+            daxDialogCtaBinding.dialogTextCta.textInDialog = ctaText.html(it)
+            daxDialogCtaBinding.dialogTextCta.setTextColor(ContextCompat.getColor(it, R.color.grayishBrown))
+            daxDialogCtaBinding.cardView.backgroundTintList = ContextCompat.getColorStateList(it, R.color.white)
         }
-        includeDaxDialogBinding.triangle.setImageResource(R.drawable.ic_triangle_bubble_white)
+        daxDialogCtaBinding.triangle.setImageResource(R.drawable.ic_triangle_bubble_white)
     }
 
     private fun setSkipAnimationListener() {
         binding.longDescriptionContainer.setOnClickListener {
-            if (includeDaxDialogBinding.dialogTextCta.hasAnimationStarted()) {
+            if (daxDialogCtaBinding.dialogTextCta.hasAnimationStarted()) {
                 finishTypingAnimation()
             } else if (!welcomeAnimationFinished) {
                 welcomeAnimation?.cancel()
@@ -174,12 +176,12 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
             .setDuration(ANIMATION_DURATION)
             .setStartDelay(startDelay)
             .withEndAction {
-                typingAnimation = ViewCompat.animate(includeDaxDialogBinding.daxCtaContainer)
+                typingAnimation = ViewCompat.animate(daxDialogCtaBinding.daxCtaContainer)
                     .alpha(MAX_ALPHA)
                     .setDuration(ANIMATION_DURATION)
                     .withEndAction {
                         welcomeAnimationFinished = true
-                        includeDaxDialogBinding.dialogTextCta.startTypingAnimation(ctaText)
+                        daxDialogCtaBinding.dialogTextCta.startTypingAnimation(ctaText)
                         setPrimaryCtaListenerAfterWelcomeAlphaAnimation()
                     }
             }
@@ -187,12 +189,12 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
 
     private fun finishTypingAnimation() {
         welcomeAnimation?.cancel()
-        includeDaxDialogBinding.dialogTextCta.finishAnimation()
+        daxDialogCtaBinding.dialogTextCta.finishAnimation()
         setPrimaryCtaListenerAfterWelcomeAlphaAnimation()
     }
 
     private fun setPrimaryCtaListenerAfterWelcomeAlphaAnimation() {
-        includeDaxDialogBinding.primaryCta.setOnClickListener { event(WelcomePageView.Event.OnPrimaryCtaClicked) }
+        daxDialogCtaBinding.primaryCta.setOnClickListener { event(WelcomePageView.Event.OnPrimaryCtaClicked) }
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -30,10 +30,11 @@ import androidx.core.view.ViewPropertyAnimatorCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ContentOnboardingWelcomeBinding
+import com.duckduckgo.app.browser.databinding.IncludeDaxDialogCtaBinding
 import com.duckduckgo.app.global.view.html
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.content_onboarding_welcome.*
-import kotlinx.android.synthetic.main.include_dax_dialog_cta.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.flow.asFlow
@@ -43,10 +44,13 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ExperimentalCoroutinesApi
-class WelcomePage : OnboardingPageFragment() {
+class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) {
 
     @Inject
     lateinit var viewModelFactory: WelcomePageViewModelFactory
+
+    private val binding: ContentOnboardingWelcomeBinding by viewBinding()
+    private val includeDaxDialogBinding: IncludeDaxDialogCtaBinding by viewBinding()
 
     private var ctaText: String = ""
     private var welcomeAnimation: ViewPropertyAnimatorCompat? = null
@@ -59,8 +63,6 @@ class WelcomePage : OnboardingPageFragment() {
     private val welcomePageViewModel: WelcomePageViewModel by lazy {
         ViewModelProvider(this, viewModelFactory).get(WelcomePageViewModel::class.java)
     }
-
-    override fun layoutResource(): Int = R.layout.content_onboarding_welcome
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
@@ -140,23 +142,23 @@ class WelcomePage : OnboardingPageFragment() {
             decorView.systemUiVisibility += View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
             statusBarColor = Color.TRANSPARENT
         }
-        ViewCompat.requestApplyInsets(longDescriptionContainer)
+        ViewCompat.requestApplyInsets(binding.longDescriptionContainer)
     }
 
     private fun configureDaxCta() {
         context?.let {
             ctaText = it.getString(R.string.onboardingDaxText)
-            hiddenTextCta.text = ctaText.html(it)
-            dialogTextCta.textInDialog = ctaText.html(it)
-            dialogTextCta.setTextColor(ContextCompat.getColor(it, R.color.grayishBrown))
-            cardView.backgroundTintList = ContextCompat.getColorStateList(it, R.color.white)
+            includeDaxDialogBinding.hiddenTextCta.text = ctaText.html(it)
+            includeDaxDialogBinding.dialogTextCta.textInDialog = ctaText.html(it)
+            includeDaxDialogBinding.dialogTextCta.setTextColor(ContextCompat.getColor(it, R.color.grayishBrown))
+            includeDaxDialogBinding.cardView.backgroundTintList = ContextCompat.getColorStateList(it, R.color.white)
         }
-        triangle.setImageResource(R.drawable.ic_triangle_bubble_white)
+        includeDaxDialogBinding.triangle.setImageResource(R.drawable.ic_triangle_bubble_white)
     }
 
     private fun setSkipAnimationListener() {
-        longDescriptionContainer.setOnClickListener {
-            if (dialogTextCta.hasAnimationStarted()) {
+        binding.longDescriptionContainer.setOnClickListener {
+            if (includeDaxDialogBinding.dialogTextCta.hasAnimationStarted()) {
                 finishTypingAnimation()
             } else if (!welcomeAnimationFinished) {
                 welcomeAnimation?.cancel()
@@ -167,17 +169,17 @@ class WelcomePage : OnboardingPageFragment() {
     }
 
     private fun scheduleWelcomeAnimation(startDelay: Long = ANIMATION_DELAY) {
-        welcomeAnimation = ViewCompat.animate(welcomeContent as View)
+        welcomeAnimation = ViewCompat.animate(binding.welcomeContent as View)
             .alpha(MIN_ALPHA)
             .setDuration(ANIMATION_DURATION)
             .setStartDelay(startDelay)
             .withEndAction {
-                typingAnimation = ViewCompat.animate(daxCtaContainer)
+                typingAnimation = ViewCompat.animate(includeDaxDialogBinding.daxCtaContainer)
                     .alpha(MAX_ALPHA)
                     .setDuration(ANIMATION_DURATION)
                     .withEndAction {
                         welcomeAnimationFinished = true
-                        dialogTextCta.startTypingAnimation(ctaText)
+                        includeDaxDialogBinding.dialogTextCta.startTypingAnimation(ctaText)
                         setPrimaryCtaListenerAfterWelcomeAlphaAnimation()
                     }
             }
@@ -185,12 +187,12 @@ class WelcomePage : OnboardingPageFragment() {
 
     private fun finishTypingAnimation() {
         welcomeAnimation?.cancel()
-        dialogTextCta.finishAnimation()
+        includeDaxDialogBinding.dialogTextCta.finishAnimation()
         setPrimaryCtaListenerAfterWelcomeAlphaAnimation()
     }
 
     private fun setPrimaryCtaListenerAfterWelcomeAlphaAnimation() {
-        primaryCta.setOnClickListener { event(WelcomePageView.Event.OnPrimaryCtaClicked) }
+        includeDaxDialogBinding.primaryCta.setOnClickListener { event(WelcomePageView.Event.OnPrimaryCtaClicked) }
     }
 
     companion object {

--- a/app/src/main/res/layout/content_onboarding_default_browser.xml
+++ b/app/src/main/res/layout/content_onboarding_default_browser.xml
@@ -24,7 +24,8 @@
     tools:background="@color/white"
     tools:context="com.duckduckgo.app.onboarding.ui.OnboardingActivity">
 
-    <include layout="@layout/include_default_browser_buttons"/>
+    <include android:id="@+id/default_browser_buttons"
+        layout="@layout/include_default_browser_buttons"/>
 
     <ImageView
         android:id="@+id/defaultBrowserImage"

--- a/app/src/main/res/layout/content_onboarding_welcome.xml
+++ b/app/src/main/res/layout/content_onboarding_welcome.xml
@@ -58,6 +58,7 @@
     </LinearLayout>
 
     <include
+        android:id="@+id/include_dax_dialog_cta"
         layout="@layout/include_dax_dialog_cta"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/DialogViewBindingDelegate.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/DialogViewBindingDelegate.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.viewbinding
+
+import android.view.LayoutInflater
+import androidx.appcompat.app.AppCompatDialog
+import androidx.viewbinding.ViewBinding
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+inline fun <reified T : ViewBinding> AppCompatDialog.viewBinding() = DialogViewBindingDelegate(T::class.java, this)
+
+class DialogViewBindingDelegate<T : ViewBinding>(
+    private val bindingClass: Class<T>,
+    private val dialog: AppCompatDialog
+) : ReadOnlyProperty<AppCompatDialog, T> {
+    private var binding: T? = null
+
+    override fun getValue(thisRef: AppCompatDialog, property: KProperty<*>): T {
+        binding?.let { return it }
+
+        val inflateMethod = bindingClass.getMethod("inflate", LayoutInflater::class.java)
+        binding = inflateMethod.invoke(null, LayoutInflater.from(dialog.context)).cast<T>()
+
+        return binding!!
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> Any.cast(): T = this as T


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL:https://github.com/duckduckgo/Android/issues/1478

### Description
Migrated fragments to ViewBinding.
Does not include `BrowserTabFragment` because couldn't figure out how to migrate PopupMenu to view binding.
