### PR TITLE
Allow configure local cache using local.properties file

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -38,9 +38,31 @@ rootProject.children.each { subproject ->
 
 
 buildCache {
+
+    def getFile = { dir, filename ->
+        File file = new File("$dir$File.separator$filename")
+        file?.exists() ? file : null
+    }
+
+    def getLocalProperties = { dir ->
+        def file = getFile(dir, "local.properties")
+        if (!file) {
+            return null
+        }
+
+        Properties properties = new Properties()
+        properties.load(file.newInputStream())
+        return properties
+    }
+
     local {
+        def properties = getLocalProperties(rootDir)
+        if (properties != null) {
+            enabled = "true" == properties.getProperty("local.build.cache", "true")
+        } else {
+            enabled = true
+        }
         // configure local build cache directory so that it is local to the project dir
-        enabled = true
         directory = new File(rootDir, 'build-cache')
         removeUnusedEntriesAfterDays = 7
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201433136298885/f

### Description
* Some time ago we enabled gradle local build cache
* Bugs in kotlin incremental compilation sometimes interfere with the local cache
* This generally happens when modifying Dagger components
* The changes are sometimes not picked up by the compiler
* The easy fix when that happens is to remove the local cache directory
* Given that this is a local cache, it makes sense to be able to enable/disable it locally through local.properties

This PR will:
* allow to enable/disable local build cache through a property in local.properties file
  * the name of the property will be local.build.cache and will take true or false values


### Steps to test this PR
1. remove `build-cache` directory from root project directory
1. run `./gradlew clean`
1. ensure the `local.properties` file DOES NOT contain the `local.build.cache` property
1. build the app, `./gradlew assembleID` for instance
1. verity the `build.cache` directory is NOT created
1. run `./gradlew clean`
1. set `local.build.cache = false` in `local.properties` file
1. build the app, `./gradlew assembleID` for instance
1. verity the `build.cache` directory is NOT created
1. set `local.build.cache = true` in `local.properties` file
1. build the app, `./gradlew assembleID` for instance
1. verity the `build.cache` directory IS now created
