### PR TITLE
Add reported app default protection info to breakage report

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnAppTrackerListInfoCollector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnAppTrackerListInfoCollector.kt
@@ -17,8 +17,11 @@
 package com.duckduckgo.mobile.android.vpn.bugreport
 
 import com.duckduckgo.di.scopes.VpnScope
+import com.duckduckgo.mobile.android.vpn.apps.AppCategory
+import com.duckduckgo.mobile.android.vpn.apps.AppCategoryDetector
 import com.duckduckgo.mobile.android.vpn.state.VpnStateCollectorPlugin
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
+import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import org.json.JSONObject
 import javax.inject.Inject
@@ -26,6 +29,8 @@ import javax.inject.Inject
 @ContributesMultibinding(VpnScope::class)
 class VpnAppTrackerListInfoCollector @Inject constructor(
     private val vpnDatabase: VpnDatabase,
+    private val appTrackerRepository: AppTrackerRepository,
+    private val appCategoryDetector: AppCategoryDetector,
 ) : VpnStateCollectorPlugin {
 
     override val collectorName: String
@@ -36,12 +41,21 @@ class VpnAppTrackerListInfoCollector @Inject constructor(
             put(APP_TRACKER_BLOCKLIST, vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBlocklistMetadata()?.eTag.orEmpty())
             put(APP_EXCLUSION_LIST, vpnDatabase.vpnAppTrackerBlockingDao().getExclusionListMetadata()?.eTag.orEmpty())
             put(APP_EXCEPTION_RULE_LIST, vpnDatabase.vpnAppTrackerBlockingDao().getTrackerExceptionRulesMetadata()?.eTag.orEmpty())
+            appPackageId?.let {
+                put(PACKAGE_ID_IS_PROTECTED, isUnprotectedByDefault(appPackageId).toString())
+            }
         }
+    }
+
+    private fun isUnprotectedByDefault(appPackageId: String): Boolean {
+        return appCategoryDetector.getAppCategory(appPackageId) is AppCategory.Game ||
+            appTrackerRepository.getAppExclusionList().any { it.packageId == appPackageId }
     }
 
     companion object {
         private const val APP_TRACKER_BLOCKLIST = "appTrackerListEtag"
         private const val APP_EXCLUSION_LIST = "appExclusionListEtag"
         private const val APP_EXCEPTION_RULE_LIST = "appExceptionRuleListEtag"
+        private const val PACKAGE_ID_IS_PROTECTED = "reportedAppUnprotectedByDefault"
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201539333793164/f

### Description
During the breakage it is benefitial to know whether the reported app was enabled by default of not.

This PR adds a field inside the `vpnTrackerLists` JSON object that contains whether the package ID was unprotected (ie. inside the exclusion list) or not. 
The new field is called `reportedAppUnprotectedByDefault` and can take a "true" or "false" value.

### Steps to test this PR

_Test_
- [x] install from this branch
- [x] enable AppTP
- [x] go to App tracking protection scree and click on "report an issue"
- [x] select any app and report
- [x] verify the breakage metadata contains the field `reportedAppUnprotectedByDefault` inside the `vpnTrackerLists` object
- [x] verify the field is `true` or `false` depending on whether the reported app is in the exclusion list or not

