### PR TITLE
Ensure ATP onboarding pixel is sent

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/DeviceShieldOnboardingViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/DeviceShieldOnboardingViewModel.kt
@@ -17,17 +17,24 @@
 package com.duckduckgo.mobile.android.vpn.ui.onboarding
 
 import androidx.lifecycle.ViewModel
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.plugins.view_model.ViewModelFactoryPlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.R
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Provider
 
 class DeviceShieldOnboardingViewModel(
     private val deviceShieldPixels: DeviceShieldPixels,
-    private val deviceShieldOnboardingStore: DeviceShieldOnboardingStore
+    private val deviceShieldOnboardingStore: DeviceShieldOnboardingStore,
+    private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 
     data class OnboardingPage(
@@ -61,22 +68,28 @@ class DeviceShieldOnboardingViewModel(
 
     fun onDeviceShieldEnabled() {
         Timber.i("App Tracking Protection, is now enabled")
-        deviceShieldPixels.enableFromOnboarding()
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            deviceShieldPixels.enableFromOnboarding()
+        }
     }
 }
 
 @ContributesMultibinding(AppScope::class)
 class DeviceShieldOnboardingViewModelFactory @Inject constructor(
-    private val deviceShieldPixels: DeviceShieldPixels,
-    private val deviceShieldOnboardingStore: DeviceShieldOnboardingStore
+    private val deviceShieldPixels: Provider<DeviceShieldPixels>,
+    private val deviceShieldOnboardingStore: Provider<DeviceShieldOnboardingStore>,
+    @AppCoroutineScope private val appCoroutineScope: Provider<CoroutineScope>,
+    private val dispatcherProvider: Provider<DispatcherProvider>,
 ) : ViewModelFactoryPlugin {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T? {
         with(modelClass) {
             return when {
                 isAssignableFrom(DeviceShieldOnboardingViewModel::class.java) -> (
                     DeviceShieldOnboardingViewModel(
-                        deviceShieldPixels,
-                        deviceShieldOnboardingStore
+                        deviceShieldPixels.get(),
+                        deviceShieldOnboardingStore.get(),
+                        appCoroutineScope.get(),
+                        dispatcherProvider.get(),
                     ) as T
                     )
                 else -> null


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201641519620987/f

### Description
Fix bug where the ATP onboarding pixel was not sent. The onboarding activity was finished, cancelling the VM coroutine scope, that cancel the pixel sender job.

The fix uses the app coroutine scope to ensure the pixel goes through.

### Steps to test this PR

_Test onboarding pixel_
- [ ] fresh install from this branch
- [ ] go through ATP onboarding
- [ ] verify `m_atp_ev_enabled_onboarding_[c/d/u]` pixels are sent

