### PR TITLE
Enable access to AppTP to Internal users

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_ANIMATION
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.BuildFlavor.INTERNAL
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/AtpWaitlistStateRepository.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/AtpWaitlistStateRepository.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.mobile.android.vpn.waitlist.store
 
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.BuildFlavor.INTERNAL
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.waitlist.AppTrackingProtectionWaitlistDataStore
 import com.squareup.anvil.annotations.ContributesBinding
@@ -29,10 +31,14 @@ interface AtpWaitlistStateRepository {
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class WaitlistStateRepository @Inject constructor(
-    private val dataStore: AppTrackingProtectionWaitlistDataStore
+    private val dataStore: AppTrackingProtectionWaitlistDataStore,
+    private val appBuildConfig: AppBuildConfig
 ) : AtpWaitlistStateRepository {
 
     override fun getState(): WaitlistState {
+        if (appBuildConfig.flavor == INTERNAL){
+            return WaitlistState.InBeta
+        }
         if (didJoinBeta()) {
             return WaitlistState.InBeta
         }


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/488551667048375/1201734657760137

### Description
With the latest release we accidentally restricted the access to AppTP to internal users. 
This PR fixes that

### Steps to test this PR

_Launch in Internal Flavor_
- [ ] From Settings, tap App Tracking Protection
- [ ] Onboarding / Trackers screen should appear

_Launch in Play Flavor_
- [ ] From Settings, tap App Tracking Protectiojn
- [ ] Waitlist screen should appear
