### PR TITLE
Fix NPE when getting the running process

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/process/ProcessDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/process/ProcessDetector.kt
@@ -43,8 +43,8 @@ class ProcessDetector {
             return Application.getProcessName()
         }
 
-        val am = context.getSystemService(Application.ACTIVITY_SERVICE) as ActivityManager
-        return am.runningAppProcesses.firstOrNull { it.pid == Process.myPid() }?.processName.orEmpty()
+        val am = context.getSystemService(Application.ACTIVITY_SERVICE) as ActivityManager?
+        return am?.runningAppProcesses?.firstOrNull { it.pid == Process.myPid() }?.processName.orEmpty()
     }
 
     sealed class DuckDuckGoProcess(open val processName: String) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201395476838293/f

### Description
This PR fixes an NPE we're seeing in some devices when getting the running procss on `Application#onCreate`.

The `getSystemService` call can return a nullable value

### Steps to test this PR
Nothing to test

