### PR TITLE
Move GPC headers to remote config

### DIFF
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Gpc.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Gpc.kt
@@ -63,3 +63,6 @@ interface Gpc {
 
 /** Public data class for GPC Exceptions */
 data class GpcException(val domain: String)
+
+/** Public data class for GPC Header Enable Sites */
+data class GpcHeaderEnabledSite(val domain: String)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcFeature.kt
@@ -17,8 +17,7 @@
 package com.duckduckgo.privacy.config.impl.features.gpc
 
 import com.duckduckgo.privacy.config.store.GpcExceptionEntity
-import com.duckduckgo.privacy.config.store.GpcHeaderEnabledSiteEntity
 
 data class GpcFeature(val state: String, val exceptions: List<GpcExceptionEntity>, val settings: GpcSettings)
 
-data class GpcSettings(val gpcHeaderEnabledSites: List<GpcHeaderEnabledSiteEntity>)
+data class GpcSettings(val gpcHeaderEnabledSites: List<String>)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcFeature.kt
@@ -21,4 +21,4 @@ import com.duckduckgo.privacy.config.store.GpcHeaderEnabledSiteEntity
 
 data class GpcFeature(val state: String, val exceptions: List<GpcExceptionEntity>, val settings: GpcSettings)
 
-data class GpcSettings(val hpcHeaderEnabledSites: List<GpcHeaderEnabledSiteEntity>)
+data class GpcSettings(val gpcHeaderEnabledSites: List<GpcHeaderEnabledSiteEntity>)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcFeature.kt
@@ -17,5 +17,8 @@
 package com.duckduckgo.privacy.config.impl.features.gpc
 
 import com.duckduckgo.privacy.config.store.GpcExceptionEntity
+import com.duckduckgo.privacy.config.store.GpcHeaderEnabledSiteEntity
 
-data class GpcFeature(val state: String, val exceptions: List<GpcExceptionEntity>)
+data class GpcFeature(val state: String, val exceptions: List<GpcExceptionEntity>, val settings: GpcSettings)
+
+data class GpcSettings(val hpcHeaderEnabledSites: List<GpcHeaderEnabledSiteEntity>)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
@@ -47,7 +47,7 @@ class GpcPlugin @Inject constructor(
             gpcFeature?.exceptions?.map {
                 gpcExceptions.add(GpcExceptionEntity(it.domain))
             }
-            gpcFeature?.settings?.hpcHeaderEnabledSites?.map {
+            gpcFeature?.settings?.gpcHeaderEnabledSites?.map {
                 gpcHeaders.add(GpcHeaderEnabledSiteEntity(it.domain))
             }
             gpcRepository.updateAll(gpcExceptions, gpcHeaders)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
@@ -48,7 +48,7 @@ class GpcPlugin @Inject constructor(
                 gpcExceptions.add(GpcExceptionEntity(it.domain))
             }
             gpcFeature?.settings?.gpcHeaderEnabledSites?.map {
-                gpcHeaders.add(GpcHeaderEnabledSiteEntity(it.domain))
+                gpcHeaders.add(GpcHeaderEnabledSiteEntity(it))
             }
             gpcRepository.updateAll(gpcExceptions, gpcHeaders)
             val isEnabled = gpcFeature?.state == "enabled"

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.GpcExceptionEntity
+import com.duckduckgo.privacy.config.store.GpcHeaderEnabledSiteEntity
 import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
@@ -37,6 +38,7 @@ class GpcPlugin @Inject constructor(
     override fun store(name: String, jsonString: String): Boolean {
         if (name == featureName.value) {
             val gpcExceptions = mutableListOf<GpcExceptionEntity>()
+            val gpcHeaders = mutableListOf<GpcHeaderEnabledSiteEntity>()
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<GpcFeature> =
                 moshi.adapter(GpcFeature::class.java)
@@ -45,7 +47,10 @@ class GpcPlugin @Inject constructor(
             gpcFeature?.exceptions?.map {
                 gpcExceptions.add(GpcExceptionEntity(it.domain))
             }
-            gpcRepository.updateAll(gpcExceptions)
+            gpcFeature?.settings?.hpcHeaderEnabledSites?.map {
+                gpcHeaders.add(GpcHeaderEnabledSiteEntity(it.domain))
+            }
+            gpcRepository.updateAll(gpcExceptions, gpcHeaders)
             val isEnabled = gpcFeature?.state == "enabled"
             privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled))
             return true

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
@@ -53,7 +53,7 @@ class RealGpc @Inject constructor(context: Context, private val featureToggle: F
 
     override fun canUrlAddHeaders(url: String, existingHeaders: Map<String, String>): Boolean {
         return if (canGpcBeUsedByUrl(url) && !containsGpcHeader(existingHeaders)) {
-            headerConsumers.any { sameOrSubdomain(url, it) }
+            gpcRepository.headerEnabledSites.any { sameOrSubdomain(url, it.domain) }
         } else {
             false
         }
@@ -90,13 +90,6 @@ class RealGpc @Inject constructor(context: Context, private val featureToggle: F
     companion object {
         const val GPC_HEADER = "sec-gpc"
         const val GPC_HEADER_VALUE = "1"
-
-        private val headerConsumers = listOf(
-            "nytimes.com",
-            "washingtonpost.com",
-            "globalprivacycontrol.org",
-            "global-privacy-control.glitch.me"
-        )
     }
 
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPluginTest.kt
@@ -25,7 +25,7 @@ import org.mockito.kotlin.verify
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.anyList
 
 class GpcPluginTest {
     lateinit var testee: GpcPlugin
@@ -67,12 +67,12 @@ class GpcPluginTest {
     }
 
     @Test
-    fun whenFeatureNameMatchesGpcThenUpdateAllExistingExceptions() {
+    fun whenFeatureNameMatchesGpcThenUpdateAllExistingExceptionsAndHeaders() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/gpc.json")
 
         testee.store(FEATURE_NAME, jsonString)
 
-        verify(mockGpcRepository).updateAll(ArgumentMatchers.anyList())
+        verify(mockGpcRepository).updateAll(anyList(), anyList())
     }
 
     companion object {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
@@ -21,6 +21,7 @@ import android.content.res.Resources
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.GpcException
+import com.duckduckgo.privacy.config.api.GpcHeaderEnabledSite
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.R
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
@@ -51,10 +52,13 @@ class RealGpcTest {
     fun setup() {
         val exceptions =
             CopyOnWriteArrayList<GpcException>().apply { add(GpcException(EXCEPTION_URL)) }
+        val headers =
+            CopyOnWriteArrayList<GpcHeaderEnabledSite>().apply { add(GpcHeaderEnabledSite(VALID_CONSUMER_URL)) }
         whenever(mockContext.resources).thenReturn(mockResources)
         whenever(mockResources.openRawResource(any()))
             .thenReturn(ByteArrayInputStream("".toByteArray()))
         whenever(mockGpcRepository.exceptions).thenReturn(exceptions)
+        whenever(mockGpcRepository.headerEnabledSites).thenReturn(headers)
 
         testee =
             RealGpc(mockContext, mockFeatureToggle, mockGpcRepository, mockUnprotectedTemporary)

--- a/privacy-config/privacy-config-impl/src/test/resources/json/gpc.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/gpc.json
@@ -7,5 +7,14 @@
     {
       "domain": "weather.com"
     }
-  ]
+  ],
+  "settings": {
+    "gpcHeaderEnabledSites": [
+      "global-privacy-control.glitch.me",
+      "globalprivacycontrol.org",
+      "washingtonpost.com",
+      "nytimes.com",
+      "privacy-test-pages.glitch.me"
+    ]
+  }
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
@@ -24,7 +24,8 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingDao
 import com.duckduckgo.privacy.config.store.features.drm.DrmDao
-import com.duckduckgo.privacy.config.store.features.gpc.GpcDao
+import com.duckduckgo.privacy.config.store.features.gpc.GpcExceptionsDao
+import com.duckduckgo.privacy.config.store.features.gpc.GpcHeadersDao
 import com.duckduckgo.privacy.config.store.features.https.HttpsDao
 import com.duckduckgo.privacy.config.store.features.trackerallowlist.TrackerAllowlistDao
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryDao
@@ -33,12 +34,13 @@ import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.Unprote
     RuleTypeConverter::class,
 )
 @Database(
-    exportSchema = true, version = 4,
+    exportSchema = true, version = 5,
     entities = [
         TrackerAllowlistEntity::class,
         UnprotectedTemporaryEntity::class,
         HttpsExceptionEntity::class,
         GpcExceptionEntity::class,
+        GpcHeaderEnabledSiteEntity::class,
         ContentBlockingExceptionEntity::class,
         DrmExceptionEntity::class,
         PrivacyConfig::class
@@ -48,7 +50,8 @@ abstract class PrivacyConfigDatabase : RoomDatabase() {
     abstract fun trackerAllowlistDao(): TrackerAllowlistDao
     abstract fun unprotectedTemporaryDao(): UnprotectedTemporaryDao
     abstract fun httpsDao(): HttpsDao
-    abstract fun gpcDao(): GpcDao
+    abstract fun gpcExceptionsDao(): GpcExceptionsDao
+    abstract fun gpcHeadersDao(): GpcHeadersDao
     abstract fun contentBlockingDao(): ContentBlockingDao
     abstract fun privacyConfigDao(): PrivacyConfigDao
     abstract fun drmDao(): DrmDao

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -22,6 +22,7 @@ import androidx.room.TypeConverter
 import com.duckduckgo.privacy.config.api.ContentBlockingException
 import com.duckduckgo.privacy.config.api.DrmException
 import com.duckduckgo.privacy.config.api.GpcException
+import com.duckduckgo.privacy.config.api.GpcHeaderEnabledSite
 import com.duckduckgo.privacy.config.api.HttpsException
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -66,6 +67,12 @@ data class HttpsExceptionEntity(@PrimaryKey val domain: String, val reason: Stri
 
 fun HttpsExceptionEntity.toHttpsException(): HttpsException {
     return HttpsException(domain = this.domain, reason = this.reason)
+}
+
+@Entity(tableName = "gpc_header_enabled_sites") data class GpcHeaderEnabledSiteEntity(@PrimaryKey val domain: String)
+
+fun GpcHeaderEnabledSiteEntity.toGpcHeaderEnabledSite(): GpcHeaderEnabledSite {
+    return GpcHeaderEnabledSite(domain = this.domain)
 }
 
 @Entity(tableName = "gpc_exceptions") data class GpcExceptionEntity(@PrimaryKey val domain: String)

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/gpc/GpcExceptionsDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/gpc/GpcExceptionsDao.kt
@@ -24,7 +24,7 @@ import androidx.room.Transaction
 import com.duckduckgo.privacy.config.store.GpcExceptionEntity
 
 @Dao
-abstract class GpcDao {
+abstract class GpcExceptionsDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract fun insertAll(domains: List<GpcExceptionEntity>)

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/gpc/GpcHeadersDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/gpc/GpcHeadersDao.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.gpc
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.privacy.config.store.GpcHeaderEnabledSiteEntity
+
+@Dao
+abstract class GpcHeadersDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertAll(domains: List<GpcHeaderEnabledSiteEntity>)
+
+    @Transaction
+    open fun updateAll(domains: List<GpcHeaderEnabledSiteEntity>) {
+        deleteAll()
+        insertAll(domains)
+    }
+
+    @Query("select * from gpc_header_enabled_sites where domain = :domain")
+    abstract fun get(domain: String): GpcHeaderEnabledSiteEntity
+
+    @Query("select * from gpc_header_enabled_sites") abstract fun getAll(): List<GpcHeaderEnabledSiteEntity>
+
+    @Query("delete from gpc_header_enabled_sites") abstract fun deleteAll()
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1201624035922285

### Description
This PR deletes the hardcoded headers list for GPC in the app and instead uses the list from the remote config.

### Steps to test this PR
_Headers sent when navigating via links_
1. Install and launch the app
2. Go to https://globalprivacycontrol.org 
3. On the top of the site it should say `GPC signal detected`
4. Click below where it says `Test against the reference server`
5. Header should be present in the next site.

