### PR TITLE
Android: Implement retention experiment to treat returning users differently

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -695,6 +695,32 @@ class CtaViewModelTest {
         assertNull(fireDialogCta)
     }
 
+    @Test
+    fun whenRefreshCtaOnHomeTabAndReturningUsersNoOnboardingEnabledTrueAndWidgetCompatibleThenReturnNull() = coroutineRule.runBlocking {
+        whenever(mockSettingsDataStore.hideTips).thenReturn(false)
+        whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
+        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
+        whenever(mockVariantManager.getVariant()).thenReturn(ACTIVE_VARIANTS.first { it.key == "zv" })
+        whenever(mockOnboardingStore.userMarkedAsReturningUser).thenReturn(true)
+        whenever(mockOnboardingStore.hasReachedThresholdToShowWidgetForReturningUser()).thenReturn(false)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
+        assertNull(value)
+    }
+
+    @Test
+    fun whenRefreshCtaOnHomeTabAndReturningUsersNoOnboardingEnabledTrueAndAboveThresholdAndWidgetCompatibleThenReturnWidget() = coroutineRule.runBlocking {
+        whenever(mockSettingsDataStore.hideTips).thenReturn(false)
+        whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
+        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
+        whenever(mockVariantManager.getVariant()).thenReturn(ACTIVE_VARIANTS.first { it.key == "zv" })
+        whenever(mockOnboardingStore.userMarkedAsReturningUser).thenReturn(true)
+        whenever(mockOnboardingStore.hasReachedThresholdToShowWidgetForReturningUser()).thenReturn(true)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
+        assertTrue(value is HomePanelCta)
+    }
+
     private suspend fun givenDaxOnboardingActive() {
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -223,28 +223,6 @@ class WelcomePageViewModelTest {
     @Test
     fun whenOnPrimaryCtaClickedAndReturningUsersNoOnboardingEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zv" })
-        emitShowDialogAndFireAndNeverHideTips()
-    }
-
-    @Test
-    fun whenOnPrimaryCtaClickedAndReturningUsersWidgetPromotionEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
-        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zz" })
-        emitShowDialogAndFireAndNeverHideTips()
-    }
-
-    @Test
-    fun whenOnReturningUserClickedAndReturningUsersNoOnboardingEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
-        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zv" })
-        emitShowDialogAndFireAndHideTips()
-    }
-
-    @Test
-    fun whenOnReturningUserClickedAndReturningUsersWidgetPromotionEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
-        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zz" })
-        emitShowDialogAndFireAndHideTips()
-    }
-
-    private fun emitShowDialogAndFireAndNeverHideTips() = coroutineRule.runBlocking {
         whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
         val intent = Intent()
         whenever(defaultRoleBrowserDialog.createIntent(any())).thenReturn(intent)
@@ -262,7 +240,49 @@ class WelcomePageViewModelTest {
         launch.cancel()
     }
 
-    private fun emitShowDialogAndFireAndHideTips() = coroutineRule.runBlocking {
+    @Test
+    fun whenOnPrimaryCtaClickedAndReturningUsersWidgetPromotionEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zz" })
+        whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
+        val intent = Intent()
+        whenever(defaultRoleBrowserDialog.createIntent(any())).thenReturn(intent)
+
+        val launch = launch {
+            viewEvents.collect { state ->
+                assertTrue(state == WelcomePageView.State.ShowDefaultBrowserDialog(intent))
+            }
+        }
+        events.send(WelcomePageView.Event.OnPrimaryCtaClicked)
+
+        verify(mockOnboardingStore, never()).userMarkedAsReturningUser = true
+        verify(pixel).fire(AppPixelName.ONBOARDING_DAX_NEW_USER_CTA_PRESSED)
+
+        launch.cancel()
+    }
+
+    @Test
+    fun whenOnReturningUserClickedAndReturningUsersNoOnboardingEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zv" })
+        whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
+        val intent = Intent()
+        whenever(defaultRoleBrowserDialog.createIntent(any())).thenReturn(intent)
+
+        val launch = launch {
+            viewEvents.collect { state ->
+                assertTrue(state == WelcomePageView.State.ShowDefaultBrowserDialog(intent))
+            }
+        }
+        events.send(WelcomePageView.Event.OnReturningUserClicked)
+
+        verify(mockOnboardingStore).userMarkedAsReturningUser = true
+        verify(pixel).fire(AppPixelName.ONBOARDING_DAX_RETURNING_USER_CTA_PRESSED)
+
+        launch.cancel()
+    }
+
+    @Test
+    fun whenOnReturningUserClickedAndReturningUsersWidgetPromotionEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zz" })
         whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
         val intent = Intent()
         whenever(defaultRoleBrowserDialog.createIntent(any())).thenReturn(intent)

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -65,7 +65,7 @@ class VariantManagerTest {
     @Test
     fun automaticFireproofingControlVariantHasExpectedWeightAndNoFeatures() {
         val variant = variants.first { it.key == "mi" }
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(0, variant.features.size)
         assertEquals(0, variant.features.size)
     }
@@ -73,7 +73,7 @@ class VariantManagerTest {
     @Test
     fun automaticFireproofingExperimentalVariantHasExpectedWeightAndFeatures() {
         val variant = variants.first { it.key == "mj" }
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(FireproofExperiment))
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -156,8 +156,10 @@ import java.io.File
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import android.content.pm.ApplicationInfo
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.statistics.isFireproofExperimentEnabled
 import com.google.android.material.snackbar.BaseTransientBottomBar
+import kotlinx.android.synthetic.main.include_cta.*
 
 class BrowserTabFragment :
     Fragment(),
@@ -249,6 +251,9 @@ class BrowserTabFragment :
     lateinit var themingDataStore: ThemingDataStore
 
     @Inject
+    lateinit var onboardingStore: OnboardingStore
+
+    @Inject
     @AppCoroutineScope
     lateinit var appCoroutineScope: CoroutineScope
 
@@ -278,6 +283,8 @@ class BrowserTabFragment :
 
     private lateinit var omnibarQuickAccessAdapter: FavoritesQuickAccessAdapter
     private lateinit var omnibarQuickAccessItemTouchHelper: ItemTouchHelper
+
+    private var hideDaxBackgroundLogo = false
 
     private val viewModel: BrowserTabViewModel by lazy {
         val viewModel = ViewModelProvider(this, viewModelFactory).get(BrowserTabViewModel::class.java)
@@ -2259,7 +2266,7 @@ class BrowserTabFragment :
 
         private fun showHomeBackground(favorites: List<FavoritesQuickAccessAdapter.QuickAccessFavorite>) {
             if (favorites.isEmpty()) {
-                homeBackgroundLogo.showLogo()
+                if (hideDaxBackgroundLogo) homeBackgroundLogo.hideLogo() else homeBackgroundLogo.showLogo()
                 quickAccessRecyclerView.gone()
             } else {
                 homeBackgroundLogo.hideLogo()
@@ -2307,14 +2314,21 @@ class BrowserTabFragment :
 
             ctaContainer.removeAllViews()
 
-            inflate(context, R.layout.include_cta, ctaContainer)
+            if (configuration is HomePanelCta.AddReturningUsersWidgetAuto) {
+                hideDaxBackgroundLogo = true
+                inflate(context, R.layout.include_experiment_returning_users_cta, ctaContainer)
+            } else {
+                inflate(context, R.layout.include_cta, ctaContainer)
+            }
 
             configuration.showCta(ctaContainer)
             ctaContainer.ctaOkButton.setOnClickListener {
+                hideDaxBackgroundLogo = false
                 viewModel.onUserClickCtaOkButton()
             }
 
             ctaContainer.ctaDismissButton.setOnClickListener {
+                hideDaxBackgroundLogo = false
                 viewModel.onUserDismissedCta()
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -156,7 +156,6 @@ import java.io.File
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import android.content.pm.ApplicationInfo
-import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.statistics.isFireproofExperimentEnabled
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import kotlinx.android.synthetic.main.include_cta.*
@@ -249,9 +248,6 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var themingDataStore: ThemingDataStore
-
-    @Inject
-    lateinit var onboardingStore: OnboardingStore
 
     @Inject
     @AppCoroutineScope

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1878,7 +1878,7 @@ class BrowserTabViewModel(
         ctaViewModel.onUserClickCtaOkButton(cta)
         command.value = when (cta) {
             is HomePanelCta.Survey -> LaunchSurvey(cta.survey)
-            is HomePanelCta.AddWidgetAuto -> LaunchAddWidget
+            is HomePanelCta.AddWidgetAuto, is HomePanelCta.AddReturningUsersWidgetAuto -> LaunchAddWidget
             is HomePanelCta.AddWidgetInstructions -> LaunchLegacyAddWidget
             else -> return
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.browser.rating.db.AppEnjoymentRepository
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.rating.*
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.playstore.PlayStoreAndroidUtils
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.usage.app.AppDaysUsedRepository
@@ -70,9 +71,10 @@ class RatingModule {
         searchCountDao: SearchCountDao,
         @Named(INITIAL_PROMPT_DECIDER_NAME) initialPromptDecider: ShowPromptDecider,
         @Named(SECONDARY_PROMPT_DECIDER_NAME) secondaryPromptDecider: ShowPromptDecider,
-        context: Context
+        context: Context,
+        onboardingStore: OnboardingStore
     ): PromptTypeDecider {
-        return InitialPromptTypeDecider(playStoreUtils, searchCountDao, initialPromptDecider, secondaryPromptDecider, context)
+        return InitialPromptTypeDecider(playStoreUtils, searchCountDao, initialPromptDecider, secondaryPromptDecider, context, onboardingStore)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -371,9 +371,9 @@ sealed class HomePanelCta(
 ) : Cta, ViewCta {
 
     override fun showCta(view: View) {
-        view.ctaIcon.setImageResource(image)
-        view.ctaTitle.text = view.context.getString(title)
-        view.ctaSubtitle.text = view.context.getString(description)
+        view.ctaIcon?.setImageResource(image)
+        view.ctaTitle?.text = view.context.getString(title)
+        view.ctaSubtitle?.text = view.context.getString(description)
         view.ctaOkButton.text = view.context.getString(okButton)
         view.ctaDismissButton.text = view.context.getString(dismissButton)
         view.show()
@@ -416,6 +416,18 @@ sealed class HomePanelCta(
         R.string.addWidgetCtaDescription,
         R.string.addWidgetCtaAutoLaunchButton,
         R.string.addWidgetCtaDismissButton,
+        AppPixelName.WIDGET_CTA_SHOWN,
+        AppPixelName.WIDGET_CTA_LAUNCHED,
+        AppPixelName.WIDGET_CTA_DISMISSED
+    )
+
+    object AddReturningUsersWidgetAuto : HomePanelCta(
+        CtaId.ADD_WIDGET,
+        R.drawable.add_widget_cta_icon,
+        R.string.addWidgetCtaTitle,
+        R.string.addWidgetCtaDescription,
+        R.string.addWidgetCtaAutoLaunchButton,
+        R.string.returningUsersWidgetDismissButtonLabel,
         AppPixelName.WIDGET_CTA_SHOWN,
         AppPixelName.WIDGET_CTA_LAUNCHED,
         AppPixelName.WIDGET_CTA_DISMISSED

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -38,6 +38,8 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.isFireproofExperimentEnabled
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.returningUsersNoOnboardingEnabled
+import com.duckduckgo.app.statistics.returningUsersWidgetPromotionEnabled
 import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -214,7 +216,7 @@ class CtaViewModel @Inject constructor(
         if (!daxOnboardingActive()) return null
 
         return withContext(dispatchers.io()) {
-            if (settingsDataStore.hideTips || daxDialogFireEducationShown()) return@withContext null
+            if (hideTips() || daxDialogFireEducationShown()) return@withContext null
             return@withContext DaxFireDialogCta.TryClearDataCta(onboardingStore, appInstallStore)
         }
     }
@@ -231,10 +233,25 @@ class CtaViewModel @Inject constructor(
                 DaxBubbleCta.DaxEndCta(onboardingStore, appInstallStore)
             }
             canShowWidgetCta() -> {
-                if (widgetCapabilities.supportsAutomaticWidgetAdd) AddWidgetAuto else AddWidgetInstructions
+                getWidgetCta()
             }
             else -> null
         }
+    }
+
+    private fun getWidget(): HomePanelCta = if (widgetCapabilities.supportsAutomaticWidgetAdd) getWidgetAuto() else AddWidgetInstructions
+
+    private fun getWidgetAuto() = if (variantManager.returningUsersWidgetPromotionEnabled() && onboardingStore.userMarkedAsReturningUser) AddReturningUsersWidgetAuto else AddWidgetAuto
+
+    private fun getWidgetCta(): HomePanelCta? {
+        if (variantManager.returningUsersNoOnboardingEnabled() && onboardingStore.userMarkedAsReturningUser) {
+            onboardingStore.countNewTabForReturningUser++
+            if (onboardingStore.hasReachedThresholdToShowWidgetForReturningUser()) {
+                return getWidget()
+            }
+            return null
+        }
+        return getWidget()
     }
 
     private suspend fun getBrowserCta(site: Site?): Cta? {
@@ -273,7 +290,7 @@ class CtaViewModel @Inject constructor(
     }
 
     @WorkerThread
-    private suspend fun canShowDaxIntroCta(): Boolean = daxOnboardingActive() && !daxDialogIntroShown() && !settingsDataStore.hideTips
+    private suspend fun canShowDaxIntroCta(): Boolean = daxOnboardingActive() && !daxDialogIntroShown() && !hideTips()
 
     @WorkerThread
     private suspend fun canShowDaxFireproofCta(): Boolean = variantManager.isFireproofExperimentEnabled() &&
@@ -288,11 +305,11 @@ class CtaViewModel @Inject constructor(
     private suspend fun canShowDaxCtaEndOfJourney(): Boolean = daxOnboardingActive() &&
         !daxDialogEndShown() &&
         daxDialogIntroShown() &&
-        !settingsDataStore.hideTips &&
+        !hideTips() &&
         (daxDialogNetworkShown() || daxDialogOtherShown() || daxDialogSerpShown() || daxDialogTrackersFoundShown())
 
     private suspend fun canShowDaxDialogCta(): Boolean {
-        if (!daxOnboardingActive() || settingsDataStore.hideTips) {
+        if (!daxOnboardingActive() || hideTips()) {
             return false
         }
         return true
@@ -354,7 +371,7 @@ class CtaViewModel @Inject constructor(
 
     private suspend fun daxOnboardingActive(): Boolean = userStageStore.daxOnboardingActive()
 
-    private suspend fun pulseAnimationDisabled(): Boolean = !daxOnboardingActive() || pulseFireButtonShown() || daxDialogFireEducationShown() || settingsDataStore.hideTips
+    private suspend fun pulseAnimationDisabled(): Boolean = !daxOnboardingActive() || pulseFireButtonShown() || daxDialogFireEducationShown() || hideTips()
 
     private suspend fun allOnboardingCtasShown(): Boolean {
         return withContext(dispatchers.io()) {
@@ -398,6 +415,8 @@ class CtaViewModel @Inject constructor(
             }
         }
     }
+
+    private fun hideTips() = settingsDataStore.hideTips || onboardingStore.userMarkedAsReturningUser
 
     companion object {
         private const val SURVEY_DEFAULT_MIN_DAYS_INSTALLED = 30

--- a/app/src/main/java/com/duckduckgo/app/global/rating/PromptTypeDecider.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/PromptTypeDecider.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions.ShowEnjoymentPrompt
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions.ShowNothing
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.usage.search.SearchCountDao
 import kotlinx.coroutines.Dispatchers
@@ -35,11 +36,17 @@ class InitialPromptTypeDecider(
     private val searchCountDao: SearchCountDao,
     private val initialPromptDecider: ShowPromptDecider,
     private val secondaryPromptDecider: ShowPromptDecider,
-    private val context: Context
+    private val context: Context,
+    private val onboardingStore: OnboardingStore
 ) : PromptTypeDecider {
 
     override suspend fun determineInitialPromptType(): AppEnjoymentPromptOptions {
         return withContext(Dispatchers.IO) {
+
+            if (onboardingStore.userMarkedAsReturningUser) {
+                Timber.i("Users marked as returning should not see any app enjoyment prompts as per experiment definition")
+                return@withContext ShowNothing
+            }
 
             if (!isPlayStoreInstalled()) return@withContext ShowNothing
             if (!wasInstalledThroughPlayStore()) return@withContext ShowNothing

--- a/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
@@ -20,7 +20,9 @@ import android.content.Context
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.RealDefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModelFactory
+import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import dagger.Module
 import dagger.Provides
@@ -33,8 +35,10 @@ class WelcomePageModule {
         appInstallStore: AppInstallStore,
         context: Context,
         pixel: Pixel,
-        defaultRoleBrowserDialog: DefaultRoleBrowserDialog
-    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialog)
+        defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
+        onboardingStore: OnboardingStore,
+        variantManager: VariantManager
+    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialog, onboardingStore, variantManager)
 
     @Provides
     fun defaultRoleBrowserDialog(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingSharedPreferences.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingSharedPreferences.kt
@@ -27,11 +27,24 @@ class OnboardingSharedPreferences @Inject constructor(private val context: Conte
         get() = preferences.getString(ONBOARDING_JOURNEY, null)
         set(dialogJourney) = preferences.edit { putString(ONBOARDING_JOURNEY, dialogJourney) }
 
+    override var userMarkedAsReturningUser: Boolean
+        get() = preferences.getBoolean(KEY_HIDE_TIPS_FOR_RETURNING_USER, false)
+        set(enabled) = preferences.edit { putBoolean(KEY_HIDE_TIPS_FOR_RETURNING_USER, enabled) }
+
+    override var countNewTabForReturningUser: Int
+        get() = preferences.getInt(KEY_COUNT_NEW_TAB_FOR_RETURNING_USER, 0)
+        set(value) = preferences.edit { putInt(KEY_COUNT_NEW_TAB_FOR_RETURNING_USER, value) }
+
+    override fun hasReachedThresholdToShowWidgetForReturningUser(): Boolean = preferences.getInt(KEY_COUNT_NEW_TAB_FOR_RETURNING_USER, 0) >= THRESHOLD_COUNT_NEW_TAB_FOR_RETURNING_USER
+
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
 
     companion object {
         const val FILENAME = "com.duckduckgo.app.onboarding.settings"
         const val ONBOARDING_JOURNEY = "onboardingJourney"
+        const val KEY_HIDE_TIPS_FOR_RETURNING_USER = "HIDE_TIPS_FOR_RETURNING_USER"
+        const val KEY_COUNT_NEW_TAB_FOR_RETURNING_USER = "COUNT_NEW_TAB_FOR_RETURNING_USER"
+        const val THRESHOLD_COUNT_NEW_TAB_FOR_RETURNING_USER = 4
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
@@ -18,4 +18,7 @@ package com.duckduckgo.app.onboarding.store
 
 interface OnboardingStore {
     var onboardingDialogJourney: String?
+    var userMarkedAsReturningUser: Boolean
+    var countNewTabForReturningUser: Int
+    fun hasReachedThresholdToShowWidgetForReturningUser(): Boolean
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageView.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 
 object WelcomePageView {
     sealed class Event {
+        object OnReturningUserClicked : Event()
         object OnPrimaryCtaClicked : Event()
         object OnDefaultBrowserSet : Event()
         object OnDefaultBrowserNotSet : Event()

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -20,24 +20,51 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import com.duckduckgo.app.statistics.returningUsersNoOnboardingEnabled
+import com.duckduckgo.app.statistics.returningUsersWidgetPromotionEnabled
+import kotlinx.coroutines.flow.*
 
 @SuppressLint("StaticFieldLeak")
 class WelcomePageViewModel(
     private val appInstallStore: AppInstallStore,
     private val context: Context,
     private val pixel: Pixel,
-    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog
+    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
+    private val onboardingStore: OnboardingStore,
+    private val variantManager: VariantManager
 ) : ViewModel() {
+
+    sealed class ViewState {
+        object NewOrReturningUsersState : ViewState()
+        object DefaultOnboardingState : ViewState()
+    }
+
+    val screenContent = flow {
+        if (variantManager.returningUsersNoOnboardingEnabled() || variantManager.returningUsersWidgetPromotionEnabled()) {
+            emit(ViewState.NewOrReturningUsersState)
+        } else {
+            emit(ViewState.DefaultOnboardingState)
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState.DefaultOnboardingState)
 
     fun reduce(event: WelcomePageView.Event): Flow<WelcomePageView.State> {
         return when (event) {
-            WelcomePageView.Event.OnPrimaryCtaClicked -> onPrimaryCtaClicked()
+            WelcomePageView.Event.OnPrimaryCtaClicked -> {
+                firePrimaryCtaPressed()
+                onPrimaryCtaClicked()
+            }
+            WelcomePageView.Event.OnReturningUserClicked -> {
+                onboardingStore.userMarkedAsReturningUser = true
+                fireReturningUserPressed()
+                onPrimaryCtaClicked()
+            }
             WelcomePageView.Event.OnDefaultBrowserSet -> onDefaultBrowserSet()
             WelcomePageView.Event.OnDefaultBrowserNotSet -> onDefaultBrowserNotSet()
         }
@@ -54,6 +81,18 @@ class WelcomePageViewModel(
             }
         } else {
             emit(WelcomePageView.State.Finish)
+        }
+    }
+
+    private fun fireReturningUserPressed() {
+        pixel.fire(AppPixelName.ONBOARDING_DAX_RETURNING_USER_CTA_PRESSED)
+    }
+
+    private fun firePrimaryCtaPressed() {
+        when {
+            variantManager.returningUsersNoOnboardingEnabled() ||
+                variantManager.returningUsersWidgetPromotionEnabled() -> pixel.fire(AppPixelName.ONBOARDING_DAX_NEW_USER_CTA_PRESSED)
+            else -> pixel.fire(AppPixelName.ONBOARDING_DAX_PRIMARY_CTA_PRESSED)
         }
     }
 
@@ -89,14 +128,16 @@ class WelcomePageViewModelFactory(
     private val appInstallStore: AppInstallStore,
     private val context: Context,
     private val pixel: Pixel,
-    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog
+    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
+    private val onboardingStore: OnboardingStore,
+    private val variantManager: VariantManager
 ) : ViewModelProvider.NewInstanceFactory() {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return with(modelClass) {
             when {
                 isAssignableFrom(WelcomePageViewModel::class.java) -> WelcomePageViewModel(
-                    appInstallStore, context, pixel, defaultRoleBrowserDialog
+                    appInstallStore, context, pixel, defaultRoleBrowserDialog, onboardingStore, variantManager
                 )
                 else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -39,6 +39,10 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     ONBOARDING_DAX_ALL_CTA_HIDDEN("m_odc_h"),
     ONBOARDING_DAX_CTA_OK_BUTTON("m_odc_ok"),
 
+    ONBOARDING_DAX_PRIMARY_CTA_PRESSED("m_odp_p"),
+    ONBOARDING_DAX_NEW_USER_CTA_PRESSED("m_odn_p"),
+    ONBOARDING_DAX_RETURNING_USER_CTA_PRESSED("m_odr_p"),
+
     ONBOARDING_FIREPROOF_CTA_SHOWN("m_fireproof_cta_shown"),
     ONBOARDING_FIREPROOF_CTA_KEEP_ME_SIGNED_IN_BUTTON("m_fireproof_cta_keep_me_signed_in_button"),
     ONBOARDING_FIREPROOF_CTA_BURN_EVERYTHING_BUTTON("m_fireproof_cta_burn_everything_button"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -39,9 +39,9 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     ONBOARDING_DAX_ALL_CTA_HIDDEN("m_odc_h"),
     ONBOARDING_DAX_CTA_OK_BUTTON("m_odc_ok"),
 
-    ONBOARDING_DAX_PRIMARY_CTA_PRESSED("m_odp_p"),
-    ONBOARDING_DAX_NEW_USER_CTA_PRESSED("m_odn_p"),
-    ONBOARDING_DAX_RETURNING_USER_CTA_PRESSED("m_odr_p"),
+    ONBOARDING_DAX_PRIMARY_CTA_PRESSED("m_onboarding_dax_primary_cta_pressed"),
+    ONBOARDING_DAX_NEW_USER_CTA_PRESSED("m_onboarding_dax_new_user_cta_pressed"),
+    ONBOARDING_DAX_RETURNING_USER_CTA_PRESSED("m_onboarding_dax_returning_user_cta_pressed"),
 
     ONBOARDING_FIREPROOF_CTA_SHOWN("m_fireproof_cta_shown"),
     ONBOARDING_FIREPROOF_CTA_KEEP_ME_SIGNED_IN_BUTTON("m_fireproof_cta_keep_me_signed_in_button"),

--- a/app/src/main/res/layout-land/content_onboarding_welcome.xml
+++ b/app/src/main/res/layout-land/content_onboarding_welcome.xml
@@ -61,10 +61,10 @@
         layout="@layout/include_dax_dialog_cta"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="93dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintWidth_max="600dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-w600dp/include_experiment_returning_users_cta.xml
+++ b/app/src/main/res/layout-w600dp/include_experiment_returning_users_cta.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2021 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/cta"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorPrimary"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent">
+
+    <include
+        android:id="@+id/experimentalCtaContent"
+        layout="@layout/include_experimental_cta_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/centerGuideline"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/centerGuideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5" />
+
+    <include
+        layout="@layout/include_cta_buttons"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/centerGuideline" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/include_dax_dialog_cta.xml
+++ b/app/src/main/res/layout/include_dax_dialog_cta.xml
@@ -147,9 +147,26 @@
         android:textColor="@color/white"
         android:letterSpacing="0.0"
         app:cornerRadius="22dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/returningUserCta"
         app:layout_constraintEnd_toEndOf="@id/cardView"
         app:layout_constraintStart_toStartOf="@id/cardView"
         app:layout_constraintTop_toBottomOf="@id/cardView" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/returningUserCta"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="0dp"
+        android:layout_height="60dp"
+        android:letterSpacing="0.0"
+        android:text="@string/returningUsersReturningUserButton"
+        android:textAllCaps="false"
+        android:textColor="@color/cornflowerBlue"
+        android:visibility="gone"
+        app:backgroundTint="@color/white"
+        app:cornerRadius="22dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/cardView"
+        app:layout_constraintStart_toStartOf="@id/cardView"
+        app:layout_constraintTop_toBottomOf="@id/primaryCta" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/include_experiment_returning_users_cta.xml
+++ b/app/src/main/res/layout/include_experiment_returning_users_cta.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2021 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/cta"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?toolbarBgColor"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent">
+
+    <include
+        android:id="@+id/experimentalCtaContent"
+        layout="@layout/include_experimental_cta_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <include
+        layout="@layout/include_experiment_returning_users_cta_buttons"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/experimentalCtaContent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/include_experiment_returning_users_cta_buttons.xml
+++ b/app/src/main/res/layout/include_experiment_returning_users_cta_buttons.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2021 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <Button
+        android:id="@+id/ctaDismissButton"
+        style="?android:attr/borderlessButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="36dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="22dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="16dp"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:foreground="?attr/selectableItemBackgroundBorderless"
+        android:textColor="?attr/buttonOutlinedTextColor"
+        android:textSize="13sp"
+        tools:text="@string/surveyCtaDismissButton" />
+
+    <Button
+        android:id="@+id/ctaOkButton"
+        style="?android:attr/borderlessButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="36dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="22dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:background="@drawable/button_contained_bg"
+        android:foreground="?attr/selectableItemBackgroundBorderless"
+        android:textColor="@color/white"
+        android:textSize="13sp"
+        tools:text="@string/surveyCtaLaunchButton" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/include_experimental_cta_content.xml
+++ b/app/src/main/res/layout/include_experimental_cta_content.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2021 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/experimentalCtaContent"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/widgetConfigTitle"
+        style="@style/SearchWidgetCtaTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="32dp"
+        android:paddingTop="16dp"
+        android:paddingEnd="32dp"
+        android:paddingBottom="16dp"
+        android:text="@string/returningUsersWidgetPromptTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/widgetConfigPreview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/search_favorites_widget_preview"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/widgetConfigTitle" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -30,6 +30,13 @@
     <string name="favoritesWidgetLabel">Favorites Widget</string>
     <string name="searchWidgetLabel">Search Widget</string>
 
+    <!-- Treat returning users differently Experiment -->
+    <string name="returningUsersNewUserButton">I\'m new!</string>
+    <string name="returningUsersReturningUserButton">I\'ve been here before.</string>
+    <string name="returningUsersOnboardingDaxText"><![CDATA[The Internet can be kinda creepy.<br/><br/>Not to worry! Searching and browsing privately is easier than you think.<br/><br/>Let\'s get started 👍]]></string>
+    <string name="returningUsersWidgetPromptTitle">Add the DuckDuckGo widget to your home screen</string>
+    <string name="returningUsersWidgetDismissButtonLabel">No Thanks</string>
+
     <!-- Email -->
     <string name="emailNotSupported">Device not supported</string>
     <string name="emailNotSupportedExplanation">Email Protection allows you to create private email addresses that remove email trackers. We need to encrypt and store these addresses you create locally on your device. Because your device does not support encrypted storage, Email Protection is unavailable.</string>

--- a/common-ui/src/main/res/values/styles.xml
+++ b/common-ui/src/main/res/values/styles.xml
@@ -754,6 +754,14 @@
         <item name="android:textColor">@color/cornflowerBlue</item>
     </style>
 
+    <style name="SearchWidgetCtaTitle">
+        <item name="android:textAlignment">center</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">?attr/normalTextColor</item>
+        <item name="android:textSize">20sp</item>
+        <item name="lineHeight">23dp</item>
+    </style>
+
     <style name="SavedSiteFullScreenDialog">
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowTranslucentStatus">true</item>

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -48,8 +48,8 @@ interface VariantManager {
             Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
 
             // Fireproof experiment
-            Variant(key = "mi", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),
-            Variant(key = "mj", weight = 1.0, features = listOf(VariantFeature.FireproofExperiment), filterBy = { isEnglishLocale() }),
+            Variant(key = "mi", weight = 0.0, features = emptyList(), filterBy = { isEnglishLocale() }),
+            Variant(key = "mj", weight = 0.0, features = listOf(VariantFeature.FireproofExperiment), filterBy = { isEnglishLocale() }),
 
             // Returning users
             Variant(key = "zk", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -29,6 +29,9 @@ interface VariantManager {
     // variant-dependant features listed here
     sealed class VariantFeature {
         object FireproofExperiment : VariantFeature()
+
+        object ReturningUsersNoOnboarding : VariantFeature()
+        object ReturningUsersWidgetPromotion : VariantFeature()
     }
 
     companion object {
@@ -47,6 +50,11 @@ interface VariantManager {
             // Fireproof experiment
             Variant(key = "mi", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),
             Variant(key = "mj", weight = 1.0, features = listOf(VariantFeature.FireproofExperiment), filterBy = { isEnglishLocale() }),
+
+            // Returning users
+            Variant(key = "zk", weight = 1.0, features = emptyList(), filterBy = { isEnglishLocale() }),
+            Variant(key = "zv", weight = 1.0, features = listOf(VariantFeature.ReturningUsersNoOnboarding), filterBy = { isEnglishLocale() }),
+            Variant(key = "zz", weight = 1.0, features = listOf(VariantFeature.ReturningUsersWidgetPromotion), filterBy = { isEnglishLocale() }),
         )
 
         val REFERRER_VARIANTS = listOf(
@@ -174,6 +182,9 @@ class ExperimentationVariantManager(
 }
 
 fun VariantManager.isFireproofExperimentEnabled() = this.getVariant().hasFeature(VariantManager.VariantFeature.FireproofExperiment)
+
+fun VariantManager.returningUsersNoOnboardingEnabled() = this.getVariant().hasFeature(VariantManager.VariantFeature.ReturningUsersNoOnboarding)
+fun VariantManager.returningUsersWidgetPromotionEnabled() = this.getVariant().hasFeature(VariantManager.VariantFeature.ReturningUsersWidgetPromotion)
 
 /**
  * A variant which can be used for experimentation.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201408441367239/f

### Description
This adds a 3-way experiment (control and 2 variants). Videos for all versions and exact details can be found in https://app.asana.com/0/1142021229838617/1201393848577545/f

### Steps to test this PR

**_Control_**
_**Code changes before testing**: Change the weighting of all variants in the VariantManager to 0.0 and keep the weight of "zk" to 1.0_

1. Freshly install the app.
2. On the Welcome page you should see the normal welcome screen:
- text: _The Internet can be kinda creepy. Not to worry! Searching and browsing privately is easier than you think._
- only one button with the label: _Let’s Do It!_
3. Tap on Let’s Do It! button (Pixel: _m_odp_p_)
4. You should see the normal onboarding.

![control](https://user-images.githubusercontent.com/7963079/142871381-79d2036a-9ca0-4fb5-8efe-e2b8a97eb372.png)


**_Variant 1 - New users path_**
_**Code changes before testing**: Change the weighting of all variants in the VariantManager to 0.0 and keep the weight of "zv" to 1.0_

1. Freshly install the app.
2. On the Welcome page you should see a welcome screen with a text and two buttons:
- text: _The Internet can be kinda creepy. Not to worry! Searching and browsing privately is easier than you think. Let’s get started 👍_
- two buttons with the labels: _I’m new!_ and _I’ve been here before._
3. Tap on I’m new! button (Pixel: _m_odn_p_)
4. You should see the normal onboarding.

![variant1](https://user-images.githubusercontent.com/7963079/142872541-ba2863a1-d733-4e5d-8885-803162f4dd09.png)


**_Variant 1 - Returning users path_**
_**Code changes before testing**: Change the weighting of all variants in the VariantManager to 0.0 and keep the weight of "zv" to 1.0_

1. Freshly install the app.
2. On the Welcome page you should see a welcome screen with a text and two buttons:
- text: _The Internet can be kinda creepy. Not to worry! Searching and browsing privately is easier than you think. Let’s get started 👍_
- two buttons with the labels: _I’m new!_ and _I’ve been here before._
3. Tap on I’ve been here before. button (Pixel: _m_odr_p_)
4. You should see the default browser check and no other dialogs afterwards.


**_Variant 2 - New users path_**
_**Code changes before testing**: Change the weighting of all variants in the VariantManager to 0.0 and keep the weight of "zz" to 1.0_

1. Freshly install the app.
2. On the Welcome page you should see a welcome screen with a text and two buttons:
- text: _The Internet can be kinda creepy. Not to worry! Searching and browsing privately is easier than you think. Let’s get started 👍_
- two buttons with the labels: _I’m new!_ and _I’ve been here before._
3. Tap on I’m new! button (Pixel: _m_odn_p_)
4. You should see the normal onboarding.

![variant2](https://user-images.githubusercontent.com/7963079/142872541-ba2863a1-d733-4e5d-8885-803162f4dd09.png)


**_Variant 2 - Returning users path_**
_**Code changes before testing**: Change the weighting of all variants in the VariantManager to 0.0 and keep the weight of "zz" to 1.0_

1. Freshly install the app.
2. On the Welcome page you should see a welcome screen with a text and two buttons:
- text: _The Internet can be kinda creepy. Not to worry! Searching and browsing privately is easier than you think. Let’s get started 👍_
- two buttons with the labels: _I’m new!_ and _I’ve been here before._
3. Tap on I’ve been here before. button (Pixel: _m_odr_p_)
4. You should see the default browser check and then a prompt to add the search widget. 
- widget prompt title: Add the DuckDuckGo widget to your home screen
- widget prompt buttons: No Thanks and Add Widget 
- notice no Dax logo on the background while the widget prompt is shown.
- no other dialogs shown after this step
- the Dax logo is shown on empty new tab.

![widget](https://user-images.githubusercontent.com/7963079/142874247-33e5eb1b-d280-41b4-b710-0ab6f4e91291.png)

