### PR TITLE
Add unknown (protocol) packets to the tunReads alert report information

### DIFF
--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthStatsStore.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthStatsStore.kt
@@ -48,6 +48,7 @@ data class SimpleEvent(
     companion object {
         fun build(type: String) = SimpleEvent(type = type, timestamp = System.currentTimeMillis())
 
+        fun TUN_READ_UNKNOWN_PACKET() = build("TUN_READ_UNKNOWN_PACKET")
         fun TUN_READ() = build("TUN_READ")
         fun ADD_TO_DEVICE_TO_NETWORK_QUEUE() = build("ADD_TO_DEVICE_TO_NETWORK_QUEUE")
         fun ADD_TO_TCP_DEVICE_TO_NETWORK_QUEUE() = build("ADD_TO_TCP_DEVICE_TO_NETWORK_QUEUE")

--- a/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifierTest.kt
+++ b/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifierTest.kt
@@ -140,7 +140,7 @@ class HealthClassifierTest {
     @Test
     fun whenTooFewTunInputsThenReportsInitializing() {
         val tunInputs: Long = 0
-        val queueReads = QueueReads(0, 0, 0)
+        val queueReads = QueueReads(0, 0, 0, 0)
         testee.determineHealthTunInputQueueReadRatio(tunInputs, queueReads).assertInitializing()
     }
 
@@ -149,7 +149,7 @@ class HealthClassifierTest {
 
         // success rate: 0%
         val tunInputs: Long = 100
-        val queueReads = QueueReads(0, 0, 0)
+        val queueReads = QueueReads(0, 0, 0, 0)
 
         testee.determineHealthTunInputQueueReadRatio(tunInputs, queueReads).assertBadHealth()
     }
@@ -159,7 +159,7 @@ class HealthClassifierTest {
 
         // success rate: 10%
         val tunInputs: Long = 900
-        val queueReads = QueueReads(100, 100, 0)
+        val queueReads = QueueReads(100, 100, 0, 0)
 
         testee.determineHealthTunInputQueueReadRatio(tunInputs, queueReads).assertBadHealth()
     }
@@ -169,7 +169,7 @@ class HealthClassifierTest {
 
         // success rate: 100%
         val tunInputs: Long = 900
-        val queueReads = QueueReads(900, 900, 0)
+        val queueReads = QueueReads(900, 900, 0, 0)
 
         testee.determineHealthTunInputQueueReadRatio(tunInputs, queueReads).assertGoodHealth()
     }
@@ -179,7 +179,7 @@ class HealthClassifierTest {
 
         // success rate: 900%
         val tunInputs: Long = 100
-        val queueReads = QueueReads(900, 900, 0)
+        val queueReads = QueueReads(900, 900, 0, 0)
 
         testee.determineHealthTunInputQueueReadRatio(tunInputs, queueReads).assertGoodHealth()
     }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPHealthMonitor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPHealthMonitor.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.SOCKET_CHA
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.SOCKET_CHANNEL_READ_EXCEPTION
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.SOCKET_CHANNEL_WRITE_EXCEPTION
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_READ
+import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_READ_UNKNOWN_PACKET
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_WRITE_IO_EXCEPTION
 import com.duckduckgo.mobile.android.vpn.service.VpnQueues
 import com.squareup.anvil.annotations.ContributesBinding
@@ -171,13 +172,19 @@ class AppTPHealthMonitor @Inject constructor(
         healthAlerts: HealthRule
     ): HealthState {
         val tunReads = healthMetricCounter.getStat(TUN_READ(), timeWindow)
+        val unknownPackets = healthMetricCounter.getStat(TUN_READ_UNKNOWN_PACKET(), timeWindow)
         val readFromNetworkQueue = healthMetricCounter.getStat(REMOVE_FROM_DEVICE_TO_NETWORK_QUEUE(), timeWindow)
         val readFromTCPNetworkQueue = healthMetricCounter.getStat(REMOVE_FROM_TCP_DEVICE_TO_NETWORK_QUEUE(), timeWindow)
         val readFromUDPNetworkQueue = healthMetricCounter.getStat(REMOVE_FROM_UDP_DEVICE_TO_NETWORK_QUEUE(), timeWindow)
 
         val state = healthClassifier.determineHealthTunInputQueueReadRatio(
             tunReads,
-            QueueReads(queueReads = readFromNetworkQueue, queueTCPReads = readFromTCPNetworkQueue, queueUDPReads = readFromUDPNetworkQueue)
+            QueueReads(
+                queueReads = readFromNetworkQueue,
+                queueTCPReads = readFromTCPNetworkQueue,
+                queueUDPReads = readFromUDPNetworkQueue,
+                unknownPackets = unknownPackets
+            )
         )
         healthAlerts.updateAlert(state)
         return state

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
@@ -39,6 +39,7 @@ class HealthClassifier @Inject constructor(val applicationContext: Context) {
 
         rawMetrics["tunInputsQueueReadRate"] = Metric(percentage.toString(), badHealthIf { percentage < 70 })
         rawMetrics["tunInputs"] = Metric(tunInputs.toString())
+        rawMetrics["unknownPackets"] = Metric(queueReads.unknownPackets.toString())
         rawMetrics["queueReads"] = Metric(queueReads.queueReads.toString())
         rawMetrics["queueTCPReads"] = Metric(queueReads.queueTCPReads.toString())
         rawMetrics["queueUDPReads"] = Metric(queueReads.queueUDPReads.toString())
@@ -177,4 +178,5 @@ data class QueueReads(
     val queueReads: Long,
     val queueTCPReads: Long,
     val queueUDPReads: Long,
+    val unknownPackets: Long,
 )

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthMetricCounter.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthMetricCounter.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.SOCKET_CHA
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.SOCKET_CHANNEL_READ_EXCEPTION
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.SOCKET_CHANNEL_WRITE_EXCEPTION
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_READ
+import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_READ_UNKNOWN_PACKET
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_WRITE_IO_EXCEPTION
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
@@ -60,6 +61,12 @@ class HealthMetricCounter @Inject constructor(
         coroutineScope.launch(databaseDispatcher) {
             db.clearAllTables()
             tracerPacketRegister.deleteAll()
+        }
+    }
+
+    fun onTunUnknownPacketReceived() {
+        coroutineScope.launch(databaseDispatcher) {
+            healthStatsDao.insertEvent(TUN_READ_UNKNOWN_PACKET())
         }
     }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -145,5 +145,7 @@ enum class DeviceShieldPixelNames(override val pixelName: String) : Pixel.PixelN
     ATP_DID_SHOW_WAITLIST_DIALOG("m_atp_imp_waitlist_dialog_c"),
     ATP_DID_PRESS_WAITLIST_DIALOG_NOTIFY_ME("m_atp_ev_waitlist_dialog_notify_me_c"),
     ATP_DID_PRESS_WAITLIST_DIALOG_DISMISS("m_atp_ev_waitlist_dialog_dismiss_c"),
+
+    ATP_RECEIVED_UNKNOWN_PACKET_PROTOCOL("m_atp_ev_unknown_packet_%d_c"),
     ;
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -287,6 +287,11 @@ interface DeviceShieldPixels {
      * Will send a first-in-day pixel for the given alertName
      */
     fun sendHealthMonitorAlert(alertName: String)
+
+    /**
+     * Will fire when the VPN receives a packet of unknown protocol
+     */
+    fun sendUnknownPacketProtocol(protocol: Int)
 }
 
 @ContributesBinding(AppScope::class)
@@ -583,6 +588,10 @@ class RealDeviceShieldPixels @Inject constructor(
         )
     }
 
+    override fun sendUnknownPacketProtocol(protocol: Int) {
+        firePixel(String.format(Locale.US, DeviceShieldPixelNames.ATP_RECEIVED_UNKNOWN_PACKET_PROTOCOL.pixelName, protocol))
+    }
+
     private fun suddenKill() {
         firePixel(DeviceShieldPixelNames.ATP_KILLED)
     }
@@ -591,7 +600,14 @@ class RealDeviceShieldPixels @Inject constructor(
         p: DeviceShieldPixelNames,
         payload: Map<String, String> = emptyMap()
     ) {
-        pixel.fire(p, payload)
+        firePixel(p.pixelName, payload)
+    }
+
+    private fun firePixel(
+        pixelName: String,
+        payload: Map<String, String> = emptyMap()
+    ) {
+        pixel.fire(pixelName, payload)
     }
 
     private fun tryToFireDailyPixel(

--- a/vpn/src/main/java/xyz/hexene/localvpn/Packet.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/Packet.java
@@ -243,7 +243,7 @@ public class Packet {
         public int identificationAndFlagsAndFragmentOffset;
 
         public short TTL;
-        private short protocolNum;
+        public final short protocolNum;
         public TransportProtocol protocol;
         public int headerChecksum;
 

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
@@ -87,7 +87,7 @@ class RealDeviceShieldPixelsTest {
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_REMINDER_NOTIFICATION_UNIQUE)
         verify(pixel).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_REMINDER_NOTIFICATION_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_REMINDER_NOTIFICATION)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_REMINDER_NOTIFICATION.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -98,7 +98,7 @@ class RealDeviceShieldPixelsTest {
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_ONBOARDING_UNIQUE)
         verify(pixel).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_ONBOARDING_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_ONBOARDING)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_ONBOARDING.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -109,7 +109,7 @@ class RealDeviceShieldPixelsTest {
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_SETTINGS_TILE_UNIQUE)
         verify(pixel).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_SETTINGS_TILE_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_SETTINGS_TILE)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_SETTINGS_TILE.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -120,7 +120,7 @@ class RealDeviceShieldPixelsTest {
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_SUMMARY_TRACKER_ACTIVITY_UNIQUE)
         verify(pixel).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_SUMMARY_TRACKER_ACTIVITY_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_SUMMARY_TRACKER_ACTIVITY)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_ENABLE_FROM_SUMMARY_TRACKER_ACTIVITY.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -130,7 +130,7 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.disableFromQuickSettingsTile()
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_DISABLE_FROM_SETTINGS_TILE_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_DISABLE_FROM_SETTINGS_TILE)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_DISABLE_FROM_SETTINGS_TILE.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -180,7 +180,7 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.didPressOngoingNotification()
 
         verify(pixel).fire(DeviceShieldPixelNames.DID_PRESS_ONGOING_NOTIFICATION_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_PRESS_ONGOING_NOTIFICATION)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_PRESS_ONGOING_NOTIFICATION.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -190,7 +190,7 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.didShowReminderNotification()
 
         verify(pixel).fire(DeviceShieldPixelNames.DID_SHOW_REMINDER_NOTIFICATION_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_SHOW_REMINDER_NOTIFICATION)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_SHOW_REMINDER_NOTIFICATION.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -200,7 +200,7 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.didPressReminderNotification()
 
         verify(pixel).fire(DeviceShieldPixelNames.DID_PRESS_REMINDER_NOTIFICATION_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_PRESS_REMINDER_NOTIFICATION)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_PRESS_REMINDER_NOTIFICATION.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -211,7 +211,7 @@ class RealDeviceShieldPixelsTest {
 
         verify(pixel).fire(DeviceShieldPixelNames.DID_SHOW_NEW_TAB_SUMMARY_UNIQUE)
         verify(pixel).fire(DeviceShieldPixelNames.DID_SHOW_NEW_TAB_SUMMARY_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_SHOW_NEW_TAB_SUMMARY)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_SHOW_NEW_TAB_SUMMARY.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -221,7 +221,7 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.didPressNewTabSummary()
 
         verify(pixel).fire(DeviceShieldPixelNames.DID_PRESS_NEW_TAB_SUMMARY_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_PRESS_NEW_TAB_SUMMARY)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_PRESS_NEW_TAB_SUMMARY.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -232,7 +232,7 @@ class RealDeviceShieldPixelsTest {
 
         verify(pixel).fire(DeviceShieldPixelNames.DID_SHOW_SUMMARY_TRACKER_ACTIVITY_UNIQUE)
         verify(pixel).fire(DeviceShieldPixelNames.DID_SHOW_SUMMARY_TRACKER_ACTIVITY_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_SHOW_SUMMARY_TRACKER_ACTIVITY)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_SHOW_SUMMARY_TRACKER_ACTIVITY.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -243,7 +243,7 @@ class RealDeviceShieldPixelsTest {
 
         verify(pixel).fire(DeviceShieldPixelNames.DID_SHOW_DETAILED_TRACKER_ACTIVITY_UNIQUE)
         verify(pixel).fire(DeviceShieldPixelNames.DID_SHOW_DETAILED_TRACKER_ACTIVITY_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_SHOW_DETAILED_TRACKER_ACTIVITY)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.DID_SHOW_DETAILED_TRACKER_ACTIVITY.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -253,7 +253,7 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.startError()
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_START_ERROR_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_START_ERROR)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_START_ERROR.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -263,7 +263,7 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.automaticRestart()
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_AUTOMATIC_RESTART_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_AUTOMATIC_RESTART)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_AUTOMATIC_RESTART.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -273,8 +273,8 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.suddenKillBySystem()
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_KILLED_BY_SYSTEM_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_KILLED_BY_SYSTEM)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_KILLED)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_KILLED_BY_SYSTEM.pixelName)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_KILLED.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -284,8 +284,8 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.suddenKillByVpnRevoked()
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_KILLED_VPN_REVOKED_DAILY.pixelName)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_KILLED_VPN_REVOKED)
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_KILLED)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_KILLED_VPN_REVOKED.pixelName)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_KILLED.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -294,7 +294,7 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.privacyReportArticleDisplayed()
         deviceShieldPixels.privacyReportArticleDisplayed()
 
