### PR TITLE
BUG: Crash on Email protection sign in screen rotation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignOutFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/ui/EmailProtectionSignOutFragment.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.email.ui
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
@@ -33,7 +34,7 @@ import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-class EmailProtectionSignOutFragment(val emailAddress: String) : EmailProtectionFragment(R.layout.fragment_email_protection_sign_out) {
+class EmailProtectionSignOutFragment() : EmailProtectionFragment(R.layout.fragment_email_protection_sign_out) {
 
     private val viewModel by bindViewModel<EmailProtectionSignOutViewModel>()
 
@@ -54,6 +55,8 @@ class EmailProtectionSignOutFragment(val emailAddress: String) : EmailProtection
     override fun configureUi() {
         configureUiEventHandlers()
         setClickableSpan()
+
+        val emailAddress = requireArguments()[EMAIL_ADDRESS_EXTRA] as String
         binding.primaryAddress.setSubtitle(emailAddress)
     }
 
@@ -106,9 +109,14 @@ class EmailProtectionSignOutFragment(val emailAddress: String) : EmailProtection
 
     companion object {
         private const val SIGN_OUT_DIALOG_TAG = "SIGN_OUT_DIALOG_TAG"
+        private const val EMAIL_ADDRESS_EXTRA = "EMAIL_ADDRESS_EXTRA"
 
         fun instance(emailAddress: String): EmailProtectionSignOutFragment {
-            return EmailProtectionSignOutFragment(emailAddress)
+            val fragment = EmailProtectionSignOutFragment()
+            fragment.arguments = Bundle().also {
+                it.putString(EMAIL_ADDRESS_EXTRA, emailAddress)
+            }
+            return fragment
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201458023475315/f

### Description
App crashing in email sign out screen when the device is rotated.

### Steps to test this PR

- install from this branch
- open the app and go to Settings → Email Protection
- add your Duck email address
- when on Email protection screen rotate the device (the screen mentioning your Personal Duck Address at the top)
- notice app doesn't crash

### No UI changes
