### PR TITLE
Use fade out animation after fire button animation preview

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/FireAnimationActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/FireAnimationActivity.kt
@@ -23,6 +23,7 @@ import android.content.Intent
 import android.os.Bundle
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.RenderMode
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityFireAnimationBinding
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.settings.clear.FireAnimation
@@ -60,6 +61,7 @@ class FireAnimationActivity : DuckDuckGoActivity() {
             override fun onAnimationStart(animation: Animator?) {}
             override fun onAnimationEnd(animation: Animator?) {
                 finish()
+                overridePendingTransition(0, R.anim.tab_anim_fade_out)
             }
         })
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201193768905224/f

### Description
This enforces a fade out animation after previewing a fire animation.

### Steps to test this PR

1. Choose a fire animation in settings.
2. Verify that it is dismissed with a fade out animation.

### UI changes

**Before:**

https://user-images.githubusercontent.com/3471025/137483264-4bea6e81-d0fa-4375-a077-8901779e728a.mp4

**After:**

https://user-images.githubusercontent.com/3471025/137485819-6cfa786b-3e08-4ffe-a9e7-eddc01452db1.mp4