### PR TITLE
Capture default UserAgent crashes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
@@ -22,6 +22,8 @@ import android.webkit.WebSettings
 import androidx.core.net.toUri
 import com.duckduckgo.app.global.UriString
 import com.duckduckgo.app.global.device.DeviceInfo
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -37,7 +39,11 @@ import javax.inject.Provider
  * Example Default Desktop User Agent (From Chrome):
  * Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
  */
-class UserAgentProvider constructor(@Named("defaultUserAgent") private val defaultUserAgent: Provider<String>, private val device: DeviceInfo) {
+class UserAgentProvider constructor(
+    @Named("defaultUserAgent") private val defaultUserAgent: Provider<String>,
+    private val device: DeviceInfo,
+    private val pixel: Pixel
+) {
 
     private val baseAgent: String by lazy { concatWithSpaces(mobilePrefix, getWebKitVersionOnwards(false)) }
     private val baseDesktopAgent: String by lazy { concatWithSpaces(desktopPrefix, getWebKitVersionOnwards(true)) }
@@ -83,7 +89,7 @@ class UserAgentProvider constructor(@Named("defaultUserAgent") private val defau
     }
 
     private fun getWebKitVersionOnwards(forDesktop: Boolean): String? {
-        val matches = AgentRegex.webkitUntilSafari.find(defaultUserAgent.get()) ?: AgentRegex.webkitUntilEnd.find(defaultUserAgent.get()) ?: return null
+        val matches = AgentRegex.webkitUntilSafari.find(defaultUserAgent()) ?: AgentRegex.webkitUntilEnd.find(defaultUserAgent()) ?: return null
         var result = matches.groupValues.last()
         if (forDesktop) {
             result = result.replace(" Mobile", "")
@@ -96,8 +102,18 @@ class UserAgentProvider constructor(@Named("defaultUserAgent") private val defau
     }
 
     private fun getSafariComponentFromUserAgent(): String? {
-        val matches = AgentRegex.safari.find(defaultUserAgent.get()) ?: return null
+        val matches = AgentRegex.safari.find(defaultUserAgent()) ?: return null
         return matches.groupValues.last()
+    }
+
+    private fun defaultUserAgent(): String = runCatching {
+        defaultUserAgent.get()
+    }.let { result ->
+        if (result.isFailure) {
+            pixel.fire(AppPixelName.WEBVIEW_DEFAULT_USER_AGENT_CRASH)
+            return fallbackDefaultUA
+        }
+        return@let result.getOrDefault(fallbackDefaultUA)
     }
 
     private object AgentRegex {
@@ -111,6 +127,7 @@ class UserAgentProvider constructor(@Named("defaultUserAgent") private val defau
         const val SPACE = " "
         val mobilePrefix = "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE})"
         val desktopPrefix = "Mozilla/5.0 (X11; Linux ${System.getProperty("os.arch")})"
+        val fallbackDefaultUA = "$mobilePrefix AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/96.0.4664.104 Mobile Safari/537.36"
 
         val sitesThatOmitApplication = listOf(
             "cvs.com",

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -250,5 +250,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     BOOKMARK_EXPORT_ERROR("m_be_e"),
 
     ENCRYPTED_IO_EXCEPTION("m_e_io_e"),
-    ENCRYPTED_GENERAL_EXCEPTION("m_e_g_e")
+    ENCRYPTED_GENERAL_EXCEPTION("m_e_g_e"),
+
+    WEBVIEW_DEFAULT_USER_AGENT_CRASH("default_ua_failed")
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -250,7 +250,5 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     BOOKMARK_EXPORT_ERROR("m_be_e"),
 
     ENCRYPTED_IO_EXCEPTION("m_e_io_e"),
-    ENCRYPTED_GENERAL_EXCEPTION("m_e_g_e"),
-
-    WEBVIEW_DEFAULT_USER_AGENT_CRASH("default_ua_failed")
+    ENCRYPTED_GENERAL_EXCEPTION("m_e_g_e")
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201519018374192/f

### Description
This PR intends to capture a crash when getting WebView default user agent on some devices.

### Steps to test this PR

_No changes_
1. run the app
2. visit any website
3. Filter logs by `User Agent is`
4. Ensure your UA matches the one on your device (e.g: check if chrome version is the one installed on your device)

_Capture crash_
1. Go to `provideDefaultUserAgent` method in `UserAgentProvider`
2. hardcode `throw RuntimeException("")`  before `WebSettings.getDefaultUserAgent(context)`
3. run the app
4. visit any website
5. Ensure app does not crash
