### PR TITLE
Fix: honour user intent to skip reporting

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModel.kt
@@ -54,7 +54,7 @@ class ExcludedAppsViewModel(
 
         viewModelScope.launch {
             excludedApps.manuallyExcludedApp(packageName)
-            if (answer == ManuallyDisableAppProtectionDialog.STOPPED_WORKING) {
+            if (answer == ManuallyDisableAppProtectionDialog.STOPPED_WORKING && !skippedReport) {
                 command.send(Command.LaunchFeedback(ReportBreakageScreen.IssueDescriptionForm(appName, packageName)))
             }
         }

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModelTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModelTest.kt
@@ -127,6 +127,26 @@ class ExcludedAppsViewModelTest {
     }
 
     @Test
+    fun whenOnAppProtectionDisabledSkipDialogThenDoNotLaunchFeedback() = runTest {
+        val packageName = "com.package.name"
+        viewModel.onAppProtectionDisabled(STOPPED_WORKING, packageName, packageName, skippedReport = true)
+
+        viewModel.commands().test {
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun whenOnAppProtectionDisabledSkipFalseDialogThenLaunchFeedback() = runTest {
+        val packageName = "com.package.name"
+        viewModel.onAppProtectionDisabled(STOPPED_WORKING, packageName, packageName, skippedReport = false)
+
+        viewModel.commands().test {
+            assertEquals(LaunchFeedback(IssueDescriptionForm(packageName, packageName)), awaitItem())
+        }
+    }
+
+    @Test
     fun whenUserLeavesScreenAndNoChangesWereMadeThenTheVpnIsNotRestarted() = runTest {
         viewModel.commands().test {
             viewModel.onLeavingScreen()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201640572393751/f

### Description
We were not honour the skip reportint intent from the user.

_Repro steps_
* Go to Manage Protections for your Apps
* Disable protection for an app
* Select It stopped working as expected
* Click SKIP
* Expected results: Prompt closes, app is disabled
* Actual results: Issue report screen shown (which should only be shown when SUBMIT is clicked)


### Steps to test this PR

_Test fix_
- [x] install from this branch
- [x] go to manage protection for your apps
- [x] disable protection for an app
- [x] select it stopped working as expected
- [x] click SKIP
- [x] verify prompt closes and app protection is disabled

