### PR TITLE
Lazily initialize encrypted shared preferences

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
@@ -31,11 +31,12 @@ import com.duckduckgo.app.runBlocking
 import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestCoroutineScope
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -51,40 +52,38 @@ class AppEmailManagerTest {
     var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private val mockEmailService: EmailService = mock()
-    private val mockEmailDataStore: EmailDataStore = mock()
-    private val aliasSharedFlow = MutableStateFlow<String?>(null)
+    private val mockEmailDataStore: EmailDataStore = FakeEmailDataStore()
     lateinit var testee: AppEmailManager
 
     @Before
     fun setup() {
-        whenever(mockEmailDataStore.nextAliasFlow()).thenReturn(aliasSharedFlow.asStateFlow())
         testee = AppEmailManager(mockEmailService, mockEmailDataStore, coroutineRule.testDispatcherProvider, TestCoroutineScope())
     }
 
     @Test
     fun whenFetchAliasFromServiceThenStoreAliasAddingDuckDomain() = coroutineRule.runBlocking {
-        whenever(mockEmailDataStore.emailToken).thenReturn("token")
+        mockEmailDataStore.emailToken = "token"
         whenever(mockEmailService.newAlias(any())).thenReturn(EmailAlias("test"))
         testee.getAlias()
 
-        verify(mockEmailDataStore).nextAlias = "test$DUCK_EMAIL_DOMAIN"
+        assertEquals("test$DUCK_EMAIL_DOMAIN", mockEmailDataStore.nextAlias)
     }
 
     @Test
     fun whenFetchAliasFromServiceAndTokenDoesNotExistThenDoNothing() = coroutineRule.runBlocking {
-        whenever(mockEmailDataStore.emailToken).thenReturn(null)
+        mockEmailDataStore.emailToken = null
         testee.getAlias()
 
         verify(mockEmailService, never()).newAlias(any())
     }
 
     @Test
-    fun whenFetchAliasFromServiceAndAddressIsBlankThenStoreNullTwice() = coroutineRule.runBlocking {
-        whenever(mockEmailDataStore.emailToken).thenReturn("token")
+    fun whenFetchAliasFromServiceAndAddressIsBlankThenStoreNull() = coroutineRule.runBlocking {
+        mockEmailDataStore.emailToken = "token"
         whenever(mockEmailService.newAlias(any())).thenReturn(EmailAlias(""))
         testee.getAlias()
 
-        verify(mockEmailDataStore, times(2)).nextAlias = null
+        assertNull(mockEmailDataStore.nextAlias)
     }
 
     @Test
@@ -103,36 +102,36 @@ class AppEmailManagerTest {
     fun whenGetAliasThenClearNextAlias() {
         testee.getAlias()
 
-        verify(mockEmailDataStore).nextAlias = null
+        assertNull(mockEmailDataStore.nextAlias)
     }
 
     @Test
     fun whenIsSignedInAndTokenDoesNotExistThenReturnFalse() {
-        whenever(mockEmailDataStore.emailUsername).thenReturn("username")
-        whenever(mockEmailDataStore.nextAlias).thenReturn("alias")
+        mockEmailDataStore.emailUsername = "username"
+        mockEmailDataStore.nextAlias = "alias"
 
         assertFalse(testee.isSignedIn())
     }
 
     @Test
     fun whenIsSignedInAndUsernameDoesNotExistThenReturnFalse() {
-        whenever(mockEmailDataStore.emailToken).thenReturn("token")
-        whenever(mockEmailDataStore.nextAlias).thenReturn("alias")
+        mockEmailDataStore.emailToken = "token"
+        mockEmailDataStore.nextAlias = "alias"
 
         assertFalse(testee.isSignedIn())
     }
 
     @Test
     fun whenIsSignedInAndTokenAndUsernameExistThenReturnTrue() {
-        whenever(mockEmailDataStore.emailToken).thenReturn("token")
-        whenever(mockEmailDataStore.emailUsername).thenReturn("username")
+        mockEmailDataStore.emailToken = "token"
+        mockEmailDataStore.emailUsername = "username"
 
         assertTrue(testee.isSignedIn())
     }
 
     @Test
     fun whenStoreCredentialsThenGenerateNewAlias() = coroutineRule.runBlocking {
-        whenever(mockEmailDataStore.emailToken).thenReturn("token")
+        mockEmailDataStore.emailToken = "token"
         whenever(mockEmailService.newAlias(any())).thenReturn(EmailAlias(""))
 
         testee.storeCredentials("token", "username", "cohort")
@@ -144,24 +143,21 @@ class AppEmailManagerTest {
     fun whenStoreCredentialsThenCredentialsAreStoredInDataStore() {
         testee.storeCredentials("token", "username", "cohort")
 
-        verify(mockEmailDataStore).emailUsername = "username"
-        verify(mockEmailDataStore).emailToken = "token"
-        verify(mockEmailDataStore).cohort = "cohort"
+        assertEquals("username", mockEmailDataStore.emailUsername)
+        assertEquals("token", mockEmailDataStore.emailToken)
+        assertEquals("cohort", mockEmailDataStore.cohort)
     }
 
     @Test
     fun whenStoreCredentialsIfCredentialsWereCorrectlyStoredThenIsSignedInChannelSendsTrue() = coroutineRule.runBlocking {
-        whenever(mockEmailDataStore.emailToken).thenReturn("token")
-        whenever(mockEmailDataStore.emailUsername).thenReturn("username")
-
         testee.storeCredentials("token", "username", "cohort")
 
         assertTrue(testee.signedInFlow().first())
     }
 
     @Test
-    fun whenStoreCredentialsIfCredentialsWereNotCorrectlyStoredThenIsSignedInChannelSendsFalse() = coroutineRule.runBlocking {
-        testee.storeCredentials("token", "username", "cohort")
+    fun whenStoreCredentialsIfCredentialsAreBlankThenIsSignedInChannelSendsFalse() = coroutineRule.runBlocking {
+        testee.storeCredentials("", "", "cohort")
 
         assertFalse(testee.signedInFlow().first())
     }
@@ -170,9 +166,10 @@ class AppEmailManagerTest {
     fun whenSignedOutThenClearEmailDataAndAliasIsNull() {
         testee.signOut()
 
-        verify(mockEmailDataStore).emailUsername = null
-        verify(mockEmailDataStore).emailToken = null
-        verify(mockEmailDataStore).nextAlias = null
+        assertNull(mockEmailDataStore.emailUsername)
+        assertNull(mockEmailDataStore.emailToken)
+        assertNull(mockEmailDataStore.nextAlias)
+
         assertNull(testee.getAlias())
     }
 
@@ -185,93 +182,93 @@ class AppEmailManagerTest {
 
     @Test
     fun whenGetEmailAddressThenDuckEmailDomainIsAppended() {
-        whenever(mockEmailDataStore.emailUsername).thenReturn("username")
+        mockEmailDataStore.emailUsername = "username"
 
         assertEquals("username$DUCK_EMAIL_DOMAIN", testee.getEmailAddress())
     }
 
     @Test
     fun whenWaitlistStateIfTimestampExistsCodeDoesNotExistAndSendNotificationIsTrueThenReturnJoinedQueueWithTrue() {
-        whenever(mockEmailDataStore.waitlistTimestamp).thenReturn(1234)
-        whenever(mockEmailDataStore.sendNotification).thenReturn(true)
+        mockEmailDataStore.waitlistTimestamp = 1234
+        mockEmailDataStore.sendNotification = true
 
         assertEquals(JoinedQueue(true), testee.waitlistState())
     }
 
     @Test
     fun whenWaitlistStateIfTimestampExistsCodeDoesNotExistAndSendNotificationIsFalseThenReturnJoinedQueueWithFalse() {
-        whenever(mockEmailDataStore.waitlistTimestamp).thenReturn(1234)
-        whenever(mockEmailDataStore.sendNotification).thenReturn(false)
+        mockEmailDataStore.waitlistTimestamp = 1234
+        mockEmailDataStore.sendNotification = false
 
         assertEquals(JoinedQueue(false), testee.waitlistState())
     }
 
     @Test
     fun whenWaitlistStateIfTimestampExistsAndCodeExistsThenReturnInBeta() {
-        whenever(mockEmailDataStore.waitlistTimestamp).thenReturn(1234)
-        whenever(mockEmailDataStore.inviteCode).thenReturn("abcde")
+        mockEmailDataStore.waitlistTimestamp = 1234
+        mockEmailDataStore.inviteCode = "abcde"
 
         assertEquals(InBeta, testee.waitlistState())
     }
 
     @Test
     fun whenWaitlistStateIfTimestampAndCodeDoesNotExistThenReturnNotJoinedQueue() {
-        whenever(mockEmailDataStore.waitlistTimestamp).thenReturn(-1)
-        whenever(mockEmailDataStore.inviteCode).thenReturn(null)
+        mockEmailDataStore.waitlistTimestamp = -1
+        mockEmailDataStore.waitlistToken = null
 
         assertEquals(NotJoinedQueue, testee.waitlistState())
     }
 
     @Test
     fun whenJoinWaitlistIfTimestampAndTokenDidNotExistThenStoreTimestampAndToken() {
-        whenever(mockEmailDataStore.waitlistTimestamp).thenReturn(-1)
-        whenever(mockEmailDataStore.waitlistToken).thenReturn(null)
+        mockEmailDataStore.waitlistTimestamp = -1
+        mockEmailDataStore.waitlistToken = null
 
         testee.joinWaitlist(1234, "abcde")
 
-        verify(mockEmailDataStore).waitlistTimestamp = 1234
-        verify(mockEmailDataStore).waitlistToken = "abcde"
+        assertEquals(1234, mockEmailDataStore.waitlistTimestamp)
+        assertEquals("abcde", mockEmailDataStore.waitlistToken)
     }
     @Test
     fun whenJoinWaitlistIfTimestampAndTokenDidExistThenStoreTimestampAndTokenAreNotStored() {
-        whenever(mockEmailDataStore.waitlistTimestamp).thenReturn(1234)
-        whenever(mockEmailDataStore.waitlistToken).thenReturn("abcde")
+        mockEmailDataStore.waitlistTimestamp = 1234
+        mockEmailDataStore.waitlistToken = "abcde"
 
         testee.joinWaitlist(4321, "edcba")
 
-        verify(mockEmailDataStore, never()).waitlistTimestamp = 4321
-        verify(mockEmailDataStore, never()).waitlistToken = "edcba"
+        assertEquals(1234, mockEmailDataStore.waitlistTimestamp)
+        assertEquals("abcde", mockEmailDataStore.waitlistToken)
     }
 
     @Test
     fun whenGetInviteCodeIfCodeExistsThenReturnCode() {
-        whenever(mockEmailDataStore.inviteCode).thenReturn("abcde")
+        mockEmailDataStore.inviteCode = "abcde"
         assertEquals("abcde", testee.getInviteCode())
     }
 
     @Test
     fun whenGetInviteCodeIfCodeDoesNotExistThenReturnEmpty() {
-        whenever(mockEmailDataStore.inviteCode).thenReturn(null)
+        mockEmailDataStore.inviteCode = null
         assertEquals("", testee.getInviteCode())
     }
 
     @Test
     fun whenDoesCodeAlreadyExistIfCodeExistsThenReturnTrue() {
-        whenever(mockEmailDataStore.inviteCode).thenReturn("inviteCode")
+        mockEmailDataStore.inviteCode = "inviteCode"
 
         assertTrue(testee.doesCodeAlreadyExist())
     }
 
     @Test
     fun whenDoesCodeAlreadyExistIfCodeIsNullThenReturnFalse() {
-        whenever(mockEmailDataStore.inviteCode).thenReturn(null)
+        mockEmailDataStore.inviteCode = null
 
         assertFalse(testee.doesCodeAlreadyExist())
     }
 
     @Test
     fun whenFetchInviteCodeIfCodeAlreadyExistsThenReturnCodeExisted() = coroutineRule.runBlocking {
-        whenever(mockEmailDataStore.inviteCode).thenReturn("inviteCode")
+        mockEmailDataStore.inviteCode = "inviteCode"
 
         assertEquals(AppEmailManager.FetchCodeResult.CodeExisted, testee.fetchInviteCode())
     }
@@ -330,34 +327,35 @@ class AppEmailManagerTest {
 
     @Test
     fun whenNotifyOnJoinedWaitlistThenSendNotificationSetToTrue() {
+        mockEmailDataStore.sendNotification = false
         testee.notifyOnJoinedWaitlist()
-        verify(mockEmailDataStore).sendNotification = true
+        assertTrue(mockEmailDataStore.sendNotification)
     }
 
     @Test
     fun whenGetCohortThenReturnCohort() {
-        whenever(mockEmailDataStore.cohort).thenReturn("cohort")
+        mockEmailDataStore.cohort = "cohort"
 
         assertEquals("cohort", testee.getCohort())
     }
 
     @Test
     fun whenGetCohortIfCohortIsNullThenReturnUnknown() {
-        whenever(mockEmailDataStore.cohort).thenReturn(null)
+        mockEmailDataStore.cohort = null
 
         assertEquals(UNKNOWN_COHORT, testee.getCohort())
     }
 
     @Test
     fun whenGetCohortIfCohortIsEmtpyThenReturnUnknown() {
-        whenever(mockEmailDataStore.cohort).thenReturn("")
+        mockEmailDataStore.cohort = ""
 
         assertEquals(UNKNOWN_COHORT, testee.getCohort())
     }
 
     @Test
     fun whenIsEmailFeatureSupportedAndEncryptionCanBeUsedThenReturnTrue() {
-        whenever(mockEmailDataStore.canUseEncryption()).thenReturn(true)
+        (mockEmailDataStore as FakeEmailDataStore).canUseEncryption = true
 
         assertTrue(testee.isEmailFeatureSupported())
     }
@@ -369,20 +367,20 @@ class AppEmailManagerTest {
 
     @Test
     fun whenGetLastUsedDateIfNotNullThenReturnValueFromStore() {
-        whenever(mockEmailDataStore.lastUsedDate).thenReturn("2021-01-01")
+        mockEmailDataStore.lastUsedDate = "2021-01-01"
         assertEquals("2021-01-01", testee.getLastUsedDate())
     }
 
     @Test
     fun whenIsEmailFeatureSupportedAndEncryptionCannotBeUsedThenReturnFalse() {
-        whenever(mockEmailDataStore.canUseEncryption()).thenReturn(false)
+        (mockEmailDataStore as FakeEmailDataStore).canUseEncryption = false
 
         assertFalse(testee.isEmailFeatureSupported())
     }
 
     private fun givenUserIsInWaitlist() {
-        whenever(mockEmailDataStore.waitlistTimestamp).thenReturn(1234)
-        whenever(mockEmailDataStore.waitlistToken).thenReturn("token")
+        mockEmailDataStore.waitlistTimestamp = 1234
+        mockEmailDataStore.waitlistToken = "token"
     }
 
     private fun givenUserIsTopOfTheQueue() = coroutineRule.runBlocking {
@@ -390,8 +388,9 @@ class AppEmailManagerTest {
         whenever(mockEmailService.waitlistStatus()).thenReturn(WaitlistStatusResponse(1234))
     }
 
-    private suspend fun givenNextAliasExists() {
-        aliasSharedFlow.emit("alias")
+    private fun givenNextAliasExists() {
+//        cachedAlias.set("alias")
+        mockEmailDataStore.nextAlias = "alias"
     }
 
     class TestEmailService : EmailService {
@@ -404,4 +403,20 @@ class AppEmailManagerTest {
             throw Exception()
         }
     }
+}
+
+class FakeEmailDataStore : EmailDataStore {
+    override var emailToken: String? = null
+    override var nextAlias: String? = null
+    override var emailUsername: String? = null
+    override var inviteCode: String? = null
+    override var waitlistTimestamp: Int = 0
+    override var waitlistToken: String? = null
+    override var sendNotification: Boolean = false
+    override var cohort: String? = null
+    override var lastUsedDate: String? = null
+
+    var canUseEncryption: Boolean = false
+    override fun canUseEncryption(): Boolean = canUseEncryption
+
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/email/db/EmailEncryptedSharedPreferencesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/db/EmailEncryptedSharedPreferencesTest.kt
@@ -23,8 +23,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.TestCoroutineScope
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -42,20 +40,20 @@ class EmailEncryptedSharedPreferencesTest {
 
     @Before
     fun before() {
-        testee = EmailEncryptedSharedPreferences(InstrumentationRegistry.getInstrumentation().targetContext, mockPixel, TestCoroutineScope())
+        testee = EmailEncryptedSharedPreferences(InstrumentationRegistry.getInstrumentation().targetContext, mockPixel)
     }
 
     @Test
     fun whenNextAliasEqualsValueThenValueIsSentToNextAliasChannel() = coroutineRule.runBlocking {
         testee.nextAlias = "test"
 
-        assertEquals("test", testee.nextAliasFlow().first())
+        assertEquals("test", testee.nextAlias)
     }
 
     @Test
     fun whenNextAliasEqualsNullThenNullIsSentToNextAliasChannel() = coroutineRule.runBlocking {
         testee.nextAlias = null
 
-        assertNull(testee.nextAliasFlow().first())
+        assertNull(testee.nextAlias)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.email
 
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.email.api.EmailService
 import com.duckduckgo.app.email.db.EmailDataStore
 import com.duckduckgo.app.global.DispatcherProvider
@@ -30,7 +29,7 @@ import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.*
 
-interface EmailManager : LifecycleObserver {
+interface EmailManager {
     fun signedInFlow(): StateFlow<Boolean>
     fun getAlias(): String?
     fun isSignedIn(): Boolean
@@ -55,8 +54,6 @@ class AppEmailManager(
     private val dispatcherProvider: DispatcherProvider,
     private val appCoroutineScope: CoroutineScope
 ) : EmailManager {
-
-    private val nextAliasFlow = emailDataStore.nextAliasFlow()
 
     private val isSignedInStateFlow = MutableStateFlow(isSignedIn())
     override fun signedInFlow(): StateFlow<Boolean> = isSignedInStateFlow.asStateFlow()
@@ -154,7 +151,7 @@ class AppEmailManager(
     }
 
     private fun consumeAlias(): String? {
-        val alias = nextAliasFlow.value
+        val alias = emailDataStore.nextAlias
         emailDataStore.clearNextAlias()
         appCoroutineScope.launch(dispatcherProvider.io()) {
             generateNewAlias()

--- a/app/src/main/java/com/duckduckgo/app/email/db/EmailDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/db/EmailDataStore.kt
@@ -23,12 +23,6 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import java.io.IOException
 import java.security.GeneralSecurityException
 
@@ -42,21 +36,15 @@ interface EmailDataStore {
     var sendNotification: Boolean
     var cohort: String?
     var lastUsedDate: String?
-    fun nextAliasFlow(): StateFlow<String?>
     fun canUseEncryption(): Boolean
 }
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 class EmailEncryptedSharedPreferences(
     private val context: Context,
     private val pixel: Pixel,
-    private val appCoroutineScope: CoroutineScope
 ) : EmailDataStore {
 
-    private val encryptedPreferences: SharedPreferences? = encryptedPreferences()
-    private val nextAliasSharedFlow: MutableStateFlow<String?> = MutableStateFlow(nextAlias)
-    override fun nextAliasFlow(): StateFlow<String?> = nextAliasSharedFlow
+    private val encryptedPreferences: SharedPreferences? by lazy { encryptedPreferences() }
 
     @Synchronized
     private fun encryptedPreferences(): SharedPreferences? {
@@ -93,9 +81,6 @@ class EmailEncryptedSharedPreferences(
             encryptedPreferences?.edit(commit = true) {
                 if (value == null) remove(KEY_NEXT_ALIAS)
                 else putString(KEY_NEXT_ALIAS, value)
-                appCoroutineScope.launch {
-                    nextAliasSharedFlow.emit(value)
-                }
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/email/di/EmailModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/di/EmailModule.kt
@@ -64,9 +64,8 @@ class EmailModule {
     fun providesEmailDataStore(
         context: Context,
         pixel: Pixel,
-        @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): EmailDataStore {
-        return EmailEncryptedSharedPreferences(context, pixel, appCoroutineScope)
+        return EmailEncryptedSharedPreferences(context, pixel)
     }
 
     @SingleInstanceIn(AppScope::class)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/DefaultAppTrackingProtectionWaitlistDataStore.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/DefaultAppTrackingProtectionWaitlistDataStore.kt
@@ -36,7 +36,9 @@ class DefaultAppTrackingProtectionWaitlistDataStore @Inject constructor(
     private val pixel: Pixel
 ) : AppTrackingProtectionWaitlistDataStore {
 
-    private val encryptedPreferences: SharedPreferences? = encryptedPreferences()
+    private val encryptedPreferences: SharedPreferences? by lazy {
+        encryptedPreferences()
+    }
 
     @Synchronized
     private fun encryptedPreferences(): SharedPreferences? {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201464810536292/f

### Description
Adding a `by lazy` to both the ATP encrypted preferences.

Simplified the `EmailDataStore` so that encrypted preferences are not needed during instance creation

### Steps to test this PR
1. install from this branch
2. run smoke tests for email waitlist and appTP waitlist
3. go to "Settings" -> "Developer settings" and enable start up tracing
4. close and reopen app
5. download the trace
6. ensure encrypted preferences is only present in the SurveyDownloader path -- in develop it's present in many other paths during app onCreate
