### PR TITLE
Fix guessing logic when a dot is present

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -86,7 +86,7 @@ class UriUtilsFilenameExtractorTest {
     @SdkSuppress(minSdkVersion = 22)
     fun whenUrlContainsAmbiguousFilenameButContainsPathSegmentsWhichLookLikeAFilenameAndMimeTypeProvidedThenFilenameShouldBeExtracted() {
         val url = "https://foo.example.com/path/dotted.path/b/b1/realFilename"
-        val mimeType: String? = "image/jpeg"
+        val mimeType = "image/jpeg"
         val contentDisposition: String? = null
 
         val extractionResult = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
@@ -97,10 +97,9 @@ class UriUtilsFilenameExtractorTest {
     }
 
     @Test
-    @SdkSuppress(minSdkVersion = 22)
     fun whenUrlContainsFilenameAndContainsMultiplePathSegmentsAndMimeTypeProvidedThenFilenameShouldBeExtracted() {
         val url = "https://foo.example.com/path/images/b/b1/realFilename.jpg"
-        val mimeType: String? = "image/jpeg"
+        val mimeType = "image/jpeg"
         val contentDisposition: String? = null
 
         val extractionResult = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/downloader/UriUtilsFilenameExtractorTest.kt
@@ -70,6 +70,47 @@ class UriUtilsFilenameExtractorTest {
     }
 
     @Test
+    fun whenUrlContainsFilenameButContainsPathSegmentsWhichLookLikeAFilenameThenFilenameShouldBeExtracted() {
+        val url = "https://foo.example.com/path/dotted.path/b/b1/realFilename.jpg"
+        val mimeType: String? = null
+        val contentDisposition: String? = null
+
+        val extractionResult = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
+        assertTrue(extractionResult is FilenameExtractor.FilenameExtractionResult.Extracted)
+
+        extractionResult as FilenameExtractor.FilenameExtractionResult.Extracted
+        assertEquals("realFilename.jpg", extractionResult.filename)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 22)
+    fun whenUrlContainsAmbiguousFilenameButContainsPathSegmentsWhichLookLikeAFilenameAndMimeTypeProvidedThenFilenameShouldBeExtracted() {
+        val url = "https://foo.example.com/path/dotted.path/b/b1/realFilename"
+        val mimeType: String? = "image/jpeg"
+        val contentDisposition: String? = null
+
+        val extractionResult = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
+        assertTrue(extractionResult is FilenameExtractor.FilenameExtractionResult.Extracted)
+
+        extractionResult as FilenameExtractor.FilenameExtractionResult.Extracted
+        assertEquals("realFilename.jpg", extractionResult.filename)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 22)
+    fun whenUrlContainsFilenameAndContainsMultiplePathSegmentsAndMimeTypeProvidedThenFilenameShouldBeExtracted() {
+        val url = "https://foo.example.com/path/images/b/b1/realFilename.jpg"
+        val mimeType: String? = "image/jpeg"
+        val contentDisposition: String? = null
+
+        val extractionResult = testee.extract(buildPendingDownload(url, contentDisposition, mimeType))
+        assertTrue(extractionResult is FilenameExtractor.FilenameExtractionResult.Extracted)
+
+        extractionResult as FilenameExtractor.FilenameExtractionResult.Extracted
+        assertEquals("realFilename.jpg", extractionResult.filename)
+    }
+
+    @Test
     fun whenUrlContainsFilenameButContainsAdditionalPathSegmentsAndQueryParamsWhichLookLikeAFilenameThenFilenameShouldBeExtracted() {
         val url = "https://foo.example.com/path/images/b/b1/realFilename.jpg/other/stuff?cb=123.com"
         val mimeType: String? = null

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FilenameExtractor.kt
@@ -50,9 +50,10 @@ class FilenameExtractor @Inject constructor(
 
     private fun evaluateGuessQuality(guesses: Guesses, pathSegments: List<String>): GuessQuality {
         val latestGuess = guesses.latestGuess
+        val bestGuess = guesses.bestGuess
 
         // if it contains a '.' then it's a good chance of a filetype and we can update our best guess
-        if (latestGuess.contains(".")) {
+        if (latestGuess.contains(".") && bestGuess.isNullOrEmpty()) {
             guesses.bestGuess = latestGuess
         }
 


### PR DESCRIPTION
### Description

This is a simplified version of https://github.com/duckduckgo/Android/pull/1530, focusing on improved handling when a `.` character is present in the guess. It also addresses an issue where URLs with multiple path segments and a MIME type was guessing the first segment of the path as the filename, as opposed to the last.

### Steps to test this PR

Navigate to any of the following URLs and observe the filename they're downloaded as

| URL      |  5.101.0 | This branch |
| ----------- | ----------- | ----------- | 
| https://d1x9zcshh2aa46.cloudfront.net/abc.def/example.pdf  | abc.def  | example.pdf |
| https://d1x9zcshh2aa46.cloudfront.net/abc.123/example.pdf | abc.123  | example.pdf |
| https://d1x9zcshh2aa46.cloudfront.net/123.abc/example.pdf | 123.abc  | example.pdf |
| https://d1x9zcshh2aa46.cloudfront.net/123.456/example.pdf | 123.456 | example.pdf |
| https://d1x9zcshh2aa46.cloudfront.net/abc.pdf/example.pdf  | abc.pdf | example.pdf |
| https://d1x9zcshh2aa46.cloudfront.net/pdfs/example.pdf | pdfs.pdf | example.pdf |
| https://d1x9zcshh2aa46.cloudfront.net/pdfs/example | pdfs.pdf | example.pdf |

_Note_: All of the above URLs have a MIME type of `application/pdf` and no content disposition.