### PR TITLE
Bump room version to fix build in M1 builds

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,7 +27,7 @@ version.androidx.legacy=1.0.0
 
 version.androidx.lifecycle=2.4.0-alpha03
 
-version.androidx.room=2.3.0
+version.androidx.room=2.4.0-beta02
 
 version.androidx.swiperefreshlayout=1.1.0
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201403896220544/f

### Description
Room has a [bug](https://issuetracker.google.com/issues/174695268?pli=1) prior to 2.4.0-alpha03, in the native SQL library, that makes it not compile in M1 chips.

This PR just bumps room to unblock M1 developers

### Steps to test this PR
If you're amongst the lucky to have an M1, just build and enjoy :rocket:

