### PR TITLE
Use a Provider to lazily initialize the default user agent

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
@@ -57,7 +57,7 @@ class WebViewRequestInterceptorTest {
     private val mockPrivacyProtectionCountDao: PrivacyProtectionCountDao = mock()
     private val mockGpc: Gpc = mock()
     private val mockWebBackForwardList: WebBackForwardList = mock()
-    private val userAgentProvider: UserAgentProvider = UserAgentProvider(DEFAULT, mock())
+    private val userAgentProvider: UserAgentProvider = UserAgentProvider({ DEFAULT }, mock())
 
     private var webView: WebView = mock()
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
@@ -36,98 +36,98 @@ class UserAgentProviderTest {
 
     @Test
     fun whenUaRetrievedWithNoParamsThenDeviceStrippedAndApplicationComponentAddedBeforeSafari() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent()
         assertTrue("$actual does not match expected regex", ValidationRegex.converted.matches(actual))
     }
 
     @Test
     fun whenMobileUaRetrievedThenDeviceStrippedAndApplicationComponentAddedBeforeSafari() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(isDesktop = false)
         assertTrue("$actual does not match expected regex", ValidationRegex.converted.matches(actual))
     }
 
     @Test
     fun whenDesktopUaRetrievedThenDeviceStrippedAndApplicationComponentAddedBeforeSafari() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(isDesktop = true)
         assertTrue("$actual does not match expected regex", ValidationRegex.desktop.matches(actual))
     }
 
     @Test
     fun whenMissingAppleWebKitComponentThenUaContainsMozillaAndApplicationAndSafariComponents() {
-        testee = UserAgentProvider(Agent.NO_WEBKIT, deviceInfo)
+        testee = UserAgentProvider({ Agent.NO_WEBKIT }, deviceInfo)
         val actual = testee.userAgent(isDesktop = false)
         assertTrue("$actual does not match expected regex", ValidationRegex.missingWebKit.matches(actual))
     }
 
     @Test
     fun whenMissingSafariComponentThenUaContainsMozillaAndVersionAndApplicationComponents() {
-        testee = UserAgentProvider(Agent.NO_SAFARI, deviceInfo)
+        testee = UserAgentProvider({ Agent.NO_SAFARI }, deviceInfo)
         val actual = testee.userAgent(isDesktop = false)
         assertTrue("$actual does not match expected result", ValidationRegex.missingSafari.matches(actual))
     }
 
     @Test
     fun whenMissingVersionComponentThenUaContainsMozillaAndApplicationAndSafariComponents() {
-        testee = UserAgentProvider(Agent.NO_VERSION, deviceInfo)
+        testee = UserAgentProvider({ Agent.NO_VERSION }, deviceInfo)
         val actual = testee.userAgent(isDesktop = false)
         assertTrue("$actual does not match expected result", ValidationRegex.noVersion.matches(actual))
     }
 
     @Test
     fun whenDomainDoesNotSupportApplicationThenUaOmitsApplicationComponent() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(NO_APPLICATION_DOMAIN)
         assertTrue("$actual does not match expected regex", ValidationRegex.noApplication.matches(actual))
     }
 
     @Test
     fun whenSubdomsinDoesNotSupportApplicationThenUaOmitsApplicationComponent() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(NO_APPLICATION_SUBDOMAIN)
         assertTrue("$actual does not match expected regex", ValidationRegex.noApplication.matches(actual))
     }
 
     @Test
     fun whenDomainSupportsApplicationThenUaAddsApplicationComponentBeforeSafari() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(DOMAIN)
         assertTrue("$actual does not match expected regex", ValidationRegex.converted.matches(actual))
     }
 
     @Test
     fun whenDomainDoesNotSupportVersionThenUaOmitsVersionComponent() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(NO_VERSION_DOMAIN)
         assertTrue("$actual does not match expected regex", ValidationRegex.noVersion.matches(actual))
     }
 
     @Test
     fun whenSubdomainDoesNotSupportVersionThenUaOmitsVersionComponent() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(NO_VERSION_SUBDOMAIN)
         assertTrue("$actual does not match expected regex", ValidationRegex.noVersion.matches(actual))
     }
 
     @Test
     fun whenDomainSupportsVersionThenUaIncludesVersionComponentInUsualLocation() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(DOMAIN)
         assertTrue("$actual does not match expected regex", ValidationRegex.converted.matches(actual))
     }
 
     @Test
     fun whenUserAgentIsForASiteThatShouldUseDesktopAgentThenReturnDesktopUserAgent() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(DESKTOP_ONLY_SITE)
         assertTrue("$actual does not match expected regex", ValidationRegex.desktop.matches(actual))
     }
 
     @Test
     fun whenUserAgentIsForASiteThatShouldUseDesktopAgentButContainsAnExclusionThenDoNotReturnConvertedUserAgent() {
-        testee = UserAgentProvider(Agent.DEFAULT, deviceInfo)
+        testee = UserAgentProvider({ Agent.DEFAULT }, deviceInfo)
         val actual = testee.userAgent(DESKTOP_ONLY_SITE_EXCEPTION)
         assertTrue("$actual does not match expected regex", ValidationRegex.converted.matches(actual))
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
@@ -33,7 +33,7 @@ class ApiRequestInterceptorTest {
     @Before
     fun before() {
         userAgentProvider = UserAgentProvider(
-            WebSettings.getDefaultUserAgent(InstrumentationRegistry.getInstrumentation().context),
+            { WebSettings.getDefaultUserAgent(InstrumentationRegistry.getInstrumentation().context) },
             ContextDeviceInfo(InstrumentationRegistry.getInstrumentation().context)
         )
 

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -20,7 +20,6 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.webkit.CookieManager
-import android.webkit.WebSettings
 import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.accessibility.AccessibilityManager
 import com.duckduckgo.app.browser.*
@@ -183,7 +182,7 @@ class BrowserModule {
     @Provides
     @Singleton
     fun userAgentProvider(context: Context, deviceInfo: DeviceInfo): UserAgentProvider {
-        return UserAgentProvider(WebSettings.getDefaultUserAgent(context), deviceInfo)
+        return UserAgentProvider(context, deviceInfo)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -76,6 +76,7 @@ import dagger.multibindings.IntoSet
 import kotlinx.coroutines.CoroutineScope
 import retrofit2.Retrofit
 import javax.inject.Named
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module
@@ -181,8 +182,8 @@ class BrowserModule {
 
     @Provides
     @Singleton
-    fun userAgentProvider(context: Context, deviceInfo: DeviceInfo): UserAgentProvider {
-        return UserAgentProvider(context, deviceInfo)
+    fun userAgentProvider(@Named("defaultUserAgent") defaultUserAgent: Provider<String>, deviceInfo: DeviceInfo): UserAgentProvider {
+        return UserAgentProvider(defaultUserAgent, deviceInfo)
     }
 
     @Provides


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201472407198007

### Description

### Steps to test this PR
We currently try to access the default user agent from `WebSettings` on startup. This is not necessary and having two side effects:
1. Delaying our startup time and hence being a factor in the cause of ANRs
2. Crash the app in some cases where the WebView process is not ready yet.

_User agent creation correctly referred_
1. Go to the task and apply the `Reproduce_ANR.patch` patch. This will create a new trace when the app launches.
2. Download https://github.com/Grigory-Rylov/android-methods-profiler to analyze the trace.
3. Launch the app, wait a few seconds and then close the app.
4. From the device file explorer, go to `data/data/com/duckduckgo.com.mobile.android.debug` and download the trace created.
5. Analyze the trace with Android Methods Profiler.
6. Search for `Chromium`
7. You shouldn't not see any instances created under the `com.duckduckgo.app.di.DaggerAppComponent.pixel`
8. You can also analyze the `prod.trace` trace included in the task to see the difference.

_User agent gets created correctly_
1. Launch the app
1. Filter the logcat by `user agent`.
1. Go to SERP, you should see a log message with the user agent.
1. Change to desktop mode, you should see the desktop user agent.

Note: The user agent log might be duplicated, this is expected.