### PR TITLE
Ensure AppTP restarts after an app update

### DIFF
--- a/vpn/src/main/AndroidManifest.xml
+++ b/vpn/src/main/AndroidManifest.xml
@@ -135,6 +135,12 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name="com.duckduckgo.mobile.android.vpn.appupdates.AppUpdateReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/appupdates/AppUpdateReceiver.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/appupdates/AppUpdateReceiver.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.appupdates
+
+import android.annotation.SuppressLint
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import timber.log.Timber
+
+/**
+ * We don't need to take any action here; but having this registered
+ * ensures our VPN process is restarted after an app update
+ */
+class AppUpdateReceiver : BroadcastReceiver() {
+
+    @SuppressLint("UnsafeProtectedBroadcastReceiver")
+    override fun onReceive(context: Context?, intent: Intent?) {
+        Timber.i("Notified of app update")
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201383124676579/f

### Description
During an app update, the app is killed while the APK is being swapped. The app is not automatically opened again afterwards, meaning the underlying VPNService in AppTP will not resume immediately.

By adding a BroadcastReceiver to listen for "app update" events, our process will be created and therefore the VPN Service will restart itself if it was previously running.


### Steps to test this PR

Add logcat filter: "Notified of app"

* Run the app and enable appTP
* Build the APK using `gradlew assembleID`
* Install it using `adb install -r`   (e.g., `adb install -r app/build/outputs/apk/internal/debug/duckduckgo-5.102.2-internal-debug.apk`)
* Verify that after a few seconds, appTP restarts (you'll see the VPN icon showing) and there is a logcat entry for being notified of an app update
