### PR TITLE
added pixels to ctas that open the feedback form

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModel.kt
@@ -51,8 +51,12 @@ class ExcludedAppsViewModel(
         skippedReport: Boolean
     ) {
         recordManualChange(packageName)
-
         viewModelScope.launch {
+            if (skippedReport) {
+                pixel.didSkipManuallyDisableAppProtectionDialog()
+            } else {
+                pixel.didSubmitManuallyDisableAppProtectionDialog()
+            }
             excludedApps.manuallyExcludedApp(packageName)
             if (answer == ManuallyDisableAppProtectionDialog.STOPPED_WORKING && !skippedReport) {
                 command.send(Command.LaunchFeedback(ReportBreakageScreen.IssueDescriptionForm(appName, packageName)))

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -116,9 +116,12 @@ enum class DeviceShieldPixelNames(override val pixelName: String) : Pixel.PixelN
     ATP_LAUNCH_FEEDBACK("m_atp_ev_launch_feedback_c"),
     ATP_LAUNCH_FEEDBACK_DAILY("m_atp_ev_launch_feedback_d"),
 
-    ATP_DID_SUBMIT_DISABLE_APP_PROTECTION_DIALOG("m_atp_submit_disable_app_protection_dialog"),
-    ATP_DID_SKIP_DISABLE_APP_PROTECTION_DIALOG("m_atp_skip_disable_app_protection_dialog"),
-    ATP_DID_REPORT_ISSUES_FROM_TRACKER_ACTIVITY("m_atp_imp_tracker_activity_report_issues"),
+    ATP_DID_SUBMIT_DISABLE_APP_PROTECTION_DIALOG("m_atp_ev_submit_disable_app_protection_dialog_c"),
+    ATP_DID_SUBMIT_DISABLE_APP_PROTECTION_DIALOG_DAILY("m_atp_ev_submit_disable_app_protection_dialog_d"),
+    ATP_DID_SKIP_DISABLE_APP_PROTECTION_DIALOG("m_atp_ev_skip_disable_app_protection_dialog_c"),
+    ATP_DID_SKIP_DISABLE_APP_PROTECTION_DIALOG_DAILY("m_atp_ev_skip_disable_app_protection_dialog_d"),
+    ATP_DID_REPORT_ISSUES_FROM_TRACKER_ACTIVITY("m_atp_imp_tracker_activity_report_issues_c"),
+    ATP_DID_REPORT_ISSUES_FROM_TRACKER_ACTIVITY_DAILY("m_atp_imp_tracker_activity_report_issues_d"),
 
     ATP_APP_BREAKAGE_REPORT("m_atp_breakage_report"),
     ATP_APP_HEALTH_MONITOR_REPORT("m_atp_health_monitor_report"),

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -116,6 +116,10 @@ enum class DeviceShieldPixelNames(override val pixelName: String) : Pixel.PixelN
     ATP_LAUNCH_FEEDBACK("m_atp_ev_launch_feedback_c"),
     ATP_LAUNCH_FEEDBACK_DAILY("m_atp_ev_launch_feedback_d"),
 
+    ATP_DID_SUBMIT_DISABLE_APP_PROTECTION_DIALOG("m_atp_submit_disable_app_protection_dialog"),
+    ATP_DID_SKIP_DISABLE_APP_PROTECTION_DIALOG("m_atp_skip_disable_app_protection_dialog"),
+    ATP_DID_REPORT_ISSUES_FROM_TRACKER_ACTIVITY("m_atp_imp_tracker_activity_report_issues"),
+
     ATP_APP_BREAKAGE_REPORT("m_atp_breakage_report"),
     ATP_APP_HEALTH_MONITOR_REPORT("m_atp_health_monitor_report"),
     ATP_APP_HEALTH_ALERT_DAILY("m_atp_health_alert_%s_d"),

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -232,6 +232,15 @@ interface DeviceShieldPixels {
     /** Will fire when the user restores to the default protection list */
     fun launchAppTPFeedback()
 
+    /** Will fire when the user submits the form that disables protection for an app */
+    fun didSubmitManuallyDisableAppProtectionDialog()
+
+    /** Will fire when the user skips the form that disables protection for an app */
+    fun didSkipManuallyDisableAppProtectionDialog()
+
+    /** Will fire when the user launches the report issues screen from the tracker activity */
+    fun didSubmitReportIssuesFromTrackerActivity()
+
     /**
      * Will fire when the user reports an app breakage
      */
@@ -500,6 +509,18 @@ class RealDeviceShieldPixels @Inject constructor(
     override fun launchAppTPFeedback() {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_LAUNCH_FEEDBACK_DAILY)
         firePixel(DeviceShieldPixelNames.ATP_LAUNCH_FEEDBACK)
+    }
+
+    override fun didSubmitManuallyDisableAppProtectionDialog() {
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_SUBMIT_DISABLE_APP_PROTECTION_DIALOG)
+    }
+
+    override fun didSkipManuallyDisableAppProtectionDialog() {
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_SKIP_DISABLE_APP_PROTECTION_DIALOG)
+    }
+
+    override fun didSubmitReportIssuesFromTrackerActivity() {
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_REPORT_ISSUES_FROM_TRACKER_ACTIVITY)
     }
 
     override fun sendAppBreakageReport(metadata: Map<String, String>) {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -512,15 +512,18 @@ class RealDeviceShieldPixels @Inject constructor(
     }
 
     override fun didSubmitManuallyDisableAppProtectionDialog() {
-        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_SUBMIT_DISABLE_APP_PROTECTION_DIALOG)
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_SUBMIT_DISABLE_APP_PROTECTION_DIALOG_DAILY)
+        firePixel(DeviceShieldPixelNames.ATP_DID_SUBMIT_DISABLE_APP_PROTECTION_DIALOG)
     }
 
     override fun didSkipManuallyDisableAppProtectionDialog() {
-        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_SKIP_DISABLE_APP_PROTECTION_DIALOG)
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_SKIP_DISABLE_APP_PROTECTION_DIALOG_DAILY)
+        firePixel(DeviceShieldPixelNames.ATP_DID_SKIP_DISABLE_APP_PROTECTION_DIALOG)
     }
 
     override fun didSubmitReportIssuesFromTrackerActivity() {
-        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_REPORT_ISSUES_FROM_TRACKER_ACTIVITY)
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_REPORT_ISSUES_FROM_TRACKER_ACTIVITY_DAILY)
+        firePixel(DeviceShieldPixelNames.ATP_DID_REPORT_ISSUES_FROM_TRACKER_ACTIVITY)
     }
 
     override fun sendAppBreakageReport(metadata: Map<String, String>) {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -450,6 +450,7 @@ class DeviceShieldTrackerActivity :
     }
 
     private fun launchFeedback() {
+        deviceShieldPixels.didSubmitReportIssuesFromTrackerActivity()
         reportBreakage.launch(ReportBreakageScreen.ListOfInstalledApps)
     }
 

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModelTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/apps/ExcludedAppsViewModelTest.kt
@@ -60,8 +60,25 @@ class ExcludedAppsViewModelTest {
         val packageName = "com.package.name"
         viewModel.onAppProtectionDisabled(ManuallyDisableAppProtectionDialog.NO_REASON_NEEDED, packageName, packageName, skippedReport = false)
 
-        verifyNoInteractions(deviceShieldPixels)
         verify(trackingProtectionAppsRepository).manuallyExcludedApp(packageName)
+    }
+
+    @Test
+    fun whenAppProtectionisDisabledAndReportIsSkippedThenDisablePixelIsSent() = runTest {
+        val packageName = "com.package.name"
+        val skippedReport = true
+        viewModel.onAppProtectionDisabled(ManuallyDisableAppProtectionDialog.NO_REASON_NEEDED, packageName, packageName, skippedReport)
+
+        verify(deviceShieldPixels).didSkipManuallyDisableAppProtectionDialog()
+    }
+
+    @Test
+    fun whenAppProtectionisSubmittedAndReportIsSkippedThenSubmitPixelIsSent() = runTest {
+        val packageName = "com.package.name"
+        val skippedReport = false
+        viewModel.onAppProtectionDisabled(ManuallyDisableAppProtectionDialog.NO_REASON_NEEDED, packageName, packageName, skippedReport)
+
+        verify(deviceShieldPixels).didSubmitManuallyDisableAppProtectionDialog()
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1157893581871903/1201688799714577

### Description
One of the potential causes that may have caused Incident: unexpected spike in app breakage reports 2022-01-15 is a fix in the flow to open the feedback form (✓ Bug: Increase scrolling area for Disabling app Dialog)

There are two user journeys that end up in that feedback form:
Via the Info panel in the Tracker activity screen "Report issues"
Via the App Protection Management screen, when using the toggle

### Steps to test this PR
 
_ Disable App Protection Dialog_
- [ ] Enable AppTP
- [ ] Open Manage Apps Protection screen
- [ ] Tap on the switch to disable protection for an app, a dialog should appear
- [ ] Tap skip
- [ ] Verify "m_atp_skip_disable_app_protection_dialog" was sent
- [ ] Tap on the switch to disable protection for an app, a dialog should appear
- [ ] Choose and answer and tap submit
- [ ] Verify "m_atp_submit_disable_app_protection_dialog" was sent

_ Trackers activity screen_
- [ ] Open Trackers screen
- [ ] Enable AppTP
- [ ] Tap on "Report issues"
- [ ] Verify "m_atp_imp_tracker_activity_report_issues" was sent
- [ ] Go back to Trackers screen
- [ ] Disable AppTP
- [ ] Tap on "Report issues"
- [ ] Verify "m_atp_imp_tracker_activity_report_issues" was sent

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
