### PR TITLE
Internal feature to disable mitigation

### DIFF
--- a/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/health/BadHealthMitigationFeature.kt
+++ b/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/health/BadHealthMitigationFeature.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.health
+
+interface BadHealthMitigationFeature {
+    var isEnabled: Boolean
+}

--- a/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
+++ b/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.mobile.android.vpn.health.AppHealthMonitor
+import com.duckduckgo.mobile.android.vpn.health.BadHealthMitigationFeature
 import com.duckduckgo.vpn.internal.databinding.ActivityVpnInternalSettingsBinding
 import com.duckduckgo.vpn.internal.feature.bugreport.VpnBugReporter
 import com.duckduckgo.vpn.internal.feature.logs.DebugLoggingReceiver
@@ -43,6 +44,9 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var appHealthMonitor: AppHealthMonitor
 
+    @Inject
+    lateinit var badHealthMitigationFeature: BadHealthMitigationFeature
+
     private val binding: ActivityVpnInternalSettingsBinding by viewBinding()
     private var transparencyModeDebugReceiver: TransparencyModeDebugReceiver? = null
     private var debugLoggingReceiver: DebugLoggingReceiver? = null
@@ -61,6 +65,10 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
         } else {
             appHealthMonitor.stopMonitoring()
         }
+    }
+
+    private val badHealthMitigationFeatureToggle = CompoundButton.OnCheckedChangeListener { _, toggleState ->
+        badHealthMitigationFeature.isEnabled = toggleState
     }
 
     private val debugLoggingToggleListener = CompoundButton.OnCheckedChangeListener { _, toggleState ->
@@ -154,6 +162,9 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
     private fun setupBadHealthMonitoring() {
         binding.badHealthMonitorToggle.isChecked = appHealthMonitor.isMonitoringStarted()
         binding.badHealthMonitorToggle.setOnCheckedChangeListener(badHealthMonitoringToggleListener)
+
+        binding.badHealthMitigationToggle.isChecked = badHealthMitigationFeature.isEnabled
+        binding.badHealthMitigationToggle.setOnCheckedChangeListener(badHealthMitigationFeatureToggle)
     }
 
     private fun setupDebugLogging() {

--- a/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
+++ b/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
@@ -112,6 +112,15 @@
                     android:theme="@style/SettingsSwitchTheme"
             />
 
+            <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/badHealthMitigationToggle"
+                    style="@style/SettingsSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Bad health mitigation action"
+                    android:theme="@style/SettingsSwitchTheme"
+            />
+
         </LinearLayout>
 
     </ScrollView>

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.mobile.android.vpn.model.HealthEventType.GOOD_HEALTH
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.store.AppHealthDatabase
+import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.Moshi
 import dagger.SingleInstanceIn
@@ -46,7 +47,14 @@ import timber.log.Timber
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.minutes
 
-@ContributesMultibinding(AppScope::class)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AppHealthCallback::class
+)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = BadHealthMitigationFeature::class
+)
 @SingleInstanceIn(AppScope::class)
 class AppBadHealthStateHandler @Inject constructor(
     private val context: Context,
@@ -55,7 +63,7 @@ class AppBadHealthStateHandler @Inject constructor(
     private val deviceShieldPixels: DeviceShieldPixels,
     private val dispatcherProvider: DispatcherProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-) : AppHealthCallback {
+) : AppHealthCallback, BadHealthMitigationFeature {
 
     private var debounceJob = ConflatedJob()
 
@@ -74,7 +82,18 @@ class AppBadHealthStateHandler @Inject constructor(
             preferences.edit { putString("restartBoundary", value) }
         }
 
+    override var isEnabled: Boolean
+        get() = preferences.getBoolean("isEnabled", true)
+        set(value) {
+            preferences.edit { putBoolean("isEnabled", value) }
+        }
+
     override suspend fun onAppHealthUpdate(appHealthData: AppHealthData): Boolean {
+        if (!isEnabled) {
+            Timber.d("Feature is disabled, skipping mitigation")
+            return false
+        }
+
         return withContext(dispatcherProvider.io()) {
             if (appHealthData.alerts.isNotEmpty()) {
                 // send first-in-day pixels for alerts so what we can gather how many users see a particular alert every day


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201677777496472/f

### Description
* we currently can disable the entire bad health detection
* but can't keep detection running and disable mitigation
* while this is important both for triaging breakage and debugging purposes

This PR simply adds an internal feature toggle for the bad health mitigation

### Steps to test this PR

_Test feature toggle_
- [x] install from this branch
- [x] open all and enable appTP
- [x] filter logcat with `AppBadHealthStateHandler`
- [x] verify that every ~30s the log `No alerts` appear
- [x] go to settings -> AppTP settings and `Disable bad health mitigation action`
- [x] verify that every ~30s the log `Feature is disabled, skipping mitigation`
- [x] click on `View diagnostics data`
- [x] Scroll down and click on `bad health`
- [x] verify a bad health notification appears (can take up to 30s)
- [x] very the logs continues to be `Feature is disabled, skipping mitigation`
- [x] go back to settings -> AppTP settings and enable bad health mitigationaction
- [x] verify the log `Internal flavor detected, restarting the VPN...` eventually appears (can take up to 30s)

