### PR TITLE
Allow onboarding pixel to be sent without cohort

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortPixelInterceptor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortPixelInterceptor.kt
@@ -38,7 +38,7 @@ class CohortPixelInterceptor @Inject constructor(
         val request = chain.request().newBuilder()
         val pixel = chain.request().url.pathSegments.last()
 
-        val url = if (pixel.startsWith(PIXEL_PREFIX)) {
+        val url = if (pixel.startsWith(PIXEL_PREFIX) && !EXCEPTIONS.any { exception -> pixel.startsWith(exception) }) {
             // IF there is no cohort for ATP we just drop the pixel request
             // ELSE we add the cohort param
             cohortStore.getCohortStoredLocalDate()?.let {
@@ -70,5 +70,8 @@ class CohortPixelInterceptor @Inject constructor(
     companion object {
         private const val COHORT_PARAM = "atp_cohort"
         private const val PIXEL_PREFIX = "m_atp_"
+        private val EXCEPTIONS = listOf(
+            "m_atp_ev_enabled_onboarding_",
+        )
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1201790503855341/f

### Description
Allow the onboarding pixel to be sent without AppTP cohort

### Steps to test this PR

_Test onboarding pixel_
- [x] fresh install from this branch
- [x] enable AppTP and complete onboarding
- [x] verify `m_atp_ev_enabled_onboarding_x` pixels are sent and that `Pixel URL request dropped` logcat messages are not sent
- [x] recommend to verify that pixels are sent using Charles

Doing the same test above in current develop would not send the pixel and `Pixel URL request dropped` would appear for all onboarding pixels
