### PR TITLE
Add logic to provide system app overrides

### DIFF
--- a/vpn-store/build.gradle
+++ b/vpn-store/build.gradle
@@ -22,6 +22,19 @@ plugins {
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
+android {
+    defaultConfig {
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = ["room.schemaLocation": "$projectDir/schemas".toString()]
+            }
+        }
+    }
+    sourceSets {
+        androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
+    }
+}
+
 dependencies {
 
     implementation Kotlin.stdlib.jdk7
@@ -50,4 +63,5 @@ dependencies {
     androidTestUtil AndroidX.test.orchestrator
     androidTestImplementation Testing.mockito.android
     androidTestImplementation Testing.mockito.kotlin
+    androidTestImplementation AndroidX.archCore.testing
 }

--- a/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.VpnDatabase/18.json
+++ b/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.VpnDatabase/18.json
@@ -1,0 +1,562 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "2279dd342e3f2465f0dddab33e09d554",
+    "entities": [
+      {
+        "tableName": "vpn_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `uuid` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_tracker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackerId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackerCompanyId` INTEGER NOT NULL, `domain` TEXT NOT NULL, `company` TEXT NOT NULL, `companyDisplayName` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `packageId` TEXT NOT NULL, `appDisplayName` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerCompanyId",
+            "columnName": "trackerCompanyId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "company",
+            "columnName": "company",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "companyDisplayName",
+            "columnName": "companyDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackingApp.packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackingApp.appDisplayName",
+            "columnName": "appDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "trackerId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_vpn_tracker_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_vpn_tracker_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_running_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `timeRunningMillis` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeRunningMillis",
+            "columnName": "timeRunningMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_service_state_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` TEXT NOT NULL, `state` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_data_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dataSent` INTEGER NOT NULL, `dataReceived` INTEGER NOT NULL, `packetsSent` INTEGER NOT NULL, `packetsReceived` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataSent",
+            "columnName": "dataSent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataReceived",
+            "columnName": "dataReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetsSent",
+            "columnName": "packetsSent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetsReceived",
+            "columnName": "packetsReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`preference` TEXT NOT NULL, `value` INTEGER NOT NULL, PRIMARY KEY(`preference`))",
+        "fields": [
+          {
+            "fieldPath": "preference",
+            "columnName": "preference",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "preference"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_heartbeat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`type`))",
+        "fields": [
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "type"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_phoenix",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `reason` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `formattedTimestamp` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formattedTimestamp",
+            "columnName": "formattedTimestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_notification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `timesRun` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timesRun",
+            "columnName": "timesRun",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_blocking_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hostname` TEXT NOT NULL, `trackerCompanyId` INTEGER NOT NULL, `isCdn` INTEGER NOT NULL, `name` TEXT NOT NULL, `displayName` TEXT NOT NULL, `score` INTEGER NOT NULL, `prevalence` REAL NOT NULL, PRIMARY KEY(`hostname`))",
+        "fields": [
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerCompanyId",
+            "columnName": "trackerCompanyId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCdn",
+            "columnName": "isCdn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner.name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner.displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "app.score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "app.prevalence",
+            "columnName": "prevalence",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "hostname"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_blocking_list_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exclusion_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageId` TEXT NOT NULL, PRIMARY KEY(`packageId`))",
+        "fields": [
+          {
+            "fieldPath": "packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exclusion_list_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exception_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rule` TEXT NOT NULL, `packageNames` TEXT NOT NULL, PRIMARY KEY(`rule`))",
+        "fields": [
+          {
+            "fieldPath": "rule",
+            "columnName": "rule",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageNames",
+            "columnName": "packageNames",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "rule"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exception_rules_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_blocking_app_packages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `entityName` TEXT NOT NULL, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityName",
+            "columnName": "entityName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageName"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_manual_exclusion_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageId` TEXT NOT NULL, `isProtected` INTEGER NOT NULL, PRIMARY KEY(`packageId`))",
+        "fields": [
+          {
+            "fieldPath": "packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isProtected",
+            "columnName": "isProtected",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2279dd342e3f2465f0dddab33e09d554')"
+    ]
+  }
+}

--- a/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.VpnDatabase/19.json
+++ b/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.VpnDatabase/19.json
@@ -1,0 +1,608 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "2df4da3c9c8d7b1a065d03c5d6970721",
+    "entities": [
+      {
+        "tableName": "vpn_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `uuid` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_tracker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackerId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackerCompanyId` INTEGER NOT NULL, `domain` TEXT NOT NULL, `company` TEXT NOT NULL, `companyDisplayName` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `packageId` TEXT NOT NULL, `appDisplayName` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "trackerId",
+            "columnName": "trackerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerCompanyId",
+            "columnName": "trackerCompanyId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "company",
+            "columnName": "company",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "companyDisplayName",
+            "columnName": "companyDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackingApp.packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackingApp.appDisplayName",
+            "columnName": "appDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "trackerId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_vpn_tracker_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_vpn_tracker_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_running_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `timeRunningMillis` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeRunningMillis",
+            "columnName": "timeRunningMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_service_state_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` TEXT NOT NULL, `state` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_data_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dataSent` INTEGER NOT NULL, `dataReceived` INTEGER NOT NULL, `packetsSent` INTEGER NOT NULL, `packetsReceived` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataSent",
+            "columnName": "dataSent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataReceived",
+            "columnName": "dataReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetsSent",
+            "columnName": "packetsSent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetsReceived",
+            "columnName": "packetsReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`preference` TEXT NOT NULL, `value` INTEGER NOT NULL, PRIMARY KEY(`preference`))",
+        "fields": [
+          {
+            "fieldPath": "preference",
+            "columnName": "preference",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "preference"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_heartbeat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`type`))",
+        "fields": [
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "type"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_phoenix",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `reason` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `formattedTimestamp` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formattedTimestamp",
+            "columnName": "formattedTimestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_notification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `timesRun` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timesRun",
+            "columnName": "timesRun",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_blocking_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hostname` TEXT NOT NULL, `trackerCompanyId` INTEGER NOT NULL, `isCdn` INTEGER NOT NULL, `name` TEXT NOT NULL, `displayName` TEXT NOT NULL, `score` INTEGER NOT NULL, `prevalence` REAL NOT NULL, PRIMARY KEY(`hostname`))",
+        "fields": [
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerCompanyId",
+            "columnName": "trackerCompanyId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCdn",
+            "columnName": "isCdn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner.name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner.displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "app.score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "app.prevalence",
+            "columnName": "prevalence",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "hostname"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_blocking_list_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exclusion_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageId` TEXT NOT NULL, PRIMARY KEY(`packageId`))",
+        "fields": [
+          {
+            "fieldPath": "packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exclusion_list_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exception_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rule` TEXT NOT NULL, `packageNames` TEXT NOT NULL, PRIMARY KEY(`rule`))",
+        "fields": [
+          {
+            "fieldPath": "rule",
+            "columnName": "rule",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageNames",
+            "columnName": "packageNames",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "rule"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exception_rules_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_blocking_app_packages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `entityName` TEXT NOT NULL, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityName",
+            "columnName": "entityName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageName"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_manual_exclusion_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageId` TEXT NOT NULL, `isProtected` INTEGER NOT NULL, PRIMARY KEY(`packageId`))",
+        "fields": [
+          {
+            "fieldPath": "packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isProtected",
+            "columnName": "isProtected",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_system_app_override_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageId` TEXT NOT NULL, PRIMARY KEY(`packageId`))",
+        "fields": [
+          {
+            "fieldPath": "packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_system_app_override_list_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2df4da3c9c8d7b1a065d03c5d6970721')"
+    ]
+  }
+}

--- a/vpn-store/src/androidTest/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseTest.kt
+++ b/vpn-store/src/androidTest/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.store
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+
+class VpnDatabaseTest {
+    @get:Rule
+    @Suppress("unused")
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val testHelper = MigrationTestHelper(InstrumentationRegistry.getInstrumentation(), VpnDatabase::class.qualifiedName, FrameworkSQLiteOpenHelperFactory())
+
+    @Test
+    fun whenTestingAllMigrationsThenSucceeds() {
+        createDatabase(18)
+
+        Room.databaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            VpnDatabase::class.java,
+            TEST_DB_NAME
+        ).addMigrations(*VpnDatabase.ALL_MIGRATIONS.toTypedArray()).build().apply {
+            openHelper.writableDatabase.close()
+        }
+    }
+
+    private fun createDatabase(version: Int) {
+        testHelper.createDatabase(TEST_DB_NAME, version).apply {
+            close()
+        }
+    }
+
+    companion object {
+        private const val TEST_DB_NAME = "TEST_DB_NAME"
+    }
+}

--- a/vpn-store/src/androidTest/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerRepositoryTest.kt
+++ b/vpn-store/src/androidTest/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerRepositoryTest.kt
@@ -38,7 +38,7 @@ class AppTrackerRepositoryTest {
             VpnDatabase.prepopulateAppTrackerBlockingList(context, this)
         }
 
-        appTrackerRepository = RealAppTrackerRepository(vpnDatabase.vpnAppTrackerBlockingDao())
+        appTrackerRepository = RealAppTrackerRepository(vpnDatabase.vpnAppTrackerBlockingDao(), vpnDatabase.vpnSystemAppsOverridesDao())
     }
 
     @Test

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnAppTrackerSystemAppsOverridesDao.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnAppTrackerSystemAppsOverridesDao.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerSystemAppOverrideListMetadata
+import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerSystemAppOverridePackage
+
+@Dao
+interface VpnAppTrackerSystemAppsOverridesDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertSystemAppOverrides(tracker: List<AppTrackerSystemAppOverridePackage>)
+
+    @Transaction
+    fun upsertSystemAppOverrides(systemAppOverrides: List<AppTrackerSystemAppOverridePackage>, metadata: AppTrackerSystemAppOverrideListMetadata) {
+        setSystemAppOverridesMetadata(metadata)
+        deleteSystemAppOverrides()
+        insertSystemAppOverrides(systemAppOverrides)
+    }
+
+    @Query("DELETE from vpn_app_tracker_system_app_override_list")
+    fun deleteSystemAppOverrides()
+
+    @Query("SELECT * FROM vpn_app_tracker_system_app_override_list")
+    fun getSystemAppOverrides(): List<AppTrackerSystemAppOverridePackage>
+
+    @Query("SELECT * from vpn_app_tracker_system_app_override_list_metadata ORDER BY id DESC LIMIT 1")
+    fun getSystemAppOverridesMetadata(): AppTrackerSystemAppOverrideListMetadata?
+
+    @Insert
+    fun setSystemAppOverridesMetadata(systemAppOverridesMetadata: AppTrackerSystemAppOverrideListMetadata)
+}

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabase.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabase.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.mobile.android.vpn.store
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.room.*
+import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.duckduckgo.mobile.android.vpn.dao.*
 import com.duckduckgo.mobile.android.vpn.model.*
@@ -34,7 +35,7 @@ import java.util.*
 import java.util.concurrent.Executors
 
 @Database(
-    exportSchema = true, version = 18,
+    exportSchema = true, version = 19,
     entities = [
         VpnState::class,
         VpnTracker::class,
@@ -52,7 +53,9 @@ import java.util.concurrent.Executors
         AppTrackerExceptionRule::class,
         AppTrackerExceptionRuleMetadata::class,
         AppTrackerPackage::class,
-        AppTrackerManualExcludedApp::class
+        AppTrackerManualExcludedApp::class,
+        AppTrackerSystemAppOverridePackage::class,
+        AppTrackerSystemAppOverrideListMetadata::class,
     ]
 )
 
@@ -69,6 +72,7 @@ abstract class VpnDatabase : RoomDatabase() {
     abstract fun vpnNotificationsDao(): VpnNotificationsDao
     abstract fun vpnAppTrackerBlockingDao(): VpnAppTrackerBlockingDao
     abstract fun vpnServiceStateDao(): VpnServiceStateStatsDao
+    abstract fun vpnSystemAppsOverridesDao(): VpnAppTrackerSystemAppsOverridesDao
 
     companion object {
 
@@ -83,7 +87,8 @@ abstract class VpnDatabase : RoomDatabase() {
         private fun buildDatabase(context: Context): VpnDatabase {
             return Room.databaseBuilder(context, VpnDatabase::class.java, "vpn.db")
                 .enableMultiInstanceInvalidation()
-                .fallbackToDestructiveMigration()
+                .fallbackToDestructiveMigrationFrom(*IntRange(1, 17).toList().toIntArray())
+                .addMigrations(*ALL_MIGRATIONS.toTypedArray())
                 .addCallback(object : Callback() {
                     override fun onCreate(db: SupportSQLiteDatabase) {
                         super.onCreate(db)
@@ -163,6 +168,17 @@ abstract class VpnDatabase : RoomDatabase() {
             return adapter.fromJson(json)?.rules.orEmpty()
         }
 
+        private val MIGRATION_18_TO_19: Migration = object : Migration(18, 19) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE TABLE IF NOT EXISTS `vpn_app_tracker_system_app_override_list` (`packageId` TEXT NOT NULL, PRIMARY KEY (`packageId`))")
+                database.execSQL("CREATE TABLE IF NOT EXISTS `vpn_app_tracker_system_app_override_list_metadata` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)")
+            }
+        }
+
+        val ALL_MIGRATIONS: List<Migration>
+            get() = listOf(
+                MIGRATION_18_TO_19,
+            )
     }
 }
 

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTracker.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTracker.kt
@@ -54,6 +54,17 @@ data class AppTrackerExclusionListMetadata(
     val eTag: String?
 )
 
+@Entity(tableName = "vpn_app_tracker_system_app_override_list")
+data class AppTrackerSystemAppOverridePackage(
+    @PrimaryKey val packageId: String
+)
+
+@Entity(tableName = "vpn_app_tracker_system_app_override_list_metadata")
+data class AppTrackerSystemAppOverrideListMetadata(
+    @PrimaryKey(autoGenerate = true) var id: Long = 0,
+    val eTag: String?
+)
+
 @Entity(tableName = "vpn_app_tracker_exception_rules")
 data class AppTrackerExceptionRule(
     @PrimaryKey
@@ -103,6 +114,11 @@ sealed class AppTrackerType {
 
 /** JSON Model that represents the app exclusion list */
 data class JsonAppTrackerExclusionList(
+    val rules: List<String>
+)
+
+/** JSON Model that represents the system app overrides */
+data class JsonAppTrackerSystemAppOverrides(
     val rules: List<String>
 )
 

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerRepository.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerRepository.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.mobile.android.vpn.trackers
 
 import androidx.annotation.WorkerThread
 import com.duckduckgo.mobile.android.vpn.dao.VpnAppTrackerBlockingDao
+import com.duckduckgo.mobile.android.vpn.dao.VpnAppTrackerSystemAppsOverridesDao
 import kotlinx.coroutines.flow.Flow
 
 @WorkerThread
@@ -32,6 +33,8 @@ interface AppTrackerRepository {
 
     fun getManualAppExclusionListFlow(): Flow<List<AppTrackerManualExcludedApp>>
 
+    fun getSystemAppOverrideList(): List<AppTrackerSystemAppOverridePackage>
+
     fun manuallyExcludedApp(packageName: String)
 
     fun manuallyEnabledApp(packageName: String)
@@ -39,7 +42,10 @@ interface AppTrackerRepository {
     fun restoreDefaultProtectedList()
 }
 
-class RealAppTrackerRepository(private val vpnAppTrackerBlockingDao: VpnAppTrackerBlockingDao) : AppTrackerRepository {
+class RealAppTrackerRepository(
+    private val vpnAppTrackerBlockingDao: VpnAppTrackerBlockingDao,
+    private val vpnSystemAppsOverrides: VpnAppTrackerSystemAppsOverridesDao
+) : AppTrackerRepository {
 
     override fun findTracker(hostname: String, packageName: String): AppTrackerType {
         val tracker = vpnAppTrackerBlockingDao.getTrackerBySubdomain(hostname) ?: return AppTrackerType.NotTracker
@@ -70,6 +76,10 @@ class RealAppTrackerRepository(private val vpnAppTrackerBlockingDao: VpnAppTrack
 
     override fun getManualAppExclusionListFlow(): Flow<List<AppTrackerManualExcludedApp>> {
         return vpnAppTrackerBlockingDao.getManualAppExclusionListFlow()
+    }
+
+    override fun getSystemAppOverrideList(): List<AppTrackerSystemAppOverridePackage> {
+        return vpnSystemAppsOverrides.getSystemAppOverrides()
     }
 
     override fun manuallyExcludedApp(packageName: String) {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerExclusionListUpdateWorker.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerExclusionListUpdateWorker.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExclusionListMetadata
+import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerSystemAppOverrideListMetadata
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -39,30 +40,73 @@ class AppTrackerExclusionListUpdateWorker(context: Context, workerParameters: Wo
 
     override suspend fun doWork(): Result {
         return withContext(Dispatchers.IO) {
-            Timber.d("Updating the app tracker exclusion list")
-            val exclusionList = appTrackerListDownloader.downloadAppTrackerExclusionList()
+            val exclusionListResult = updateExclusionList()
+            val sysAppOverridesListResult = updateSystemAppOverrides()
 
-            when (exclusionList.etag) {
-                is ETag.ValidETag -> {
-                    val currentEtag = vpnDatabase.vpnAppTrackerBlockingDao().getExclusionListMetadata()?.eTag
-                    val updatedEtag = exclusionList.etag.value
+            val success = Result.success()
+            if (exclusionListResult != success) {
+                Timber.w("Failed downloading exclution or system app override lists, scheduling a retry")
+                return@withContext Result.retry()
+            }
 
-                    if (updatedEtag == currentEtag) {
-                        Timber.v("Downloaded exclusion list has same eTag, noop")
-                        return@withContext Result.success()
-                    }
+            return@withContext success
+        }
+    }
 
-                    Timber.d("Updating the app tracker exclusion list, eTag: ${exclusionList.etag.value}")
-                    vpnDatabase.vpnAppTrackerBlockingDao().updateExclusionList(exclusionList.excludedPackages, AppTrackerExclusionListMetadata(eTag = exclusionList.etag.value))
+    private suspend fun updateSystemAppOverrides(): Result {
+        Timber.d("Updating the app system app overrides list")
 
-                    TrackerBlockingVpnService.restartVpnService(applicationContext)
+        val sysAppsOverrides = appTrackerListDownloader.downloadSystemAppOverrideList()
 
-                    return@withContext Result.success()
+        when (sysAppsOverrides.etag) {
+            is ETag.ValidETag -> {
+                val currentEtag = vpnDatabase.vpnSystemAppsOverridesDao().getSystemAppOverridesMetadata()?.eTag
+                val updatedEtag = sysAppsOverrides.etag.value
+
+                if (updatedEtag == currentEtag) {
+                    Timber.v("Downloaded system app overrides has same eTag, noop")
+                    return Result.success()
                 }
-                else -> {
-                    Timber.w("Received app tracker exclusion list with invalid eTag")
-                    return@withContext Result.retry()
+
+                Timber.d("Updating the app tracker system app overrides, eTag: ${sysAppsOverrides.etag.value}")
+                vpnDatabase.vpnSystemAppsOverridesDao().upsertSystemAppOverrides(
+                        sysAppsOverrides.overridePackages, AppTrackerSystemAppOverrideListMetadata(eTag = updatedEtag))
+
+                TrackerBlockingVpnService.restartVpnService(applicationContext)
+
+                return Result.success()
+            }
+            else -> {
+                Timber.w("Received app tracker exclusion list with invalid eTag")
+                return Result.retry()
+            }
+        }
+    }
+
+    private suspend fun updateExclusionList(): Result {
+        Timber.d("Updating the app tracker exclusion list")
+        val exclusionList = appTrackerListDownloader.downloadAppTrackerExclusionList()
+
+        when (exclusionList.etag) {
+            is ETag.ValidETag -> {
+                val currentEtag = vpnDatabase.vpnAppTrackerBlockingDao().getExclusionListMetadata()?.eTag
+                val updatedEtag = exclusionList.etag.value
+
+                if (updatedEtag == currentEtag) {
+                    Timber.v("Downloaded exclusion list has same eTag, noop")
+                    return Result.success()
                 }
+
+                Timber.d("Updating the app tracker exclusion list, eTag: ${exclusionList.etag.value}")
+                vpnDatabase.vpnAppTrackerBlockingDao().updateExclusionList(exclusionList.excludedPackages, AppTrackerExclusionListMetadata(eTag = exclusionList.etag.value))
+
+                TrackerBlockingVpnService.restartVpnService(applicationContext)
+
+                return Result.success()
+            }
+            else -> {
+                Timber.w("Received app tracker exclusion list with invalid eTag")
+                return Result.retry()
             }
         }
     }
@@ -80,7 +124,7 @@ class AppTrackerExclusionListUpdateWorkerScheduler @Inject constructor(
             .addTag(APP_TRACKER_EXCLUSION_LIST_UPDATE_WORKER_TAG)
             .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
             .build()
-        workManager.enqueueUniquePeriodicWork(APP_TRACKER_EXCLUSION_LIST_UPDATE_WORKER_TAG, ExistingPeriodicWorkPolicy.KEEP, workerRequest)
+        workManager.enqueueUniquePeriodicWork(APP_TRACKER_EXCLUSION_LIST_UPDATE_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, workerRequest)
     }
 
     companion object {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListDownloader.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListDownloader.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerPackage
 import com.duckduckgo.mobile.android.vpn.trackers.JsonAppBlockingList
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExcludedPackage
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExceptionRule
+import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerSystemAppOverridePackage
 import com.squareup.anvil.annotations.ContributesBinding
 import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
@@ -40,6 +41,11 @@ data class AppTrackerBlocklist(
 data class AppTrackerExclusionList(
     val etag: ETag = ETag.InvalidETag,
     val excludedPackages: List<AppTrackerExcludedPackage> = listOf()
+)
+
+data class AppTrackerSystemAppOverrideList(
+    val etag: ETag = ETag.InvalidETag,
+    val overridePackages: List<AppTrackerSystemAppOverridePackage> = listOf()
 )
 
 data class AppTrackerRuleList(
@@ -58,6 +64,9 @@ interface AppTrackerListDownloader {
 
     @WorkerThread
     fun downloadAppTrackerExclusionList(): AppTrackerExclusionList
+
+    @WorkerThread
+    fun downloadSystemAppOverrideList(): AppTrackerSystemAppOverrideList
 
     @WorkerThread
     fun downloadAppTrackerExceptionRules(): AppTrackerRuleList
@@ -121,6 +130,29 @@ class RealAppTrackerListDownloader @Inject constructor(
         Timber.d("Received the app tracker exclusion list, size: ${exclusionList.size}")
 
         return AppTrackerExclusionList(etag = ETag.ValidETag(eTag), excludedPackages = exclusionList)
+    }
+
+    override fun downloadSystemAppOverrideList(): AppTrackerSystemAppOverrideList {
+        Timber.d("Downloading the app tracker system app overrides list...")
+        val response = runCatching {
+            appTrackerListService.appTrackerSystemAppsOverrides().execute()
+        }.getOrElse {
+            Timber.w("Error downloading system app overrides list: $it")
+            Response.error(400, "".toResponseBody(null))
+        }
+
+        if (!response.isSuccessful) {
+            Timber.e("Fail to download the app system app overrides list, error code: ${response.code()}")
+            return AppTrackerSystemAppOverrideList()
+        }
+
+        val eTag = response.headers().extractETag()
+        val systemAppOverrides = response.body()?.rules.orEmpty()
+                .map { AppTrackerSystemAppOverridePackage(it) }
+
+        Timber.d("Received the app system app overrides list, size: ${systemAppOverrides.size}")
+
+        return AppTrackerSystemAppOverrideList(etag = ETag.ValidETag(eTag), overridePackages = systemAppOverrides)
     }
 
     override fun downloadAppTrackerExceptionRules(): AppTrackerRuleList {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListService.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.mobile.android.vpn.blocklist
 import com.duckduckgo.mobile.android.vpn.trackers.JsonAppBlockingList
 import com.duckduckgo.mobile.android.vpn.trackers.JsonAppTrackerExclusionList
 import com.duckduckgo.mobile.android.vpn.trackers.JsonAppTrackerExceptionRules
+import com.duckduckgo.mobile.android.vpn.trackers.JsonAppTrackerSystemAppOverrides
 import retrofit2.Call
 import retrofit2.http.GET
 
@@ -31,4 +32,7 @@ interface AppTrackerListService {
 
     @GET("https://staticcdn.duckduckgo.com/trackerblocking/appTB/1.0/unbreak.json")
     fun appTrackerExceptionRules(): Call<JsonAppTrackerExceptionRules>
+
+    @GET("https://staticcdn.duckduckgo.com/trackerblocking/appTB/1.0/system-apps-overrides.json")
+    fun appTrackerSystemAppsOverrides(): Call<JsonAppTrackerSystemAppOverrides>
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
@@ -53,7 +53,7 @@ class VpnAppModule {
     fun provideAppTrackerLoader(
         vpnDatabase: VpnDatabase
     ): AppTrackerRepository {
-        return RealAppTrackerRepository(vpnDatabase.vpnAppTrackerBlockingDao())
+        return RealAppTrackerRepository(vpnDatabase.vpnAppTrackerBlockingDao(), vpnDatabase.vpnSystemAppsOverridesDao())
     }
 
     @Provides


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201403499648047/f

### Description
Some beta users have flagged that some of the popular apps that are installed in their device don't appear under the "Manage protection for your apps" screen. This is the case for eg. Chrome

These apps don't appear because they're flagged by Android as "system apps" as all system apps are unprotected but also don't show in the "Manage protection for your apps" screen:
* they don't appear in there because there's a lot of internal Android libraries are also system apps
* showing them all would clutter that screen and create confusion

However we need to add those that are popular apps so that users have control over their protection.


This PR uses a new endpoint to fetch the system app overrides and also modifies the logic so that overrided apps appear under the "Manage protection for your apps" screen

### Steps to test this PR
Install chrome browser

_test the feature_
* install app from develop
* enable appTP
* navigate to "Manage protection for your apps"
* Chrome should not appear in the list of apps
* install from this branch
* enable appTP
* navigate to "Manage protection for your apps"
* Chrome should appear in the list of apps and you can protect/unprotect

_test the migration_
This feature introduces for the first time migrations
1. install from develop
2. enable appTp
3. verify the vpn database does not contain neither the `vpn_app_tracker_system_app_override_list` nor the `vpn_app_tracker_system_app_override_list_metadata` tables
4. install/update from this branch
5. launch the app
6. verify app doesn't crash
7. verify app contains the `vpn_app_tracker_system_app_override_list` AND the `vpn_app_tracker_system_app_override_list_metadata` tables


The initial list of overrides for system apps are [here](https://github.com/duckduckgo/app-tracking-protection-lists/pull/21/files)

