### PR TITLE
Open new sign up flow in full browser tab

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -363,7 +363,8 @@ class BrowserTabViewModelTest {
             tabRepository = mockTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             variantManager = mockVariantManager,
-            userEventsStore = mockUserEventsStore
+            userEventsStore = mockUserEventsStore,
+            duckDuckGoUrlDetector = DuckDuckGoUrlDetector()
         )
 
         val siteFactory = SiteFactory(mockPrivacyPractices, mockEntityLookup)

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -550,6 +550,14 @@ class CtaViewModelTest {
     }
 
     @Test
+    fun whenRefreshCtaWhileDaxOnboardingActiveAndBrowsingOnDuckDuckGoEmailUrlThenReturnNull() = runBlockingTest {
+        givenDaxOnboardingActive()
+        val site = site(url = "https://duckduckgo.com/email/")
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
+        assertNull(value)
+    }
+
+    @Test
     fun whenUserHidesAllTipsThenFireButtonAnimationShouldNotShow() = coroutineRule.runBlocking {
         givenOnboardingActive()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -23,6 +23,7 @@ import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.InstantSchedulersRule
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
@@ -163,7 +164,8 @@ class CtaViewModelTest {
             tabRepository = mockTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             variantManager = mockVariantManager,
-            userEventsStore = mockUserEventsStore
+            userEventsStore = mockUserEventsStore,
+            duckDuckGoUrlDetector = DuckDuckGoUrlDetector()
         )
 
         whenever(mockVariantManager.getVariant()).thenReturn(ACTIVE_VARIANTS.first { it.key == "mi" })

--- a/app/src/androidTest/java/com/duckduckgo/app/email/ui/EmailProtectionSignInViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/ui/EmailProtectionSignInViewModelTest.kt
@@ -93,26 +93,26 @@ class EmailProtectionSignInViewModelTest {
     }
 
     @Test
-    fun whenHaveAnInviteCodeThenEmitCommandOpenUrlWithCorrectUrl() = coroutineRule.runBlocking {
+    fun whenHaveAnInviteCodeThenEmitCommandOpenUrlInBrowserTabWithCorrectUrl() = coroutineRule.runBlocking {
         val inviteCode = "abcde"
         whenever(mockEmailManager.getInviteCode()).thenReturn(inviteCode)
         val expectedURL = "$SIGN_UP_URL$inviteCode"
 
         testee.commands.test {
             testee.haveAnInviteCode()
-            assertEquals(OpenUrl(url = expectedURL), awaitItem())
+            assertEquals(OpenUrlInBrowserTab(url = expectedURL), awaitItem())
         }
     }
 
     @Test
-    fun whenGetStartedThenEmitCommandOpenUrlWithCorrectUrl() = coroutineRule.runBlocking {
+    fun whenGetStartedThenEmitCommandOpenUrlInBrowserTabWithCorrectUrl() = coroutineRule.runBlocking {
         val inviteCode = "abcde"
         whenever(mockEmailManager.getInviteCode()).thenReturn(inviteCode)
         val expectedURL = "$GET_STARTED_URL$inviteCode"
 
         testee.commands.test {
             testee.getStarted()
-            assertEquals(OpenUrl(url = expectedURL), awaitItem())
+            assertEquals(OpenUrlInBrowserTab(url = expectedURL), awaitItem())
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -326,6 +326,11 @@ class CtaViewModel @Inject constructor(
         }
 
         nonNullSite.let {
+
+            if (isDuckDuckGoEmailUrl(it.url)) {
+                return null
+            }
+
             // Is major network
             if (it.entity != null) {
                 it.entity?.let { entity ->
@@ -369,6 +374,8 @@ class CtaViewModel @Inject constructor(
     private fun pulseFireButtonShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON_PULSE)
 
     private fun isSerpUrl(url: String): Boolean = url.contains(DaxDialogCta.SERP)
+
+    private fun isDuckDuckGoEmailUrl(url: String): Boolean = url.contains(DUCK_DUCK_GO_EMAIL_URL_PART)
 
     private suspend fun daxOnboardingActive(): Boolean = userStageStore.daxOnboardingActive()
 
@@ -424,5 +431,6 @@ class CtaViewModel @Inject constructor(
         private const val SURVEY_NO_MIN_DAYS_INSTALLED_REQUIRED = -1L
         private const val MAX_TABS_OPEN_FIRE_EDUCATION = 2
         private val ALLOWED_LOCALES = listOf(Locale.US, Locale.UK, Locale.CANADA)
+        private val DUCK_DUCK_GO_EMAIL_URL_PART = "duckduckgo.com/email"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.cta.ui
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import androidx.lifecycle.LiveData
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.DismissedCta
@@ -70,7 +71,8 @@ class CtaViewModel @Inject constructor(
     private val tabRepository: TabRepository,
     private val dispatchers: DispatcherProvider,
     private val variantManager: VariantManager,
-    private val userEventsStore: UserEventsStore
+    private val userEventsStore: UserEventsStore,
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector
 ) {
     val surveyLiveData: LiveData<Survey> = surveyDao.getLiveScheduled()
 
@@ -327,7 +329,7 @@ class CtaViewModel @Inject constructor(
 
         nonNullSite.let {
 
-            if (isDuckDuckGoEmailUrl(it.url)) {
+            if (duckDuckGoUrlDetector.isDuckDuckGoEmailUrl(it.url)) {
                 return null
             }
 
@@ -374,8 +376,6 @@ class CtaViewModel @Inject constructor(
     private fun pulseFireButtonShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON_PULSE)
 
     private fun isSerpUrl(url: String): Boolean = url.contains(DaxDialogCta.SERP)
-
-    private fun isDuckDuckGoEmailUrl(url: String): Boolean = url.contains(DUCK_DUCK_GO_EMAIL_URL_PART)
 
     private suspend fun daxOnboardingActive(): Boolean = userStageStore.daxOnboardingActive()
 
@@ -431,6 +431,5 @@ class CtaViewModel @Inject constructor(
         private const val SURVEY_NO_MIN_DAYS_INSTALLED_REQUIRED = -1L
         private const val MAX_TABS_OPEN_FIRE_EDUCATION = 2
         private val ALLOWED_LOCALES = listOf(Locale.US, Locale.UK, Locale.CANADA)
-        private val DUCK_DUCK_GO_EMAIL_URL_PART = "duckduckgo.com/email"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignInFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignInFragment.kt
@@ -24,6 +24,7 @@ import android.widget.Toast
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.FragmentEmailProtectionSignInBinding
 import com.duckduckgo.app.email.AppEmailManager
@@ -97,6 +98,7 @@ class EmailProtectionSignInFragment : EmailProtectionFragment(R.layout.fragment_
     private fun executeCommand(command: EmailProtectionSignInViewModel.Command) {
         when (command) {
             is EmailProtectionSignInViewModel.Command.OpenUrl -> openWebsite(command.url)
+            is EmailProtectionSignInViewModel.Command.OpenUrlInBrowserTab -> openBrowserTab(command.url)
             is EmailProtectionSignInViewModel.Command.ShowErrorMessage -> renderErrorMessage()
             is EmailProtectionSignInViewModel.Command.ShowNotificationDialog -> showNotificationDialog()
         }
@@ -171,6 +173,13 @@ class EmailProtectionSignInFragment : EmailProtectionFragment(R.layout.fragment_
                 text = spannableString
                 movementMethod = LinkMovementMethod.getInstance()
             }
+        }
+    }
+
+    private fun openBrowserTab(url: String) {
+        context?.let {
+            startActivity(BrowserActivity.intent(it, url))
+            activity?.finish()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignInViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignInViewModel.kt
@@ -53,6 +53,7 @@ class EmailProtectionSignInViewModel(
 
     sealed class Command {
         data class OpenUrl(val url: String) : Command()
+        data class OpenUrlInBrowserTab(val url: String) : Command()
         object ShowErrorMessage : Command()
         object ShowNotificationDialog : Command()
     }
@@ -67,13 +68,13 @@ class EmailProtectionSignInViewModel(
 
     fun haveAnInviteCode() {
         viewModelScope.launch {
-            commandChannel.send(Command.OpenUrl(url = "$SIGN_UP_URL${emailManager.getInviteCode()}"))
+            commandChannel.send(Command.OpenUrlInBrowserTab(url = "$SIGN_UP_URL${emailManager.getInviteCode()}"))
         }
     }
 
     fun getStarted() {
         viewModelScope.launch {
-            commandChannel.send(Command.OpenUrl(url = "$GET_STARTED_URL${emailManager.getInviteCode()}"))
+            commandChannel.send(Command.OpenUrlInBrowserTab(url = "$GET_STARTED_URL${emailManager.getInviteCode()}"))
         }
     }
 

--- a/app/src/main/res/layout/fragment_email_protection_sign_in.xml
+++ b/app/src/main/res/layout/fragment_email_protection_sign_in.xml
@@ -19,8 +19,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:fillViewport="true"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -39,6 +39,8 @@
             android:id="@+id/statusTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginEnd="24dp"
             android:fontFamily="sans-serif"
             android:lineSpacingExtra="4sp"
             android:paddingTop="24dp"
@@ -50,12 +52,14 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/emailPrivacyDescription"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center"
             android:layout_marginStart="24dp"
             android:layout_marginEnd="24dp"
             android:fontFamily="sans-serif"
             android:lineSpacingExtra="4sp"
+            android:maxWidth="500dp"
             android:paddingTop="8dp"
             android:text="@string/emailProtectionDescriptionJoin"
             android:textAlignment="center"
@@ -69,34 +73,39 @@
             android:layout_marginStart="24dp"
             android:layout_marginTop="32dp"
             android:layout_marginEnd="24dp"
+            android:gravity="center"
             android:orientation="vertical">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/waitListButton"
                 style="@style/EmailButton.Primary"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="55dp"
+                android:minWidth="500dp"
                 android:text="@string/emailProtectionWaitlistCta" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/getStartedButton"
                 style="@style/EmailButton.Primary"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="55dp"
+                android:minWidth="500dp"
                 android:text="@string/emailProtectionGetStartedCta" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/inviteCodeButton"
                 style="@style/EmailButton.Secondary"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="55dp"
+                android:minWidth="500dp"
                 android:text="@string/emailProtectionInviteCodeCta" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/duckAddressButton"
                 style="@style/EmailButton.Secondary"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="55dp"
+                android:minWidth="500dp"
                 android:text="@string/emailProtectionDuckAddressCta" />
         </LinearLayout>
 
@@ -105,6 +114,9 @@
             android:id="@+id/footerDescription"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="24dp"
+            android:layout_marginEnd="24dp"
             android:layout_marginBottom="35dp"
             android:fontFamily="sans-serif"
             android:gravity="bottom|center_horizontal"

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -588,7 +588,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Поверителност на имейла с две думи.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Блокирайте имейл тракерите и скрийте своя адрес,<br/>без да променяте своя имейл доставчик. <a href=\"\"><b>Научете повече</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Блокирайте имейл тракерите и скрийте своя адрес, без да променяте своя имейл доставчик. <a href=\"\"><b>Научете повече</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Вече сте в списъка!</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -600,7 +600,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">E-mailové soukromí, zjednodušené.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Zablokovat sledování e-mailů a skrýt vaši adresu,<br/>bez přepínání vašeho poskytovatele e-mailů. <a href=\"\"><b>Více informací</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Zablokovat sledování e-mailů a skrýt vaši adresu, bez přepínání vašeho poskytovatele e-mailů. <a href=\"\"><b>Více informací</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Jste na seznamu!</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Fortrolighed af e-mail, forenklet.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokér e-mailtrackere og skjul din adresse,<br/> uden at ændre din e-mailudbyder. <a href=\"\"><b>Få mere at vide</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokér e-mailtrackere og skjul din adresse, uden at ændre din e-mailudbyder. <a href=\"\"><b>Få mere at vide</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Du er på listen!</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">E-Mail-Datenschutz, vereinfacht.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[E-Mail-Tracker blockieren und deine Adresse verbergen,<br/>ohne dafür den E-Mail-Anbieter wechseln zu müssen. <a href=\"\"><b>Mehr erfahren</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[E-Mail-Tracker blockieren und deine Adresse verbergen, ohne dafür den E-Mail-Anbieter wechseln zu müssen. <a href=\"\"><b>Mehr erfahren</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Du stehst jetzt auf der Warteliste.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Ιδιωτικότητα email, απλοποιημένη.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας,<br/>χωρίς να αλλάξετε πάροχο email. <a href=\"\"><b>Μάθετε περισσότερα</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας, χωρίς να αλλάξετε πάροχο email. <a href=\"\"><b>Μάθετε περισσότερα</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Είστε στη λίστα!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Privacidad de correo electrónico, simplificada.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Bloquea los rastreadores de correo electrónico y oculta tu dirección<br/>sin cambiar de proveedor de correo electrónico. <a href=\"\"><b>Más información</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Bloquea los rastreadores de correo electrónico y oculta tu dirección sin cambiar de proveedor de correo electrónico. <a href=\"\"><b>Más información</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">¡Estás en la lista!</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">E-posti privaatsus, lihtsustatud.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokeerige e-posti jälgijad ja peitke oma aadress<br/> ilma oma e-posti teenuse pakkujat vahetamata. <a href=\"\"><b>Lisateave</b></a> .]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokeerige e-posti jälgijad ja peitke oma aadress ilma oma e-posti teenuse pakkujat vahetamata. <a href=\"\"><b>Lisateave</b></a> .]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Olete nimekirjas!</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Sähköpostin tietosuoja, yksinkertaisesti.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Estä sähköpostiseuranta ja piilota osoitteesi<br/>vaihtamatta sähköpostintarjoajaa. <a href=\"\"><b>Lue lisää</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Estä sähköpostiseuranta ja piilota osoitteesi vaihtamatta sähköpostintarjoajaa. <a href=\"\"><b>Lue lisää</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Olet listalla!</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">La confidentialité des e-mails, simplifiée.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Bloquez les traqueurs d\'e-mails et masquez votre adresse,<br/>sans changer de fournisseur de messagerie. <a href=\"\"><b>En savoir plus</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Bloquez les traqueurs d\'e-mails et masquez votre adresse, sans changer de fournisseur de messagerie. <a href=\"\"><b>En savoir plus</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Vous êtes sur la liste !</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -616,7 +616,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Zaštita privatnosti e-pošte, na jednostavan način.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokirajte programe za praćenje e-pošte i sakrijte svoju adresu<br/>bez promjene pružatelja usluga e-pošte. <a href=\"\"><b>Saznajte više</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokirajte programe za praćenje e-pošte i sakrijte svoju adresu bez promjene pružatelja usluga e-pošte. <a href=\"\"><b>Saznajte više</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Na popisu ste!</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">E-mail adatvédelem, egyszerűsítve.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Tiltsd le az e-mail nyomkövetőket, és rejtsd el a címedet<br/> anélkül, hogy leváltanád az e-mail szolgáltatódat. <a href=\"\"><b>További részletek</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Tiltsd le az e-mail nyomkövetőket, és rejtsd el a címedet anélkül, hogy leváltanád az e-mail szolgáltatódat. <a href=\"\"><b>További részletek</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Rajta vagy a listán!</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Tutelare la privacy delle e-mail, ora è semplice.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blocca il sistema di tracciamento e-mail e nascondi il tuo indirizzo,<br/>senza cambiare il provider di posta elettronica. <a href=\"\"><b>Ulteriori informazioni</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blocca il sistema di tracciamento e-mail e nascondi il tuo indirizzo, senza cambiare il provider di posta elettronica. <a href=\"\"><b>Ulteriori informazioni</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Sei sulla lista.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -616,7 +616,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Supaprastintas el. pašto privatumas.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokuokite el. pašto sekimo priemones ir slėpkite savo adresą<br />nekeisdami savo el. pašto teikėjo. <b><a href=\"\">Sužinoti daugiau</a></b>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokuokite el. pašto sekimo priemones ir slėpkite savo adresą nekeisdami savo el. pašto teikėjo. <b><a href=\"\">Sužinoti daugiau</a></b>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Jūs jau sąraše!</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -610,7 +610,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">E-pasta konfidencialitāte, vienkāršota.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Bloķē e-pasta izsekotājus un paslēp savu adresi,<br/> nemainot e-pasta pakalpojumu sniedzēju. <a href=\"\"><b>Uzzini vairāk</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Bloķē e-pasta izsekotājus un paslēp savu adresi, nemainot e-pasta pakalpojumu sniedzēju. <a href=\"\"><b>Uzzini vairāk</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Tu esi sarakstā!</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Personvern for e-post gjort enkelt.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokker e-postsporere og skjul adressen din,<br/>uten å bytte e-postleverandør. <a href=\"\"><b>Finn ut mer</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokker e-postsporere og skjul adressen din, uten å bytte e-postleverandør. <a href=\"\"><b>Finn ut mer</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Du er satt på listen!</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">E-mailprivacy, vereenvoudigd.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokkeer e-mailtrackers en verberg je adres,<br/>zonder van e-mailprovider te wisselen. <a href=\"\"><b>Meer informatie</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokkeer e-mailtrackers en verberg je adres, zonder van e-mailprovider te wisselen. <a href=\"\"><b>Meer informatie</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Je staat op de lijst!</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -616,7 +616,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Uproszczona prywatność poczty e-mail.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Zablokuj skrypty śledzące pocztę e-mail i ukryj swój adres<br/>bez zmiany dostawcy poczty e-mail. <a href=\"\"><b>Dowiedz się więcej</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Zablokuj skrypty śledzące pocztę e-mail i ukryj swój adres bez zmiany dostawcy poczty e-mail. <a href=\"\"><b>Dowiedz się więcej</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Jesteś na liście!</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">A privacidade dos e-mails, simplificada.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Bloqueie rastreadores de e-mail e oculte o seu endereço,<br/>sem mudar de fornecedor de e-mail. <a href=\"\"><b>Saiba mais</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Bloqueie rastreadores de e-mail e oculte o seu endereço, sem mudar de fornecedor de e-mail. <a href=\"\"><b>Saiba mais</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Já está na lista!</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -610,7 +610,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Confidențialitatea e-mailurilor, simplificată.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa, <br/> fără a schimba furnizorul de e-mail. <a href=\"\"><b>Află mai multe</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa, fără a schimba furnizorul de e-mail. <a href=\"\"><b>Află mai multe</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Ești pe listă!</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -616,7 +616,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Надежная защита почты и ничего лишнего.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Оказывается, чтобы избавиться от трекеров и скрыть свой адрес,<br/>вовсе не нужно менять почтовый сервис. <a href=\"\"><b>Подробнее</b></a>...]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Оказывается, чтобы избавиться от трекеров и скрыть свой адрес, вовсе не нужно менять почтовый сервис. <a href=\"\"><b>Подробнее</b></a>...]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Теперь вы в списке!</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -616,7 +616,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Zjednodušená ochrana súkromia v e‑mailoch.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Zablokujte si e‑mailové trackery<br/>bez zmeny poskytovateľa e‑mailu. <b><a href=\"\">Zistite viac</a></b>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Zablokujte si e‑mailové trackery bez zmeny poskytovateľa e‑mailu. <b><a href=\"\">Zistite viac</a></b>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Ste na zozname!</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -616,7 +616,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Poenostavljena zasebnost e-pošte.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokirajte sledilce e-pošte in skrijte svoj naslov,<br/>brez zamenjave ponudnika e-pošte. <a href=\"\"><b>Več</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blokirajte sledilce e-pošte in skrijte svoj naslov, brez zamenjave ponudnika e-pošte. <a href=\"\"><b>Več</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Ste na seznamu!</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -604,7 +604,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Enklare E-postintegritet.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Blockera e-postspårare och dölj din adress<br/>utan att byta e-postleverantör. <a href=\"\"><b>Mer information</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Blockera e-postspårare och dölj din adress utan att byta e-postleverantör. <a href=\"\"><b>Mer information</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Du står på listan!</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -588,7 +588,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">E-posta gizliliğinin basitleştirilmiş hâli.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[E-posta sağlayıcınızı<br/>değiştirmeden e-posta izleyicileri engelleyin ve adresinizi gizleyin. <a href=\"\"><b>Daha fazla bilgi</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[E-posta sağlayıcınızı değiştirmeden e-posta izleyicileri engelleyin ve adresinizi gizleyin. <a href=\"\"><b>Daha fazla bilgi</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">Listedesiniz!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -589,7 +589,7 @@
 
     <!-- Screen 1-->
     <string name="emailProtectionStatusTitleJoin">Email privacy, simplified.</string>
-    <string name="emailProtectionDescriptionJoin"><![CDATA[Block email trackers and hide your address,<br/>without switching your email provider. <a href=""><b>Learn more</b></a>.]]></string>
+    <string name="emailProtectionDescriptionJoin"><![CDATA[Block email trackers and hide your address, without switching your email provider. <a href=""><b>Learn more</b></a>.]]></string>
 
     <!-- Screen 2 -->
     <string name="emailProtectionStatusTitleJoined">You\'re on the list!</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1162895505193104/1201376613225734/f

### Description
When signing up for Email Protection, tapping on "Get Started" or "I have an invite code" opens a URL in a webview within a new activity. 
Updated to have both "Get Started" and "I have an invite" open the URL in a full browser tab.

### Steps to test this PR

Test the `Get Started` flow

1. Checkout this branch
2. Change the `render` function in `EmailProtectionSignInFragment` to always call `renderInBeta()` 
3. Install 
4. Open the app, go to Settings and tap on `Email Protection`
5. On `Email Protection` screen tap on `Get Started` and notice a tab is opened with the URL `https://duckduckgo.com/email/start`

Test the `I have an invite code` flow
 
1. Checkout this branch
2. Change the `render` function in `EmailProtectionSignInFragment` to always call `renderNotJoinedQueue()` 
3. Install 
4. Open the app, go to Settings and tap on `Email Protection`
5. On `Email Protection` screen tap on `I have an Invite Code` and notice a tab is opened with the URL `https://duckduckgo.com/email/start`

### UI changes
| Before (displayed in webview)| After (displayed in browser tab) |
| ------ | ----- |
![get_started_in_activity](https://user-images.githubusercontent.com/7963079/143489343-e820d0b9-3b40-493e-b28c-a0994a7a7449.png)|![get_started_in_tab](https://user-images.githubusercontent.com/7963079/143489272-7bd49619-90ce-4a72-95db-d501d8c0b2b6.png)

| Before Portrait | After Portrait |
| ------ | ----- |
![device-2021-12-10-155236](https://user-images.githubusercontent.com/7963079/145602701-3771348c-e94d-498a-9c9b-135c65d6d290.png)|![device-2021-12-10-155252](https://user-images.githubusercontent.com/7963079/145602752-06e14b79-0c07-48e9-9109-f27fdc98ef0c.png)


| Before Landscape | After Landscape |
| ------ | ----- |
![device-2021-12-10-155315](https://user-images.githubusercontent.com/7963079/145602885-9b54e2ea-586f-4751-b445-b9d990a27761.png)|![device-2021-12-10-162102](https://user-images.githubusercontent.com/7963079/145606910-9491bff8-65a9-4883-b162-b16c6e1020af.png)


After Landscape (scrolling, previously was not working)
![device-2021-12-10-162114](https://user-images.githubusercontent.com/7963079/145606940-a9267114-93b3-4fa7-b63d-8e0c4cec2111.png)

