### PR TITLE
Alternative method of determining originating app package

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/DetectOriginatingAppPackageModern.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/DetectOriginatingAppPackageModern.kt
@@ -41,8 +41,20 @@ class DetectOriginatingAppPackageModern(
     }
 
     private fun getPackageIdForUid(uid: Int): String {
-        return packageManager.getNameForUid(uid) ?: OriginatingAppPackageIdentifierStrategy.UNKNOWN.also {
-            Timber.i("Failed to get package ID for UID: $uid")
+        val packages = packageManager.getPackagesForUid(uid)
+        if (packages.isNullOrEmpty()) {
+            Timber.w("Failed to get package ID for UID: $uid")
+            return OriginatingAppPackageIdentifierStrategy.UNKNOWN
         }
+
+        if (packages.size > 1) {
+            val sb = StringBuilder(String.format("Found %d packages for uid:%d", packages.size, uid))
+            packages.forEach {
+                sb.append(String.format("\npackage: %s", it))
+            }
+            Timber.d(sb.toString())
+        }
+
+        return packages.first()
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1200811292912063/f

### Description
Changes the way we detect the originating app package to overcome some edge cases with the existing implementation.

### Steps to test this PR
 
- Enable appTP as normal
- Use some apps with known trackers to smoke test. Verify they show up correctly in the tracker dashboard
- Launch `Noom Health & Weight` app and `MX Player`. Verify both of these show up correctly in the tracker dashboard (these are two apps which weren't correctly identified using the existing method of obtaining app package)