### PR TITLE
Add link to diagnostics from internal settings

### DIFF
--- a/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
+++ b/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
@@ -69,6 +69,7 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
         setupDebugLogging()
         setupBugReport()
         setupDeleteTrackingHistory()
+        setupViewDiagnosticsView()
     }
 
     override fun onDestroy() {
@@ -80,6 +81,13 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
         binding.deleteTrackingHistory.setOnClickListener {
             sendBroadcast(DeleteTrackersDebugReceiver.createIntent())
             Snackbar.make(binding.root, "Tracking history deleted", Snackbar.LENGTH_LONG).show()
+        }
+    }
+
+    private fun setupViewDiagnosticsView() {
+        binding.viewDiagnostics.setOnClickListener {
+            val i = Intent().also { it.setClassName(packageName, "dummy.ui.VpnDiagnosticsActivity") }
+            startActivity(i)
         }
     }
 

--- a/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
+++ b/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
@@ -96,6 +96,13 @@
                 android:text="Delete Tracking History"
             />
 
+            <TextView
+                android:id="@+id/viewDiagnostics"
+                style="@style/SettingsItemClickable"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:text="View Diagnostics Data"/>
+
         </LinearLayout>
 
     </ScrollView>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201546096051166/f

### Description
Enable a way to access the diagnostics view on `INTERNAL` builds

### Steps to test this PR
- On an **INTERNAL** build flavor, visit settings.
- Open **AppTP dev settings**
- Verify **View Diagnostics Data** shows up
- Verify clicking on it reveals the diagnostics view