### PR TITLE
Remove count pixels for the different memory state conditions

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -103,18 +103,12 @@ enum class DeviceShieldPixelNames(override val pixelName: String) : Pixel.PixelN
     ATP_TUN_INTERFACE_DOWN_DAILY("m_atp_ev_tun_down_d"),
     ATP_TUN_INTERFACE_DOWN("m_atp_ev_tun_down_c"),
 
-    ATP_PROCESS_EXPENDABLE_LOW("m_atp_ev_expen_memory_low_c"),
     ATP_PROCESS_EXPENDABLE_LOW_DAILY("m_atp_ev_expen_memory_low_d"),
-    ATP_PROCESS_EXPENDABLE_MODERATE("m_atp_ev_expen_memory_moderate_c"),
     ATP_PROCESS_EXPENDABLE_MODERATE_DAILY("m_atp_ev_expen_memory_moderate_d"),
-    ATP_PROCESS_EXPENDABLE_COMPLETE("m_atp_ev_expen_memory_complete_c"),
     ATP_PROCESS_EXPENDABLE_COMPLETE_DAILY("m_atp_ev_expen_memory_complete_d"),
 
-    ATP_PROCESS_MEMORY_LOW("m_atp_ev_memory_low_c"),
     ATP_PROCESS_MEMORY_LOW_DAILY("m_atp_ev_memory_low_d"),
-    ATP_PROCESS_MEMORY_MODERATE("m_atp_ev_memory_moderate_c"),
     ATP_PROCESS_MEMORY_MODERATE_DAILY("m_atp_ev_memory_moderate_d"),
-    ATP_PROCESS_MEMORY_CRITICAL("m_atp_ev_memory_critical_c"),
     ATP_PROCESS_MEMORY_CRITICAL_DAILY("m_atp_ev_memory_critical_d"),
 
     ATP_DISABLE_APP_PROTECTION("m_atp_ev_disabled_protection_c"),

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -454,32 +454,26 @@ class RealDeviceShieldPixels @Inject constructor(
 
     override fun vpnProcessExpendableLow(payload: Map<String, String>) {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_PROCESS_EXPENDABLE_LOW_DAILY, payload)
-        firePixel(DeviceShieldPixelNames.ATP_PROCESS_EXPENDABLE_LOW, payload)
     }
 
     override fun vpnProcessExpendableModerate(payload: Map<String, String>) {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_PROCESS_EXPENDABLE_MODERATE_DAILY, payload)
-        firePixel(DeviceShieldPixelNames.ATP_PROCESS_EXPENDABLE_MODERATE, payload)
     }
 
     override fun vpnProcessExpendableComplete(payload: Map<String, String>) {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_PROCESS_EXPENDABLE_COMPLETE_DAILY, payload)
-        firePixel(DeviceShieldPixelNames.ATP_PROCESS_EXPENDABLE_COMPLETE, payload)
     }
 
     override fun vpnMemoryRunningLow(payload: Map<String, String>) {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_PROCESS_MEMORY_LOW_DAILY, payload)
-        firePixel(DeviceShieldPixelNames.ATP_PROCESS_MEMORY_LOW, payload)
     }
 
     override fun vpnMemoryRunningModerate(payload: Map<String, String>) {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_PROCESS_MEMORY_MODERATE_DAILY, payload)
-        firePixel(DeviceShieldPixelNames.ATP_PROCESS_MEMORY_MODERATE, payload)
     }
 
     override fun vpnMemoryRunningCritical(payload: Map<String, String>) {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_PROCESS_MEMORY_CRITICAL_DAILY, payload)
-        firePixel(DeviceShieldPixelNames.ATP_PROCESS_MEMORY_CRITICAL, payload)
     }
 
     override fun disableAppProtection(payload: Map<String, String>) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201404025058112/f

### Description
This PR removes the count pixels we fire when devices enter the different low memory states

* During internal and F&F we added pixels to detect how often user devices would get into different memory criticality states
* We added m_atp_ev_memory_[low/moderate/critical]_[c/d] pixels
where _c pixels would fire every time the device would enter that level of criticality 
and _d pixels would be fired for that respective criticality level but on a first-in-day basis
* And we consider these don't add a lot of value anymore


### Steps to test this PR

1. install assembleID
1. execute `adb shell am send-trim-memory com.duckduckgo.mobile.android:vpn <N>` where:
  * N is 5, 10 or 15 to send MODERATE, LOW or CRITICAL level respectively
1. verify the `m_atp_ev_memory_[low/moderate/critical]_c` pixels don't fire

