### PR TITLE
Add FLAG_ACTIVITY_NEW_TASK to App Link Intents

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1011,6 +1011,7 @@ class BrowserTabFragment :
 
     private fun openAppLink(appLink: SpecialUrlDetector.UrlType.AppLink) {
         if (appLink.appIntent != null) {
+            appLink.appIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             startActivity(appLink.appIntent)
         } else if (appLink.excludedComponents != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val title = getString(R.string.appLinkIntentChooserTitle)
@@ -1032,6 +1033,7 @@ class BrowserTabFragment :
         excludedComponents: List<ComponentName>
     ): Intent {
         val urlIntent = Intent.parseUri(url, Intent.URI_ANDROID_APP_SCHEME)
+        urlIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         val chooserIntent = Intent.createChooser(urlIntent, title)
         chooserIntent.putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludedComponents.toTypedArray())
         return chooserIntent


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201757992830589/f

### Description
App Links will now open in a new task. This resolves some usability issues with certain App Links.

### Steps to test this PR

- [ ] Type "google maps" in the search bar.
- [ ] Click the Google Maps link in SERP.
- [ ] Select "Open in app" from the Snackbar.
- [ ] Verify that the App Link opens correctly.
- [ ] Navigate back.
- [ ] Verify that you are navigated back to DuckDuckGo.
