### PR TITLE
AppTP: Ensure Enable VPN Switch uses proper API

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -31,6 +31,7 @@ import android.text.style.UnderlineSpan
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.widget.CompoundButton
 import androidx.appcompat.widget.SwitchCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
@@ -104,6 +105,10 @@ class DeviceShieldTrackerActivity :
         }
     }
 
+    private val enableAppTPSwitchListener = CompoundButton.OnCheckedChangeListener { _, isChecked ->
+        viewModel.onAppTPToggleSwitched(isChecked)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -158,7 +163,7 @@ class DeviceShieldTrackerActivity :
                     return
                 }
                 else -> {
-                    deviceShieldSwitch.quietlySetIsChecked(false, null)
+                    deviceShieldSwitch.quietlySetIsChecked(false, enableAppTPSwitchListener)
                     Timber.d("Permission not granted")
                 }
             }
@@ -242,6 +247,7 @@ class DeviceShieldTrackerActivity :
     }
 
     private fun launchDisableConfirmationDialog() {
+        deviceShieldSwitch.quietlySetIsChecked(true, enableAppTPSwitchListener)
         deviceShieldPixels.didShowDisableTrackingProtectionDialog()
         val dialog = AppTPDisableConfirmationDialog.instance()
         dialog.show(
@@ -256,13 +262,12 @@ class DeviceShieldTrackerActivity :
     }
 
     override fun onTurnAppTrackingProtectionOff() {
-        deviceShieldPixels.didShowDisableTrackingProtectionDialog()
+        deviceShieldSwitch.quietlySetIsChecked(false, enableAppTPSwitchListener)
         viewModel.onAppTpManuallyDisabled()
     }
 
     override fun onDisableDialogCancelled() {
         deviceShieldPixels.didChooseToCancelTrackingProtectionDialog()
-        deviceShieldSwitch.quietlySetIsChecked(true, null)
     }
 
     private fun launchBetaInstructions() {
@@ -282,17 +287,19 @@ class DeviceShieldTrackerActivity :
     }
 
     private fun startVPN() {
+        deviceShieldSwitch.quietlySetIsChecked(true, enableAppTPSwitchListener)
         TrackerBlockingVpnService.startService(this)
     }
 
     private fun stopDeviceShield() {
+        deviceShieldSwitch.quietlySetIsChecked(false, enableAppTPSwitchListener)
         TrackerBlockingVpnService.stopService(this)
     }
 
     private fun renderViewState(state: DeviceShieldTrackerActivityViewModel.TrackerActivityViewState) {
         // is there a better way to do this?
         if (::deviceShieldSwitch.isInitialized) {
-            deviceShieldSwitch.quietlySetIsChecked(state.runningState.isRunning, null)
+            deviceShieldSwitch.quietlySetIsChecked(state.runningState.isRunning, enableAppTPSwitchListener)
         } else {
             Timber.v("switch view reference not yet initialized; cache value until menu populated")
             deviceShieldCachedState = state.runningState.isRunning
@@ -380,15 +387,7 @@ class DeviceShieldTrackerActivity :
 
         val switchMenuItem = menu.findItem(R.id.deviceShieldSwitch)
         deviceShieldSwitch = switchMenuItem?.actionView as SwitchCompat
-        deviceShieldSwitch.setOnClickListener {
-            viewModel.onAppTPToggleSwitched(deviceShieldSwitch.isChecked)
-            if (!deviceShieldSwitch.isChecked) {
-                // because we now show a dialog before shutting the vpn down, we want to reset to a positive value
-                // until the user decides to stop it.
-                deviceShieldSwitch.quietlySetIsChecked(true, null)
-            }
-        }
-
+        deviceShieldSwitch.setOnCheckedChangeListener(enableAppTPSwitchListener)
         return true
     }
 
@@ -402,7 +401,7 @@ class DeviceShieldTrackerActivity :
         menu.findItem(R.id.customDnsServer).isVisible = appBuildConfig.isDebug
 
         deviceShieldCachedState?.let { checked ->
-            deviceShieldSwitch.quietlySetIsChecked(checked, null)
+            deviceShieldSwitch.quietlySetIsChecked(checked, enableAppTPSwitchListener)
             deviceShieldCachedState = null
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199371158290272/1201656298066485/f

### Description
Description
One of the issues described in Bug: AppTP can't be toggled ON is that the switch to enable the VPN doesn't work properly. 

Looking at the code, we are currently using the wrong API to listen to the widget updates.

Objective
Ensure we use the proper API for the Switch,  that is the CheckedChangeListener instead of the ClickListener

### Steps to test this PR

_Enable VPN_
- [x] With the VPN Disabled
- [x] Open Tracker screen and use the Switch
- [x] VPN should be enabled

_Disable VPN_
- [x] With the VPN Enabled
- [x] Open Tracker screen and use the Switch
- [x] VPN should be disabled
