### PR TITLE
Bugfix: Handle non-http fallback URL

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -156,6 +156,7 @@ import java.io.File
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import android.content.pm.ApplicationInfo
+import android.content.pm.ResolveInfo
 import com.duckduckgo.app.statistics.isFireproofExperimentEnabled
 import com.google.android.material.snackbar.BaseTransientBottomBar
 
@@ -626,7 +627,7 @@ class BrowserTabFragment :
             is Command.DialNumber -> {
                 val intent = Intent(Intent.ACTION_DIAL)
                 intent.data = Uri.parse("tel:${it.telephoneNumber}")
-                openExternalDialog(intent, null, false)
+                openExternalDialog(intent = intent, fallbackUrl = null, fallbackIntent = null, useFirstActivityFound = false)
             }
             is Command.SendEmail -> {
                 val intent = Intent(Intent.ACTION_SENDTO)
@@ -675,7 +676,13 @@ class BrowserTabFragment :
                 openAppLink(it.appLink)
             }
             is Command.HandleNonHttpAppLink -> {
-                openExternalDialog(it.nonHttpAppLink.intent, it.nonHttpAppLink.fallbackUrl, false, it.headers)
+                openExternalDialog(
+                    intent = it.nonHttpAppLink.intent,
+                    fallbackUrl = it.nonHttpAppLink.fallbackUrl,
+                    fallbackIntent = it.nonHttpAppLink.fallbackIntent,
+                    useFirstActivityFound = false,
+                    headers = it.headers
+                )
             }
             is Command.LaunchSurvey -> launchSurvey(it.survey)
             is Command.LaunchAddWidget -> launchAddWidget()
@@ -922,6 +929,7 @@ class BrowserTabFragment :
     private fun openExternalDialog(
         intent: Intent,
         fallbackUrl: String? = null,
+        fallbackIntent: Intent? = null,
         useFirstActivityFound: Boolean = true,
         headers: Map<String, String> = emptyMap()
     ) {
@@ -930,23 +938,40 @@ class BrowserTabFragment :
             val activities = pm.queryIntentActivities(intent, 0)
 
             if (activities.isEmpty()) {
-                if (fallbackUrl != null) {
-                    webView?.loadUrl(fallbackUrl, headers)
-                } else {
-                    showToast(R.string.unableToOpenLink)
+                when {
+                    fallbackIntent != null -> {
+                        val fallbackActivities = pm.queryIntentActivities(fallbackIntent, 0)
+                        launchDialogForIntent(it, pm, fallbackIntent, fallbackActivities, useFirstActivityFound)
+                    }
+                    fallbackUrl != null -> {
+                        webView?.loadUrl(fallbackUrl, headers)
+                    }
+                    else -> {
+                        showToast(R.string.unableToOpenLink)
+                    }
                 }
             } else {
-                if (activities.size == 1 || useFirstActivityFound) {
-                    val activity = activities.first()
-                    val appTitle = activity.loadLabel(pm)
-                    Timber.i("Exactly one app available for intent: $appTitle")
-                    launchExternalAppDialog(it) { it.startActivity(intent) }
-                } else {
-                    val title = getString(R.string.openExternalApp)
-                    val intentChooser = Intent.createChooser(intent, title)
-                    launchExternalAppDialog(it) { it.startActivity(intentChooser) }
-                }
+                launchDialogForIntent(it, pm, intent, activities, useFirstActivityFound)
             }
+        }
+    }
+
+    private fun launchDialogForIntent(
+        context: Context,
+        pm: PackageManager?,
+        intent: Intent,
+        activities: List<ResolveInfo>,
+        useFirstActivityFound: Boolean
+    ) {
+        if (activities.size == 1 || useFirstActivityFound) {
+            val activity = activities.first()
+            val appTitle = activity.loadLabel(pm)
+            Timber.i("Exactly one app available for intent: $appTitle")
+            launchExternalAppDialog(context) { context.startActivity(intent) }
+        } else {
+            val title = getString(R.string.openExternalApp)
+            val intentChooser = Intent.createChooser(intent, title)
+            launchExternalAppDialog(context) { context.startActivity(intentChooser) }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1201451355283242/f

### Description

**Problem**
When a `NonHttpAppLink` is intercepted (_intent://_ etc.) and the `fallbackUrl` is used (When no activities are found for the initial `Intent`), then the `fallbackUrl` is loaded as a normal web link.

This is problematic if the `fallbackUrl` is a _market://_ link for example, which will fail to load in the `WebView`.

**Solution**
If the `fallbackUrl` is a `NonHttpAppLink`, then an `Intent` for that link is created and launched if the initial `Intent` does not resolve any activities.
### Steps to test this PR

_Before_
1. Build the app from _develop_.
2. Visit: https://studio.click.godaddy.com/FVXM/f2c4755d
3. Verify that the link does not load.

_After_
1. Build the app from this branch.
2. Visit: https://studio.click.godaddy.com/FVXM/f2c4755d
3. Verify that the "Open in another app" dialog is shown.

### UI changes

**Before**

https://user-images.githubusercontent.com/3471025/144226872-4df9396d-c19a-4378-8707-49d5a833391b.mp4

**After**

https://user-images.githubusercontent.com/3471025/144226895-7eefe73d-b7e4-4ec1-98df-feabeca97918.mp4



