### PR TITLE
Remove bottom inset for Snackbars on the BrowserTabFragment

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -305,7 +305,7 @@ class BrowserTabFragment :
     private var webView: DuckDuckGoWebView? = null
 
     private val errorSnackbar: Snackbar by lazy {
-        Snackbar.make(browserLayout, R.string.crashedWebViewErrorMessage, Snackbar.LENGTH_INDEFINITE)
+        browserLayout.makeSnackbarWithNoBottomInset(R.string.crashedWebViewErrorMessage, Snackbar.LENGTH_INDEFINITE)
             .setBehavior(NonDismissibleBehavior())
     }
 
@@ -748,7 +748,7 @@ class BrowserTabFragment :
             is DownloadCommand.ShowDownloadFailedNotification -> {
                 fileDownloadNotificationManager.showDownloadFailedNotification()
 
-                val snackbar = Snackbar.make(toolbar, R.string.downloadFailed, Snackbar.LENGTH_INDEFINITE)
+                val snackbar = toolbar.makeSnackbarWithNoBottomInset(R.string.downloadFailed, Snackbar.LENGTH_INDEFINITE)
                 if (it.reason == DownloadFailReason.DownloadManagerDisabled) {
                     snackbar.setText(it.message)
                     snackbar.setAction(getString(R.string.enable)) {
@@ -810,7 +810,7 @@ class BrowserTabFragment :
 
     private fun showDomainHasLocationPermission(domain: String) {
         val snackbar =
-            Snackbar.make(rootView, getString(R.string.preciseLocationSnackbarMessage, domain.websiteFromGeoLocationsApiOrigin()), Snackbar.LENGTH_SHORT)
+            rootView.makeSnackbarWithNoBottomInset(getString(R.string.preciseLocationSnackbarMessage, domain.websiteFromGeoLocationsApiOrigin()), Snackbar.LENGTH_SHORT)
         snackbar.view.setOnClickListener {
             browserActivity?.launchLocationSettings()
         }
@@ -858,8 +858,7 @@ class BrowserTabFragment :
                 action = getString(R.string.appLinkMultipleSnackBarAction)
             }
 
-            appLinksSnackBar = Snackbar.make(
-                view,
+            appLinksSnackBar = view.makeSnackbarWithNoBottomInset(
                 message,
                 Snackbar.LENGTH_LONG
             ).setAction(action) {
@@ -1340,7 +1339,7 @@ class BrowserTabFragment :
             is SavedSite.Bookmark -> R.string.bookmarkAddedMessage
             is SavedSite.Favorite -> R.string.favoriteAddedMessage
         }
-        Snackbar.make(browserLayout, snackbarMessage, Snackbar.LENGTH_LONG)
+        browserLayout.makeSnackbarWithNoBottomInset(snackbarMessage, Snackbar.LENGTH_LONG)
             .setAction(R.string.edit) {
                 editSavedSite(savedSite)
             }
@@ -1356,8 +1355,7 @@ class BrowserTabFragment :
     private fun confirmDeleteSavedSite(savedSite: SavedSite) {
         val message = getString(R.string.bookmarkDeleteConfirmationMessage, savedSite.title).html(requireContext())
         viewModel.deleteQuickAccessItem(savedSite)
-        Snackbar.make(
-            rootView,
+        rootView.makeSnackbarWithNoBottomInset(
             message,
             Snackbar.LENGTH_LONG
         ).setAction(R.string.fireproofWebsiteSnackbarAction) {
@@ -1366,15 +1364,12 @@ class BrowserTabFragment :
     }
 
     private fun fireproofWebsiteConfirmation(entity: FireproofWebsiteEntity) {
-        Snackbar.make(
-            rootView,
+        rootView.makeSnackbarWithNoBottomInset(
             HtmlCompat.fromHtml(getString(R.string.fireproofWebsiteSnackbarConfirmation, entity.website()), FROM_HTML_MODE_LEGACY),
             Snackbar.LENGTH_LONG
-        )
-            .setAction(R.string.fireproofWebsiteSnackbarAction) {
-                viewModel.onFireproofWebsiteSnackbarUndoClicked(entity)
-            }
-            .show()
+        ).setAction(R.string.fireproofWebsiteSnackbarAction) {
+            viewModel.onFireproofWebsiteSnackbarUndoClicked(entity)
+        }.show()
     }
 
     private fun launchSharePageChooser(url: String) {
@@ -1588,7 +1583,7 @@ class BrowserTabFragment :
                     downloadFile(requestUserConfirmation = false)
                 } else {
                     Timber.i("Write external storage permission refused")
-                    Snackbar.make(toolbar, R.string.permissionRequiredToDownload, Snackbar.LENGTH_LONG).show()
+                    toolbar.makeSnackbarWithNoBottomInset(R.string.permissionRequiredToDownload, Snackbar.LENGTH_LONG).show()
                 }
             }
             PERMISSION_REQUEST_GEO_LOCATION -> {
@@ -2342,7 +2337,7 @@ class BrowserTabFragment :
             startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             Timber.w(e, "Could not open DownloadManager settings")
-            Snackbar.make(toolbar, R.string.downloadManagerIncompatible, Snackbar.LENGTH_INDEFINITE).show()
+            toolbar.makeSnackbarWithNoBottomInset(R.string.downloadManagerIncompatible, Snackbar.LENGTH_INDEFINITE).show()
         }
     }
 

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/ViewExtension.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/ViewExtension.kt
@@ -22,7 +22,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.CompoundButton
+import androidx.annotation.StringRes
 import androidx.core.view.children
+import com.google.android.material.snackbar.BaseTransientBottomBar.Duration
+import com.google.android.material.snackbar.Snackbar
 
 /*
  * Common view operations, simplified as Kotlin extensions
@@ -117,4 +120,16 @@ fun CompoundButton.quietlySetIsChecked(newCheckedState: Boolean, changeListener:
     setOnCheckedChangeListener(null)
     isChecked = newCheckedState
     setOnCheckedChangeListener(changeListener)
+}
+
+fun View.makeSnackbarWithNoBottomInset(text: CharSequence, @Duration duration: Int): Snackbar {
+    val snackbar = Snackbar.make(this, text, duration)
+    snackbar.isGestureInsetBottomIgnored = true
+    return snackbar
+}
+
+fun View.makeSnackbarWithNoBottomInset(@StringRes resId: Int, @Duration duration: Int): Snackbar {
+    val snackbar = Snackbar.make(this, resId, duration)
+    snackbar.isGestureInsetBottomIgnored = true
+    return snackbar
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201193768905176/f

### Description
This removes the gap between the gesture nav bar and the `Snackbars` on the `BrowserTabFragment`.

### Steps to test this PR

_Feature 1_
1. Enable gesture navigation on you device/emulator.
2. Tap "Add Bookmark" from the browser overflow menu.
3. Verify that there is no gap between the `Snackbar` and gesture nav bar.

### UI changes
| Before  | After |
| ------ | ----- |
![before](https://user-images.githubusercontent.com/3471025/137444684-ce3e3bba-1bf6-446d-8311-bb4c7f7f1b09.png)|![after](https://user-images.githubusercontent.com/3471025/137444702-ba3b392a-d3c2-4d6f-b8c9-e937a15a7fd6.png)|


