### PR TITLE
Send Pixels for download start / success / fail

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2164,6 +2164,7 @@ class BrowserTabViewModel(
 
     fun download(pendingFileDownload: FileDownloader.PendingFileDownload) {
         viewModelScope.launch(dispatchers.io()) {
+            pixel.fire(AppPixelName.DOWNLOAD_REQUEST_STARTED)
             fileDownloader.download(
                 pendingFileDownload,
                 object : FileDownloader.FileDownloadListener {
@@ -2174,6 +2175,7 @@ class BrowserTabViewModel(
                     }
 
                     override fun downloadFinishedNetworkFile(file: File, mimeType: String?) {
+                        // TODO [Improve downloads] This is unused.
                         Timber.i("downloadFinished network file")
                     }
 
@@ -2185,12 +2187,15 @@ class BrowserTabViewModel(
 
                     override fun downloadFinishedDataUri(file: File, mimeType: String?) {
                         Timber.i("downloadFinished data uri")
+                        pixel.fire(AppPixelName.DOWNLOAD_REQUEST_SUCCEEDED)
                         command.postValue(DownloadCommand.ScanMediaFiles(file))
                         command.postValue(DownloadCommand.ShowDownloadFinishedNotification(file, mimeType))
                     }
 
                     override fun downloadFailed(message: String, downloadFailReason: DownloadFailReason) {
+                        // TODO [Improve downloads] This used only when DownloadManager is not involved.
                         Timber.w("Failed to download file [$message]")
+                        pixel.fire(AppPixelName.DOWNLOAD_REQUEST_FAILED)
                         command.postValue(DownloadCommand.ShowDownloadFailedNotification(message, downloadFailReason))
                     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloadBroadcastReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/FileDownloadBroadcastReceiver.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.downloader
+
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = LifecycleObserver::class,
+)
+@SingleInstanceIn(AppScope::class)
+class FileDownloadBroadcastReceiver @Inject constructor(
+    private val context: Context,
+    private val pixel: Pixel,
+    private val dispatcher: DispatcherProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
+) : BroadcastReceiver(), DefaultLifecycleObserver {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        Timber.d("Download completed.")
+
+        val downloadManager = context?.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager?
+
+        val query = DownloadManager.Query()
+        query.setFilterByStatus(DownloadManager.STATUS_FAILED or DownloadManager.STATUS_SUCCESSFUL)
+
+        val cursor = downloadManager?.query(query) ?: return
+        if (cursor.moveToFirst()) {
+            val index = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
+            when (cursor.getInt(index)) {
+                DownloadManager.STATUS_SUCCESSFUL -> appCoroutineScope.launch(dispatcher.io()) {
+                    Timber.d("Download completed with success.")
+                    pixel.fire(AppPixelName.DOWNLOAD_REQUEST_SUCCEEDED)
+                }
+                DownloadManager.STATUS_FAILED -> appCoroutineScope.launch(dispatcher.io()) {
+                    Timber.d("Download completed, but failed.")
+                    pixel.fire(AppPixelName.DOWNLOAD_REQUEST_FAILED)
+                }
+            }
+        }
+    }
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        context.registerReceiver(this, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        context.unregisterReceiver(this)
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/downloader/NetworkFileDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/downloader/NetworkFileDownloader.kt
@@ -65,12 +65,14 @@ class NetworkFileDownloader @Inject constructor(
                         }
                     }
                 } else {
+                    // TODO [Improve downloads] This is not a connection failed error, but a non-[200..300) response code.
                     Timber.d("Connection failed ${response.errorBody()}")
                     callback.downloadFailed("Connection failed", DownloadFailReason.ConnectionRefused)
                 }
             }
 
             override fun onFailure(call: Call<Void>, t: Throwable) {
+                // TODO [Improve downloads] This is a connection failed, the reason provided is misleading.
                 callback.downloadFailed(context.getString(R.string.downloadManagerDisabled), DownloadFailReason.DownloadManagerDisabled)
                 return
             }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -112,6 +112,10 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
 
     DOWNLOAD_FILE_DEFAULT_GUESSED_NAME("m_df_dgn"),
 
+    DOWNLOAD_REQUEST_STARTED("m_download_request_started"),
+    DOWNLOAD_REQUEST_SUCCEEDED("m_download_request_succeeded"),
+    DOWNLOAD_REQUEST_FAILED("m_download_request_failed"),
+
     SETTINGS_OPENED("ms"),
     SETTINGS_THEME_OPENED("ms_t_o"),
     SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201507366427630/f

### Description
Send 3 types of pixels to roughly understand how many downloads fail compared to all downloads.

### Steps to test this PR

- install the app from this branch and have logcat filtered by `V/RxBasedPixel: Pixel sent: m_download_request_`
- download various files and check you get in the log the `m_download_request_started` / `m_download_request_succeeded` / `m_download_request_failed` as expected

_Example URLs:_
- Data URL success -> Go to https://dopiaza.org/tools/datauri/examples/index.php long press on the photo and select `Download Image`. It should trigger `m_download_request_started` and `m_download_request_succeeded`
- Can't find a way to test Data URL fail.
- Network URL success -> Go to https://duckduckgo.com/?q=succulent%20plants&ko=-1&iax=images&ia=images long press on any image and select `Download Image`. It should trigger `m_download_request_started` and `m_download_request_succeeded`
- Network URL fail -> Go to https://telegram.org/android and tap on Download Telegram. It should trigger `m_download_request_started` and `m_download_request_failed`
- Various files available for download: https://file-examples.com/

### No UI changes
