### PR TITLE
Coroutine test improvements, using newest coroutine test techniques

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/accessibility/AccessibilitySettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/accessibility/AccessibilitySettingsViewModelTest.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.app.accessibility
 
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.accessibility.data.AccessibilitySettingsDataStore
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -41,7 +41,7 @@ class AccessibilitySettingsViewModelTest {
     private val testee = AccessibilitySettingsViewModel(accessibilitySettings)
 
     @Test
-    fun whenViewModelCreatedThenDefaultViewStateEmitted() = coroutineRule.runBlocking {
+    fun whenViewModelCreatedThenDefaultViewStateEmitted() = runTest {
         val viewState = AccessibilitySettingsViewModel.ViewState(
             overrideSystemFontSize = false,
             appFontSize = 100f,
@@ -54,7 +54,7 @@ class AccessibilitySettingsViewModelTest {
     }
 
     @Test
-    fun whenViewModelStartedThenViewStateEmitted() = coroutineRule.runBlocking {
+    fun whenViewModelStartedThenViewStateEmitted() = runTest {
         val viewState = AccessibilitySettingsViewModel.ViewState(
             overrideSystemFontSize = true,
             appFontSize = 150f,
@@ -73,7 +73,7 @@ class AccessibilitySettingsViewModelTest {
     }
 
     @Test
-    fun whenForceZoomEnabledThenViewStateEmitted() = coroutineRule.runBlocking {
+    fun whenForceZoomEnabledThenViewStateEmitted() = runTest {
         val viewState = defaultViewState()
         whenever(accessibilitySettings.forceZoom).thenReturn(true)
 
@@ -86,7 +86,7 @@ class AccessibilitySettingsViewModelTest {
     }
 
     @Test
-    fun whenForceZoomEnabledThenSettingsUpdated() = coroutineRule.runBlocking {
+    fun whenForceZoomEnabledThenSettingsUpdated() = runTest {
         whenever(accessibilitySettings.forceZoom).thenReturn(true)
 
         testee.onForceZoomChanged(true)
@@ -96,7 +96,7 @@ class AccessibilitySettingsViewModelTest {
     }
 
     @Test
-    fun whenOverrideSystemFontSizeEnabledThenViewStateEmitted() = coroutineRule.runBlocking {
+    fun whenOverrideSystemFontSizeEnabledThenViewStateEmitted() = runTest {
         val viewState = defaultViewState()
         whenever(accessibilitySettings.overrideSystemFontSize).thenReturn(true)
 
@@ -109,7 +109,7 @@ class AccessibilitySettingsViewModelTest {
     }
 
     @Test
-    fun whenOverrideSystemFontSizeEnabledThenSettingsUpdated() = coroutineRule.runBlocking {
+    fun whenOverrideSystemFontSizeEnabledThenSettingsUpdated() = runTest {
         whenever(accessibilitySettings.overrideSystemFontSize).thenReturn(true)
 
         testee.onSystemFontSizeChanged(true)
@@ -119,7 +119,7 @@ class AccessibilitySettingsViewModelTest {
     }
 
     @Test
-    fun whenFontSizeChangedThenViewStateEmitted() = coroutineRule.runBlocking {
+    fun whenFontSizeChangedThenViewStateEmitted() = runTest {
         val viewState = defaultViewState()
         whenever(accessibilitySettings.appFontSize).thenReturn(150f)
 
@@ -132,7 +132,7 @@ class AccessibilitySettingsViewModelTest {
     }
 
     @Test
-    fun whenFontSizeChangedThenSettingsUpdated() = coroutineRule.runBlocking {
+    fun whenFontSizeChangedThenSettingsUpdated() = runTest {
         whenever(accessibilitySettings.appFontSize).thenReturn(150f)
 
         testee.onFontSizeChanged(150f)

--- a/app/src/androidTest/java/com/duckduckgo/app/accessibility/data/AccessibilitySettingsSharedPreferencesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/accessibility/data/AccessibilitySettingsSharedPreferencesTest.kt
@@ -20,11 +20,11 @@ import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.accessibility.data.AccessibilitySettingsSharedPreferences.Companion.FONT_SIZE_DEFAULT
-import com.duckduckgo.app.runBlocking
 import junit.framework.Assert.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
@@ -40,7 +40,7 @@ class AccessibilitySettingsSharedPreferencesTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
-    private val testee = AccessibilitySettingsSharedPreferences(context, coroutineRule.testDispatcherProvider, TestCoroutineScope())
+    private val testee = AccessibilitySettingsSharedPreferences(context, coroutineRule.testDispatcherProvider, TestScope())
 
     @After
     fun after() {
@@ -105,7 +105,7 @@ class AccessibilitySettingsSharedPreferencesTest {
     }
 
     @Test
-    fun whenValuesChangedThenNewChangesEmitted() = coroutineRule.runBlocking {
+    fun whenValuesChangedThenNewChangesEmitted() = runTest {
         var accessibilitySetting = AccessibilitySettings(false, 100f, false)
 
         testee.settingsFlow().test {

--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/db/BookmarkFoldersDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/db/BookmarkFoldersDaoTest.kt
@@ -24,13 +24,14 @@ import com.duckduckgo.app.bookmarks.model.BookmarkFolder
 import com.duckduckgo.app.global.db.AppDatabase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class BookmarkFoldersDaoTest {
 
     @get:Rule
@@ -72,7 +73,7 @@ class BookmarkFoldersDaoTest {
     }
 
     @Test
-    fun whenBookmarkFolderAddedThenItIsInTheList() = runBlocking {
+    fun whenBookmarkFolderAddedThenItIsInTheList() = runTest {
         val bookmarkFolderEntity = BookmarkFolderEntity(id = 1, name = "name", parentId = 0)
         bookmarkFoldersDao.insert(bookmarkFolderEntity)
         val list = bookmarkFoldersDao.getBookmarkFolders().first()
@@ -80,14 +81,14 @@ class BookmarkFoldersDaoTest {
     }
 
     @Test
-    fun whenBookmarkFoldersAddedThenTheyAreInTheList() = runBlocking {
+    fun whenBookmarkFoldersAddedThenTheyAreInTheList() = runTest {
         bookmarkFoldersDao.insertList(bookmarkFolderList)
         val list = bookmarkFoldersDao.getBookmarkFoldersSync()
         assertEquals(bookmarkFolderList, list)
     }
 
     @Test
-    fun whenBookmarksAndBookmarkFoldersAddedThenNumBookmarksAndNumFoldersPopulated() = runBlocking {
+    fun whenBookmarksAndBookmarkFoldersAddedThenNumBookmarksAndNumFoldersPopulated() = runTest {
         bookmarkFoldersDao.insertList(bookmarkFolderList)
         bookmarksDao.insertList(bookmarksList)
 
@@ -105,7 +106,7 @@ class BookmarkFoldersDaoTest {
     }
 
     @Test
-    fun whenBookmarksAndBookmarkFoldersAddedThenNumBookmarksAndNumFoldersPopulatedByParentId() = runBlocking {
+    fun whenBookmarksAndBookmarkFoldersAddedThenNumBookmarksAndNumFoldersPopulatedByParentId() = runTest {
         bookmarkFoldersDao.insertList(bookmarkFolderList)
         bookmarksDao.insertList(bookmarksList)
 
@@ -128,14 +129,14 @@ class BookmarkFoldersDaoTest {
     }
 
     @Test
-    fun whenInInitialStateThenTheBookmarkFoldersAreEmpty() = runBlocking {
+    fun whenInInitialStateThenTheBookmarkFoldersAreEmpty() = runTest {
         val list = bookmarkFoldersDao.getBookmarkFoldersByParentId(0).first()
         assertNotNull(list)
         assertTrue(list.isEmpty())
     }
 
     @Test
-    fun whenBookmarkFolderDeletedThenItIsNoLongerInTheList() = runBlocking {
+    fun whenBookmarkFolderDeletedThenItIsNoLongerInTheList() = runTest {
         val bookmarkFolder = BookmarkFolderEntity(id = 1, name = "name", parentId = 0)
         bookmarkFoldersDao.insert(bookmarkFolder)
         bookmarkFoldersDao.delete(listOf(bookmarkFolder))
@@ -144,7 +145,7 @@ class BookmarkFoldersDaoTest {
     }
 
     @Test
-    fun whenBookmarkFolderUpdatedThenUpdateBookmarkFolder() = runBlocking {
+    fun whenBookmarkFolderUpdatedThenUpdateBookmarkFolder() = runTest {
         bookmarkFoldersDao.insert(BookmarkFolderEntity(id = 1, name = "name", parentId = 0))
 
         val bookmarkFolderEntity = BookmarkFolderEntity(id = 1, name = "updated name", parentId = 0)

--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/db/BookmarksDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/db/BookmarksDaoTest.kt
@@ -23,13 +23,14 @@ import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.db.AppDatabase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class BookmarksDaoTest {
 
     @get:Rule
@@ -57,7 +58,7 @@ class BookmarksDaoTest {
     }
 
     @Test
-    fun whenBookmarkDeleteThenItIsNoLongerInTheList() = runBlocking {
+    fun whenBookmarkDeleteThenItIsNoLongerInTheList() = runTest {
         val bookmark = BookmarkEntity(id = 1, title = "title", url = "www.example.com", parentId = 0)
         dao.insert(bookmark)
         dao.delete(bookmark)
@@ -66,7 +67,7 @@ class BookmarksDaoTest {
     }
 
     @Test
-    fun whenBookmarksDeletedThenTheyAreNoLongerInTheList() = runBlocking {
+    fun whenBookmarksDeletedThenTheyAreNoLongerInTheList() = runTest {
         val bookmarks = listOf(
             BookmarkEntity(id = 1, title = "title", url = "www.example.com", parentId = 0),
             BookmarkEntity(id = 2, title = "another title", url = "www.foo.example.com", parentId = 0)
@@ -78,7 +79,7 @@ class BookmarksDaoTest {
     }
 
     @Test
-    fun whenBookmarkAddedThenItIsInList() = runBlocking {
+    fun whenBookmarkAddedThenItIsInList() = runTest {
         val bookmark = BookmarkEntity(id = 1, title = "title", url = "www.example.com", parentId = 0)
         dao.insert(bookmark)
         val list = dao.getBookmarks().first()
@@ -86,7 +87,7 @@ class BookmarksDaoTest {
     }
 
     @Test
-    fun whenBookmarksAddedThenTheyAreInTheList() = runBlocking {
+    fun whenBookmarksAddedThenTheyAreInTheList() = runTest {
         val bookmarks = listOf(
             BookmarkEntity(id = 1, title = "title", url = "www.example.com", parentId = 0),
             BookmarkEntity(id = 2, title = "another title", url = "www.foo.example.com", parentId = 0)
@@ -97,7 +98,7 @@ class BookmarksDaoTest {
     }
 
     @Test
-    fun whenBookmarksAddedThenTheyAreInTheListByParentId() = runBlocking {
+    fun whenBookmarksAddedThenTheyAreInTheListByParentId() = runTest {
         val bookmarks = listOf(
             BookmarkEntity(id = 1, title = "title", url = "www.example.com", parentId = 1),
             BookmarkEntity(id = 2, title = "another title", url = "www.foo.example.com", parentId = 1)
@@ -109,21 +110,21 @@ class BookmarksDaoTest {
     }
 
     @Test
-    fun whenInInitialStateThenTheBookmarksAreEmpty() = runBlocking {
+    fun whenInInitialStateThenTheBookmarksAreEmpty() = runTest {
         val list = dao.getBookmarks().first()
         assertNotNull(list)
         assertTrue(list.isEmpty())
     }
 
     @Test
-    fun whenBookmarksExistThenReturnTrue() = runBlocking {
+    fun whenBookmarksExistThenReturnTrue() = runTest {
         val bookmark = BookmarkEntity(id = 1, title = "title", url = "www.example.com", parentId = 0)
         dao.insert(bookmark)
         assertTrue(dao.hasBookmarks())
     }
 
     @Test
-    fun whenBookmarkAreEmptyThenReturnFalse() = runBlocking {
+    fun whenBookmarkAreEmptyThenReturnFalse() = runTest {
         assertFalse(dao.hasBookmarks())
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/model/BookmarksDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/model/BookmarksDataRepositoryTest.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.app.global.db.AppDatabase
 import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -63,25 +63,25 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenInsertBookmarkFolderThenReturnId() = runBlocking {
+    fun whenInsertBookmarkFolderThenReturnId() = runTest {
         val id = repository.insert(BookmarkFolder(id = 1, name = "name", parentId = 0))
         assertEquals(1, id)
     }
 
     @Test
-    fun whenInsertBookmarkThenPopulateDB() = runBlocking {
+    fun whenInsertBookmarkThenPopulateDB() = runTest {
         repository.insert(bookmark)
         assertEquals(listOf(bookmarkEntity), bookmarksDao.getBookmarks().first())
     }
 
     @Test
-    fun whenInsertBookmarkByTitleAndUrlThenPopulateDB() = runBlocking {
+    fun whenInsertBookmarkByTitleAndUrlThenPopulateDB() = runTest {
         repository.insert(title = bookmark.title, url = bookmark.url, parentId = bookmark.parentId)
         assertEquals(listOf(bookmarkEntity), bookmarksDao.getBookmarks().first())
     }
 
     @Test
-    fun whenUpdateBookmarkThenUpdateBookmarkInDB() = runBlocking {
+    fun whenUpdateBookmarkThenUpdateBookmarkInDB() = runTest {
         repository.insert(bookmark)
 
         val updatedBookmark = SavedSite.Bookmark(id = bookmark.id, title = "new title", url = "example.com", parentId = 2)
@@ -94,14 +94,14 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenDeleteBookmarkThenRemoveBookmarkFromDB() = runBlocking {
+    fun whenDeleteBookmarkThenRemoveBookmarkFromDB() = runTest {
         repository.insert(bookmark)
         repository.delete(bookmark)
         assertFalse(bookmarksDao.hasBookmarks())
     }
 
     @Test
-    fun whenGetBookmarkFoldersByParentIdThenReturnBookmarkFoldersForParentId() = runBlocking {
+    fun whenGetBookmarkFoldersByParentIdThenReturnBookmarkFoldersForParentId() = runTest {
         val folder = BookmarkFolder(id = 1, name = "name", parentId = 2)
         repository.insert(folder)
         val folders = repository.getBookmarkFoldersByParentId(2)
@@ -111,7 +111,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenGetBookmarksByParentIdThenReturnBookmarksForParentId() = runBlocking {
+    fun whenGetBookmarksByParentIdThenReturnBookmarksForParentId() = runTest {
         val bookmark = SavedSite.Bookmark(id = 1, title = "name", url = "foo.com", parentId = 2)
         repository.insert(bookmark)
         val bookmarks = repository.getBookmarksByParentId(2)
@@ -121,7 +121,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenUpdateBookmarkFolderThenUpdateBookmarkFolderCalled() = runBlocking {
+    fun whenUpdateBookmarkFolderThenUpdateBookmarkFolderCalled() = runTest {
         repository = BookmarksDataRepository(mockBookmarkFoldersDao, bookmarksDao, db)
         val bookmarkFolder = BookmarkFolder(id = 1, name = "name", parentId = 0)
         repository.update(bookmarkFolder)
@@ -130,7 +130,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenGetBookmarkFolderBranchThenReturnFoldersAndBookmarksForBranch() = runBlocking {
+    fun whenGetBookmarkFolderBranchThenReturnFoldersAndBookmarksForBranch() = runTest {
         val parentFolder = BookmarkFolderEntity(id = 1, name = "name", parentId = 0)
         val childFolder = BookmarkFolderEntity(id = 2, name = "another name", parentId = 1)
         val childBookmark = BookmarkEntity(id = 1, title = "title", url = "www.example.com", parentId = 1)
@@ -144,7 +144,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenGetBranchFoldersThenReturnFolderListForBranch() = runBlocking {
+    fun whenGetBranchFoldersThenReturnFolderListForBranch() = runTest {
         val parentFolderEntity = BookmarkFolderEntity(id = 1, name = "name", parentId = 0)
         val childFolderEntity = BookmarkFolderEntity(id = 2, name = "another name", parentId = 1)
 
@@ -159,7 +159,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenDeleteFolderBranchThenDeletedBookmarksAndFoldersAreNoLongerInDB() = runBlocking {
+    fun whenDeleteFolderBranchThenDeletedBookmarksAndFoldersAreNoLongerInDB() = runTest {
         val parentFolderEntity = BookmarkFolderEntity(id = 1, name = "name", parentId = 0)
         val childFolderEntity = BookmarkFolderEntity(id = 2, name = "another name", parentId = 1)
         val childBookmark = BookmarkEntity(id = 1, title = "title", url = "www.example.com", parentId = 1)
@@ -175,7 +175,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenFetchBookmarksAndFoldersWithNullParentIdThenFetchAllBookmarksAndFolders() = runBlocking {
+    fun whenFetchBookmarksAndFoldersWithNullParentIdThenFetchAllBookmarksAndFolders() = runTest {
         val folder = BookmarkFolder(id = 1, name = "name", parentId = 0)
         val bookmark = BookmarkEntity(id = 1, title = "title", url = "www.example.com", parentId = 1)
 
@@ -189,7 +189,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenFetchBookmarksAndFoldersWithParentIdThenFetchBookmarksAndFoldersForParentId() = runBlocking {
+    fun whenFetchBookmarksAndFoldersWithParentIdThenFetchBookmarksAndFoldersForParentId() = runTest {
         val folder = BookmarkFolderEntity(id = 1, name = "name", parentId = 0)
         val anotherFolder = BookmarkFolderEntity(id = 2, name = "another name", parentId = 0)
         val childFolder = BookmarkFolderEntity(id = 3, name = "child folder", parentId = 2)
@@ -206,7 +206,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenBuildFlatStructureThenReturnFolderListWithDepth() = runBlocking {
+    fun whenBuildFlatStructureThenReturnFolderListWithDepth() = runTest {
         val parentFolder = BookmarkFolder(id = 1, name = "name", parentId = 0)
         val childFolder = BookmarkFolder(id = 2, name = "another name", parentId = 1)
         val folder = BookmarkFolder(id = 3, name = "folder name", parentId = 0)
@@ -232,7 +232,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenBuildFlatStructureThenReturnFolderListWithDepthWithoutCurrentFolderBranch() = runBlocking {
+    fun whenBuildFlatStructureThenReturnFolderListWithDepthWithoutCurrentFolderBranch() = runTest {
         val parentFolder = BookmarkFolder(id = 1, name = "name", parentId = 0)
         val childFolder = BookmarkFolder(id = 2, name = "another name", parentId = 1)
         val folder = BookmarkFolder(id = 3, name = "folder name", parentId = 0)
@@ -256,7 +256,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenBookmarksRequestedAndAvailableThenReturnListOfBookmarks() = runBlocking {
+    fun whenBookmarksRequestedAndAvailableThenReturnListOfBookmarks() = runTest {
         val firstBookmark = SavedSite.Bookmark(id = 1, title = "title", url = "www.website.com", parentId = 0)
         val secondBookmark = SavedSite.Bookmark(id = 2, title = "other title", url = "www.other-website.com", parentId = 0)
 
@@ -269,14 +269,14 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenBookmarksRequestedAndNoneAvailableThenReturnEmptyList() = runBlocking {
+    fun whenBookmarksRequestedAndNoneAvailableThenReturnEmptyList() = runTest {
         val bookmarks = repository.bookmarks()
 
         assertEquals(emptyList<SavedSite.Bookmark>(), bookmarks.first())
     }
 
     @Test
-    fun whenBookmarkByUrlRequestedAndAvailableThenReturnBookmark() = runBlocking {
+    fun whenBookmarkByUrlRequestedAndAvailableThenReturnBookmark() = runTest {
         val firstBookmark = SavedSite.Bookmark(id = 1, title = "title", url = "www.website.com", parentId = 0)
         val secondBookmark = SavedSite.Bookmark(id = 2, title = "other title", url = "www.other-website.com", parentId = 0)
 
@@ -289,7 +289,7 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenBookmarkByUrlRequestedAndNotAvailableThenReturnNull() = runBlocking {
+    fun whenBookmarkByUrlRequestedAndNotAvailableThenReturnNull() = runTest {
         val firstBookmark = SavedSite.Bookmark(id = 1, title = "title", url = "www.website.com", parentId = 0)
         val secondBookmark = SavedSite.Bookmark(id = 2, title = "other title", url = "www.other-website.com", parentId = 0)
 
@@ -302,21 +302,21 @@ class BookmarksDataRepositoryTest {
     }
 
     @Test
-    fun whenBookmarkByUrlRequestedAndNoBookmarksAvailableThenReturnNull() = runBlocking {
+    fun whenBookmarkByUrlRequestedAndNoBookmarksAvailableThenReturnNull() = runTest {
         val bookmark = repository.getBookmark("www.test.com")
 
         assertNull(bookmark)
     }
 
     @Test
-    fun whenHasBookmarksRequestedAndNoBookmarksAvailableThenReturnFalse() = runBlocking {
+    fun whenHasBookmarksRequestedAndNoBookmarksAvailableThenReturnFalse() = runTest {
         val result = repository.hasBookmarks()
 
         assertFalse(result)
     }
 
     @Test
-    fun whenHasBookmarksRequestedAndBookmarksAvailableThenReturnTrue() = runBlocking {
+    fun whenHasBookmarksRequestedAndBookmarksAvailableThenReturnTrue() = runTest {
         repository.insert(SavedSite.Bookmark(id = 1, title = "title", url = "www.website.com", parentId = 0))
 
         val result = repository.hasBookmarks()

--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/model/FavoritesDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/model/FavoritesDataRepositoryTest.kt
@@ -20,12 +20,12 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.bookmarks.db.FavoriteEntity
 import com.duckduckgo.app.bookmarks.db.FavoritesDao
 import com.duckduckgo.app.bookmarks.model.SavedSite.Favorite
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.global.db.AppDatabase
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.*
@@ -129,7 +129,7 @@ class FavoritesDataRepositoryTest {
     }
 
     @Test
-    fun whenFavoriteDeletedThenDatabaseUpdated() = coroutineRule.runBlocking {
+    fun whenFavoriteDeletedThenDatabaseUpdated() = runTest {
         val favorite = Favorite(1, "Favorite", "http://favexample.com", 1)
         givenFavorite(favorite)
 
@@ -140,7 +140,7 @@ class FavoritesDataRepositoryTest {
     }
 
     @Test
-    fun whenUserHasFavoritesThenReturnTrue() = coroutineRule.runBlocking {
+    fun whenUserHasFavoritesThenReturnTrue() = runTest {
         val favorite = Favorite(1, "Favorite", "http://favexample.com", 1)
         givenFavorite(favorite)
 
@@ -148,7 +148,7 @@ class FavoritesDataRepositoryTest {
     }
 
     @Test
-    fun whenFavoriteByUrlRequestedAndAvailableThenReturnFavorite() = coroutineRule.runBlocking {
+    fun whenFavoriteByUrlRequestedAndAvailableThenReturnFavorite() = runTest {
         val favorite = Favorite(id = 1, title = "title", url = "www.website.com", position = 1)
         val otherFavorite = Favorite(id = 2, title = "other title", url = "www.other-website.com", position = 2)
 
@@ -161,7 +161,7 @@ class FavoritesDataRepositoryTest {
     }
 
     @Test
-    fun whenFavoriteByUrlRequestedAndNotAvailableThenReturnNull() = coroutineRule.runBlocking {
+    fun whenFavoriteByUrlRequestedAndNotAvailableThenReturnNull() = runTest {
         val favorite = Favorite(id = 1, title = "title", url = "www.website.com", position = 1)
         val otherFavorite = Favorite(id = 2, title = "other title", url = "www.other-website.com", position = 2)
 
@@ -174,7 +174,7 @@ class FavoritesDataRepositoryTest {
     }
 
     @Test
-    fun whenFavoriteByUrlRequestedAndNoFavoritesAvailableThenReturnNull() = coroutineRule.runBlocking {
+    fun whenFavoriteByUrlRequestedAndNoFavoritesAvailableThenReturnNull() = runTest {
         val result = repository.favorite("www.test.com")
 
         assertNull(result)

--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/service/SavedSitesExporterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/service/SavedSitesExporterTest.kt
@@ -30,12 +30,13 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.global.db.AppDatabase
 import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import java.io.File
 import dagger.Lazy
+import kotlinx.coroutines.test.runTest
 import org.junit.*
 
+@ExperimentalCoroutinesApi
 class SavedSitesExporterTest {
 
     @get:Rule
@@ -77,7 +78,7 @@ class SavedSitesExporterTest {
     }
 
     @Test
-    fun whenSomeBookmarksExistThenExportingSucceeds() = runBlocking {
+    fun whenSomeBookmarksExistThenExportingSucceeds() = runTest {
         val bookmark = BookmarkEntity(id = 1, title = "example", url = "www.example.com", parentId = 0)
         bookmarksDao.insert(bookmark)
 
@@ -91,7 +92,7 @@ class SavedSitesExporterTest {
     }
 
     @Test
-    fun whenFileDoesNotExistThenExportingFails() = runBlocking {
+    fun whenFileDoesNotExistThenExportingFails() = runTest {
         val bookmark = BookmarkEntity(id = 1, title = "example", url = "www.example.com", parentId = 0)
         bookmarksDao.insert(bookmark)
 
@@ -103,14 +104,14 @@ class SavedSitesExporterTest {
     }
 
     @Test
-    fun whenNoSavedSitesExistThenNothingIsExported() = runBlocking {
+    fun whenNoSavedSitesExistThenNothingIsExported() = runTest {
         val localUri = Uri.parse("whatever")
         val result = exporter.export(localUri)
         assertTrue(result is ExportSavedSitesResult.NoSavedSitesExported)
     }
 
     @Test
-    fun whenSomeFavoritesExistThenExportingSucceeds() = runBlocking {
+    fun whenSomeFavoritesExistThenExportingSucceeds() = runTest {
         val favorite = SavedSite.Favorite(id = 1, title = "example", url = "www.example.com", position = 0)
         favoritesRepository.insert(favorite)
 
@@ -124,7 +125,7 @@ class SavedSitesExporterTest {
     }
 
     @Test
-    fun whenGetTreeStructureThenReturnTraversableTree() = runBlocking {
+    fun whenGetTreeStructureThenReturnTraversableTree() = runTest {
         val root = BookmarkFolderEntity(id = 0, name = "DuckDuckGo Bookmarks", parentId = -1)
         val parentFolder = BookmarkFolderEntity(id = 1, name = "name", parentId = 0)
         val childFolder = BookmarkFolderEntity(id = 2, name = "another name", parentId = 1)

--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/service/SavedSitesManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/service/SavedSitesManagerTest.kt
@@ -26,11 +26,12 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class SavedSitesManagerTest {
 
     @get:Rule
@@ -52,7 +53,7 @@ class SavedSitesManagerTest {
     }
 
     @Test
-    fun whenBookmarksImportSucceedsThenPixelIsSent() = runBlocking {
+    fun whenBookmarksImportSucceedsThenPixelIsSent() = runTest {
         val someUri = Uri.parse("")
         val importedBookmarks = listOf(aBookmark())
         whenever(importer.import(someUri)).thenReturn(ImportSavedSitesResult.Success(importedBookmarks))
@@ -63,7 +64,7 @@ class SavedSitesManagerTest {
     }
 
     @Test
-    fun whenFavoritesImportSucceedsThenPixelIsSent() = runBlocking {
+    fun whenFavoritesImportSucceedsThenPixelIsSent() = runTest {
         val someUri = Uri.parse("")
         val importedFavorites = listOf(aFavorite())
         whenever(importer.import(someUri)).thenReturn(ImportSavedSitesResult.Success(importedFavorites))
@@ -74,7 +75,7 @@ class SavedSitesManagerTest {
     }
 
     @Test
-    fun whenSavedSitesImportFailsThenPixelIsSent() = runBlocking {
+    fun whenSavedSitesImportFailsThenPixelIsSent() = runTest {
         val someUri = Uri.parse("")
         whenever(importer.import(someUri)).thenReturn(ImportSavedSitesResult.Error(Exception()))
 
@@ -84,7 +85,7 @@ class SavedSitesManagerTest {
     }
 
     @Test
-    fun whenSavedSitesExportSucceedsThenPixelIsSent() = runBlocking {
+    fun whenSavedSitesExportSucceedsThenPixelIsSent() = runTest {
         val someUri = Uri.parse("")
         whenever(exporter.export(someUri)).thenReturn(ExportSavedSitesResult.Success)
 
@@ -94,7 +95,7 @@ class SavedSitesManagerTest {
     }
 
     @Test
-    fun whenSavedSitesExportFailsThenPixelIsSent() = runBlocking {
+    fun whenSavedSitesExportFailsThenPixelIsSent() = runTest {
         val someUri = Uri.parse("")
         whenever(exporter.export(someUri)).thenReturn(ExportSavedSitesResult.Error(Exception()))
 

--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/service/SavedSitesParserTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/service/SavedSitesParserTest.kt
@@ -25,6 +25,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.jsoup.Jsoup
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -32,6 +33,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class SavedSitesParserTest {
 
     @get:Rule
@@ -55,7 +57,7 @@ class SavedSitesParserTest {
     }
 
     @Test
-    fun whenSomeBookmarksExistThenHtmlIsGenerated() = runBlocking {
+    fun whenSomeBookmarksExistThenHtmlIsGenerated() = runTest {
         val bookmark = SavedSite.Bookmark(id = 1, title = "example", url = "www.example.com", 0)
         val favorite = SavedSite.Favorite(id = 1, title = "example", url = "www.example.com", 0)
 
@@ -85,7 +87,7 @@ class SavedSitesParserTest {
     }
 
     @Test
-    fun whenNoSavedSitesExistThenNothingIsGenerated() = runBlocking {
+    fun whenNoSavedSitesExistThenNothingIsGenerated() = runTest {
         val node = TreeNode(FolderTreeItem(0, RealSavedSitesParser.BOOKMARKS_FOLDER, -1, null, 0))
 
         val result = parser.generateHtml(node, emptyList())
@@ -95,7 +97,7 @@ class SavedSitesParserTest {
     }
 
     @Test
-    fun doesNotImportAnythingWhenFileIsNotProperlyFormatted() = runBlocking {
+    fun doesNotImportAnythingWhenFileIsNotProperlyFormatted() = runTest {
         val inputStream = FileUtilities.loadResource("bookmarks/bookmarks_invalid.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
@@ -105,7 +107,7 @@ class SavedSitesParserTest {
     }
 
     @Test
-    fun canImportFromFirefox() = runBlocking {
+    fun canImportFromFirefox() = runTest {
         val inputStream = FileUtilities.loadResource("bookmarks/bookmarks_firefox.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
@@ -123,7 +125,7 @@ class SavedSitesParserTest {
     }
 
     @Test
-    fun canImportFromChrome() = runBlocking {
+    fun canImportFromChrome() = runTest {
         val inputStream = FileUtilities.loadResource("bookmarks/bookmarks_chrome.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
@@ -144,7 +146,7 @@ class SavedSitesParserTest {
     }
 
     @Test
-    fun canImportBookmarksFromDDG() = runBlocking {
+    fun canImportBookmarksFromDDG() = runTest {
         val inputStream = FileUtilities.loadResource("bookmarks/bookmarks_ddg.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
@@ -157,7 +159,7 @@ class SavedSitesParserTest {
     }
 
     @Test
-    fun canImportBookmarksAndFavoritesFromDDG() = runBlocking {
+    fun canImportBookmarksAndFavoritesFromDDG() = runTest {
         val inputStream = FileUtilities.loadResource("bookmarks/bookmarks_favorites_ddg.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 

--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.bookmarks.ui
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.bookmarks.db.BookmarkEntity
 import com.duckduckgo.app.bookmarks.db.BookmarkFolderEntity
@@ -26,7 +27,6 @@ import com.duckduckgo.app.bookmarks.model.*
 import com.duckduckgo.app.bookmarks.service.SavedSitesManager
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -80,7 +80,7 @@ class BookmarksViewModelTest {
     }
 
     @Before
-    fun before() = coroutineRule.runBlocking {
+    fun before() = runTest {
         whenever(favoritesRepository.favorites()).thenReturn(flowOf())
 
         whenever(bookmarksRepository.fetchBookmarksAndFolders(anyLong())).thenReturn(flowOf(Pair(listOf(bookmark), listOf(bookmarkFolder, bookmarkFolder, bookmarkFolder))))
@@ -93,21 +93,21 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenBookmarkInsertedThenDaoUpdated() = coroutineRule.runBlocking {
+    fun whenBookmarkInsertedThenDaoUpdated() = runTest {
         testee.insert(bookmark)
 
         verify(bookmarksRepository).insert(bookmark)
     }
 
     @Test
-    fun whenFavoriteInsertedThenRepositoryUpdated() = coroutineRule.runBlocking {
+    fun whenFavoriteInsertedThenRepositoryUpdated() = runTest {
         testee.insert(favorite)
 
         verify(favoritesRepository).insert(favorite)
     }
 
     @Test
-    fun whenBookmarkDeleteRequestedThenDaoUpdated() = coroutineRule.runBlocking {
+    fun whenBookmarkDeleteRequestedThenDaoUpdated() = runTest {
         testee.onDeleteSavedSiteRequested(bookmark)
 
         verify(faviconManager).deletePersistedFavicon(bookmark.url)
@@ -115,21 +115,21 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenFavoriteDeleteRequestedThenDeleteFromRepository() = coroutineRule.runBlocking {
+    fun whenFavoriteDeleteRequestedThenDeleteFromRepository() = runTest {
         testee.onDeleteSavedSiteRequested(favorite)
 
         verify(favoritesRepository).delete(favorite)
     }
 
     @Test
-    fun whenBookmarkEditedThenDaoUpdated() = coroutineRule.runBlocking {
+    fun whenBookmarkEditedThenDaoUpdated() = runTest {
         testee.onSavedSiteEdited(bookmark)
 
         verify(bookmarksRepository).update(bookmark)
     }
 
     @Test
-    fun whenFavoriteEditedThenRepositoryUpdated() = coroutineRule.runBlocking {
+    fun whenFavoriteEditedThenRepositoryUpdated() = runTest {
         testee.onSavedSiteEdited(favorite)
 
         verify(favoritesRepository).update(favorite)
@@ -169,7 +169,7 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenFavoritesChangedThenObserverNotified() = coroutineRule.runBlocking {
+    fun whenFavoritesChangedThenObserverNotified() = runTest {
         whenever(favoritesRepository.favorites()).thenReturn(
             flow {
                 emit(emptyList<SavedSite.Favorite>())
@@ -191,7 +191,7 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenFetchBookmarksAndFoldersThenUpdateStateWithCollectedBookmarksAndFolders() = coroutineRule.runBlocking {
+    fun whenFetchBookmarksAndFoldersThenUpdateStateWithCollectedBookmarksAndFolders() = runTest {
         val parentId = 1L
 
         testee.fetchBookmarksAndFolders(parentId = parentId)
@@ -210,7 +210,7 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenBookmarkFolderAddedThenCallInsertOnRepository() = coroutineRule.runBlocking {
+    fun whenBookmarkFolderAddedThenCallInsertOnRepository() = runTest {
         testee.onBookmarkFolderAdded(bookmarkFolder)
 
         verify(bookmarksRepository).insert(bookmarkFolder)
@@ -225,14 +225,14 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenBookmarkFolderUpdatedThenCallUpdateOnRepository() = coroutineRule.runBlocking {
+    fun whenBookmarkFolderUpdatedThenCallUpdateOnRepository() = runTest {
         testee.onBookmarkFolderUpdated(bookmarkFolder)
 
         verify(bookmarksRepository).update(bookmarkFolder)
     }
 
     @Test
-    fun whenDeleteEmptyBookmarkFolderRequestedThenDeleteFolderAndIssueConfirmDeleteBookmarkFolderCommand() = coroutineRule.runBlocking {
+    fun whenDeleteEmptyBookmarkFolderRequestedThenDeleteFolderAndIssueConfirmDeleteBookmarkFolderCommand() = runTest {
         val bookmarkFolderBranch = BookmarkFolderBranch(
             listOf(bookmarkEntity),
             listOf(BookmarkFolderEntity(bookmarkFolder.id, bookmarkFolder.name, bookmarkFolder.parentId))
@@ -249,7 +249,7 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenDeleteNonEmptyBookmarkFolderRequestedThenIssueDeleteBookmarkFolderCommand() = coroutineRule.runBlocking {
+    fun whenDeleteNonEmptyBookmarkFolderRequestedThenIssueDeleteBookmarkFolderCommand() = runTest {
         val bookmarkFolderBranch = BookmarkFolderBranch(
             listOf(bookmarkEntity),
             listOf(BookmarkFolderEntity(bookmarkFolder.id, bookmarkFolder.name, bookmarkFolder.parentId))
@@ -264,7 +264,7 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenInsertRecentlyDeletedBookmarksAndFoldersThenInsertCachedFolderBranch() = coroutineRule.runBlocking {
+    fun whenInsertRecentlyDeletedBookmarksAndFoldersThenInsertCachedFolderBranch() = runTest {
         val bookmarkFolderBranch = BookmarkFolderBranch(
             listOf(bookmarkEntity),
             listOf(BookmarkFolderEntity(bookmarkFolder.id, bookmarkFolder.name, bookmarkFolder.parentId))

--- a/app/src/androidTest/java/com/duckduckgo/app/bookmarks/ui/bookmarkfolders/BookmarkFoldersViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/bookmarks/ui/bookmarkfolders/BookmarkFoldersViewModelTest.kt
@@ -19,11 +19,11 @@ package com.duckduckgo.app.bookmarks.ui.bookmarkfolders
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.bookmarks.model.BookmarkFolder
 import com.duckduckgo.app.bookmarks.model.BookmarkFolderItem
 import com.duckduckgo.app.bookmarks.model.BookmarksRepository
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.*
 import junit.framework.TestCase.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -70,12 +70,12 @@ class BookmarkFoldersViewModelTest {
     }
 
     @Before
-    fun before() = coroutineRule.runBlocking {
+    fun before() = runTest {
         whenever(bookmarksRepository.getFlatFolderStructure(anyLong(), any(), anyString())).thenReturn(folderStructure)
     }
 
     @Test
-    fun whenFetchBookmarkFoldersThenCallRepoAndUpdateViewState() = coroutineRule.runBlocking {
+    fun whenFetchBookmarkFoldersThenCallRepoAndUpdateViewState() = runTest {
         val selectedFolderId = 0L
         val rootFolderName = "Bookmarks"
         val folder = BookmarkFolder(2, "a folder", 1)
@@ -90,7 +90,7 @@ class BookmarkFoldersViewModelTest {
     }
 
     @Test
-    fun whenItemSelectedThenIssueSelectFolderCommand() = coroutineRule.runBlocking {
+    fun whenItemSelectedThenIssueSelectFolderCommand() = runTest {
         val folder = BookmarkFolder(2, "a folder", 1)
 
         testee.onItemSelected(folder)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -30,13 +30,12 @@ import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
 import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.ui.PrivacyDashboardActivity
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -106,7 +105,7 @@ class BrowserViewModelTest {
 
         testee.command.observeForever(mockCommandObserver)
 
-        runBlocking<Unit> {
+        runTest {
             whenever(mockTabRepository.add()).thenReturn(TAB_ID)
             whenever(mockOmnibarEntryConverter.convertQueryToUrl(any(), any(), any())).then { it.arguments.first() }
         }
@@ -120,21 +119,21 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenNewTabRequestedThenTabAddedToRepository() = runBlocking<Unit> {
+    fun whenNewTabRequestedThenTabAddedToRepository() = runTest {
         whenever(mockTabRepository.liveSelectedTab).doReturn(MutableLiveData())
         testee.onNewTabRequested()
         verify(mockTabRepository).add()
     }
 
     @Test
-    fun whenNewTabRequestedFromSourceTabThenTabAddedToRepositoryWithSourceTabId() = runBlocking<Unit> {
+    fun whenNewTabRequestedFromSourceTabThenTabAddedToRepositoryWithSourceTabId() = runTest {
         whenever(mockTabRepository.liveSelectedTab).doReturn(MutableLiveData())
         testee.onNewTabRequested("sourceTabId")
         verify(mockTabRepository).addFromSourceTab(sourceTabId = "sourceTabId")
     }
 
     @Test
-    fun whenOpenInNewTabRequestedThenTabAddedToRepository() = runBlocking<Unit> {
+    fun whenOpenInNewTabRequestedThenTabAddedToRepository() = runTest {
         val url = "http://example.com"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         whenever(mockTabRepository.liveSelectedTab).doReturn(MutableLiveData())
@@ -143,7 +142,7 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenOpenInNewTabRequestedWithSourceTabIdThenTabAddedToRepositoryWithSourceTabId() = runBlocking<Unit> {
+    fun whenOpenInNewTabRequestedWithSourceTabIdThenTabAddedToRepositoryWithSourceTabId() = runTest {
         val url = "http://example.com"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         whenever(mockTabRepository.liveSelectedTab).doReturn(MutableLiveData())
@@ -152,13 +151,13 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenTabsUpdatedAndNoTabsThenDefaultTabAddedToRepository() = runBlocking<Unit> {
+    fun whenTabsUpdatedAndNoTabsThenDefaultTabAddedToRepository() = runTest {
         testee.onTabsUpdated(ArrayList())
         verify(mockTabRepository).addDefaultTab()
     }
 
     @Test
-    fun whenTabsUpdatedWithTabsThenNewTabNotLaunched() = runBlocking {
+    fun whenTabsUpdatedWithTabsThenNewTabNotLaunched() = runTest {
         testee.onTabsUpdated(listOf(TabEntity(TAB_ID, "", "", skipHome = false, viewed = true, position = 0)))
         verify(mockCommandObserver, never()).onChanged(any())
     }
@@ -196,7 +195,7 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenOpenShortcutThenSelectByUrlOrNewTab() = coroutinesTestRule.runBlocking {
+    fun whenOpenShortcutThenSelectByUrlOrNewTab() = runTest {
         val url = "example.com"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenShortcut(url)
@@ -212,7 +211,7 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenOpenFavoriteThenSelectByUrlOrNewTab() = coroutinesTestRule.runBlocking {
+    fun whenOpenFavoriteThenSelectByUrlOrNewTab() = runTest {
         val url = "example.com"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenFavoriteFromWidget(url)
@@ -220,7 +219,7 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenOpenFavoriteFromWidgetThenFirePixel() = coroutinesTestRule.runBlocking {
+    fun whenOpenFavoriteFromWidgetThenFirePixel() = runTest {
         val url = "example.com"
         whenever(mockOmnibarEntryConverter.convertQueryToUrl(url)).thenReturn(url)
         testee.onOpenFavoriteFromWidget(url)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -20,7 +20,11 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import android.webkit.*
+import android.webkit.CookieManager
+import android.webkit.HttpAuthHandler
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
 import androidx.core.net.toUri
 import androidx.test.annotation.UiThreadTest
 import androidx.test.filters.SdkSuppress
@@ -36,14 +40,19 @@ import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.email.EmailInjector
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
 import com.duckduckgo.privacy.config.api.Gpc
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -92,7 +101,7 @@ class BrowserWebViewClientTest {
             dosDetector,
             gpc,
             thirdPartyCookieManager,
-            TestCoroutineScope(),
+            TestScope(),
             coroutinesTestRule.testDispatcherProvider,
             emailInjector,
             accessibilitySettings
@@ -126,14 +135,14 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenEventSentToLoginDetector() = coroutinesTestRule.runBlocking {
+    fun whenOnPageStartedCalledThenEventSentToLoginDetector() = runTest {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         verify(loginDetector).onEvent(WebNavigationEvent.OnPageStarted(webView))
     }
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledIfUrlIsNullThenDoNotInjectGpcToDom() = coroutinesTestRule.runBlocking {
+    fun whenOnPageStartedCalledIfUrlIsNullThenDoNotInjectGpcToDom() = runTest {
         whenever(gpc.canGpcBeUsedByUrl(any())).thenReturn(true)
 
         testee.onPageStarted(webView, null, null)
@@ -142,7 +151,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledIfUrlIsValidThenInjectGpcToDom() = coroutinesTestRule.runBlocking {
+    fun whenOnPageStartedCalledIfUrlIsValidThenInjectGpcToDom() = runTest {
         whenever(gpc.canGpcBeUsedByUrl(any())).thenReturn(true)
 
         testee.onPageStarted(webView, EXAMPLE_URL, null)
@@ -151,7 +160,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledIfUrlIsNotAndValidThenDoNotInjectGpcToDom() = coroutinesTestRule.runBlocking {
+    fun whenOnPageStartedCalledIfUrlIsNotAndValidThenDoNotInjectGpcToDom() = runTest {
         whenever(gpc.canGpcBeUsedByUrl(any())).thenReturn(false)
 
         testee.onPageStarted(webView, EXAMPLE_URL, null)
@@ -160,7 +169,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenProcessUriForThirdPartyCookiesCalled() = coroutinesTestRule.runBlocking {
+    fun whenOnPageStartedCalledThenProcessUriForThirdPartyCookiesCalled() = runTest {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         verify(thirdPartyCookieManager).processUriForThirdPartyCookies(webView, EXAMPLE_URL.toUri())
     }
@@ -183,7 +192,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnReceivedHttpAuthRequestThrowsExceptionThenRecordException() = coroutinesTestRule.runBlocking {
+    fun whenOnReceivedHttpAuthRequestThrowsExceptionThenRecordException() = runTest {
         val exception = RuntimeException()
         val mockHandler = mock<HttpAuthHandler>()
         val mockWebView = mock<WebView>()
@@ -194,7 +203,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenShouldInterceptRequestThenEventSentToLoginDetector() = coroutinesTestRule.runBlocking {
+    fun whenShouldInterceptRequestThenEventSentToLoginDetector() = runTest {
         val webResourceRequest = mock<WebResourceRequest>()
         testee.shouldInterceptRequest(webView, webResourceRequest)
         verify(loginDetector).onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, webResourceRequest))
@@ -250,7 +259,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageFinishedThrowsExceptionThenRecordException() = coroutinesTestRule.runBlocking {
+    fun whenOnPageFinishedThrowsExceptionThenRecordException() = runTest {
         val exception = RuntimeException()
         val mockWebView: WebView = mock()
         whenever(mockWebView.url).thenThrow(exception)
@@ -274,7 +283,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenOnPageStartedThrowsExceptionThenRecordException() = coroutinesTestRule.runBlocking {
+    fun whenOnPageStartedThrowsExceptionThenRecordException() = runTest {
         val exception = RuntimeException()
         val mockWebView: WebView = mock()
         whenever(mockWebView.url).thenThrow(exception)
@@ -283,7 +292,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenShouldOverrideThrowsExceptionThenRecordException() = coroutinesTestRule.runBlocking {
+    fun whenShouldOverrideThrowsExceptionThenRecordException() = runTest {
         val exception = RuntimeException()
         whenever(specialUrlDetector.determineType(any<Uri>())).thenThrow(exception)
         testee.shouldOverrideUrlLoading(webView, "")
@@ -291,7 +300,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenAppLinkDetectedAndIsHandledThenReturnTrue() = coroutinesTestRule.runBlocking {
+    fun whenAppLinkDetectedAndIsHandledThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
             whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
@@ -304,7 +313,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenAppLinkDetectedAndIsNotHandledThenReturnFalse() = coroutinesTestRule.runBlocking {
+    fun whenAppLinkDetectedAndIsNotHandledThenReturnFalse() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
             whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
@@ -317,7 +326,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenAppLinkDetectedAndListenerIsNullThenReturnFalse() = coroutinesTestRule.runBlocking {
+    fun whenAppLinkDetectedAndListenerIsNullThenReturnFalse() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL))
             testee.webViewClientListener = null
@@ -327,7 +336,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenNonHttpAppLinkDetectedAndIsHandledThenReturnTrue() = coroutinesTestRule.runBlocking {
+    fun whenNonHttpAppLinkDetectedAndIsHandledThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
             whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
@@ -339,7 +348,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenNonHttpAppLinkDetectedAndIsHandledOnApiLessThan24ThenReturnTrue() = coroutinesTestRule.runBlocking {
+    fun whenNonHttpAppLinkDetectedAndIsHandledOnApiLessThan24ThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
             whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
@@ -350,7 +359,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenNonHttpAppLinkDetectedAndIsNotHandledThenReturnFalse() = coroutinesTestRule.runBlocking {
+    fun whenNonHttpAppLinkDetectedAndIsNotHandledThenReturnFalse() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
             whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
@@ -362,7 +371,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenNonHttpAppLinkDetectedAndIsNotHandledOnApiLessThan24ThenReturnFalse() = coroutinesTestRule.runBlocking {
+    fun whenNonHttpAppLinkDetectedAndIsNotHandledOnApiLessThan24ThenReturnFalse() = runTest {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
             whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
@@ -373,7 +382,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenNonHttpAppLinkDetectedAndListenerIsNullThenReturnTrue() = coroutinesTestRule.runBlocking {
+    fun whenNonHttpAppLinkDetectedAndListenerIsNullThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL))
             testee.webViewClientListener = null
@@ -383,7 +392,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenNonHttpAppLinkDetectedAndListenerIsNullOnApiLessThan24ThenReturnTrue() = coroutinesTestRule.runBlocking {
+    fun whenNonHttpAppLinkDetectedAndListenerIsNullOnApiLessThan24ThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL))
             testee.webViewClientListener = null

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
@@ -27,11 +27,13 @@ import com.duckduckgo.app.global.file.FileDeleter
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 @Suppress("RemoveExplicitTypeArguments")
 class WebViewDataManagerTest {
 
@@ -43,7 +45,7 @@ class WebViewDataManagerTest {
     private val testee = WebViewDataManager(context, WebViewSessionInMemoryStorage(), mockCookieManager, mockFileDeleter, mockWebViewHttpAuthStore)
 
     @Test
-    fun whenDataClearedThenWebViewHistoryCleared() = runBlocking<Unit> {
+    fun whenDataClearedThenWebViewHistoryCleared() = runTest {
         withContext(Dispatchers.Main) {
             val webView = TestWebView(context)
             testee.clearData(webView, mockStorage)
@@ -52,7 +54,7 @@ class WebViewDataManagerTest {
     }
 
     @Test
-    fun whenDataClearedThenWebViewCacheCleared() = runBlocking<Unit> {
+    fun whenDataClearedThenWebViewCacheCleared() = runTest {
         withContext(Dispatchers.Main) {
             val webView = TestWebView(context)
             testee.clearData(webView, mockStorage)
@@ -61,7 +63,7 @@ class WebViewDataManagerTest {
     }
 
     @Test
-    fun whenDataClearedThenWebViewFormDataCleared() = runBlocking<Unit> {
+    fun whenDataClearedThenWebViewFormDataCleared() = runTest {
         withContext(Dispatchers.Main) {
             val webView = TestWebView(context)
             testee.clearData(webView, mockStorage)
@@ -70,7 +72,7 @@ class WebViewDataManagerTest {
     }
 
     @Test
-    fun whenDataClearedThenWebViewWebStorageCleared() = runBlocking<Unit> {
+    fun whenDataClearedThenWebViewWebStorageCleared() = runTest {
         withContext(Dispatchers.Main) {
             val webView = TestWebView(context)
             testee.clearData(webView, mockStorage)
@@ -79,7 +81,7 @@ class WebViewDataManagerTest {
     }
 
     @Test
-    fun whenDataClearedThenWebViewAuthCredentialsCleared() = runBlocking<Unit> {
+    fun whenDataClearedThenWebViewAuthCredentialsCleared() = runTest {
         withContext(Dispatchers.Main) {
             val webView = TestWebView(context)
             testee.clearData(webView, mockStorage)
@@ -88,7 +90,7 @@ class WebViewDataManagerTest {
     }
 
     @Test
-    fun whenDataClearedThenHttpAuthDatabaseCleaned() = runBlocking<Unit> {
+    fun whenDataClearedThenHttpAuthDatabaseCleaned() = runTest {
         withContext(Dispatchers.Main) {
             val webView = TestWebView(context)
             testee.clearData(webView, mockStorage)
@@ -97,7 +99,7 @@ class WebViewDataManagerTest {
     }
 
     @Test
-    fun whenDataClearedThenWebViewCookiesRemoved() = runBlocking<Unit> {
+    fun whenDataClearedThenWebViewCookiesRemoved() = runTest {
         withContext(Dispatchers.Main) {
             val webView = TestWebView(context)
             testee.clearData(webView, mockStorage)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
@@ -34,7 +34,7 @@ import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -42,6 +42,7 @@ import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.MockitoAnnotations
 
+@ExperimentalCoroutinesApi
 class WebViewRequestInterceptorTest {
 
     @ExperimentalCoroutinesApi
@@ -79,7 +80,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUrlShouldBeUpgradedThenUpgraderInvoked() = runBlocking<Unit> {
+    fun whenUrlShouldBeUpgradedThenUpgraderInvoked() = runTest {
         configureShouldUpgrade()
         testee.shouldIntercept(
             request = mockRequest,
@@ -92,7 +93,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUrlShouldBeUpgradedThenCancelledResponseReturned() = runBlocking<Unit> {
+    fun whenUrlShouldBeUpgradedThenCancelledResponseReturned() = runTest {
         configureShouldUpgrade()
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -105,7 +106,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUrlShouldBeUpgradedButNotOnMainFrameThenNotUpgraded() = runBlocking<Unit> {
+    fun whenUrlShouldBeUpgradedButNotOnMainFrameThenNotUpgraded() = runTest {
         configureShouldUpgrade()
         whenever(mockRequest.isForMainFrame).thenReturn(false)
         testee.shouldIntercept(
@@ -119,7 +120,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUrlShouldBeUpgradedButUrlIsNullThenNotUpgraded() = runBlocking<Unit> {
+    fun whenUrlShouldBeUpgradedButUrlIsNullThenNotUpgraded() = runTest {
         configureShouldUpgrade()
         whenever(mockRequest.url).thenReturn(null)
         testee.shouldIntercept(
@@ -133,7 +134,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUrlShouldNotBeUpgradedThenUpgraderNotInvoked() = runBlocking<Unit> {
+    fun whenUrlShouldNotBeUpgradedThenUpgraderNotInvoked() = runTest {
         whenever(mockHttpsUpgrader.shouldUpgrade(any())).thenReturn(false)
         testee.shouldIntercept(
             request = mockRequest,
@@ -146,7 +147,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenDocumentUrlIsNullThenShouldContinueToLoad() = runBlocking<Unit> {
+    fun whenDocumentUrlIsNullThenShouldContinueToLoad() = runTest {
         configureShouldNotUpgrade()
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -158,7 +159,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenIsTrustedSite_DuckDuckGo_ThenShouldContinueToLoad() = runBlocking<Unit> {
+    fun whenIsTrustedSite_DuckDuckGo_ThenShouldContinueToLoad() = runTest {
         configureShouldNotUpgrade()
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -171,7 +172,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenIsTrustedSite_DontTrack_ThenShouldContinueToLoad() = runBlocking<Unit> {
+    fun whenIsTrustedSite_DontTrack_ThenShouldContinueToLoad() = runTest {
         configureShouldNotUpgrade()
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -184,7 +185,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenIsTrustedSite_SpreadPrivacy_ThenShouldContinueToLoad() = runBlocking<Unit> {
+    fun whenIsTrustedSite_SpreadPrivacy_ThenShouldContinueToLoad() = runTest {
         configureShouldNotUpgrade()
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -197,7 +198,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenIsTrustedSite_DuckDuckHack_ThenShouldContinueToLoad() = runBlocking<Unit> {
+    fun whenIsTrustedSite_DuckDuckHack_ThenShouldContinueToLoad() = runTest {
         configureShouldNotUpgrade()
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -210,7 +211,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenIsTrustedSite_PrivateBrowsingMyths_ThenShouldContinueToLoad() = runBlocking<Unit> {
+    fun whenIsTrustedSite_PrivateBrowsingMyths_ThenShouldContinueToLoad() = runTest {
         configureShouldNotUpgrade()
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -223,7 +224,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenIsTrustedSite_DuckDotCo_ThenShouldContinueToLoad() = runBlocking<Unit> {
+    fun whenIsTrustedSite_DuckDotCo_ThenShouldContinueToLoad() = runTest {
         configureShouldNotUpgrade()
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -236,7 +237,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenIsHttpRequestThenHttpRequestListenerCalled() = runBlocking<Unit> {
+    fun whenIsHttpRequestThenHttpRequestListenerCalled() = runTest {
         configureShouldNotUpgrade()
         whenever(mockRequest.url).thenReturn(Uri.parse("http://example.com"))
         val mockListener = mock<WebViewClientListener>()
@@ -253,7 +254,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenIsHttpsRequestThenHttpRequestListenerNotCalled() = runBlocking<Unit> {
+    fun whenIsHttpsRequestThenHttpRequestListenerNotCalled() = runTest {
         configureShouldNotUpgrade()
         whenever(mockRequest.url).thenReturn(Uri.parse("https://example.com"))
         val mockListener = mock<WebViewClientListener>()
@@ -270,7 +271,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenRequestShouldBlockAndNoSurrogateThenCancellingResponseReturned() = runBlocking<Unit> {
+    fun whenRequestShouldBlockAndNoSurrogateThenCancellingResponseReturned() = runTest {
         whenever(mockResourceSurrogates.get(any())).thenReturn(SurrogateResponse(responseAvailable = false))
 
         configureShouldNotUpgrade()
@@ -286,7 +287,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenRequestShouldBlockButThereIsASurrogateThenResponseReturnedContainsTheSurrogateData() = runBlocking<Unit> {
+    fun whenRequestShouldBlockButThereIsASurrogateThenResponseReturnedContainsTheSurrogateData() = runTest {
         val availableSurrogate = SurrogateResponse(
             scriptId = "testId",
             responseAvailable = true,
@@ -308,7 +309,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenRequestShouldBlockButThereIsASurrogateThenCallSurrogateDetected() = runBlocking<Unit> {
+    fun whenRequestShouldBlockButThereIsASurrogateThenCallSurrogateDetected() = runTest {
         val availableSurrogate = SurrogateResponse(
             scriptId = "testId",
             responseAvailable = true,
@@ -331,7 +332,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUrlShouldBeUpgradedThenNotifyWebViewClientListener() = runBlocking<Unit> {
+    fun whenUrlShouldBeUpgradedThenNotifyWebViewClientListener() = runTest {
         configureShouldUpgrade()
         val mockWebViewClientListener: WebViewClientListener = mock()
         testee.shouldIntercept(
@@ -345,7 +346,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUrlShouldBeUpgradedAndGcpActiveThenLoadUrlWithGpcHeaders() = runBlocking<Unit> {
+    fun whenUrlShouldBeUpgradedAndGcpActiveThenLoadUrlWithGpcHeaders() = runTest {
         configureShouldUpgrade()
         configureShouldAddGpcHeader()
         val mockWebViewClientListener: WebViewClientListener = mock()
@@ -361,7 +362,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenRequestShouldAddGcpHeadersThenRedirectTriggeredByGpcCalled() = runBlocking<Unit> {
+    fun whenRequestShouldAddGcpHeadersThenRedirectTriggeredByGpcCalled() = runTest {
         configureShouldNotUpgrade()
         configureShouldAddGpcHeader()
         configureUrlDoesNotExistInTheStack()
@@ -378,7 +379,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenRequestShouldAddGcpHeadersThenLoadUrlWithGpcHeaders() = runBlocking<Unit> {
+    fun whenRequestShouldAddGcpHeadersThenLoadUrlWithGpcHeaders() = runTest {
         configureShouldNotUpgrade()
         configureShouldAddGpcHeader()
         configureUrlDoesNotExistInTheStack()
@@ -395,7 +396,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenRequestShouldAddGcpHeadersButUrlExistsInTheStackThenLoadUrlNotCalled() = runBlocking<Unit> {
+    fun whenRequestShouldAddGcpHeadersButUrlExistsInTheStackThenLoadUrlNotCalled() = runTest {
         configureShouldNotUpgrade()
         configureShouldAddGpcHeader()
         configureUrlExistsInTheStack()
@@ -412,7 +413,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenRequestShouldAddGcpHeadersButAlreadyContainsHeadersThenLoadUrlNotCalled() = runBlocking<Unit> {
+    fun whenRequestShouldAddGcpHeadersButAlreadyContainsHeadersThenLoadUrlNotCalled() = runTest {
         configureShouldNotUpgrade()
         configureRequestContainsGcpHeader()
 
@@ -429,7 +430,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenRequestShouldNotAddGcpHeadersThenLoadUrlNotCalled() = runBlocking<Unit> {
+    fun whenRequestShouldNotAddGcpHeadersThenLoadUrlNotCalled() = runTest {
         configureShouldNotUpgrade()
         configureShouldNotAddGpcHeader()
         val mockWebViewClientListener: WebViewClientListener = mock()
@@ -445,7 +446,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUserAgentShouldChangeThenReloadUrl() = runBlocking<Unit> {
+    fun whenUserAgentShouldChangeThenReloadUrl() = runTest {
         configureUserAgentShouldChange()
         configureUrlDoesNotExistInTheStack()
 
@@ -461,7 +462,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUserAgentShouldChangeAndUrlAlreadyWasInTheStackButIsNotTheLastElementThenDoNotReloadUrl() = runBlocking<Unit> {
+    fun whenUserAgentShouldChangeAndUrlAlreadyWasInTheStackButIsNotTheLastElementThenDoNotReloadUrl() = runTest {
         configureUserAgentShouldChange()
         configureUrlExistsInTheStack("https://m.facebook.com".toUri())
 
@@ -477,7 +478,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenUserAgentHasNotChangedThenDoNotReloadUrl() = runBlocking<Unit> {
+    fun whenUserAgentHasNotChangedThenDoNotReloadUrl() = runTest {
         configureShouldNotUpgrade()
         configureUrlDoesNotExistInTheStack()
 
@@ -493,7 +494,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenInterceptFromServiceWorkerAndRequestShouldBlockAndNoSurrogateThenCancellingResponseReturned() = runBlocking<Unit> {
+    fun whenInterceptFromServiceWorkerAndRequestShouldBlockAndNoSurrogateThenCancellingResponseReturned() = runTest {
         whenever(mockResourceSurrogates.get(any())).thenReturn(SurrogateResponse(responseAvailable = false))
 
         configureShouldNotUpgrade()
@@ -507,7 +508,7 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenInterceptFromServiceWorkerAndRequestShouldBlockButThereIsASurrogateThenResponseReturnedContainsTheSurrogateData() = runBlocking<Unit> {
+    fun whenInterceptFromServiceWorkerAndRequestShouldBlockButThereIsASurrogateThenResponseReturnedContainsTheSurrogateData() = runTest {
         val availableSurrogate = SurrogateResponse(
             scriptId = "testId",
             responseAvailable = true,
@@ -527,12 +528,12 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
-    fun whenInterceptFromServiceWorkerAndRequestIsNullThenReturnNull() = runBlocking<Unit> {
+    fun whenInterceptFromServiceWorkerAndRequestIsNullThenReturnNull() = runTest {
         assertNull(testee.shouldInterceptFromServiceWorker(request = null, documentUrl = "foo.com"))
     }
 
     @Test
-    fun whenInterceptFromServiceWorkerAndDocumentUrlIsNullThenReturnNull() = runBlocking<Unit> {
+    fun whenInterceptFromServiceWorkerAndDocumentUrlIsNullThenReturnNull() = runTest {
         assertNull(testee.shouldInterceptFromServiceWorker(request = mockRequest, documentUrl = null))
     }
 
@@ -571,41 +572,41 @@ class WebViewRequestInterceptorTest {
         configureUrlExistsInTheStack()
     }
 
-    private fun configureRequestContainsGcpHeader() = runBlocking<Unit> {
+    private fun configureRequestContainsGcpHeader() = runTest {
         whenever(mockGpc.isEnabled()).thenReturn(true)
         whenever(mockRequest.method).thenReturn("GET")
         whenever(mockRequest.requestHeaders).thenReturn(mapOf(GPC_HEADER to "test"))
 
     }
 
-    private fun configureShouldAddGpcHeader() = runBlocking<Unit> {
+    private fun configureShouldAddGpcHeader() = runTest {
         whenever(mockGpc.isEnabled()).thenReturn(true)
         whenever(mockGpc.getHeaders(anyString())).thenReturn(mapOf("test" to "test"))
         whenever(mockGpc.canUrlAddHeaders(any(), any())).thenReturn(true)
         whenever(mockRequest.method).thenReturn("GET")
     }
 
-    private fun configureShouldNotAddGpcHeader() = runBlocking<Unit> {
+    private fun configureShouldNotAddGpcHeader() = runTest {
         whenever(mockGpc.isEnabled()).thenReturn(false)
         whenever(mockGpc.getHeaders(anyString())).thenReturn(mapOf("test" to "test"))
         whenever(mockGpc.canUrlAddHeaders(any(), any())).thenReturn(false)
         whenever(mockRequest.method).thenReturn("GET")
     }
 
-    private fun configureUserAgentShouldChange() = runBlocking<Unit> {
+    private fun configureUserAgentShouldChange() = runTest {
         whenever(mockRequest.url).thenReturn(Uri.parse("https://m.facebook.com"))
         whenever(mockRequest.isForMainFrame).thenReturn(true)
         whenever(mockRequest.method).thenReturn("GET")
     }
 
-    private fun configureShouldUpgrade() = runBlocking<Unit> {
+    private fun configureShouldUpgrade() = runTest {
         whenever(mockHttpsUpgrader.shouldUpgrade(any())).thenReturn(true)
         whenever(mockHttpsUpgrader.upgrade(any())).thenReturn(validHttpsUri())
         whenever(mockRequest.url).thenReturn(validUri())
         whenever(mockRequest.isForMainFrame).thenReturn(true)
     }
 
-    private fun configureShouldNotUpgrade() = runBlocking<Unit> {
+    private fun configureShouldNotUpgrade() = runTest {
         whenever(mockHttpsUpgrader.shouldUpgrade(any())).thenReturn(false)
 
         whenever(mockRequest.url).thenReturn(validUri())

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
@@ -28,8 +28,8 @@ import com.duckduckgo.app.browser.cookies.AppThirdPartyCookieManager.Companion.U
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsDao
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsRepository
 import com.duckduckgo.app.global.db.AppDatabase
-import com.duckduckgo.app.runBlocking
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.*
@@ -71,7 +71,7 @@ class AppThirdPartyCookieManagerTest {
 
     @UiThreadTest
     @Test
-    fun whenProcessUriForThirdPartyCookiesIfDomainIsNotGoogleAuthAndIsNotInTheListThenThirdPartyCookiesDisabled() = coroutinesTestRule.runBlocking {
+    fun whenProcessUriForThirdPartyCookiesIfDomainIsNotGoogleAuthAndIsNotInTheListThenThirdPartyCookiesDisabled() = runTest {
         testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI)
 
         assertFalse(cookieManager.acceptThirdPartyCookies(webView))
@@ -79,7 +79,7 @@ class AppThirdPartyCookieManagerTest {
 
     @UiThreadTest
     @Test
-    fun whenProcessUriForThirdPartyCookiesIfDomainIsNotGoogleAuthAndIsInTheListAndHasCookieThenThirdPartyCookiesEnabled() = coroutinesTestRule.runBlocking {
+    fun whenProcessUriForThirdPartyCookiesIfDomainIsNotGoogleAuthAndIsInTheListAndHasCookieThenThirdPartyCookiesEnabled() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
         givenUserIdCookieIsSet()
 
@@ -90,7 +90,7 @@ class AppThirdPartyCookieManagerTest {
 
     @UiThreadTest
     @Test
-    fun whenProcessUriForThirdPartyCookiesIfDomainIsNotGoogleAuthAndIsInTheListAndDoesNotHaveCookieThenThirdPartyCookiesDisabled() = coroutinesTestRule.runBlocking {
+    fun whenProcessUriForThirdPartyCookiesIfDomainIsNotGoogleAuthAndIsInTheListAndDoesNotHaveCookieThenThirdPartyCookiesDisabled() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
 
         testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI)
@@ -100,7 +100,7 @@ class AppThirdPartyCookieManagerTest {
 
     @UiThreadTest
     @Test
-    fun whenProcessUriForThirdPartyCookiesIfDomainIsInTheListAndCookieIsSetThenDomainRemovedFromList() = coroutinesTestRule.runBlocking {
+    fun whenProcessUriForThirdPartyCookiesIfDomainIsInTheListAndCookieIsSetThenDomainRemovedFromList() = runTest {
         givenUserIdCookieIsSet()
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
 
@@ -111,7 +111,7 @@ class AppThirdPartyCookieManagerTest {
 
     @UiThreadTest
     @Test
-    fun whenProcessUriForThirdPartyCookiesIfDomainIsInTheListAndCookieIsNotSetThenDomainRemovedFromList() = coroutinesTestRule.runBlocking {
+    fun whenProcessUriForThirdPartyCookiesIfDomainIsInTheListAndCookieIsNotSetThenDomainRemovedFromList() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
 
         testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI)
@@ -121,7 +121,7 @@ class AppThirdPartyCookieManagerTest {
 
     @UiThreadTest
     @Test
-    fun whenProcessUriForThirdPartyCookiesIfDomainIsInTheListAndIsFromExceptionListThenDomainNotRemovedFromList() = coroutinesTestRule.runBlocking {
+    fun whenProcessUriForThirdPartyCookiesIfDomainIsInTheListAndIsFromExceptionListThenDomainNotRemovedFromList() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXCLUDED_DOMAIN_URI.host!!)
 
         testee.processUriForThirdPartyCookies(webView, EXCLUDED_DOMAIN_URI)
@@ -131,7 +131,7 @@ class AppThirdPartyCookieManagerTest {
 
     @UiThreadTest
     @Test
-    fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthAndIsTokenTypeThenDomainAddedToTheList() = coroutinesTestRule.runBlocking {
+    fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthAndIsTokenTypeThenDomainAddedToTheList() = runTest {
         testee.processUriForThirdPartyCookies(webView, THIRD_PARTY_AUTH_URI)
 
         assertNotNull(authCookiesAllowedDomainsRepository.getDomain(EXAMPLE_URI.host!!))
@@ -139,14 +139,14 @@ class AppThirdPartyCookieManagerTest {
 
     @UiThreadTest
     @Test
-    fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthAndIsNotTokenTypeThenDomainNotAddedToTheList() = coroutinesTestRule.runBlocking {
+    fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthAndIsNotTokenTypeThenDomainNotAddedToTheList() = runTest {
         testee.processUriForThirdPartyCookies(webView, NON_THIRD_PARTY_AUTH_URI)
 
         assertNull(authCookiesAllowedDomainsRepository.getDomain(EXAMPLE_URI.host!!))
     }
 
     @Test
-    fun whenClearAllDataThenDomainDeletedFromDatabase() = coroutinesTestRule.runBlocking {
+    fun whenClearAllDataThenDomainDeletedFromDatabase() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
 
         testee.clearAllData()
@@ -155,7 +155,7 @@ class AppThirdPartyCookieManagerTest {
     }
 
     @Test
-    fun whenClearAllDataIfDomainIsInExclusionListThenDomainNotDeletedFromDatabase() = coroutinesTestRule.runBlocking {
+    fun whenClearAllDataIfDomainIsInExclusionListThenDomainNotDeletedFromDatabase() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXCLUDED_DOMAIN_URI.host!!)
 
         testee.clearAllData()
@@ -163,7 +163,7 @@ class AppThirdPartyCookieManagerTest {
         assertNotNull(authCookiesAllowedDomainsRepository.getDomain(EXCLUDED_DOMAIN_URI.host!!))
     }
 
-    private suspend fun givenDomainIsInTheThirdPartyCookieList(domain: String) = coroutinesTestRule.runBlocking {
+    private suspend fun givenDomainIsInTheThirdPartyCookieList(domain: String) = runTest {
         withContext(coroutinesTestRule.testDispatcherProvider.io()) {
             authCookiesAllowedDomainsRepository.addDomain(domain)
         }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/db/AuthCookiesAllowedDomainsRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/db/AuthCookiesAllowedDomainsRepositoryTest.kt
@@ -20,8 +20,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.global.db.AppDatabase
-import com.duckduckgo.app.runBlocking
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After
 import org.junit.Assert.*
@@ -58,22 +58,22 @@ class AuthCookiesAllowedDomainsRepositoryTest {
     }
 
     @Test
-    fun whenAddDomainIfIsEmptyThenReturnNull() = coroutineRule.runBlocking {
+    fun whenAddDomainIfIsEmptyThenReturnNull() = runTest {
         assertNull(authCookiesAllowedDomainsRepository.addDomain(""))
     }
 
     @Test
-    fun whenAddDomainAndDomainNotValidThenReturnNull() = coroutineRule.runBlocking {
+    fun whenAddDomainAndDomainNotValidThenReturnNull() = runTest {
         assertNull(authCookiesAllowedDomainsRepository.addDomain("https://example.com"))
     }
 
     @Test
-    fun whenAddValidDomainThenReturnNonNull() = coroutineRule.runBlocking {
+    fun whenAddValidDomainThenReturnNonNull() = runTest {
         assertNotNull(authCookiesAllowedDomainsRepository.addDomain("example.com"))
     }
 
     @Test
-    fun whenGetDomainIfDomainExistsThenReturnAllowedDomainEntity() = coroutineRule.runBlocking {
+    fun whenGetDomainIfDomainExistsThenReturnAllowedDomainEntity() = runTest {
         givenAuthCookieAllowedDomain("example.com")
 
         val authCookieAllowedDomainEntity = authCookiesAllowedDomainsRepository.getDomain("example.com")
@@ -81,13 +81,13 @@ class AuthCookiesAllowedDomainsRepositoryTest {
     }
 
     @Test
-    fun whenGetDomainIfDomainDoesNotExistThenReturnNull() = coroutineRule.runBlocking {
+    fun whenGetDomainIfDomainDoesNotExistThenReturnNull() = runTest {
         val authCookieAllowedDomainEntity = authCookiesAllowedDomainsRepository.getDomain("example.com")
         assertNull(authCookieAllowedDomainEntity)
     }
 
     @Test
-    fun whenRemoveDomainThenDomainDeletedFromDatabase() = coroutineRule.runBlocking {
+    fun whenRemoveDomainThenDomainDeletedFromDatabase() = runTest {
         givenAuthCookieAllowedDomain("example.com")
         val authCookieAllowedDomainEntity = authCookiesAllowedDomainsRepository.getDomain("example.com")
 
@@ -98,7 +98,7 @@ class AuthCookiesAllowedDomainsRepositoryTest {
     }
 
     @Test
-    fun whenDeleteAllThenAllDomainsDeletedExceptFromTheExceptionList() = coroutineRule.runBlocking {
+    fun whenDeleteAllThenAllDomainsDeletedExceptFromTheExceptionList() = runTest {
         givenAuthCookieAllowedDomain("example.com", "example2.com")
 
         authCookiesAllowedDomainsRepository.deleteAll(listOf("example.com"))

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
@@ -24,6 +24,7 @@ import androidx.core.net.toUri
 import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.bookmarks.model.FavoritesRepository
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_PERSISTED_DIR
@@ -34,7 +35,6 @@ import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
 import com.duckduckgo.app.global.faviconLocation
 import com.duckduckgo.app.location.data.LocationPermissionsDao
 import com.duckduckgo.app.location.data.LocationPermissionsRepository
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertNull
@@ -80,7 +80,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenLoadFromDiskIfFileExistsInTempThenGetFaviconFromDisk() = coroutineRule.runBlocking {
+    fun whenLoadFromDiskIfFileExistsInTempThenGetFaviconFromDisk() = runTest {
         givenFaviconExistsInTemp()
 
         testee.loadFromDisk("subfolder", "example.com")
@@ -89,7 +89,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenLoadFromDiskIfFileExistsInPersistedThenGetFaviconFromDisk() = coroutineRule.runBlocking {
+    fun whenLoadFromDiskIfFileExistsInPersistedThenGetFaviconFromDisk() = runTest {
         givenFaviconExistsInDirectory(FAVICON_PERSISTED_DIR)
 
         testee.loadFromDisk("subfolder", "example.com")
@@ -98,7 +98,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenLoadFromDiskIfFileDoesNotExistThenDoNothing() = coroutineRule.runBlocking {
+    fun whenLoadFromDiskIfFileDoesNotExistThenDoNothing() = runTest {
         testee.loadFromDisk("subfolder", "example.com")
 
         verify(mockFaviconDownloader, never()).getFaviconFromDisk(any())
@@ -106,7 +106,7 @@ class DuckDuckGoFaviconManagerTest {
 
     @Test
     @UiThreadTest
-    fun whenLoadToViewFromLocalOrFallbackIfCannotFindFaviconThenDownloadFromUrl() = coroutineRule.runBlocking {
+    fun whenLoadToViewFromLocalOrFallbackIfCannotFindFaviconThenDownloadFromUrl() = runTest {
         val view = ImageView(context)
         val url = "https://example.com"
 
@@ -117,7 +117,7 @@ class DuckDuckGoFaviconManagerTest {
 
     @Test
     @UiThreadTest
-    fun whenLoadToViewFromLocalOrFallbackWithTabIdIfCannotFindFaviconThenDownloadFromUrl() = coroutineRule.runBlocking {
+    fun whenLoadToViewFromLocalOrFallbackWithTabIdIfCannotFindFaviconThenDownloadFromUrl() = runTest {
         val view = ImageView(context)
         val url = "https://example.com"
 
@@ -127,7 +127,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenTryFetchFaviconForUrlThenGetFaviconFromUrlAndStoreFile() = coroutineRule.runBlocking {
+    fun whenTryFetchFaviconForUrlThenGetFaviconFromUrlAndStoreFile() = runTest {
         val bitmap = asBitmap()
         val url = "https://example.com"
         whenever(mockFaviconDownloader.getFaviconFromUrl(url.toUri().faviconLocation()!!)).thenReturn(bitmap)
@@ -138,7 +138,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenTryFetchFaviconForUrlAndCannotDownloadThenReturnNull() = coroutineRule.runBlocking {
+    fun whenTryFetchFaviconForUrlAndCannotDownloadThenReturnNull() = runTest {
         val url = "https://example.com"
         whenever(mockFaviconDownloader.getFaviconFromUrl(url.toUri().faviconLocation()!!)).thenReturn(null)
 
@@ -148,7 +148,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenStoreFaviconIfFaviconHasBetterQualityThenReplacePersistedFavicons() = coroutineRule.runBlocking {
+    fun whenStoreFaviconIfFaviconHasBetterQualityThenReplacePersistedFavicons() = runTest {
         val bitmap = asBitmap()
         givenFaviconShouldBePersisted()
         whenever(mockFaviconPersister.store(FAVICON_TEMP_DIR, "subFolder", bitmap, "example.com")).thenReturn(File("example"))
@@ -159,7 +159,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenStoreFaviconIfFaviconDoesNotHaveBetterQualityThenDoNotReplacePersistedFavicons() = coroutineRule.runBlocking {
+    fun whenStoreFaviconIfFaviconDoesNotHaveBetterQualityThenDoNotReplacePersistedFavicons() = runTest {
         val bitmap = asBitmap()
         givenFaviconShouldBePersisted()
         whenever(mockFaviconPersister.store(FAVICON_TEMP_DIR, "subFolder", bitmap, "example.com")).thenReturn(null)
@@ -170,7 +170,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenStoreFaviconThenStoreFile() = coroutineRule.runBlocking {
+    fun whenStoreFaviconThenStoreFile() = runTest {
         val bitmap = asBitmap()
 
         testee.storeFavicon("subFolder", FaviconSource.ImageFavicon(bitmap, "example.com"))
@@ -179,7 +179,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenPersistFaviconThenCopyToPersistedDirectory() = coroutineRule.runBlocking {
+    fun whenPersistFaviconThenCopyToPersistedDirectory() = runTest {
         givenFaviconExistsInTemp()
 
         testee.persistCachedFavicon("subFolder", "example.com")
@@ -188,14 +188,14 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenPersistFaviconIfFaviconDoesNotExistThenDoNotCopyToPersistedDirectory() = coroutineRule.runBlocking {
+    fun whenPersistFaviconIfFaviconDoesNotExistThenDoNotCopyToPersistedDirectory() = runTest {
         testee.persistCachedFavicon("subFolder", "example.com")
 
         verify(mockFaviconPersister, never()).copyToDirectory(any(), any(), any(), any())
     }
 
     @Test
-    fun whenDeletePersistedFaviconIfNoRemainingFaviconsInDatabaseThenDeleteFavicon() = coroutineRule.runBlocking {
+    fun whenDeletePersistedFaviconIfNoRemainingFaviconsInDatabaseThenDeleteFavicon() = runTest {
         givenFaviconShouldBePersisted()
         testee.deletePersistedFavicon("example.com")
 
@@ -203,7 +203,7 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenDeletePersistedFaviconIfRemainingFaviconsInDatabaseThenDoNotDeleteFavicon() = coroutineRule.runBlocking {
+    fun whenDeletePersistedFaviconIfRemainingFaviconsInDatabaseThenDoNotDeleteFavicon() = runTest {
         whenever(mockFireproofWebsiteDao.fireproofWebsitesCountByDomain(any())).thenReturn(2)
 
         testee.deletePersistedFavicon("example.com")
@@ -212,14 +212,14 @@ class DuckDuckGoFaviconManagerTest {
     }
 
     @Test
-    fun whenDeleteOldFaviconThenDeleteFaviconFromTempDirectory() = coroutineRule.runBlocking {
+    fun whenDeleteOldFaviconThenDeleteFaviconFromTempDirectory() = runTest {
         testee.deleteOldTempFavicon("subFolder", "example.com")
 
         verify(mockFaviconPersister).deleteFaviconsForSubfolder(FAVICON_TEMP_DIR, "subFolder", "example.com")
     }
 
     @Test
-    fun whenDeleteAllTempThenDeleteAllFaviconsFromTempDirectory() = coroutineRule.runBlocking {
+    fun whenDeleteAllTempThenDeleteAllFaviconsFromTempDirectory() = runTest {
         testee.deleteAllTemp()
 
         verify(mockFaviconPersister).deleteAll(FAVICON_TEMP_DIR)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/FileBasedFaviconPersisterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/FileBasedFaviconPersisterTest.kt
@@ -22,9 +22,9 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.global.file.FileDeleter
 import com.duckduckgo.app.global.sha256
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
@@ -61,12 +61,12 @@ class FileBasedFaviconPersisterTest {
     }
 
     @After
-    fun after() = coroutineRule.runBlocking {
+    fun after() = runTest {
         deleteTestFolders()
     }
 
     @Test
-    fun whenDeleteAllCalledThenEntireDirectoryDeleted() = coroutineRule.runBlocking {
+    fun whenDeleteAllCalledThenEntireDirectoryDeleted() = runTest {
         testee.deleteAll(testDirectory)
         val captor = argumentCaptor<File>()
 
@@ -75,7 +75,7 @@ class FileBasedFaviconPersisterTest {
     }
 
     @Test
-    fun whenFaviconFileReturnedThenCorrectDirectoryUsed() = coroutineRule.runBlocking {
+    fun whenFaviconFileReturnedThenCorrectDirectoryUsed() = runTest {
         createNewFile()
         val file = testee.faviconFile(testDirectory, subFolder, domain)
 
@@ -85,7 +85,7 @@ class FileBasedFaviconPersisterTest {
     }
 
     @Test
-    fun whenCopyToDirectoryThenFileCopiedToNewDirectory() = coroutineRule.runBlocking {
+    fun whenCopyToDirectoryThenFileCopiedToNewDirectory() = runTest {
         val filename = "newFileName"
         createNewFile()
 
@@ -97,7 +97,7 @@ class FileBasedFaviconPersisterTest {
     }
 
     @Test
-    fun whenStoreBitmapCorrectlyThenReturnFile() = coroutineRule.runBlocking {
+    fun whenStoreBitmapCorrectlyThenReturnFile() = runTest {
         val bitmap: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.RGB_565)
 
         val file = testee.store(testDirectory, subFolder, bitmap, "filename")
@@ -107,7 +107,7 @@ class FileBasedFaviconPersisterTest {
     }
 
     @Test
-    fun whenStoreBitmapAndSizeIsBiggerThanPreviouslySavedThenReturnNewFile() = coroutineRule.runBlocking {
+    fun whenStoreBitmapAndSizeIsBiggerThanPreviouslySavedThenReturnNewFile() = runTest {
         val bitmap: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.RGB_565)
         val newBitmap: Bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.RGB_565)
 
@@ -120,7 +120,7 @@ class FileBasedFaviconPersisterTest {
     }
 
     @Test
-    fun whenStoreBitmapAndSizeIsSmallerThanPreviouslySavedThenReturnNull() = coroutineRule.runBlocking {
+    fun whenStoreBitmapAndSizeIsSmallerThanPreviouslySavedThenReturnNull() = runTest {
         val bitmap: Bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.RGB_565)
         val newBitmap: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.RGB_565)
 
@@ -131,7 +131,7 @@ class FileBasedFaviconPersisterTest {
     }
 
     @Test
-    fun whenStoreBitmapAndSizeIsEqualsThanPreviouslySavedThenDoesNotReturnNull() = coroutineRule.runBlocking {
+    fun whenStoreBitmapAndSizeIsEqualsThanPreviouslySavedThenDoesNotReturnNull() = runTest {
         val bitmap: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.RGB_565)
         val newBitmap: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.RGB_565)
 
@@ -142,7 +142,7 @@ class FileBasedFaviconPersisterTest {
     }
 
     @Test
-    fun whenDeletePersistedFaviconThenDeleteTheFile() = coroutineRule.runBlocking {
+    fun whenDeletePersistedFaviconThenDeleteTheFile() = runTest {
 
         val captor = argumentCaptor<List<String>>()
 
@@ -151,13 +151,13 @@ class FileBasedFaviconPersisterTest {
     }
 
     @Test
-    fun whenDeletingNonSpecificFaviconForSubfolderThenDeleteTheDirectory() = coroutineRule.runBlocking {
+    fun whenDeletingNonSpecificFaviconForSubfolderThenDeleteTheDirectory() = runTest {
         testee.deleteFaviconsForSubfolder(testDirectory, subFolder, domain = null)
         verify(mockFileDeleter).deleteDirectory(any())
     }
 
     @Test
-    fun whenDeletingOldFaviconForATabButANewOneExistsThenOnlySingleFaviconDeleted() = coroutineRule.runBlocking {
+    fun whenDeletingOldFaviconForATabButANewOneExistsThenOnlySingleFaviconDeleted() = runTest {
         val newFaviconFilename = "newFavicon"
         val captor = argumentCaptor<List<String>>()
         testee.deleteFaviconsForSubfolder(testDirectory, subFolder, newFaviconFilename)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/httpauth/WebViewHttpAuthStoreTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/httpauth/WebViewHttpAuthStoreTest.kt
@@ -21,15 +21,15 @@ import android.webkit.WebViewDatabase
 import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.fire.AuthDatabaseLocator
 import com.duckduckgo.app.fire.DatabaseCleaner
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -46,7 +46,7 @@ class WebViewHttpAuthStoreTest {
     private val webView: WebView = mock()
     private val databaseLocator = AuthDatabaseLocator(context)
 
-    private val webViewHttpAuthStore = RealWebViewHttpAuthStore(webViewDatabase, mockDatabaseCleaner, databaseLocator, coroutineRule.testDispatcherProvider, TestCoroutineScope())
+    private val webViewHttpAuthStore = RealWebViewHttpAuthStore(webViewDatabase, mockDatabaseCleaner, databaseLocator, coroutineRule.testDispatcherProvider, TestScope())
 
     @Test
     @SdkSuppress(minSdkVersion = android.os.Build.VERSION_CODES.O)
@@ -99,28 +99,28 @@ class WebViewHttpAuthStoreTest {
     }
 
     @Test
-    fun whenCleanHttpAuthDatabaseThenCleanDatabaseCalled() = coroutineRule.runBlocking {
+    fun whenCleanHttpAuthDatabaseThenCleanDatabaseCalled() = runTest {
         webViewHttpAuthStore.cleanHttpAuthDatabase()
         verify(mockDatabaseCleaner).cleanDatabase(databaseLocator.getDatabasePath())
     }
 
     @Test
     @SdkSuppress(minSdkVersion = android.os.Build.VERSION_CODES.LOLLIPOP, maxSdkVersion = android.os.Build.VERSION_CODES.O_MR1)
-    fun whenAppCreatedAndApiBetween21And27ThenJournalModeChangedToDelete() = coroutineRule.runBlocking {
+    fun whenAppCreatedAndApiBetween21And27ThenJournalModeChangedToDelete() = runTest {
         webViewHttpAuthStore.onAppCreated()
         verify(mockDatabaseCleaner).changeJournalModeToDelete(databaseLocator.getDatabasePath())
     }
 
     @Test
     @SdkSuppress(minSdkVersion = android.os.Build.VERSION_CODES.Q)
-    fun whenAppCreatedAndApiGreaterThan28ThenJournalModeChangedToDelete() = coroutineRule.runBlocking {
+    fun whenAppCreatedAndApiGreaterThan28ThenJournalModeChangedToDelete() = runTest {
         webViewHttpAuthStore.onAppCreated()
         verify(mockDatabaseCleaner).changeJournalModeToDelete(databaseLocator.getDatabasePath())
     }
 
     @Test
     @SdkSuppress(minSdkVersion = android.os.Build.VERSION_CODES.P, maxSdkVersion = android.os.Build.VERSION_CODES.P)
-    fun whenAppCreatedAndApiIs28ThenJournalModeChangedToDeleteNotCalled() = coroutineRule.runBlocking {
+    fun whenAppCreatedAndApiIs28ThenJournalModeChangedToDeleteNotCalled() = runTest {
         webViewHttpAuthStore.onAppCreated()
         verify(mockDatabaseCleaner, never()).changeJournalModeToDelete(databaseLocator.getDatabasePath())
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/BrowserTabFireproofDialogsEventHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/BrowserTabFireproofDialogsEventHandlerTest.kt
@@ -20,6 +20,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.blockingObserve
 import com.duckduckgo.app.browser.logindetection.FireproofDialogsEventHandler.Event
 import com.duckduckgo.app.browser.logindetection.FireproofDialogsEventHandler.Event.FireproofWebSiteSuccess
@@ -30,7 +31,6 @@ import com.duckduckgo.app.global.events.db.UserEventEntity
 import com.duckduckgo.app.global.events.db.UserEventKey.*
 import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -87,7 +87,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenFireproofLoginShownBeforeUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenFireproofLoginShownBeforeUserTriedFireButtonThenPixelSent() = runTest {
         testee.onFireproofLoginDialogShown()
 
         verify(mockPixel).fire(
@@ -97,7 +97,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenFireproofLoginShownAfterUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenFireproofLoginShownAfterUserTriedFireButtonThenPixelSent() = runTest {
         givenUserTriedFireButton()
 
         testee.onFireproofLoginDialogShown()
@@ -109,7 +109,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserConfirmsToFireproofWebsiteBeforeUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenUserConfirmsToFireproofWebsiteBeforeUserTriedFireButtonThenPixelSent() = runTest {
         testee.onUserConfirmedFireproofDialog("twitter.com")
 
         verify(mockPixel).fire(
@@ -119,7 +119,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserConfirmsToFireproofWebsiteAfterUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenUserConfirmsToFireproofWebsiteAfterUserTriedFireButtonThenPixelSent() = runTest {
         givenUserTriedFireButton()
 
         testee.onUserConfirmedFireproofDialog("twitter.com")
@@ -131,7 +131,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserConfirmsToFireproofWebsiteThenEventEmitted() = coroutineRule.runBlocking {
+    fun whenUserConfirmsToFireproofWebsiteThenEventEmitted() = runTest {
         testee.onUserConfirmedFireproofDialog("twitter.com")
 
         val event = testee.event.blockingObserve()
@@ -139,14 +139,14 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserConfirmsToFireproofWebsiteThenResetLoginDismissedEvents() = coroutineRule.runBlocking {
+    fun whenUserConfirmsToFireproofWebsiteThenResetLoginDismissedEvents() = runTest {
         testee.onUserConfirmedFireproofDialog("twitter.com")
 
         verify(mockUserEventsStore).removeUserEvent(FIREPROOF_LOGIN_DIALOG_DISMISSED)
     }
 
     @Test
-    fun whenUserDismissesFireproofLoginDialogBeforeUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenUserDismissesFireproofLoginDialogBeforeUserTriedFireButtonThenPixelSent() = runTest {
         testee.onUserDismissedFireproofLoginDialog()
 
         verify(mockPixel).fire(
@@ -156,7 +156,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserDismissesFireproofLoginDialogAfterUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenUserDismissesFireproofLoginDialogAfterUserTriedFireButtonThenPixelSent() = runTest {
         givenUserTriedFireButton()
         testee.onUserDismissedFireproofLoginDialog()
 
@@ -167,14 +167,14 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserDismissedFireproofLoginDialogThenRegisterEvent() = coroutineRule.runBlocking {
+    fun whenUserDismissedFireproofLoginDialogThenRegisterEvent() = runTest {
         testee.onUserDismissedFireproofLoginDialog()
 
         verify(mockUserEventsStore).registerUserEvent(FIREPROOF_LOGIN_DIALOG_DISMISSED)
     }
 
     @Test
-    fun whenUserDismissedFireproofLoginDialogTwiceInRowThenAskToDisableLoginDetection() = coroutineRule.runBlocking {
+    fun whenUserDismissedFireproofLoginDialogTwiceInRowThenAskToDisableLoginDetection() = runTest {
         givenUserPreviouslyDismissedDialog()
 
         testee.onUserDismissedFireproofLoginDialog()
@@ -184,7 +184,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserEnabledFireproofLoginDetectionThenNeverAskToDisableIt() = coroutineRule.runBlocking {
+    fun whenUserEnabledFireproofLoginDetectionThenNeverAskToDisableIt() = runTest {
         givenUserEnabledFireproofLoginDetection()
         givenUserPreviouslyDismissedDialog()
 
@@ -195,7 +195,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserDidNotDisableLoginDetectionThenNeverAskToDisableItAgain() = coroutineRule.runBlocking {
+    fun whenUserDidNotDisableLoginDetectionThenNeverAskToDisableItAgain() = runTest {
         givenUserDidNotDisableLoginDetection()
         givenUserPreviouslyDismissedDialog()
 
@@ -206,7 +206,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenDisableLoginDetectionDialogShownBeforeUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenDisableLoginDetectionDialogShownBeforeUserTriedFireButtonThenPixelSent() = runTest {
         testee.onDisableLoginDetectionDialogShown()
 
         verify(mockPixel).fire(
@@ -216,7 +216,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserConfirmsToDisableLoginDetectionBeforeUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenUserConfirmsToDisableLoginDetectionBeforeUserTriedFireButtonThenPixelSent() = runTest {
         testee.onUserConfirmedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
@@ -226,7 +226,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserConfirmsToDisableLoginDetectionAfterUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenUserConfirmsToDisableLoginDetectionAfterUserTriedFireButtonThenPixelSent() = runTest {
         givenUserTriedFireButton()
 
         testee.onUserConfirmedDisableLoginDetectionDialog()
@@ -238,14 +238,14 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserConfirmsToDisableLoginDetectionThenLoginDetectionDisabled() = coroutineRule.runBlocking {
+    fun whenUserConfirmsToDisableLoginDetectionThenLoginDetectionDisabled() = runTest {
         testee.onUserConfirmedDisableLoginDetectionDialog()
 
         verify(mockAppSettingsPreferencesStore).appLoginDetection = false
     }
 
     @Test
-    fun whenUserDismissesDisableFireproofLoginDialogBeforeUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenUserDismissesDisableFireproofLoginDialogBeforeUserTriedFireButtonThenPixelSent() = runTest {
         testee.onUserDismissedDisableLoginDetectionDialog()
 
         verify(mockPixel).fire(
@@ -255,7 +255,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserDismissesDisableFireproofLoginDialogAfterUserTriedFireButtonThenPixelSent() = coroutineRule.runBlocking {
+    fun whenUserDismissesDisableFireproofLoginDialogAfterUserTriedFireButtonThenPixelSent() = runTest {
         givenUserTriedFireButton()
 
         testee.onUserDismissedDisableLoginDetectionDialog()
@@ -267,7 +267,7 @@ class BrowserTabFireproofDialogsEventHandlerTest {
     }
 
     @Test
-    fun whenUserDismissesDisableFireproofLoginDialogThenRegisterEvent() = coroutineRule.runBlocking {
+    fun whenUserDismissesDisableFireproofLoginDialogThenRegisterEvent() = runTest {
         givenUserTriedFireButton()
 
         testee.onUserDismissedDisableLoginDetectionDialog()

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/JsLoginDetectorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/JsLoginDetectorTest.kt
@@ -24,10 +24,10 @@ import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.browser.logindetection.LoginDetectionJavascriptInterface.Companion.JAVASCRIPT_INTERFACE_NAME
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -44,7 +44,7 @@ class JsLoginDetectorTest {
     @UiThreadTest
     @Test
     @SdkSuppress(minSdkVersion = 24)
-    fun whenAddLoginDetectionThenJSInterfaceAdded() = coroutinesTestRule.runBlocking {
+    fun whenAddLoginDetectionThenJSInterfaceAdded() = runTest {
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))
         testee.addLoginDetection(webView) {}
         verify(webView).addJavascriptInterface(any<LoginDetectionJavascriptInterface>(), eq(JAVASCRIPT_INTERFACE_NAME))
@@ -53,7 +53,7 @@ class JsLoginDetectorTest {
     @UiThreadTest
     @Test
     @SdkSuppress(minSdkVersion = 24)
-    fun whenLoginDetectionDisabledAndPageStartedEventThenNoWebViewInteractions() = coroutinesTestRule.runBlocking {
+    fun whenLoginDetectionDisabledAndPageStartedEventThenNoWebViewInteractions() = runTest {
         whenever(settingsDataStore.appLoginDetection).thenReturn(false)
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))
         testee.onEvent(WebNavigationEvent.OnPageStarted(webView))
@@ -63,7 +63,7 @@ class JsLoginDetectorTest {
     @UiThreadTest
     @Test
     @SdkSuppress(minSdkVersion = 24)
-    fun whenLoginDetectionDisabledAndInterceptRequestEventThenNoWebViewInteractions() = coroutinesTestRule.runBlocking {
+    fun whenLoginDetectionDisabledAndInterceptRequestEventThenNoWebViewInteractions() = runTest {
         whenever(settingsDataStore.appLoginDetection).thenReturn(false)
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))
         val webResourceRequest = aWebResourceRequest()
@@ -74,7 +74,7 @@ class JsLoginDetectorTest {
     @UiThreadTest
     @Test
     @SdkSuppress(minSdkVersion = 24)
-    fun whenLoginDetectionEnabledAndPageStartedEventThenJSLoginDetectionInjected() = coroutinesTestRule.runBlocking {
+    fun whenLoginDetectionEnabledAndPageStartedEventThenJSLoginDetectionInjected() = runTest {
         whenever(settingsDataStore.appLoginDetection).thenReturn(true)
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))
         testee.onEvent(WebNavigationEvent.OnPageStarted(webView))
@@ -84,7 +84,7 @@ class JsLoginDetectorTest {
     @UiThreadTest
     @Test
     @SdkSuppress(minSdkVersion = 24)
-    fun whenLoginDetectionEnabledAndLoginPostRequestCapturedThenJSLoginDetectionInjected() = coroutinesTestRule.runBlocking {
+    fun whenLoginDetectionEnabledAndLoginPostRequestCapturedThenJSLoginDetectionInjected() = runTest {
         whenever(settingsDataStore.appLoginDetection).thenReturn(true)
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))
         val webResourceRequest = aWebResourceRequest("POST", "login")
@@ -95,7 +95,7 @@ class JsLoginDetectorTest {
     @UiThreadTest
     @Test
     @SdkSuppress(minSdkVersion = 24)
-    fun whenLoginDetectionEnabledAndNoLoginPostRequestCapturedThenNoWebViewInteractions() = coroutinesTestRule.runBlocking {
+    fun whenLoginDetectionEnabledAndNoLoginPostRequestCapturedThenNoWebViewInteractions() = runTest {
         whenever(settingsDataStore.appLoginDetection).thenReturn(true)
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))
         val webResourceRequest = aWebResourceRequest("POST", "")
@@ -106,7 +106,7 @@ class JsLoginDetectorTest {
     @UiThreadTest
     @Test
     @SdkSuppress(minSdkVersion = 24)
-    fun whenLoginDetectionEnabledAndGetRequestCapturedThenNoWebViewInteractions() = coroutinesTestRule.runBlocking {
+    fun whenLoginDetectionEnabledAndGetRequestCapturedThenNoWebViewInteractions() = runTest {
         whenever(settingsDataStore.appLoginDetection).thenReturn(true)
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))
         val webResourceRequest = aWebResourceRequest("GET")

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/NextPageLoginDetectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/logindetection/NextPageLoginDetectionTest.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.Observer
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.browser.WebNavigationStateChange
 import com.duckduckgo.app.browser.WebNavigationStateChange.NewPage
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.atLeastOnce
@@ -29,11 +28,9 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.*
+import org.junit.*
 import org.junit.Assert.*
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
 import org.mockito.Mockito.verify
 
 @ExperimentalCoroutinesApi
@@ -47,10 +44,10 @@ class NextPageLoginDetectionTest {
     var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private val mockSettingsDataStore: SettingsDataStore = mock()
-    private val loginDetector = NextPageLoginDetection(mockSettingsDataStore, TestCoroutineScope())
 
     private val loginObserver = mock<Observer<LoginDetected>>()
     private val loginEventCaptor = argumentCaptor<LoginDetected>()
+    private val loginDetector = NextPageLoginDetection(mockSettingsDataStore, coroutineRule.testScope, coroutineRule.testDispatcherProvider)
 
     @Before
     fun setup() {
@@ -58,7 +55,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserForwardedToNewPageThenLoginDetected() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserForwardedToNewPageThenLoginDetected() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
 
@@ -69,7 +66,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedInsideOAuthFlowThenLoginDetectedWhenUserForwardedToDifferentDomain() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedInsideOAuthFlowThenLoginDetectedWhenUserForwardedToDifferentDomain() = runTest {
         givenLoginDetector(enabled = true)
         redirectTo("https://accounts.google.com/o/oauth2/v2/auth")
         giveLoginDetectorChanceToExecute()
@@ -89,7 +86,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedInsideSSOFlowThenLoginDetectedWhenUserForwardedToDifferentDomain() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedInsideSSOFlowThenLoginDetectedWhenUserForwardedToDifferentDomain() = runTest {
         givenLoginDetector(enabled = true)
         fullyLoadSite("https://app.asana.com/-/login")
         giveLoginDetectorChanceToExecute()
@@ -109,7 +106,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedSkip2FAUrlsThenLoginDetectedForLatestOne() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedSkip2FAUrlsThenLoginDetectedForLatestOne() = runTest {
         givenLoginDetector(enabled = true)
         fullyLoadSite("https://accounts.google.com/ServiceLogin")
         giveLoginDetectorChanceToExecute()
@@ -127,7 +124,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserForwardedToMultipleNewPagesThenLoginDetectedForLatestOne() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserForwardedToMultipleNewPagesThenLoginDetectedForLatestOne() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
 
@@ -142,7 +139,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserForwardedToSamePageThenLoginNotDetected() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserForwardedToSamePageThenLoginNotDetected() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
 
@@ -153,7 +150,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenNotDetectedLoginAttemptAndForwardedToNewPageThenLoginNotDetected() = coroutineRule.runBlocking {
+    fun whenNotDetectedLoginAttemptAndForwardedToNewPageThenLoginNotDetected() = runTest {
         givenLoginDetector(enabled = true)
         fullyLoadSite("http://example.com")
         giveLoginDetectorChanceToExecute()
@@ -162,7 +159,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserForwardedToNewUrlThenLoginDetected() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserForwardedToNewUrlThenLoginDetected() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
 
@@ -174,7 +171,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserForwardedToSameUrlThenLoginNotDetected() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserForwardedToSameUrlThenLoginNotDetected() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
 
@@ -186,7 +183,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenNotDetectedLoginAttemptAndForwardedToNewUrlThenLoginNotDetected() = coroutineRule.runBlocking {
+    fun whenNotDetectedLoginAttemptAndForwardedToNewUrlThenLoginNotDetected() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.WebNavigationEvent(WebNavigationStateChange.UrlUpdated(url = "http://example.com")))
         loginDetector.onEvent(NavigationEvent.PageFinished)
@@ -196,7 +193,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndNextPageFinishedThenLoadingNewPageDoesNotDetectLogin() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndNextPageFinishedThenLoadingNewPageDoesNotDetectLogin() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
         loginDetector.onEvent(NavigationEvent.PageFinished)
@@ -209,7 +206,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserNavigatesBackThenNewPageDoesNotDetectLogin() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserNavigatesBackThenNewPageDoesNotDetectLogin() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
         loginDetector.onEvent(NavigationEvent.UserAction.NavigateBack)
@@ -221,7 +218,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserNavigatesForwardThenNewPageDoesNotDetectLogin() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserNavigatesForwardThenNewPageDoesNotDetectLogin() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
         loginDetector.onEvent(NavigationEvent.UserAction.NavigateForward)
@@ -233,7 +230,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserReloadsWebsiteThenNewPageDoesNotDetectLogin() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserReloadsWebsiteThenNewPageDoesNotDetectLogin() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
         loginDetector.onEvent(NavigationEvent.UserAction.Refresh)
@@ -245,7 +242,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserSubmitsNewQueryThenNewPageDoesNotDetectLogin() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserSubmitsNewQueryThenNewPageDoesNotDetectLogin() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
         loginDetector.onEvent(NavigationEvent.UserAction.NewQuerySubmitted)
@@ -257,7 +254,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedHasInvalidURLThenNewPageDoesNotDetectLogin() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedHasInvalidURLThenNewPageDoesNotDetectLogin() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt(""))
 
@@ -268,7 +265,7 @@ class NextPageLoginDetectionTest {
     }
 
     @Test
-    fun whenLoginAttemptedAndUserForwardedToInvalidNewPageThenLoginDetected() = coroutineRule.runBlocking {
+    fun whenLoginAttemptedAndUserForwardedToInvalidNewPageThenLoginDetected() = runTest {
         givenLoginDetector(enabled = true)
         loginDetector.onEvent(NavigationEvent.LoginAttempt("http://example.com/login"))
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/rating/db/AppEnjoymentDatabaseRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/rating/db/AppEnjoymentDatabaseRepositoryTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.rating.PromptCount
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -30,6 +30,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 @Suppress("RemoveExplicitTypeArguments")
 class AppEnjoymentDatabaseRepositoryTest {
 
@@ -58,66 +59,66 @@ class AppEnjoymentDatabaseRepositoryTest {
     }
 
     @Test
-    fun whenFirstCreatedThenPrompt1CanBeShown() = runBlocking<Unit> {
+    fun whenFirstCreatedThenPrompt1CanBeShown() = runTest {
         assertTrue(testee.canUserBeShownFirstPrompt())
     }
 
     @Test
-    fun whenUserGaveFeedbackForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+    fun whenUserGaveFeedbackForPrompt1ThenPrompt1CannotBeShown() = runTest {
         testee.onUserSelectedToGiveFeedback(FIRST_PROMPT)
         assertFalse(testee.canUserBeShownFirstPrompt())
     }
 
     @Test
-    fun whenUserDeclinedToGiveFeedbackForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+    fun whenUserDeclinedToGiveFeedbackForPrompt1ThenPrompt1CannotBeShown() = runTest {
         testee.onUserDeclinedToGiveFeedback(FIRST_PROMPT)
         assertFalse(testee.canUserBeShownFirstPrompt())
     }
 
     @Test
-    fun whenUserGaveRatingForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+    fun whenUserGaveRatingForPrompt1ThenPrompt1CannotBeShown() = runTest {
         testee.onUserSelectedToRateApp(FIRST_PROMPT)
         assertFalse(testee.canUserBeShownFirstPrompt())
     }
 
     @Test
-    fun whenUserDeclinedRatingForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+    fun whenUserDeclinedRatingForPrompt1ThenPrompt1CannotBeShown() = runTest {
         testee.onUserDeclinedToRateApp(FIRST_PROMPT)
         assertFalse(testee.canUserBeShownFirstPrompt())
     }
 
     @Test
-    fun whenUserDeclinedToSayWhetherEnjoyingForPrompt1ThenPrompt1CannotBeShown() = runBlocking<Unit> {
+    fun whenUserDeclinedToSayWhetherEnjoyingForPrompt1ThenPrompt1CannotBeShown() = runTest {
         testee.onUserDeclinedToSayIfEnjoyingApp(FIRST_PROMPT)
         assertFalse(testee.canUserBeShownFirstPrompt())
     }
 
     @Test
-    fun whenUserGaveFeedbackForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+    fun whenUserGaveFeedbackForPrompt2ThenPrompt2CannotBeShownAgain() = runTest {
         testee.onUserSelectedToGiveFeedback(SECOND_PROMPT)
         assertFalse(testee.canUserBeShownSecondPrompt())
     }
 
     @Test
-    fun whenUserDeclinedToGiveFeedbackForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+    fun whenUserDeclinedToGiveFeedbackForPrompt2ThenPrompt2CannotBeShownAgain() = runTest {
         testee.onUserDeclinedToGiveFeedback(SECOND_PROMPT)
         assertFalse(testee.canUserBeShownSecondPrompt())
     }
 
     @Test
-    fun whenUserGaveRatingForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+    fun whenUserGaveRatingForPrompt2ThenPrompt2CannotBeShownAgain() = runTest {
         testee.onUserSelectedToRateApp(SECOND_PROMPT)
         assertFalse(testee.canUserBeShownSecondPrompt())
     }
 
     @Test
-    fun whenUserDeclinedRatingForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+    fun whenUserDeclinedRatingForPrompt2ThenPrompt2CannotBeShownAgain() = runTest {
         testee.onUserDeclinedToRateApp(SECOND_PROMPT)
         assertFalse(testee.canUserBeShownSecondPrompt())
     }
 
     @Test
-    fun whenUserDeclinedToSayWhetherEnjoyingForPrompt2ThenPrompt2CannotBeShownAgain() = runBlocking<Unit> {
+    fun whenUserDeclinedToSayWhetherEnjoyingForPrompt2ThenPrompt2CannotBeShownAgain() = runTest {
         testee.onUserDeclinedToSayIfEnjoyingApp(SECOND_PROMPT)
         assertFalse(testee.canUserBeShownSecondPrompt())
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/serviceworker/BrowserServiceWorkerClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/serviceworker/BrowserServiceWorkerClientTest.kt
@@ -21,11 +21,11 @@ import androidx.test.filters.SdkSuppress
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.browser.RequestInterceptor
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -48,7 +48,7 @@ class BrowserServiceWorkerClientTest {
     }
 
     @Test
-    fun whenShouldInterceptRequestAndOriginHeaderExistThenSendItToInterceptor() = coroutinesTestRule.runBlocking {
+    fun whenShouldInterceptRequestAndOriginHeaderExistThenSendItToInterceptor() = runTest {
         val webResourceRequest: WebResourceRequest = mock()
         whenever(webResourceRequest.requestHeaders).thenReturn(mapOf("Origin" to "example.com"))
 
@@ -58,7 +58,7 @@ class BrowserServiceWorkerClientTest {
     }
 
     @Test
-    fun whenShouldInterceptRequestAndOriginHeaderDoesNotExistButRefererExistThenSendItToInterceptor() = coroutinesTestRule.runBlocking {
+    fun whenShouldInterceptRequestAndOriginHeaderDoesNotExistButRefererExistThenSendItToInterceptor() = runTest {
         val webResourceRequest: WebResourceRequest = mock()
         whenever(webResourceRequest.requestHeaders).thenReturn(mapOf("Referer" to "example.com"))
 
@@ -68,7 +68,7 @@ class BrowserServiceWorkerClientTest {
     }
 
     @Test
-    fun whenShouldInterceptRequestAndNoOriginOrRefererHeadersExistThenSendNullToInterceptor() = coroutinesTestRule.runBlocking {
+    fun whenShouldInterceptRequestAndNoOriginOrRefererHeadersExistThenSendNullToInterceptor() = runTest {
         val webResourceRequest: WebResourceRequest = mock()
         whenever(webResourceRequest.requestHeaders).thenReturn(mapOf())
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/shortcut/ShortcutReceiverTest.kt
@@ -24,7 +24,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,7 +41,7 @@ class ShortcutReceiverTest {
     @Before
     fun before() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-        testee = ShortcutReceiver(context, mockPixel, coroutinesTestRule.testDispatcherProvider, TestCoroutineScope())
+        testee = ShortcutReceiver(context, mockPixel, coroutinesTestRule.testDispatcherProvider, TestScope())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/tabpreview/FileBasedWebViewPreviewPersisterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/tabpreview/FileBasedWebViewPreviewPersisterTest.kt
@@ -24,13 +24,15 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.File
 
+@ExperimentalCoroutinesApi
 class FileBasedWebViewPreviewPersisterTest {
 
     private lateinit var testee: FileBasedWebViewPreviewPersister
@@ -68,7 +70,7 @@ class FileBasedWebViewPreviewPersisterTest {
     }
 
     @Test
-    fun whenDeleteAllCalledThenEntireTabPreviewDirectoryDeleted() = runBlocking<Unit> {
+    fun whenDeleteAllCalledThenEntireTabPreviewDirectoryDeleted() = runTest {
         testee.deleteAll()
         val captor = argumentCaptor<File>()
         verify(mockFileDeleter).deleteDirectory(captor.capture())
@@ -76,14 +78,14 @@ class FileBasedWebViewPreviewPersisterTest {
     }
 
     @Test
-    fun whenDeletingOnlyPreviewForATabThenTabDirectoryRemoved() = runBlocking<Unit> {
+    fun whenDeletingOnlyPreviewForATabThenTabDirectoryRemoved() = runTest {
         val tabId = "ABC-123"
         testee.deletePreviewsForTab(tabId, currentPreviewImage = null)
         verify(mockFileDeleter).deleteDirectory(any())
     }
 
     @Test
-    fun whenDeletingOldPreviewForATabButANewOneExistsThenOnlySinglePreviewImageDeleted() = runBlocking<Unit> {
+    fun whenDeletingOldPreviewForATabButANewOneExistsThenOnlySinglePreviewImageDeleted() = runTest {
         val tabId = "ABC-123"
         val newTabPreviewFilename = "new.jpg"
         val captor = argumentCaptor<List<String>>()

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -35,17 +35,16 @@ import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.privacy.model.HttpsStatus
 import com.duckduckgo.app.privacy.model.PrivacyGrade
 import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.model.TestEntity
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.statistics.VariantManager.Companion.ACTIVE_VARIANTS
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.model.Survey.Status.SCHEDULED
@@ -57,11 +56,10 @@ import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
@@ -177,42 +175,42 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenScheduledSurveyChangesAndInstalledDaysIsMinusOneThenCtaIsSurvey() = coroutineRule.runBlocking {
+    fun whenScheduledSurveyChangesAndInstalledDaysIsMinusOneThenCtaIsSurvey() = runTest {
         testee.onSurveyChanged(Survey("abc", "http://example.com", -1, SCHEDULED))
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, site = null, locale = Locale.US)
         assertTrue(value is HomePanelCta.Survey)
     }
 
     @Test
-    fun whenScheduledSurveyChangesAndInstalledDaysMatchAndLocaleIsUsThenCtaIsSurvey() = coroutineRule.runBlocking {
+    fun whenScheduledSurveyChangesAndInstalledDaysMatchAndLocaleIsUsThenCtaIsSurvey() = runTest {
         testee.onSurveyChanged(Survey("abc", "http://example.com", 1, SCHEDULED))
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, site = null, locale = Locale.US)
         assertTrue(value is HomePanelCta.Survey)
     }
 
     @Test
-    fun whenScheduledSurveyChangesAndInstalledDaysMatchAndLocaleIsUkThenCtaIsSurvey() = coroutineRule.runBlocking {
+    fun whenScheduledSurveyChangesAndInstalledDaysMatchAndLocaleIsUkThenCtaIsSurvey() = runTest {
         testee.onSurveyChanged(Survey("abc", "http://example.com", 1, SCHEDULED))
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, site = null, locale = Locale.UK)
         assertTrue(value is HomePanelCta.Survey)
     }
 
     @Test
-    fun whenScheduledSurveyChangesAndInstalledDaysMatchAndLocaleIsCanadaThenCtaIsSurvey() = coroutineRule.runBlocking {
+    fun whenScheduledSurveyChangesAndInstalledDaysMatchAndLocaleIsCanadaThenCtaIsSurvey() = runTest {
         testee.onSurveyChanged(Survey("abc", "http://example.com", 1, SCHEDULED))
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, site = null, locale = Locale.CANADA)
         assertTrue(value is HomePanelCta.Survey)
     }
 
     @Test
-    fun whenScheduledSurveyChangesAndInstalledDaysMatchButLocaleIsNotUsCanadaOrUkThenCtaIsNotSurvey() = coroutineRule.runBlocking {
+    fun whenScheduledSurveyChangesAndInstalledDaysMatchButLocaleIsNotUsCanadaOrUkThenCtaIsNotSurvey() = runTest {
         testee.onSurveyChanged(Survey("abc", "http://example.com", 1, SCHEDULED))
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, site = null, locale = Locale.FRANCE)
         assertFalse(value is HomePanelCta.Survey)
     }
 
     @Test
-    fun whenScheduledSurveyIsNullThenCtaIsNotSurvey() = coroutineRule.runBlocking {
+    fun whenScheduledSurveyIsNullThenCtaIsNotSurvey() = runTest {
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, site = null, locale = Locale.US)
         assertFalse(value is HomePanelCta.Survey)
     }
@@ -263,26 +261,26 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenCtaDismissedPixelIsFired() = coroutineRule.runBlocking {
+    fun whenCtaDismissedPixelIsFired() = runTest {
         testee.onUserDismissedCta(HomePanelCta.Survey(Survey("abc", "http://example.com", 1, SCHEDULED)))
         verify(mockPixel).fire(eq(SURVEY_CTA_DISMISSED), any(), any())
     }
 
     @Test
-    fun whenSurveyCtaDismissedThenScheduledSurveysAreCancelled() = coroutineRule.runBlocking {
+    fun whenSurveyCtaDismissedThenScheduledSurveysAreCancelled() = runTest {
         testee.onUserDismissedCta(HomePanelCta.Survey(Survey("abc", "http://example.com", 1, SCHEDULED)))
         verify(mockSurveyDao).cancelScheduledSurveys()
         verify(mockDismissedCtaDao, never()).insert(any())
     }
 
     @Test
-    fun whenNonSurveyCtaDismissedCtaThenDatabaseNotified() = coroutineRule.runBlocking {
+    fun whenNonSurveyCtaDismissedCtaThenDatabaseNotified() = runTest {
         testee.onUserDismissedCta(HomePanelCta.AddWidgetAuto)
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.ADD_WIDGET))
     }
 
     @Test
-    fun whenCtaDismissedAndUserHasPendingOnboardingCtasThenStageNotCompleted() = coroutineRule.runBlocking {
+    fun whenCtaDismissedAndUserHasPendingOnboardingCtasThenStageNotCompleted() = runTest {
         givenOnboardingActive()
         givenShownDaxOnboardingCtas(emptyList())
         testee.onUserDismissedCta(DaxBubbleCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore))
@@ -290,7 +288,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenCtaDismissedAndAllDaxOnboardingCtasShownThenStageCompleted() = coroutineRule.runBlocking {
+    fun whenCtaDismissedAndAllDaxOnboardingCtasShownThenStageCompleted() = runTest {
         givenOnboardingActive()
         givenShownDaxOnboardingCtas(requiredDaxOnboardingCtas)
         testee.onUserDismissedCta(DaxDialogCta.DaxSerpCta(mockOnboardingStore, mockAppInstallStore))
@@ -298,37 +296,37 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenHideTipsForeverThenPixelIsFired() = coroutineRule.runBlocking {
+    fun whenHideTipsForeverThenPixelIsFired() = runTest {
         testee.hideTipsForever(HomePanelCta.AddWidgetAuto)
         verify(mockPixel).fire(eq(ONBOARDING_DAX_ALL_CTA_HIDDEN), any(), any())
     }
 
     @Test
-    fun whenHideTipsForeverThenHideTipsSetToTrueOnSettings() = coroutineRule.runBlocking {
+    fun whenHideTipsForeverThenHideTipsSetToTrueOnSettings() = runTest {
         testee.hideTipsForever(HomePanelCta.AddWidgetAuto)
         verify(mockSettingsDataStore).hideTips = true
     }
 
     @Test
-    fun whenHideTipsForeverThenDaxOnboardingStageCompleted() = coroutineRule.runBlocking {
+    fun whenHideTipsForeverThenDaxOnboardingStageCompleted() = runTest {
         testee.hideTipsForever(HomePanelCta.AddWidgetAuto)
         verify(mockUserStageStore).stageCompleted(AppStage.DAX_ONBOARDING)
     }
 
     @Test
-    fun whenRegisterDaxBubbleIntroCtaThenDatabaseNotified() = coroutineRule.runBlocking {
+    fun whenRegisterDaxBubbleIntroCtaThenDatabaseNotified() = runTest {
         testee.registerDaxBubbleCtaDismissed(DaxBubbleCta.DaxIntroCta(mockOnboardingStore, mockAppInstallStore))
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_INTRO))
     }
 
     @Test
-    fun whenRegisterDaxBubbleEndCtaThenDatabaseNotified() = coroutineRule.runBlocking {
+    fun whenRegisterDaxBubbleEndCtaThenDatabaseNotified() = runTest {
         testee.registerDaxBubbleCtaDismissed(DaxBubbleCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore))
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_END))
     }
 
     @Test
-    fun whenRegisterCtaAndUserHasPendingOnboardingCtasThenStageNotCompleted() = coroutineRule.runBlocking {
+    fun whenRegisterCtaAndUserHasPendingOnboardingCtasThenStageNotCompleted() = runTest {
         givenOnboardingActive()
         givenShownDaxOnboardingCtas(emptyList())
         testee.registerDaxBubbleCtaDismissed(DaxBubbleCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore))
@@ -336,7 +334,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRegisterCtaAndAllDaxOnboardingCtasShownThenStageCompleted() = coroutineRule.runBlocking {
+    fun whenRegisterCtaAndAllDaxOnboardingCtasShownThenStageCompleted() = runTest {
         givenOnboardingActive()
         givenShownDaxOnboardingCtas(requiredDaxOnboardingCtas)
         testee.registerDaxBubbleCtaDismissed(DaxBubbleCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore))
@@ -344,13 +342,13 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingAndSiteIsNullThenReturnNull() = coroutineRule.runBlocking {
+    fun whenRefreshCtaWhileBrowsingAndSiteIsNullThenReturnNull() = runTest {
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = null)
         assertNull(value)
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingAndHideTipsIsTrueThenReturnNull() = coroutineRule.runBlocking {
+    fun whenRefreshCtaWhileBrowsingAndHideTipsIsTrueThenReturnNull() = runTest {
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
 
@@ -359,7 +357,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueAndWidgetCompatibleThenReturnWidgetCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueAndWidgetCompatibleThenReturnWidgetCta() = runTest {
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
@@ -369,7 +367,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingAndPrivacyOffForSiteThenReturnNull() = coroutineRule.runBlocking {
+    fun whenRefreshCtaWhileBrowsingAndPrivacyOffForSiteThenReturnNull() = runTest {
         givenDaxOnboardingActive()
         whenever(mockUserWhitelistDao.contains(any())).thenReturn(true)
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
@@ -379,7 +377,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnWidgetAutoCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnWidgetAutoCta() = runTest {
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
@@ -390,7 +388,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnWidgetInstructionsCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnWidgetInstructionsCta() = runTest {
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
@@ -401,7 +399,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingMajorTrackerSiteThenReturnNetworkCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaWhileBrowsingMajorTrackerSiteThenReturnNetworkCta() = runTest {
         givenDaxOnboardingActive()
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
         val expectedCtaText = context.resources.getString(
@@ -418,7 +416,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingOnSiteOwnedByMajorTrackerThenReturnNetworkCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaWhileBrowsingOnSiteOwnedByMajorTrackerThenReturnNetworkCta() = runTest {
         givenDaxOnboardingActive()
         val site = site(url = "http://m.instagram.com", entity = TestEntity("Facebook", "Facebook", 9.0))
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site) as DaxDialogCta
@@ -434,7 +432,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingThenReturnTrackersBlockedCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaWhileBrowsingThenReturnTrackersBlockedCta() = runTest {
         givenDaxOnboardingActive()
         val trackingEvent = TrackingEvent("test.com", "test.com", null, TestEntity("test", "test", 9.0), true, null)
         val site = site(url = "http://www.cnn.com", trackerCount = 1, events = listOf(trackingEvent))
@@ -444,7 +442,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingAndTrackersAreNotMajorThenReturnTrackersBlockedCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaWhileBrowsingAndTrackersAreNotMajorThenReturnTrackersBlockedCta() = runTest {
         givenDaxOnboardingActive()
         val trackingEvent = TrackingEvent("test.com", "test.com", null, TestEntity("test", "test", 0.123), true, null)
         val site = site(url = "http://www.cnn.com", trackerCount = 1, events = listOf(trackingEvent))
@@ -454,7 +452,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingAndNoTrackersInformationThenReturnNoSerpCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaWhileBrowsingAndNoTrackersInformationThenReturnNoSerpCta() = runTest {
         givenDaxOnboardingActive()
         val site = site(url = "http://www.cnn.com", trackerCount = 1)
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
@@ -463,7 +461,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnSerpWhileBrowsingThenReturnSerpCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnSerpWhileBrowsingThenReturnSerpCta() = runTest {
         givenDaxOnboardingActive()
         val site = site(url = "http://www.duckduckgo.com")
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
@@ -472,7 +470,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingThenReturnNoSerpCta() = coroutineRule.runBlocking {
+    fun whenRefreshCtaWhileBrowsingThenReturnNoSerpCta() = runTest {
         givenDaxOnboardingActive()
         val site = site(url = "http://www.wikipedia.com")
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
@@ -481,7 +479,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabThenValueReturnedIsNotDaxDialogCtaType() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabThenValueReturnedIsNotDaxDialogCtaType() = runTest {
         givenDaxOnboardingActive()
         val site = site(url = "http://www.wikipedia.com")
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, site = site)
@@ -490,7 +488,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndIntroCtaWasNotPreviouslyShownThenIntroCtaShown() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabAndIntroCtaWasNotPreviouslyShownThenIntroCtaShown() = runTest {
         givenDaxOnboardingActive()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(false)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
@@ -500,7 +498,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndIntroCtaWasShownThenFireproofCtaShown() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabAndIntroCtaWasShownThenFireproofCtaShown() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(ACTIVE_VARIANTS.first { it.key == "mj" })
 
         givenDaxOnboardingActive()
@@ -512,7 +510,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndFireproofCtaWasShownThenEndCtaShown() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabAndFireproofCtaWasShownThenEndCtaShown() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(ACTIVE_VARIANTS.first { it.key == "mj" })
 
         givenDaxOnboardingActive()
@@ -525,7 +523,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndIntroCtaWasShownThenEndCtaShown() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabAndIntroCtaWasShownThenEndCtaShown() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(ACTIVE_VARIANTS.first { it.key == "mi" })
 
         givenDaxOnboardingActive()
@@ -537,7 +535,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaWhileBrowsingWithDaxOnboardingCompletedButNotAllCtasWereShownThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaWhileBrowsingWithDaxOnboardingCompletedButNotAllCtasWereShownThenReturnNull() = runTest {
         givenShownDaxOnboardingCtas(listOf(CtaId.DAX_INTRO))
         givenUserIsEstablished()
 
@@ -546,13 +544,13 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaInHomeTabDuringFavoriteOnboardingThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaInHomeTabDuringFavoriteOnboardingThenReturnNull() = runTest {
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, favoritesOnboarding = true)
         assertTrue(value is BubbleCta.DaxFavoritesOnboardingCta)
     }
 
     @Test
-    fun whenRefreshCtaWhileDaxOnboardingActiveAndBrowsingOnDuckDuckGoEmailUrlThenReturnNull() = runBlockingTest {
+    fun whenRefreshCtaWhileDaxOnboardingActiveAndBrowsingOnDuckDuckGoEmailUrlThenReturnNull() = runTest {
         givenDaxOnboardingActive()
         val site = site(url = "https://duckduckgo.com/email/")
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
@@ -560,7 +558,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenUserHidesAllTipsThenFireButtonAnimationShouldNotShow() = coroutineRule.runBlocking {
+    fun whenUserHidesAllTipsThenFireButtonAnimationShouldNotShow() = runTest {
         givenOnboardingActive()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
 
@@ -568,7 +566,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenUserHasTwoOrMoreTabsThenFireButtonAnimationShouldNotShow() = coroutineRule.runBlocking {
+    fun whenUserHasTwoOrMoreTabsThenFireButtonAnimationShouldNotShow() = runTest {
         givenOnboardingActive()
         db.tabsDao().insertTab(TabEntity(tabId = "0", position = 0))
         db.tabsDao().insertTab(TabEntity(tabId = "1", position = 1))
@@ -577,7 +575,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenFireAnimationStopsThenDaxFireButtonDisabled() = coroutineRule.runBlocking {
+    fun whenFireAnimationStopsThenDaxFireButtonDisabled() = runTest {
         givenOnboardingActive()
         db.tabsDao().insertTab(TabEntity(tabId = "0", position = 0))
         db.tabsDao().insertTab(TabEntity(tabId = "1", position = 1))
@@ -588,7 +586,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenFireButtonAnimationActiveAndUserOpensANewTabThenFireButtonAnimationStops() = coroutineRule.runBlocking {
+    fun whenFireButtonAnimationActiveAndUserOpensANewTabThenFireButtonAnimationStops() = runTest {
         givenOnboardingActive()
         db.tabsDao().insertTab(TabEntity(tabId = "0", position = 0))
         db.dismissedCtaDao().insert(DismissedCta(CtaId.DAX_DIALOG_TRACKERS_FOUND))
@@ -603,7 +601,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenUserHasAlreadySeenFireButtonCtaThenFireButtonAnimationShouldNotShow() = coroutineRule.runBlocking {
+    fun whenUserHasAlreadySeenFireButtonCtaThenFireButtonAnimationShouldNotShow() = runTest {
         givenOnboardingActive()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON)).thenReturn(true)
 
@@ -611,7 +609,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenUserHasAlreadySeenFireButtonPulseAnimationThenFireButtonAnimationShouldNotShow() = coroutineRule.runBlocking {
+    fun whenUserHasAlreadySeenFireButtonPulseAnimationThenFireButtonAnimationShouldNotShow() = runTest {
         givenOnboardingActive()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON_PULSE)).thenReturn(true)
 
@@ -619,7 +617,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenTipsActiveAndUserSeesAnyTriggerFirePulseAnimationCtaThenFireButtonAnimationShouldShow() = coroutineRule.runBlocking {
+    fun whenTipsActiveAndUserSeesAnyTriggerFirePulseAnimationCtaThenFireButtonAnimationShouldShow() = runTest {
         givenOnboardingActive()
         val willTriggerFirePulseAnimationCtas = listOf(CtaId.DAX_DIALOG_TRACKERS_FOUND, CtaId.DAX_DIALOG_NETWORK, CtaId.DAX_DIALOG_OTHER)
         val launch = launch {
@@ -635,7 +633,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenFirePulseAnimationDismissedThenCtaInsertedInDatabase() = coroutineRule.runBlocking {
+    fun whenFirePulseAnimationDismissedThenCtaInsertedInDatabase() = runTest {
         testee.dismissPulseAnimation()
 
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_FIRE_BUTTON))
@@ -643,7 +641,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenOnboardingCompletedThenNewDismissedCtasDoNotEmitValues() = coroutineRule.runBlocking {
+    fun whenOnboardingCompletedThenNewDismissedCtasDoNotEmitValues() = runTest {
         givenDaxOnboardingCompleted()
         val launch = launch {
             testee.showFireButtonPulseAnimation.collect { /* noop */ }
@@ -659,7 +657,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenTipsActiveAndUserSeesAnyNonTriggerFirePulseAnimationCtaThenFireButtonAnimationShouldNotShow() = coroutineRule.runBlocking {
+    fun whenTipsActiveAndUserSeesAnyNonTriggerFirePulseAnimationCtaThenFireButtonAnimationShouldNotShow() = runTest {
         givenOnboardingActive()
         val willTriggerFirePulseAnimationCtas = listOf(CtaId.DAX_DIALOG_TRACKERS_FOUND, CtaId.DAX_DIALOG_NETWORK, CtaId.DAX_DIALOG_OTHER)
         val willNotTriggerFirePulseAnimationCtas = CtaId.values().toList() - willTriggerFirePulseAnimationCtas
@@ -677,7 +675,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenFirstTimeUserClicksOnFireButtonThenFireDialogCtaReturned() = coroutineRule.runBlocking {
+    fun whenFirstTimeUserClicksOnFireButtonThenFireDialogCtaReturned() = runTest {
         givenOnboardingActive()
 
         val fireDialogCta = testee.getFireDialogCta()
@@ -686,7 +684,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenFirstTimeUserClicksOnFireButtonButUserHidAllTipsThenFireDialogCtaIsNull() = coroutineRule.runBlocking {
+    fun whenFirstTimeUserClicksOnFireButtonButUserHidAllTipsThenFireDialogCtaIsNull() = runTest {
         givenOnboardingActive()
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
 
@@ -696,7 +694,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenFireCtaDismissedThenFireDialogCtaIsNull() = coroutineRule.runBlocking {
+    fun whenFireCtaDismissedThenFireDialogCtaIsNull() = runTest {
         givenOnboardingActive()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON)).thenReturn(true)
 
@@ -706,7 +704,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndReturningUsersNoOnboardingEnabledTrueAndWidgetCompatibleThenReturnNull() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabAndReturningUsersNoOnboardingEnabledTrueAndWidgetCompatibleThenReturnNull() = runTest {
         whenever(mockSettingsDataStore.hideTips).thenReturn(false)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
@@ -719,7 +717,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaOnHomeTabAndReturningUsersNoOnboardingEnabledTrueAndAboveThresholdAndWidgetCompatibleThenReturnWidget() = coroutineRule.runBlocking {
+    fun whenRefreshCtaOnHomeTabAndReturningUsersNoOnboardingEnabledTrueAndAboveThresholdAndWidgetCompatibleThenReturnWidget() = runTest {
         whenever(mockSettingsDataStore.hideTips).thenReturn(false)
         whenever(mockWidgetCapabilities.supportsStandardWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)

--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubCoroutinesModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubCoroutinesModule.kt
@@ -23,7 +23,9 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@ExperimentalCoroutinesApi
 @Module
 @ContributesTo(
     scope = AppScope::class,

--- a/app/src/androidTest/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
@@ -18,21 +18,27 @@ package com.duckduckgo.app.email
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.email.AppEmailManager.WaitlistState.*
 import com.duckduckgo.app.email.AppEmailManager.Companion.DUCK_EMAIL_DOMAIN
 import com.duckduckgo.app.email.AppEmailManager.Companion.UNKNOWN_COHORT
+import com.duckduckgo.app.email.AppEmailManager.WaitlistState.InBeta
+import com.duckduckgo.app.email.AppEmailManager.WaitlistState.JoinedQueue
+import com.duckduckgo.app.email.AppEmailManager.WaitlistState.NotJoinedQueue
 import com.duckduckgo.app.email.api.EmailAlias
 import com.duckduckgo.app.email.api.EmailInviteCodeResponse
 import com.duckduckgo.app.email.api.EmailService
 import com.duckduckgo.app.email.api.WaitlistResponse
 import com.duckduckgo.app.email.api.WaitlistStatusResponse
 import com.duckduckgo.app.email.db.EmailDataStore
-import com.duckduckgo.app.runBlocking
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -57,11 +63,11 @@ class AppEmailManagerTest {
 
     @Before
     fun setup() {
-        testee = AppEmailManager(mockEmailService, mockEmailDataStore, coroutineRule.testDispatcherProvider, TestCoroutineScope())
+        testee = AppEmailManager(mockEmailService, mockEmailDataStore, coroutineRule.testDispatcherProvider, TestScope())
     }
 
     @Test
-    fun whenFetchAliasFromServiceThenStoreAliasAddingDuckDomain() = coroutineRule.runBlocking {
+    fun whenFetchAliasFromServiceThenStoreAliasAddingDuckDomain() = runTest {
         mockEmailDataStore.emailToken = "token"
         whenever(mockEmailService.newAlias(any())).thenReturn(EmailAlias("test"))
         testee.getAlias()
@@ -70,7 +76,7 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenFetchAliasFromServiceAndTokenDoesNotExistThenDoNothing() = coroutineRule.runBlocking {
+    fun whenFetchAliasFromServiceAndTokenDoesNotExistThenDoNothing() = runTest {
         mockEmailDataStore.emailToken = null
         testee.getAlias()
 
@@ -78,7 +84,7 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenFetchAliasFromServiceAndAddressIsBlankThenStoreNull() = coroutineRule.runBlocking {
+    fun whenFetchAliasFromServiceAndAddressIsBlankThenStoreNull() = runTest {
         mockEmailDataStore.emailToken = "token"
         whenever(mockEmailService.newAlias(any())).thenReturn(EmailAlias(""))
         testee.getAlias()
@@ -87,7 +93,7 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenGetAliasThenReturnNextAlias() = coroutineRule.runBlocking {
+    fun whenGetAliasThenReturnNextAlias() = runTest {
         givenNextAliasExists()
 
         assertEquals("alias", testee.getAlias())
@@ -130,7 +136,7 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenStoreCredentialsThenGenerateNewAlias() = coroutineRule.runBlocking {
+    fun whenStoreCredentialsThenGenerateNewAlias() = runTest {
         mockEmailDataStore.emailToken = "token"
         whenever(mockEmailService.newAlias(any())).thenReturn(EmailAlias(""))
 
@@ -149,14 +155,14 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenStoreCredentialsIfCredentialsWereCorrectlyStoredThenIsSignedInChannelSendsTrue() = coroutineRule.runBlocking {
+    fun whenStoreCredentialsIfCredentialsWereCorrectlyStoredThenIsSignedInChannelSendsTrue() = runTest {
         testee.storeCredentials("token", "username", "cohort")
 
         assertTrue(testee.signedInFlow().first())
     }
 
     @Test
-    fun whenStoreCredentialsIfCredentialsAreBlankThenIsSignedInChannelSendsFalse() = coroutineRule.runBlocking {
+    fun whenStoreCredentialsIfCredentialsAreBlankThenIsSignedInChannelSendsFalse() = runTest {
         testee.storeCredentials("", "", "cohort")
 
         assertFalse(testee.signedInFlow().first())
@@ -174,7 +180,7 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenSignedOutThenIsSignedInChannelSendsFalse() = coroutineRule.runBlocking {
+    fun whenSignedOutThenIsSignedInChannelSendsFalse() = runTest {
         testee.signOut()
 
         assertFalse(testee.signedInFlow().first())
@@ -267,14 +273,14 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenFetchInviteCodeIfCodeAlreadyExistsThenReturnCodeExisted() = coroutineRule.runBlocking {
+    fun whenFetchInviteCodeIfCodeAlreadyExistsThenReturnCodeExisted() = runTest {
         mockEmailDataStore.inviteCode = "inviteCode"
 
         assertEquals(AppEmailManager.FetchCodeResult.CodeExisted, testee.fetchInviteCode())
     }
 
     @Test
-    fun whenFetchInviteCodeIfTimestampIsSmallerThanQueueTimestampThenCallGetCode() = coroutineRule.runBlocking {
+    fun whenFetchInviteCodeIfTimestampIsSmallerThanQueueTimestampThenCallGetCode() = runTest {
         givenUserIsInWaitlist()
         whenever(mockEmailService.waitlistStatus()).thenReturn(WaitlistStatusResponse(12345))
 
@@ -284,7 +290,7 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenFetchInviteCodeIfTimestampIsEqualsThanQueueTimestampThenCallGetCode() = coroutineRule.runBlocking {
+    fun whenFetchInviteCodeIfTimestampIsEqualsThanQueueTimestampThenCallGetCode() = runTest {
         givenUserIsInWaitlist()
         whenever(mockEmailService.waitlistStatus()).thenReturn(WaitlistStatusResponse(1234))
 
@@ -294,7 +300,7 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenFetchInviteCodeIfUserIsTopOfQueueAndCodeAvailableThenReturnCode() = coroutineRule.runBlocking {
+    fun whenFetchInviteCodeIfUserIsTopOfQueueAndCodeAvailableThenReturnCode() = runTest {
         givenUserIsTopOfTheQueue()
         whenever(mockEmailService.getCode(any())).thenReturn(EmailInviteCodeResponse("code"))
 
@@ -302,7 +308,7 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenFetchInviteCodeIfUserIsTopOfQueueAndCodeNotAvailableThenReturnNoCode() = coroutineRule.runBlocking {
+    fun whenFetchInviteCodeIfUserIsTopOfQueueAndCodeNotAvailableThenReturnNoCode() = runTest {
         givenUserIsTopOfTheQueue()
         whenever(mockEmailService.getCode(any())).thenReturn(EmailInviteCodeResponse(""))
 
@@ -310,16 +316,16 @@ class AppEmailManagerTest {
     }
 
     @Test
-    fun whenFetchInviteCodeIfUserIsTopOfQueueAndCodeServiceNotAvailableThenReturnNoCode() = coroutineRule.runBlocking {
-        testee = AppEmailManager(TestEmailService(), mockEmailDataStore, coroutineRule.testDispatcherProvider, TestCoroutineScope())
+    fun whenFetchInviteCodeIfUserIsTopOfQueueAndCodeServiceNotAvailableThenReturnNoCode() = runTest {
+        testee = AppEmailManager(TestEmailService(), mockEmailDataStore, coroutineRule.testDispatcherProvider, TestScope())
         givenUserIsTopOfTheQueue()
 
         assertEquals(AppEmailManager.FetchCodeResult.NoCode, testee.fetchInviteCode())
     }
 
     @Test
-    fun whenFetchInviteCodeIfUserInTheQueueAndStatusServiceNotAvailableThenReturnNoCode() = coroutineRule.runBlocking {
-        testee = AppEmailManager(TestEmailService(), mockEmailDataStore, coroutineRule.testDispatcherProvider, TestCoroutineScope())
+    fun whenFetchInviteCodeIfUserInTheQueueAndStatusServiceNotAvailableThenReturnNoCode() = runTest {
+        testee = AppEmailManager(TestEmailService(), mockEmailDataStore, coroutineRule.testDispatcherProvider, TestScope())
         givenUserIsInWaitlist()
 
         assertEquals(AppEmailManager.FetchCodeResult.NoCode, testee.fetchInviteCode())
@@ -383,7 +389,7 @@ class AppEmailManagerTest {
         mockEmailDataStore.waitlistToken = "token"
     }
 
-    private fun givenUserIsTopOfTheQueue() = coroutineRule.runBlocking {
+    private fun givenUserIsTopOfTheQueue() = runTest {
         givenUserIsInWaitlist()
         whenever(mockEmailService.waitlistStatus()).thenReturn(WaitlistStatusResponse(1234))
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/email/EmailJavascriptInterfaceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/EmailJavascriptInterfaceTest.kt
@@ -23,11 +23,13 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class EmailJavascriptInterfaceTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/duckduckgo/app/email/db/EmailEncryptedSharedPreferencesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/db/EmailEncryptedSharedPreferencesTest.kt
@@ -18,11 +18,11 @@ package com.duckduckgo.app.email.db
 
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -44,14 +44,14 @@ class EmailEncryptedSharedPreferencesTest {
     }
 
     @Test
-    fun whenNextAliasEqualsValueThenValueIsSentToNextAliasChannel() = coroutineRule.runBlocking {
+    fun whenNextAliasEqualsValueThenValueIsSentToNextAliasChannel() = runTest {
         testee.nextAlias = "test"
 
         assertEquals("test", testee.nextAlias)
     }
 
     @Test
-    fun whenNextAliasEqualsNullThenNullIsSentToNextAliasChannel() = coroutineRule.runBlocking {
+    fun whenNextAliasEqualsNullThenNullIsSentToNextAliasChannel() = runTest {
         testee.nextAlias = null
 
         assertNull(testee.nextAlias)

--- a/app/src/androidTest/java/com/duckduckgo/app/email/ui/EmailProtectionSignOutViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/ui/EmailProtectionSignOutViewModelTest.kt
@@ -18,9 +18,9 @@ package com.duckduckgo.app.email.ui
 
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.email.EmailManager
 import com.duckduckgo.app.email.ui.EmailProtectionSignOutViewModel.Command.*
-import com.duckduckgo.app.runBlocking
 import org.junit.Rule
 import com.nhaarman.mockitokotlin2.*
 import org.junit.Assert.*
@@ -47,7 +47,7 @@ class EmailProtectionSignOutViewModelTest {
     }
 
     @Test
-    fun whenOnSignOutButtonClickedThenEmitSignOutCommand() = coroutineRule.runBlocking {
+    fun whenOnSignOutButtonClickedThenEmitSignOutCommand() = runTest {
         testee.commands.test {
             testee.onSignOutButtonClicked()
             assertEquals(SignOut, awaitItem())

--- a/app/src/androidTest/java/com/duckduckgo/app/email/ui/EmailProtectionViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/ui/EmailProtectionViewModelTest.kt
@@ -18,13 +18,14 @@ package com.duckduckgo.app.email.ui
 
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.email.EmailManager
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -50,7 +51,7 @@ class EmailProtectionViewModelTest {
     }
 
     @Test
-    fun whenViewModelCreatedThenEmitEmailState() = coroutineRule.runBlocking {
+    fun whenViewModelCreatedThenEmitEmailState() = runTest {
         testee.viewState.test {
             assert(awaitItem().emailState is EmailProtectionViewModel.EmailState.SignedOut)
 
@@ -59,7 +60,7 @@ class EmailProtectionViewModelTest {
     }
 
     @Test
-    fun whenSignedInIfFeatureIsSupportedAndFlowEmitsFalseThenViewStateFlowEmitsEmailState() = coroutineRule.runBlocking {
+    fun whenSignedInIfFeatureIsSupportedAndFlowEmitsFalseThenViewStateFlowEmitsEmailState() = runTest {
         testee.viewState.test {
             emailStateFlow.emit(false)
             (awaitItem().emailState is EmailProtectionViewModel.EmailState.SignedIn)
@@ -69,7 +70,7 @@ class EmailProtectionViewModelTest {
     }
 
     @Test
-    fun whenSignedInIfFeatureIsSupportedAndFlowEmitsTrueThenViewStateFlowEmitsEmailState() = coroutineRule.runBlocking {
+    fun whenSignedInIfFeatureIsSupportedAndFlowEmitsTrueThenViewStateFlowEmitsEmailState() = runTest {
         testee.viewState.test {
             emailStateFlow.emit(true)
             assert(awaitItem().emailState is EmailProtectionViewModel.EmailState.SignedOut)
@@ -79,7 +80,7 @@ class EmailProtectionViewModelTest {
     }
 
     @Test
-    fun whenFeatureIsNotSupportedThenEmitNotSupportedState() = coroutineRule.runBlocking {
+    fun whenFeatureIsNotSupportedThenEmitNotSupportedState() = runTest {
         whenever(mockEmailManager.isEmailFeatureSupported()).thenReturn(false)
         testee.viewState.test {
             emailStateFlow.emit(true)

--- a/app/src/androidTest/java/com/duckduckgo/app/email/waitlist/AppEmailWaitlistCodeFetcherTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/waitlist/AppEmailWaitlistCodeFetcherTest.kt
@@ -25,12 +25,12 @@ import androidx.work.WorkManager
 import androidx.work.impl.utils.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.email.AppEmailManager
 import com.duckduckgo.app.email.EmailManager
 import com.duckduckgo.app.job.TestWorker
 import com.duckduckgo.app.notification.NotificationSender
 import com.duckduckgo.app.notification.model.SchedulableNotification
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.waitlist.email.AppEmailWaitlistCodeFetcher
 import com.duckduckgo.app.waitlist.email.EmailWaitlistCodeFetcher
 import com.duckduckgo.app.waitlist.email.EmailWaitlistWorkRequestBuilder
@@ -39,7 +39,8 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -64,11 +65,11 @@ class AppEmailWaitlistCodeFetcherTest {
     @Before
     fun before() {
         initializeWorkManager()
-        testee = AppEmailWaitlistCodeFetcher(workManager, mockEmailManager, mockNotification, mockNotificationSender, coroutineRule.testDispatcherProvider, TestCoroutineScope())
+        testee = AppEmailWaitlistCodeFetcher(workManager, mockEmailManager, mockNotification, mockNotificationSender, coroutineRule.testDispatcherProvider, TestScope())
     }
 
     @Test
-    fun whenFetchInviteCodeIfUserInQueueCodeAlreadyExistsAndWorkerIsRunningThenCancelWorker() = coroutineRule.runBlocking {
+    fun whenFetchInviteCodeIfUserInQueueCodeAlreadyExistsAndWorkerIsRunningThenCancelWorker() = runTest {
         givenUserIsInTheQueueAndCodeAlreadyExists()
         enqueueWaitlistWorker()
 
@@ -78,7 +79,7 @@ class AppEmailWaitlistCodeFetcherTest {
     }
 
     @Test
-    fun whenFetchInviteCodeIfUserInQueueAndCodeReturnedThenCancelWorker() = coroutineRule.runBlocking {
+    fun whenFetchInviteCodeIfUserInQueueAndCodeReturnedThenCancelWorker() = runTest {
         givenUserIsInTheQueueAndCodeReturned()
         enqueueWaitlistWorker()
 
@@ -88,7 +89,7 @@ class AppEmailWaitlistCodeFetcherTest {
     }
 
     @Test
-    fun whenFetchInviteCodeIfUserInQueueAndCodeReturnedThenNotificationSent() = coroutineRule.runBlocking {
+    fun whenFetchInviteCodeIfUserInQueueAndCodeReturnedThenNotificationSent() = runTest {
         givenUserIsInTheQueueAndCodeReturned()
         enqueueWaitlistWorker()
 
@@ -98,7 +99,7 @@ class AppEmailWaitlistCodeFetcherTest {
     }
 
     @Test
-    fun whenFetchInviteCodeIfUserInQueueAndNoCodeReturnedThenDoNothing() = coroutineRule.runBlocking {
+    fun whenFetchInviteCodeIfUserInQueueAndNoCodeReturnedThenDoNothing() = runTest {
         givenUserIsInTheQueueAndNoCodeReturned()
         enqueueWaitlistWorker()
 
@@ -109,7 +110,7 @@ class AppEmailWaitlistCodeFetcherTest {
     }
 
     @Test
-    fun whenExecuteWaitlistCodeFetcherIfUserInNotInQueueThenDoNothing() = coroutineRule.runBlocking {
+    fun whenExecuteWaitlistCodeFetcherIfUserInNotInQueueThenDoNothing() = runTest {
         whenever(mockEmailManager.waitlistState()).thenReturn(AppEmailManager.WaitlistState.NotJoinedQueue)
 
         (testee as AppEmailWaitlistCodeFetcher).executeWaitlistCodeFetcher()
@@ -118,7 +119,7 @@ class AppEmailWaitlistCodeFetcherTest {
     }
 
     @Test
-    fun whenExecuteWaitlistCodeFetcherIfUserIsInBetaThenDoNothing() = coroutineRule.runBlocking {
+    fun whenExecuteWaitlistCodeFetcherIfUserIsInBetaThenDoNothing() = runTest {
         whenever(mockEmailManager.waitlistState()).thenReturn(AppEmailManager.WaitlistState.InBeta)
 
         (testee as AppEmailWaitlistCodeFetcher).executeWaitlistCodeFetcher()
@@ -126,17 +127,17 @@ class AppEmailWaitlistCodeFetcherTest {
         verify(mockEmailManager, never()).fetchInviteCode()
     }
 
-    private fun givenUserIsInTheQueueAndCodeAlreadyExists() = coroutineRule.runBlocking {
+    private fun givenUserIsInTheQueueAndCodeAlreadyExists() = runTest {
         whenever(mockEmailManager.waitlistState()).thenReturn(AppEmailManager.WaitlistState.JoinedQueue())
         whenever(mockEmailManager.fetchInviteCode()).thenReturn(AppEmailManager.FetchCodeResult.CodeExisted)
     }
 
-    private fun givenUserIsInTheQueueAndCodeReturned() = coroutineRule.runBlocking {
+    private fun givenUserIsInTheQueueAndCodeReturned() = runTest {
         whenever(mockEmailManager.waitlistState()).thenReturn(AppEmailManager.WaitlistState.JoinedQueue())
         whenever(mockEmailManager.fetchInviteCode()).thenReturn(AppEmailManager.FetchCodeResult.Code)
     }
 
-    private fun givenUserIsInTheQueueAndNoCodeReturned() = coroutineRule.runBlocking {
+    private fun givenUserIsInTheQueueAndNoCodeReturned() = runTest {
         whenever(mockEmailManager.waitlistState()).thenReturn(AppEmailManager.WaitlistState.JoinedQueue())
         whenever(mockEmailManager.fetchInviteCode()).thenReturn(AppEmailManager.FetchCodeResult.NoCode)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/feedback/ui/common/FeedbackViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/feedback/ui/common/FeedbackViewModelTest.kt
@@ -31,8 +31,8 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -40,6 +40,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 @Suppress("RemoveExplicitTypeArguments")
 class FeedbackViewModelTest {
 
@@ -70,7 +71,7 @@ class FeedbackViewModelTest {
     @Before
     @UiThreadTest
     fun setup() {
-        testee = FeedbackViewModel(playStoreUtils, feedbackSubmitter, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+        testee = FeedbackViewModel(playStoreUtils, feedbackSubmitter, TestScope(), coroutineRule.testDispatcherProvider)
         testee.command.observeForever(commandObserver)
     }
 
@@ -126,14 +127,14 @@ class FeedbackViewModelTest {
     }
 
     @Test
-    fun whenUserChoosesNotToProvideFurtherDetailsForPositiveFeedbackThenSubmitted() = runBlocking<Unit> {
+    fun whenUserChoosesNotToProvideFurtherDetailsForPositiveFeedbackThenSubmitted() = runTest {
         testee.userGavePositiveFeedbackNoDetails()
 
         verify(feedbackSubmitter).sendPositiveFeedback(null)
     }
 
     @Test
-    fun whenUserChoosesNotToProvideFurtherDetailsForPositiveFeedbackThenExitCommandIssued() = runBlocking<Unit> {
+    fun whenUserChoosesNotToProvideFurtherDetailsForPositiveFeedbackThenExitCommandIssued() = runTest {
         testee.userGavePositiveFeedbackNoDetails()
 
         val command = captureCommand() as Command.Exit
@@ -141,14 +142,14 @@ class FeedbackViewModelTest {
     }
 
     @Test
-    fun whenUserProvidesFurtherDetailsForPositiveFeedbackThenFeedbackSubmitted() = runBlocking<Unit> {
+    fun whenUserProvidesFurtherDetailsForPositiveFeedbackThenFeedbackSubmitted() = runTest {
         testee.userProvidedPositiveOpenEndedFeedback("foo")
 
         verify(feedbackSubmitter).sendPositiveFeedback("foo")
     }
 
     @Test
-    fun whenUserProvidesFurtherDetailsForPositiveFeedbackThenExitCommandIssued() = runBlocking<Unit> {
+    fun whenUserProvidesFurtherDetailsForPositiveFeedbackThenExitCommandIssued() = runTest {
         testee.userProvidedPositiveOpenEndedFeedback("foo")
 
         val command = captureCommand() as Command.Exit
@@ -156,19 +157,19 @@ class FeedbackViewModelTest {
     }
 
     @Test
-    fun whenUserProvidesNegativeFeedbackThenFeedbackSubmitted() = runBlocking<Unit> {
+    fun whenUserProvidesNegativeFeedbackThenFeedbackSubmitted() = runTest {
         testee.userProvidedNegativeOpenEndedFeedback(MISSING_BROWSING_FEATURES, TAB_MANAGEMENT, "foo")
         verify(feedbackSubmitter).sendNegativeFeedback(MISSING_BROWSING_FEATURES, TAB_MANAGEMENT, "foo")
     }
 
     @Test
-    fun whenUserProvidesNegativeFeedbackNoSubReasonThenFeedbackSubmitted() = runBlocking<Unit> {
+    fun whenUserProvidesNegativeFeedbackNoSubReasonThenFeedbackSubmitted() = runTest {
         testee.userProvidedNegativeOpenEndedFeedback(MISSING_BROWSING_FEATURES, null, "foo")
         verify(feedbackSubmitter).sendNegativeFeedback(MISSING_BROWSING_FEATURES, null, "foo")
     }
 
     @Test
-    fun whenUserProvidesNegativeFeedbackEmptyOpenEndedFeedbackThenFeedbackSubmitted() = runBlocking<Unit> {
+    fun whenUserProvidesNegativeFeedbackEmptyOpenEndedFeedbackThenFeedbackSubmitted() = runTest {
         testee.userProvidedNegativeOpenEndedFeedback(MISSING_BROWSING_FEATURES, null, "")
         verify(feedbackSubmitter).sendNegativeFeedback(MISSING_BROWSING_FEATURES, null, "")
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/AutomaticDataClearerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/AutomaticDataClearerTest.kt
@@ -28,11 +28,13 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class AutomaticDataClearerTest {
 
     private lateinit var testee: AutomaticDataClearer
@@ -59,7 +61,7 @@ class AutomaticDataClearerTest {
     /* Clear None tests */
 
     @Test
-    fun whenFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearThenDataNotCleared() = runBlocking {
+    fun whenFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearThenDataNotCleared() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_NONE, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureEnoughTimePassed()
@@ -72,7 +74,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenFreshAppLaunchAndEnoughTimePassedAndAppNotUsedSinceLastClearThenDataNotCleared() = runBlocking {
+    fun whenFreshAppLaunchAndEnoughTimePassedAndAppNotUsedSinceLastClearThenDataNotCleared() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_NONE, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureEnoughTimePassed()
@@ -85,7 +87,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearThenDataNotCleared() = runBlocking {
+    fun whenFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearThenDataNotCleared() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_NONE, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureNotEnoughTimePassed()
@@ -98,7 +100,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearThenDataNotCleared() = runBlocking {
+    fun whenFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearThenDataNotCleared() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_NONE, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureNotEnoughTimePassed()
@@ -111,7 +113,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearThenDataNotCleared() = runBlocking {
+    fun whenNotFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearThenDataNotCleared() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_NONE, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureEnoughTimePassed()
@@ -124,7 +126,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndEnoughTimePassedAndAppNotUsedSinceLastClearThenDataNotCleared() = runBlocking {
+    fun whenNotFreshAppLaunchAndEnoughTimePassedAndAppNotUsedSinceLastClearThenDataNotCleared() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_NONE, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureEnoughTimePassed()
@@ -137,7 +139,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearThenDataNotCleared() = runBlocking {
+    fun whenNotFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearThenDataNotCleared() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_NONE, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureNotEnoughTimePassed()
@@ -150,7 +152,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearThenDataNotCleared() = runBlocking {
+    fun whenNotFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearThenDataNotCleared() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_NONE, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureNotEnoughTimePassed()
@@ -165,7 +167,7 @@ class AutomaticDataClearerTest {
     /* Clear tabs tests */
 
     @Test
-    fun whenFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearThenShouldClearTabs() = runBlocking<Unit> {
+    fun whenFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearThenShouldClearTabs() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_ONLY)
         configureEnoughTimePassed()
@@ -178,7 +180,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenFreshAppLaunchAndEnoughTimePassedAndAppNotUsedSinceLastClearThenShouldNotClearTabs() = runBlocking<Unit> {
+    fun whenFreshAppLaunchAndEnoughTimePassedAndAppNotUsedSinceLastClearThenShouldNotClearTabs() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_ONLY)
         configureEnoughTimePassed()
@@ -191,7 +193,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearThenShouldClearTabs() = runBlocking<Unit> {
+    fun whenFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearThenShouldClearTabs() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_ONLY)
         configureNotEnoughTimePassed()
@@ -204,7 +206,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearThenShouldNotClearTabs() = runBlocking<Unit> {
+    fun whenFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearThenShouldNotClearTabs() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_ONLY)
         configureNotEnoughTimePassed()
@@ -217,7 +219,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearThenShouldNotClearTabs() = runBlocking<Unit> {
+    fun whenNotFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearThenShouldNotClearTabs() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_ONLY)
         configureEnoughTimePassed()
@@ -230,7 +232,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndEnoughTimePassedAndAppNotUsedSinceLastClearThenShouldNotClearTabs() = runBlocking<Unit> {
+    fun whenNotFreshAppLaunchAndEnoughTimePassedAndAppNotUsedSinceLastClearThenShouldNotClearTabs() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_ONLY)
         configureEnoughTimePassed()
@@ -243,7 +245,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearThenShouldNotClearTabs() = runBlocking<Unit> {
+    fun whenNotFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearThenShouldNotClearTabs() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_ONLY)
         configureNotEnoughTimePassed()
@@ -256,7 +258,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearThenShouldNotClearTabs() = runBlocking<Unit> {
+    fun whenNotFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearThenShouldNotClearTabs() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_ONLY)
         configureNotEnoughTimePassed()
@@ -269,7 +271,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotAppExitOnlyAndFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearShouldClearTabs() = runBlocking<Unit> {
+    fun whenNotAppExitOnlyAndFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearShouldClearTabs() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureEnoughTimePassed()
@@ -282,7 +284,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotAppExitOnlyAndNotFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearShouldClearTabs() = runBlocking<Unit> {
+    fun whenNotAppExitOnlyAndNotFreshAppLaunchAndEnoughTimePassedAndAppUsedSinceLastClearShouldClearTabs() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureEnoughTimePassed()
@@ -295,7 +297,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotAppExitOnlyAndFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearShouldClearTabs() = runBlocking<Unit> {
+    fun whenNotAppExitOnlyAndFreshAppLaunchAndNotEnoughTimePassedAndAppUsedSinceLastClearShouldClearTabs() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureNotEnoughTimePassed()
@@ -308,7 +310,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotAppExitOnlyAndFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearShouldNotClearTabs() = runBlocking<Unit> {
+    fun whenNotAppExitOnlyAndFreshAppLaunchAndNotEnoughTimePassedAndAppNotUsedSinceLastClearShouldNotClearTabs() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_ONLY, ClearWhenOption.APP_EXIT_OR_15_MINS)
         configureNotEnoughTimePassed()
@@ -323,7 +325,7 @@ class AutomaticDataClearerTest {
     /* Clear Tabs and Data tests */
 
     @Test
-    fun whenAppExitOnlyFreshAppLaunchAndEnoughTimePassedAppUsedSinceLastClearThenShouldClear() = runBlocking<Unit> {
+    fun whenAppExitOnlyFreshAppLaunchAndEnoughTimePassedAppUsedSinceLastClearThenShouldClear() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_ONLY)
         configureEnoughTimePassed()
@@ -336,7 +338,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOnlyFreshAppLaunchAndEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOnlyFreshAppLaunchAndEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_ONLY)
         configureEnoughTimePassed()
@@ -349,7 +351,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOnlyFreshAppLaunchAndNotEnoughTimePassedAppUsedSinceLastClearThenShouldClear() = runBlocking<Unit> {
+    fun whenAppExitOnlyFreshAppLaunchAndNotEnoughTimePassedAppUsedSinceLastClearThenShouldClear() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_ONLY)
         configureNotEnoughTimePassed()
@@ -362,7 +364,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOnlyFreshAppLaunchAndNotEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOnlyFreshAppLaunchAndNotEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = true
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_ONLY)
         configureNotEnoughTimePassed()
@@ -375,7 +377,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOnlyNotFreshAppLaunchAndEnoughTimePassedAppUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOnlyNotFreshAppLaunchAndEnoughTimePassedAppUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_ONLY)
         configureEnoughTimePassed()
@@ -388,7 +390,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOnlyNotFreshAppLaunchAndEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOnlyNotFreshAppLaunchAndEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_ONLY)
         configureEnoughTimePassed()
@@ -401,7 +403,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOnlyNotFreshAppLaunchAndNotEnoughTimePassedAppUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOnlyNotFreshAppLaunchAndNotEnoughTimePassedAppUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_ONLY)
         configureNotEnoughTimePassed()
@@ -414,7 +416,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOnlyNotFreshAppLaunchAndNotEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOnlyNotFreshAppLaunchAndNotEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_ONLY)
         configureNotEnoughTimePassed()
@@ -427,7 +429,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOrTimerFreshAppLaunchAndNotEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOrTimerFreshAppLaunchAndNotEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_OR_5_MINS)
         configureNotEnoughTimePassed()
@@ -440,7 +442,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOrTimerNotFreshAppLaunchAndEnoughTimePassedAppUsedSinceLastClearThenShouldClear() = runBlocking<Unit> {
+    fun whenAppExitOrTimerNotFreshAppLaunchAndEnoughTimePassedAppUsedSinceLastClearThenShouldClear() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_OR_5_MINS)
         configureEnoughTimePassed()
@@ -453,7 +455,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOrTimerNotFreshAppLaunchAndEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOrTimerNotFreshAppLaunchAndEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_OR_5_MINS)
         configureEnoughTimePassed()
@@ -466,7 +468,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOrTimerNotFreshAppLaunchAndNotEnoughTimePassedAppUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOrTimerNotFreshAppLaunchAndNotEnoughTimePassedAppUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_OR_5_MINS)
         configureNotEnoughTimePassed()
@@ -479,7 +481,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenAppExitOrTimerNotFreshAppLaunchAndNotEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runBlocking<Unit> {
+    fun whenAppExitOrTimerNotFreshAppLaunchAndNotEnoughTimePassedAppNotUsedSinceLastClearThenShouldNotClear() = runTest {
         val isFreshAppLaunch = false
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_OR_5_MINS)
         configureNotEnoughTimePassed()
@@ -492,7 +494,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndIconJustChangedButAppNotUsedThenShouldNotClear() = runBlocking<Unit> {
+    fun whenNotFreshAppLaunchAndIconJustChangedButAppNotUsedThenShouldNotClear() = runTest {
         val isFreshAppLaunch = false
 
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_OR_5_MINS)
@@ -507,7 +509,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenFreshAppLaunchAndIconJustChangedButAppUsedThenShouldClear() = runBlocking<Unit> {
+    fun whenFreshAppLaunchAndIconJustChangedButAppUsedThenShouldClear() = runTest {
         val isFreshAppLaunch = true
 
         configureUserOptions(ClearWhatOption.CLEAR_TABS_AND_DATA, ClearWhenOption.APP_EXIT_OR_5_MINS)
@@ -522,7 +524,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndIconNotChangedThenShouldClear() = runBlocking<Unit> {
+    fun whenNotFreshAppLaunchAndIconNotChangedThenShouldClear() = runTest {
         val isFreshAppLaunch = false
 
         configureAppIconNotChanged()
@@ -538,7 +540,7 @@ class AutomaticDataClearerTest {
     }
 
     @Test
-    fun whenNotFreshAppLaunchAndIconNotChangedAppUsedThenShouldClear() = runBlocking<Unit> {
+    fun whenNotFreshAppLaunchAndIconNotChangedAppUsedThenShouldClear() = runTest {
         val isFreshAppLaunch = false
 
         configureAppIconNotChanged()

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/DatabaseCleanerHelperTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/DatabaseCleanerHelperTest.kt
@@ -17,12 +17,19 @@
 package com.duckduckgo.app.fire
 
 import androidx.test.platform.app.InstrumentationRegistry
-import kotlinx.coroutines.runBlocking
+import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class DatabaseCleanerHelperTest {
+
+    @get:Rule
+    private val coroutineRule = CoroutineTestRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
@@ -31,16 +38,16 @@ class DatabaseCleanerHelperTest {
 
     @Before
     fun before() {
-        testee = DatabaseCleanerHelper()
+        testee = DatabaseCleanerHelper(coroutineRule.testDispatcherProvider)
     }
 
     @Test
-    fun whenCleanDatabaseThenReturnTrue() = runBlocking {
+    fun whenCleanDatabaseThenReturnTrue() = runTest {
         assertTrue(testee.cleanDatabase(databaseLocator.getDatabasePath()))
     }
 
     @Test
-    fun whenChangeJournalModeToDeleteThenReturnTrue() = runBlocking {
+    fun whenChangeJournalModeToDeleteThenReturnTrue() = runTest {
         assertTrue(testee.changeJournalModeToDelete(databaseLocator.getDatabasePath()))
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/RemoveCookiesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/RemoveCookiesTest.kt
@@ -21,7 +21,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -32,7 +32,7 @@ class RemoveCookiesTest {
     private val removeCookies = RemoveCookies(cookieManagerRemover, selectiveCookieRemover)
 
     @Test
-    fun whenSelectiveCookieRemoverSucceedsThenNoMoreInteractions() = runBlockingTest {
+    fun whenSelectiveCookieRemoverSucceedsThenNoMoreInteractions() = runTest {
         selectiveCookieRemover.succeeds()
 
         removeCookies.removeCookies()
@@ -41,7 +41,7 @@ class RemoveCookiesTest {
     }
 
     @Test
-    fun whenSelectiveCookieRemoverFailsThenFallbackToCookieManagerRemover() = runBlockingTest {
+    fun whenSelectiveCookieRemoverFailsThenFallbackToCookieManagerRemover() = runTest {
         selectiveCookieRemover.fails()
 
         removeCookies.removeCookies()

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/SQLCookieRemoverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/SQLCookieRemoverTest.kt
@@ -30,7 +30,9 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.assertTrue
@@ -38,6 +40,7 @@ import org.junit.Test
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
+@ExperimentalCoroutinesApi
 class SQLCookieRemoverTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -56,7 +59,7 @@ class SQLCookieRemoverTest {
     }
 
     @Test
-    fun whenCookiesStoredAndRemoveExecutedThenResultTrue() = runBlocking {
+    fun whenCookiesStoredAndRemoveExecutedThenResultTrue() = runTest {
         givenDatabaseWithCookies()
         val sqlCookieRemover = givenSQLCookieRemover()
 
@@ -66,7 +69,7 @@ class SQLCookieRemoverTest {
     }
 
     @Test
-    fun whenNoCookiesStoredAndRemoveExecutedThenResultTrue() = runBlocking {
+    fun whenNoCookiesStoredAndRemoveExecutedThenResultTrue() = runTest {
         val sqlCookieRemover = givenSQLCookieRemover()
 
         val success = sqlCookieRemover.removeCookies()
@@ -75,7 +78,7 @@ class SQLCookieRemoverTest {
     }
 
     @Test
-    fun whenUserHasFireproofWebsitesAndRemoveExecutedThenResultTrue() = runBlocking {
+    fun whenUserHasFireproofWebsitesAndRemoveExecutedThenResultTrue() = runTest {
         val sqlCookieRemover = givenSQLCookieRemover()
         givenDatabaseWithCookies()
         givenFireproofWebsitesStored()
@@ -86,7 +89,7 @@ class SQLCookieRemoverTest {
     }
 
     @Test
-    fun whenDatabasePathNotFoundThenPixelFired() = runBlocking {
+    fun whenDatabasePathNotFoundThenPixelFired() = runTest {
         val mockDatabaseLocator = mock<DatabaseLocator> {
             on { getDatabasePath() } doReturn ""
         }
@@ -98,7 +101,7 @@ class SQLCookieRemoverTest {
     }
 
     @Test
-    fun whenUnableToOpenDatabaseThenPixelFiredAndSaveOfflineCount() = runBlocking {
+    fun whenUnableToOpenDatabaseThenPixelFiredAndSaveOfflineCount() = runTest {
         val mockDatabaseLocator = mock<DatabaseLocator> {
             on { getDatabasePath() } doReturn "fakePath"
         }

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/WebViewCookieManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/WebViewCookieManagerTest.kt
@@ -19,10 +19,11 @@ package com.duckduckgo.app.fire
 import android.webkit.CookieManager
 import android.webkit.ValueCallback
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
+import kotlinx.coroutines.test.runTest
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.Before
 import org.junit.Rule
@@ -55,7 +56,7 @@ class WebViewCookieManagerTest {
     }
 
     @Test
-    fun whenCookiesRemovedThenInternalCookiesRecreated() = coroutineRule.runBlocking {
+    fun whenCookiesRemovedThenInternalCookiesRecreated() = runTest {
         givenCookieManagerWithCookies(ddgCookie, externalHostCookie)
 
         withContext(Dispatchers.Main) {
@@ -66,7 +67,7 @@ class WebViewCookieManagerTest {
     }
 
     @Test
-    fun whenCookiesStoredThenRemoveCookiesExecuted() = coroutineRule.runBlocking {
+    fun whenCookiesStoredThenRemoveCookiesExecuted() = runTest {
         givenCookieManagerWithCookies(ddgCookie, externalHostCookie)
 
         withContext(Dispatchers.Main) {
@@ -77,7 +78,7 @@ class WebViewCookieManagerTest {
     }
 
     @Test
-    fun whenCookiesStoredThenFlushBeforeAndAfterInteractingWithCookieManager() = coroutineRule.runBlocking {
+    fun whenCookiesStoredThenFlushBeforeAndAfterInteractingWithCookieManager() = runTest {
         givenCookieManagerWithCookies(ddgCookie, externalHostCookie)
 
         withContext(Dispatchers.Main) {
@@ -94,7 +95,7 @@ class WebViewCookieManagerTest {
     }
 
     @Test
-    fun whenNoCookiesThenRemoveProcessNotExecuted() = coroutineRule.runBlocking {
+    fun whenNoCookiesThenRemoveProcessNotExecuted() = runTest {
         givenCookieManagerWithCookies()
 
         withContext(Dispatchers.Main) {

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/data/FireproofWebsiteRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/data/FireproofWebsiteRepositoryTest.kt
@@ -20,14 +20,15 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.blockingObserve
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.global.db.AppDatabase
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import dagger.Lazy
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -67,38 +68,38 @@ class FireproofWebsiteRepositoryTest {
     }
 
     @Test
-    fun whenFireproofWebsiteEmptyThenNoEntityIsCreated() = coroutineRule.runBlocking {
+    fun whenFireproofWebsiteEmptyThenNoEntityIsCreated() = runTest {
         val fireproofWebsiteEntity = fireproofWebsiteRepository.fireproofWebsite("")
         assertNull(fireproofWebsiteEntity)
     }
 
     @Test
-    fun whenFireproofWebsiteInvalidThenNoEntityIsCreated() = coroutineRule.runBlocking {
+    fun whenFireproofWebsiteInvalidThenNoEntityIsCreated() = runTest {
         val fireproofWebsiteEntity = fireproofWebsiteRepository.fireproofWebsite("aa1111")
         assertNull(fireproofWebsiteEntity)
     }
 
     @Test
-    fun whenFireproofWebsiteWithSchemaThenNoEntityIsCreated() = coroutineRule.runBlocking {
+    fun whenFireproofWebsiteWithSchemaThenNoEntityIsCreated() = runTest {
         val fireproofWebsiteEntity = fireproofWebsiteRepository.fireproofWebsite("https://aa1111.com")
         assertNull(fireproofWebsiteEntity)
     }
 
     @Test
-    fun whenFireproofWebsiteIsValidThenEntityCreated() = coroutineRule.runBlocking {
+    fun whenFireproofWebsiteIsValidThenEntityCreated() = runTest {
         val fireproofWebsiteEntity = fireproofWebsiteRepository.fireproofWebsite("example.com")
         assertEquals(FireproofWebsiteEntity("example.com"), fireproofWebsiteEntity)
     }
 
     @Test
-    fun whenGetAllFireproofWebsitesThenReturnLiveDataWithAllItemsFromDatabase() = coroutineRule.runBlocking {
+    fun whenGetAllFireproofWebsitesThenReturnLiveDataWithAllItemsFromDatabase() = runTest {
         givenFireproofWebsiteDomain("example.com", "example2.com")
         val fireproofWebsiteEntities = fireproofWebsiteRepository.getFireproofWebsites().blockingObserve()!!
         assertEquals(fireproofWebsiteEntities.size, 2)
     }
 
     @Test
-    fun whenRemoveFireproofWebsiteThenItemRemovedFromDatabase() = coroutineRule.runBlocking {
+    fun whenRemoveFireproofWebsiteThenItemRemovedFromDatabase() = runTest {
         givenFireproofWebsiteDomain("example.com", "example2.com")
 
         fireproofWebsiteRepository.removeFireproofWebsite(FireproofWebsiteEntity("example.com"))
@@ -108,7 +109,7 @@ class FireproofWebsiteRepositoryTest {
     }
 
     @Test
-    fun whenRemoveFireproofWebsiteThenDeletePersistedFavicon() = coroutineRule.runBlocking {
+    fun whenRemoveFireproofWebsiteThenDeletePersistedFavicon() = runTest {
         givenFireproofWebsiteDomain("example.com")
 
         fireproofWebsiteRepository.removeFireproofWebsite(FireproofWebsiteEntity("example.com"))
@@ -117,7 +118,7 @@ class FireproofWebsiteRepositoryTest {
     }
 
     @Test
-    fun whenFireproofWebsitesCountByDomainAndNoWebsitesMatchThenReturnZero() = coroutineRule.runBlocking {
+    fun whenFireproofWebsitesCountByDomainAndNoWebsitesMatchThenReturnZero() = runTest {
         givenFireproofWebsiteDomain("example.com")
 
         val count = fireproofWebsiteRepository.fireproofWebsitesCountByDomain("test.com")
@@ -126,7 +127,7 @@ class FireproofWebsiteRepositoryTest {
     }
 
     @Test
-    fun whenFireproofWebsitesCountByDomainAndWebsitsMatchThenReturnCount() = coroutineRule.runBlocking {
+    fun whenFireproofWebsitesCountByDomainAndWebsitsMatchThenReturnCount() = runTest {
         givenFireproofWebsiteDomain("example.com")
 
         val count = fireproofWebsiteRepository.fireproofWebsitesCountByDomain("example.com")

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModelTest.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.Observer
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteDao
@@ -31,7 +32,6 @@ import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.events.db.UserEventKey
 import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.pixels.AppPixelName.FIREPROOF_LOGIN_TOGGLE_ENABLED
@@ -39,6 +39,7 @@ import com.nhaarman.mockitokotlin2.atLeastOnce
 import com.nhaarman.mockitokotlin2.mock
 import dagger.Lazy
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
@@ -168,7 +169,7 @@ class FireproofWebsitesViewModelTest {
     }
 
     @Test
-    fun whenUserEnablesLoginDetectionThenRegisterEvent() = coroutineRule.runBlocking {
+    fun whenUserEnablesLoginDetectionThenRegisterEvent() = runTest {
         viewModel.onUserToggleLoginDetection(true)
 
         verify(mockUserEventsStore).registerUserEvent(UserEventKey.USER_ENABLED_FIREPROOF_LOGIN)

--- a/app/src/androidTest/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/AlertingUncaughtExceptionHandlerTest.kt
@@ -17,13 +17,15 @@
 package com.duckduckgo.app.global
 
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.app.global.exception.UncaughtExceptionSource
 import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -47,12 +49,12 @@ class AlertingUncaughtExceptionHandlerTest {
             mockPixelCountDataStore,
             mockUncaughtExceptionRepository,
             coroutineTestRule.testDispatcherProvider,
-            TestCoroutineScope()
+            TestScope()
         )
     }
 
     @Test
-    fun whenExceptionIsNotInIgnoreListThenCrashRecordedInDatabase() = coroutineTestRule.testDispatcher.runBlockingTest {
+    fun whenExceptionIsNotInIgnoreListThenCrashRecordedInDatabase() = runTest {
         testee.uncaughtException(Thread.currentThread(), NullPointerException("Deliberate"))
         advanceUntilIdle()
 
@@ -60,7 +62,7 @@ class AlertingUncaughtExceptionHandlerTest {
     }
 
     @Test
-    fun whenExceptionIsNotInIgnoreListThenDefaultExceptionHandlerCalled() = coroutineTestRule.testDispatcher.runBlockingTest {
+    fun whenExceptionIsNotInIgnoreListThenDefaultExceptionHandlerCalled() = runTest {
         val exception = NullPointerException("Deliberate")
         testee.uncaughtException(Thread.currentThread(), exception)
         advanceUntilIdle()
@@ -69,7 +71,7 @@ class AlertingUncaughtExceptionHandlerTest {
     }
 
     @Test
-    fun whenExceptionIsInterruptedIoExceptionThenCrashNotRecorded() = coroutineTestRule.testDispatcher.runBlockingTest {
+    fun whenExceptionIsInterruptedIoExceptionThenCrashNotRecorded() = runTest {
         testee.uncaughtException(Thread.currentThread(), InterruptedIOException("Deliberate"))
         advanceUntilIdle()
 
@@ -77,7 +79,7 @@ class AlertingUncaughtExceptionHandlerTest {
     }
 
     @Test
-    fun whenExceptionIsInterruptedExceptionThenCrashNotRecorded() = coroutineTestRule.testDispatcher.runBlockingTest {
+    fun whenExceptionIsInterruptedExceptionThenCrashNotRecorded() = runTest {
         testee.uncaughtException(Thread.currentThread(), InterruptedException("Deliberate"))
         advanceUntilIdle()
 
@@ -85,7 +87,7 @@ class AlertingUncaughtExceptionHandlerTest {
     }
 
     @Test
-    fun whenExceptionIsNotRecordedButInDebugModeThenDefaultExceptionHandlerCalled() = coroutineTestRule.testDispatcher.runBlockingTest {
+    fun whenExceptionIsNotRecordedButInDebugModeThenDefaultExceptionHandlerCalled() = runTest {
         val exception = InterruptedIOException("Deliberate")
         testee.uncaughtException(Thread.currentThread(), exception)
         advanceUntilIdle()

--- a/app/src/androidTest/java/com/duckduckgo/app/global/events/db/UserEventsDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/events/db/UserEventsDaoTest.kt
@@ -20,9 +20,10 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.global.db.AppDatabase
-import com.duckduckgo.app.runBlocking
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Test
 import org.junit.Assert.*
@@ -57,19 +58,19 @@ class UserEventsDaoTest {
     }
 
     @Test
-    fun whenGetUserEventAndDatabaseEmptyThenReturnNull() = coroutineRule.runBlocking {
+    fun whenGetUserEventAndDatabaseEmptyThenReturnNull() = runTest {
         assertNull(testee.getUserEvent(UserEventKey.FIRE_BUTTON_EXECUTED))
     }
 
     @Test
-    fun whenInsertingUserEventThenTimestampIsNotNull() = coroutineRule.runBlocking {
+    fun whenInsertingUserEventThenTimestampIsNotNull() = runTest {
         testee.registerUserEvent(UserEventKey.FIRE_BUTTON_EXECUTED)
 
         assertNotNull(testee.getUserEvent(UserEventKey.FIRE_BUTTON_EXECUTED)?.timestamp)
     }
 
     @Test
-    fun whenInsertingSameUserEventThenReplaceOldTimestamp() = coroutineRule.runBlocking {
+    fun whenInsertingSameUserEventThenReplaceOldTimestamp() = runTest {
         testee.registerUserEvent(UserEventKey.FIRE_BUTTON_EXECUTED)
         val timestamp = testee.getUserEvent(UserEventKey.FIRE_BUTTON_EXECUTED)?.timestamp
 

--- a/app/src/androidTest/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepositoryDbTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepositoryDbTest.kt
@@ -23,11 +23,12 @@ import com.nhaarman.mockitokotlin2.*
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class UncaughtExceptionRepositoryDbTest {
 
     @get:Rule
@@ -54,24 +55,24 @@ class UncaughtExceptionRepositoryDbTest {
     }
 
     @Test
-    fun whenLatestExceptionIsNullThenReturnTrue() = runBlocking {
+    fun whenLatestExceptionIsNullThenReturnTrue() = runTest {
         whenever(uncaughtExceptionDao.getLatestException()).thenReturn(null)
         assertTrue(testee.isNotDuplicate(entity.copy(timestamp = 1500)))
     }
 
     @Test
-    fun whenIsBelowTimeThresholdAndSameExceptionThenReturnFalseAndUpdateTimestamp() = runBlocking {
+    fun whenIsBelowTimeThresholdAndSameExceptionThenReturnFalseAndUpdateTimestamp() = runTest {
         assertFalse(testee.isNotDuplicate(entity.copy(timestamp = 1500)))
         verify(uncaughtExceptionDao).update(entity.copy(timestamp = 1500))
     }
 
     @Test
-    fun whenIsAboveTimeThresholdAndSameExceptionThenReturnTrue() = runBlocking {
+    fun whenIsAboveTimeThresholdAndSameExceptionThenReturnTrue() = runTest {
         assertTrue(testee.isNotDuplicate(entity.copy(timestamp = 2001)))
     }
 
     @Test
-    fun whenIsDifferentExceptionThenReturnTrue() = runBlocking {
+    fun whenIsDifferentExceptionThenReturnTrue() = runTest {
         assertTrue(testee.isNotDuplicate(entity.copy(message = "different message", timestamp = 1500)))
         assertTrue(testee.isNotDuplicate(entity.copy(version = "different version", timestamp = 1500)))
         assertTrue(testee.isNotDuplicate(entity.copy(exceptionSource = UncaughtExceptionSource.HIDE_CUSTOM_VIEW, timestamp = 1500)))

--- a/app/src/androidTest/java/com/duckduckgo/app/global/rating/InitialPromptDeciderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/rating/InitialPromptDeciderTest.kt
@@ -22,13 +22,14 @@ import com.duckduckgo.app.usage.app.AppDaysUsedRepository
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 @Suppress("RemoveExplicitTypeArguments", "PrivatePropertyName")
 class InitialPromptDeciderTest {
 
@@ -51,42 +52,42 @@ class InitialPromptDeciderTest {
     }
 
     @Test
-    fun whenUserHasNotSeenPromptBeforeAndNotUsedTheAppEnoughThenShouldNotSeePrompt() = runBlocking<Unit> {
+    fun whenUserHasNotSeenPromptBeforeAndNotUsedTheAppEnoughThenShouldNotSeePrompt() = runTest {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(NOT_ENOUGH_DAYS)
         whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(true)
         assertFalse(testee.shouldShowPrompt())
     }
 
     @Test
-    fun whenUserHasNotSeenPromptBeforeAndUsedTheAppExactEnoughDaysThenShouldSeePrompt() = runBlocking<Unit> {
+    fun whenUserHasNotSeenPromptBeforeAndUsedTheAppExactEnoughDaysThenShouldSeePrompt() = runTest {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(EXACT_NUMBER_OF_DAYS)
         whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(true)
         assertTrue(testee.shouldShowPrompt())
     }
 
     @Test
-    fun whenUserHasNotSeenPromptBeforeAndUsedTheAppMoreThanEnoughDaysThenShouldSeePrompt() = runBlocking<Unit> {
+    fun whenUserHasNotSeenPromptBeforeAndUsedTheAppMoreThanEnoughDaysThenShouldSeePrompt() = runTest {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(MORE_THAN_ENOUGH_DAYS)
         whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(true)
         assertTrue(testee.shouldShowPrompt())
     }
 
     @Test
-    fun whenUserHasSeenPromptBeforeAndNotUsedTheAppEnoughThenShouldNotSeePrompt() = runBlocking<Unit> {
+    fun whenUserHasSeenPromptBeforeAndNotUsedTheAppEnoughThenShouldNotSeePrompt() = runTest {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(NOT_ENOUGH_DAYS)
         whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(false)
         assertFalse(testee.shouldShowPrompt())
     }
 
     @Test
-    fun whenUserHasSeenPromptBeforeAndUsedTheAppExactEnoughDaysThenShouldNotSeePrompt() = runBlocking<Unit> {
+    fun whenUserHasSeenPromptBeforeAndUsedTheAppExactEnoughDaysThenShouldNotSeePrompt() = runTest {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(EXACT_NUMBER_OF_DAYS)
         whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(false)
         assertFalse(testee.shouldShowPrompt())
     }
 
     @Test
-    fun whenUserHasSeenPromptBeforeAndUsedTheAppMoreThanEnoughDaysThenShouldNotSeePrompt() = runBlocking<Unit> {
+    fun whenUserHasSeenPromptBeforeAndUsedTheAppMoreThanEnoughDaysThenShouldNotSeePrompt() = runTest {
         whenever(mockAppDaysUsedRepository.getNumberOfDaysAppUsed()).thenReturn(MORE_THAN_ENOUGH_DAYS)
         whenever(mockAppEnjoymentRepository.canUserBeShownFirstPrompt()).thenReturn(false)
         assertFalse(testee.shouldShowPrompt())

--- a/app/src/androidTest/java/com/duckduckgo/app/global/rating/InitialPromptTypeDeciderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/rating/InitialPromptTypeDeciderTest.kt
@@ -22,12 +22,14 @@ import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.usage.search.SearchCountDao
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 @Suppress("RemoveExplicitTypeArguments")
 class InitialPromptTypeDeciderTest {
 
@@ -40,7 +42,7 @@ class InitialPromptTypeDeciderTest {
     private val mockOnboardingStore: OnboardingStore = mock()
 
     @Before
-    fun setup() = runBlocking<Unit> {
+    fun setup() = runTest {
 
         testee = InitialPromptTypeDecider(
             playStoreUtils = mockPlayStoreUtils,
@@ -58,19 +60,19 @@ class InitialPromptTypeDeciderTest {
     }
 
     @Test
-    fun whenPlayNotInstalledThenNoPromptShown() = runBlocking<Unit> {
+    fun whenPlayNotInstalledThenNoPromptShown() = runTest {
         whenever(mockPlayStoreUtils.isPlayStoreInstalled()).thenReturn(false)
         assertPromptNotShown(testee.determineInitialPromptType())
     }
 
     @Test
-    fun whenNotEnoughSearchesMadeThenNoPromptShown() = runBlocking<Unit> {
+    fun whenNotEnoughSearchesMadeThenNoPromptShown() = runTest {
         whenever(mockSearchCountDao.getSearchesMade()).thenReturn(0)
         assertPromptNotShown(testee.determineInitialPromptType())
     }
 
     @Test
-    fun whenEnoughSearchesMadeAndFirstPromptNotShownBeforeThenShouldShowFirstPrompt() = runBlocking<Unit> {
+    fun whenEnoughSearchesMadeAndFirstPromptNotShownBeforeThenShouldShowFirstPrompt() = runTest {
         whenever(mockInitialPromptDecider.shouldShowPrompt()).thenReturn(true)
         whenever(mockSearchCountDao.getSearchesMade()).thenReturn(Long.MAX_VALUE)
         val type = testee.determineInitialPromptType() as AppEnjoymentPromptOptions.ShowEnjoymentPrompt
@@ -78,7 +80,7 @@ class InitialPromptTypeDeciderTest {
     }
 
     @Test
-    fun whenEnoughSearchesMadeAndFirstPromptShownBeforeThenShouldShowSecondPrompt() = runBlocking<Unit> {
+    fun whenEnoughSearchesMadeAndFirstPromptShownBeforeThenShouldShowSecondPrompt() = runTest {
         whenever(mockInitialPromptDecider.shouldShowPrompt()).thenReturn(false)
         whenever(mockSecondaryPromptDecider.shouldShowPrompt()).thenReturn(true)
         whenever(mockSearchCountDao.getSearchesMade()).thenReturn(Long.MAX_VALUE)
@@ -87,7 +89,7 @@ class InitialPromptTypeDeciderTest {
     }
 
     @Test
-    fun whenUsersMarkedAsReturningUserThenNoPromptShown() = runBlocking {
+    fun whenUsersMarkedAsReturningUserThenNoPromptShown() = runTest {
         whenever(mockOnboardingStore.userMarkedAsReturningUser).thenReturn(true)
         assertPromptNotShown(testee.determineInitialPromptType())
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/rating/SecondaryPromptDeciderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/rating/SecondaryPromptDeciderTest.kt
@@ -23,7 +23,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -31,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.util.*
 
+@ExperimentalCoroutinesApi
 @Suppress("RemoveExplicitTypeArguments")
 class SecondaryPromptDeciderTest {
 
@@ -44,27 +45,27 @@ class SecondaryPromptDeciderTest {
     private val mockAppEnjoymentRepository: AppEnjoymentRepository = mock()
 
     @Before
-    fun setup() = runBlocking<Unit> {
+    fun setup() = runTest {
         testee = SecondaryPromptDecider(mockAppDaysUsedRepository, mockAppEnjoymentRepository)
         whenever(mockAppEnjoymentRepository.dateUserDismissedFirstPrompt()).thenReturn(Date())
         whenever(mockAppEnjoymentRepository.canUserBeShownSecondPrompt()).thenReturn(true)
     }
 
     @Test
-    fun whenUserHasUsedTheAppForAWhileSinceSeeingFirstPromptThenTheySeeSecondPrompt() = runBlocking<Unit> {
+    fun whenUserHasUsedTheAppForAWhileSinceSeeingFirstPromptThenTheySeeSecondPrompt() = runTest {
         configureLotsOfAppUsage()
         assertTrue(testee.shouldShowPrompt())
     }
 
     @Test
-    fun whenUserHasNotUsedTheAppMuchSinceSeeingFirstPromptThenTheyDoNotSeeSecondPrompt() = runBlocking<Unit> {
+    fun whenUserHasNotUsedTheAppMuchSinceSeeingFirstPromptThenTheyDoNotSeeSecondPrompt() = runTest {
         whenever(mockAppEnjoymentRepository.canUserBeShownSecondPrompt()).thenReturn(true)
         configureNotALotOfAppUsage()
         assertFalse(testee.shouldShowPrompt())
     }
 
     @Test
-    fun whenUserHasAlreadyRatedOrGaveFeedbackThenTheyDoNoSeeASecondPromptEvenAfterALotOfUsage() = runBlocking<Unit> {
+    fun whenUserHasAlreadyRatedOrGaveFeedbackThenTheyDoNoSeeASecondPromptEvenAfterALotOfUsage() = runTest {
         whenever(mockAppEnjoymentRepository.canUserBeShownSecondPrompt()).thenReturn(false)
         configureLotsOfAppUsage()
         assertFalse(testee.shouldShowPrompt())

--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -29,10 +29,12 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 @Suppress("RemoveExplicitTypeArguments")
 class ClearPersonalDataActionTest {
 
@@ -63,49 +65,49 @@ class ClearPersonalDataActionTest {
     }
 
     @Test
-    fun whenClearCalledWithPixelIncrementSetToTrueThenPixelCountIncremented() = runBlocking<Unit> {
+    fun whenClearCalledWithPixelIncrementSetToTrueThenPixelCountIncremented() = runTest {
         testee.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = true)
         verify(mockClearingUnsentForgetAllPixelStore).incrementCount()
     }
 
     @Test
-    fun whenClearCalledWithPixelIncrementSetToFalseThenPixelCountNotIncremented() = runBlocking<Unit> {
+    fun whenClearCalledWithPixelIncrementSetToFalseThenPixelCountNotIncremented() = runTest {
         testee.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = false)
         verify(mockClearingUnsentForgetAllPixelStore, never()).incrementCount()
     }
 
     @Test
-    fun whenClearCalledThenDataManagerClearsSessions() = runBlocking<Unit> {
+    fun whenClearCalledThenDataManagerClearsSessions() = runTest {
         testee.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = false)
         verify(mockDataManager).clearWebViewSessions()
     }
 
     @Test
-    fun whenClearCalledThenDataManagerClearsData() = runBlocking<Unit> {
+    fun whenClearCalledThenDataManagerClearsData() = runTest {
         testee.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = false)
         verify(mockDataManager).clearData(any(), any())
     }
 
     @Test
-    fun whenClearCalledThenAppCacheClearerClearsCache() = runBlocking<Unit> {
+    fun whenClearCalledThenAppCacheClearerClearsCache() = runTest {
         testee.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = false)
         verify(mockAppCacheClearer).clearCache()
     }
 
     @Test
-    fun whenClearCalledThenTabsCleared() = runBlocking<Unit> {
+    fun whenClearCalledThenTabsCleared() = runTest {
         testee.clearTabsAndAllDataAsync(false, false)
         verify(mockTabRepository).deleteAll()
     }
 
     @Test
-    fun whenClearCalledThenGeoLocationPermissionsAreCleared() = runBlocking<Unit> {
+    fun whenClearCalledThenGeoLocationPermissionsAreCleared() = runTest {
         testee.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = false)
         verify(mockGeoLocationPermissions).clearAllButFireproofed()
     }
 
     @Test
-    fun whenClearCalledThenThirdPartyCookieSitesAreCleared() = runBlocking<Unit> {
+    fun whenClearCalledThenThirdPartyCookieSitesAreCleared() = runTest {
         testee.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = false)
         verify(mockThirdPartyCookieManager).clearAllData()
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/job/WorkSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/job/WorkSchedulerTest.kt
@@ -16,15 +16,22 @@
 
 package com.duckduckgo.app.job
 
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class WorkSchedulerTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
 
     private val notificationScheduler: AndroidNotificationScheduler = mock()
     private val jobCleaner: JobCleaner = mock()
@@ -33,15 +40,11 @@ class WorkSchedulerTest {
 
     @Before
     fun before() {
-        testee = AndroidWorkScheduler(
-            TestCoroutineScope(),
-            notificationScheduler,
-            jobCleaner
-        )
+        testee = AndroidWorkScheduler(TestScope(), notificationScheduler, jobCleaner, coroutineRule.testDispatcherProvider)
     }
 
     @Test
-    fun schedulesNextNotificationAndCleansDeprecatedJobs() = runBlocking<Unit> {
+    fun schedulesNextNotificationAndCleansDeprecatedJobs() = runTest {
         testee.scheduleWork()
 
         verify(notificationScheduler).scheduleNextNotification()

--- a/app/src/androidTest/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
@@ -28,7 +28,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
@@ -55,7 +55,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingShouldShowAndReferrerDataReturnsQuicklyThenCommandIsOnboarding() = runBlockingTest {
+    fun whenOnboardingShouldShowAndReferrerDataReturnsQuicklyThenCommandIsOnboarding() = runTest {
         testee = LaunchViewModel(userStageStore, StubAppReferrerFoundStateListener("xx"))
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.command.observeForever(mockCommandObserver)
@@ -66,7 +66,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingShouldShowAndReferrerDataReturnsButNotInstantlyThenCommandIsOnboarding() = runBlockingTest {
+    fun whenOnboardingShouldShowAndReferrerDataReturnsButNotInstantlyThenCommandIsOnboarding() = runTest {
         testee = LaunchViewModel(userStageStore, StubAppReferrerFoundStateListener("xx", mockDelayMs = 1_000))
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.command.observeForever(mockCommandObserver)
@@ -77,7 +77,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingShouldShowAndReferrerDataTimesOutThenCommandIsOnboarding() = runBlockingTest {
+    fun whenOnboardingShouldShowAndReferrerDataTimesOutThenCommandIsOnboarding() = runTest {
         testee = LaunchViewModel(userStageStore, StubAppReferrerFoundStateListener("xx", mockDelayMs = Long.MAX_VALUE))
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.command.observeForever(mockCommandObserver)
@@ -88,7 +88,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingShouldNotShowAndReferrerDataReturnsQuicklyThenCommandIsHome() = runBlockingTest {
+    fun whenOnboardingShouldNotShowAndReferrerDataReturnsQuicklyThenCommandIsHome() = runTest {
         testee = LaunchViewModel(userStageStore, StubAppReferrerFoundStateListener("xx"))
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.command.observeForever(mockCommandObserver)
@@ -97,7 +97,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingShouldNotShowAndReferrerDataReturnsButNotInstantlyThenCommandIsHome() = runBlockingTest {
+    fun whenOnboardingShouldNotShowAndReferrerDataReturnsButNotInstantlyThenCommandIsHome() = runTest {
         testee = LaunchViewModel(userStageStore, StubAppReferrerFoundStateListener("xx", mockDelayMs = 1_000))
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.command.observeForever(mockCommandObserver)
@@ -106,7 +106,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingShouldNotShowAndReferrerDataTimesOutThenCommandIsHome() = runBlockingTest {
+    fun whenOnboardingShouldNotShowAndReferrerDataTimesOutThenCommandIsHome() = runTest {
         testee = LaunchViewModel(userStageStore, StubAppReferrerFoundStateListener("xx", mockDelayMs = Long.MAX_VALUE))
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.command.observeForever(mockCommandObserver)

--- a/app/src/androidTest/java/com/duckduckgo/app/location/GeoLocationPermissionsTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/location/GeoLocationPermissionsTest.kt
@@ -20,6 +20,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteDao
@@ -30,10 +31,10 @@ import com.duckduckgo.app.location.data.LocationPermissionEntity
 import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.location.data.LocationPermissionsDao
 import com.duckduckgo.app.location.data.LocationPermissionsRepository
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.mock
 import dagger.Lazy
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
@@ -86,7 +87,7 @@ class GeoLocationPermissionsTest {
     }
 
     @Test
-    fun whenClearingAllPermissionsButFireproofedThenOnlyNonFireproofedSitesAreDeleted() = coroutineRule.runBlocking {
+    fun whenClearingAllPermissionsButFireproofedThenOnlyNonFireproofedSitesAreDeleted() = runTest {
         givenFireproofWebsiteDomain("anotherdomain.com")
         givenLocationPermissionsDomain("https://domain.com")
 
@@ -106,7 +107,7 @@ class GeoLocationPermissionsTest {
     }
 
     @Test
-    fun whenClearingAllPermissionsButFireproofedAndNoFireproofedSitesThenAllSitePermissionsAreDeleted() = coroutineRule.runBlocking {
+    fun whenClearingAllPermissionsButFireproofedAndNoFireproofedSitesThenAllSitePermissionsAreDeleted() = runTest {
         givenLocationPermissionsDomain("https://domain.com")
 
         val oldLocationPermissions = locationPermissionsDao.allPermissions()
@@ -119,7 +120,7 @@ class GeoLocationPermissionsTest {
     }
 
     @Test
-    fun whenClearingAllPermissionsButFireproofedAndSiteIsFireproofedThenNothingIsDeleted() = coroutineRule.runBlocking {
+    fun whenClearingAllPermissionsButFireproofedAndSiteIsFireproofedThenNothingIsDeleted() = runTest {
         givenFireproofWebsiteDomain("domain.com")
         givenLocationPermissionsDomain("https://domain.com")
 
@@ -139,7 +140,7 @@ class GeoLocationPermissionsTest {
     }
 
     @Test
-    fun whenClearingAllPermissionsThenAllPermissionsAreDeleted() = coroutineRule.runBlocking {
+    fun whenClearingAllPermissionsThenAllPermissionsAreDeleted() = runTest {
         givenLocationPermissionsDomain("https://domain.com")
 
         val oldLocationPermissions = locationPermissionsDao.allPermissions()

--- a/app/src/androidTest/java/com/duckduckgo/app/location/data/LocationPermissionsRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/location/data/LocationPermissionsRepositoryTest.kt
@@ -20,14 +20,15 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.blockingObserve
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.global.db.AppDatabase
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import dagger.Lazy
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -71,7 +72,7 @@ class LocationPermissionsRepositoryTest {
     }
 
     @Test
-    fun whenPermissionIsValidThenItIsStored() = coroutineRule.runBlocking {
+    fun whenPermissionIsValidThenItIsStored() = runTest {
         val permissionType = LocationPermissionType.ALLOW_ALWAYS
         val permission = LocationPermissionEntity(domain, permissionType)
         val permissionStored = repository.savePermission(domain, LocationPermissionType.ALLOW_ALWAYS)
@@ -79,28 +80,28 @@ class LocationPermissionsRepositoryTest {
     }
 
     @Test
-    fun whenGetAllPermissionsAsyncThenReturnLiveDataWithAllItemsFromDatabase() = coroutineRule.runBlocking {
+    fun whenGetAllPermissionsAsyncThenReturnLiveDataWithAllItemsFromDatabase() = runTest {
         givenPermissionStored("example.com", "example2.com")
         val entities = repository.getLocationPermissionsAsync().blockingObserve()!!
         assertEquals(entities.size, 2)
     }
 
     @Test
-    fun whenGetAllPermissionsSyncThenReturnListWithAllItemsFromDatabase() = coroutineRule.runBlocking {
+    fun whenGetAllPermissionsSyncThenReturnListWithAllItemsFromDatabase() = runTest {
         givenPermissionStored("example.com", "example2.com")
         val entities = repository.getLocationPermissionsSync()
         assertEquals(entities.size, 2)
     }
 
     @Test
-    fun whenGetAllFireproofWebsitesThenReturnLiveDataWithAllItemsFromDatabase() = coroutineRule.runBlocking {
+    fun whenGetAllFireproofWebsitesThenReturnLiveDataWithAllItemsFromDatabase() = runTest {
         givenPermissionStored("example.com", "example2.com")
         val entities = repository.getLocationPermissionsAsync().blockingObserve()!!
         assertEquals(entities.size, 2)
     }
 
     @Test
-    fun whenDeletePermissionStoredThenItemRemovedFromDatabase() = coroutineRule.runBlocking {
+    fun whenDeletePermissionStoredThenItemRemovedFromDatabase() = runTest {
         givenPermissionStored("example.com", "example2.com")
 
         assertEquals(dao.allPermissions().size, 2)
@@ -111,7 +112,7 @@ class LocationPermissionsRepositoryTest {
     }
 
     @Test
-    fun whenDeletePermissionNotStoredThenNotingIsRemovedFromDatabase() = coroutineRule.runBlocking {
+    fun whenDeletePermissionNotStoredThenNotingIsRemovedFromDatabase() = runTest {
         givenPermissionStored("example.com", "example2.com")
 
         assertEquals(dao.allPermissions().size, 2)
@@ -122,7 +123,7 @@ class LocationPermissionsRepositoryTest {
     }
 
     @Test
-    fun whenRetrievingStoredPermissionThenItCanBeRetrieved() = coroutineRule.runBlocking {
+    fun whenRetrievingStoredPermissionThenItCanBeRetrieved() = runTest {
         givenPermissionStored("example.com", "example2.com")
 
         val retrieved = repository.getDomainPermission("example2.com")!!
@@ -131,7 +132,7 @@ class LocationPermissionsRepositoryTest {
     }
 
     @Test
-    fun whenRetrievingNotStoredPermissionThenNothingCanBeRetrieved() = coroutineRule.runBlocking {
+    fun whenRetrievingNotStoredPermissionThenNothingCanBeRetrieved() = runTest {
         givenPermissionStored("example.com", "example2.com")
 
         val retrieved = repository.getDomainPermission("exampl3.com")
@@ -140,7 +141,7 @@ class LocationPermissionsRepositoryTest {
     }
 
     @Test
-    fun whenDeletePermissionStoredThenDeletePersistedFavicon() = coroutineRule.runBlocking {
+    fun whenDeletePermissionStoredThenDeletePersistedFavicon() = runTest {
         givenPermissionStored("example.com")
 
         repository.deletePermission("example.com")
@@ -149,7 +150,7 @@ class LocationPermissionsRepositoryTest {
     }
 
     @Test
-    fun whenPermissionEntitiesCountByDomainAndNoWebsitesMatchThenReturnZero() = coroutineRule.runBlocking {
+    fun whenPermissionEntitiesCountByDomainAndNoWebsitesMatchThenReturnZero() = runTest {
         givenPermissionStored("example.com")
 
         val count = repository.permissionEntitiesCountByDomain("test.com")
@@ -158,7 +159,7 @@ class LocationPermissionsRepositoryTest {
     }
 
     @Test
-    fun whenPermissionEntitiesCountByDomainAndWebsitsMatchThenReturnCount() = coroutineRule.runBlocking {
+    fun whenPermissionEntitiesCountByDomainAndWebsitsMatchThenReturnCount() = runTest {
         val query = "%example%"
         givenPermissionStored("example.com")
 

--- a/app/src/androidTest/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/location/ui/LocationPermissionsViewModelTest.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.Observer
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.global.db.AppDatabase
@@ -30,7 +31,6 @@ import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.location.data.LocationPermissionsDao
 import com.duckduckgo.app.location.data.LocationPermissionsRepository
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.atLeastOnce
@@ -39,6 +39,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import dagger.Lazy
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -152,7 +153,7 @@ class LocationPermissionsViewModelTest {
     }
 
     @Test
-    fun whenUserDeletesLocationPermissionThenViewStateIsUpdated() = coroutineRule.runBlocking {
+    fun whenUserDeletesLocationPermissionThenViewStateIsUpdated() = runTest {
         givenLocationPermission(LocationPermissionType.ALLOW_ONCE, "domain.com")
 
         viewModel.loadLocationPermissions(true)
@@ -165,7 +166,7 @@ class LocationPermissionsViewModelTest {
     }
 
     @Test
-    fun whenUserDeletesLocationPermissionThenGeoLocationPermissionDeletesDomain() = coroutineRule.runBlocking {
+    fun whenUserDeletesLocationPermissionThenGeoLocationPermissionDeletesDomain() = runTest {
         val domain = "domain.com"
         givenLocationPermission(LocationPermissionType.ALLOW_ONCE, domain)
 
@@ -187,7 +188,7 @@ class LocationPermissionsViewModelTest {
     }
 
     @Test
-    fun whenUserTogglesLocationPermissionsThenViewStateUpdated() = coroutineRule.runBlocking {
+    fun whenUserTogglesLocationPermissionsThenViewStateUpdated() = runTest {
         viewModel.loadLocationPermissions(true)
         viewModel.onLocationPermissionToggled(true)
 
@@ -203,21 +204,21 @@ class LocationPermissionsViewModelTest {
     }
 
     @Test
-    fun whenUserDisablesLocationPermissionThenAllPermissionsAreCleared() = coroutineRule.runBlocking {
+    fun whenUserDisablesLocationPermissionThenAllPermissionsAreCleared() = runTest {
         viewModel.onLocationPermissionToggled(false)
 
         Mockito.verify(mockGeoLocationPermissions).clearAll()
     }
 
     @Test
-    fun whenUserEnablesLocationPermissionThenPermissionsAreNotModified() = coroutineRule.runBlocking {
+    fun whenUserEnablesLocationPermissionThenPermissionsAreNotModified() = runTest {
         viewModel.onLocationPermissionToggled(true)
 
         Mockito.verifyNoMoreInteractions(mockGeoLocationPermissions)
     }
 
     @Test
-    fun whenUserEditsLocationPermissionThenViewStateIsUpdated() = coroutineRule.runBlocking {
+    fun whenUserEditsLocationPermissionThenViewStateIsUpdated() = runTest {
         givenLocationPermission(LocationPermissionType.ALLOW_ONCE, "domain.com")
 
         viewModel.loadLocationPermissions(true)
@@ -233,7 +234,7 @@ class LocationPermissionsViewModelTest {
     }
 
     @Test
-    fun whenAllowAlwaysPermissionsIsGrantedThenGeoLocationPermissionIsAllowed() = coroutineRule.runBlocking {
+    fun whenAllowAlwaysPermissionsIsGrantedThenGeoLocationPermissionIsAllowed() = runTest {
         val domain = "example.com"
 
         viewModel.onSiteLocationPermissionSelected(domain, LocationPermissionType.ALLOW_ALWAYS)
@@ -244,7 +245,7 @@ class LocationPermissionsViewModelTest {
     }
 
     @Test
-    fun whenAllowOncePermissionsIsGrantedThenGeoLocationPermissionIsClearedAndRemovedFromDb() = coroutineRule.runBlocking {
+    fun whenAllowOncePermissionsIsGrantedThenGeoLocationPermissionIsClearedAndRemovedFromDb() = runTest {
         val domain = "example.com"
         viewModel.onSiteLocationPermissionSelected(domain, LocationPermissionType.ALLOW_ONCE)
 
@@ -254,7 +255,7 @@ class LocationPermissionsViewModelTest {
     }
 
     @Test
-    fun whenDenyOncePermissionsIsGrantedThenGeoLocationPermissionIsClearedAndRemovedFromDb() = coroutineRule.runBlocking {
+    fun whenDenyOncePermissionsIsGrantedThenGeoLocationPermissionIsClearedAndRemovedFromDb() = runTest {
         val domain = "example.com"
         viewModel.onSiteLocationPermissionSelected(domain, LocationPermissionType.DENY_ONCE)
 
@@ -264,7 +265,7 @@ class LocationPermissionsViewModelTest {
     }
 
     @Test
-    fun whenDenyAlwaysPermissionsIsGrantedThenGeoLocationPermissionIsAllowed() = coroutineRule.runBlocking {
+    fun whenDenyAlwaysPermissionsIsGrantedThenGeoLocationPermissionIsAllowed() = runTest {
         val domain = "example.com"
         viewModel.onSiteLocationPermissionSelected(domain, LocationPermissionType.DENY_ALWAYS)
 

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
@@ -32,13 +32,14 @@ import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import kotlin.reflect.jvm.jvmName
 
+@ExperimentalCoroutinesApi
 class AndroidNotificationSchedulerTest {
 
     @ExperimentalCoroutinesApi
@@ -75,7 +76,7 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenPrivacyNotificationClearDataCanShowThenPrivacyNotificationIsScheduled() = runBlocking<Unit> {
+    fun whenPrivacyNotificationClearDataCanShowThenPrivacyNotificationIsScheduled() = runTest {
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(true)
         testee.scheduleNextNotification()
@@ -84,7 +85,7 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenPrivacyNotificationCanShowButClearDataCannotThenPrivacyNotificationIsScheduled() = runBlocking<Unit> {
+    fun whenPrivacyNotificationCanShowButClearDataCannotThenPrivacyNotificationIsScheduled() = runTest {
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(false)
         testee.scheduleNextNotification()
@@ -93,7 +94,7 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenPrivacyNotificationCannotShowAndClearNotificationCanShowThenClearNotificationIsScheduled() = runBlocking<Unit> {
+    fun whenPrivacyNotificationCannotShowAndClearNotificationCanShowThenClearNotificationIsScheduled() = runTest {
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(true)
         testee.scheduleNextNotification()
@@ -102,7 +103,7 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenPrivacyNotificationAndClearNotificationCannotShowThenNoNotificationScheduled() = runBlocking<Unit> {
+    fun whenPrivacyNotificationAndClearNotificationCannotShowThenNoNotificationScheduled() = runTest {
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(false)
         testee.scheduleNextNotification()

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
@@ -26,10 +26,12 @@ import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.*
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class NotificationRegistrarTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -46,7 +48,7 @@ class NotificationRegistrarTest {
     fun before() {
         whenever(mockVariantManager.getVariant(any())).thenReturn(DEFAULT_VARIANT)
         testee = NotificationRegistrar(
-            TestCoroutineScope(),
+            TestScope(),
             context,
             notificationManager,
             notifcationManagerCompat,

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/AppFeatureNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/AppFeatureNotificationTest.kt
@@ -24,13 +24,15 @@ import com.duckduckgo.app.notification.db.NotificationDao
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class AppFeatureNotificationTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -43,19 +45,19 @@ class AppFeatureNotificationTest {
     }
 
     @Test
-    fun whenNotificationNotSeenThenCanShowIsTrue() = runBlocking<Unit> {
+    fun whenNotificationNotSeenThenCanShowIsTrue() = runTest {
         whenever(notificationsDao.exists(any())).thenReturn(false)
         assertTrue(testee.canShow())
     }
 
     @Test
-    fun whenNotificationAlreadySeenThenCanShowIsFalse() = runBlocking<Unit> {
+    fun whenNotificationAlreadySeenThenCanShowIsFalse() = runTest {
         whenever(notificationsDao.exists(any())).thenReturn(true)
         assertFalse(testee.canShow())
     }
 
     @Test
-    fun whenBuildSpecificationSetCorrectPixelSuffix() = runBlocking<Unit> {
+    fun whenBuildSpecificationSetCorrectPixelSuffix() = runTest {
         val spec = testee.buildSpecification()
         assertEquals(PIXEL, spec.pixelSuffix)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/ClearDataNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/ClearDataNotificationTest.kt
@@ -25,12 +25,14 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class ClearDataNotificationTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -45,21 +47,21 @@ class ClearDataNotificationTest {
     }
 
     @Test
-    fun whenNotificationNotSeenAndOptionNotSetThenCanShowIsTrue() = runBlocking<Unit> {
+    fun whenNotificationNotSeenAndOptionNotSetThenCanShowIsTrue() = runTest {
         whenever(notificationsDao.exists(any())).thenReturn(false)
         whenever(settingsDataStore.automaticallyClearWhatOption).thenReturn(ClearWhatOption.CLEAR_NONE)
         assertTrue(testee.canShow())
     }
 
     @Test
-    fun whenNotificationNotSeenButOptionAlreadySetThenCanShowIsFalse() = runBlocking<Unit> {
+    fun whenNotificationNotSeenButOptionAlreadySetThenCanShowIsFalse() = runTest {
         whenever(notificationsDao.exists(any())).thenReturn(false)
         whenever(settingsDataStore.automaticallyClearWhatOption).thenReturn(ClearWhatOption.CLEAR_TABS_ONLY)
         assertFalse(testee.canShow())
     }
 
     @Test
-    fun whenNotificationAlreadySeenAndOptionNotSetThenCanShowIsFalse() = runBlocking<Unit> {
+    fun whenNotificationAlreadySeenAndOptionNotSetThenCanShowIsFalse() = runTest {
         whenever(notificationsDao.exists(any())).thenReturn(true)
         whenever(settingsDataStore.automaticallyClearWhatOption).thenReturn(ClearWhatOption.CLEAR_NONE)
         assertFalse(testee.canShow())

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/EmailWaitlistCodeNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/EmailWaitlistCodeNotificationTest.kt
@@ -18,13 +18,14 @@ package com.duckduckgo.app.notification.model
 
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.email.db.EmailDataStore
 import com.duckduckgo.app.notification.db.NotificationDao
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -48,21 +49,21 @@ class EmailWaitlistCodeNotificationTest {
     }
 
     @Test
-    fun whenNotificationNotSeenAndSendNotificationIsTrueThenReturnTrue() = coroutineTestRule.runBlocking {
+    fun whenNotificationNotSeenAndSendNotificationIsTrueThenReturnTrue() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(false)
         whenever(mockEmailDataStore.sendNotification).thenReturn(true)
         assertTrue(testee.canShow())
     }
 
     @Test
-    fun whenNotificationNotSeenAndSendNotificationIsFalseThenReturnFalse() = coroutineTestRule.runBlocking {
+    fun whenNotificationNotSeenAndSendNotificationIsFalseThenReturnFalse() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(false)
         whenever(mockEmailDataStore.sendNotification).thenReturn(false)
         assertFalse(testee.canShow())
     }
 
     @Test
-    fun whenNotificationSeenThenReturnFalse() = coroutineTestRule.runBlocking {
+    fun whenNotificationSeenThenReturnFalse() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(true)
         whenever(mockEmailDataStore.sendNotification).thenReturn(true)
         assertFalse(testee.canShow())

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/PrivacyProtectionNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/PrivacyProtectionNotificationTest.kt
@@ -24,12 +24,14 @@ import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class PrivacyProtectionNotificationTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -44,13 +46,13 @@ class PrivacyProtectionNotificationTest {
     }
 
     @Test
-    fun whenNotificationNotSeenThenCanShowIsTrue() = runBlocking<Unit> {
+    fun whenNotificationNotSeenThenCanShowIsTrue() = runTest {
         whenever(notificationsDao.exists(any())).thenReturn(false)
         assertTrue(testee.canShow())
     }
 
     @Test
-    fun whenNotificationAlreadySeenThenCanShowIsFalse() = runBlocking<Unit> {
+    fun whenNotificationAlreadySeenThenCanShowIsFalse() = runTest {
         whenever(notificationsDao.exists(any())).thenReturn(true)
         assertFalse(testee.canShow())
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/WebsiteNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/WebsiteNotificationTest.kt
@@ -24,13 +24,15 @@ import com.duckduckgo.app.notification.db.NotificationDao
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class WebsiteNotificationTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -44,25 +46,25 @@ class WebsiteNotificationTest {
     }
 
     @Test
-    fun whenNotificationNotSeenThenCanShowIsTrue() = runBlocking<Unit> {
+    fun whenNotificationNotSeenThenCanShowIsTrue() = runTest {
         whenever(notificationsDao.exists(any())).thenReturn(false)
         assertTrue(testee.canShow())
     }
 
     @Test
-    fun whenNotificationAlreadySeenThenCanShowIsFalse() = runBlocking<Unit> {
+    fun whenNotificationAlreadySeenThenCanShowIsFalse() = runTest {
         whenever(notificationsDao.exists(any())).thenReturn(true)
         assertFalse(testee.canShow())
     }
 
     @Test
-    fun whenBuildSpecificationSetCorrectUrl() = runBlocking<Unit> {
+    fun whenBuildSpecificationSetCorrectUrl() = runTest {
         val spec = testee.buildSpecification()
         assertEquals(URL, spec.bundle.get(WebsiteNotificationSpecification.WEBSITE_KEY))
     }
 
     @Test
-    fun whenBuildSpecificationSetCorrectPixelSuffix() = runBlocking<Unit> {
+    fun whenBuildSpecificationSetCorrectPixelSuffix() = runTest {
         val spec = testee.buildSpecification()
         assertEquals(PIXEL, spec.pixelSuffix)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/store/AppUserStageStoreTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/store/AppUserStageStoreTest.kt
@@ -17,11 +17,12 @@
 package com.duckduckgo.app.onboarding.store
 
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
+import kotlinx.coroutines.test.runTest
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -36,7 +37,7 @@ class AppUserStageStoreTest {
     private val testee = AppUserStageStore(userStageDao, coroutineRule.testDispatcherProvider)
 
     @Test
-    fun whenGetUserAppStageThenReturnCurrentStage() = coroutineRule.runBlocking {
+    fun whenGetUserAppStageThenReturnCurrentStage() = runTest {
         givenCurrentStage(AppStage.DAX_ONBOARDING)
 
         val userAppStage = testee.getUserAppStage()
@@ -45,7 +46,7 @@ class AppUserStageStoreTest {
     }
 
     @Test
-    fun whenStageNewCompletedThenStageDaxOnboardingReturned() = coroutineRule.runBlocking {
+    fun whenStageNewCompletedThenStageDaxOnboardingReturned() = runTest {
         givenCurrentStage(AppStage.NEW)
 
         val nextStage = testee.stageCompleted(AppStage.NEW)
@@ -54,7 +55,7 @@ class AppUserStageStoreTest {
     }
 
     @Test
-    fun whenStageDaxOnboardingCompletedThenStageEstablishedReturned() = coroutineRule.runBlocking {
+    fun whenStageDaxOnboardingCompletedThenStageEstablishedReturned() = runTest {
         givenCurrentStage(AppStage.DAX_ONBOARDING)
 
         val nextStage = testee.stageCompleted(AppStage.DAX_ONBOARDING)
@@ -63,7 +64,7 @@ class AppUserStageStoreTest {
     }
 
     @Test
-    fun whenStageEstablishedCompletedThenStageEstablishedReturned() = coroutineRule.runBlocking {
+    fun whenStageEstablishedCompletedThenStageEstablishedReturned() = runTest {
         givenCurrentStage(AppStage.ESTABLISHED)
 
         val nextStage = testee.stageCompleted(AppStage.ESTABLISHED)
@@ -72,7 +73,7 @@ class AppUserStageStoreTest {
     }
 
     @Test
-    fun whenMoveToStageThenUpdateUserStageInDao() = coroutineRule.runBlocking {
+    fun whenMoveToStageThenUpdateUserStageInDao() = runTest {
         testee.moveToStage(AppStage.DAX_ONBOARDING)
         verify(userStageDao).updateUserStage(AppStage.DAX_ONBOARDING)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModelTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -45,7 +45,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun whenOnboardingDoneThenCompleteStage() = runBlockingTest {
+    fun whenOnboardingDoneThenCompleteStage() = runTest {
         testee.onOnboardingDone()
         verify(userStageStore).stageCompleted(AppStage.NEW)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -21,11 +21,11 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.any
@@ -34,8 +34,10 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import junit.framework.Assert.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -44,6 +46,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import kotlin.time.ExperimentalTime
 
+@ObsoleteCoroutinesApi
 @ExperimentalTime
 @ExperimentalCoroutinesApi
 class WelcomePageViewModelTest {
@@ -100,7 +103,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnPrimaryCtaClickedAndShouldNotShowDialogThenFireAndFinish() = coroutineRule.runBlocking {
+    fun whenOnPrimaryCtaClickedAndShouldNotShowDialogThenFireAndFinish() = runTest {
         whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(false)
 
         events.send(WelcomePageView.Event.OnPrimaryCtaClicked)
@@ -112,7 +115,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnPrimaryCtaClickedAndShouldShowDialogAndShowThenFireAndEmitShowDialog() = coroutineRule.runBlocking {
+    fun whenOnPrimaryCtaClickedAndShouldShowDialogAndShowThenFireAndEmitShowDialog() = runTest {
         whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
         val intent = Intent()
         whenever(defaultRoleBrowserDialog.createIntent(any())).thenReturn(intent)
@@ -126,7 +129,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnPrimaryCtaClickedAndShouldShowDialogNullIntentThenFireAndFinish() = coroutineRule.runBlocking {
+    fun whenOnPrimaryCtaClickedAndShouldShowDialogNullIntentThenFireAndFinish() = runTest {
         whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
         whenever(defaultRoleBrowserDialog.createIntent(any())).thenReturn(null)
 
@@ -140,7 +143,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnDefaultBrowserSetThenCallDialogShownFireAndFinish() = coroutineRule.runBlocking {
+    fun whenOnDefaultBrowserSetThenCallDialogShownFireAndFinish() = runTest {
         events.send(WelcomePageView.Event.OnDefaultBrowserSet)
 
         viewEvents.test {
@@ -154,7 +157,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnDefaultBrowserNotSetThenCallDialogShownFireAndFinish() = coroutineRule.runBlocking {
+    fun whenOnDefaultBrowserNotSetThenCallDialogShownFireAndFinish() = runTest {
         events.send(WelcomePageView.Event.OnDefaultBrowserNotSet)
 
         viewEvents.test {
@@ -168,7 +171,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenReturningUsersNoOnboardingEnabledShowExpectedState() = coroutineRule.runBlocking {
+    fun whenReturningUsersNoOnboardingEnabledShowExpectedState() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zv" })
 
         viewModel.screenContent.test {
@@ -178,7 +181,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenReturningUsersWidgetPromotionEnabledShowExpectedState() = coroutineRule.runBlocking {
+    fun whenReturningUsersWidgetPromotionEnabledShowExpectedState() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zz" })
 
         viewModel.screenContent.test {
@@ -188,7 +191,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenControlEnabledShowDefaultOnboardingState() = coroutineRule.runBlocking {
+    fun whenControlEnabledShowDefaultOnboardingState() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zk" })
 
         viewModel.screenContent.test {
@@ -198,7 +201,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnPrimaryCtaClickedAndReturningUsersNoOnboardingEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
+    fun whenOnPrimaryCtaClickedAndReturningUsersNoOnboardingEnabledThenEmitShowDialog() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zv" })
         whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
         val intent = Intent()
@@ -214,7 +217,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnPrimaryCtaClickedAndReturningUsersWidgetPromotionEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
+    fun whenOnPrimaryCtaClickedAndReturningUsersWidgetPromotionEnabledThenEmitShowDialog() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zz" })
         whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
         val intent = Intent()
@@ -230,7 +233,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnReturningUserClickedAndReturningUsersNoOnboardingEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
+    fun whenOnReturningUserClickedAndReturningUsersNoOnboardingEnabledThenEmitShowDialog() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zv" })
         whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
         val intent = Intent()
@@ -246,7 +249,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnReturningUserClickedAndReturningUsersWidgetPromotionEnabledThenEmitShowDialog() = coroutineRule.runBlocking {
+    fun whenOnReturningUserClickedAndReturningUsersWidgetPromotionEnabledThenEmitShowDialog() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zz" })
         whenever(defaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
         val intent = Intent()

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/model/PrivacyPracticesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/model/PrivacyPracticesTest.kt
@@ -30,12 +30,14 @@ import com.duckduckgo.app.trackerdetection.model.TdsDomainEntity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class PrivacyPracticesTest {
 
     private lateinit var db: AppDatabase
@@ -61,7 +63,7 @@ class PrivacyPracticesTest {
     }
 
     @Test
-    fun whenUrlButNoParentEntityThenStillHasScore() = runBlocking {
+    fun whenUrlButNoParentEntityThenStillHasScore() = runTest {
         whenever(mockTermsStore.terms).thenReturn(
             listOf(
                 TermsOfService("example.com", classification = "D")
@@ -72,7 +74,7 @@ class PrivacyPracticesTest {
     }
 
     @Test
-    fun whenUrlHasParentEntityThenItsScoreIsWorstInNetwork() = runBlocking {
+    fun whenUrlHasParentEntityThenItsScoreIsWorstInNetwork() = runTest {
         whenever(mockTermsStore.terms).thenReturn(
             listOf(
                 TermsOfService("sibling1.com", classification = "A"),
@@ -106,14 +108,14 @@ class PrivacyPracticesTest {
     }
 
     @Test
-    fun whenUrlHasMatchingEntityWithTermsThenPracticesAreReturned() = runBlocking {
+    fun whenUrlHasMatchingEntityWithTermsThenPracticesAreReturned() = runTest {
         whenever(mockTermsStore.terms).thenReturn(listOf(TermsOfService("example.com", classification = "A")))
         val expected = Practices(score = 0, summary = GOOD, goodReasons = emptyList(), badReasons = emptyList())
         assertEquals(expected, testee.privacyPracticesFor("http://www.example.com"))
     }
 
     @Test
-    fun whenInitialisedWithEmptyTermsStoreAndEntityListThenReturnsUnknownForUrl() = runBlocking {
+    fun whenInitialisedWithEmptyTermsStoreAndEntityListThenReturnsUnknownForUrl() = runTest {
         assertEquals(PrivacyPractices.UNKNOWN, testee.privacyPracticesFor("http://www.example.com"))
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyDashboardViewModelTest.kt
@@ -38,13 +38,14 @@ import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class PrivacyDashboardViewModelTest {
 
     @get:Rule
@@ -68,7 +69,7 @@ class PrivacyDashboardViewModelTest {
 
     @ExperimentalCoroutinesApi
     private val testee: PrivacyDashboardViewModel by lazy {
-        val model = PrivacyDashboardViewModel(mockUserWhitelistDao, mockContentBlocking, networkLeaderboardDao, mockPixel, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+        val model = PrivacyDashboardViewModel(mockUserWhitelistDao, mockContentBlocking, networkLeaderboardDao, mockPixel, TestScope(), coroutineRule.testDispatcherProvider)
         model.viewState.observeForever(viewStateObserver)
         model.command.observeForever(commandObserver)
         model

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/PrivacyPracticesViewModelTest.kt
@@ -21,16 +21,17 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.POOR
 import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.UNKNOWN
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -58,7 +59,7 @@ class PrivacyPracticesViewModelTest {
     }
 
     @Test
-    fun whenNoDataThenDefaultValuesAreUsed() = coroutineTestRule.runBlocking {
+    fun whenNoDataThenDefaultValuesAreUsed() = runTest {
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(MutableLiveData())
 
         testee.privacyPractices("1").test {
@@ -71,7 +72,7 @@ class PrivacyPracticesViewModelTest {
     }
 
     @Test
-    fun whenUrlIsUpdatedThenViewModelDomainIsUpdated() = coroutineTestRule.runBlocking {
+    fun whenUrlIsUpdatedThenViewModelDomainIsUpdated() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -83,7 +84,7 @@ class PrivacyPracticesViewModelTest {
     }
 
     @Test
-    fun whenPrivacyPracticesAreUpdatedThenViewModelPracticesAndTermsListsAreUpdated() = coroutineTestRule.runBlocking {
+    fun whenPrivacyPracticesAreUpdatedThenViewModelPracticesAndTermsListsAreUpdated() = runTest {
         val privacyPractices = PrivacyPractices.Practices(0, POOR, listOf("good", "also good"), listOf("bad"))
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/ScorecardViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/ScorecardViewModelTest.kt
@@ -20,6 +20,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.privacy.model.HttpsStatus
@@ -28,7 +29,6 @@ import com.duckduckgo.app.privacy.model.PrivacyPractices
 import com.duckduckgo.app.privacy.model.PrivacyPractices.Practices
 import com.duckduckgo.app.privacy.model.PrivacyPractices.Summary.GOOD
 import com.duckduckgo.app.privacy.model.TestEntity
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.privacy.config.api.ContentBlocking
@@ -36,6 +36,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -71,7 +72,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenNoDataThenDefaultValuesAreUsed() = coroutineTestRule.runBlocking {
+    fun whenNoDataThenDefaultValuesAreUsed() = runTest {
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(MutableLiveData())
 
         testee.scoreCard("1").test {
@@ -91,7 +92,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenSiteGradesAreUpdatedThenViewModelGradesAreUpdated() = coroutineTestRule.runBlocking {
+    fun whenSiteGradesAreUpdatedThenViewModelGradesAreUpdated() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -105,7 +106,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenSiteHttpsStatusIsUpdatedThenViewModelIsUpdated() = coroutineTestRule.runBlocking {
+    fun whenSiteHttpsStatusIsUpdatedThenViewModelIsUpdated() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -117,7 +118,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenTrackerCountIsUpdatedThenCountIsUpdatedInViewModel() = coroutineTestRule.runBlocking {
+    fun whenTrackerCountIsUpdatedThenCountIsUpdatedInViewModel() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -129,7 +130,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenMajorNetworkCountIsUpdatedThenCountIsUpdatedInViewModel() = coroutineTestRule.runBlocking {
+    fun whenMajorNetworkCountIsUpdatedThenCountIsUpdatedInViewModel() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -141,7 +142,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenAllBlockedUpdatedToFalseThenViewModelIsUpdated() = coroutineTestRule.runBlocking {
+    fun whenAllBlockedUpdatedToFalseThenViewModelIsUpdated() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -153,7 +154,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenAllBlockedUpdatedToTrueThenViewModelIsUpdated() = coroutineTestRule.runBlocking {
+    fun whenAllBlockedUpdatedToTrueThenViewModelIsUpdated() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -165,7 +166,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenTermsAreUpdatedThenPracticesAreUpdatedInViewModel() = coroutineTestRule.runBlocking {
+    fun whenTermsAreUpdatedThenPracticesAreUpdatedInViewModel() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -178,7 +179,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenIsMemberOfMajorNetworkThenShowIsMemberOfMajorNetworkIsTrue() = coroutineTestRule.runBlocking {
+    fun whenIsMemberOfMajorNetworkThenShowIsMemberOfMajorNetworkIsTrue() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -190,7 +191,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenIsNotMemberOfMajorNetworkThenShowIsMemberOfMajorNetworkIsFalse() = coroutineTestRule.runBlocking {
+    fun whenIsNotMemberOfMajorNetworkThenShowIsMemberOfMajorNetworkIsFalse() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -202,7 +203,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenIsNotMemberOfAnyNetworkThenShowIsMemberOfMajorNetworkIsFalse() = coroutineTestRule.runBlocking {
+    fun whenIsNotMemberOfAnyNetworkThenShowIsMemberOfMajorNetworkIsFalse() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -214,7 +215,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenSiteHasDifferentBeforeAndImprovedGradeThenShowEnhancedGradeIsTrue() = coroutineTestRule.runBlocking {
+    fun whenSiteHasDifferentBeforeAndImprovedGradeThenShowEnhancedGradeIsTrue() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -226,7 +227,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenSiteHasSameBeforeAndImprovedGradeThenShowEnhancedGradeIsFalse() = coroutineTestRule.runBlocking {
+    fun whenSiteHasSameBeforeAndImprovedGradeThenShowEnhancedGradeIsFalse() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -238,7 +239,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenOnSiteChangedAndSiteIsInContentBlockingExceptionListThenReturnTrue() = coroutineTestRule.runBlocking {
+    fun whenOnSiteChangedAndSiteIsInContentBlockingExceptionListThenReturnTrue() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
         whenever(contentBlocking.isAnException(any())).thenReturn(true)
@@ -251,7 +252,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenOnSiteChangedAndSiteIsInContentBlockingExceptionListThenPrivacyOnIsFalse() = coroutineTestRule.runBlocking {
+    fun whenOnSiteChangedAndSiteIsInContentBlockingExceptionListThenPrivacyOnIsFalse() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
         whenever(userWhitelistDao.contains(any())).thenReturn(true)
@@ -265,7 +266,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenOnSiteChangedAndSiteIsNotInContentBlockingExceptionListThenPrivacyOnIsFalse() = coroutineTestRule.runBlocking {
+    fun whenOnSiteChangedAndSiteIsNotInContentBlockingExceptionListThenPrivacyOnIsFalse() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
         whenever(userWhitelistDao.contains(any())).thenReturn(false)
@@ -279,7 +280,7 @@ class ScorecardViewModelTest {
     }
 
     @Test
-    fun whenOnSiteChangedAndSiteIsNotInUserAllowListAndNotInContentBlockingExceptionListThenPrivacyOnIsTrue() = coroutineTestRule.runBlocking {
+    fun whenOnSiteChangedAndSiteIsNotInUserAllowListAndNotInContentBlockingExceptionListThenPrivacyOnIsTrue() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
         whenever(userWhitelistDao.contains(any())).thenReturn(false)

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/TrackerNetworksViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/TrackerNetworksViewModelTest.kt
@@ -21,14 +21,16 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.privacy.model.TestEntity
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -36,6 +38,7 @@ import org.junit.Rule
 import org.junit.Test
 import kotlin.time.ExperimentalTime
 
+@ExperimentalCoroutinesApi
 @ExperimentalTime
 class TrackerNetworksViewModelTest {
 
@@ -56,7 +59,7 @@ class TrackerNetworksViewModelTest {
     }
 
     @Test
-    fun whenNoDataThenDefaultValuesAreUsed() = coroutineTestRule.runBlocking {
+    fun whenNoDataThenDefaultValuesAreUsed() = runTest {
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(MutableLiveData())
 
         testee.trackers("1").test {
@@ -68,7 +71,7 @@ class TrackerNetworksViewModelTest {
     }
 
     @Test
-    fun whenUrlIsUpdatedThenViewModelDomainIsUpdated() = coroutineTestRule.runBlocking {
+    fun whenUrlIsUpdatedThenViewModelDomainIsUpdated() = runTest {
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
 
@@ -80,7 +83,7 @@ class TrackerNetworksViewModelTest {
     }
 
     @Test
-    fun whenTrackersUpdatedWithNoTrackersThenViewModelListIsEmpty() = coroutineTestRule.runBlocking {
+    fun whenTrackersUpdatedWithNoTrackersThenViewModelListIsEmpty() = runTest {
         val input = listOf(TrackingEvent(Url.DOCUMENT, Url.tracker(1), null, Entity.MINOR_ENTITY_A, true, null))
         val siteData = MutableLiveData<Site>()
         whenever(tabRepository.retrieveSiteData(any())).thenReturn(siteData)
@@ -97,7 +100,7 @@ class TrackerNetworksViewModelTest {
     }
 
     @Test
-    fun whenTrackersUpdatedThenViewModelUpdatedWithDistinctEntitiesOrderedBy() = coroutineTestRule.runBlocking {
+    fun whenTrackersUpdatedThenViewModelUpdatedWithDistinctEntitiesOrderedBy() = runTest {
         val input = listOf(
             // Minor entity with 3 distinct trackers
             TrackingEvent(Url.DOCUMENT, Url.tracker(1), null, Entity.MINOR_ENTITY_A, true, null),

--- a/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/WhitelistViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/privacy/ui/WhitelistViewModelTest.kt
@@ -20,21 +20,23 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.privacy.model.UserWhitelistedDomain
 import com.duckduckgo.app.privacy.ui.WhitelistViewModel.Command
 import com.duckduckgo.app.privacy.ui.WhitelistViewModel.Command.ShowAdd
 import com.duckduckgo.app.privacy.ui.WhitelistViewModel.Command.ShowWhitelistFormatError
-import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class WhitelistViewModelTest {
 
     @ExperimentalCoroutinesApi
@@ -51,10 +53,10 @@ class WhitelistViewModelTest {
     private val mockCommandObserver: Observer<Command> = mock()
     private var commandCaptor: KArgumentCaptor<Command> = argumentCaptor()
 
-    private val testee by lazy { WhitelistViewModel(mockDao, TestCoroutineScope(), coroutineRule.testDispatcherProvider) }
+    private val testee by lazy { WhitelistViewModel(mockDao, TestScope(), coroutineRule.testDispatcherProvider) }
 
     @Before
-    fun before() = coroutineRule.runBlocking {
+    fun before() = runTest {
         liveData.value = emptyList()
         whenever(mockDao.all()).thenReturn(liveData)
         testee.command.observeForever(mockCommandObserver)

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -18,8 +18,9 @@
 
 package com.duckduckgo.app.referencetests
 
-import android.util.Base64
-import android.webkit.*
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
 import androidx.core.net.toUri
 import androidx.room.Room
 import androidx.test.annotation.UiThreadTest
@@ -49,20 +50,23 @@ import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.TrackerAllowlist
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.json.JSONObject
-import org.junit.Assert.*
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+@ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class DomainsReferenceTest(private val testCase: TestCase) {
 
@@ -191,7 +195,7 @@ class DomainsReferenceTest(private val testCase: TestCase) {
 
     private fun initialiseResourceSurrogates() {
         val dataStore = ResourceSurrogateDataStore(InstrumentationRegistry.getInstrumentation().targetContext)
-        val resourceSurrogateLoader = ResourceSurrogateLoader(TestCoroutineScope(), resourceSurrogates, dataStore)
+        val resourceSurrogateLoader = ResourceSurrogateLoader(TestScope(), resourceSurrogates, dataStore)
         val surrogatesFile = FileUtilities.loadText("reference_tests/surrogates.txt").toByteArray()
         val surrogates = resourceSurrogateLoader.convertBytes(surrogatesFile)
         resourceSurrogates.loadSurrogates(surrogates)

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -54,7 +54,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.json.JSONObject
 import org.junit.Assert.*
 import org.junit.Before
@@ -63,6 +63,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+@ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class SurrogatesReferenceTest(private val testCase: TestCase) {
 
@@ -191,7 +192,7 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
 
     private fun initialiseResourceSurrogates() {
         val dataStore = ResourceSurrogateDataStore(InstrumentationRegistry.getInstrumentation().targetContext)
-        val resourceSurrogateLoader = ResourceSurrogateLoader(TestCoroutineScope(), resourceSurrogates, dataStore)
+        val resourceSurrogateLoader = ResourceSurrogateLoader(TestScope(), resourceSurrogates, dataStore)
         val surrogatesFile = FileUtilities.loadText("reference_tests/surrogates.txt").toByteArray()
         val surrogates = resourceSurrogateLoader.convertBytes(surrogatesFile)
         resourceSurrogates.loadSurrogates(surrogates)

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -20,12 +20,12 @@ import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.fire.FireAnimationLoader
 import com.duckduckgo.app.icon.api.AppIcon
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.settings.SettingsViewModel.Command
 import com.duckduckgo.app.settings.clear.ClearWhatOption.CLEAR_NONE
 import com.duckduckgo.app.settings.clear.ClearWhenOption.APP_EXIT_ONLY
@@ -46,6 +46,7 @@ import com.nhaarman.mockitokotlin2.*
 import kotlinx.android.synthetic.main.content_settings_general.view.*
 import kotlinx.android.synthetic.main.settings_automatically_clear_what_fragment.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -136,7 +137,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenStartIfGpcToggleDisabledAndGpcEnabledThenGpgDisabled() = coroutineTestRule.runBlocking {
+    fun whenStartIfGpcToggleDisabledAndGpcEnabledThenGpgDisabled() = runTest {
         whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName()), any())).thenReturn(false)
         whenever(mockGpc.isEnabled()).thenReturn(true)
 
@@ -149,7 +150,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenStartIfGpcToggleEnabledAndGpcDisabledThenGpgDisabled() = coroutineTestRule.runBlocking {
+    fun whenStartIfGpcToggleEnabledAndGpcDisabledThenGpgDisabled() = runTest {
         whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName()), any())).thenReturn(true)
         whenever(mockGpc.isEnabled()).thenReturn(false)
         testee.start()
@@ -161,7 +162,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenStartIfGpcToggleEnabledAndGpcEnabledThenGpgEnabled() = coroutineTestRule.runBlocking {
+    fun whenStartIfGpcToggleEnabledAndGpcEnabledThenGpgEnabled() = runTest {
         whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName()), any())).thenReturn(true)
         whenever(mockGpc.isEnabled()).thenReturn(true)
         testee.start()
@@ -173,7 +174,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenStartNotCalledYetThenViewStateInitialisedDefaultValues() = coroutineTestRule.runBlocking {
+    fun whenStartNotCalledYetThenViewStateInitialisedDefaultValues() = runTest {
         testee.viewState().test {
             val value = awaitItem()
             assertTrue(value.loading)
@@ -187,7 +188,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenStartCalledThenLoadingSetToFalse() = coroutineTestRule.runBlocking {
+    fun whenStartCalledThenLoadingSetToFalse() = runTest {
         testee.start()
         testee.viewState().test {
             val value = awaitItem()
@@ -198,7 +199,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenStartCalledThenVersionSetCorrectly() = coroutineTestRule.runBlocking {
+    fun whenStartCalledThenVersionSetCorrectly() = runTest {
         testee.start()
         testee.viewState().test {
             val value = expectMostRecentItem()
@@ -216,7 +217,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenThemeSettingsClickedThenCommandIsLaunchThemeSettingsIsSent() = coroutineTestRule.runBlocking {
+    fun whenThemeSettingsClickedThenCommandIsLaunchThemeSettingsIsSent() = runTest {
         testee.commands().test {
             testee.userRequestedToChangeTheme()
 
@@ -227,7 +228,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenThemeChangedThenDataStoreIsUpdatedAndUpdateThemeCommandIsSent() = coroutineTestRule.runBlocking {
+    fun whenThemeChangedThenDataStoreIsUpdatedAndUpdateThemeCommandIsSent() = runTest {
         testee.commands().test {
             givenThemeSelected(DuckDuckGoTheme.LIGHT)
             testee.onThemeSelected(DuckDuckGoTheme.DARK)
@@ -262,7 +263,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenThemeChangedButThemeWasAlreadySetThenDoNothing() = coroutineTestRule.runBlocking {
+    fun whenThemeChangedButThemeWasAlreadySetThenDoNothing() = runTest {
         testee.commands().test {
             givenThemeSelected(DuckDuckGoTheme.LIGHT)
             testee.onThemeSelected(DuckDuckGoTheme.LIGHT)
@@ -277,7 +278,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenDefaultBrowserTogglesOffThenLaunchDefaultBrowserCommandIsSent() = coroutineTestRule.runBlocking {
+    fun whenDefaultBrowserTogglesOffThenLaunchDefaultBrowserCommandIsSent() = runTest {
         testee.commands().test {
             whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
             testee.onDefaultBrowserToggled(false)
@@ -289,7 +290,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenDefaultBrowserTogglesOnThenLaunchDefaultBrowserCommandIsSent() = coroutineTestRule.runBlocking {
+    fun whenDefaultBrowserTogglesOnThenLaunchDefaultBrowserCommandIsSent() = runTest {
         testee.commands().test {
             whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
             testee.onDefaultBrowserToggled(true)
@@ -302,7 +303,7 @@ class SettingsViewModelTest {
 
     @Test
     fun whenDefaultBrowserTogglesOnAndBrowserWasAlreadyDefaultThenLaunchDefaultBrowserCommandIsNotSent() =
-        coroutineTestRule.runBlocking {
+        runTest {
             testee.commands().test {
                 whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
                 testee.onDefaultBrowserToggled(true)
@@ -359,7 +360,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenLeaveFeedBackRequestedThenCommandIsLaunchFeedback() = coroutineTestRule.runBlocking {
+    fun whenLeaveFeedBackRequestedThenCommandIsLaunchFeedback() = runTest {
         testee.commands().test {
             testee.userRequestedToSendFeedback()
 
@@ -370,7 +371,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenDefaultBrowserAppAlreadySetToOursThenIsDefaultBrowserFlagIsTrue() = coroutineTestRule.runBlocking {
+    fun whenDefaultBrowserAppAlreadySetToOursThenIsDefaultBrowserFlagIsTrue() = runTest {
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
         testee.start()
 
@@ -382,7 +383,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenDefaultBrowserAppNotSetToOursThenIsDefaultBrowserFlagIsFalse() = coroutineTestRule.runBlocking {
+    fun whenDefaultBrowserAppNotSetToOursThenIsDefaultBrowserFlagIsFalse() = runTest {
         testee.viewState().test {
             whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
             testee.start()
@@ -394,7 +395,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenBrowserDetectorIndicatesDefaultCannotBeSetThenFlagToShowSettingIsFalse() = coroutineTestRule.runBlocking {
+    fun whenBrowserDetectorIndicatesDefaultCannotBeSetThenFlagToShowSettingIsFalse() = runTest {
         testee.viewState().test {
             whenever(mockDefaultBrowserDetector.deviceSupportsDefaultBrowserConfiguration()).thenReturn(false)
             testee.start()
@@ -406,7 +407,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenBrowserDetectorIndicatesDefaultCanBeSetThenFlagToShowSettingIsTrue() = coroutineTestRule.runBlocking {
+    fun whenBrowserDetectorIndicatesDefaultCanBeSetThenFlagToShowSettingIsTrue() = runTest {
         whenever(mockDefaultBrowserDetector.deviceSupportsDefaultBrowserConfiguration()).thenReturn(true)
         testee.start()
         testee.viewState().test {
@@ -417,7 +418,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenWhitelistSelectedThenPixelIsSentAndWhitelistLaunched() = coroutineTestRule.runBlocking {
+    fun whenWhitelistSelectedThenPixelIsSentAndWhitelistLaunched() = runTest {
         testee.commands().test {
             testee.onManageWhitelistSelected()
 
@@ -429,7 +430,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenVariantIsEmptyThenEmptyVariantIncludedInSettings() = coroutineTestRule.runBlocking {
+    fun whenVariantIsEmptyThenEmptyVariantIncludedInSettings() = runTest {
         testee.start()
         testee.viewState().test {
             val expectedStartString = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -440,7 +441,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenVariantIsSetThenVariantKeyIncludedInSettings() = coroutineTestRule.runBlocking {
+    fun whenVariantIsSetThenVariantKeyIncludedInSettings() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(Variant("ab", filterBy = { true }))
         testee.start()
 
@@ -453,7 +454,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenChangeIconRequestedThenCommandIsChangeIcon() = coroutineTestRule.runBlocking {
+    fun whenChangeIconRequestedThenCommandIsChangeIcon() = runTest {
         testee.commands().test {
             testee.userRequestedToChangeIcon()
 
@@ -464,7 +465,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenFireAnimationSettingClickedThenCommandIsLaunchFireAnimationSettings() = coroutineTestRule.runBlocking {
+    fun whenFireAnimationSettingClickedThenCommandIsLaunchFireAnimationSettings() = runTest {
         testee.commands().test {
             testee.userRequestedToChangeFireAnimation()
 
@@ -482,7 +483,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenNewFireAnimationSelectedThenUpdateViewState() = coroutineTestRule.runBlocking {
+    fun whenNewFireAnimationSelectedThenUpdateViewState() = runTest {
         val expectedAnimation = FireAnimation.HeroAbstract
         testee.onFireAnimationSelected(expectedAnimation)
 
@@ -531,7 +532,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenOnGlobalPrivacyControlClickedThenCommandIsLaunchGlobalPrivacyControl() = coroutineTestRule.runBlocking {
+    fun whenOnGlobalPrivacyControlClickedThenCommandIsLaunchGlobalPrivacyControl() = runTest {
         testee.commands().test {
             testee.onGlobalPrivacyControlClicked()
 
@@ -542,7 +543,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenOnAutomaticallyClearWhatClickedEmitCommandShowClearWhatDialog() = coroutineTestRule.runBlocking {
+    fun whenOnAutomaticallyClearWhatClickedEmitCommandShowClearWhatDialog() = runTest {
         testee.commands().test {
             testee.onAutomaticallyClearWhatClicked()
 
@@ -553,7 +554,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenOnAutomaticallyClearWhenClickedEmitCommandShowClearWhenDialog() = coroutineTestRule.runBlocking {
+    fun whenOnAutomaticallyClearWhenClickedEmitCommandShowClearWhenDialog() = runTest {
         testee.commands().test {
             testee.onAutomaticallyClearWhenClicked()
 
@@ -564,7 +565,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenUserDidJoinBetaBetaAndOnboardingDidShowThenClickingOnSettingOpensTrackersScreen() = coroutineTestRule.runBlocking {
+    fun whenUserDidJoinBetaBetaAndOnboardingDidShowThenClickingOnSettingOpensTrackersScreen() = runTest {
         testee.commands().test {
 
             whenever(mockDeviceShieldOnboarding.didShowOnboarding()).thenReturn(true)
@@ -579,7 +580,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenUserDidJoinBetaAndOnboardingDidNotShowThenClickingOnSettingOpensTrackersScreen() = coroutineTestRule.runBlocking {
+    fun whenUserDidJoinBetaAndOnboardingDidNotShowThenClickingOnSettingOpensTrackersScreen() = runTest {
         testee.commands().test {
 
             whenever(mockDeviceShieldOnboarding.didShowOnboarding()).thenReturn(false)
@@ -594,7 +595,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenUserDidNotJoinBetaThenClickingOnSettingLaunchAppTPWaitlist() = coroutineTestRule.runBlocking {
+    fun whenUserDidNotJoinBetaThenClickingOnSettingLaunchAppTPWaitlist() = runTest {
         testee.commands().test {
 
             whenever(appTPWaitlistManager.didJoinBeta()).thenReturn(false)
@@ -608,7 +609,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenUserNotJoinedQueueForAppTPBetaThenClickingOnSettingOpensWaitlistScreen() = coroutineTestRule.runBlocking {
+    fun whenUserNotJoinedQueueForAppTPBetaThenClickingOnSettingOpensWaitlistScreen() = runTest {
         testee.commands().test {
 
             whenever(appTPWaitlistManager.waitlistState()).thenReturn(WaitlistState.NotJoinedQueue)
@@ -622,7 +623,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenUserJoinedQueueAppTPBetaThenClickingOnSettingOpensWaitlistScreen() = coroutineTestRule.runBlocking {
+    fun whenUserJoinedQueueAppTPBetaThenClickingOnSettingOpensWaitlistScreen() = runTest {
         testee.commands().test {
 
             whenever(appTPWaitlistManager.waitlistState()).thenReturn(WaitlistState.JoinedQueue(false))
@@ -636,7 +637,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenOnEmailProtectionSettingClickedThenEmitCommandLaunchEmailProtection() = coroutineTestRule.runBlocking {
+    fun whenOnEmailProtectionSettingClickedThenEmitCommandLaunchEmailProtection() = runTest {
         testee.commands().test {
             testee.onEmailProtectionSettingClicked()
 

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/AtbInitializerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/AtbInitializerTest.kt
@@ -23,8 +23,8 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -37,10 +37,10 @@ class AtbInitializerTest {
     private lateinit var appReferrerStateListener: AtbInitializerListener
 
     @Test
-    fun whenReferrerInformationInstantlyAvailableThenAtbInitialized() = runBlockingTest {
+    fun whenReferrerInformationInstantlyAvailableThenAtbInitialized() = runTest {
         whenever(statisticsDataStore.hasInstallationStatistics).thenReturn(false)
         appReferrerStateListener = StubAppReferrerFoundStateListener(referrer = "xx")
-        testee = AtbInitializer(TestCoroutineScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
 
         testee.initialize()
 
@@ -48,10 +48,10 @@ class AtbInitializerTest {
     }
 
     @Test
-    fun whenReferrerInformationQuicklyAvailableThenAtbInitialized() = runBlockingTest {
+    fun whenReferrerInformationQuicklyAvailableThenAtbInitialized() = runTest {
         whenever(statisticsDataStore.hasInstallationStatistics).thenReturn(false)
         appReferrerStateListener = StubAppReferrerFoundStateListener(referrer = "xx", mockDelayMs = 1000L)
-        testee = AtbInitializer(TestCoroutineScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
 
         testee.initialize()
 
@@ -59,10 +59,10 @@ class AtbInitializerTest {
     }
 
     @Test
-    fun whenReferrerInformationTimesOutThenAtbInitialized() = runBlockingTest {
+    fun whenReferrerInformationTimesOutThenAtbInitialized() = runTest {
         whenever(statisticsDataStore.hasInstallationStatistics).thenReturn(false)
         appReferrerStateListener = StubAppReferrerFoundStateListener(referrer = "xx", mockDelayMs = Long.MAX_VALUE)
-        testee = AtbInitializer(TestCoroutineScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
 
         testee.initialize()
 
@@ -70,9 +70,9 @@ class AtbInitializerTest {
     }
 
     @Test
-    fun whenAlreadyInitializedThenRefreshCalled() = runBlockingTest {
+    fun whenAlreadyInitializedThenRefreshCalled() = runTest {
         configureAlreadyInitialized()
-        testee = AtbInitializer(TestCoroutineScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
 
         testee.initialize()
         verify(statisticsUpdater).refreshAppRetentionAtb()

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/OfflinePixelSenderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/OfflinePixelSenderTest.kt
@@ -29,8 +29,7 @@ import com.duckduckgo.app.statistics.store.OfflinePixelCountDataStore
 import com.nhaarman.mockitokotlin2.*
 import io.reactivex.Completable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
-import org.junit.Before
+import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -50,18 +49,13 @@ class OfflinePixelSenderTest {
     @get:Rule
     var coroutineRule = CoroutineTestRule()
 
-    @Before
-    fun before() {
+    @Test
+    fun whenSendUncaughtExceptionsPixelThenTimestampFormattedToUtc() = runTest {
         val exceptionEntity = UncaughtExceptionEntity(1, UncaughtExceptionSource.GLOBAL, "test", "version", 1588167165000)
 
-        runBlocking<Unit> {
-            whenever(mockPixel.sendPixel(any(), any(), any())).thenReturn(Completable.complete())
-            whenever(mockUncaughtExceptionRepository.getExceptions()).thenReturn(listOf(exceptionEntity))
-        }
-    }
+        whenever(mockPixel.sendPixel(any(), any(), any())).thenReturn(Completable.complete())
+        whenever(mockUncaughtExceptionRepository.getExceptions()).thenReturn(listOf(exceptionEntity))
 
-    @Test
-    fun whenSendUncaughtExceptionsPixelThenTimestampFormattedToUtc() {
         val params = mapOf(
             EXCEPTION_MESSAGE to "test",
             EXCEPTION_APP_VERSION to "version",

--- a/app/src/androidTest/java/com/duckduckgo/app/surrogates/ResourceSurrogateLoaderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/surrogates/ResourceSurrogateLoaderTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.app.surrogates
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.surrogates.store.ResourceSurrogateDataStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -36,7 +36,7 @@ class ResourceSurrogateLoaderTest {
     fun setup() {
         resourceSurrogates = ResourceSurrogatesImpl()
         dataStore = ResourceSurrogateDataStore(InstrumentationRegistry.getInstrumentation().targetContext)
-        testee = ResourceSurrogateLoader(TestCoroutineScope(), resourceSurrogates, dataStore)
+        testee = ResourceSurrogateLoader(TestScope(), resourceSurrogates, dataStore)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/survey/ui/SurveyViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/survey/ui/SurveyViewModelTest.kt
@@ -41,6 +41,7 @@ import org.junit.Test
 import org.mockito.MockitoAnnotations
 import java.util.concurrent.TimeUnit
 
+@ExperimentalCoroutinesApi
 class SurveyViewModelTest {
 
     @get:Rule

--- a/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.app.bookmarks.model.SavedSite.Favorite
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter.QuickAccessFavorite
 import com.duckduckgo.app.onboarding.store.*
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -39,13 +38,9 @@ import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.SystemS
 import com.nhaarman.mockitokotlin2.*
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
-import org.junit.After
+import kotlinx.coroutines.test.*
+import org.junit.*
 import org.junit.Assert.*
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
 import org.mockito.Mockito.verify
 
 @Suppress("EXPERIMENTAL_API_USAGE")
@@ -91,7 +86,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingShouldNotShowThenViewIsNotVisibleAndUnexpanded() = runBlockingTest {
+    fun whenOnboardingShouldNotShowThenViewIsNotVisibleAndUnexpanded() = runTest {
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.resetViewState()
 
@@ -101,7 +96,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingShouldShowThenViewIsVisibleAndUnexpanded() = runBlockingTest {
+    fun whenOnboardingShouldShowThenViewIsVisibleAndUnexpanded() = runTest {
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.resetViewState()
 
@@ -111,25 +106,14 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenDatabaseIsSlowThenIntroducingTextDoesNotCrashTheApp() = coroutineRule.runBlocking {
-        (coroutineRule.testDispatcherProvider.io() as TestCoroutineDispatcher).pauseDispatcher()
-        testee =
-            SystemSearchViewModel(givenEmptyUserStageStore(), mockAutoComplete, mockDeviceAppLookup, mockPixel, mockFavoritesRepository, mockFaviconManager, mockSettingsStore, coroutineRule.testDispatcherProvider)
-        testee.resetViewState()
-        testee.userUpdatedQuery("test")
-
-        // no crash
-    }
-
-    @Test
-    fun whenOnboardingShownThenPixelSent() = runBlockingTest {
+    fun whenOnboardingShownThenPixelSent() = runTest {
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.resetViewState()
         verify(mockPixel).fire(INTERSTITIAL_ONBOARDING_SHOWN)
     }
 
     @Test
-    fun whenOnboardingIsUnexpandedAndUserPressesToggleThenItIsExpandedAndPixelSent() = runBlockingTest {
+    fun whenOnboardingIsUnexpandedAndUserPressesToggleThenItIsExpandedAndPixelSent() = runTest {
         whenOnboardingShowing()
         testee.userTappedOnboardingToggle()
 
@@ -139,7 +123,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingIsExpandedAndUserPressesToggleThenItIsUnexpandedAndPixelSent() = runBlockingTest {
+    fun whenOnboardingIsExpandedAndUserPressesToggleThenItIsUnexpandedAndPixelSent() = runTest {
         whenOnboardingShowing()
         testee.userTappedOnboardingToggle() // first press to expand
         testee.userTappedOnboardingToggle() // second press to minimize
@@ -150,7 +134,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenOnboardingIsDismissedThenViewHiddenPixelSentAndOnboardingStoreNotified() = runBlockingTest {
+    fun whenOnboardingIsDismissedThenViewHiddenPixelSentAndOnboardingStoreNotified() = runTest {
         whenOnboardingShowing()
         testee.userDismissedOnboarding()
 
@@ -161,7 +145,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUserUpdatesQueryThenViewStateUpdated() = coroutineRule.runBlocking {
+    fun whenUserUpdatesQueryThenViewStateUpdated() = runTest {
         testee.userUpdatedQuery(QUERY)
 
         val newViewState = testee.resultsViewState.value as SystemSearchResultsViewState
@@ -171,7 +155,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUserAddsSpaceToQueryThenViewStateMatchesAndSpaceTrimmedFromAutocomplete() = coroutineRule.runBlocking {
+    fun whenUserAddsSpaceToQueryThenViewStateMatchesAndSpaceTrimmedFromAutocomplete() = runTest {
         testee.userUpdatedQuery(QUERY)
         testee.userUpdatedQuery("$QUERY ")
 
@@ -182,7 +166,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUsersUpdatesWithAutoCompleteEnabledThenAutoCompleteSuggestionsIsNotEmpty() = coroutineRule.runBlocking {
+    fun whenUsersUpdatesWithAutoCompleteEnabledThenAutoCompleteSuggestionsIsNotEmpty() = runTest {
         doReturn(true).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
         testee.userUpdatedQuery(QUERY)
 
@@ -193,7 +177,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUsersUpdatesWithAutoCompleteDisabledThenViewStateReset() = coroutineRule.runBlocking {
+    fun whenUsersUpdatesWithAutoCompleteDisabledThenViewStateReset() = runTest {
         doReturn(false).whenever(mockSettingsStore).autoCompleteSuggestionsEnabled
         testee.userUpdatedQuery(QUERY)
 
@@ -201,7 +185,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUserClearsQueryThenViewStateReset() = coroutineRule.runBlocking {
+    fun whenUserClearsQueryThenViewStateReset() = runTest {
         testee.userUpdatedQuery(QUERY)
         testee.userRequestedClear()
 
@@ -209,7 +193,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUsersUpdatesWithBlankQueryThenViewStateReset() = coroutineRule.runBlocking {
+    fun whenUsersUpdatesWithBlankQueryThenViewStateReset() = runTest {
         testee.userUpdatedQuery(QUERY)
         testee.userUpdatedQuery(BLANK_QUERY)
 
@@ -240,7 +224,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUserSubmitsQueryThenOnboardingCompleted() = coroutineRule.runBlocking {
+    fun whenUserSubmitsQueryThenOnboardingCompleted() = runTest {
         testee.userSubmittedQuery(QUERY)
         verify(mockUserStageStore).stageCompleted(AppStage.NEW)
     }
@@ -270,18 +254,18 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenUserTapsDaxThenOnboardingCompleted() = coroutineRule.runBlocking {
+    fun whenUserTapsDaxThenOnboardingCompleted() = runTest {
         testee.userTappedDax()
         verify(mockUserStageStore).stageCompleted(AppStage.NEW)
     }
 
     @Test
-    fun whenViewModelCreatedThenAppsRefreshed() = coroutineRule.runBlocking {
+    fun whenViewModelCreatedThenAppsRefreshed() = runTest {
         verify(mockDeviceAppLookup).refreshAppList()
     }
 
     @Test
-    fun whenUserSelectsAppThatCannotBeFoundThenAppsRefreshedAndUserMessageShown() = coroutineRule.runBlocking {
+    fun whenUserSelectsAppThatCannotBeFoundThenAppsRefreshedAndUserMessageShown() = runTest {
         testee.appNotFound(deviceApp)
         verify(mockDeviceAppLookup, times(2)).refreshAppList()
         verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
@@ -345,7 +329,7 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun whenQuickAccessDeleteRequestedThenRepositoryUpdated() = coroutineRule.runBlocking {
+    fun whenQuickAccessDeleteRequestedThenRepositoryUpdated() = runTest {
         val savedSite = Favorite(1, "title", "http://example.com", 0)
 
         testee.onDeleteQuickAccessItemRequested(QuickAccessFavorite(savedSite))

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -40,7 +40,8 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
@@ -96,7 +97,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenAddNewTabAfterExistingTabWithUrlWithNoHostThenUsesUrlAsTitle() = runBlocking<Unit> {
+    fun whenAddNewTabAfterExistingTabWithUrlWithNoHostThenUsesUrlAsTitle() = runTest {
         val badUrl = "//bad/url"
         testee.addNewTabAfterExistingTab(badUrl, "tabid")
         val captor = argumentCaptor<TabEntity>()
@@ -105,7 +106,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenTabAddDirectlyThenViewedIsTrue() = runBlocking<Unit> {
+    fun whenTabAddDirectlyThenViewedIsTrue() = runTest {
         testee.add("http://www.example.com")
 
         val captor = argumentCaptor<TabEntity>()
@@ -114,7 +115,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenTabUpdatedAfterOpenInBackgroundThenViewedIsTrue() = runBlocking<Unit> {
+    fun whenTabUpdatedAfterOpenInBackgroundThenViewedIsTrue() = runTest {
         testee.addNewTabAfterExistingTab("http://www.example.com", "tabid")
         testee.update("tabid", null)
 
@@ -124,7 +125,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenNewTabAddedAfterNonExistingTabThenTitleUrlPositionOfNewTabAreCorrectAndTabIsNotViewed() = runBlocking<Unit> {
+    fun whenNewTabAddedAfterNonExistingTabThenTitleUrlPositionOfNewTabAreCorrectAndTabIsNotViewed() = runTest {
         testee.addNewTabAfterExistingTab("http://www.example.com", "tabid")
 
         val captor = argumentCaptor<TabEntity>()
@@ -135,7 +136,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenNewTabAddedAfterExistingTabThenTitleUrlPositionOfNewTabAreCorrect() = runBlocking<Unit> {
+    fun whenNewTabAddedAfterExistingTabThenTitleUrlPositionOfNewTabAreCorrect() = runTest {
         val tab = TabEntity("tabid", position = 3)
         whenever(mockDao.tab(any())).thenReturn(tab)
 
@@ -150,14 +151,14 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenAddCalledThenTabAddedAndSelectedAndBlankSiteDataCreated() = runBlocking<Unit> {
+    fun whenAddCalledThenTabAddedAndSelectedAndBlankSiteDataCreated() = runTest {
         val createdId = testee.add()
         verify(mockDao).addAndSelectTab(any())
         assertNotNull(testee.retrieveSiteData(createdId))
     }
 
     @Test
-    fun whenAddCalledWithUrlThenTabAddedAndSelectedAndUrlSiteDataCreated() = runBlocking<Unit> {
+    fun whenAddCalledWithUrlThenTabAddedAndSelectedAndUrlSiteDataCreated() = runTest {
         val url = "http://example.com"
         val createdId = testee.add(url)
         verify(mockDao).addAndSelectTab(any())
@@ -171,7 +172,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenTabDeletedThenTabAndDataCleared() = runBlocking<Unit> {
+    fun whenTabDeletedThenTabAndDataCleared() = runTest {
         val addedTabId = testee.add()
         val siteData = testee.retrieveSiteData(addedTabId)
 
@@ -182,7 +183,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenAllDeletedThenTabAndDataCleared() = runBlocking<Unit> {
+    fun whenAllDeletedThenTabAndDataCleared() = runTest {
         val addedTabId = testee.add()
         val siteData = testee.retrieveSiteData(addedTabId)
 
@@ -193,13 +194,13 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenIdSelectedThenCurrentUpdated() = runBlocking<Unit> {
+    fun whenIdSelectedThenCurrentUpdated() = runTest {
         testee.select(TAB_ID)
         verify(mockDao).insertTabSelection(eq(TabSelectionEntity(tabId = TAB_ID)))
     }
 
     @Test
-    fun whenAddingFirstTabPositionIsAlwaysZero() = runBlocking<Unit> {
+    fun whenAddingFirstTabPositionIsAlwaysZero() = runTest {
         whenever(mockDao.tabs()).thenReturn(emptyList())
 
         testee.add("http://www.example.com")
@@ -210,7 +211,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenAddingTabToExistingTabsPositionIsAlwaysIncreased() = runBlocking<Unit> {
+    fun whenAddingTabToExistingTabsPositionIsAlwaysIncreased() = runTest {
         val tab0 = TabEntity("tabid", position = 0)
         val existingTabs = listOf(tab0)
 
@@ -224,7 +225,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenAddDefaultTabToExistingListOfTabsThenTabIsNotCreated() = runBlocking<Unit> {
+    fun whenAddDefaultTabToExistingListOfTabsThenTabIsNotCreated() = runTest {
         val db = createDatabase()
         val dao = db.tabsDao()
         testee = tabDataRepository(dao)
@@ -237,7 +238,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenAddDefaultTabToEmptyTabsThenTabIsCreated() = runBlocking<Unit> {
+    fun whenAddDefaultTabToEmptyTabsThenTabIsCreated() = runTest {
         val db = createDatabase()
         val dao = db.tabsDao()
         testee = tabDataRepository(dao)
@@ -248,7 +249,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenSelectByUrlOrNewTabIfUrlAlreadyExistedInATabThenSelectTheTab() = runBlocking<Unit> {
+    fun whenSelectByUrlOrNewTabIfUrlAlreadyExistedInATabThenSelectTheTab() = runTest {
         val db = createDatabase()
         val dao = db.tabsDao()
         dao.insertTab(TabEntity(tabId = "id", url = "http://www.example.com", skipHome = false, viewed = true, position = 0))
@@ -262,7 +263,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenSelectByUrlOrNewTabIfUrlNotExistedInATabThenAddNewTab() = runBlocking<Unit> {
+    fun whenSelectByUrlOrNewTabIfUrlNotExistedInATabThenAddNewTab() = runTest {
         val db = createDatabase()
         val dao = db.tabsDao()
         testee = tabDataRepository(dao)
@@ -275,7 +276,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenAddFromSourceTabEnsureTabEntryContainsExpectedSourceId() = runBlocking<Unit> {
+    fun whenAddFromSourceTabEnsureTabEntryContainsExpectedSourceId() = runTest {
         val db = createDatabase()
         val dao = db.tabsDao()
         val sourceTab = TabEntity(tabId = "sourceId", url = "http://www.example.com", position = 0)
@@ -290,7 +291,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenDeleteTabAndSelectSourceLiveSelectedTabReturnsToSourceTab() = runBlocking<Unit> {
+    fun whenDeleteTabAndSelectSourceLiveSelectedTabReturnsToSourceTab() = runTest {
         val db = createDatabase()
         val dao = db.tabsDao()
         val sourceTab = TabEntity(tabId = "sourceId", url = "http://www.example.com", position = 0)
@@ -308,7 +309,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenMarkDeletableTrueThenMarksTabAsDeletable() = runBlocking {
+    fun whenMarkDeletableTrueThenMarksTabAsDeletable() = runTest {
         val tab = TabEntity(
             tabId = "tabid",
             position = 0,
@@ -321,7 +322,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenMarkDeletableFalseThenMarksTabAsNonDeletable() = runBlocking {
+    fun whenMarkDeletableFalseThenMarksTabAsNonDeletable() = runTest {
         val tab = TabEntity(
             tabId = "tabid",
             position = 0,
@@ -334,7 +335,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenPurgeDeletableTabsThenPurgeDeletableTabsAndUpdateSelection() = runBlocking {
+    fun whenPurgeDeletableTabsThenPurgeDeletableTabsAndUpdateSelection() = runTest {
         testee.purgeDeletableTabs()
 
         verify(mockDao).purgeDeletableTabsAndUpdateSelection()
@@ -342,7 +343,7 @@ class TabDataRepositoryTest {
 
     @Test
     @ExperimentalCoroutinesApi
-    fun whenDaoFLowDeletableTabsEmitsThenDropFirstEmission() = runBlocking {
+    fun whenDaoFLowDeletableTabsEmitsThenDropFirstEmission() = runTest {
         val tab = TabEntity("ID", position = 0)
 
         val job = launch {
@@ -357,7 +358,7 @@ class TabDataRepositoryTest {
 
     @Test
     @ExperimentalCoroutinesApi
-    fun whenDaoFLowDeletableTabsEmitsThenEmit() = runBlocking {
+    fun whenDaoFLowDeletableTabsEmitsThenEmit() = runTest {
         val tab = TabEntity("ID1", position = 0)
         val expectedTab = TabEntity("ID2", position = 0)
 
@@ -374,7 +375,7 @@ class TabDataRepositoryTest {
 
     @Test
     @ExperimentalCoroutinesApi
-    fun whenDaoFLowDeletableTabsDoubleEmitsThenDistinctUntilChanged() = runBlocking {
+    fun whenDaoFLowDeletableTabsDoubleEmitsThenDistinctUntilChanged() = runTest {
         val tab = TabEntity("ID1", position = 0)
 
         var count = 0
@@ -394,7 +395,7 @@ class TabDataRepositoryTest {
     }
 
     @Test
-    fun whenDeleteTabAndSelectSourceIfTabHadAParentThenEmitParentTabId() = runBlocking {
+    fun whenDeleteTabAndSelectSourceIfTabHadAParentThenEmitParentTabId() = runTest {
         val db = createDatabase()
         val dao = db.tabsDao()
         val sourceTab = TabEntity(tabId = "sourceId", url = "http://www.example.com", position = 0)
@@ -420,7 +421,7 @@ class TabDataRepositoryTest {
             SiteFactory(mockPrivacyPractices, mockEntityLookup),
             mockWebViewPreviewPersister,
             mockFaviconManager,
-            TestCoroutineScope()
+            TestScope()
         )
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -40,6 +41,7 @@ import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
+@ExperimentalCoroutinesApi
 class TabSwitcherViewModelTest {
 
     @get:Rule
@@ -82,7 +84,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun whenNewTabRequestedThenRepositoryNotifiedAndSwitcherClosed() = runBlocking<Unit> {
+    fun whenNewTabRequestedThenRepositoryNotifiedAndSwitcherClosed() = runTest {
         testee.onNewTabRequested()
         verify(mockTabRepository).add()
         verify(mockCommandObserver).onChanged(commandCaptor.capture())
@@ -90,7 +92,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun whenTabSelectedThenRepositoryNotifiedAndSwitcherClosed() = runBlocking<Unit> {
+    fun whenTabSelectedThenRepositoryNotifiedAndSwitcherClosed() = runTest {
         testee.onTabSelected(TabEntity("abc", "", "", position = 0))
         verify(mockTabRepository).select(eq("abc"))
         verify(mockCommandObserver).onChanged(commandCaptor.capture())
@@ -98,14 +100,14 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun whenTabDeletedThenRepositoryNotified() = runBlocking<Unit> {
+    fun whenTabDeletedThenRepositoryNotified() = runTest {
         val entity = TabEntity("abc", "", "", position = 0)
         testee.onTabDeleted(entity)
         verify(mockTabRepository).delete(entity)
     }
 
     @Test
-    fun whenOnMarkTabAsDeletableThenCallMarkDeletable() = runBlocking {
+    fun whenOnMarkTabAsDeletableThenCallMarkDeletable() = runTest {
         val entity = TabEntity("abc", "", "", position = 0)
         testee.onMarkTabAsDeletable(entity)
 
@@ -113,7 +115,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun whenUndoDeletableTabThenUndoDeletable() = runBlocking {
+    fun whenUndoDeletableTabThenUndoDeletable() = runTest {
         val entity = TabEntity("abc", "", "", position = 0)
         testee.undoDeletableTab(entity)
 
@@ -121,14 +123,14 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun whenPurgeDeletableTabsThenCallRepositoryPurgeDeletableTabs() = runBlocking {
+    fun whenPurgeDeletableTabsThenCallRepositoryPurgeDeletableTabs() = runTest {
         testee.purgeDeletableTabs()
 
         verify(mockTabRepository).purgeDeletableTabs()
     }
 
     @Test
-    fun whenRepositoryDeletableTabsUpdatesThenDeletableTabsEmits() = runBlocking {
+    fun whenRepositoryDeletableTabsUpdatesThenDeletableTabsEmits() = runTest {
         val tab = TabEntity("ID", position = 0)
 
         val expectedTabs = listOf(listOf(), listOf(tab))
@@ -142,7 +144,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun whenRepositoryDeletableTabsEmitsSameValueThenDeletableTabsEmitsAll() = runBlocking {
+    fun whenRepositoryDeletableTabsEmitsSameValueThenDeletableTabsEmitsAll() = runTest {
         val tab = TabEntity("ID", position = 0)
 
         testee.deletableTabs.observeForever {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -146,7 +146,7 @@ class BrowserWebViewClient(
                 }
             }
         } catch (e: Throwable) {
-            appCoroutineScope.launch {
+            appCoroutineScope.launch(dispatcherProvider.default()) {
                 uncaughtExceptionRepository.recordUncaughtException(e, SHOULD_OVERRIDE_REQUEST)
                 throw e
             }
@@ -173,7 +173,7 @@ class BrowserWebViewClient(
             injectGpcToDom(webView, url)
             loginDetector.onEvent(WebNavigationEvent.OnPageStarted(webView))
         } catch (e: Throwable) {
-            appCoroutineScope.launch {
+            appCoroutineScope.launch(dispatcherProvider.default()) {
                 uncaughtExceptionRepository.recordUncaughtException(e, ON_PAGE_STARTED)
                 throw e
             }
@@ -192,7 +192,7 @@ class BrowserWebViewClient(
             }
             flushCookies()
         } catch (e: Throwable) {
-            appCoroutineScope.launch {
+            appCoroutineScope.launch(dispatcherProvider.default()) {
                 uncaughtExceptionRepository.recordUncaughtException(e, ON_PAGE_FINISHED)
                 throw e
             }
@@ -266,7 +266,7 @@ class BrowserWebViewClient(
                 super.onReceivedHttpAuthRequest(view, handler, host, realm)
             }
         } catch (e: Throwable) {
-            appCoroutineScope.launch {
+            appCoroutineScope.launch(dispatcherProvider.default()) {
                 uncaughtExceptionRepository.recordUncaughtException(e, ON_HTTP_AUTH_REQUEST)
                 throw e
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/logindetection/NavigationAwareLoginDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/logindetection/NavigationAwareLoginDetector.kt
@@ -21,9 +21,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.duckduckgo.app.browser.WebNavigationStateChange
-import com.duckduckgo.app.global.ValidUrl
-import com.duckduckgo.app.global.baseHost
-import com.duckduckgo.app.global.getValidUrl
+import com.duckduckgo.app.global.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import kotlinx.coroutines.*
 import timber.log.Timber
@@ -52,7 +50,8 @@ sealed class NavigationEvent {
 
 class NextPageLoginDetection constructor(
     private val settingsDataStore: SettingsDataStore,
-    private val appCoroutineScope: CoroutineScope
+    private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider()
 ) : NavigationAwareLoginDetector {
 
     override val loginEventLiveData = MutableLiveData<LoginDetected>()
@@ -94,7 +93,7 @@ class NextPageLoginDetection constructor(
     private fun scheduleLoginDetection(): Job {
         // Ideally, we should be using a scope tied to the Activity/Fragment lifecycle instead of AppCoroutineScope.
         // AToW, it's not possible to inject such scope as dependency due to our single Component Dagger setup.
-        return appCoroutineScope.launch(Dispatchers.Main) {
+        return appCoroutineScope.launch(dispatcherProvider.main()) {
             delay(NAVIGATION_EVENT_GRACE_PERIOD)
             Timber.v("LoginDetectionDelegate execute Login detection Job for $urlToCheck")
             val loginUrlCandidate = urlToCheck

--- a/app/src/main/java/com/duckduckgo/app/fire/DatabaseCleaner.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DatabaseCleaner.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.app.fire
 
 import android.database.sqlite.SQLiteDatabase
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -26,7 +28,7 @@ interface DatabaseCleaner {
     suspend fun changeJournalModeToDelete(databasePath: String): Boolean
 }
 
-class DatabaseCleanerHelper : DatabaseCleaner {
+class DatabaseCleanerHelper(private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider()) : DatabaseCleaner {
 
     override suspend fun cleanDatabase(databasePath: String): Boolean {
         return executeCommand("VACUUM", databasePath)
@@ -37,7 +39,7 @@ class DatabaseCleanerHelper : DatabaseCleaner {
     }
 
     private suspend fun executeCommand(command: String, databasePath: String): Boolean {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcherProvider.io()) {
             if (databasePath.isNotEmpty()) {
                 var commandExecuted = false
                 openReadableDatabase(databasePath)?.use { db ->

--- a/app/src/main/java/com/duckduckgo/app/job/WorkScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/WorkScheduler.kt
@@ -20,6 +20,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -34,13 +36,14 @@ import dagger.SingleInstanceIn
 class AndroidWorkScheduler @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val notificationScheduler: AndroidNotificationScheduler,
-    private val jobCleaner: JobCleaner
+    private val jobCleaner: JobCleaner,
+    private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider()
 ) : LifecycleObserver {
 
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     fun scheduleWork() {
         Timber.v("Scheduling work")
-        appCoroutineScope.launch {
+        appCoroutineScope.launch(dispatcherProvider.default()) {
             jobCleaner.cleanDeprecatedJobs()
             notificationScheduler.scheduleNextNotification()
         }

--- a/app/src/test/java/com/duckduckgo/app/waitlist/trackerprotection/AppTrackingProtectionWaitlistCodeFetcherTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/waitlist/trackerprotection/AppTrackingProtectionWaitlistCodeFetcherTest.kt
@@ -18,9 +18,9 @@ package com.duckduckgo.app.waitlist.trackerprotection
 
 import androidx.work.WorkManager
 import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.app.notification.NotificationSender
 import com.duckduckgo.app.notification.model.SchedulableNotification
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.app.waitlist.trackerprotection.AppTPWaitlistWorkRequestBuilder.Companion.APP_TP_WAITLIST_SYNC_WORK_TAG
 import com.duckduckgo.mobile.android.vpn.waitlist.FetchCodeResult
 import com.duckduckgo.mobile.android.vpn.waitlist.TrackingProtectionWaitlistManager
@@ -29,7 +29,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -55,12 +55,12 @@ class AppTrackingProtectionWaitlistCodeFetcherTest {
             mockNotification,
             mockNotificationSender,
             coroutineRule.testDispatcherProvider,
-            TestCoroutineScope()
+            TestScope()
         )
     }
 
     @Test
-    fun whenFetchingInviteCodeAndCodeAlreadyExistedThenWorkIsCancelled() = coroutineRule.runBlocking {
+    fun whenFetchingInviteCodeAndCodeAlreadyExistedThenWorkIsCancelled() = runTest {
         whenever(waitlistManager.fetchInviteCode()).thenReturn(FetchCodeResult.CodeExisted)
         whenever(workManager.cancelAllWorkByTag(APP_TP_WAITLIST_SYNC_WORK_TAG)).thenReturn(mock())
         testee.fetchInviteCode()
@@ -68,7 +68,7 @@ class AppTrackingProtectionWaitlistCodeFetcherTest {
     }
 
     @Test
-    fun whenCodeIsFetchedThenWorkIsCancelledAndNotificationIsSent() = coroutineRule.runBlocking {
+    fun whenCodeIsFetchedThenWorkIsCancelledAndNotificationIsSent() = runTest {
         whenever(waitlistManager.fetchInviteCode()).thenReturn(FetchCodeResult.Code)
         testee.fetchInviteCode()
         whenever(workManager.cancelAllWorkByTag(APP_TP_WAITLIST_SYNC_WORK_TAG)).thenReturn(mock())

--- a/app/src/test/java/com/duckduckgo/app/waitlist/trackerprotection/ui/AppTPWaitlistRedeemCodeViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/waitlist/trackerprotection/ui/AppTPWaitlistRedeemCodeViewModelTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.app.waitlist.trackerprotection.ui
 
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.mobile.android.vpn.waitlist.RedeemCodeResult
 import com.duckduckgo.mobile.android.vpn.waitlist.TrackingProtectionWaitlistManager
 import com.nhaarman.mockitokotlin2.mock
@@ -49,7 +49,7 @@ class AppTPWaitlistRedeemCodeViewModelTest {
     }
 
     @Test
-    fun whenUserSuccessfullyRedeemsCodeThenViewStateisRedeemed() = coroutineRule.runBlocking {
+    fun whenUserSuccessfullyRedeemsCodeThenViewStateisRedeemed() = runTest {
         whenever(manager.redeemCode("1234")).thenReturn(RedeemCodeResult.Redeemed)
 
         viewModel.viewState.test {
@@ -61,7 +61,7 @@ class AppTPWaitlistRedeemCodeViewModelTest {
     }
 
     @Test
-    fun whenUserRedeemsInvalidCodeThenViewStateisInvalidCode() = coroutineRule.runBlocking {
+    fun whenUserRedeemsInvalidCodeThenViewStateisInvalidCode() = runTest {
         whenever(manager.redeemCode("1234")).thenReturn(RedeemCodeResult.InvalidCode)
         viewModel.viewState.test {
             viewModel.redeemCode("1234")
@@ -72,7 +72,7 @@ class AppTPWaitlistRedeemCodeViewModelTest {
     }
 
     @Test
-    fun whenUserRedeemsAlreadyRedeemedCodeThenViewStateisInvalidCode() = coroutineRule.runBlocking {
+    fun whenUserRedeemsAlreadyRedeemedCodeThenViewStateisInvalidCode() = runTest {
         whenever(manager.redeemCode("1234")).thenReturn(RedeemCodeResult.AlreadyRedeemed)
         viewModel.viewState.test {
             viewModel.redeemCode("1234")
@@ -83,7 +83,7 @@ class AppTPWaitlistRedeemCodeViewModelTest {
     }
 
     @Test
-    fun whenRedeemCodeFailsThenViewStateIsGeneralError() = coroutineRule.runBlocking {
+    fun whenRedeemCodeFailsThenViewStateIsGeneralError() = runTest {
         whenever(manager.redeemCode("1234")).thenReturn(RedeemCodeResult.Failure)
         viewModel.viewState.test {
             viewModel.redeemCode("1234")

--- a/build.gradle
+++ b/build.gradle
@@ -40,3 +40,5 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+apply plugin: 'android-reporting'

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
@@ -18,20 +18,23 @@ package com.duckduckgo.privacy.config.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.impl.network.PrivacyConfigService
 import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
-import org.junit.Assert.*
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class RealPrivacyConfigDownloaderTest {
 
@@ -48,7 +51,7 @@ class RealPrivacyConfigDownloaderTest {
 
     @Test
     fun whenDownloadIsNotSuccessfulThenReturnFalse() =
-        coroutineRule.runBlocking {
+        runTest {
             testee =
                 RealPrivacyConfigDownloader(
                     TestFailingPrivacyConfigService(), mockPrivacyConfigPersister)
@@ -57,11 +60,11 @@ class RealPrivacyConfigDownloaderTest {
 
     @Test
     fun whenDownloadIsSuccessfulThenReturnTrue() =
-        coroutineRule.runBlocking { assertTrue(testee.download()) }
+        runTest { assertTrue(testee.download()) }
 
     @Test
     fun whenDownloadIsSuccessfulThenPersistPrivacyConfigCalled() =
-        coroutineRule.runBlocking {
+        runTest {
             testee.download()
 
             verify(mockPrivacyConfigPersister).persistPrivacyConfig(any())

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/ReferenceTestUtilities.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/ReferenceTestUtilities.kt
@@ -48,7 +48,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 
 @ExperimentalCoroutinesApi
 class ReferenceTestUtilities(db: PrivacyConfigDatabase, val dispatcherProvider: DispatcherProvider) {
@@ -56,12 +56,12 @@ class ReferenceTestUtilities(db: PrivacyConfigDatabase, val dispatcherProvider: 
 
     var privacyRepository: PrivacyConfigRepository = RealPrivacyConfigRepository(db)
     var privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository = mock()
-    var unprotectedTemporaryRepository: UnprotectedTemporaryRepository = RealUnprotectedTemporaryRepository(db, TestCoroutineScope(), dispatcherProvider)
-    var contentBlockingRepository: ContentBlockingRepository = RealContentBlockingRepository(db, TestCoroutineScope(), dispatcherProvider)
-    var httpsRepository: HttpsRepository = RealHttpsRepository(db, TestCoroutineScope(), dispatcherProvider)
-    var drmRepository: DrmRepository = RealDrmRepository(db, TestCoroutineScope(), dispatcherProvider)
-    var gpcRepository: GpcRepository = RealGpcRepository(mock(), db, TestCoroutineScope(), dispatcherProvider)
-    var trackerAllowlistRepository: TrackerAllowlistRepository = RealTrackerAllowlistRepository(db, TestCoroutineScope(), dispatcherProvider)
+    var unprotectedTemporaryRepository: UnprotectedTemporaryRepository = RealUnprotectedTemporaryRepository(db, TestScope(), dispatcherProvider)
+    var contentBlockingRepository: ContentBlockingRepository = RealContentBlockingRepository(db, TestScope(), dispatcherProvider)
+    var httpsRepository: HttpsRepository = RealHttpsRepository(db, TestScope(), dispatcherProvider)
+    var drmRepository: DrmRepository = RealDrmRepository(db, TestScope(), dispatcherProvider)
+    var gpcRepository: GpcRepository = RealGpcRepository(mock(), db, TestScope(), dispatcherProvider)
+    var trackerAllowlistRepository: TrackerAllowlistRepository = RealTrackerAllowlistRepository(db, TestScope(), dispatcherProvider)
 
     // Add your plugin to this list in order for it to be tested against some basic reference tests
     private fun getPrivacyFeaturePlugins(): List<PrivacyFeaturePlugin> {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserverTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserverTest.kt
@@ -20,19 +20,21 @@ import android.content.Context
 import android.content.res.Resources
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.impl.FileUtilities.loadResource
 import com.duckduckgo.privacy.config.impl.PrivacyConfigPersister
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class LocalPrivacyConfigObserverTest {
 
@@ -48,13 +50,13 @@ class LocalPrivacyConfigObserverTest {
             LocalPrivacyConfigObserver(
                 mockContext,
                 mockPrivacyConfigPersister,
-                TestCoroutineScope(),
+                TestScope(),
                 coroutineRule.testDispatcherProvider)
     }
 
     @Test
     fun whenOnCreateApplicationThenCallPersistPrivacyConfig() =
-        coroutineRule.runBlocking {
+        runTest {
             givenLocalPrivacyConfigFileExists()
 
             testee.storeLocalPrivacyConfig()

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeatureTogglesPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeatureTogglesPluginTest.kt
@@ -17,17 +17,22 @@
 package com.duckduckgo.privacy.config.impl.plugins
 
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import org.junit.Assert.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class PrivacyFeatureTogglesPluginTest {
 
     @get:Rule var coroutineRule = CoroutineTestRule()
@@ -41,12 +46,13 @@ class PrivacyFeatureTogglesPluginTest {
     }
 
     @Test
-    fun whenIsEnabledAndFeatureIsNotAPrivacyFeatureThenReturnNull() =
-        coroutineRule.runBlocking { assertNull(testee.isEnabled(NonPrivacyFeature(), true)) }
+    fun whenIsEnabledAndFeatureIsNotAPrivacyFeatureThenReturnNull() = runTest {
+        assertNull(testee.isEnabled(NonPrivacyFeature(), true)) 
+    }
 
     @Test
     fun whenIsEnabledAndFeatureIsPrivacyFeatureThenReturnTrueWhenEnabled() =
-        coroutineRule.runBlocking {
+        runTest {
             givenPrivacyFeatureIsEnabled()
 
             val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName(), true)
@@ -56,7 +62,7 @@ class PrivacyFeatureTogglesPluginTest {
 
     @Test
     fun whenIsEnabledAndFeatureIsPrivacyFeatureThenReturnFalseWhenDisabled() =
-        coroutineRule.runBlocking {
+        runTest {
             givenPrivacyFeatureIsDisabled()
 
             val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName(), true)
@@ -66,7 +72,7 @@ class PrivacyFeatureTogglesPluginTest {
 
     @Test
     fun whenIsEnabledAndFeatureIsPrivacyFeatureThenReturnDefaultValueIfFeatureDoesNotExist() =
-        coroutineRule.runBlocking {
+        runTest {
             val defaultValue = true
             givenPrivacyFeatureReturnsDefaultValue(defaultValue)
 

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigDisabledReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigDisabledReferenceTest.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.impl.FileUtilities
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
@@ -31,6 +30,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -85,7 +85,7 @@ class PrivacyConfigDisabledReferenceTest(private val testCase: TestCase) {
     }
 
     @Test
-    fun whenReferenceTestRunsItReturnsTheExpectedResult() = coroutineRule.runBlocking {
+    fun whenReferenceTestRunsItReturnsTheExpectedResult() = runTest {
         testee.persistPrivacyConfig(referenceTestUtilities.getJsonPrivacyConfig("reference_tests/privacyconfig/$referenceJsonFile"))
 
         verify(referenceTestUtilities.privacyFeatureTogglesRepository).insert(PrivacyFeatureToggles(testCase.featureName, testCase.expectFeatureEnabled))

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigEnabledReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigEnabledReferenceTest.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.impl.FileUtilities
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
@@ -31,6 +30,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -84,7 +84,7 @@ class PrivacyConfigEnabledReferenceTest(private val testCase: TestCase) {
     }
 
     @Test
-    fun whenReferenceTestRunsItReturnsTheExpectedResult() = coroutineRule.runBlocking {
+    fun whenReferenceTestRunsItReturnsTheExpectedResult() = runTest {
         testee.persistPrivacyConfig(referenceTestUtilities.getJsonPrivacyConfig("reference_tests/privacyconfig/$referenceJsonFile"))
 
         verify(referenceTestUtilities.privacyFeatureTogglesRepository).insert(PrivacyFeatureToggles(testCase.featureName, testCase.expectFeatureEnabled))

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigGlobalExceptionsReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigGlobalExceptionsReferenceTest.kt
@@ -18,36 +18,24 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.global.plugins.PluginPoint
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.impl.FileUtilities
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
-import com.duckduckgo.privacy.config.impl.features.contentblocking.ContentBlockingPlugin
 import com.duckduckgo.privacy.config.impl.features.contentblocking.RealContentBlocking
 import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.RealUnprotectedTemporary
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
-import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
-import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
-import com.duckduckgo.privacy.config.store.RealPrivacyConfigRepository
-import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingRepository
-import com.duckduckgo.privacy.config.store.features.contentblocking.RealContentBlockingRepository
-import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.RealUnprotectedTemporaryRepository
-import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
-import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -95,7 +83,7 @@ class PrivacyConfigGlobalExceptionsReferenceTest(private val testCase: TestCase)
     }
 
     @Test
-    fun whenReferenceTestRunsItReturnsTheExpectedResult() = coroutineRule.runBlocking {
+    fun whenReferenceTestRunsItReturnsTheExpectedResult() = runTest {
         givenFeatureToggleIsEnabled()
         when(testCase.featureName) {
             "contentBlocking" -> { testFeatureEnabledForContentBlocking() }
@@ -117,7 +105,7 @@ class PrivacyConfigGlobalExceptionsReferenceTest(private val testCase: TestCase)
                 .build()
     }
 
-    private fun loadPrivacyConfig() = coroutineRule.runBlocking {
+    private fun loadPrivacyConfig() = runTest {
         referenceTestUtilities = ReferenceTestUtilities(db, coroutineRule.testDispatcherProvider)
         privacyConfigPersister = RealPrivacyConfigPersister(
             referenceTestUtilities.getPrivacyFeaturePluginPoint(),

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigLocalExceptionsReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigLocalExceptionsReferenceTest.kt
@@ -18,36 +18,23 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.global.plugins.PluginPoint
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.impl.FileUtilities
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
-import com.duckduckgo.privacy.config.impl.features.contentblocking.ContentBlockingPlugin
 import com.duckduckgo.privacy.config.impl.features.contentblocking.RealContentBlocking
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.RealUnprotectedTemporary
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
-import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
-import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
-import com.duckduckgo.privacy.config.store.RealPrivacyConfigRepository
-import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingRepository
-import com.duckduckgo.privacy.config.store.features.contentblocking.RealContentBlockingRepository
-import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.RealUnprotectedTemporaryRepository
-import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
-import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -95,7 +82,7 @@ class PrivacyConfigLocalExceptionsReferenceTest(private val testCase: TestCase) 
     }
 
     @Test
-    fun whenReferenceTestRunsItReturnsTheExpectedResult() = coroutineRule.runBlocking {
+    fun whenReferenceTestRunsItReturnsTheExpectedResult() = runTest {
         givenFeatureToggleIsEnabled()
         when(testCase.featureName) {
             "contentBlocking" -> { testFeatureEnabledForContentBlocking() }
@@ -116,7 +103,7 @@ class PrivacyConfigLocalExceptionsReferenceTest(private val testCase: TestCase) 
                 .build()
     }
 
-    private fun loadPrivacyConfig() = coroutineRule.runBlocking {
+    private fun loadPrivacyConfig() = runTest {
         referenceTestUtilities = ReferenceTestUtilities(db, coroutineRule.testDispatcherProvider)
         privacyConfigPersister = RealPrivacyConfigPersister(
             referenceTestUtilities.getPrivacyFeaturePluginPoint(),

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigMissingReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigMissingReferenceTest.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.impl.FileUtilities
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
@@ -32,6 +31,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -86,7 +86,7 @@ class PrivacyConfigMissingReferenceTest(private val testCase: TestCase) {
     }
 
     @Test
-    fun whenReferenceTestRunsItReturnsTheExpectedResult() = coroutineRule.runBlocking {
+    fun whenReferenceTestRunsItReturnsTheExpectedResult() = runTest {
         testee.persistPrivacyConfig(referenceTestUtilities.getJsonPrivacyConfig("reference_tests/privacyconfig/$referenceJsonFile"))
 
         verify(referenceTestUtilities.privacyFeatureTogglesRepository, never()).insert(PrivacyFeatureToggles(testCase.featureName, true))

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/workers/PrivacyConfigDownloadWorkerTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/workers/PrivacyConfigDownloadWorkerTest.kt
@@ -20,16 +20,18 @@ import android.content.Context
 import androidx.work.ListenableWorker
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.impl.PrivacyConfigDownloader
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class PrivacyConfigDownloadWorkerTest {
 
     @get:Rule var coroutineRule = CoroutineTestRule()
@@ -46,7 +48,7 @@ class PrivacyConfigDownloadWorkerTest {
 
     @Test
     fun whenDoWorkIfDownloadReturnsTrueThenReturnSuccess() =
-        coroutineRule.runBlocking {
+        runTest {
             whenever(mockPrivacyConfigDownloader.download()).thenReturn(true)
 
             val worker =
@@ -61,7 +63,7 @@ class PrivacyConfigDownloadWorkerTest {
 
     @Test
     fun whenDoWorkIfDownloadReturnsFalseThenReturnRetry() =
-        coroutineRule.runBlocking {
+        runTest {
             whenever(mockPrivacyConfigDownloader.download()).thenReturn(false)
 
             val worker =

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/contentblocking/RealContentBlockingRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/contentblocking/RealContentBlockingRepositoryTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.store.features.contentblocking
 
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.store.ContentBlockingExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.toContentBlockingException
@@ -25,13 +24,16 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.test.TestCoroutineScope
-import org.junit.Assert.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyList
 
+@ExperimentalCoroutinesApi
 class RealContentBlockingRepositoryTest {
 
     @get:Rule var coroutineRule = CoroutineTestRule()
@@ -52,7 +54,7 @@ class RealContentBlockingRepositoryTest {
 
         testee =
             RealContentBlockingRepository(
-                mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
 
         assertEquals(
             contentBlockingException.toContentBlockingException(), testee.exceptions.first())
@@ -60,10 +62,10 @@ class RealContentBlockingRepositoryTest {
 
     @Test
     fun whenUpdateAllThenUpdateAllCalled() =
-        coroutineRule.runBlocking {
+        runTest {
             testee =
                 RealContentBlockingRepository(
-                    mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
 
             testee.updateAll(listOf())
 
@@ -72,11 +74,11 @@ class RealContentBlockingRepositoryTest {
 
     @Test
     fun whenUpdateAllThenPreviousExceptionsAreCleared() =
-        coroutineRule.runBlocking {
+        runTest {
             givenContentBlockingDaoContainsExceptions()
             testee =
                 RealContentBlockingRepository(
-                    mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
             assertEquals(1, testee.exceptions.size)
             reset(mockContentBlockingDao)
 

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/gpc/RealGpcRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/gpc/RealGpcRepositoryTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.store.features.gpc
 
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.store.GpcExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.toGpcException
@@ -25,13 +24,16 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyList
 
+@ExperimentalCoroutinesApi
 class RealGpcRepositoryTest {
     @get:Rule var coroutineRule = CoroutineTestRule()
 
@@ -48,7 +50,7 @@ class RealGpcRepositoryTest {
             RealGpcRepository(
                 mockGpcDataStore,
                 mockDatabase,
-                TestCoroutineScope(),
+                TestScope(),
                 coroutineRule.testDispatcherProvider)
     }
 
@@ -60,7 +62,7 @@ class RealGpcRepositoryTest {
             RealGpcRepository(
                 mockGpcDataStore,
                 mockDatabase,
-                TestCoroutineScope(),
+                TestScope(),
                 coroutineRule.testDispatcherProvider)
 
         assertEquals(gpcException.toGpcException(), testee.exceptions.first())
@@ -68,12 +70,12 @@ class RealGpcRepositoryTest {
 
     @Test
     fun whenUpdateAllThenUpdateAllCalled() =
-        coroutineRule.runBlocking {
+        runTest {
             testee =
                 RealGpcRepository(
                     mockGpcDataStore,
                     mockDatabase,
-                    TestCoroutineScope(),
+                    TestScope(),
                     coroutineRule.testDispatcherProvider)
 
             testee.updateAll(listOf())
@@ -83,13 +85,13 @@ class RealGpcRepositoryTest {
 
     @Test
     fun whenUpdateAllThenPreviousExceptionsAreCleared() =
-        coroutineRule.runBlocking {
+        runTest {
             givenGpcDaoContainsExceptions()
             testee =
                 RealGpcRepository(
                     mockGpcDataStore,
                     mockDatabase,
-                    TestCoroutineScope(),
+                    TestScope(),
                     coroutineRule.testDispatcherProvider)
             assertEquals(1, testee.exceptions.size)
             reset(mockGpcDao)

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/https/RealHttpsRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/https/RealHttpsRepositoryTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.store.features.https
 
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.toHttpsException
@@ -25,13 +24,16 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers
 
+@ExperimentalCoroutinesApi
 class RealHttpsRepositoryTest {
 
     @get:Rule var coroutineRule = CoroutineTestRule()
@@ -46,7 +48,7 @@ class RealHttpsRepositoryTest {
         whenever(mockDatabase.httpsDao()).thenReturn(mockHttpsDao)
         testee =
             RealHttpsRepository(
-                mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
     }
 
     @Test
@@ -55,17 +57,17 @@ class RealHttpsRepositoryTest {
 
         testee =
             RealHttpsRepository(
-                mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
 
         assertEquals(httpException.toHttpsException(), testee.exceptions.first())
     }
 
     @Test
     fun whenUpdateAllThenUpdateAllCalled() =
-        coroutineRule.runBlocking {
+        runTest {
             testee =
                 RealHttpsRepository(
-                    mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
 
             testee.updateAll(listOf())
 
@@ -74,11 +76,11 @@ class RealHttpsRepositoryTest {
 
     @Test
     fun whenUpdateAllThenPreviousExceptionsAreCleared() =
-        coroutineRule.runBlocking {
+        runTest {
             givenHttpsDaoContainsExceptions()
             testee =
                 RealHttpsRepository(
-                    mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
             assertEquals(1, testee.exceptions.size)
             reset(mockHttpsDao)
 

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/RealTrackerAllowlistRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/RealTrackerAllowlistRepositoryTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.store.features.trackerallowlist
 
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.store.AllowlistRuleEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.TrackerAllowlistEntity
@@ -25,13 +24,16 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyList
 
+@ExperimentalCoroutinesApi
 class RealTrackerAllowlistRepositoryTest {
 
     @get:Rule var coroutineRule = CoroutineTestRule()
@@ -46,7 +48,7 @@ class RealTrackerAllowlistRepositoryTest {
         whenever(mockDatabase.trackerAllowlistDao()).thenReturn(mockTrackerAllowlistDao)
         testee =
             RealTrackerAllowlistRepository(
-                mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
     }
 
     @Test
@@ -55,17 +57,17 @@ class RealTrackerAllowlistRepositoryTest {
 
         testee =
             RealTrackerAllowlistRepository(
-                mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
 
         assertEquals(trackerAllowlistEntity, testee.exceptions.first())
     }
 
     @Test
     fun whenUpdateAllThenUpdateAllCalled() =
-        coroutineRule.runBlocking {
+        runTest {
             testee =
                 RealTrackerAllowlistRepository(
-                    mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
 
             testee.updateAll(listOf())
 
@@ -74,11 +76,11 @@ class RealTrackerAllowlistRepositoryTest {
 
     @Test
     fun whenUpdateAllThenPreviousExceptionsAreCleared() =
-        coroutineRule.runBlocking {
+        runTest {
             givenHttpsDaoContainsExceptions()
             testee =
                 RealTrackerAllowlistRepository(
-                    mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
             assertEquals(1, testee.exceptions.size)
             reset(mockTrackerAllowlistDao)
 

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
@@ -17,20 +17,22 @@
 package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
 
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers
 
+@ExperimentalCoroutinesApi
 class RealUnprotectedTemporaryRepositoryTest {
 
     @get:Rule var coroutineRule = CoroutineTestRule()
@@ -45,7 +47,7 @@ class RealUnprotectedTemporaryRepositoryTest {
         whenever(mockDatabase.unprotectedTemporaryDao()).thenReturn(mockUnprotectedTemporaryDao)
         testee =
             RealUnprotectedTemporaryRepository(
-                mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
     }
 
     @Test
@@ -54,17 +56,17 @@ class RealUnprotectedTemporaryRepositoryTest {
 
         testee =
             RealUnprotectedTemporaryRepository(
-                mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
 
         assertEquals(unprotectedTemporaryException, testee.exceptions.first())
     }
 
     @Test
     fun whenUpdateAllThenUpdateAllCalled() =
-        coroutineRule.runBlocking {
+        runTest {
             testee =
                 RealUnprotectedTemporaryRepository(
-                    mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
 
             testee.updateAll(listOf())
 
@@ -73,11 +75,11 @@ class RealUnprotectedTemporaryRepositoryTest {
 
     @Test
     fun whenUpdateAllThenPreviousExceptionsAreCleared() =
-        coroutineRule.runBlocking {
+        runTest {
             givenUnprotectedTemporaryDaoContainsExceptions()
             testee =
                 RealUnprotectedTemporaryRepository(
-                    mockDatabase, TestCoroutineScope(), coroutineRule.testDispatcherProvider)
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
             assertEquals(1, testee.exceptions.size)
             reset(mockUnprotectedTemporaryDao)
 

--- a/versions.properties
+++ b/versions.properties
@@ -75,7 +75,7 @@ version.io.reactivex.rxjava2..rxjava=2.2.9
 
 version.kotlin=1.6.10
 
-version.kotlinx.coroutines=1.5.2
+version.kotlinx.coroutines=1.6.0-RC3
 
 version.leakcanary=2.7
 

--- a/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortStoreTest.kt
+++ b/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortStoreTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.mobile.android.vpn.cohort
 import androidx.test.platform.app.InstrumentationRegistry
 import com.jakewharton.threetenabp.AndroidThreeTen
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -52,7 +52,7 @@ class RealCohortStoreTest {
 
     @Test
     fun whenInitialCohortFirstCalledThenStoreInitialCohort() {
-        (cohortStore as RealCohortStore).onVpnStarted(TestCoroutineScope())
+        (cohortStore as RealCohortStore).onVpnStarted(TestScope())
 
         assertEquals(LocalDate.now(), cohortStore.getCohortStoredLocalDate())
     }
@@ -62,7 +62,7 @@ class RealCohortStoreTest {
         val date = LocalDate.now().plusDays(3)
         cohortStore.setCohortLocalDate(date)
 
-        (cohortStore as RealCohortStore).onVpnStarted(TestCoroutineScope())
+        (cohortStore as RealCohortStore).onVpnStarted(TestScope())
 
         assertEquals(date, cohortStore.getCohortStoredLocalDate())
     }

--- a/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldReminderNotificationSchedulerTest.kt
+++ b/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldReminderNotificationSchedulerTest.kt
@@ -33,7 +33,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import org.junit.*
 import java.util.concurrent.TimeUnit
 
@@ -80,14 +80,14 @@ class DeviceShieldReminderNotificationSchedulerTest {
     fun whenVPNStartsThenUndesiredReminderIsEnqueued() {
         assertWorkersAreNotEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_UNDESIRED_TAG)
 
-        testee.onVpnStarted(TestCoroutineScope())
+        testee.onVpnStarted(TestScope())
 
         assertWorkersAreEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_UNDESIRED_TAG)
     }
 
     @Test
     fun whenVPNStartsThenDailyReminderIsNotEnqueued() {
-        testee.onVpnStarted(TestCoroutineScope())
+        testee.onVpnStarted(TestScope())
 
         assertWorkersAreNotEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_DAILY_TAG)
     }
@@ -97,7 +97,7 @@ class DeviceShieldReminderNotificationSchedulerTest {
         enqueueDailyReminderNotificationWorker()
         assertWorkersAreEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_DAILY_TAG)
 
-        testee.onVpnStarted(TestCoroutineScope())
+        testee.onVpnStarted(TestScope())
 
         assertWorkersAreNotEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_DAILY_TAG)
     }
@@ -107,7 +107,7 @@ class DeviceShieldReminderNotificationSchedulerTest {
         configureMockNotification()
         assertWorkersAreNotEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_DAILY_TAG)
 
-        testee.onVpnStopped(TestCoroutineScope(), VpnStopReason.SelfStop)
+        testee.onVpnStopped(TestScope(), VpnStopReason.SelfStop)
 
         assertWorkersAreEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_DAILY_TAG)
     }
@@ -118,7 +118,7 @@ class DeviceShieldReminderNotificationSchedulerTest {
         enqueueDailyReminderNotificationWorker()
         assertWorkersAreEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_DAILY_TAG)
 
-        testee.onVpnStopped(TestCoroutineScope(), VpnStopReason.SelfStop)
+        testee.onVpnStopped(TestScope(), VpnStopReason.SelfStop)
 
         assertWorkersAreEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_DAILY_TAG)
     }
@@ -126,7 +126,7 @@ class DeviceShieldReminderNotificationSchedulerTest {
     @Test
     fun whenVPNManuallyStopsThenUndesiredReminderIsNotScheduled() {
         configureMockNotification()
-        testee.onVpnStopped(TestCoroutineScope(), VpnStopReason.SelfStop)
+        testee.onVpnStopped(TestScope(), VpnStopReason.SelfStop)
 
         assertWorkersAreNotEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_UNDESIRED_TAG)
     }
@@ -137,14 +137,14 @@ class DeviceShieldReminderNotificationSchedulerTest {
         enqueueUndesiredReminderNotificationWorker()
         assertWorkersAreEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_UNDESIRED_TAG)
 
-        testee.onVpnStopped(TestCoroutineScope(), VpnStopReason.SelfStop)
+        testee.onVpnStopped(TestScope(), VpnStopReason.SelfStop)
 
         assertWorkersAreNotEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_UNDESIRED_TAG)
     }
 
     @Test
     fun whenVPNIsKilledThenUndesiredReminderIsEnqueued() {
-        testee.onVpnStopped(TestCoroutineScope(), VpnStopReason.Revoked)
+        testee.onVpnStopped(TestScope(), VpnStopReason.Revoked)
 
         assertWorkersAreEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_UNDESIRED_TAG)
     }
@@ -152,7 +152,7 @@ class DeviceShieldReminderNotificationSchedulerTest {
     @Test
     fun whenVPNIsKilledAndReminderWasScheduledThenUndesiredReminderIsStillEnqueued() {
         enqueueUndesiredReminderNotificationWorker()
-        testee.onVpnStopped(TestCoroutineScope(), VpnStopReason.Revoked)
+        testee.onVpnStopped(TestScope(), VpnStopReason.Revoked)
 
         assertWorkersAreEnqueued(VpnReminderNotificationWorker.WORKER_VPN_REMINDER_UNDESIRED_TAG)
     }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageSingleChoiceFormViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageSingleChoiceFormViewModel.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.mobile.android.vpn.breakage
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.R
@@ -29,7 +31,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-class ReportBreakageSingleChoiceFormViewModel : ViewModel() {
+class ReportBreakageSingleChoiceFormViewModel(private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider()) : ViewModel() {
 
     private var selectedChoice: Choice? = null
 
@@ -48,7 +50,7 @@ class ReportBreakageSingleChoiceFormViewModel : ViewModel() {
 
     internal fun onChoiceSelected(choice: Choice) {
         selectedChoice = choice.copy(isSelected = true)
-        viewModelScope.launch { refreshTickerChannel.emit(System.currentTimeMillis()) }
+        viewModelScope.launch(dispatcherProvider.main()) { refreshTickerChannel.emit(System.currentTimeMillis()) }
     }
 
     private fun List<Choice>.update(newValue: Choice?): List<Choice> {
@@ -58,7 +60,7 @@ class ReportBreakageSingleChoiceFormViewModel : ViewModel() {
     }
 
     fun onSubmitChoices() {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcherProvider.main()) {
             selectedChoice?.let {
                 command.send(ReportBreakageSingleChoiceFormView.Command.SubmitChoice(it))
             }

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModelTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModelTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.mobile.android.vpn.apps
 
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.mobile.android.vpn.apps.Command.LaunchFeedback
 import com.duckduckgo.mobile.android.vpn.apps.ui.ManuallyDisableAppProtectionDialog
 import com.duckduckgo.mobile.android.vpn.apps.ui.ManuallyDisableAppProtectionDialog.Companion.STOPPED_WORKING
@@ -56,7 +56,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenPackageNameIsExcludedThenProtectedAppsExcludesIt() = coroutineRule.runBlocking {
+    fun whenPackageNameIsExcludedThenProtectedAppsExcludesIt() = runTest {
         val packageName = "com.package.name"
         viewModel.onAppProtectionDisabled(ManuallyDisableAppProtectionDialog.NO_REASON_NEEDED, packageName, packageName, skippedReport = false)
 
@@ -65,7 +65,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenPackageNameIsExcludedBecauseStoppedWorkingThenProtectedAppsExcludesItAndLaunchesFeedback() = coroutineRule.runBlocking {
+    fun whenPackageNameIsExcludedBecauseStoppedWorkingThenProtectedAppsExcludesItAndLaunchesFeedback() = runTest {
         viewModel.commands().test {
             val packageName = "com.package.name"
             val appName = "name"
@@ -79,7 +79,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenPackageNameIsExcludedAndWasPreviouslyExcludedThenProtectedAppsExcludesItAndPixelIsSent() = coroutineRule.runBlocking {
+    fun whenPackageNameIsExcludedAndWasPreviouslyExcludedThenProtectedAppsExcludesItAndPixelIsSent() = runTest {
         val packageName = "com.package.name"
         viewModel.onAppProtectionDisabled(ManuallyDisableAppProtectionDialog.DONT_USE, packageName, packageName, skippedReport = false)
 
@@ -87,7 +87,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenPackageNameIsEnabledAndAppHasNoIssuesThenProtectedAppsEnablesIt() = coroutineRule.runBlocking {
+    fun whenPackageNameIsEnabledAndAppHasNoIssuesThenProtectedAppsEnablesIt() = runTest {
         val packageName = "com.package.name"
         viewModel.onAppProtectionEnabled(packageName, 0)
 
@@ -96,7 +96,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenPackageNameIsEnabledAndAppHasIssuesThenProtectedAppsEnablesItAndSendsPixel() = coroutineRule.runBlocking {
+    fun whenPackageNameIsEnabledAndAppHasIssuesThenProtectedAppsEnablesItAndSendsPixel() = runTest {
         val packageName = "com.package.name"
         viewModel.onAppProtectionEnabled(packageName, 1, true)
 
@@ -104,7 +104,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenUserWantsToRestoreDefaultThenDefaultListIsRestoredAndVpnRestarted() = coroutineRule.runBlocking {
+    fun whenUserWantsToRestoreDefaultThenDefaultListIsRestoredAndVpnRestarted() = runTest {
         viewModel.commands().test {
             viewModel.restoreProtectedApps()
             assertEquals(Command.RestartVpn, awaitItem())
@@ -115,7 +115,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenUserLeavesScreenAndChangesWereMadeThenTheVpnIsRestarted() = coroutineRule.runBlocking {
+    fun whenUserLeavesScreenAndChangesWereMadeThenTheVpnIsRestarted() = runTest {
         val packageName = "com.package.name"
         viewModel.onAppProtectionDisabled(0, packageName, packageName, skippedReport = true)
 
@@ -127,7 +127,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenUserLeavesScreenAndNoChangesWereMadeThenTheVpnIsNotRestarted() = coroutineRule.runBlocking {
+    fun whenUserLeavesScreenAndNoChangesWereMadeThenTheVpnIsNotRestarted() = runTest {
         viewModel.commands().test {
             viewModel.onLeavingScreen()
             expectNoEvents()
@@ -136,7 +136,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenAppWithKnownIssuesIsEnabledThenEnableProtectionDialogIsShown() = coroutineRule.runBlocking {
+    fun whenAppWithKnownIssuesIsEnabledThenEnableProtectionDialogIsShown() = runTest {
         viewModel.commands().test {
             viewModel.onAppProtectionChanged(appWithKnownIssues, 0, true)
             assertEquals(Command.ShowEnableProtectionDialog(appWithKnownIssues, 0), awaitItem())
@@ -145,7 +145,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenAppWithKnownIssuesIsDisabledThenNoDialogIsShown() = coroutineRule.runBlocking {
+    fun whenAppWithKnownIssuesIsDisabledThenNoDialogIsShown() = runTest {
         viewModel.commands().test {
             viewModel.onAppProtectionChanged(appWithKnownIssues, 0, false)
             expectNoEvents()
@@ -154,7 +154,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenAppLoadsWebsitesIsEnabledThenEnableProtectionDialogIsShown() = coroutineRule.runBlocking {
+    fun whenAppLoadsWebsitesIsEnabledThenEnableProtectionDialogIsShown() = runTest {
         viewModel.commands().test {
             viewModel.onAppProtectionChanged(appLoadsWebsites, 0, true)
             assertEquals(Command.ShowEnableProtectionDialog(appLoadsWebsites, 0), awaitItem())
@@ -163,7 +163,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenAppLoadsWebsitesIsDisabledThenNoDialogIsShown() = coroutineRule.runBlocking {
+    fun whenAppLoadsWebsitesIsDisabledThenNoDialogIsShown() = runTest {
         viewModel.commands().test {
             viewModel.onAppProtectionChanged(appLoadsWebsites, 0, false)
             expectNoEvents()
@@ -172,7 +172,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenAppWithNoIssuesIsEnabledThenNoDialogIsShown() = coroutineRule.runBlocking {
+    fun whenAppWithNoIssuesIsEnabledThenNoDialogIsShown() = runTest {
         viewModel.commands().test {
             viewModel.onAppProtectionChanged(appWithoutIssues, 0, true)
             expectNoEvents()
@@ -181,7 +181,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenAppWithNoIssuesIsDisabledThenDisabledDialogIsShown() = coroutineRule.runBlocking {
+    fun whenAppWithNoIssuesIsDisabledThenDisabledDialogIsShown() = runTest {
         viewModel.commands().test {
             viewModel.onAppProtectionChanged(appWithoutIssues, 0, false)
             assertEquals(Command.ShowDisableProtectionDialog(appWithoutIssues), awaitItem())
@@ -190,7 +190,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenAppManuallyDisabledIsEnabledThenNoDialogIsShown() = coroutineRule.runBlocking {
+    fun whenAppManuallyDisabledIsEnabledThenNoDialogIsShown() = runTest {
         viewModel.commands().test {
             viewModel.onAppProtectionChanged(appManuallyExcluded, 0, true)
             expectNoEvents()
@@ -199,7 +199,7 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
-    fun whenAppManuallyDisabledIsDisabledThenDisableDialogIsShown() = coroutineRule.runBlocking {
+    fun whenAppManuallyDisabledIsDisabledThenDisableDialogIsShown() = runTest {
         viewModel.commands().test {
             viewModel.onAppProtectionChanged(appManuallyExcluded, 0, false)
             assertEquals(Command.ShowDisableProtectionDialog(appManuallyExcluded), awaitItem())

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageAppListViewModelTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageAppListViewModelTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.mobile.android.vpn.breakage
 
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.mobile.android.vpn.apps.AppCategory
 import com.duckduckgo.mobile.android.vpn.apps.TrackingProtectionAppInfo
 import com.duckduckgo.mobile.android.vpn.apps.TrackingProtectionAppsRepository
@@ -28,6 +28,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -53,7 +54,7 @@ class ReportBreakageAppListViewModelTest {
     }
 
     @Test
-    fun whenOnSubmitBreakageAndNoSelectedItemThenEmitNoCommand() = coroutineRule.runBlocking {
+    fun whenOnSubmitBreakageAndNoSelectedItemThenEmitNoCommand() = runTest {
         viewModel.commands().test {
             viewModel.onSubmitBreakage()
 
@@ -63,7 +64,7 @@ class ReportBreakageAppListViewModelTest {
     }
 
     @Test
-    fun whenOnSubmitBreakageAndAppSelectedThenEmitLaunchBreakageFormCommand() = coroutineRule.runBlocking {
+    fun whenOnSubmitBreakageAndAppSelectedThenEmitLaunchBreakageFormCommand() = runTest {
         viewModel.commands().test {
             val expectedItem = InstalledApp(packageName = "com.android.ddg", name = "ddg", isSelected = true)
             viewModel.onAppSelected(expectedItem)
@@ -75,7 +76,7 @@ class ReportBreakageAppListViewModelTest {
     }
 
     @Test
-    fun whenGetInstalledAppsAndNoInstalledAppsThenEmitNoItem() = coroutineRule.runBlocking {
+    fun whenGetInstalledAppsAndNoInstalledAppsThenEmitNoItem() = runTest {
         whenever(trackingProtectionAppsRepository.getProtectedApps()).thenReturn(protectedAppsChannel.receiveAsFlow())
         viewModel.getInstalledApps().test {
             expectNoEvents()
@@ -83,7 +84,7 @@ class ReportBreakageAppListViewModelTest {
     }
 
     @Test
-    fun whenGetInstalledAppsThenEmitState() = coroutineRule.runBlocking {
+    fun whenGetInstalledAppsThenEmitState() = runTest {
         whenever(trackingProtectionAppsRepository.getProtectedApps()).thenReturn(protectedAppsChannel.receiveAsFlow())
         viewModel.getInstalledApps().test {
             protectedAppsChannel.send(listOf(appWithoutIssues))
@@ -95,7 +96,7 @@ class ReportBreakageAppListViewModelTest {
     }
 
     @Test
-    fun whenGetInstalledAppsAndSelectedAppThenEmitState() = coroutineRule.runBlocking {
+    fun whenGetInstalledAppsAndSelectedAppThenEmitState() = runTest {
         whenever(trackingProtectionAppsRepository.getProtectedApps()).thenReturn(protectedAppsChannel.receiveAsFlow())
         viewModel.getInstalledApps().test {
             viewModel.onAppSelected(InstalledApp(packageName = appWithIssues.packageName, name = appWithIssues.name))
@@ -112,7 +113,7 @@ class ReportBreakageAppListViewModelTest {
     }
 
     @Test
-    fun whenGetInstalledAppsAndUnknownSelectedAppThenEmitState() = coroutineRule.runBlocking {
+    fun whenGetInstalledAppsAndUnknownSelectedAppThenEmitState() = runTest {
         whenever(trackingProtectionAppsRepository.getProtectedApps()).thenReturn(protectedAppsChannel.receiveAsFlow())
         viewModel.getInstalledApps().test {
             viewModel.onAppSelected(InstalledApp(packageName = "unknown.package.name", name = appWithIssues.name))
@@ -129,7 +130,7 @@ class ReportBreakageAppListViewModelTest {
     }
 
     @Test
-    fun whenOnBreakageSubmittedNoExtraInfoThenEmitSendBreakageInfoCommand() = coroutineRule.runBlocking {
+    fun whenOnBreakageSubmittedNoExtraInfoThenEmitSendBreakageInfoCommand() = runTest {
         viewModel.commands().test {
             val selectedApp = InstalledApp("com.package.com", name = "AppName")
             viewModel.onAppSelected(selectedApp)
@@ -145,7 +146,7 @@ class ReportBreakageAppListViewModelTest {
     }
 
     @Test
-    fun whenOnBreakageSubmittedWithExtraInfoThenEmitSendBreakageInfoCommand() = coroutineRule.runBlocking {
+    fun whenOnBreakageSubmittedWithExtraInfoThenEmitSendBreakageInfoCommand() = runTest {
         viewModel.commands().test {
             val selectedApp = InstalledApp("com.package.com", name = "AppName")
             viewModel.onAppSelected(selectedApp)

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageSingleChoiceFormViewModelTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageSingleChoiceFormViewModelTest.kt
@@ -18,9 +18,10 @@ package com.duckduckgo.mobile.android.vpn.breakage
 
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.runBlocking
+import kotlinx.coroutines.test.runTest
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageSingleChoiceFormViewModel.Companion.CHOICES
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -38,11 +39,11 @@ class ReportBreakageSingleChoiceFormViewModelTest {
 
     @Before
     fun setup() {
-        viewModel = ReportBreakageSingleChoiceFormViewModel()
+        viewModel = ReportBreakageSingleChoiceFormViewModel(coroutineRule.testDispatcherProvider)
     }
 
     @Test
-    fun whenGetChoicesAndNoSelectedChoiceThenReturnChoicesState() = coroutineRule.runBlocking {
+    fun whenGetChoicesAndNoSelectedChoiceThenReturnChoicesState() = runTest {
         viewModel.getChoices().test {
             val expectedChoices = ReportBreakageSingleChoiceFormView.State(CHOICES, false)
 
@@ -53,7 +54,7 @@ class ReportBreakageSingleChoiceFormViewModelTest {
     }
 
     @Test
-    fun whenGetChoicesAndChoiceSelectedThenReturnChoicesState() = coroutineRule.runBlocking {
+    fun whenGetChoicesAndChoiceSelectedThenReturnChoicesState() = runTest {
         val selectedChoice = CHOICES.first().copy(isSelected = true)
         viewModel.onChoiceSelected(selectedChoice)
         viewModel.getChoices().test {
@@ -69,7 +70,7 @@ class ReportBreakageSingleChoiceFormViewModelTest {
     }
 
     @Test
-    fun whenOnChoiceSelectedThenEmitUpdatedChoices() = coroutineRule.runBlocking {
+    fun whenOnChoiceSelectedThenEmitUpdatedChoices() = runTest {
         viewModel.getChoices().test {
             val selectedChoice = CHOICES.first().copy(isSelected = true)
             viewModel.onChoiceSelected(selectedChoice)
@@ -90,7 +91,7 @@ class ReportBreakageSingleChoiceFormViewModelTest {
     }
 
     @Test
-    fun whenOnSubmitChoicesAndNoChoiceSelectedThenEmitNoEvent() = coroutineRule.runBlocking {
+    fun whenOnSubmitChoicesAndNoChoiceSelectedThenEmitNoEvent() = runTest {
         viewModel.commands().test {
             viewModel.onSubmitChoices()
 
@@ -99,7 +100,7 @@ class ReportBreakageSingleChoiceFormViewModelTest {
     }
 
     @Test
-    fun whenOnSubmitChoicesAndChoiceSelectedThenEmitSubmitChoiceCommand() = coroutineRule.runBlocking {
+    fun whenOnSubmitChoicesAndChoiceSelectedThenEmitSubmitChoiceCommand() = runTest {
         val selectedChoice = CHOICES.first().copy(isSelected = true)
         viewModel.onChoiceSelected(selectedChoice)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/42792087274227/1201411646571239/f

### Description
Updates the tests to use the new method of testing coroutines, utilising `runTest` coroutine builder. Because it changes just about every test class, there is a large diff, but the bulk of changes come down to do:
  1. Replacing `runBlockingTest` and `runBlocking` with `runTest` coroutine builder in the tests
  2. Ensuring dispatchers are injected using our `DispatcherProvider` pattern
  3. Replacing now deprecated `TestCoroutineScope` with new `TestScope`


### Steps to test this PR
- Run `./gradlew checks` and verify all tests passing