### PR TITLE
Add buffer alloc health metrics

### DIFF
--- a/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppHealthCallback.kt
+++ b/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppHealthCallback.kt
@@ -37,7 +37,8 @@ data class SystemHealthData(
 data class RawMetricsSubmission(
     val name: String,
     val metrics: Map<String, Metric> = emptyMap(),
-    val redacted: Boolean = false
+    val redacted: Boolean = false,
+    val informational: Boolean = false,
 )
 
 data class Metric(

--- a/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandlerTest.kt
+++ b/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandlerTest.kt
@@ -90,7 +90,8 @@ class AppBadHealthStateHandlerTest {
         assertEquals(listOf("alert"), state?.alerts)
         assertEquals(
             "{\"alerts\":[\"alert\"],\"systemHealth\":{\"isBadHealth\":true,\"rawMetrics\"" +
-                ":[{\"metrics\":{\"metric\":{\"isBadState\":true,\"value\":\"value\"}},\"name\":\"rawMetric\",\"redacted\":false}]}}",
+                ":[{\"informational\":false,\"metrics\":{\"metric\":{\"isBadState\":true,\"value\":\"value\"}}" +
+                ",\"name\":\"rawMetric\",\"redacted\":false}]}}",
             state?.healthDataJsonString
         )
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
@@ -101,7 +101,9 @@ class AppBadHealthStateHandler @Inject constructor(
 
                 // we don't include raw metrics marked as "redacted" as they can contain information that could
                 // be used to fingerprint.
-                val (badHealthMetrics, _) = appHealthData.systemHealth.rawMetrics.partition { it.isInBadHealth() && !it.redacted }
+                val (badHealthMetrics, _) = appHealthData.systemHealth.rawMetrics.partition {
+                    (it.isInBadHealth() || it.informational) && !it.redacted
+                }
                 val badHealthData = appHealthData.copy(systemHealth = appHealthData.systemHealth.copy(rawMetrics = badHealthMetrics))
                 val jsonAdapter = Moshi.Builder().build().run {
                     adapter(AppHealthData::class.java)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
@@ -81,6 +81,16 @@ class HealthClassifier @Inject constructor(val applicationContext: Context) {
         return if (metricSummary.isInBadHealth()) BadHealth(metricSummary) else GoodHealth(metricSummary)
     }
 
+    fun determineHealthBufferAllocations(bufferAllocations: Long): HealthState {
+        val rawMetrics = mutableMapOf<String, Metric>()
+        val metricSummary = RawMetricsSubmission("buffer-allocations", rawMetrics, informational = true)
+
+        // never trigger an alert for this. We just one the info
+        rawMetrics["numberAllocations"] = Metric(bufferAllocations.toString(), badHealthIf { false })
+
+        return if (metricSummary.isInBadHealth()) BadHealth(metricSummary) else GoodHealth(metricSummary)
+    }
+
     fun determineHealthMemory(): HealthState {
         val rawMetrics = mutableMapOf<String, Metric>()
         val metricSummary = RawMetricsSubmission("memory", rawMetrics, redacted = true)

--- a/vpn/src/main/java/dummy/ui/VpnDiagnosticsActivity.kt
+++ b/vpn/src/main/java/dummy/ui/VpnDiagnosticsActivity.kt
@@ -84,6 +84,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import xyz.hexene.localvpn.ByteBufferPool
 
 class VpnDiagnosticsActivity : DuckDuckGoActivity(), CoroutineScope by MainScope() {
 
@@ -291,6 +292,13 @@ class VpnDiagnosticsActivity : DuckDuckGoActivity(), CoroutineScope by MainScope
             ),
         )
 
+        healthMetricsStrings.add(
+            String.format(
+                "\n\nBuffer allocations: %d",
+                healthMetricsInfo.bufferAllocations,
+            ),
+        )
+
         val sb = StringBuilder()
         healthMetricsStrings.forEach { sb.append(it) }
 
@@ -332,6 +340,7 @@ class VpnDiagnosticsActivity : DuckDuckGoActivity(), CoroutineScope by MainScope
         val socketConnectExceptions =
             healthMetricCounter.getStat(SOCKET_CHANNEL_CONNECT_EXCEPTION(), timeWindow)
         val tunWriteIOExceptions = healthMetricCounter.getStat(TUN_WRITE_IO_EXCEPTION(), timeWindow)
+        val bufferAllocations = ByteBufferPool.allocations.get()
 
         return HealthMetricsInfo(
             tunPacketReceived = tunPacketReceived,
@@ -346,6 +355,7 @@ class VpnDiagnosticsActivity : DuckDuckGoActivity(), CoroutineScope by MainScope
             socketWriteExceptions = socketWriteExceptions,
             socketConnectException = socketConnectExceptions,
             tunWriteIOExceptions = tunWriteIOExceptions,
+            bufferAllocations = bufferAllocations
         )
     }
 
@@ -628,7 +638,8 @@ data class HealthMetricsInfo(
     val socketReadExceptions: Long,
     val socketWriteExceptions: Long,
     val socketConnectException: Long,
-    val tunWriteIOExceptions: Long
+    val tunWriteIOExceptions: Long,
+    val bufferAllocations: Long,
 )
 
 data class NetworkInfo(

--- a/vpn/src/main/java/xyz/hexene/localvpn/ByteBufferPool.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/ByteBufferPool.java
@@ -18,16 +18,19 @@ package xyz.hexene.localvpn;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ByteBufferPool {
     static final int BUFFER_SIZE = 16384; // XXX: Is this ideal?
     private static final ConcurrentLinkedQueue<ByteBuffer> pool = new ConcurrentLinkedQueue<>();
+    public static final AtomicLong allocations = new AtomicLong();
 
     public static ByteBuffer acquire() {
 
         ByteBuffer buffer = pool.poll();
         if (buffer == null) {
             buffer = ByteBuffer.allocateDirect(BUFFER_SIZE); // Using DirectBuffer for zero-copy
+            allocations.incrementAndGet();
         }
         buffer.clear();
         return buffer;
@@ -36,9 +39,22 @@ public class ByteBufferPool {
     public static void release(ByteBuffer buffer) {
         buffer.clear();
         pool.offer(buffer);
+        atomicUpdateAndGet(allocations, value -> value > 0 ? value - 1 : 0);
     }
 
     public static void clear() {
         pool.clear();
+    }
+
+    private static void atomicUpdateAndGet(AtomicLong atomicLong, UpdateAllocation updateFunction) {
+        long prev, next;
+        do {
+            prev = atomicLong.get();
+            next = updateFunction.applyUpdate(prev);
+        } while (!atomicLong.compareAndSet(prev, next));
+    }
+
+    private interface UpdateAllocation {
+        long applyUpdate(long operand);
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201752109049661/f

### Description
In order to monitor the impact of the upcoming memory leak fixes, we are instrumenting the AppTP buffer allocations to be sent in breakage reports.

### Steps to test this PR

_Feature 1_
- [x] Install from this branch
- [x] Enable AppTP
- [x] Go to diagnostics screen
- [x] Force some traffic through the VPN (eg. speed test?)
- [x] Verify the `buffer allocations` increase
- [x] click on `BAD HEALTH`
- [x] Wait until bad health happens
- [x] Verify the `numberAllocations` is included in the `badHealthData` object of the `m_atp_health_monitor_report` pixel

