### PR TITLE
Remove the usage of TabRepository in PrivacyPracticesActivity

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesViewModel.kt
@@ -17,20 +17,22 @@
 package com.duckduckgo.app.privacy.ui
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
-import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
 import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.UNKNOWN
+import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
+import javax.inject.Provider
 
-class PrivacyPracticesViewModel : ViewModel() {
+class PrivacyPracticesViewModel(
+    private val tabRepository: TabRepository
+) : ViewModel() {
 
     data class ViewState(
         val domain: String = "",
@@ -39,42 +41,28 @@ class PrivacyPracticesViewModel : ViewModel() {
         val badTerms: List<String> = emptyList()
     )
 
-    private val viewState = MutableStateFlow(ViewState())
-
-    private suspend fun resetViewState() {
-        viewState.emit(ViewState())
-    }
-
-    private suspend fun updateViewState(site: Site) {
-        viewState.emit(
-            viewState.value.copy(
-                domain = site.domain ?: "",
-                practices = site.privacyPractices.summary,
-                goodTerms = site.privacyPractices.goodReasons,
-                badTerms = site.privacyPractices.badReasons
+    fun privacyPractices(tabId: String): StateFlow<ViewState> = flow {
+        tabRepository.retrieveSiteData(tabId).asFlow().collect { site ->
+            emit(
+                ViewState(
+                    domain = site.domain ?: "",
+                    practices = site.privacyPractices.summary,
+                    goodTerms = site.privacyPractices.goodReasons,
+                    badTerms = site.privacyPractices.badReasons
+                )
             )
-        )
-    }
-
-    fun onSiteChanged(site: Site?) {
-        viewModelScope.launch {
-            site?.let {
-                updateViewState(it)
-            } ?: resetViewState()
         }
-    }
-
-    fun viewState(): StateFlow<ViewState> {
-        return viewState
-    }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
 }
 
 @ContributesMultibinding(AppObjectGraph::class)
-class PrivacyPracticesViewModelFactory @Inject constructor() : ViewModelFactoryPlugin {
+class PrivacyPracticesViewModelFactory @Inject constructor(
+    private val tabRepository: Provider<TabRepository>
+) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(PrivacyPracticesViewModel::class.java) -> (PrivacyPracticesViewModel() as T)
+                isAssignableFrom(PrivacyPracticesViewModel::class.java) -> (PrivacyPracticesViewModel(tabRepository.get()) as T)
                 else -> null
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201307807827049/f

### Description
Removed the reference to tab repository from PrivacyPracticesActivity.

### Steps to test this PR

- install / upgrade from this branch
- navigate to a website (e.g https://www.amazon.com, https://www.theguardian.com)
- tap on the score bubbles displayed at the left side of the URL and you'll open the "Privacy Dashboard" screen
- on "Privacy Dashboard" screen tap on "Privacy Practices" (can be "Poor Privacy Practices" / "Unknown Privacy Practices" / etc) and you'll open the "Privacy Practices" screen
-  check the "Privacy Practices" screen behaves as expected (correct information displayed for poor / unknown / etc)

### Video

https://user-images.githubusercontent.com/7963079/140561826-a635f132-bded-4c51-8430-0ca97f9b568e.mp4


### No UI changes
