### PR TITLE
Remove the usage of TabRepository in ScorecardActivity

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/ScorecardViewModel.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Provider
 
-class ScorecardViewModel(
+class ScorecardViewModel @Inject constructor(
     private val tabRepository: TabRepository,
     private val userWhitelistDao: UserWhitelistDao,
     private val contentBlocking: ContentBlocking,
@@ -93,18 +93,12 @@ class ScorecardViewModel(
 
 @ContributesMultibinding(AppObjectGraph::class)
 class ScorecardViewModelFactory @Inject constructor(
-    private val tabRepository: Provider<TabRepository>,
-    private val userWhitelistDao: Provider<UserWhitelistDao>,
-    private val contentBlocking: Provider<ContentBlocking>
+    private val viewModel: Provider<ScorecardViewModel>
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
-                isAssignableFrom(ScorecardViewModel::class.java) -> ScorecardViewModel(
-                    tabRepository.get(),
-                    userWhitelistDao.get(),
-                    contentBlocking.get()
-                ) as T
+                isAssignableFrom(ScorecardViewModel::class.java) -> viewModel.get() as T
                 else -> null
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201307807827051/f

### Description
Removed the reference to tab repository from ScorecardActivity.

### Steps to test this PR

- install / upgrade from this branch
- navigate to a website (e.g https://www.amazon.com, https://www.duckduckgo.com)
- tap on the score bubbles displayed at the left side of the URL and you'll open the "Privacy Dashboard" screen
- on "Privacy Dashboard" screen tap on the image at the top which displays the privacy grade and you'll open the "Privacy Grade" screen
-  check the "Privacy Grade" screen behaves as expected (correct information displayed for Grade A / B+ / etc)

### Video

https://user-images.githubusercontent.com/7963079/142637932-8ba88671-c423-4492-b2b8-85b24a0e0853.mp4

### No UI changes
