### PR TITLE
Replace LiveData with StateFlow in the PrivacyPracticesViewModel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesActivity.kt
@@ -19,7 +19,10 @@ package com.duckduckgo.app.privacy.ui
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.databinding.ActivityPrivacyPracticesBinding
@@ -31,6 +34,8 @@ import com.duckduckgo.app.privacy.renderer.text
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.tabId
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 class PrivacyPracticesActivity : DuckDuckGoActivity() {
@@ -57,12 +62,9 @@ class PrivacyPracticesActivity : DuckDuckGoActivity() {
         configureRecycler()
         setupClickListeners()
 
-        viewModel.viewState.observe(
-            this,
-            Observer<PrivacyPracticesViewModel.ViewState> {
-                it?.let { render(it) }
-            }
-        )
+        viewModel.viewState().flowWithLifecycle(lifecycle, Lifecycle.State.CREATED).onEach { viewState ->
+            render(viewState)
+        }.launchIn(lifecycleScope)
 
         repository.retrieveSiteData(intent.tabId!!).observe(
             this,
@@ -100,7 +102,5 @@ class PrivacyPracticesActivity : DuckDuckGoActivity() {
             intent.tabId = tabId
             return intent
         }
-
     }
-
 }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesViewModel.kt
@@ -16,8 +16,8 @@
 
 package com.duckduckgo.app.privacy.ui
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
@@ -25,43 +25,47 @@ import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.UNKNOWN
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class PrivacyPracticesViewModel : ViewModel() {
 
     data class ViewState(
-        val domain: String,
-        val practices: PrivacyPractices.Summary,
-        val goodTerms: List<String>,
-        val badTerms: List<String>
+        val domain: String = "",
+        val practices: PrivacyPractices.Summary = UNKNOWN,
+        val goodTerms: List<String> = emptyList(),
+        val badTerms: List<String> = emptyList()
     )
 
-    val viewState: MutableLiveData<ViewState> = MutableLiveData()
+    private val viewState = MutableStateFlow(ViewState())
 
-    init {
-        resetViewState()
+    private suspend fun resetViewState() {
+        viewState.emit(ViewState())
     }
 
-    private fun resetViewState() {
-        viewState.value = ViewState(
-            domain = "",
-            practices = UNKNOWN,
-            goodTerms = ArrayList(),
-            badTerms = ArrayList()
+    private suspend fun updateViewState(site: Site) {
+        viewState.emit(
+            viewState.value.copy(
+                domain = site.domain ?: "",
+                practices = site.privacyPractices.summary,
+                goodTerms = site.privacyPractices.goodReasons,
+                badTerms = site.privacyPractices.badReasons
+            )
         )
     }
 
     fun onSiteChanged(site: Site?) {
-        if (site == null) {
-            resetViewState()
-            return
+        viewModelScope.launch {
+            site?.let {
+                updateViewState(it)
+            } ?: resetViewState()
         }
-        viewState.value = viewState.value?.copy(
-            domain = site.domain ?: "",
-            practices = site.privacyPractices.summary,
-            goodTerms = site.privacyPractices.goodReasons,
-            badTerms = site.privacyPractices.badReasons
-        )
+    }
+
+    fun viewState(): StateFlow<ViewState> {
+        return viewState
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201197350399987/f

### Description
Moved the `PrivacyPracticesViewModel` and partially the `PrivacyPracticesActivity` from using `LiveData` to `StateFlow`.

The complete removal of `LiveData` from `PrivacyPracticesActivity` will be addressed as part of another PR which changes the `TabRepository` as this is used in multiple places.

### Steps to test this PR

- install / upgrade from this branch
- navigate to a website (e.g https://www.amazon.com, https://www.theguardian.com)
- tap on the score bubbles displayed at the left side of the URL and you'll open the "Privacy Dashboard" screen
- on "Privacy Dashboard" screen tap on "Privacy Practices" (can be "Poor Privacy Practices" / "Unknown Privacy Practices" / etc) and you'll open the "Privacy Practices" screen
-  check the "Privacy Practices" screen behaves as expected (correct information displayed for poor / unknown / etc)

### Video

https://user-images.githubusercontent.com/7963079/137721202-ab778feb-c6ce-4279-87fa-b164349fda4d.mp4


### No UI changes
