### PR TITLE
Issue fixed #1513 : [Bug] Dropdown menu items hard to read in dark mode

### DIFF
--- a/common-ui/src/main/res/values/themes.xml
+++ b/common-ui/src/main/res/values/themes.xml
@@ -115,6 +115,9 @@
         <item name="quickAccessItemTitleTextColor">@color/white</item>
 
         <item name="savedSiteEditTextUnderlineColor">@color/whiteSemiTransparent</item>
+        <item name="android:textColorPrimary">?attr/normalTextColor</item>
+        <item name="android:textColorSecondary">?attr/normalTextColor</item>
+        <item name="android:textColorAlertDialogListItem">?attr/normalTextColor</item>
     </style>
 
     <style name="AppTheme.Dark" parent="AppTheme.BaseDark" />

--- a/common-ui/src/main/res/values/themes.xml
+++ b/common-ui/src/main/res/values/themes.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <style name="SplashScreen" parent="AppTheme.Light"/>
 
@@ -307,7 +307,7 @@
         <item name="android:textColorSecondary">?attr/normalTextColor</item>
         <item name="android:background">?attr/dialogBgColor</item>
         <item name="colorAccent">@color/cornflowerBlue</item>
-        <item name="textColorAlertDialogListItem">?attr/normalTextColor</item>
+        <item name="android:textColorAlertDialogListItem">?attr/normalTextColor</item>
         <item name="android:buttonBarButtonStyle">@style/AlertDialogButtonStyle</item>
         <item name="buttonBarNegativeButtonStyle">@style/AlertDialogButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/AlertDialogButtonStyle</item>

--- a/common-ui/src/main/res/values/themes.xml
+++ b/common-ui/src/main/res/values/themes.xml
@@ -116,7 +116,7 @@
 
         <item name="savedSiteEditTextUnderlineColor">@color/whiteSemiTransparent</item>
         <item name="android:textColorPrimary">?attr/normalTextColor</item>
-        <item name="android:textColorSecondary">?attr/normalTextColor</item>
+        <item name="android:textColorSecondary">?attr/secondaryTextColor</item>
         <item name="android:textColorAlertDialogListItem">?attr/normalTextColor</item>
     </style>
 
@@ -307,7 +307,7 @@
     <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:textColor">?attr/normalTextColor</item>
         <item name="android:textColorPrimary">?attr/normalTextColor</item>
-        <item name="android:textColorSecondary">?attr/normalTextColor</item>
+        <item name="android:textColorSecondary">?attr/secondaryTextColor</item>
         <item name="android:background">?attr/dialogBgColor</item>
         <item name="colorAccent">@color/cornflowerBlue</item>
         <item name="android:textColorAlertDialogListItem">?attr/normalTextColor</item>


### PR DESCRIPTION
Task/Issue URL:
Resolves #1513 

### Description
Changed text color of list items in drop down list to set as per selected mode.

### Steps to test this PR

1. Set DuckDuckGo Browser to dark mode
2. Find a page with a dropdown list (example: https://archlinux.org/mirrorlist/)
3. Tap the list to bring up the popup


### UI changes
| Before |
![Screenshot_20211027-103928_DuckDuckGo](https://user-images.githubusercontent.com/50566871/139004321-50ad18b8-0e00-4624-a67a-d040b64124e4.jpg)

 | After |

![Screenshot_20211027-104318_DuckDuckGo](https://user-images.githubusercontent.com/50566871/139004346-18ee96ed-bebe-40cb-a764-73eb8c7c3d1f.jpg)
