### PR TITLE
Add device info to the app breakage report

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/buildconfig/RealAppBuildConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/buildconfig/RealAppBuildConfig.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.buildconfig
 
+import android.os.Build
 import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.BuildFlavor
@@ -38,4 +39,7 @@ class RealAppBuildConfig @Inject constructor() : AppBuildConfig {
             "play" -> BuildFlavor.PLAY
             else -> throw IllegalStateException("Unknown app flavor")
         }
+    override val sdkInt: Int = Build.VERSION.SDK_INT
+    override val manufacturer: String = Build.MANUFACTURER
+    override val model: String = Build.MODEL
 }

--- a/appbuildconfig-api/src/main/java/com/duckduckgo/appbuildconfig/api/AppBuildConfig.kt
+++ b/appbuildconfig-api/src/main/java/com/duckduckgo/appbuildconfig/api/AppBuildConfig.kt
@@ -23,6 +23,9 @@ interface AppBuildConfig {
     val versionCode: Int
     val versionName: String
     val flavor: BuildFlavor
+    val sdkInt: Int
+    val manufacturer: String
+    val model: String
 }
 
 enum class BuildFlavor {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/DeviceInfoCollector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/DeviceInfoCollector.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.bugreport
+
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.di.scopes.VpnScope
+import com.duckduckgo.mobile.android.vpn.state.VpnStateCollectorPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import org.json.JSONObject
+import javax.inject.Inject
+
+@ContributesMultibinding(VpnScope::class)
+class DeviceInfoCollector @Inject constructor(
+    private val appBuildConfig: AppBuildConfig
+) : VpnStateCollectorPlugin {
+    override val collectorName: String
+        get() = "deviceInfo"
+
+    override suspend fun collectVpnRelatedState(appPackageId: String?): JSONObject {
+        return JSONObject().apply {
+            put("buildFlavor", appBuildConfig.flavor.toString())
+            put("manufacturer", appBuildConfig.manufacturer)
+            put("model", appBuildConfig.model)
+            put("os", appBuildConfig.sdkInt)
+        }
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/bugreport/DeviceInfoCollectorTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/bugreport/DeviceInfoCollectorTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.bugreport
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.BuildFlavor
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class DeviceInfoCollectorTest {
+
+    @Mock private lateinit var appBuildConfig: AppBuildConfig
+
+    private lateinit var deviceInfoCollector: DeviceInfoCollector
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.PLAY)
+        whenever(appBuildConfig.manufacturer).thenReturn("manufacturer")
+        whenever(appBuildConfig.model).thenReturn("model")
+        whenever(appBuildConfig.sdkInt).thenReturn(30)
+
+        deviceInfoCollector = DeviceInfoCollector(appBuildConfig)
+    }
+
+    @Test
+    fun whenCollectVpnRelatedStateThenReturnDeviceInfo() = runTest {
+        val state = deviceInfoCollector.collectVpnRelatedState()
+
+        assertEquals("deviceInfo", deviceInfoCollector.collectorName)
+
+        assertEquals(4, state.length())
+        assertEquals("PLAY", state.get("buildFlavor"))
+        assertEquals("manufacturer", state.get("manufacturer"))
+        assertEquals("model", state.get("model"))
+        assertEquals(30, state.get("os"))
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201472311099046/f

### Description
Some of the app breakage reports we get relate to specific OEM issues. We are adding some device information to the report to aid during debugging

### Steps to test this PR
Add logcat filter: `m_atp_breakage_report`

_Test app breakage report_
1. install from this branch
2. enable AppTP
3. go to "App Tracking Protection Screen"
4. click on "Please report an issue"
5. select any app and click SUBMIT
6. click NEXT
7. select any option and click SUBMIT
8. copy the `breakageMetadata` base64 value
9. you can use https://onlinestringtools.com/convert-base64-to-string and jsonlint to convert to JSON
10. verify the json contains a `deviceInfo` section with manufacturer, bildFlavor, model and os params

