### PR TITLE
Enable the VPN-process restart mitigation in production builds

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
@@ -185,7 +185,7 @@ class AppBadHealthStateHandler @Inject constructor(
     private suspend fun restartVpn(isCriticalBadHealth: Boolean) {
         // place this in a different job to ensure the restart completes successfully and nobody can cancel it by mistake
         appCoroutineScope.launch {
-            if (appBuildConfig.flavor.isInternal() && isCriticalBadHealth) {
+            if (isCriticalBadHealth) {
                 Timber.d("Internal build and critical bad health, killing VPN process...")
                 deviceShieldPixels.didRestartVpnProcessOnBadHealth()
                 // delay a bit to ensure pixel is sent. This is not great but our pixel API doesn't leave an option in this case


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201748194657735/f

### Description
* https://github.com/duckduckgo/Android/pull/1731 implemented the VPN-process restart mitigation for internal builds only
* This PR enables that in production builds

### Steps to test this PR

_Test VPN process restart_
- [x] Install from this branch the PLAY build
- [x] Launch app and enable AppTP
- [x] Filter logcat by `m_atp_did_restart_vpn`
- [x] Go to diagnostics settings
- [x] Click on `BAD HEALTH` button
- [x] Wait until VPN restarts
- [x] Verify the `m_atp_did_restart_vpn_process_on_bad_health_c/d` is NOT sent
- [x] Verify the `m_atp_did_restart_vpn_on_bad_health_c/d` is sent
- [x] Click on `CRITICAL HEALTH`
- [x] Wait until VPN process restarts (Diagnostics screen should be killed)
- [x] Verify the `m_atp_did_restart_vpn_process_on_bad_health_c/d` is sent
- [x] Verify the `m_atp_did_restart_vpn_on_bad_health_c/d` is NOT sent

