### PR TITLE
added priority and reboot intent to the HB

### DIFF
--- a/vpn/src/main/AndroidManifest.xml
+++ b/vpn/src/main/AndroidManifest.xml
@@ -138,8 +138,9 @@
             android:name=".heartbeat.VpnHeartbeatDeviceBootMonitor"
             android:enabled="false"
             android:process=":vpn">
-            <intent-filter>
+            <intent-filter android:priority="999">
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.REBOOT" />
             </intent-filter>
         </receiver>
 


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1157893581871903/1201759869770201

### Description
Our HB is currently listening to the [ACTION_BOOT_COMPLETED](https://developer.android.com/reference/android/content/Intent#ACTION_BOOT_COMPLETED) intent, which tells us that the device has finished booting. 

There is another intent, [ACTION_REBOOT](https://developer.android.com/reference/android/content/Intent#ACTION_REBOOT), that is called by system apps after the phone has finished rebooting.

The theory is that we might be missing device restarts that could be used to restart our VPN.  [Other VPNs are listening to both of these intents with high priority](https://developer.android.com/reference/android/content/Intent#ACTION_REBOOT), therefore being able to start their service before ours.
