### PR TITLE
Only record pixel when different exception or over time threshold

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/exception/UncaughtExceptionDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/exception/UncaughtExceptionDaoTest.kt
@@ -115,6 +115,26 @@ class UncaughtExceptionDaoTest {
         }
     }
 
+    @Test
+    fun whenGetLatestExceptionThenReturnLatestExceptionFromDatabase() {
+        val exception1 = UncaughtExceptionEntity(id = 1, exceptionSource = GLOBAL, message = "foo", "version")
+        val exception2 = UncaughtExceptionEntity(id = 2, exceptionSource = GLOBAL, message = "bar", "version")
+        dao.add(exception1)
+        dao.add(exception2)
+        val latestException = dao.getLatestException()
+        assertEquals(exception2, latestException)
+    }
+
+    @Test
+    fun whenUpdateExceptionThenUpdateExceptionInDatabase() {
+        val exception = UncaughtExceptionEntity(id = 1, exceptionSource = GLOBAL, message = "foo", "version", timestamp = 1000)
+        dao.add(exception)
+        val updatedException = exception.copy(timestamp = 2000)
+        dao.update(updatedException)
+        val latestException = dao.getLatestException()
+        assertEquals(updatedException, latestException)
+    }
+
     private fun anUncaughtExceptionEntity(id: Long? = null) =
         UncaughtExceptionEntity(id = id ?: 0, exceptionSource = GLOBAL, message = "foo", "version")
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepositoryDbTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepositoryDbTest.kt
@@ -56,30 +56,30 @@ class UncaughtExceptionRepositoryDbTest {
     @Test
     fun whenLatestExceptionIsNullThenReturnTrue() = runBlocking {
         whenever(uncaughtExceptionDao.getLatestException()).thenReturn(null)
-        assertTrue(testee.isOverTimeThreshold(entity.copy(timestamp = 1500)))
+        assertTrue(testee.isNotDuplicate(entity.copy(timestamp = 1500)))
     }
 
     @Test
     fun whenIsBelowTimeThresholdAndSameExceptionThenReturnFalseAndUpdateTimestamp() = runBlocking {
-        assertFalse(testee.isOverTimeThreshold(entity.copy(timestamp = 1500)))
+        assertFalse(testee.isNotDuplicate(entity.copy(timestamp = 1500)))
         verify(uncaughtExceptionDao).update(entity.copy(timestamp = 1500))
     }
 
     @Test
     fun whenIsAboveTimeThresholdAndSameExceptionThenReturnTrue() = runBlocking {
-        assertTrue(testee.isOverTimeThreshold(entity.copy(timestamp = 2001)))
+        assertTrue(testee.isNotDuplicate(entity.copy(timestamp = 2001)))
     }
 
     @Test
     fun whenIsDifferentExceptionThenReturnTrue() = runBlocking {
-        assertTrue(testee.isOverTimeThreshold(entity.copy(message = "different message", timestamp = 1500)))
-        assertTrue(testee.isOverTimeThreshold(entity.copy(version = "different version", timestamp = 1500)))
-        assertTrue(testee.isOverTimeThreshold(entity.copy(exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
+        assertTrue(testee.isNotDuplicate(entity.copy(message = "different message", timestamp = 1500)))
+        assertTrue(testee.isNotDuplicate(entity.copy(version = "different version", timestamp = 1500)))
+        assertTrue(testee.isNotDuplicate(entity.copy(exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
 
-        assertTrue(testee.isOverTimeThreshold(entity.copy(message = "different message", version = "different version", timestamp = 1500)))
-        assertTrue(testee.isOverTimeThreshold(entity.copy(message = "different message", exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
-        assertTrue(testee.isOverTimeThreshold(entity.copy(version = "different version", exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
+        assertTrue(testee.isNotDuplicate(entity.copy(message = "different message", version = "different version", timestamp = 1500)))
+        assertTrue(testee.isNotDuplicate(entity.copy(message = "different message", exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
+        assertTrue(testee.isNotDuplicate(entity.copy(version = "different version", exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
 
-        assertTrue(testee.isOverTimeThreshold(entity.copy(message = "different message", version = "different version", exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
+        assertTrue(testee.isNotDuplicate(entity.copy(message = "different message", version = "different version", exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepositoryDbTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepositoryDbTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.exception
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.global.device.DeviceInfo
+import com.nhaarman.mockitokotlin2.*
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class UncaughtExceptionRepositoryDbTest {
+
+    @get:Rule
+    @Suppress("unused")
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    private lateinit var testee: UncaughtExceptionRepositoryDb
+
+    private var uncaughtExceptionDao: UncaughtExceptionDao = mock()
+    private var rootExceptionFinder = RootExceptionFinder()
+    private var deviceInfo: DeviceInfo = mock()
+
+    private val entity = UncaughtExceptionEntity(exceptionSource = UncaughtExceptionSource.GLOBAL, message = "message", version = "version", timestamp = 1000)
+
+    @Before
+    fun before() {
+        testee = UncaughtExceptionRepositoryDb(uncaughtExceptionDao, rootExceptionFinder, deviceInfo)
+        whenever(deviceInfo.appVersion).thenReturn("version")
+        whenever(uncaughtExceptionDao.getLatestException()).thenReturn(entity)
+    }
+
+    @Test
+    fun whenLatestExceptionIsNullThenReturnTrue() = runBlocking {
+        whenever(uncaughtExceptionDao.getLatestException()).thenReturn(null)
+        assertTrue(testee.isOverTimeThreshold(entity.copy(timestamp = 1500)))
+    }
+
+    @Test
+    fun whenIsBelowTimeThresholdAndSameExceptionThenReturnFalseAndUpdateTimestamp() = runBlocking {
+        assertFalse(testee.isOverTimeThreshold(entity.copy(timestamp = 1500)))
+        verify(uncaughtExceptionDao).update(entity.copy(timestamp = 1500))
+    }
+
+    @Test
+    fun whenIsAboveTimeThresholdAndSameExceptionThenReturnTrue() = runBlocking {
+        assertTrue(testee.isOverTimeThreshold(entity.copy(timestamp = 2001)))
+    }
+
+    @Test
+    fun whenIsDifferentExceptionThenReturnTrue() = runBlocking {
+        assertTrue(testee.isOverTimeThreshold(entity.copy(message = "different message", timestamp = 1500)))
+        assertTrue(testee.isOverTimeThreshold(entity.copy(version = "different version", timestamp = 1500)))
+        assertTrue(testee.isOverTimeThreshold(entity.copy(exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
+
+        assertTrue(testee.isOverTimeThreshold(entity.copy(message = "different message", version = "different version", timestamp = 1500)))
+        assertTrue(testee.isOverTimeThreshold(entity.copy(message = "different message", exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
+        assertTrue(testee.isOverTimeThreshold(entity.copy(version = "different version", exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
+
+        assertTrue(testee.isOverTimeThreshold(entity.copy(message = "different message", version = "different version", exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))
+    }
+}

--- a/common/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionDao.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionDao.kt
@@ -16,10 +16,7 @@
 
 package com.duckduckgo.app.global.exception
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.Query
-import androidx.room.TypeConverter
+import androidx.room.*
 
 @Dao
 abstract class UncaughtExceptionDao {
@@ -32,6 +29,12 @@ abstract class UncaughtExceptionDao {
 
     @Query("SELECT * FROM UncaughtExceptionEntity")
     abstract fun all(): List<UncaughtExceptionEntity>
+
+    @Query("SELECT * FROM UncaughtExceptionEntity ORDER BY id DESC LIMIT 1")
+    abstract fun getLatestException(): UncaughtExceptionEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun update(uncaughtException: UncaughtExceptionEntity)
 
     @Query("DELETE FROM UncaughtExceptionEntity WHERE id=:id")
     abstract fun delete(id: Long)

--- a/common/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepository.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepository.kt
@@ -51,7 +51,7 @@ class UncaughtExceptionRepositoryDb(
                 version = deviceInfo.appVersion
             )
 
-            if (isOverTimeThreshold(exceptionEntity)) {
+            if (isNotDuplicate(exceptionEntity)) {
                 uncaughtExceptionDao.add(exceptionEntity)
             }
 
@@ -60,7 +60,7 @@ class UncaughtExceptionRepositoryDb(
     }
 
     @VisibleForTesting
-    fun isOverTimeThreshold(incomingException: UncaughtExceptionEntity): Boolean {
+    fun isNotDuplicate(incomingException: UncaughtExceptionEntity): Boolean {
 
         val lastRecordedException = uncaughtExceptionDao.getLatestException() ?: return true
 

--- a/common/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepository.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepository.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.global.exception
 
+import androidx.annotation.VisibleForTesting
 import com.duckduckgo.app.global.device.DeviceInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -49,10 +50,35 @@ class UncaughtExceptionRepositoryDb(
                 exceptionSource = exceptionSource,
                 version = deviceInfo.appVersion
             )
-            uncaughtExceptionDao.add(exceptionEntity)
+
+            if (isOverTimeThreshold(exceptionEntity)) {
+                uncaughtExceptionDao.add(exceptionEntity)
+            }
 
             lastSeenException = e
         }
+    }
+
+    @VisibleForTesting
+    fun isOverTimeThreshold(incomingException: UncaughtExceptionEntity): Boolean {
+
+        val lastRecordedException = uncaughtExceptionDao.getLatestException() ?: return true
+
+        if (incomingException.message == lastRecordedException.message &&
+            incomingException.exceptionSource == lastRecordedException.exceptionSource &&
+            incomingException.version == lastRecordedException.version
+        ) {
+
+            val timeDiff = incomingException.timestamp - lastRecordedException.timestamp
+
+            return if (timeDiff > TIME_THRESHOLD_MILLIS) {
+                true
+            } else {
+                uncaughtExceptionDao.update(lastRecordedException.copy(timestamp = incomingException.timestamp))
+                false
+            }
+        }
+        return true
     }
 
     override suspend fun getExceptions(): List<UncaughtExceptionEntity> {
@@ -65,5 +91,9 @@ class UncaughtExceptionRepositoryDb(
         return withContext(Dispatchers.IO) {
             uncaughtExceptionDao.delete(id)
         }
+    }
+
+    companion object {
+        const val TIME_THRESHOLD_MILLIS = 1000L
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1182255336053236/f

### Description
This PR limits the frequency of duplicate exceptions from being stored into the `UncaughtException` DB. The time threshold between storing duplicates has been set to 1s.

### Steps to test this PR

This one is tricky to test but with some patience the issue can be simulated.

_To simulate several duplicate `UnsatisfiedLinkErrors` being sent, do the following:_
1. Checkout this branch.
2. Comment out the following in the app `build.gradle` (Line 94-99):

![Screenshot 2021-11-19 at 08 09 25](https://user-images.githubusercontent.com/3471025/142573901-21853fe0-fc73-4f10-a69c-3c711f60e0c1.png)

3. Set the `TIME_THRESHOLD_MILLIS` in `UncaughtExceptionRepository` (Line 97) to `0L`.
4. Filter Logcat with "m_d_ac_g".
5. Run the app, it should crash on startup.
6. Keep opening the app until the system shows the "DuckDuckGo keeps crashing" dialog.
7. At this point several enqueued  `UnsatisfiedLinkError` pixels should be sent.
8. Verify that this is the case in Logcat.

_Now to test the fix, do the following:_
1. Set the `TIME_THRESHOLD_MILLIS` in `UncaughtExceptionRepository` (Line 97) to `10000L`.
2. Run the app, it should crash on startup.
3. Keep opening the app (With less than 10s between openings) until the system shows the "DuckDuckGo keeps crashing" dialog.
4. At this point only a single `UnsatisfiedLinkError` pixel should be sent.
5. Verify that this is the case in Logcat.
