### PR TITLE
Fix native memory leaks

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpSocketWriter.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpSocketWriter.kt
@@ -29,6 +29,7 @@ import dagger.Module
 import dagger.SingleInstanceIn
 import dagger.multibindings.IntoSet
 import timber.log.Timber
+import xyz.hexene.localvpn.ByteBufferPool
 import xyz.hexene.localvpn.Packet
 import xyz.hexene.localvpn.TCB
 import java.nio.ByteBuffer
@@ -172,6 +173,7 @@ class RealTcpSocketWriter @Inject constructor(
             tcb.acknowledgementNumberToClient,
             0
         )
+        ByteBufferPool.release(writeData.payloadBuffer)
         queues.networkToDevice.offer(responseBuffer)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201748194657736/f

### Description
After auditing the AppTP runtime, [these](https://app.asana.com/0/0/1201778487362550/f) are the memory leaks we've found. Basically places where the buffers need to be released because they're no longer in used, but they're not.

### Steps to test this PR

_Memory leak test_
- [x] install from develop
- [x] enable AppTP and go to diagnostics screen
- [x] Open apps that send trackers, even run speed tests
- [x] verify (diagnostics screen) how the `Buffer allocations` never go down to `0`
- [x] install from this branch
- [x] repeat steps above
- [x] verify how the `Buffer allocations` go eventually to `0`

_AppTP smoke tests_
- [x] install from this branch
- [x] enable AppTP and open some of you regular apps to see all works as expected, content loads, apps continue working etc.

