### PR TITLE
Add gradle tasks called `checks` which will run various checks and tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -251,3 +251,7 @@ tasks.register('fastlaneVersionCode') {
         print buildVersionCode()
     }
 }
+
+tasks.register('checks') {
+    dependsOn 'spotlessCheck', 'testPlayDebugUnitTest', 'connectedPlayDebugAndroidTest'
+}

--- a/feature-toggles/feature-toggles-api/build.gradle
+++ b/feature-toggles/feature-toggles-api/build.gradle
@@ -30,3 +30,7 @@ dependencies {
     implementation Google.dagger
     implementation Kotlin.stdlib.jdk7
 }
+
+tasks.register('checks') {
+    dependsOn 'spotlessCheck'
+}

--- a/feature-toggles/feature-toggles-impl/build.gradle
+++ b/feature-toggles/feature-toggles-impl/build.gradle
@@ -44,3 +44,7 @@ dependencies {
 anvil {
     generateDaggerFactories = true // default is false
 }
+
+tasks.register('checks') {
+    dependsOn 'spotlessCheck', 'testDebugUnitTest'
+}

--- a/privacy-config/privacy-config-api/build.gradle
+++ b/privacy-config/privacy-config-api/build.gradle
@@ -33,3 +33,7 @@ dependencies {
     implementation Google.dagger
     implementation Kotlin.stdlib.jdk7
 }
+
+tasks.register('checks') {
+    dependsOn 'spotlessCheck'
+}

--- a/privacy-config/privacy-config-impl/build.gradle
+++ b/privacy-config/privacy-config-impl/build.gradle
@@ -72,3 +72,7 @@ android {
         generateDaggerFactories = true // default is false
     }
 }
+
+tasks.register('checks') {
+    dependsOn 'spotlessCheck', 'testDebugUnitTest'
+}

--- a/privacy-config/privacy-config-store/build.gradle
+++ b/privacy-config/privacy-config-store/build.gradle
@@ -51,3 +51,7 @@ dependencies {
 
     testImplementation project(path: ':common-test')
 }
+
+tasks.register('checks') {
+    dependsOn 'spotlessCheck', 'testDebugUnitTest'
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201178246672732/f

### Description
Opt-in system for each module. Each module can define a task called `checks` which, when run, will perform checks that make sense to that module. Such a check might be to run `spotlessCheck`, run JVM unit tests, run android instrumentation tests etc...

To run all checks across all modules, run `./gradlew checks` at the top level of the project (and it will run all `checks` tasks in the submodules)

At this stage, this is an optional check that can be run locally. Its usage won't be enforced (e.g., no githooks etc...) currently.

### Steps to test this PR

- run `./gradlew checks` at the top level; verify everything passes
- deliberately break something (e.g., spotless violation in production code, a failing unit test, a failing instrumentation test); verify the build breaks

