### PR TITLE
Fix crash in Most Recent Activity

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldMostRecentActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldMostRecentActivity.kt
@@ -21,13 +21,11 @@ import android.content.Intent
 import android.os.Bundle
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
-import com.duckduckgo.mobile.android.vpn.R
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityDeviceShieldAllTracerActivityBinding
 
 class DeviceShieldMostRecentActivity : DuckDuckGoActivity() {
 
     private val binding: ActivityDeviceShieldAllTracerActivityBinding by viewBinding()
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldMostRecentActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldMostRecentActivity.kt
@@ -20,15 +20,20 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.databinding.ActivityDeviceShieldAllTracerActivityBinding
 
 class DeviceShieldMostRecentActivity : DuckDuckGoActivity() {
+
+    private val binding: ActivityDeviceShieldAllTracerActivityBinding by viewBinding()
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setContentView(R.layout.activity_device_shield_all_tracer_activity)
-        setupToolbar(findViewById(R.id.default_toolbar))
+        setContentView(binding.root)
+        setupToolbar(binding.includeToolbar.defaultToolbar)
     }
 
     override fun onBackPressed() {

--- a/vpn/src/main/res/layout/activity_device_shield_all_tracer_activity.xml
+++ b/vpn/src/main/res/layout/activity_device_shield_all_tracer_activity.xml
@@ -24,7 +24,9 @@
     android:orientation="vertical"
     tools:context="com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTrackerActivity">
 
-    <include layout="@layout/include_default_toolbar" />
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/activity_list"


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1157893581871903/1201814886085137

### Description
The Most Recent activity screen is crashing upon opening. The wrong view reference is being used.

### Steps to test this PR

- [x] Enable AppTP and have more than 5 apps with trackers blocked so Most Recent activity button is visible
- [x] Tap it
- [x] most Recent Activity screen should open
