### PR TITLE
Move the pixel dependency out of application class

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -17,9 +17,7 @@
 package com.duckduckgo.app.global
 
 import android.app.Application
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.di.AppComponent
@@ -27,15 +25,11 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.DaggerAppComponent
 import com.duckduckgo.app.di.component.BookmarksActivityComponent
 import com.duckduckgo.app.fire.FireActivity
-import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.global.plugins.PluginPoint
-import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.pixels.AppPixelName.APP_LAUNCH
 import com.duckduckgo.app.process.ProcessDetector
 import com.duckduckgo.app.process.ProcessDetector.DuckDuckGoProcess
 import com.duckduckgo.app.process.ProcessDetector.DuckDuckGoProcess.VpnProcess
 import com.duckduckgo.app.referral.AppInstallationReferrerStateListener
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.DaggerMap
 import com.duckduckgo.mobile.android.vpn.service.VpnUncaughtExceptionHandler
 import com.jakewharton.threetenabp.AndroidThreeTen
@@ -49,13 +43,7 @@ import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
-open class DuckDuckGoApplication : HasDaggerInjector, Application(), LifecycleObserver {
-
-    @Inject
-    lateinit var pixel: Pixel
-
-    @Inject
-    lateinit var unsentForgetAllPixelStore: UnsentForgetAllPixelStore
+open class DuckDuckGoApplication : HasDaggerInjector, Application() {
 
     @Inject
     lateinit var alertingUncaughtExceptionHandler: AlertingUncaughtExceptionHandler
@@ -80,8 +68,6 @@ open class DuckDuckGoApplication : HasDaggerInjector, Application(), LifecycleOb
     lateinit var injectorFactoryMap: DaggerMap<Class<*>, AndroidInjector.Factory<*>>
 
     private val processDetector = ProcessDetector()
-
-    private var launchedByFireAction: Boolean = false
 
     private val applicationCoroutineScope = CoroutineScope(SupervisorJob())
 
@@ -108,15 +94,13 @@ open class DuckDuckGoApplication : HasDaggerInjector, Application(), LifecycleOb
             return
         }
 
+        // Deprecated, we need to move all these into AppLifecycleEventObserver
         ProcessLifecycleOwner.get().lifecycle.apply {
-            addObserver(this@DuckDuckGoApplication)
             lifecycleObserverPluginPoint.getPlugins().forEach {
                 Timber.d("Registering application lifecycle observer: ${it.javaClass.canonicalName}")
                 addObserver(it)
             }
         }
-
-        submitUnsentFirePixels()
 
         appCoroutineScope.launch {
             referralStateListener.initialiseReferralRetrieval()
@@ -210,42 +194,12 @@ open class DuckDuckGoApplication : HasDaggerInjector, Application(), LifecycleOb
         return dir
     }
 
-    private fun submitUnsentFirePixels() {
-        val count = unsentForgetAllPixelStore.pendingPixelCountClearData
-        Timber.i("Found $count unsent clear data pixels")
-        if (count > 0) {
-            val timeDifferenceMillis = System.currentTimeMillis() - unsentForgetAllPixelStore.lastClearTimestamp
-            if (timeDifferenceMillis <= APP_RESTART_CAUSED_BY_FIRE_GRACE_PERIOD) {
-                Timber.i("The app was re-launched as a result of the fire action being triggered (happened ${timeDifferenceMillis}ms ago)")
-                launchedByFireAction = true
-            }
-            for (i in 1..count) {
-                pixel.fire(AppPixelName.FORGET_ALL_EXECUTED)
-            }
-            unsentForgetAllPixelStore.resetCount()
-        }
-    }
-
     private fun initializeDateLibrary() {
         AndroidThreeTen.init(this)
         // Query the ZoneRulesProvider so that it is loaded on a background coroutine
         GlobalScope.launch(Dispatchers.IO) {
             ZoneRulesProvider.getAvailableZoneIds()
         }
-    }
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun onAppForegrounded() {
-        if (launchedByFireAction) {
-            launchedByFireAction = false
-            Timber.i("Suppressing app launch pixel")
-            return
-        }
-        pixel.fire(APP_LAUNCH)
-    }
-
-    companion object {
-        private const val APP_RESTART_CAUSED_BY_FIRE_GRACE_PERIOD: Long = 10_000L
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.pixels
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.work.*
+import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
+import com.duckduckgo.app.global.plugins.worker.WorkerInjectorPlugin
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Provider
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = LifecycleObserver::class
+)
+@SingleInstanceIn(AppScope::class)
+class EnqueuedPixelWorker @Inject constructor(
+    private val workManager: WorkManager,
+    private val pixel: Provider<Pixel>,
+    private val unsentForgetAllPixelStore: UnsentForgetAllPixelStore,
+) : LifecycleEventObserver {
+
+    private var launchedByFireAction: Boolean = false
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        if (event == Lifecycle.Event.ON_CREATE) {
+            scheduleWorker(workManager)
+            launchedByFireAction = isLaunchByFireAction()
+        } else if (event == Lifecycle.Event.ON_START) {
+            if (launchedByFireAction) {
+                // skip the next on_start if branch
+                Timber.i("Suppressing app launch pixel")
+                launchedByFireAction = false
+                return
+            }
+            Timber.i("Sending app launch pixel")
+            pixel.get().fire(AppPixelName.APP_LAUNCH)
+        }
+    }
+
+    private fun isLaunchByFireAction(): Boolean {
+        val timeDifferenceMillis = System.currentTimeMillis() - unsentForgetAllPixelStore.lastClearTimestamp
+        if (timeDifferenceMillis <= APP_RESTART_CAUSED_BY_FIRE_GRACE_PERIOD) {
+            Timber.i("The app was re-launched as a result of the fire action being triggered (happened ${timeDifferenceMillis}ms ago)")
+            return true
+        }
+        return false
+    }
+
+    private fun submitUnsentFirePixels() {
+        val count = unsentForgetAllPixelStore.pendingPixelCountClearData
+        Timber.i("Found $count unsent clear data pixels")
+        if (count > 0) {
+            for (i in 1..count) {
+                pixel.get().fire(AppPixelName.FORGET_ALL_EXECUTED)
+            }
+            unsentForgetAllPixelStore.resetCount()
+        }
+    }
+
+    class RealEnqueuedPixelWorker(val context: Context, parameters: WorkerParameters) : CoroutineWorker(context, parameters) {
+        lateinit var pixel: Pixel
+        lateinit var enqueuedPixelWorker: EnqueuedPixelWorker
+
+        override suspend fun doWork(): Result {
+            Timber.v("Sending enqueued pixels")
+
+            enqueuedPixelWorker.submitUnsentFirePixels()
+
+            return Result.success()
+        }
+    }
+
+    companion object {
+        private const val APP_RESTART_CAUSED_BY_FIRE_GRACE_PERIOD: Long = 10_000L
+        private const val WORKER_SEND_ENQUEUED_PIXELS = "com.duckduckgo.pixels.enqueued.worker"
+
+        private fun scheduleWorker(workManager: WorkManager) {
+            Timber.v("Scheduling the EnqueuedPixelWorker")
+
+            val request = PeriodicWorkRequestBuilder<RealEnqueuedPixelWorker>(2, TimeUnit.HOURS)
+                .addTag(WORKER_SEND_ENQUEUED_PIXELS)
+                .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+                .build()
+
+            workManager.enqueueUniquePeriodicWork(WORKER_SEND_ENQUEUED_PIXELS, ExistingPeriodicWorkPolicy.KEEP, request)
+        }
+    }
+}
+
+
+@ContributesMultibinding(AppScope::class)
+class EnqueuedPixelWorkerInjectorPlugin @Inject constructor(
+    private val pixel: Provider<Pixel>,
+    private val enqueuedPixelWorker: Provider<EnqueuedPixelWorker>
+) : WorkerInjectorPlugin {
+    override fun inject(worker: ListenableWorker): Boolean {
+        if (worker is EnqueuedPixelWorker.RealEnqueuedPixelWorker) {
+            worker.pixel = pixel.get()
+            worker.enqueuedPixelWorker = enqueuedPixelWorker.get()
+
+            return true
+        }
+
+        return false
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.pixels
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.WorkManager
+import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.nhaarman.mockitokotlin2.*
+import org.junit.Before
+import org.junit.Test
+
+class EnqueuedPixelWorkerTest {
+    private val workManager: WorkManager = mock()
+    private val pixel: Pixel = mock()
+    private val unsentForgetAllPixelStore: UnsentForgetAllPixelStore = mock()
+    private val lifecycleOwner: LifecycleOwner = mock()
+
+    private lateinit var enqueuedPixelWorker: EnqueuedPixelWorker
+
+    @Before
+    fun setup() {
+        enqueuedPixelWorker = EnqueuedPixelWorker(workManager, { pixel }, unsentForgetAllPixelStore)
+    }
+
+    @Test
+    fun whenOnCreateAndPendingPixelCountClearDataThenScheduleWorkerToFireMf() {
+        whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(2)
+        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
+
+        verify(workManager).enqueueUniquePeriodicWork(
+            eq("com.duckduckgo.pixels.enqueued.worker"),
+            eq(ExistingPeriodicWorkPolicy.KEEP),
+            any()
+        )
+    }
+
+    @Test
+    fun whenOnCreateAndPendingPixelCountClearDataIsZeroThenDoNotFireMf() {
+        whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(0)
+        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
+
+        verify(pixel, never()).fire(AppPixelName.FORGET_ALL_EXECUTED)
+    }
+
+    @Test
+    fun whenOnStartAndLaunchByFireActionThenDoNotSendAppLaunchPixel() {
+        whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(1)
+        whenever(unsentForgetAllPixelStore.lastClearTimestamp).thenReturn(System.currentTimeMillis())
+
+        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
+        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)
+
+        verify(pixel, never()).fire(AppPixelName.APP_LAUNCH)
+    }
+
+    @Test
+    fun whenOnStartAndAppLaunchThenSendAppLaunchPixel() {
+        whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(1)
+
+        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
+        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)
+
+        verify(pixel).fire(AppPixelName.APP_LAUNCH)
+    }
+
+    @Test
+    fun whenOnStartAndLaunchByFireActionFollowedByAppLaunchThenSendOneAppLaunchPixel() {
+        whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(1)
+        whenever(unsentForgetAllPixelStore.lastClearTimestamp).thenReturn(System.currentTimeMillis())
+
+        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
+        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)
+        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)
+
+        verify(pixel).fire(AppPixelName.APP_LAUNCH)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201464810536290/f

### Description
* The current app onCreate path takes longer than it should
* One of the main contributors is the pixel dependency in the app class
* The pixel dependency is used to:
  * send the mf pixel onCreate
  * send the ml pixel onStart
* the ml pixel doesn't affect the onCreate path
* the mf pixel doesn't need to be sent at onCreate, and can be scheduled to be sent later

This PR removes the pixel dependency from the app class by:
* creating a LifecycleEventObserver that will:
  * send the ml pixel onStart--except when the app is launched as a result of a fire button press
  * schedules the sending of the mf pixel

### Steps to test this PR
_test the ml pixel_
* install from this branch
* launch the app
* verify the ml pixel is sent
* press the fire button
* verify the ml pixel is NOT sent upon app launch

_test the mf pixel_
* in EnqueuedPixelWorker change KEEP for REPLACE in line 110
* build and install from this branch
* launch the app
* verify the mf pixel is NOT sent
* press the fire button
* verify the mf pixel is sent once

In addition, when taking a startup trace, the app onCreate path should not contain the pixel dependency anymore.

