### PR TITLE
Remove m_atp_ev_tracker_blocked_c pixel

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnModule.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnModule.kt
@@ -21,7 +21,6 @@ import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.di.scopes.VpnObjectGraph
-import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.processor.requestingapp.*
 import com.duckduckgo.mobile.android.vpn.processor.tcp.hostname.*
 import com.duckduckgo.mobile.android.vpn.processor.tcp.tracker.AppTrackerRecorder
@@ -105,7 +104,6 @@ class VpnModule {
     @VpnScope
     @Provides
     fun providesVpnTrackerDetector(
-        deviceShieldPixels: DeviceShieldPixels,
         hostnameExtractor: HostnameExtractor,
         appTrackerRepository: AppTrackerRepository,
         appTrackerRecorder: AppTrackerRecorder,
@@ -114,7 +112,7 @@ class VpnModule {
         tlsContentTypeExtractor: ContentTypeExtractor,
         requestInterceptors: PluginPoint<VpnTrackerDetectorInterceptor>,
     ): VpnTrackerDetector {
-        return DomainBasedTrackerDetector(deviceShieldPixels, hostnameExtractor, appTrackerRepository, appTrackerRecorder, payloadBytesExtractor, tlsContentTypeExtractor, vpnDatabase, requestInterceptors)
+        return DomainBasedTrackerDetector(hostnameExtractor, appTrackerRepository, appTrackerRecorder, payloadBytesExtractor, tlsContentTypeExtractor, vpnDatabase, requestInterceptors)
     }
 
     @VpnScope

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -96,8 +96,6 @@ enum class DeviceShieldPixelNames(override val pixelName: String) : Pixel.PixelN
     ATP_KILLED_VPN_REVOKED_DAILY("m_atp_ev_revoke_kill_d"),
     ATP_KILLED_VPN_REVOKED("m_atp_ev_revoke_kill_c"),
 
-    ATP_TRACKER_BLOCKED("m_atp_ev_tracker_blocked_c"),
-
     ATP_DID_SHOW_PRIVACY_REPORT_ARTICLE("m_atp_imp_article_c"),
 
     ATP_DID_SHOW_ONBOARDING_FAQ("m_atp_imp_onboarding_faq_c"),

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -198,9 +198,6 @@ interface DeviceShieldPixels {
      */
     fun suddenKillByVpnRevoked()
 
-    /** This fun will fire a pixel on every call */
-    fun trackerBlocked()
-
     /** Will fire a pixel on every call */
     fun privacyReportArticleDisplayed()
 
@@ -440,10 +437,6 @@ class RealDeviceShieldPixels @Inject constructor(
         suddenKill()
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_KILLED_VPN_REVOKED_DAILY)
         firePixel(DeviceShieldPixelNames.ATP_KILLED_VPN_REVOKED)
-    }
-
-    override fun trackerBlocked() {
-        firePixel(DeviceShieldPixelNames.ATP_TRACKER_BLOCKED)
     }
 
     override fun privacyReportArticleDisplayed() {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/VpnTrackerDetector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/VpnTrackerDetector.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.mobile.android.vpn.processor.tcp.tracker
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
-import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.processor.requestingapp.AppNameResolver.OriginatingApp
 import com.duckduckgo.mobile.android.vpn.processor.tcp.hostname.ContentTypeExtractor
 import com.duckduckgo.mobile.android.vpn.processor.tcp.hostname.HostnameExtractor
@@ -47,7 +46,6 @@ interface VpnTrackerDetector {
 }
 
 class DomainBasedTrackerDetector(
-    private val deviceShieldPixels: DeviceShieldPixels,
     private val hostnameExtractor: HostnameExtractor,
     private val appTrackerRepository: AppTrackerRepository,
     private val appTrackerRecorder: AppTrackerRecorder,
@@ -150,7 +148,6 @@ class DomainBasedTrackerDetector(
             tcb.ipAndPort
         )
         insertTracker(trackerType.tracker, requestingApp)
-        deviceShieldPixels.trackerBlocked()
     }
 
     private fun isTrackerInExceptionRules(tracker: RequestTrackerType.Tracker, originatingApp: OriginatingApp): Boolean {

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
@@ -290,15 +290,6 @@ class RealDeviceShieldPixelsTest {
     }
 
     @Test
-    fun whenTrackersBlockedThenFireCountPixel() {
-        deviceShieldPixels.trackerBlocked()
-        deviceShieldPixels.trackerBlocked()
-
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_TRACKER_BLOCKED)
-        verifyNoMoreInteractions(pixel)
-    }
-
-    @Test
     fun whenPrivacyReportArticleDisplayedThenFireCountPixel() {
         deviceShieldPixels.privacyReportArticleDisplayed()
         deviceShieldPixels.privacyReportArticleDisplayed()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201395604254223/f

### Description
This PR removes the `m_atp_ev_tracker_blocked_c` pixel that was fired every time we blocked an app tracker.

The pixel is no longer needed in production

### Steps to test this PR
1. install from this branch
1. enable AppTP
1. open apps that send trackers
1. verify the `m_atp_ev_tracker_blocked_c` is no longer send when trackers are blocked


Same test in `develop` branch should send the `m_atp_ev_tracker_blocked_c` pixel