-        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_DID_SHOW_PRIVACY_REPORT_ARTICLE)
+        verify(pixel, times(2)).fire(DeviceShieldPixelNames.ATP_DID_SHOW_PRIVACY_REPORT_ARTICLE.pixelName)
         verifyNoMoreInteractions(pixel)
     }
 
@@ -302,21 +302,21 @@ class RealDeviceShieldPixelsTest {
     fun whenDidShowWaitlistDialogThenFirePixels() {
         deviceShieldPixels.didShowWaitlistDialog()
 
-        verify(pixel).fire(DeviceShieldPixelNames.ATP_DID_SHOW_WAITLIST_DIALOG)
+        verify(pixel).fire(DeviceShieldPixelNames.ATP_DID_SHOW_WAITLIST_DIALOG.pixelName)
     }
 
     @Test
     fun whenWaitlistDialogDismissThenFirePixels() {
         deviceShieldPixels.didPressWaitlistDialogDismiss()
 
-        verify(pixel).fire(DeviceShieldPixelNames.ATP_DID_PRESS_WAITLIST_DIALOG_DISMISS)
+        verify(pixel).fire(DeviceShieldPixelNames.ATP_DID_PRESS_WAITLIST_DIALOG_DISMISS.pixelName)
     }
 
     @Test
     fun whenWaitlistDialogNotifyMeThenFirePixels() {
         deviceShieldPixels.didPressWaitlistDialogNotifyMe()
 
-        verify(pixel).fire(DeviceShieldPixelNames.ATP_DID_PRESS_WAITLIST_DIALOG_NOTIFY_ME)
+        verify(pixel).fire(DeviceShieldPixelNames.ATP_DID_PRESS_WAITLIST_DIALOG_NOTIFY_ME.pixelName)
     }
 
     private fun DeviceShieldPixelNames.notificationVariant(variant: Int): String {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201677777496539/f

### Description
The VPN currently drops any IP packet which protocol is other than UDP or TCP.

We want to undertand how widespread those protocols are and whether they may have any relation to breakage. This PR:
* adds a pixel `m_atp_ev_unknown_packet_%d_c` that will fire every time we drop an unknown packet
* adds the unknown packets count to the bad health report

### Steps to test this PR

_Test_
- [x] Install the [ping](https://apkpure.com/ping/com.lipinic.ping/download?from=details) app
- [x] Install the app from this branch
- [x] Launch the app and enable AppTP
- [x] Filter the logcat by `m_atp_ev_unknown_packet_|m_atp_health_monitor_report`
- [x] Open the ping app and start pinging eg. 8.8.8.8
- [x] Verify the `m_atp_ev_unknown_packet_1_c` is sent for every ping
- [x] Got to Settings -> AppTP settings -> Diagnostics screen
- [x] Verify in the `unknown packets` count in `Other metrics` increments

