### PR TITLE
Send unique pixel upon first breakage report

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -124,6 +124,7 @@ enum class DeviceShieldPixelNames(override val pixelName: String) : Pixel.PixelN
     ATP_DID_REPORT_ISSUES_FROM_TRACKER_ACTIVITY_DAILY("m_atp_imp_tracker_activity_report_issues_d"),
 
     ATP_APP_BREAKAGE_REPORT("m_atp_breakage_report"),
+    ATP_APP_BREAKAGE_REPORT_UNIQUE("m_atp_breakage_report_u"),
     ATP_APP_HEALTH_MONITOR_REPORT("m_atp_health_monitor_report"),
     ATP_APP_HEALTH_ALERT_DAILY("m_atp_health_alert_%s_d"),
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -528,6 +528,7 @@ class RealDeviceShieldPixels @Inject constructor(
 
     override fun sendAppBreakageReport(metadata: Map<String, String>) {
         firePixel(DeviceShieldPixelNames.ATP_APP_BREAKAGE_REPORT, metadata)
+        tryToFireUniquePixel(DeviceShieldPixelNames.ATP_APP_BREAKAGE_REPORT_UNIQUE, payload = metadata)
     }
 
     override fun didShowReportBreakageAppList() {
@@ -617,13 +618,14 @@ class RealDeviceShieldPixels @Inject constructor(
 
     private fun tryToFireUniquePixel(
         pixel: DeviceShieldPixelNames,
-        tag: String? = null
+        tag: String? = null,
+        payload: Map<String, String> = emptyMap()
     ) {
         val didExecuteAlready = preferences.getBoolean(tag ?: pixel.pixelName, false)
 
         if (didExecuteAlready) return
 
-        this.pixel.fire(pixel).also { preferences.edit { putBoolean(tag ?: pixel.pixelName, true) } }
+        this.pixel.fire(pixel, payload).also { preferences.edit { putBoolean(tag ?: pixel.pixelName, true) } }
     }
 
     private fun String.appendTimestampSuffix(): String {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201677777496527/f

### Description
We want to know the impact on first ever reports from users that the bad health mitigation will have.

This PR adds a unique pixel `m_atp_breakage_report_u` that will fire only once ever the first time a user submits reports a breakage.
The pixel will carry the same info as the `m_atp_breakage_report`.

### Steps to test this PR

_Test Pixel_
- [x] Install from this branch
- [x] filter the logcat with `m_atp_breakage`
- [x] report breakage for any app
- [x] verify both `m_atp_breakage_report` and `m_atp_breakage_report_u` are sent and both contain the same information
- [x] report breakage for any app a second time
- [x] verify the `m_atp_breakage_report_u` is NOT sent

