### PR TITLE
Feature/david/apptp waitlist survey cut date

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/survey/api/SurveyDownloaderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/survey/api/SurveyDownloaderTest.kt
@@ -56,7 +56,7 @@ class SurveyDownloaderTest {
     }
 
     @Test
-    fun whenAppTpSurveyContainsSurveyThenReturnAppTpSurvey() {
+    fun whenAppTpSurveyContainsSurveyAndUserJoinedAfterCutDateThenReturnAppTpSurvey() {
         val mockAppTPCall = mock<Call<SurveyGroup?>>()
         whenever(mockAppTPCall.execute()).thenReturn(Response.success(surveyWithAllocation("abc")))
         whenever(mockService.surveyAppTp()).thenReturn(mockAppTPCall)
@@ -69,16 +69,32 @@ class SurveyDownloaderTest {
     }
 
     @Test
-    fun whenAppTpSurveyContainsWaitlistSurveyAndUserHasJoinedWaitlistThenReturnAppTpWaitlistSurvey() {
+    fun whenAppTpSurveyContainsWaitlistSurveyAndUserHasJoinedWaitlistAfterCutDateThenReturnAppTpWaitlistSurvey() {
         val mockAppTPCall = mock<Call<SurveyGroup?>>()
         whenever(mockAppTPCall.execute()).thenReturn(Response.success(surveyWithAllocationForAppTPWaitlist("abc")))
         whenever(mockService.surveyAppTp()).thenReturn(mockAppTPCall)
         whenever(mockAtpWaitlistState.getState()).thenReturn(WaitlistState.JoinedWaitlist(true))
+        whenever(mockAtpWaitlistState.joinedAfterCuttingDate()).thenReturn(true)
 
         testee.download().blockingAwait()
 
         verify(mockService, never()).survey()
         verify(mockDao).insert(Survey("abc", SURVEY_URL, 7, SCHEDULED))
+        verify(mockDao).deleteUnusedSurveys()
+    }
+
+    @Test
+    fun whenAppTpSurveyContainsWaitlistSurveyAndUserHasJoinedWaitlistBeforeCutDateThenReturnAppTpWaitlistSurvey() {
+        val mockAppTPCall = mock<Call<SurveyGroup?>>()
+        whenever(mockAppTPCall.execute()).thenReturn(Response.success(surveyWithAllocationForAppTPWaitlist("abc")))
+        whenever(mockService.surveyAppTp()).thenReturn(mockAppTPCall)
+        whenever(mockAtpWaitlistState.getState()).thenReturn(WaitlistState.JoinedWaitlist(true))
+        whenever(mockAtpWaitlistState.joinedAfterCuttingDate()).thenReturn(false)
+
+        testee.download().blockingAwait()
+
+        verify(mockService, never()).survey()
+        verify(mockDao, never()).insert(any())
         verify(mockDao).deleteUnusedSurveys()
     }
 
@@ -178,6 +194,7 @@ class SurveyDownloaderTest {
         whenever(mockAtpCohortManager.getCohort()).thenReturn("cohort")
         whenever(mockCall.execute()).thenReturn(Response.success(surveyWithAllocationForAtp("abc")))
         whenever(mockService.survey()).thenReturn(mockCall)
+
         testee.download().blockingAwait()
         verify(mockDao).insert(Survey("abc", SURVEY_URL_WITH_ATP_COHORT, -1, SCHEDULED))
     }

--- a/app/src/main/java/com/duckduckgo/app/survey/api/SurveyDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/api/SurveyDownloader.kt
@@ -135,9 +135,9 @@ class SurveyDownloader @Inject constructor(
             emailManager.isSignedIn()
         } else if (surveyOption.isAtpWaitlistRequired == true) {
             // we only want users that have joined the waitlist after the cutting date 24.12.2021 and haven't joined the Beta yet
-            atpWaitlistStateRepository.getState() is WaitlistState.JoinedWaitlist
-                && atpWaitlistStateRepository.joinedAfterCuttingDate()
-                && atpCohortManager.getCohort() == null
+            atpWaitlistStateRepository.getState() is WaitlistState.JoinedWaitlist &&
+                atpWaitlistStateRepository.joinedAfterCuttingDate() &&
+                atpCohortManager.getCohort() == null
         } else if (surveyOption.isAtpEverEnabledRequired == true) {
             atpCohortManager.getCohort() != null
         } else {

--- a/app/src/main/java/com/duckduckgo/app/survey/api/SurveyDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/api/SurveyDownloader.kt
@@ -134,8 +134,10 @@ class SurveyDownloader @Inject constructor(
         return if (surveyOption.isEmailSignedInRequired == true) {
             emailManager.isSignedIn()
         } else if (surveyOption.isAtpWaitlistRequired == true) {
-            // we only want users that have joined the waitlist and haven't joined the Beta yet
-            atpWaitlistStateRepository.getState() is WaitlistState.JoinedWaitlist && atpCohortManager.getCohort() == null
+            // we only want users that have joined the waitlist after the cutting date 24.12.2021 and haven't joined the Beta yet
+            atpWaitlistStateRepository.getState() is WaitlistState.JoinedWaitlist
+                && atpWaitlistStateRepository.joinedAfterCuttingDate()
+                && atpCohortManager.getCohort() == null
         } else if (surveyOption.isAtpEverEnabledRequired == true) {
             atpCohortManager.getCohort() != null
         } else {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/AtpWaitlistStateRepository.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/AtpWaitlistStateRepository.kt
@@ -44,7 +44,7 @@ class WaitlistStateRepository @Inject constructor(
     }
 
     override fun joinedAfterCuttingDate(): Boolean {
-       return dataStore.waitlistTimestamp > CUTTING_DATE
+        return dataStore.waitlistTimestamp > CUTTING_DATE
     }
 
     private fun didJoinBeta(): Boolean = dataStore.inviteCode != null

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/AtpWaitlistStateRepository.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/AtpWaitlistStateRepository.kt
@@ -44,7 +44,7 @@ class WaitlistStateRepository @Inject constructor(
     }
 
     override fun joinedAfterCuttingDate(): Boolean {
-        return dataStore.waitlistTimestamp > CUTTING_DATE
+        return dataStore.waitlistTimestamp > CUTOFF_DATE
     }
 
     private fun didJoinBeta(): Boolean = dataStore.inviteCode != null
@@ -52,7 +52,8 @@ class WaitlistStateRepository @Inject constructor(
     private fun didJoinWaitlist(): Boolean = dataStore.waitlistTimestamp != -1 && dataStore.waitlistToken != null
 
     companion object {
-        const val CUTTING_DATE = 1640380128
+        // Cutoff date set to 1/1/2022 https://app.asana.com/0/1174433894299346/1201742199841250
+        const val CUTOFF_DATE = 1641071328
     }
 }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/AtpWaitlistStateRepository.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/waitlist/store/AtpWaitlistStateRepository.kt
@@ -24,6 +24,7 @@ import javax.inject.Inject
 
 interface AtpWaitlistStateRepository {
     fun getState(): WaitlistState
+    fun joinedAfterCuttingDate(): Boolean
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -42,9 +43,17 @@ class WaitlistStateRepository @Inject constructor(
         return WaitlistState.NotJoinedQueue
     }
 
-    fun didJoinBeta(): Boolean = dataStore.inviteCode != null
+    override fun joinedAfterCuttingDate(): Boolean {
+       return dataStore.waitlistTimestamp > CUTTING_DATE
+    }
 
-    fun didJoinWaitlist(): Boolean = dataStore.waitlistTimestamp != -1 && dataStore.waitlistToken != null
+    private fun didJoinBeta(): Boolean = dataStore.inviteCode != null
+
+    private fun didJoinWaitlist(): Boolean = dataStore.waitlistTimestamp != -1 && dataStore.waitlistToken != null
+
+    companion object {
+        const val CUTTING_DATE = 1640380128
+    }
 }
 
 sealed class WaitlistState {

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/waitlist/store/WaitlistStateRepositoryTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/waitlist/store/WaitlistStateRepositoryTest.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.mobile.android.vpn.waitlist.store
 
-import com.duckduckgo.mobile.android.vpn.processor.tcp.TcpSocketWriter
 import com.duckduckgo.mobile.android.vpn.waitlist.AppTrackingProtectionWaitlistDataStore
 import org.junit.Assert.*
 import org.junit.Test

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/waitlist/store/WaitlistStateRepositoryTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/waitlist/store/WaitlistStateRepositoryTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.waitlist.store
+
+import com.duckduckgo.mobile.android.vpn.processor.tcp.TcpSocketWriter
+import com.duckduckgo.mobile.android.vpn.waitlist.AppTrackingProtectionWaitlistDataStore
+import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class WaitlistStateRepositoryTest {
+
+    private val dataStore: AppTrackingProtectionWaitlistDataStore = mock()
+    private val testee = WaitlistStateRepository(dataStore)
+
+    @Test
+    fun whenGettingStateAndUserInBetaTheReturnInBeta() {
+        whenever(dataStore.inviteCode).thenReturn("inviteCode")
+
+        val state = testee.getState()
+
+        assertEquals(WaitlistState.InBeta, state)
+    }
+
+    @Test
+    fun whenGettingStateAndUserJoinedWaitlistTheReturnJoinedWaitlist() {
+        whenever(dataStore.inviteCode).thenReturn(null)
+        whenever(dataStore.waitlistTimestamp).thenReturn(1643404916)
+        whenever(dataStore.waitlistToken).thenReturn("someToken")
+
+        val state = testee.getState()
+
+        assertTrue(state is WaitlistState.JoinedWaitlist)
+    }
+
+    @Test
+    fun whenGettingStateAndUserNotIntBetaOrWaitlistTheReturnNotJoinedQueue() {
+        whenever(dataStore.waitlistTimestamp).thenReturn(-1)
+        whenever(dataStore.waitlistToken).thenReturn(null)
+
+        val state = testee.getState()
+
+        assertEquals(WaitlistState.NotJoinedQueue, state)
+    }
+
+    @Test
+    fun whenUserJoinedWaitlistAfterCuttingEdgeThenReturnsTrue() {
+        whenever(dataStore.waitlistTimestamp).thenReturn(1643404916)
+
+        assertTrue(testee.joinedAfterCuttingDate())
+    }
+
+    @Test
+    fun whenUserJoinedWaitlistBeforeCuttingEdgeThenReturnsFalse() {
+        whenever(dataStore.waitlistTimestamp).thenReturn(1639343328)
+
+        assertFalse(testee.joinedAfterCuttingDate())
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1174433894299346/1201742199841250

### Description

- We want to limit the amount of users that will see survey
- Based on current numbers / participation %, showing it to 20k users will give us the 1.5k responses we need
- As of today, 20k people have joined the waitlist after 1/1/2022

This PR adds a cutoff date to the survey implementation, so only users that joined the waitlist after 1/1/2022 see it.

### Steps to test this PR

_Join waitlist after cutoff date (run in playDebug flavor)_
- [x] Change `SurveyService `and point appTP to the sandbox environment
- [x] Open app and join the AppTP waitlist
- [x] Close the app and open it again
- [x] Verify that survey is enabled

_Join waitlist after cutoff date (run in playDebug flavor)_
- [x] Change `SurveyService `and point appTP to the sandbox environment
- [x] Modify the AppTrackingProtectionWaitlistDataStore waitlistTimestamp to 1613623997 (Feb last year)
- [x] Modify the AppTrackingProtectionWaitlistDataStore waitlistToken to "someToken"
- [x] Open app and join the AppTP waitlist
- [x] Close the app and open it again
- [x] Verify that survey is not showing