### PR TITLE
Fix TracerPacket memory leak

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/TunPacketWriter.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/TunPacketWriter.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.mobile.android.vpn.service.VpnQueues
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import okio.ByteString.Companion.toByteString
 import timber.log.Timber
 import xyz.hexene.localvpn.ByteBufferPool
 import java.io.FileOutputStream
@@ -77,6 +78,7 @@ class TunPacketWriter @AssistedInject constructor(
 
             if (bufferFromNetwork.get(0) == (-1).toByte()) {
                 processTracerPacket(bufferFromNetwork)
+                ByteBufferPool.release(bufferFromNetwork)
                 return
             }
 
@@ -90,6 +92,8 @@ class TunPacketWriter @AssistedInject constructor(
             }
         } catch (e: IOException) {
             Timber.w(e, "Failed writing to the TUN")
+            bufferFromNetwork.rewind()
+            Timber.d("Failed writing to the TUN. Buffer: ${bufferFromNetwork.toByteString().hex()}")
             healthMetricCounter.onTunWriteIOException()
         } finally {
             ByteBufferPool.release(bufferFromNetwork)

--- a/vpn/src/main/java/xyz/hexene/localvpn/ByteBufferPool.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/ByteBufferPool.java
@@ -29,6 +29,7 @@ public class ByteBufferPool {
         if (buffer == null) {
             buffer = ByteBuffer.allocateDirect(BUFFER_SIZE); // Using DirectBuffer for zero-copy
         }
+        buffer.clear();
         return buffer;
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201701653646856/f

### Description
This PR fixes the memory leak caused by tracer buffer.
Tracer packets have an associated `ByteBuffer` needed to inser the packet in the network-to-device queue. One we take the packet out and process it, we were not releasing it. Causing a memory leak.

This PR:
* releases the bytebuffer associated to the tracer packet
* Incidentally
  * adds some log statements for RUN write errors
  * double ensures that `acquire` buffers are cleared so that they're ready to be used

### Steps to test this PR
Smoke tests for AppTP

