### PR TITLE
Use correct style for neutral AlertDialog button

### DIFF
--- a/common-ui/src/main/res/values/themes.xml
+++ b/common-ui/src/main/res/values/themes.xml
@@ -309,6 +309,7 @@
         <item name="android:buttonBarButtonStyle">@style/AlertDialogButtonStyle</item>
         <item name="buttonBarNegativeButtonStyle">@style/AlertDialogButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/AlertDialogButtonStyle</item>
+        <item name="buttonBarNeutralButtonStyle">@style/AlertDialogButtonStyle</item>
     </style>
 
     <style name="AlertDialogButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201193768905207/f

### Description
This sets neutral `AlertDialog` buttons to the correct style.

### Steps to test this PR

_Feature 1_
1. Type "Github phone number" in search.
2. Tap the phone number.
3. Verify that the "Close tab" button is the correct style.

### UI changes
| Before  | After | After (Dark) |
| ------ | ----- | ----- |
![before](https://user-images.githubusercontent.com/3471025/137458855-51b8df65-a16e-4640-b844-2c054d2b3822.png)|![after](https://user-images.githubusercontent.com/3471025/137458894-d0dd6963-b479-4c80-aee8-688b2934e5b0.png)|![after (dark)](https://user-images.githubusercontent.com/3471025/137458942-30f3420d-2c09-4f8b-9f1c-d6bbc626466e.png)