### PR TITLE
Promote Add Widget in Settings

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2058,11 +2058,11 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserClickedLegacyAddWidgetCtaButtonThenLaunchLegacyAddWidgetCommand() {
+    fun whenUserClickedLegacyAddWidgetCtaButtonThenLaunchAddWidgetCommand() {
         val cta = HomePanelCta.AddWidgetInstructions
         setCta(cta)
         testee.onUserClickCtaOkButton()
-        assertCommandIssued<Command.LaunchLegacyAddWidget>()
+        assertCommandIssued<Command.LaunchAddWidget>()
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -648,6 +648,17 @@ class SettingsViewModelTest {
         }
     }
 
+    @Test
+    fun whenHomeScreenWidgetSettingClickedThenEmitCommandLaunchAddHomeScreenWidget() = runTest {
+        testee.commands().test {
+            testee.userRequestedToAddHomeScreenWidget()
+
+            assertEquals(Command.LaunchAddHomeScreenWidget, awaitItem())
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
     private fun givenSelectedFireAnimation(fireAnimation: FireAnimation) {
         whenever(mockAppSettingsDataStore.selectedFireAnimation).thenReturn(fireAnimation)
         whenever(mockAppSettingsDataStore.isCurrentlySelected(fireAnimation)).thenReturn(true)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -20,7 +20,6 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity.RESULT_OK
 import android.app.ActivityOptions
-import android.appwidget.AppWidgetManager
 import android.content.*
 import android.content.pm.PackageManager
 import android.content.res.Configuration
@@ -133,11 +132,9 @@ import com.duckduckgo.app.survey.ui.SurveyActivity
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
 import com.duckduckgo.app.tabs.ui.TabSwitcherActivity
-import com.duckduckgo.app.widget.ui.AddWidgetInstructionsActivity
 import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.menu.PopupMenu
 import com.duckduckgo.mobile.android.ui.store.ThemingDataStore
-import com.duckduckgo.widget.SearchAndFavoritesWidget
 import com.google.android.material.snackbar.Snackbar
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.content_settings_general.*
@@ -170,6 +167,7 @@ import com.duckduckgo.app.browser.BrowserTabViewModel.LoadingViewState
 import com.duckduckgo.app.browser.BrowserTabViewModel.OmnibarViewState
 import com.duckduckgo.app.browser.BrowserTabViewModel.PrivacyGradeViewState
 import com.duckduckgo.app.statistics.isFireproofExperimentEnabled
+import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import kotlinx.android.synthetic.main.include_cta.*
@@ -272,6 +270,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var addWidgetLauncher: AddWidgetLauncher
 
     var messageFromPreviousTab: Message? = null
 
@@ -727,8 +728,7 @@ class BrowserTabFragment :
                 )
             }
             is Command.LaunchSurvey -> launchSurvey(it.survey)
-            is Command.LaunchAddWidget -> launchAddWidget()
-            is Command.LaunchLegacyAddWidget -> launchLegacyAddWidget()
+            is Command.LaunchAddWidget -> addWidgetLauncher.launchAddWidget(activity)
             is Command.RequiresAuthentication -> showAuthenticationDialog(it.request)
             is Command.SaveCredentials -> saveBasicAuthCredentials(it.request, it.credentials)
             is Command.GenerateWebViewPreviewImage -> generateWebViewPreviewImage()
@@ -1766,19 +1766,6 @@ class BrowserTabFragment :
         context?.let {
             startActivity(SurveyActivity.intent(it, survey))
         }
-    }
-
-    @SuppressLint("NewApi")
-    private fun launchAddWidget() {
-        val context = context ?: return
-        val provider = ComponentName(context, SearchAndFavoritesWidget::class.java)
-        AppWidgetManager.getInstance(context).requestPinAppWidget(provider, null, null)
-    }
-
-    private fun launchLegacyAddWidget() {
-        val context = context ?: return
-        val options = ActivityOptions.makeSceneTransitionAnimation(activity).toBundle()
-        startActivity(AddWidgetInstructionsActivity.intent(context), options)
     }
 
     private fun finishTrackerAnimation() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -341,7 +341,6 @@ class BrowserTabViewModel(
 
         class LaunchSurvey(val survey: Survey) : Command()
         object LaunchAddWidget : Command()
-        object LaunchLegacyAddWidget : Command()
         class RequiresAuthentication(val request: BasicAuthenticationRequest) : Command()
         class SaveCredentials(
             val request: BasicAuthenticationRequest,
@@ -2070,8 +2069,7 @@ class BrowserTabViewModel(
         ctaViewModel.onUserClickCtaOkButton(cta)
         command.value = when (cta) {
             is HomePanelCta.Survey -> LaunchSurvey(cta.survey)
-            is HomePanelCta.AddWidgetAuto, is HomePanelCta.AddReturningUsersWidgetAuto -> LaunchAddWidget
-            is HomePanelCta.AddWidgetInstructions -> LaunchLegacyAddWidget
+            is HomePanelCta.AddWidgetAuto, is HomePanelCta.AddReturningUsersWidgetAuto, is HomePanelCta.AddWidgetInstructions -> LaunchAddWidget
             else -> return
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -129,6 +129,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_APP_LINKS_ASK_EVERY_TIME_SELECTED("ms_app_links_ask_every_time_setting_selected"),
     SETTINGS_APP_LINKS_ALWAYS_SELECTED("ms_app_links_always_setting_selected"),
     SETTINGS_APP_LINKS_NEVER_SELECTED("ms_app_links_never_setting_selected"),
+    SETTINGS_ADD_HOME_SCREEN_WIDGET_CLICKED("ms_add_home_screen_widget_clicked"),
 
     SURVEY_CTA_SHOWN(pixelName = "mus_cs"),
     SURVEY_CTA_DISMISSED(pixelName = "mus_cd"),

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -56,6 +56,7 @@ import com.duckduckgo.app.settings.clear.FireAnimation
 import com.duckduckgo.app.settings.extension.InternalFeaturePlugin
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.waitlist.trackerprotection.ui.AppTPWaitlistActivity
+import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.sendThemeChangedBroadcast
 import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
@@ -84,6 +85,9 @@ class SettingsActivity :
 
     @Inject
     lateinit var internalFeaturePlugins: PluginPoint<InternalFeaturePlugin>
+
+    @Inject
+    lateinit var addWidgetLauncher: AddWidgetLauncher
 
     private val defaultBrowserChangeListener = OnCheckedChangeListener { _, isChecked ->
         viewModel.onDefaultBrowserToggled(isChecked)
@@ -128,6 +132,7 @@ class SettingsActivity :
             autocompleteToggle.setOnCheckedChangeListener(autocompleteToggleListener)
             setAsDefaultBrowserSetting.setOnCheckedChangeListener(defaultBrowserChangeListener)
             changeAppIconLabel.setOnClickListener { viewModel.userRequestedToChangeIcon() }
+            homeScreenWidgetSetting.setOnClickListener { viewModel.userRequestedToAddHomeScreenWidget() }
             selectedFireAnimationSetting.setOnClickListener { viewModel.userRequestedToChangeFireAnimation() }
             accessibilitySetting.setOnClickListener { viewModel.onAccessibilitySettingClicked() }
         }
@@ -281,6 +286,7 @@ class SettingsActivity :
             is Command.LaunchFireAnimationSettings -> launchFireAnimationSelector(it.animation)
             is Command.ShowClearWhatDialog -> launchAutomaticallyClearWhatDialog(it.option)
             is Command.ShowClearWhenDialog -> launchAutomaticallyClearWhenDialog(it.option)
+            is Command.LaunchAddHomeScreenWidget -> launchAddHomeScreenWidget()
             null -> TODO()
         }
     }
@@ -393,6 +399,11 @@ class SettingsActivity :
     private fun launchAppTPWaitlist() {
         val options = ActivityOptionsCompat.makeSceneTransitionAnimation(this)
         appTPWaitlistActivityResult.launch(AppTPWaitlistActivity.intent(this), options)
+    }
+
+    private fun launchAddHomeScreenWidget() {
+        pixel.fire(AppPixelName.SETTINGS_ADD_HOME_SCREEN_WIDGET_CLICKED)
+        addWidgetLauncher.launchAddWidget(this)
     }
 
     override fun onThemeSelected(selectedTheme: DuckDuckGoTheme) {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -108,6 +108,7 @@ class SettingsViewModel(
         object LaunchLocation : Command()
         object LaunchWhitelist : Command()
         object LaunchAppIcon : Command()
+        object LaunchAddHomeScreenWidget : Command()
         data class LaunchFireAnimationSettings(val animation: FireAnimation) : Command()
         data class LaunchThemeSettings(val theme: DuckDuckGoTheme) : Command()
         data class LaunchAppLinkSettings(val appLinksSettingType: AppLinkSettingType) : Command()
@@ -194,6 +195,10 @@ class SettingsViewModel(
 
     fun userRequestedToChangeIcon() {
         viewModelScope.launch { command.send(Command.LaunchAppIcon) }
+    }
+
+    fun userRequestedToAddHomeScreenWidget() {
+        viewModelScope.launch { command.send(Command.LaunchAddHomeScreenWidget) }
     }
 
     fun userRequestedToChangeFireAnimation() {

--- a/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.widget
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.ActivityOptions
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import com.duckduckgo.app.widget.ui.AddWidgetInstructionsActivity
+import com.duckduckgo.app.widget.ui.WidgetCapabilities
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.widget.SearchAndFavoritesWidget
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface AddWidgetLauncher {
+    fun launchAddWidget(activity: Activity?)
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class AddWidgetCompatLauncher @Inject constructor(
+    private val defaultAddWidgetLauncher: AppWidgetManagerAddWidgetLauncher,
+    private val legacyAddWidgetLauncher: LegacyAddWidgetLauncher,
+    private val widgetCapabilities: WidgetCapabilities
+) : AddWidgetLauncher {
+
+    override fun launchAddWidget(activity: Activity?) {
+        if (widgetCapabilities.supportsAutomaticWidgetAdd)
+            defaultAddWidgetLauncher.launchAddWidget(activity) else legacyAddWidgetLauncher.launchAddWidget(activity)
+    }
+}
+
+class AppWidgetManagerAddWidgetLauncher @Inject constructor() : AddWidgetLauncher {
+
+    @SuppressLint("NewApi")
+    override fun launchAddWidget(activity: Activity?) {
+        activity?.let {
+            val provider = ComponentName(it, SearchAndFavoritesWidget::class.java)
+            AppWidgetManager.getInstance(it).requestPinAppWidget(provider, null, null)
+        }
+    }
+}
+
+class LegacyAddWidgetLauncher @Inject constructor() : AddWidgetLauncher {
+    override fun launchAddWidget(activity: Activity?) {
+        activity?.let {
+            val options = ActivityOptions.makeSceneTransitionAnimation(it).toBundle()
+            it.startActivity(AddWidgetInstructionsActivity.intent(it), options)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.widget.SearchAndFavoritesWidget
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
+import javax.inject.Named
 
 interface AddWidgetLauncher {
     fun launchAddWidget(activity: Activity?)
@@ -39,8 +40,8 @@ interface AddWidgetLauncher {
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class AddWidgetCompatLauncher @Inject constructor(
-    private val defaultAddWidgetLauncher: AppWidgetManagerAddWidgetLauncher,
-    private val legacyAddWidgetLauncher: LegacyAddWidgetLauncher,
+    @Named("appWidgetManagerAddWidgetLauncher") private val defaultAddWidgetLauncher: AddWidgetLauncher,
+    @Named("legacyAddWidgetLauncher") private val legacyAddWidgetLauncher: AddWidgetLauncher,
     private val widgetCapabilities: WidgetCapabilities
 ) : AddWidgetLauncher {
 
@@ -50,6 +51,9 @@ class AddWidgetCompatLauncher @Inject constructor(
     }
 }
 
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+@Named("appWidgetManagerAddWidgetLauncher")
 class AppWidgetManagerAddWidgetLauncher @Inject constructor() : AddWidgetLauncher {
     companion object {
         const val ACTION_ADD_WIDGET = "actionWidgetAdded"
@@ -75,6 +79,9 @@ class AppWidgetManagerAddWidgetLauncher @Inject constructor() : AddWidgetLaunche
     }
 }
 
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+@Named("legacyAddWidgetLauncher")
 class LegacyAddWidgetLauncher @Inject constructor() : AddWidgetLauncher {
     override fun launchAddWidget(activity: Activity?) {
         activity?.let {

--- a/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
@@ -24,6 +24,7 @@ import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.widget.ui.AddWidgetInstructionsActivity
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.di.scopes.AppScope
@@ -57,6 +58,7 @@ class AddWidgetCompatLauncher @Inject constructor(
 class AppWidgetManagerAddWidgetLauncher @Inject constructor() : AddWidgetLauncher {
     companion object {
         const val ACTION_ADD_WIDGET = "actionWidgetAdded"
+        const val EXTRA_WIDGET_ADDED_LABEL = "extraWidgetAddedLabel"
         private const val CODE_ADD_WIDGET = 11922
     }
 
@@ -70,10 +72,13 @@ class AppWidgetManagerAddWidgetLauncher @Inject constructor() : AddWidgetLaunche
 
     @SuppressLint("UnspecifiedImmutableFlag")
     private fun buildPendingIntent(context: Context): PendingIntent? {
+        val intent = Intent(ACTION_ADD_WIDGET).run {
+            putExtra(EXTRA_WIDGET_ADDED_LABEL, context.getString(R.string.favoritesWidgetLabel))
+        }
         return PendingIntent.getBroadcast(
             context,
             CODE_ADD_WIDGET,
-            Intent(ACTION_ADD_WIDGET),
+            intent,
             PendingIntent.FLAG_UPDATE_CURRENT
         ) // Will not return null since FLAG_UPDATE_CURRENT has been supplied
     }

--- a/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
@@ -30,7 +30,6 @@ import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.widget.SearchAndFavoritesWidget
 import com.squareup.anvil.annotations.ContributesBinding
-import dagger.SingleInstanceIn
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -39,7 +38,6 @@ interface AddWidgetLauncher {
 }
 
 @ContributesBinding(AppScope::class)
-@SingleInstanceIn(AppScope::class)
 class AddWidgetCompatLauncher @Inject constructor(
     @Named("appWidgetManagerAddWidgetLauncher") private val defaultAddWidgetLauncher: AddWidgetLauncher,
     @Named("legacyAddWidgetLauncher") private val legacyAddWidgetLauncher: AddWidgetLauncher,
@@ -53,7 +51,6 @@ class AddWidgetCompatLauncher @Inject constructor(
 }
 
 @ContributesBinding(AppScope::class)
-@SingleInstanceIn(AppScope::class)
 @Named("appWidgetManagerAddWidgetLauncher")
 class AppWidgetManagerAddWidgetLauncher @Inject constructor() : AddWidgetLauncher {
     companion object {
@@ -85,7 +82,6 @@ class AppWidgetManagerAddWidgetLauncher @Inject constructor() : AddWidgetLaunche
 }
 
 @ContributesBinding(AppScope::class)
-@SingleInstanceIn(AppScope::class)
 @Named("legacyAddWidgetLauncher")
 class LegacyAddWidgetLauncher @Inject constructor() : AddWidgetLauncher {
     override fun launchAddWidget(activity: Activity?) {

--- a/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/AddWidgetLauncher.kt
@@ -19,8 +19,11 @@ package com.duckduckgo.app.widget
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.ActivityOptions
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
 import com.duckduckgo.app.widget.ui.AddWidgetInstructionsActivity
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.di.scopes.AppScope
@@ -48,13 +51,27 @@ class AddWidgetCompatLauncher @Inject constructor(
 }
 
 class AppWidgetManagerAddWidgetLauncher @Inject constructor() : AddWidgetLauncher {
+    companion object {
+        const val ACTION_ADD_WIDGET = "actionWidgetAdded"
+        private const val CODE_ADD_WIDGET = 11922
+    }
 
     @SuppressLint("NewApi")
     override fun launchAddWidget(activity: Activity?) {
         activity?.let {
             val provider = ComponentName(it, SearchAndFavoritesWidget::class.java)
-            AppWidgetManager.getInstance(it).requestPinAppWidget(provider, null, null)
+            AppWidgetManager.getInstance(it).requestPinAppWidget(provider, null, buildPendingIntent(it))
         }
+    }
+
+    @SuppressLint("UnspecifiedImmutableFlag")
+    private fun buildPendingIntent(context: Context): PendingIntent? {
+        return PendingIntent.getBroadcast(
+            context,
+            CODE_ADD_WIDGET,
+            Intent(ACTION_ADD_WIDGET),
+            PendingIntent.FLAG_UPDATE_CURRENT
+        ) // Will not return null since FLAG_UPDATE_CURRENT has been supplied
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
@@ -61,7 +61,8 @@ class WidgetAddedReceiver @Inject constructor(
     ) {
         if (!IGNORE_MANUFACTURERS_LIST.contains(Build.MANUFACTURER)) {
             context?.let {
-                Toast.makeText(it, it.getString(R.string.homeScreenWidgetAdded), Toast.LENGTH_SHORT).show()
+                val title = intent?.getStringExtra(AppWidgetManagerAddWidgetLauncher.EXTRA_WIDGET_ADDED_LABEL) ?: ""
+                Toast.makeText(it, it.getString(R.string.homeScreenWidgetAdded, title), Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.widget
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import android.widget.Toast
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.widget.AppWidgetManagerAddWidgetLauncher.Companion.ACTION_ADD_WIDGET
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = LifecycleObserver::class,
+)
+@SingleInstanceIn(AppScope::class)
+class WidgetAddedReceiver @Inject constructor(
+    private val context: Context
+) : BroadcastReceiver(), DefaultLifecycleObserver {
+
+    companion object {
+        val IGNORE_MANUFACTURERS_LIST = listOf("samsung", "huawei")
+    }
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        context.registerReceiver(this, IntentFilter(ACTION_ADD_WIDGET))
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        context.unregisterReceiver(this)
+    }
+
+    override fun onReceive(
+        context: Context?,
+        intent: Intent?
+    ) {
+        if (!IGNORE_MANUFACTURERS_LIST.contains(Build.MANUFACTURER)) {
+            context?.let {
+                Toast.makeText(it, it.getString(R.string.homeScreenWidgetAdded), Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/content_settings_general.xml
+++ b/app/src/main/res/layout/content_settings_general.xml
@@ -82,13 +82,21 @@
         app:layout_constraintTop_toTopOf="@+id/changeAppIconLabel"
         tools:srcCompat="@drawable/ic_app_icon_red_round" />
 
+    <TextView
+        android:id="@+id/homeScreenWidgetSetting"
+        style="@style/SettingsItemClickable"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:text="@string/settingsAddHomeScreenWidget"
+        app:layout_constraintTop_toBottomOf="@id/changeAppIconLabel" />
+
     <com.duckduckgo.app.settings.SettingsOptionWithSubtitle
         android:id="@+id/selectedFireAnimationSetting"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/changeAppIcon"
+        app:layout_constraintTop_toBottomOf="@id/homeScreenWidgetSetting"
         app:subtitle="@string/settingsHeroFireAnimation"
         app:title="@string/settingsFireAnimation" />
 

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -27,8 +27,8 @@
     <string name="daxFavoritesOnboardingCtaText"><![CDATA[Visit your favorite sites in a flash!<br/><br/>Go to a site you love. Then tap the \" &#x2807;\" icon and select Add Favorite.]]></string>
     <string name="daxFavoritesOnboardingCtaContentDescription">Visit your favorite sites in a flash! Go to a site you love. Then tap the browser menu icon and select Add Favorite.</string>
     <string name="widgetConfigurationActivityTitle">Widget Configuration</string>
-    <string name="favoritesWidgetLabel">Favorites Widget</string>
-    <string name="searchWidgetLabel">Search Widget</string>
+    <string name="favoritesWidgetLabel">Favorites</string>
+    <string name="searchWidgetLabel">Search</string>
 
     <!-- Treat returning users differently Experiment -->
     <string name="returningUsersNewUserButton">I\'m new!</string>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -107,4 +107,7 @@
 
     <!-- Downloads -->
     <string name="downloadsErrorMessage">Failed to download. Check internet connection.</string>
+
+    <!-- Home Screen Widget -->
+    <string name="settingsAddHomeScreenWidget">Home Screen Widget</string>
 </resources>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -109,5 +109,6 @@
     <string name="downloadsErrorMessage">Failed to download. Check internet connection.</string>
 
     <!-- Home Screen Widget -->
+    <string name="homeScreenWidgetAdded">Widget added to home screen</string>
     <string name="settingsAddHomeScreenWidget">Home Screen Widget</string>
 </resources>

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -109,6 +109,6 @@
     <string name="downloadsErrorMessage">Failed to download. Check internet connection.</string>
 
     <!-- Home Screen Widget -->
-    <string name="homeScreenWidgetAdded">Widget added to home screen</string>
+    <string name="homeScreenWidgetAdded">%s widget added to home screen</string>
     <string name="settingsAddHomeScreenWidget">Home Screen Widget</string>
 </resources>

--- a/app/src/test/java/com/duckduckgo/app/widget/AddWidgetCompatLauncherTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/widget/AddWidgetCompatLauncherTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.widget
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.widget.ui.WidgetCapabilities
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class AddWidgetCompatLauncherTest {
+    private val defaultAddWidgetLauncher: AppWidgetManagerAddWidgetLauncher = mock()
+    private val legacyAddWidgetLauncher: LegacyAddWidgetLauncher = mock()
+    private val widgetCapabilities: WidgetCapabilities = mock()
+    private val testee = AddWidgetCompatLauncher(
+        defaultAddWidgetLauncher,
+        legacyAddWidgetLauncher,
+        widgetCapabilities
+    )
+
+    @Test
+    fun whenAutomaticWidgetAddIsNotSupportedThenDelegateToLegacyAddWidgetLauncher() {
+        whenever(widgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
+
+        testee.launchAddWidget(null)
+
+        verify(legacyAddWidgetLauncher).launchAddWidget(null)
+    }
+
+    @Test
+    fun whenAutomaticWidgetAddIsSupportedThenDelegateToAppWidgetManagerAddWidgetLauncher() {
+        whenever(widgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
+
+        testee.launchAddWidget(null)
+
+        verify(defaultAddWidgetLauncher).launchAddWidget(null)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/widget/AddWidgetCompatLauncherTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/widget/AddWidgetCompatLauncherTest.kt
@@ -26,8 +26,8 @@ import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
 class AddWidgetCompatLauncherTest {
-    private val defaultAddWidgetLauncher: AppWidgetManagerAddWidgetLauncher = mock()
-    private val legacyAddWidgetLauncher: LegacyAddWidgetLauncher = mock()
+    private val defaultAddWidgetLauncher: AddWidgetLauncher = mock()
+    private val legacyAddWidgetLauncher: AddWidgetLauncher = mock()
     private val widgetCapabilities: WidgetCapabilities = mock()
     private val testee = AddWidgetCompatLauncher(
         defaultAddWidgetLauncher,

--- a/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+

--- a/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,2 +1,0 @@
-mock-maker-inline
-


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201677824560317/f

### Description
This PR adds the following:

- Add a new entry in Setting page for "Home Screen Widget" that allows the user to add widget through the settings page
- Send a new Pixel `ms_add_home_screen_widget_clicked` when the new setting item is clicked.
- Introduces a reusable `AddWidgetLauncher` that contains the logic on when to use the `AppWidgetManager` vs the `AddWidgetInstructions`.
- Use the `AddWidgetLauncher` in `BrowseTabFragment`.
- Introduce `WidgetAddedReceiver` that shows a toast whenever a widget is added through the app (both CTA and Settings)
- Changed the label for the widgets to "Favorites" and "Search" instead of "Favorites Widget" and "Search Widget"

### Steps to test this PR

Scenario 1: User has a device that supports automatically adding a widget.

1. Open Menu > Settings and click on "Home Screen Widget"
2. Launcher should be shown and allow the user to add the widget.
3. Logcat should show a message: `V/RxBasedPixel: Pixel sent: ms_add_home_screen_widget_clicked with params: {} {}`
4. If the user adds the widget, the system should show a toast similar or along the lines of: "Favorites widget added to home screen". Also confirm that the Add widget CTA has been dismissed from the browse tab page.
5. If the user doesn't add the widget, nothing changes.


Scenario 2: User doesn't have a device that supports automatically adding a widget.

1. Open Menu > Settings and click on "Home Screen Widget"
2. Logcat should show a message: `V/RxBasedPixel: Pixel sent: ms_add_home_screen_widget_clicked with params: {} {}`
3. The Add widget instructions page should be shown instead.

Scenario 3: Add widget CTA should still work as expected.
1. Click "Add widget" on the Add widget CTA in the browse tab.
2. If the device supports automatic adding of the widget, the launcher should be shown.
3. If the device doesn't support the automatic adding of the widget, the Add widget instructions page should be shown instead.

### UI changes
| Before  | After |
| ------ | ----- |
|![before](https://user-images.githubusercontent.com/2943941/150104221-150de3fe-1dad-4809-af43-e30f8adfc90f.jpg)|![after](https://user-images.githubusercontent.com/2943941/150104270-fe54a70d-5f45-4901-b095-7dee6e2c5541.jpg)|
|![Before: Pixel no toast](https://user-images.githubusercontent.com/2943941/150164297-bdb78169-7bbc-4986-8d38-034f13adddf4.png)|![After: PIxel with toast](https://user-images.githubusercontent.com/2943941/150521200-21349df2-7315-4292-af38-f4564e88c424.png)|
|![device-2022-01-21-123952](https://user-images.githubusercontent.com/2943941/150521272-91636028-0e33-40d5-9aad-9cba6dee13b5.png)|![device-2022-01-21-110325](https://user-images.githubusercontent.com/2943941/150521300-0442c236-63a7-4e85-9f7b-76c48d34cd0d.png)|


