### PR TITLE
Catch CancelledKeyExceptions to prevent service crashing

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpPacketProcessor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpPacketProcessor.kt
@@ -44,6 +44,7 @@ import xyz.hexene.localvpn.Packet.TCPHeader.FIN
 import xyz.hexene.localvpn.TCB
 import java.io.IOException
 import java.nio.ByteBuffer
+import java.nio.channels.CancelledKeyException
 import java.nio.channels.Selector
 import java.nio.channels.SocketChannel
 import java.util.concurrent.Executors.newSingleThreadExecutor
@@ -146,6 +147,8 @@ class TcpPacketProcessor @AssistedInject constructor(
                 tcpDeviceToNetwork.deviceToNetworkProcessing()
             } catch (e: IOException) {
                 Timber.w(e, "Failed to process TCP device-to-network packet")
+            } catch (e: CancelledKeyException) {
+                Timber.w(e, "Failed to process TCP device-to-network packet")
             }
         }
     }
@@ -157,6 +160,8 @@ class TcpPacketProcessor @AssistedInject constructor(
             try {
                 tcpNetworkToDevice.networkToDeviceProcessing()
             } catch (e: IOException) {
+                Timber.w(e, "Failed to process TCP network-to-device packet")
+            } catch (e: CancelledKeyException) {
                 Timber.w(e, "Failed to process TCP network-to-device packet")
             }
         }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpPacketProcessor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpPacketProcessor.kt
@@ -36,6 +36,7 @@ import xyz.hexene.localvpn.ByteBufferPool
 import xyz.hexene.localvpn.Packet
 import java.io.IOException
 import java.net.InetSocketAddress
+import java.nio.channels.CancelledKeyException
 import java.nio.channels.DatagramChannel
 import java.nio.channels.SelectionKey
 import java.nio.channels.Selector
@@ -94,7 +95,9 @@ class UdpPacketProcessor @AssistedInject constructor(
                 try {
                     deviceToNetworkProcessing()
                 } catch (e: IOException) {
-                    Timber.w(e, "Failed to process device-to-network packet")
+                    Timber.w(e, "Failed to process UDP device-to-network packet")
+                } catch (e: CancelledKeyException) {
+                    Timber.w(e, "Failed to process UDP device-to-network packet")
                 }
             }
         } finally {
@@ -110,7 +113,9 @@ class UdpPacketProcessor @AssistedInject constructor(
             try {
                 networkToDeviceProcessing()
             } catch (e: IOException) {
-                Timber.w(e, "Failed to process network-to-device packet")
+                Timber.w(e, "Failed to process UDP network-to-device packet")
+            } catch (e: CancelledKeyException) {
+                Timber.w(e, "Failed to process UDP network-to-device packet")
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201433035781456/f

### Description
It is possible to experience a cancelled key exception when registering for events using the selector. These represent local issues with that connection and shouldn't propagate up to affect the `VPNService` running

### Steps to test this PR
This was initially observed when using [Lazada](https://play.google.com/store/apps/details?id=com.lazada.android&hl=en_US&gl=US), however it is intermittent there and unclear what the exact steps are to reproduce.

You can simulate what happens by manually cancelling the key.

**TcbDeviceToNetwork**, line 280
Add this: `tcb.selectionKey.cancel()`