### PR TITLE
Fix crash when getting connection owner UID

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/DetectOriginatingAppPackageModern.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/DetectOriginatingAppPackageModern.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.mobile.android.vpn.processor.requestingapp
 import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.os.Build
+import android.os.Process
 import androidx.annotation.RequiresApi
 import timber.log.Timber
 import java.net.InetSocketAddress
@@ -37,7 +38,12 @@ class DetectOriginatingAppPackageModern(
     }
 
     private fun getConnectionOwnerUid(connectionInfo: ConnectionInfo, source: InetSocketAddress, destination: InetSocketAddress): Int {
-        return connectivityManager.getConnectionOwnerUid(connectionInfo.protocolNumber, source, destination)
+        return try {
+            connectivityManager.getConnectionOwnerUid(connectionInfo.protocolNumber, source, destination)
+        } catch (t:Throwable) {
+            Timber.e(t, "Error getting connection owner UID")
+            Process.INVALID_UID
+        }
     }
 
     private fun getPackageIdForUid(uid: Int): String {

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/requestingapp/DetectOriginatingAppPackageModernTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/requestingapp/DetectOriginatingAppPackageModernTest.kt
@@ -25,6 +25,7 @@ import org.junit.Test
 import java.net.InetAddress
 import java.net.InetSocketAddress
 
+
 class DetectOriginatingAppPackageModernTest {
 
     private val connectivityManager: ConnectivityManager = mock()
@@ -82,6 +83,17 @@ class DetectOriginatingAppPackageModernTest {
         captureSourceAddress()
 
         assertEquals(40123, addressCaptor.firstValue.port)
+    }
+
+    @Test
+    fun whenGetConnectionOwnerUidThrowsThenReturnUnknown() {
+        val connection = aConnectionInfo(sourcePort = 40123)
+
+        whenever(connectivityManager.getConnectionOwnerUid(any(), any(), any())).thenThrow(SecurityException())
+
+        val packateId = testee.resolvePackageId(connection)
+        assertEquals("unknown", packateId)
+        verify(packageManager).getPackagesForUid(-1)
     }
 
     private fun captureDestinationAddress() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201522043688142/f

### Description
* We're seeing some crashes when getting the connection owner UID.
* the result of these crashes is likely to disable AppTP
* easy fix is try-catch the call to `getConnectionOwnerUid` and return `Process.INVALID_UID`

### Steps to test this PR
Optional, just code review
