### PR TITLE
Remove the usage of TabRepository in TrackerNetworksActivity

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksViewModel.kt
@@ -36,7 +36,7 @@ import java.util.*
 import javax.inject.Inject
 import javax.inject.Provider
 
-class TrackerNetworksViewModel(
+class TrackerNetworksViewModel @Inject constructor(
     private val tabRepository: TabRepository
 ) : ViewModel() {
 
@@ -92,12 +92,12 @@ class TrackerNetworksViewModel(
 @Module
 @ContributesMultibinding(AppObjectGraph::class)
 class TrackerNetworksViewModelFactory @Inject constructor(
-    private val tabRepository: Provider<TabRepository>
+    private val viewModel: Provider<TrackerNetworksViewModel>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(TrackerNetworksViewModel::class.java) -> (TrackerNetworksViewModel(tabRepository.get()) as T)
+                isAssignableFrom(TrackerNetworksViewModel::class.java) -> (viewModel.get() as T)
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/TrackerNetworksViewModel.kt
@@ -17,22 +17,28 @@
 package com.duckduckgo.app.privacy.ui
 
 import android.net.Uri
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asFlow
+import androidx.lifecycle.viewModelScope
 import com.duckduckgo.app.global.baseHost
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
+import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.di.scopes.AppObjectGraph
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.Module
+import kotlinx.coroutines.flow.*
 import java.util.*
 import javax.inject.Inject
+import javax.inject.Provider
 
-class TrackerNetworksViewModel : ViewModel() {
+class TrackerNetworksViewModel(
+    private val tabRepository: TabRepository
+) : ViewModel() {
 
     data class ViewState(
         val domain: String,
@@ -41,33 +47,25 @@ class TrackerNetworksViewModel : ViewModel() {
         val trackingEventsByNetwork: SortedMap<Entity, List<TrackingEvent>>
     )
 
-    val viewState: MutableLiveData<ViewState> = MutableLiveData()
-
-    init {
-        resetViewState()
-    }
-
-    private fun resetViewState() {
-        viewState.value = ViewState(
-            domain = "",
-            trackerCount = 0,
-            allTrackersBlocked = true,
-            trackingEventsByNetwork = emptySortedTrackingEventMap()
-        )
-    }
-
-    fun onSiteChanged(site: Site?) {
-        if (site == null) {
-            resetViewState()
-            return
+    fun trackers(tabId: String): StateFlow<ViewState> = flow {
+        tabRepository.retrieveSiteData(tabId).asFlow().collect { site ->
+            emit(updatedState(site))
         }
-        viewState.value = viewState.value?.copy(
-            domain = site.domain ?: "",
-            trackerCount = site.trackerCount,
-            allTrackersBlocked = site.allTrackersBlocked,
-            trackingEventsByNetwork = distinctTrackersByEntity(site.trackingEvents)
-        )
-    }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), resetState())
+
+    private fun updatedState(site: Site) = ViewState(
+        domain = site.domain ?: "",
+        trackerCount = site.trackerCount,
+        allTrackersBlocked = site.allTrackersBlocked,
+        trackingEventsByNetwork = distinctTrackersByEntity(site.trackingEvents)
+    )
+
+    private fun resetState() = ViewState(
+        domain = "",
+        trackerCount = 0,
+        allTrackersBlocked = true,
+        trackingEventsByNetwork = emptySortedTrackingEventMap()
+    )
 
     private fun distinctTrackersByEntity(trackingEvents: List<TrackingEvent>): SortedMap<Entity, List<TrackingEvent>> {
         val data = emptySortedTrackingEventMap()
@@ -91,12 +89,15 @@ class TrackerNetworksViewModel : ViewModel() {
     }
 }
 
-@Module@ContributesMultibinding(AppObjectGraph::class)
-class TrackerNetworksViewModelFactory @Inject constructor() : ViewModelFactoryPlugin {
+@Module
+@ContributesMultibinding(AppObjectGraph::class)
+class TrackerNetworksViewModelFactory @Inject constructor(
+    private val tabRepository: Provider<TabRepository>
+) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(TrackerNetworksViewModel::class.java) -> (TrackerNetworksViewModel() as T)
+                isAssignableFrom(TrackerNetworksViewModel::class.java) -> (TrackerNetworksViewModel(tabRepository.get()) as T)
                 else -> null
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201307807827050/f

### Description
Removed the reference to tab repository from TrackerNetworksActivity.

### Steps to test this PR
- install / upgrade from this branch
- navigate to a website (e.g https://www.amazon.com, https://www.nfl.com)
- tap on the score bubbles displayed at the left side of the URL and you'll open the "Privacy Dashboard" screen
- on "Privacy Dashboard" screen tap on "Trackers Blocked" and you'll open the "Tracker Networks" screen
-  check the "Tracker Networks" screen behaves as expected (correct information displayed for 0 trackers / at least one tracker)

### Video

https://user-images.githubusercontent.com/7963079/142636604-b649f69e-6c1d-4ab4-968c-641af372662e.mp4

### No UI changes
