### PR TITLE
Enable bad health mitigation in production

### DIFF
--- a/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.AppHealthDatabase/4.json
+++ b/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.AppHealthDatabase/4.json
@@ -1,0 +1,58 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "f88db48cf3d7e0794731e437e44831ac",
+    "entities": [
+      {
+        "tableName": "app_health_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT NOT NULL, `localtime` TEXT NOT NULL, `alerts` TEXT NOT NULL, `healthDataJsonString` TEXT NOT NULL, `restartedAtEpochSeconds` INTEGER, PRIMARY KEY(`type`))",
+        "fields": [
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localtime",
+            "columnName": "localtime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alerts",
+            "columnName": "alerts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "healthDataJsonString",
+            "columnName": "healthDataJsonString",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restartedAtEpochSeconds",
+            "columnName": "restartedAtEpochSeconds",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "type"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f88db48cf3d7e0794731e437e44831ac')"
+    ]
+  }
+}

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/AppHealthDao.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/AppHealthDao.kt
@@ -32,11 +32,14 @@ interface AppHealthDao {
 
     @Transaction
     fun remove(type: HealthEventType): AppHealthState? {
-        return latestHealthState(type)?.also { clear(type) }
+        return latestHealthStateByType(type)?.also { clear(type) }
     }
 
     @Query("SELECT * from app_health_state where type=:type ORDER BY localtime DESC LIMIT 1")
-    fun latestHealthState(type: HealthEventType): AppHealthState?
+    fun latestHealthStateByType(type: HealthEventType): AppHealthState?
+
+    @Query("SELECT * from app_health_state ORDER BY localtime DESC LIMIT 1")
+    fun latestHealthState(): AppHealthState?
 
     @Query("delete from app_health_state where type=:type")
     fun clear(type: HealthEventType)

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/AppHealthState.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/AppHealthState.kt
@@ -28,6 +28,7 @@ data class AppHealthState(
     val localtime: String = DatabaseDateFormatter.timestamp(),
     val alerts: List<String>,
     val healthDataJsonString: String,
+    val restartedAtEpochSeconds: Long?,
 ) {
     object HealthEventTypeConverter {
         @TypeConverter

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/AppHealthDatabase.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/AppHealthDatabase.kt
@@ -29,7 +29,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 
 @Database(
-    exportSchema = true, version = 3,
+    exportSchema = true, version = 4,
     entities = [
         AppHealthState::class
     ]

--- a/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandlerTest.kt
+++ b/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandlerTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -78,7 +79,7 @@ class AppBadHealthStateHandlerTest {
 
     @Test
     fun whenOnAppHealthUpdateWithBadHealthDataThenStoreInDbAndSendPixel() = runTest {
-        assertFalse(appBadHealthStateHandler.onAppHealthUpdate(BAD_HEALTH_DATA))
+        assertTrue(appBadHealthStateHandler.onAppHealthUpdate(BAD_HEALTH_DATA))
 
         val state = db.appHealthDao().latestHealthState(BAD_HEALTH)
 
@@ -94,7 +95,7 @@ class AppBadHealthStateHandlerTest {
 
     @Test
     fun whenOnAppHealthUpdateWithRedactedBadHealthDataThenSkipRedactedMetricsFromDbAndSendPixel() = runTest {
-        assertFalse(appBadHealthStateHandler.onAppHealthUpdate(REDACTED_BAD_HEALTH_DATA))
+        assertTrue(appBadHealthStateHandler.onAppHealthUpdate(REDACTED_BAD_HEALTH_DATA))
 
         val state = db.appHealthDao().latestHealthState(BAD_HEALTH)
 

--- a/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandlerTest.kt
+++ b/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandlerTest.kt
@@ -21,6 +21,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.BuildFlavor
+import com.duckduckgo.mobile.android.vpn.model.AppHealthState
 import com.duckduckgo.mobile.android.vpn.model.HealthEventType.BAD_HEALTH
 import com.duckduckgo.mobile.android.vpn.model.HealthEventType.GOOD_HEALTH
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
@@ -37,9 +38,12 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.ZoneOffset
 
 @ExperimentalCoroutinesApi
 class AppBadHealthStateHandlerTest {
@@ -81,7 +85,7 @@ class AppBadHealthStateHandlerTest {
     fun whenOnAppHealthUpdateWithBadHealthDataThenStoreInDbAndSendPixel() = runTest {
         assertTrue(appBadHealthStateHandler.onAppHealthUpdate(BAD_HEALTH_DATA))
 
-        val state = db.appHealthDao().latestHealthState(BAD_HEALTH)
+        val state = db.appHealthDao().latestHealthStateByType(BAD_HEALTH)
 
         assertEquals(listOf("alert"), state?.alerts)
         assertEquals(
@@ -97,7 +101,7 @@ class AppBadHealthStateHandlerTest {
     fun whenOnAppHealthUpdateWithRedactedBadHealthDataThenSkipRedactedMetricsFromDbAndSendPixel() = runTest {
         assertTrue(appBadHealthStateHandler.onAppHealthUpdate(REDACTED_BAD_HEALTH_DATA))
 
-        val state = db.appHealthDao().latestHealthState(BAD_HEALTH)
+        val state = db.appHealthDao().latestHealthStateByType(BAD_HEALTH)
 
         assertEquals(listOf("alert"), state?.alerts)
         assertEquals(
@@ -112,10 +116,62 @@ class AppBadHealthStateHandlerTest {
     fun whenOnAppHealthUpdateWithGoodHealthDataThenStoreInDb() = runTest {
         assertFalse(appBadHealthStateHandler.onAppHealthUpdate(EMPTY_HEALTH_DATA))
 
-        val state = db.appHealthDao().latestHealthState(GOOD_HEALTH)
+        val state = db.appHealthDao().latestHealthStateByType(GOOD_HEALTH)
 
         assertEquals(GOOD_HEALTH, state?.type)
         assertEquals(listOf<String>(), state?.alerts)
+    }
+
+    @Test
+    fun whenAlertResolvesByRestartSendPixel() = runTest {
+        assertTrue(appBadHealthStateHandler.onAppHealthUpdate(BAD_HEALTH_DATA))
+        assertFalse(appBadHealthStateHandler.onAppHealthUpdate(EMPTY_HEALTH_DATA))
+
+        val state = db.appHealthDao().latestHealthStateByType(GOOD_HEALTH)
+        assertEquals(GOOD_HEALTH, state?.type)
+
+        verify(deviceShieldPixels).badHealthResolvedByRestart(any())
+        verify(deviceShieldPixels, never()).badHealthResolvedItself(any())
+    }
+
+    @Test
+    fun whenAlertResolvesSoonEnoughAfterRestartSendResolvedByRestartPixel() = runTest {
+        db.appHealthDao().insert(
+            AppHealthState(
+                type = BAD_HEALTH,
+                alerts = listOf("alert"),
+                healthDataJsonString = "",
+                restartedAtEpochSeconds = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) - 30
+            )
+        )
+
+        assertFalse(appBadHealthStateHandler.onAppHealthUpdate(EMPTY_HEALTH_DATA))
+
+        val state = db.appHealthDao().latestHealthStateByType(GOOD_HEALTH)
+        assertEquals(GOOD_HEALTH, state?.type)
+
+        verify(deviceShieldPixels).badHealthResolvedByRestart(any())
+        verify(deviceShieldPixels, never()).badHealthResolvedItself(any())
+    }
+
+    @Test
+    fun whenAlertResolvesWayAfterRestartSendResolvedItselfPixel() = runTest {
+        db.appHealthDao().insert(
+            AppHealthState(
+                type = BAD_HEALTH,
+                alerts = listOf("alert"),
+                healthDataJsonString = "",
+                restartedAtEpochSeconds = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) - 60
+            )
+        )
+
+        assertFalse(appBadHealthStateHandler.onAppHealthUpdate(EMPTY_HEALTH_DATA))
+
+        val state = db.appHealthDao().latestHealthStateByType(GOOD_HEALTH)
+        assertEquals(GOOD_HEALTH, state?.type)
+
+        verify(deviceShieldPixels).badHealthResolvedItself(any())
+        verify(deviceShieldPixels, never()).badHealthResolvedByRestart(any())
     }
 
     companion object {
@@ -146,6 +202,21 @@ class AppBadHealthStateHandlerTest {
                             "rawMetric",
                             metrics = mapOf("metric" to Metric("value", isBadState = true)),
                             redacted = true
+                        )
+                    )
+                )
+            )
+
+        private val BAD_HEALTH_DATA_NO_ALERT =
+            AppHealthData(
+                listOf(),
+                SystemHealthData(
+                    true,
+                    listOf(
+                        RawMetricsSubmission(
+                            "rawMetric",
+                            metrics = mapOf("metric" to Metric("value", isBadState = true)),
+                            redacted = false
                         )
                     )
                 )

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/AppHealthStateCollector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/AppHealthStateCollector.kt
@@ -87,6 +87,6 @@ class AppHealthStateCollector @Inject constructor(
         private const val SECONDS_AGO = "secondsAgo"
         private const val BAD_HEALTH_DATA = "badHealthData"
         private const val SUSTAINED_BAD_HEALTH_SEC = "secondsSustained"
-        private const val IS_CURRENTLY_IN_GOOD_HEALTH = "isCurrentlyGooHealth"
+        private const val IS_CURRENTLY_IN_GOOD_HEALTH = "isCurrentlyGoodHealth"
     }
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
@@ -42,10 +42,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.threeten.bp.LocalDateTime
+import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
 import timber.log.Timber
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.minutes
 
 @ContributesMultibinding(
     scope = AppScope::class,
@@ -108,16 +108,33 @@ class AppBadHealthStateHandler @Inject constructor(
                 }
 
                 val json = jsonAdapter.toJson(badHealthData)
-                appHealthDatabase.appHealthDao().insert(
-                    AppHealthState(type = BAD_HEALTH, alerts = appHealthData.alerts, healthDataJsonString = json)
-                )
 
                 Timber.v("Storing app health alerts in local store: $badHealthData")
 
-                return@withContext pixelAndMaybeRestartVpn(json)
-            } else {
+                val shouldRestartVpn = shouldRestartVpn(json)
+                val restartLocaltime = if (shouldRestartVpn) {
+                    LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+                } else {
+                    appHealthDatabase.appHealthDao().latestHealthStateByType(BAD_HEALTH)?.restartedAtEpochSeconds
+                }
                 appHealthDatabase.appHealthDao().insert(
-                    AppHealthState(type = GOOD_HEALTH, alerts = listOf(), healthDataJsonString = "")
+                    AppHealthState(
+                        type = BAD_HEALTH,
+                        alerts = appHealthData.alerts,
+                        healthDataJsonString = json,
+                        restartedAtEpochSeconds = restartLocaltime
+                    )
+                )
+
+                if (shouldRestartVpn) restartVpn()
+
+                return@withContext shouldRestartVpn
+            } else {
+                // first send the pixel
+                sendPixelIfBadHealthResolved(appHealthDatabase.appHealthDao().latestHealthState())
+                // then store
+                appHealthDatabase.appHealthDao().insert(
+                    AppHealthState(type = GOOD_HEALTH, alerts = listOf(), healthDataJsonString = "", restartedAtEpochSeconds = null)
                 )
                 resetBackoff()
                 Timber.d("No alerts")
@@ -140,25 +157,20 @@ class AppBadHealthStateHandler @Inject constructor(
         }
     }
 
-    private suspend fun pixelAndMaybeRestartVpn(json: String): Boolean {
+    private fun shouldRestartVpn(json: String): Boolean {
         val boundary = restartBoundary
-        return if (shouldRestartVpn(boundary)) {
+        return if (isVpnRestartAllowed(boundary)) {
             Timber.v("Restarting the VPN...")
 
             // update the restart boundary
+            backoffIncrement = if (backoffIncrement == 0L) INITIAL_BACKOFF_INCREMENT_SECONDS else backoffIncrement * 2
             DATE_FORMATTER.format(LocalDateTime.now().plusSeconds(backoffIncrement)).run {
-                backoffIncrement = if (backoffIncrement == 0L) INITIAL_BACKOFF_INCREMENT else backoffIncrement * 2
                 restartBoundary = this
             }
 
             Timber.v("backoff = $backoffIncrement, boundary = $restartBoundary")
 
             debouncedPixelBadHealth(json, restarted = true)
-
-            // place this in a different job to ensure the restart completes successfully and nobody can cancel it by mistake
-            appCoroutineScope.launch {
-                TrackerBlockingVpnService.restartVpnService(context, forceGc = true)
-            }.join()
             true
         } else {
             Timber.v("Cancelled VPN restart, backoff boundary ($boundary)...")
@@ -167,7 +179,15 @@ class AppBadHealthStateHandler @Inject constructor(
         }
     }
 
-    private fun shouldRestartVpn(boundary: String?): Boolean {
+    private suspend fun restartVpn() {
+        // place this in a different job to ensure the restart completes successfully and nobody can cancel it by mistake
+        appCoroutineScope.launch {
+            deviceShieldPixels.didRestartVpnOnBadHealth()
+            TrackerBlockingVpnService.restartVpnService(context, forceGc = true)
+        }.join()
+    }
+
+    private fun isVpnRestartAllowed(boundary: String?): Boolean {
         val now = DATE_FORMATTER.format(LocalDateTime.now())
         Timber.d("Checking if should restart VPN, boundary = $boundary")
         return (boundary == null || now >= boundary)
@@ -189,14 +209,47 @@ class AppBadHealthStateHandler @Inject constructor(
             )
             deviceShieldPixels.sendHealthMonitorReport(
                 mapOf(
-                    "manufacturer" to appBuildConfig.manufacturer,
-                    // model only in internal builds to avoid privacy issues in production for now
-                    "model" to if (appBuildConfig.flavor.isInternal()) appBuildConfig.model else "redacted",
-                    "restarted" to restarted.toString(),
-                    "badHealthData" to encodedData,
+                    MANUFACTURER_KEY to appBuildConfig.manufacturer,
+                    MODEL_KEY to if (appBuildConfig.flavor.isInternal()) appBuildConfig.model else "redacted",
+                    OS_KEY to appBuildConfig.sdkInt.toString(),
+                    RESTARTED_KEY to restarted.toString(),
+                    BAD_HEALTH_DATA_KEY to encodedData,
                 )
             )
             delay(1000)
+        }
+    }
+
+    private fun sendPixelIfBadHealthResolved(lastState: AppHealthState?) {
+        if (lastState == null || lastState.type == GOOD_HEALTH) return
+
+        // if restarted occurred less than RESTART_BAKE_TIME_SECONDS ago we consider it resolved the issue
+        val nowEpochSeconds = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+        val restartedWhenEpochSeconds = lastState.restartedAtEpochSeconds ?: Long.MAX_VALUE
+        val resolvedByRestart = (nowEpochSeconds - restartedWhenEpochSeconds) < RESTART_BAKE_TIME_SECONDS
+
+        val encodedData = Base64.encodeToString(
+            lastState.healthDataJsonString.toByteArray(), Base64.NO_WRAP or Base64.NO_PADDING or Base64.URL_SAFE,
+        )
+
+        if (resolvedByRestart) {
+            deviceShieldPixels.badHealthResolvedByRestart(
+                mapOf(
+                    MANUFACTURER_KEY to appBuildConfig.manufacturer,
+                    MODEL_KEY to if (appBuildConfig.flavor.isInternal()) appBuildConfig.model else "redacted",
+                    OS_KEY to appBuildConfig.sdkInt.toString(),
+                    RESOLVED_BAD_HEALTH_DATA_KEY to encodedData,
+                )
+            )
+        } else {
+            deviceShieldPixels.badHealthResolvedItself(
+                mapOf(
+                    MANUFACTURER_KEY to appBuildConfig.manufacturer,
+                    MODEL_KEY to if (appBuildConfig.flavor.isInternal()) appBuildConfig.model else "redacted",
+                    OS_KEY to appBuildConfig.sdkInt.toString(),
+                    RESOLVED_BAD_HEALTH_DATA_KEY to encodedData,
+                )
+            )
         }
     }
 
@@ -208,6 +261,14 @@ class AppBadHealthStateHandler @Inject constructor(
         private const val FILENAME = "com.duckduckgo.mobile.android.vpn.app.health.state"
         private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
         private const val INITIAL_BACKOFF: Long = 0
-        private val INITIAL_BACKOFF_INCREMENT: Long = 1.minutes.inWholeSeconds
+        private const val INITIAL_BACKOFF_INCREMENT_SECONDS: Long = 30
+        private const val RESTART_BAKE_TIME_SECONDS = 45
+
+        private const val MANUFACTURER_KEY = "manufacturer"
+        private const val MODEL_KEY = "model"
+        private const val OS_KEY = "os"
+        private const val RESTARTED_KEY = "restarted"
+        private const val BAD_HEALTH_DATA_KEY = "badHealthData"
+        private const val RESOLVED_BAD_HEALTH_DATA_KEY = "resolvedBadHealthData"
     }
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppHealthMonitorManager.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppHealthMonitorManager.kt
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.vpn.internal.feature.health
+package com.duckduckgo.mobile.android.vpn.health
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.health.AppHealthMonitor
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.service.VpnStopReason
 import com.squareup.anvil.annotations.ContributesMultibinding

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -127,6 +127,12 @@ enum class DeviceShieldPixelNames(override val pixelName: String) : Pixel.PixelN
     ATP_APP_BREAKAGE_REPORT_UNIQUE("m_atp_breakage_report_u"),
     ATP_APP_HEALTH_MONITOR_REPORT("m_atp_health_monitor_report"),
     ATP_APP_HEALTH_ALERT_DAILY("m_atp_health_alert_%s_d"),
+    ATP_APP_BAD_HEALTH_RESOLVED_BY_RESTART("m_atp_bad_health_resolved_by_restart_c"),
+    ATP_APP_BAD_HEALTH_RESOLVED_BY_RESTART_DAILY("m_atp_bad_health_resolved_by_restart_d"),
+    ATP_APP_BAD_HEALTH_RESOLVED_ITSELF("m_atp_bad_health_resolved_itself_c"),
+    ATP_APP_BAD_HEALTH_RESOLVED_ITSELF_DAILY("m_atp_bad_health_resolved_itself_d"),
+    ATP_DID_RESTART_VPN_ON_BAD_HEALTH("m_atp_did_restart_vpn_on_bad_health_c"),
+    ATP_DID_RESTART_VPN_ON_BAD_HEALTH_DAILY("m_atp_did_restart_vpn_on_bad_health_d"),
 
     ATP_ENCRYPTED_IO_EXCEPTION("m_atp_ev_encrypted_io_error_c"),
     ATP_ENCRYPTED_GENERAL_EXCEPTION("m_atp_ev_encrypted_error_c"),

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -292,6 +292,21 @@ interface DeviceShieldPixels {
      * Will fire when the VPN receives a packet of unknown protocol
      */
     fun sendUnknownPacketProtocol(protocol: Int)
+
+    /**
+     * Will fire when the VPN detected bad health, restarted and fixex the bad health
+     */
+    fun badHealthResolvedByRestart(data: Map<String, String>)
+
+    /**
+     * Will fire when the VPN detected bad health but it resolved itself
+     */
+    fun badHealthResolvedItself(data: Map<String, String>)
+
+    /**
+     * Will fire when the VPN restarted as a result of a bad health mitigation
+     */
+    fun didRestartVpnOnBadHealth()
 }
 
 @ContributesBinding(AppScope::class)
@@ -591,6 +606,21 @@ class RealDeviceShieldPixels @Inject constructor(
 
     override fun sendUnknownPacketProtocol(protocol: Int) {
         firePixel(String.format(Locale.US, DeviceShieldPixelNames.ATP_RECEIVED_UNKNOWN_PACKET_PROTOCOL.pixelName, protocol))
+    }
+
+    override fun badHealthResolvedByRestart(data: Map<String, String>) {
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_APP_BAD_HEALTH_RESOLVED_BY_RESTART_DAILY, data)
+        firePixel(DeviceShieldPixelNames.ATP_APP_BAD_HEALTH_RESOLVED_BY_RESTART, data)
+    }
+
+    override fun badHealthResolvedItself(data: Map<String, String>) {
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_APP_BAD_HEALTH_RESOLVED_ITSELF_DAILY, data)
+        firePixel(DeviceShieldPixelNames.ATP_APP_BAD_HEALTH_RESOLVED_ITSELF, data)
+    }
+
+    override fun didRestartVpnOnBadHealth() {
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_DID_RESTART_VPN_ON_BAD_HEALTH_DAILY)
+        firePixel(DeviceShieldPixelNames.ATP_DID_RESTART_VPN_ON_BAD_HEALTH)
     }
 
     private fun suddenKill() {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/TunPacketWriter.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/TunPacketWriter.kt
@@ -82,7 +82,7 @@ class TunPacketWriter @AssistedInject constructor(
         } catch (e: IOException) {
             Timber.w(e, "Failed writing to the TUN")
             bufferFromNetwork.rewind()
-            Timber.d("Failed writing to the TUN. Buffer: ${bufferFromNetwork.toByteString().hex()}")
+            Timber.d("Failed writing to the TUN. Buffer: %s", bufferFromNetwork.toByteString().hex())
             healthMetricCounter.onTunWriteIOException()
         } finally {
             ByteBufferPool.release(bufferFromNetwork)

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/health/AppHealthMonitorManagerTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/health/AppHealthMonitorManagerTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.health
+
+import com.duckduckgo.mobile.android.vpn.service.VpnStopReason
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+
+class AppHealthMonitorManagerTest {
+
+    @Mock private lateinit var appHealthMonitor: AppHealthMonitor
+
+    private lateinit var appHealthMonitorManager: AppHealthMonitorManager
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+
+        appHealthMonitorManager = AppHealthMonitorManager(appHealthMonitor)
+    }
+
+    @Test
+    fun whenOnVpnStartedThenStartMonitoring() {
+        appHealthMonitorManager.onVpnStarted(TestCoroutineScope())
+
+        verify(appHealthMonitor).startMonitoring()
+        verifyNoMoreInteractions(appHealthMonitor)
+    }
+
+    @Test
+    fun whenOnVpnStoppedThenStopMonitoring() {
+        appHealthMonitorManager.onVpnStopped(TestCoroutineScope(), VpnStopReason.SelfStop)
+
+        verify(appHealthMonitor).stopMonitoring()
+        verifyNoMoreInteractions(appHealthMonitor)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: 
* https://app.asana.com/0/0/1201677777496526/f
* https://app.asana.com/0/0/1201677777496524/f
* https://app.asana.com/0/0/1201711685020933/f

### Description
This PR enables the bad health mitigation in production (Play flavor) and adds some instrumentations

### Steps to test this PR

_Test mitigation is enabled in production_
- [ ] Just pass tests below

_Test first-ever breakage report pixel_
- [x] fresh install from this branch the PlayDebug flavor
- [x] open app and enable AppTP
- [x] report any app
- [x] verify the `m_atp_breakage_report_u` is sent that it contains the same metadata information as `m_atp_breakage_report`

_Test bad health instrumentation_
- [x] Go to diagnostics screen (through the app tracking protection overflow menu) and click on "BAD HEALTH"
- [x] verify `m_atp_did_restart_vpn_on_bad_health_d` is sent
- [x] verify `m_atp_health_alert_tunReadAlerts_d` is sent
- [x] verify `m_atp_health_monitor_report` is sent and includes manufacturer, model, os, `restarted=true` and the `badHealthData`
- [x] verify that `model` is redacted
- [x] wait for 30s
- [x] verify the `m_atp_health_monitor_report` is sent and includes `restarted=true`
- [x] wait for 30s
- [x] verify the `m_atp_health_monitor_report` is sent and includes `restarted=false`
- [x] wait for 30s
- [x] verify the `m_atp_health_monitor_report` is sent and includes `restarted=true`
- [x] go to diagnostics screen click `NO SIMULATION`
- [x] verify `m_atp_bad_health_resolved_by_restart_c` and `m_atp_bad_health_resolved_by_restart_d` were sent and both contain `manufacturer`, `model` and `os`
- [x] verify that model is `redacted`
- [x] wait until bad health state disappears
- [x] go to diagnostics screen and click on `BAD HEALTH`
- [x] wait until `m_atp_health_monitor_report` is sent where `restarted=false`
- [x] go to diagnostics and click on `NO SIMULATION`
- [x] wait and verify that `m_atp_bad_health_resolved_itself_d` and `m_atp_bad_health_resolved_itself_c` are sent and both contain manufacturer, model, os and resolvedBadHealthData
- [x] verify that `model` is `redacted`
