### PR TITLE
Fix AppTP survey

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/survey/api/SurveyDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/api/SurveyDownloader.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.survey.model.Survey.Status.NOT_ALLOCATED
 import com.duckduckgo.app.survey.model.Survey.Status.SCHEDULED
 import com.duckduckgo.mobile.android.vpn.cohort.AtpCohortManager
 import io.reactivex.Completable
+import retrofit2.Response
 import timber.log.Timber
 import java.io.IOException
 import java.util.*
@@ -38,14 +39,29 @@ class SurveyDownloader @Inject constructor(
     private val atpCohortManager: AtpCohortManager
 ) {
 
+    private fun getSurveyResponse(): Response<SurveyGroup?> {
+        val callAppTP = service.surveyAppTp()
+        val responseAppTP = callAppTP.execute()
+
+        // FIXME see https://app.asana.com/0/414730916066338/1201395604254213/f
+        // check temporary AppTP survey endpoint else fallback to v2 survey endpoint
+        if (responseAppTP.isSuccessful && responseAppTP.body()?.id != null) {
+            Timber.v("Returning AppTP response")
+            return responseAppTP
+        }
+
+        val call = service.survey()
+        Timber.v("Returning v2 response")
+        return call.execute()
+    }
+
     fun download(): Completable {
 
         return Completable.fromAction {
 
             Timber.d("Downloading user survey data")
 
-            val call = service.survey()
-            val response = call.execute()
+            val response = getSurveyResponse()
 
             Timber.d("Response received, success=${response.isSuccessful}")
 

--- a/app/src/main/java/com/duckduckgo/app/survey/api/SurveyService.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/api/SurveyService.kt
@@ -23,4 +23,7 @@ interface SurveyService {
 
     @GET("https://staticcdn.duckduckgo.com/survey/v2/survey-mobile.json")
     fun survey(): Call<SurveyGroup?>
+
+    @GET("https://staticcdn.duckduckgo.com/survey/apptp/survey-mobile.json")
+    fun surveyAppTp(): Call<SurveyGroup?>
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201395604254213/f

### Description
This PR fixes (temporarily) the AppTP survey. See [asana task](https://app.asana.com/0/414730916066338/1201395604254213/f) for more details about the approach

### Steps to test this PR
_Test this branch_
1. install form this branch
1. ensure [v2 endpoint](https://staticcdn.duckduckgo.com/survey/v2/survey-mobile.json) does not contain a survey
1. ensure [apptp endpoint](https://staticcdn.duckduckgo.com/survey/apptp/survey-mobile.json) does not exist - open in brower should show error
1. open app
1. get past onboarding and all Dax dialogs and search widget (you'll have to open several new tabs)
1. force close the app
1. open app
1. verify app does not crash and survey is not shown
1. verify `Returning v2 response` message appears in logcat
1. publish empty survey in apptp endpoint
1. force close app and reopen
1. verify `Returning v2 response` message appears in logcat
1. publis valid survey in apptp endpoint
1. verify `Returning AppTP response` message appears in logcat
1. verify `Returning v2 response` message DOES NOT appear in logcat

_Test Develop_
1. repeat the steps above
1. verify `Returning v2 response` messages always appear in logcat
1. verify `Returning AppTP response` message never appear in logcat

