### PR TITLE
Remove useless call to getWorkInfosByTag to reduce app onCreate execution time

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/privacy/cleanup/TrackersDbCleanerScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/cleanup/TrackersDbCleanerScheduler.kt
@@ -26,7 +26,6 @@ import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ListenableWorker
 import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.app.global.db.AppDatabase
@@ -87,22 +86,12 @@ class TrackersDbCleanerScheduler(private val workManager: WorkManager) : Lifecyc
 
     @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
     fun scheduleDbCleaner() {
-        if (isAlreadyScheduled()) {
-            Timber.v("Trackers Blocked DB cleaner worker is already scheduled, no need to schedule again")
-        } else {
-            Timber.v("Scheduling Trackers Blocked DB cleaner")
-            val dbCleanerWorkRequest = PeriodicWorkRequestBuilder<TrackersDbCleanerWorker>(7, TimeUnit.DAYS)
-                .addTag(WORKER_TRACKERS_BLOCKED_DB_CLEANER_TAG)
-                .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
-                .build()
-            workManager.enqueueUniquePeriodicWork(WORKER_TRACKERS_BLOCKED_DB_CLEANER_TAG, ExistingPeriodicWorkPolicy.KEEP, dbCleanerWorkRequest)
-        }
-    }
-
-    private fun isAlreadyScheduled(): Boolean {
-        return workManager
-            .getWorkInfosByTag(WORKER_TRACKERS_BLOCKED_DB_CLEANER_TAG)
-            .get().any { it.state == WorkInfo.State.ENQUEUED }
+        Timber.v("Scheduling Trackers Blocked DB cleaner")
+        val dbCleanerWorkRequest = PeriodicWorkRequestBuilder<TrackersDbCleanerWorker>(7, TimeUnit.DAYS)
+            .addTag(WORKER_TRACKERS_BLOCKED_DB_CLEANER_TAG)
+            .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+            .build()
+        workManager.enqueueUniquePeriodicWork(WORKER_TRACKERS_BLOCKED_DB_CLEANER_TAG, ExistingPeriodicWorkPolicy.KEEP, dbCleanerWorkRequest)
     }
 
     companion object {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201472407198058/f

### Description
We're seeing an increase of the app `onCreate` execution time. Some of the lifecycle observers may have a role in that increase. In particular the `TrackersDbCleanerScheduler` class was executing some useless code to try skip scheduling a worker when it was already scheduled.
That resulted in calling `getWorkInfosByTag` which is rather slow.

We can safely remove that call as we're already using `enqueueUniquePeriodicWork` in cobination with `KEEP` policy, which achieves the same

### Steps to test this PR
1. install from this branch
1. open the app
1. VERIFY `Registering application lifecycle observer: com.duckduckgo.app.privacy.cleanup.TrackersDbCleanerScheduler` appears in the logcat
