### PR TITLE
Faster VPN bring-up

### DIFF
--- a/vpn-main/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnStateCallbackServiceComponent.kt
+++ b/vpn-main/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnStateCallbackServiceComponent.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.di
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.VpnScope
+import com.duckduckgo.mobile.android.vpn.service.state.VpnStateMonitorService
+import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.anvil.annotations.MergeSubcomponent
+import dagger.Binds
+import dagger.Module
+import dagger.SingleInstanceIn
+import dagger.Subcomponent
+import dagger.android.AndroidInjector
+import dagger.multibindings.ClassKey
+import dagger.multibindings.IntoMap
+
+@SingleInstanceIn(VpnScope::class)
+@MergeSubcomponent(
+    scope = VpnScope::class
+)
+interface VpnStateCallbackServiceComponent : AndroidInjector<VpnStateMonitorService> {
+    @Subcomponent.Factory
+    interface Factory : AndroidInjector.Factory<VpnStateMonitorService>
+}
+
+@ContributesTo(AppScope::class)
+interface VpnStateCallbackServiceComponentProvider {
+    fun provideVpnStateCallbackServiceComponentFactory(): VpnStateCallbackServiceComponent.Factory
+}
+
+@Module
+@ContributesTo(AppScope::class)
+abstract class VpnStateCallbackServiceBindingModule {
+    @Binds
+    @IntoMap
+    @ClassKey(VpnStateMonitorService::class)
+    abstract fun VpnStateCallbackServiceComponent.Factory.bind(): AndroidInjector.Factory<*>
+}

--- a/vpn/src/main/AndroidManifest.xml
+++ b/vpn/src/main/AndroidManifest.xml
@@ -100,6 +100,10 @@
             android:screenOrientation="portrait"/>
 
         <service
+            android:name=".service.state.VpnStateMonitorService" >
+        </service>
+
+        <service
             android:name=".service.TrackerBlockingVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:process=":vpn">

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/VpnStateMonitorService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/VpnStateMonitorService.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service.state
+
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+import androidx.annotation.WorkerThread
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.mobile.android.vpn.dao.HeartBeatEntity
+import com.duckduckgo.mobile.android.vpn.heartbeat.VpnServiceHeartbeatMonitor
+import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
+import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
+import dagger.android.AndroidInjection
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+class VpnStateMonitorService : Service() {
+
+    @Inject lateinit var vpnDatabase: VpnDatabase
+
+    @Inject
+    @AppCoroutineScope lateinit var coroutineScope: CoroutineScope
+
+    @Inject lateinit var dispatcherProvider: DispatcherProvider
+
+    private val binder = Binder()
+
+    override fun onCreate() {
+        super.onCreate()
+        AndroidInjection.inject(this)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        Timber.d("Bound to VPN")
+        return binder
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        Timber.d("Unbound from VPN")
+        return super.onUnbind(intent)
+    }
+
+    override fun onDestroy() {
+        Timber.d("onDestroy")
+        coroutineScope.launch(dispatcherProvider.io()) {
+            vpnBringUpIfSuddenKill()
+        }
+        super.onDestroy()
+    }
+
+    @WorkerThread
+    private fun vpnBringUpIfSuddenKill() {
+        val lastHearBeat = vpnDatabase.vpnHeartBeatDao().hearBeats().maxByOrNull { it.timestamp }
+        if (true == lastHearBeat?.isAlive()) {
+            Timber.d("Sudden stop, restarting VPN")
+            TrackerBlockingVpnService.startService(applicationContext)
+        } else {
+            Timber.d("No need to restart the VPN")
+        }
+    }
+
+    private fun HeartBeatEntity.isAlive(): Boolean {
+        return VpnServiceHeartbeatMonitor.DATA_HEART_BEAT_TYPE_ALIVE == type
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201711685020940/f

### Description
Currently it is the HeartBeat that detects when the VPN has been killed for reasons other than user intent or revokes. In such cases the HB will bring the VPN back up.
The HB is a worker, and so it is the scheduled periodically every 15min (min period supported for work manager).
The main issu with that approach is that many users may noticed the VPN switched off (as a result of VPN process killed) way before the HB had the time to bring it back up.

This PR uses a complementary new way to bring-up the VPN upon sudden kill.
* Added a new service `VpnStateMonitorService`
* The `TrackerBlockingVpnService` will bind to the new `VpnStateMonitorService` when started and stopped (or killed)
* Every time the binding is broken, the `VpnStateMonitorService` will get notified
* The `VpnStateMonitorService` will then use the same logic used in the HB to decide whether it needs to bring te VPN back up

To make sure it all works as expected, the `VpnStateMonitorService` runs in the browser process, similar to what happens with the HB.

### Steps to test this PR

_Test sudden VPN process kill_
- [x] install from this branch
- [x] enable AppTP
- [x] Verify `D/VpnStateMonitorService: Bound to VPN` message appears in logcat
- [x] use Android Studio or Intellij to kill just the `vpn` process. For that, open logcat, and select the `:vpn` process, then click on the 🟥 in the logcat window
- [x] verify the `D/VpnStateMonitorService: Sudden stop, restarting VPN` appears in logcat
- [x] verify AppTP is re-enabled

_Test user-initiated VPN switch-off_
- [x] enable AppTP
- [x] manually disable AppTP
- [x] verify the `D/VpnStateMonitorService: Nah, all good` log appears in logcat
- [x] verify AppTP stays disabled

_Test VPN revoke switch-off_
- [x] enable AppTP
- [x] enable another VPN to force a revoke
- [x] verify the `D/VpnStateMonitorService: Nah, all good` log appears in logcat
- [x] verify AppTP stays disabled
