### PR TITLE
Catch IllegalArgumentException in deviceToNetworkProcessing

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpPacketProcessor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpPacketProcessor.kt
@@ -163,9 +163,14 @@ class UdpPacketProcessor @AssistedInject constructor(
 
                 packetPersister.persistDataSent(bytesWritten, PACKET_TYPE_UDP)
             }
-        } catch (e: IOException) {
-            Timber.w("Network write error writing to $cacheKey")
-            channelCache.remove(cacheKey)
+        } catch (e: Exception) {
+            when (e) {
+                is IOException, is IllegalArgumentException -> {
+                    Timber.w("Network write error writing to $cacheKey")
+                    channelCache.remove(cacheKey)
+                }
+                else -> throw e
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201501533153172/f

### Description
We're seeing a crash in the UDP pipeline, in the `deviceToNetworkProcessing` method when trying to write in the datagram channel.

The exception is `IllegalArgumentException` but we're only catching `IOExceptions`.

At the time of writing this is affecting 284 users, which is a lot when considering how many we've got in the beta waitlist.

### Steps to test this PR
We can't reproduce this issue, so just code review.

