### PR TITLE
Add webview version to ml pixel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
@@ -22,19 +22,20 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.Observer
-import androidx.webkit.WebViewCompat
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel.Command
-import com.duckduckgo.app.brokensite.BrokenSiteViewModel.Companion.WEBVIEW_UNKNOWN_VERSION
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel.ViewState
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.WebViewVersionProvider
 import com.duckduckgo.app.browser.databinding.ActivityBrokenSiteBinding
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import javax.inject.Inject
 
 class BrokenSiteActivity : DuckDuckGoActivity() {
 
     private val binding: ActivityBrokenSiteBinding by viewBinding()
     private val viewModel: BrokenSiteViewModel by bindViewModel()
+    @Inject lateinit var webViewVersionProvider: WebViewVersionProvider
 
     private val toolbar
         get() = binding.includeToolbar.toolbar
@@ -82,7 +83,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         }
 
         brokenSites.submitButton.setOnClickListener {
-            val webViewVersion = WebViewCompat.getCurrentWebViewPackage(applicationContext)?.versionName ?: WEBVIEW_UNKNOWN_VERSION
+            val webViewVersion = webViewVersionProvider.getFullVersion()
             viewModel.onSubmitPressed(webViewVersion)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewVersionProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewVersionProvider.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.content.Context
+import androidx.webkit.WebViewCompat
+import com.duckduckgo.app.browser.WebViewVersionProvider.Companion.WEBVIEW_UNKNOWN_VERSION
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface WebViewVersionProvider {
+    companion object {
+        const val WEBVIEW_UNKNOWN_VERSION = "unknown"
+    }
+
+    fun get(): String
+}
+
+interface RawWebViewVersionProvider {
+    fun get(): String?
+}
+
+@ContributesBinding(AppScope::class)
+class WebViewCompatRawWebViewVersionProvider @Inject constructor(
+    private val context: Context
+) : RawWebViewVersionProvider {
+
+    override fun get(): String? = WebViewCompat.getCurrentWebViewPackage(context)?.versionName
+
+}
+
+@ContributesBinding(AppScope::class)
+class MajorWebViewVersionProvider @Inject constructor(
+    private val rawWebViewVersionProvider: RawWebViewVersionProvider
+) : WebViewVersionProvider {
+    companion object {
+        const val WEBVIEW_VERSION_DELIMITER = "."
+    }
+
+    override fun get(): String = rawWebViewVersionProvider.get().run {
+        if (this.isNullOrEmpty()) {
+            WEBVIEW_UNKNOWN_VERSION
+        } else this.captureMajorVersion()
+    }
+
+    private fun String.captureMajorVersion() = this.split(WEBVIEW_VERSION_DELIMITER)[0]
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewVersionSource.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewVersionSource.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.content.Context
+import androidx.webkit.WebViewCompat
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface WebViewVersionSource {
+    fun get(): String
+}
+
+@ContributesBinding(AppScope::class)
+class WebViewCompatWebViewVersionSource @Inject constructor(
+    private val context: Context
+) : WebViewVersionSource {
+    override fun get(): String =
+        WebViewCompat.getCurrentWebViewPackage(context)?.versionName ?: ""
+}

--- a/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
@@ -22,9 +22,11 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
+import com.duckduckgo.app.browser.WebViewVersionProvider
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.global.plugins.worker.WorkerInjectorPlugin
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.WEBVIEW_VERSION
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -42,6 +44,7 @@ class EnqueuedPixelWorker @Inject constructor(
     private val workManager: WorkManager,
     private val pixel: Provider<Pixel>,
     private val unsentForgetAllPixelStore: UnsentForgetAllPixelStore,
+    private val webViewVersionProvider: WebViewVersionProvider
 ) : LifecycleEventObserver {
 
     private var launchedByFireAction: Boolean = false
@@ -58,7 +61,10 @@ class EnqueuedPixelWorker @Inject constructor(
                 return
             }
             Timber.i("Sending app launch pixel")
-            pixel.get().fire(AppPixelName.APP_LAUNCH)
+            pixel.get().fire(
+                pixel = AppPixelName.APP_LAUNCH,
+                parameters = mapOf(WEBVIEW_VERSION to webViewVersionProvider.get())
+            )
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
@@ -63,7 +63,7 @@ class EnqueuedPixelWorker @Inject constructor(
             Timber.i("Sending app launch pixel")
             pixel.get().fire(
                 pixel = AppPixelName.APP_LAUNCH,
-                parameters = mapOf(WEBVIEW_VERSION to webViewVersionProvider.get())
+                parameters = mapOf(WEBVIEW_VERSION to webViewVersionProvider.getMajorVersion())
             )
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/MajorWebViewVersionProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/MajorWebViewVersionProviderTest.kt
@@ -25,29 +25,78 @@ import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
 class MajorWebViewVersionProviderTest {
-    private val rawWebViewVersionProvider: RawWebViewVersionProvider = mock()
-    private val testee = MajorWebViewVersionProvider(
-        rawWebViewVersionProvider,
+    private val webViewVersionSource: WebViewVersionSource = mock()
+    private val testee = DefaultWebViewVersionProvider(
+        webViewVersionSource,
     )
 
     @Test
-    fun whenWebViewVersionIsEmptyThenReturnUnknown() {
-        whenever(rawWebViewVersionProvider.get()).thenReturn("")
+    fun whenWebViewVersionIsEmptyThenReturnUnknownFullVersion() {
+        whenever(webViewVersionSource.get()).thenReturn("")
 
-        assertEquals("unknown", testee.get())
+        assertEquals("unknown", testee.getFullVersion())
     }
 
     @Test
-    fun whenWebViewVersionIsNullThenReturnUnknown() {
-        whenever(rawWebViewVersionProvider.get()).thenReturn(null)
+    fun whenWebViewVersionIsAvailableThenReturnFullVersion() {
+        whenever(webViewVersionSource.get()).thenReturn("91.1.12.1234.423")
 
-        assertEquals("unknown", testee.get())
+        assertEquals("91.1.12.1234.423", testee.getFullVersion())
+    }
+
+    @Test
+    fun whenWebViewVersionIsBlankThenReturnFullVersion() {
+        whenever(webViewVersionSource.get()).thenReturn("    ")
+
+        assertEquals("unknown", testee.getFullVersion())
+    }
+
+    @Test
+    fun whenWebViewVersionIsEmptyThenReturnUnknownMajorVersion() {
+        whenever(webViewVersionSource.get()).thenReturn("")
+
+        assertEquals("unknown", testee.getMajorVersion())
     }
 
     @Test
     fun whenWebViewVersionAvailableThenReturnMajorVersionOnly() {
-        whenever(rawWebViewVersionProvider.get()).thenReturn("91.1.12.1234.423")
+        whenever(webViewVersionSource.get()).thenReturn("91.1.12.1234.423")
 
-        assertEquals("91", testee.get())
+        assertEquals("91", testee.getMajorVersion())
+    }
+
+    @Test
+    fun whenWebViewVersionHasNonNumericValuesThenReturnMajorVersionOnly() {
+        whenever(webViewVersionSource.get()).thenReturn("59.amazon-webview-v59-3071.3071.125.462")
+
+        assertEquals("59", testee.getMajorVersion())
+    }
+
+    @Test
+    fun whenWebViewVersionHasNoValidDelimiterThenReturnUnknownMajorVersion() {
+        whenever(webViewVersionSource.get()).thenReturn("37%20%281448693564-arm%29")
+
+        assertEquals("unknown", testee.getMajorVersion())
+    }
+
+    @Test
+    fun whenWebViewVersionHasNonNumericMajorThenReturnUnknownMajorVersion() {
+        whenever(webViewVersionSource.get()).thenReturn("37%20%28eng.jenkinswh-arm64%29")
+
+        assertEquals("unknown", testee.getMajorVersion())
+    }
+
+    @Test
+    fun whenWebViewVersionStartsWithDelimiterThenReturnUnknownMajorVersion() {
+        whenever(webViewVersionSource.get()).thenReturn(".91.1.12.1234.423")
+
+        assertEquals("unknown", testee.getMajorVersion())
+    }
+
+    @Test
+    fun whenWebViewVersionIsBlankThenReturnUnknownMajorVersion() {
+        whenever(webViewVersionSource.get()).thenReturn("    ")
+
+        assertEquals("unknown", testee.getMajorVersion())
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/MajorWebViewVersionProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/MajorWebViewVersionProviderTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class MajorWebViewVersionProviderTest {
+    private val rawWebViewVersionProvider: RawWebViewVersionProvider = mock()
+    private val testee = MajorWebViewVersionProvider(
+        rawWebViewVersionProvider,
+    )
+
+    @Test
+    fun whenWebViewVersionIsEmptyThenReturnUnknown() {
+        whenever(rawWebViewVersionProvider.get()).thenReturn("")
+
+        assertEquals("unknown", testee.get())
+    }
+
+    @Test
+    fun whenWebViewVersionIsNullThenReturnUnknown() {
+        whenever(rawWebViewVersionProvider.get()).thenReturn(null)
+
+        assertEquals("unknown", testee.get())
+    }
+
+    @Test
+    fun whenWebViewVersionAvailableThenReturnMajorVersionOnly() {
+        whenever(rawWebViewVersionProvider.get()).thenReturn("91.1.12.1234.423")
+
+        assertEquals("91", testee.get())
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
@@ -80,7 +80,7 @@ class EnqueuedPixelWorkerTest {
     @Test
     fun whenOnStartAndAppLaunchThenSendAppLaunchPixel() {
         whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(1)
-        whenever(webViewVersionProvider.get()).thenReturn("91")
+        whenever(webViewVersionProvider.getMajorVersion()).thenReturn("91")
 
         enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
         enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)
@@ -95,7 +95,7 @@ class EnqueuedPixelWorkerTest {
     fun whenOnStartAndLaunchByFireActionFollowedByAppLaunchThenSendOneAppLaunchPixel() {
         whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(1)
         whenever(unsentForgetAllPixelStore.lastClearTimestamp).thenReturn(System.currentTimeMillis())
-        whenever(webViewVersionProvider.get()).thenReturn("91")
+        whenever(webViewVersionProvider.getMajorVersion()).thenReturn("91")
 
         enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
         enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -72,6 +72,7 @@ interface Pixel {
         const val BOOKMARK_COUNT = "bco"
         const val COHORT = "cohort"
         const val LAST_USED_DAY = "duck_address_last_used"
+        const val WEBVIEW_VERSION = "webview_version"
     }
 
     object PixelValues {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1157223223343562/f

### Description
This PR adds the following:

1.) A provider for the webview's major version that uses the `WebViewCompat.getCurrentWebViewPackage` as the underlying implementation.
2.) Adds the "`webview_version`" as a parameter for the `ml` pixel.

### Steps to test this PR

1. Install and launch the debug version of the app from this branch
2. FIlter logcat by `V/RxBasedPixel: Pixel sent: ml`
3. The filtered message should include the webview_version=X in the params. Example: `V/RxBasedPixel: Pixel sent: ml with params: {webview_version=91} {}`
4. For API level 26 and below, the `webview_version` could be `unknown` in some cases.

### No UI changes


### Testing
Needs to be tested in API Level 25 or below.