### PR TITLE
Add app link pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -305,15 +305,36 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenAppLinksSwitchedOnThenDataStoreIsUpdated() {
+    fun whenAppLinksSetToAskEverytimeThenDataStoreIsUpdatedAndPixelIsSent() {
         testee.onAppLinksSettingChanged(AppLinkSettingType.ASK_EVERYTIME)
         verify(mockAppSettingsDataStore).appLinksEnabled = true
+        verify(mockAppSettingsDataStore).showAppLinksPrompt = true
+
+        verify(mockPixel).fire(
+            AppPixelName.SETTINGS_APP_LINKS_ASK_EVERY_TIME_SELECTED
+        )
     }
 
     @Test
-    fun whenAppLinksSwitchedOffThenDataStoreIsUpdated() {
+    fun whenAppLinksSetToAlwaysThenDataStoreIsUpdatedAndPixelIsSent() {
+        testee.onAppLinksSettingChanged(AppLinkSettingType.ALWAYS)
+        verify(mockAppSettingsDataStore).appLinksEnabled = true
+        verify(mockAppSettingsDataStore).showAppLinksPrompt = false
+
+        verify(mockPixel).fire(
+            AppPixelName.SETTINGS_APP_LINKS_ALWAYS_SELECTED
+        )
+    }
+
+    @Test
+    fun whenAppLinksSetToNeverThenDataStoreIsUpdatedAndPixelIsSent() {
         testee.onAppLinksSettingChanged(AppLinkSettingType.NEVER)
         verify(mockAppSettingsDataStore).appLinksEnabled = false
+        verify(mockAppSettingsDataStore).showAppLinksPrompt = false
+
+        verify(mockPixel).fire(
+            AppPixelName.SETTINGS_APP_LINKS_NEVER_SELECTED
+        )
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -864,8 +864,18 @@ class BrowserTabFragment :
                 message,
                 Snackbar.LENGTH_LONG
             ).setAction(action) {
+                pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED)
                 openAppLink(appLink)
-            }
+            }.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+                override fun onShown(transientBottomBar: Snackbar?) {
+                    super.onShown(transientBottomBar)
+                    pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_SHOWN)
+                }
+
+                override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                    super.onDismissed(transientBottomBar, event)
+                }
+            })
 
             appLinksSnackBar?.setDuration(6000)?.show()
         }
