### PR TITLE
Fix bug where m_atp_ev_selected_disable_protection_c was not sent

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -262,6 +262,7 @@ class DeviceShieldTrackerActivity :
 
     override fun onTurnAppTrackingProtectionOff() {
         deviceShieldSwitch.quietlySetIsChecked(false, enableAppTPSwitchListener)
+        deviceShieldPixels.didChooseToDisableTrackingProtectionFromDialog()
         viewModel.onAppTpManuallyDisabled()
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201660793106474/f

### Description
Fix bug where the `m_atp_ev_selected_disable_protection_c` was not sent.

### Steps to test this PR

_Verify pixel is sent_
- [x] Install from this branch
- [x] Enable AppTP
- [x] Go to "Tracking protection screen" and click on the toggle to disable AppTP
- [x] Select "Disable for all apps"
- [x] Verify the `m_atp_ev_selected_disable_protection_c` is sent
