### PR TITLE
Allow AppScope -> ActivityScope -> FragmentScope dagger scope nesting

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/app/global/DuckDuckGoActivity.kt
+++ b/common-ui/src/main/java/com/duckduckgo/app/global/DuckDuckGoActivity.kt
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -29,9 +28,10 @@ import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.ui.applyTheme
 import com.duckduckgo.mobile.android.ui.store.ThemingDataStore
 import dagger.android.AndroidInjection
+import dagger.android.DaggerActivity
 import javax.inject.Inject
 
-abstract class DuckDuckGoActivity : AppCompatActivity() {
+abstract class DuckDuckGoActivity : DaggerActivity() {
 
     @Inject lateinit var viewModelFactory: ViewModelFactory
 

--- a/di/build.gradle
+++ b/di/build.gradle
@@ -25,4 +25,5 @@ dependencies {
     implementation Kotlin.stdlib.jdk7
     implementation AndroidX.fragmentKtx
     implementation Google.dagger
+    implementation AndroidX.appCompat
 }

--- a/di/src/main/java/dagger/android/AndroidInjector.kt
+++ b/di/src/main/java/dagger/android/AndroidInjector.kt
@@ -61,13 +61,13 @@ interface AndroidInjector<T> {
          *  2. Use the factory to create the dagger component that relates to an Android type, eg. Activity
          *  3. Inject any dependency requested by the Android type
          */
-        inline fun <reified T> inject(application: Application, instance: T, mapKey: Class<*>? = null) {
-            if ((application is HasDaggerInjector)) {
-                (application.daggerFactoryFor(mapKey ?: instance!!::class.java) as Factory<T>)
+        inline fun <reified T> inject(injector: Any, instance: T, mapKey: Class<*>? = null) {
+            if ((injector is HasDaggerInjector)) {
+                (injector.daggerFactoryFor(mapKey ?: instance!!::class.java) as Factory<T>)
                     .create(instance)
                     .inject(instance)
             } else {
-                throw RuntimeException("Application class does not extend ${HasDaggerInjector::class.simpleName}")
+                throw RuntimeException("${injector.javaClass.canonicalName} class does not extend ${HasDaggerInjector::class.simpleName}")
             }
         }
     }
@@ -87,7 +87,7 @@ class AndroidInjection {
         }
 
         inline fun <reified T : Fragment> inject(instance: T, bindingKey: Class<*>? = null) {
-            AndroidInjector.inject(instance.context?.applicationContext as Application, instance, bindingKey)
+            AndroidInjector.inject(findHasDaggerInjectorForFragment(instance), instance, bindingKey)
         }
 
         inline fun <reified T : Service> inject(instance: T, bindingKey: Class<*>? = null) {
@@ -96,6 +96,35 @@ class AndroidInjection {
 
         inline fun <reified T : BroadcastReceiver> inject(instance: T, context: Context, bindingKey: Class<*>? = null) {
             AndroidInjector.inject(context.applicationContext as Application, instance, bindingKey)
+        }
+
+        /**
+         * Injects the [fragment] if an associated [AndroidInjector] implementation is found, otherwise [IllegalArgumentException]
+         * is thrown.
+         *
+         * The algorithm is the following:
+         * * walks the parent fragment hierarchy until if finds one that implements [HasDaggerInjector], else
+         * * uses the [fragment]'s and returns it if it implements [HasDaggerInjector], else
+         * * uses the [Application] and returns it if it implements [HasDaggerInjector], else
+         * * throws [IllegalArgumentException]
+         */
+        fun findHasDaggerInjectorForFragment(fragment: Fragment): HasDaggerInjector {
+            var parentFragment: Fragment? = fragment
+            while (parentFragment?.parentFragment != null) {
+                parentFragment = parentFragment.parentFragment
+
+                if (parentFragment is HasDaggerInjector) {
+                    return parentFragment
+                }
+            }
+            val activity = fragment.activity
+            if (activity is HasDaggerInjector) {
+                return activity
+            }
+
+            activity?.application?.let { return it as HasDaggerInjector }
+
+            throw IllegalArgumentException("No injector found for ${fragment.javaClass.canonicalName}")
         }
     }
 }

--- a/di/src/main/java/dagger/android/DaggerActivity.kt
+++ b/di/src/main/java/dagger/android/DaggerActivity.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dagger.android
+
+import androidx.appcompat.app.AppCompatActivity
+import com.duckduckgo.di.DaggerMap
+import javax.inject.Inject
+
+abstract class DaggerActivity : AppCompatActivity(), HasDaggerInjector {
+    @Inject
+    lateinit var injectorFactoryMap: DaggerMap<Class<*>, AndroidInjector.Factory<*>>
+
+    override fun daggerFactoryFor(key: Class<*>): AndroidInjector.Factory<*> {
+        return injectorFactoryMap[key]
+            ?: throw RuntimeException(
+                """
+                Could not find the dagger component for ${key.simpleName}.
+                You probably forgot to create the ${key.simpleName}Component.
+                If you DID create the ${key.simpleName}Component, check that it uses @ContributesTo(ActivityScope::class)
+                """.trimIndent()
+            )
+    }
+}

--- a/di/src/main/java/dagger/android/support/AndroidSupportInjection.kt
+++ b/di/src/main/java/dagger/android/support/AndroidSupportInjection.kt
@@ -16,14 +16,14 @@
 
 package dagger.android.support
 
-import android.app.Application
 import androidx.fragment.app.Fragment
+import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 
 class AndroidSupportInjection {
     companion object {
         inline fun <reified T : Fragment> inject(instance: T) {
-            AndroidInjector.inject(instance.context?.applicationContext as Application, instance)
+            AndroidInjector.inject(AndroidInjection.findHasDaggerInjectorForFragment(instance), instance)
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201432423603230/f

### Description
In PR #1597 we're harmonising the way we name dagger components and how we contribute dependencies to them. As a recap:
* Use @SingletonIn(AppScope::class) for app scope
* Use @SingletonIn(ActivityScope::class) for activity scope
* Use @SingletonIn(FragmentScope::class) for fragment scope


This a follow up PR to enable nesting those scopes:
* AppScope -> ActivityScope -> FragmentScope

Nesting means:
* child scopes can get access to dependencies in their parent scopes (but not the other way around), ie.
* `FragmentScope` would get access to deps in Fragment, Activity and App scopes
* `ActivityScope` would get access to deps in Activity and App scopes
* `AppScope` would get access to deps in App scope


The PR changes the fragments that were not in the `FragmentScope` to use that one instead. Functionality should not be affected at all

### Steps to test this PR
Smoke tests for app and AppTP