@@ -1857,6 +1867,7 @@ class BrowserTabFragment :
                 }
                 onMenuItemClicked(view.newEmailAliasMenuItem) { viewModel.consumeAliasAndCopyToClipboard() }
                 onMenuItemClicked(view.openInAppMenuItem) {
+                    pixel.fire(AppPixelName.MENU_ACTION_APP_LINKS_OPEN_PRESSED)
                     viewModel.openAppLink()
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -117,6 +117,10 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_DO_NOT_SELL_SHOWN("ms_dns"),
     SETTINGS_DO_NOT_SELL_ON("ms_dns_on"),
     SETTINGS_DO_NOT_SELL_OFF("ms_dns_off"),
+    SETTINGS_APP_LINKS_PRESSED("ms_app_links_setting_pressed"),
+    SETTINGS_APP_LINKS_ASK_EVERY_TIME_SELECTED("ms_app_links_ask_every_time_setting_selected"),
+    SETTINGS_APP_LINKS_ALWAYS_SELECTED("ms_app_links_always_setting_selected"),
+    SETTINGS_APP_LINKS_NEVER_SELECTED("ms_app_links_never_setting_selected"),
 
     SURVEY_CTA_SHOWN(pixelName = "mus_cs"),
     SURVEY_CTA_DISMISSED(pixelName = "mus_cd"),
@@ -156,6 +160,9 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     APP_FEEDBACK_DIALOG_USER_DECLINED_FEEDBACK("mrp_f_d%d_n"),
     APP_FEEDBACK_DIALOG_USER_CANCELLED("mrp_f_d%d_c"),
 
+    APP_LINKS_SNACKBAR_SHOWN("m_app_links_snackbar_shown"),
+    APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED("m_app_links_snackbar_open_action_pressed"),
+
     FEEDBACK_POSITIVE_SUBMISSION("mfbs_%s_submit"),
     FEEDBACK_NEGATIVE_SUBMISSION("mfbs_%s_%s_%s"),
 
@@ -184,6 +191,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED("m_nav_dsd_p"),
     MENU_ACTION_REPORT_BROKEN_SITE_PRESSED("m_nav_rbs_p"),
     MENU_ACTION_SETTINGS_PRESSED("m_nav_s_p"),
+    MENU_ACTION_APP_LINKS_OPEN_PRESSED("m_nav_app_links_open_menu_item_pressed"),
 
     COOKIE_DATABASE_EXCEPTION_OPEN_ERROR("m_cdb_e_oe"),
     COOKIE_DATABASE_EXCEPTION_DELETE_ERROR("m_cdb_e_de"),

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -162,6 +162,7 @@ class SettingsViewModel @Inject constructor(
 
     fun userRequestedToChangeAppLinkSetting() {
         viewModelScope.launch { command.send(Command.LaunchAppLinkSettings(viewState.value.appLinksSettingType)) }
+        pixel.fire(SETTINGS_APP_LINKS_PRESSED)
     }
 
     fun onFireproofWebsitesClicked() {
@@ -207,21 +208,27 @@ class SettingsViewModel @Inject constructor(
     fun onAppLinksSettingChanged(appLinkSettingType: AppLinkSettingType) {
         Timber.i("User changed app links setting, is now: ${appLinkSettingType.name}")
 
-        when (appLinkSettingType) {
-            AppLinkSettingType.ASK_EVERYTIME -> {
-                settingsDataStore.appLinksEnabled = true
-                settingsDataStore.showAppLinksPrompt = true
+        val pixelName =
+            when (appLinkSettingType) {
+                AppLinkSettingType.ASK_EVERYTIME -> {
+                    settingsDataStore.appLinksEnabled = true
+                    settingsDataStore.showAppLinksPrompt = true
+                    SETTINGS_APP_LINKS_ASK_EVERY_TIME_SELECTED
+                }
+                AppLinkSettingType.ALWAYS -> {
+                    settingsDataStore.appLinksEnabled = true
+                    settingsDataStore.showAppLinksPrompt = false
+                    SETTINGS_APP_LINKS_ALWAYS_SELECTED
+                }
+                AppLinkSettingType.NEVER -> {
+                    settingsDataStore.appLinksEnabled = false
+                    settingsDataStore.showAppLinksPrompt = false
+                    SETTINGS_APP_LINKS_NEVER_SELECTED
+                }
             }
-            AppLinkSettingType.ALWAYS -> {
-                settingsDataStore.appLinksEnabled = true
-                settingsDataStore.showAppLinksPrompt = false
-            }
-            AppLinkSettingType.NEVER -> {
-                settingsDataStore.appLinksEnabled = false
-                settingsDataStore.showAppLinksPrompt = false
-            }
-        }
         viewModelScope.launch { viewState.emit(currentViewState().copy(appLinksSettingType = appLinkSettingType)) }
+
+        pixel.fire(pixelName)
     }
 
     private fun getAppLinksSettingsState(appLinksEnabled: Boolean, showAppLinksPrompt: Boolean): AppLinkSettingType {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1201241685107301/f

### Description
This adds pixels to the app link functionality.

### Steps to test this PR

**To check if these pixels are being sent, search for "app_links" in Logcat**.
1. Go to _maps.google.com_.
2. Verify that the app links Snackbar is shown with pixel `m_app_links_snackbar_shown`.
3. Tap "Open in app" on the Snackbar.
4. Verify pixel sent: `m_app_links_snackbar_open_action_pressed`.
5. Go back and open the overflow menu.
6. Tap the "Open in App" menu item.
7. Verify pixel sent: `m_nav_app_links_open_menu_item_pressed`.
8. Go back and go to "Settings".
9. Tap "Open Links in Apps".
10. Verify pixel sent: `ms_app_links_setting_pressed`.
11. Select "Ask every time" and click "Save".
12. Verify pixel sent: `ms_app_links_ask_every_time_setting_selected`.
13. Tap "Open Links in Apps".
14. Select "Always" and click "Save".
15. Verify pixel sent: `ms_app_links_always_setting_selected`.
16. Tap "Open Links in Apps".
17. Select "Never" and click "Save".
18. Verify pixel sent: `ms_app_links_never_setting_selected`.