### PR TITLE
Ensure the deviceShieldStatePollingJob is properly cancelled

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/DeviceShieldTileService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/DeviceShieldTileService.kt
@@ -24,6 +24,7 @@ import android.service.quicksettings.Tile.STATE_INACTIVE
 import android.service.quicksettings.TileService
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
+import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.waitlist.TrackingProtectionWaitlistManager
 import dagger.android.AndroidInjection
@@ -38,7 +39,7 @@ class DeviceShieldTileService : TileService() {
     @Inject lateinit var deviceShieldPixels: DeviceShieldPixels
     @Inject lateinit var waitlistManager: TrackingProtectionWaitlistManager
 
-    private var deviceShieldStatePollingJob: Job? = null
+    private var deviceShieldStatePollingJob = ConflatedJob()
     private val serviceScope = CoroutineScope(Dispatchers.IO)
 
     override fun onCreate() {
@@ -84,7 +85,7 @@ class DeviceShieldTileService : TileService() {
     }
 
     private fun pollDeviceShieldState() {
-        deviceShieldStatePollingJob =
+        deviceShieldStatePollingJob +=
             serviceScope.launch {
                 while (isActive) {
                     val tile = qsTile
@@ -100,7 +101,7 @@ class DeviceShieldTileService : TileService() {
     }
 
     private fun stopPollingDeviceShieldState() {
-        deviceShieldStatePollingJob?.cancel()
+        deviceShieldStatePollingJob.cancel()
     }
 
     private fun hasVpnPermission(): Boolean {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201550925053701/f

### Description
There's an NPE in the tile service. However it is not clear why it happens.

One thing I saw is that the `pollDeviceShieldState` may not be cancelled correctly all the time. So adding a `ConflatedJob` to ensure of that.

### Steps to test this PR
NA
