### PR TITLE
Add rule to enable logs when running tests

### DIFF
--- a/common-test/build.gradle
+++ b/common-test/build.gradle
@@ -17,5 +17,6 @@ dependencies {
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
     implementation Testing.junit4
+    implementation JakeWharton.timber
 
 }

--- a/common-test/src/main/java/com/duckduckgo/app/TimberRule.kt
+++ b/common-test/src/main/java/com/duckduckgo/app/TimberRule.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app
+
+import org.junit.rules.TestWatcher
+import timber.log.Timber
+import org.junit.runner.Description
+
+class TimberRule : TestWatcher() {
+
+    private val printlnTree = object : Timber.DebugTree() {
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            println("$tag: $message")
+        }
+    }
+
+    override fun starting(description: Description?) {
+        super.starting(description)
+        Timber.plant(printlnTree)
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        Timber.uproot(printlnTree)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: 

### Description
Introduces a rule to enable Timber when running tests.

To enable logs, add the following rule:
`@get:Rule var timberRule = TimberRule()`

