### PR TITLE
Bugfix: BrokenSite dialog using incorrect theme

### DIFF
--- a/common-ui/src/main/res/values/themes.xml
+++ b/common-ui/src/main/res/values/themes.xml
@@ -357,6 +357,7 @@
         <item name="android:background">?attr/dialogBgColor</item>
         <item name="colorAccent">@color/cornflowerBlue</item>
         <item name="android:textColorAlertDialogListItem">?attr/normalTextColor</item>
+        <item name="textColorAlertDialogListItem">?attr/normalTextColor</item>
         <item name="android:buttonBarButtonStyle">@style/AlertDialogButtonStyle</item>
         <item name="buttonBarNegativeButtonStyle">@style/AlertDialogButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/AlertDialogButtonStyle</item>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1201451355283252/f

### Description
This PR fixes the list item color on the Broken Sites dialog when using the dark theme.

### Steps to test this PR

1. Activate the dark theme.
2. Tap the overflow menu and then "Report Broken Site".
3. Tap "Describe what happened".
4. Verify that the dialog list items are the correct color.

(Tested on API 21 and 30)

### UI changes
| Before  | After |
| ------ | ----- |
![before](https://user-images.githubusercontent.com/3471025/144233787-06df55d4-80bd-4406-8350-4b6e2cfca0d9.jpg)|![after](https://user-images.githubusercontent.com/3471025/144233811-33c48295-226d-46d8-aec4-234eb8330497.jpg)






