### PR TITLE
Bug: Choose default browser displayed twice

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -71,21 +71,17 @@ class WelcomePage : OnboardingPageFragment() {
         buildScreenContent()
         scheduleWelcomeAnimation()
         setSkipAnimationListener()
-    }
-
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
-
-    override fun onStart() {
-        super.onStart()
 
         lifecycleScope.launch {
             events.asFlow()
                 .flatMapLatest { welcomePageViewModel.reduce(it) }
                 .collect(::render)
         }
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
     }
 
     private fun buildScreenContent() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201620824138997/f

### Description
The "Choose default browser" dialog is displayed twice when you switch the app from foreground to background and back and then you tap on "I've been here before". See the video attached to the Asana task.

### Steps to test this PR

- checkout this branch
- tweak the variant manager by changing the weight of "zk" to 0.0 in VariantManager.kt
- install
- on Welcome Page screen you should see 2 buttons "I'm new!" and "I've been here before." Don't tap any of them yet.
- while on Welcome Page screen put the app in background and back to foreground a couple of times
- on Welcome Page screen tap on "I've been here before." and you should see a dialog to choose the default browser. Once you choose you'll not see the same dialog again, you'll see the next screen.

### NO UI changes
