### PR TITLE
Tracker details screen should open feedback description form

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
@@ -109,7 +109,7 @@ class AppTPCompanyTrackersActivity : DuckDuckGoActivity() {
     }
 
     private fun launchFeedback() {
-        reportBreakage.launch(ReportBreakageScreen.LoginInformation(getAppName(), getPackage()))
+        reportBreakage.launch(ReportBreakageScreen.IssueDescriptionForm(getAppName(), getPackage()))
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1157893581871903/1201814886085130

### Description
When launch the feedback screen from the Tracker details screen we are showing the wrong page of the Feedback report journey. Instead of showing the Description form, we are showing the page that asks about the login information

This PR fixes it

### Steps to test this PR

- [x] Enable AppTP and open the tracker details screen
- [x] Tap on the overflow menu -> Report app
- [x] Check that the description form screen appears
