### PR TITLE
Fix fastlane version code retrieval to trim to a single line

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -129,7 +129,7 @@ platform :android do
 
       releaseNotes = release_notes_playstore()
 
-      flversion=gradle(task: '-q fastlaneVersionCode')
+      flversion=gradle(task: '-q fastlaneVersionCode').lines.map(&:chomp)[0]
       UI.message("App version for fastlane is #{flversion}.\nRelease notes for Play Store:\n\n#{releaseNotes}")
 
       releaseNotesLocales.each do |locale|
@@ -141,7 +141,7 @@ platform :android do
     desc "Clean up local changelist metadata"
         private_lane :cleanup_fastlane_release_notes do
 
-          flversion=gradle(task: '-q fastlaneVersionCode')
+          flversion=gradle(task: '-q fastlaneVersionCode').lines.map(&:chomp)[0]
 
           releaseNotesLocales.each do |locale|
             sh("rm '../fastlane/metadata/android/#{locale}/changelogs/#{flversion}.txt'")

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -20,12 +20,12 @@ or alternatively using `brew install fastlane`
 ```
 fastlane android deploy_playstore
 ```
-Upload APK to Play Store
+Upload APK to Play Store, in pre-production staging track
 ### android deploy_dogfood
 ```
 fastlane android deploy_dogfood
 ```
-Upload APK to Play Store Dogfood track
+Upload APK to Play Store internal testing track
 ### android deploy_github
 ```
 fastlane android deploy_github


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201360798240277/f

### Description
Updates fastlane script to _chomp_ string to a single line when generating the fastlane release code, instead of accepting multiple lines

### Steps to test this PR

There are two private lanes which cannot be called directly; make them public to make testing this easier.

- `Fastfile`, lines **128** and **142**
- change `private_lane` to `lane`

1. Run `fastlane update_fastlane_release_notes`
2. Verify there are 3 files changed
    - `fastlane/metadata/android/en-CA/changelogs/51010000.txt`
    - `fastlane/metadata/android/en-GB/changelogs/51010000.txt`
    - `fastlane/metadata/android/en-US/changelogs/51010000.txt`
1. Run `fastlane cleanup_fastlane_release_notes`
2. Verify the 3 files above are deleted 
