### PR TITLE
Do not restart VPN when revoked

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/heartbeat/VpnServiceHeartbeat.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/heartbeat/VpnServiceHeartbeat.kt
@@ -69,9 +69,9 @@ class VpnServiceHeartbeat @Inject constructor(
     ) {
         Timber.v("onVpnStopped called")
         when (vpnStopReason) {
-            VpnStopReason.Error, VpnStopReason.Revoked -> Timber.v("HB monitor: sudden vpn stopped $vpnStopReason")
-            VpnStopReason.SelfStop -> {
-                Timber.v("HB monitor: self stopped $vpnStopReason")
+            VpnStopReason.Error -> Timber.v("HB monitor: sudden vpn stopped $vpnStopReason")
+            VpnStopReason.SelfStop, VpnStopReason.Revoked -> {
+                Timber.v("HB monitor: self stopped or revoked: $vpnStopReason")
                 coroutineScope.launch { storeHeartbeat(VpnServiceHeartbeatMonitor.DATA_HEART_BEAT_TYPE_STOPPED) }
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201677777496441/f

### Description
Do not restart the VPN when revoked by other VPNs

### Steps to test this PR
The HB mechanism works already in both branches:
* when restarting upon error/revoke
* when not restarting when VPN was OFFed as result of user intent
As we're only changing the `revoke` form one branch to the other, there's no need to test


