### PR TITLE
Migrate Fragments to viewBinding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/email/EmailAutofillTooltipFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailAutofillTooltipFragment.kt
@@ -19,39 +19,39 @@ package com.duckduckgo.app.email
 import android.content.Context
 import android.os.Bundle
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ContentAutofillTooltipBinding
 import com.duckduckgo.app.global.view.html
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import kotlinx.android.synthetic.main.content_autofill_tooltip.*
 
 class EmailAutofillTooltipFragment(
     context: Context,
     val address: String
 ) : BottomSheetDialog(context, R.style.EmailTooltip) {
 
+    private val binding: ContentAutofillTooltipBinding by viewBinding()
+
     var useAddress: (() -> Unit) = {}
     var usePrivateAlias: (() -> Unit) = {}
 
-    init {
-        setContentView(R.layout.content_autofill_tooltip)
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(binding.root)
         setDialog()
     }
 
     private fun setDialog() {
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
         val addressFormatted = context.getString(R.string.autofillTooltipUseYourAlias, address)
-        tooltipPrimaryCtaTitle.text = addressFormatted.html(context)
+        binding.tooltipPrimaryCtaTitle.text = addressFormatted.html(context)
 
-        secondaryCta.setOnClickListener {
+        binding.secondaryCta.setOnClickListener {
             usePrivateAlias()
             dismiss()
         }
 
-        primaryCta.setOnClickListener {
+        binding.primaryCta.setOnClickListener {
             useAddress()
             dismiss()
         }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
@@ -34,17 +34,19 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ContentOnboardingDefaultBrowserBinding
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserSystemSettings
 import com.duckduckgo.app.global.ViewModelFactory
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.content_onboarding_default_browser.*
-import kotlinx.android.synthetic.main.include_default_browser_buttons.*
 import timber.log.Timber
 import javax.inject.Inject
 
-class DefaultBrowserPage : OnboardingPageFragment() {
+class DefaultBrowserPage : OnboardingPageFragment(R.layout.content_onboarding_default_browser) {
+
+    private val binding: ContentOnboardingDefaultBrowserBinding by viewBinding()
 
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
@@ -60,8 +62,6 @@ class DefaultBrowserPage : OnboardingPageFragment() {
     private val viewModel: DefaultBrowserPageViewModel by lazy {
         ViewModelProvider(this, viewModelFactory).get(DefaultBrowserPageViewModel::class.java)
     }
-
-    override fun layoutResource(): Int = R.layout.content_onboarding_default_browser
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -113,7 +113,7 @@ class DefaultBrowserPage : OnboardingPageFragment() {
             }
             statusBarColor = Color.WHITE
         }
-        requestApplyInsets(longDescriptionContainer)
+        requestApplyInsets(binding.longDescriptionContainer)
     }
 
     private fun observeViewModel() {
@@ -155,26 +155,26 @@ class DefaultBrowserPage : OnboardingPageFragment() {
     }
 
     private fun setUiForDialog() {
-        defaultBrowserImage.setImageResource(R.drawable.set_as_default_browser_illustration_dialog)
-        browserProtectionSubtitle.setText(R.string.defaultBrowserDescriptionNoDefault)
-        browserProtectionTitle.setText(R.string.onboardingDefaultBrowserTitle)
-        launchSettingsButton.setText(R.string.defaultBrowserLetsDoIt)
+        binding.defaultBrowserImage.setImageResource(R.drawable.set_as_default_browser_illustration_dialog)
+        binding.browserProtectionSubtitle.setText(R.string.defaultBrowserDescriptionNoDefault)
+        binding.browserProtectionTitle.setText(R.string.onboardingDefaultBrowserTitle)
+        binding.browserButtons!!.launchSettingsButton.setText(R.string.defaultBrowserLetsDoIt)
         setButtonsBehaviour()
     }
 
     private fun setUiForSettings() {
-        defaultBrowserImage.setImageResource(R.drawable.set_as_default_browser_illustration_settings)
-        browserProtectionSubtitle.setText(R.string.onboardingDefaultBrowserDescription)
-        browserProtectionTitle.setText(R.string.onboardingDefaultBrowserTitle)
-        launchSettingsButton.setText(R.string.defaultBrowserLetsDoIt)
+        binding.defaultBrowserImage.setImageResource(R.drawable.set_as_default_browser_illustration_settings)
+        binding.browserProtectionSubtitle.setText(R.string.onboardingDefaultBrowserDescription)
+        binding.browserProtectionTitle.setText(R.string.onboardingDefaultBrowserTitle)
+        binding.browserButtons!!.launchSettingsButton.setText(R.string.defaultBrowserLetsDoIt)
         setButtonsBehaviour()
     }
 
     private fun setButtonsBehaviour() {
-        launchSettingsButton.setOnClickListener {
+        binding.browserButtons!!.launchSettingsButton.setOnClickListener {
             viewModel.onDefaultBrowserClicked()
         }
-        continueButton.setOnClickListener {
+        binding.browserButtons!!.continueButton.setOnClickListener {
             viewModel.onContinueToBrowser(userTriedToSetDDGAsDefault)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPageFragment.kt
@@ -16,25 +16,11 @@
 
 package com.duckduckgo.app.onboarding.ui.page
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 
-abstract class OnboardingPageFragment : Fragment() {
-
-    @LayoutRes
-    abstract fun layoutResource(): Int
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? =
-        inflater.inflate(layoutResource(), container, false)
+abstract class OnboardingPageFragment(@LayoutRes contentLayoutId: Int = 0) : Fragment(contentLayoutId) {
 
     fun onContinuePressed() {
         when (activity) {

--- a/app/src/main/res/layout/content_onboarding_default_browser.xml
+++ b/app/src/main/res/layout/content_onboarding_default_browser.xml
@@ -24,7 +24,9 @@
     tools:background="@color/white"
     tools:context="com.duckduckgo.app.onboarding.ui.OnboardingActivity">
 
-    <include layout="@layout/include_default_browser_buttons"/>
+    <include
+        android:id="@+id/browser_buttons"
+        layout="@layout/include_default_browser_buttons"/>
 
     <ImageView
         android:id="@+id/defaultBrowserImage"

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/DialogBindingDelegate.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/DialogBindingDelegate.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.viewbinding
+
+import android.app.Dialog
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.viewbinding.ViewBinding
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+inline fun <reified T : ViewBinding> Dialog.viewBinding() = DialogBindingDelegate(T::class.java, this)
+
+class DialogBindingDelegate<T : ViewBinding>(
+    bindingClass: Class<T>,
+    dialog: Dialog
+) : ReadOnlyProperty<Dialog, T> {
+    private val binding: T = try {
+        val inflateMethod = bindingClass.getMethod("inflate", LayoutInflater::class.java, ViewGroup::class.java, Boolean::class.javaPrimitiveType)
+        inflateMethod.invoke(null, LayoutInflater.from(dialog.context), null, false).cast()
+    } catch (e: NoSuchMethodException) {
+        val inflateMethod = bindingClass.getMethod("inflate", LayoutInflater::class.java, ViewGroup::class.java)
+        inflateMethod.invoke(null, LayoutInflater.from(dialog.context), null).cast()
+    }
+
+    override fun getValue(thisRef: Dialog, property: KProperty<*>): T {
+        return binding
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> Any.cast(): T = this as T


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201260849403183/f

### Description
Migrate the following fragments to use viewBindings:
* DownloadConfirmationFragment
* EmailAutofillTooltipFragment
* DefaultBrowserPage
* WelcomePage

### Steps to test this PR

==Test the onboarding fragments==
1. fresh install from this branch
1. open app
1. verify the `Set DuckDuckGo as your default browser app` dialog shows during onboarding

==Test the email autofill==
1. install from this branch
1. ensure email beta is enabled (in settings)
1. go to `https://www.idealista.com/en/nuevo-usuario`
1. in email address click on Dax
1. verify autofill dialog shows
1. verify both buttons in dialog work as expected

==Test download dialog==
1. install from this branch
1. go to https://www.thinkbroadband.com/download
1. download a file
1. download the same file
1. verify download dialog shows
1. verify all dialog options work as expected

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
