### PR TITLE
Add badHealthDurationSeconds to the bad health reports

### DIFF
--- a/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.AppHealthDatabase/5.json
+++ b/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.AppHealthDatabase/5.json
@@ -1,0 +1,64 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "99643ae107f356a3a2b721b02bc09556",
+    "entities": [
+      {
+        "tableName": "app_health_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT NOT NULL, `localtime` TEXT NOT NULL, `alerts` TEXT NOT NULL, `healthDataJsonString` TEXT NOT NULL, `restartedAtEpochSeconds` INTEGER, `badHealthStartEpochSeconds` INTEGER, PRIMARY KEY(`type`))",
+        "fields": [
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localtime",
+            "columnName": "localtime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alerts",
+            "columnName": "alerts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "healthDataJsonString",
+            "columnName": "healthDataJsonString",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restartedAtEpochSeconds",
+            "columnName": "restartedAtEpochSeconds",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "badHealthStartEpochSeconds",
+            "columnName": "badHealthStartEpochSeconds",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "type"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '99643ae107f356a3a2b721b02bc09556')"
+    ]
+  }
+}

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/AppHealthState.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/AppHealthState.kt
@@ -29,6 +29,7 @@ data class AppHealthState(
     val alerts: List<String>,
     val healthDataJsonString: String,
     val restartedAtEpochSeconds: Long?,
+    val badHealthStartEpochSeconds: Long? = null,
 ) {
     object HealthEventTypeConverter {
         @TypeConverter

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/AppHealthDatabase.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/AppHealthDatabase.kt
@@ -29,7 +29,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 
 @Database(
-    exportSchema = true, version = 4,
+    exportSchema = true, version = 5,
     entities = [
         AppHealthState::class
     ]


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201814931393743/f

### Description
Adds the `badHealthDurationSeconds` parameter to the bad health pixel

### Steps to test this PR

_Test fresh install_
- [x] Fresh install from this branch
- [x] Enable AppTP
- [x] Go to diagnostics screen
- [x] click on `BAD HEALTH` button
- [x] filter logcat by `m_atp_bad_health_resolved|m_atp_did_` and wait for couple VPN restarts
- [x] click on `GOOD_HEALTH` button
- [x] wait until the `m_atp_bad_health_resolved_itself_c` appears 
- [x] verify the `m_atp_bad_health_resolved_itself_c` contains the `badHealthDurationSeconds` and that the duration corresponds with the time the bad health was sustained
- [x] repeat from step 4/ above and verify `badHealthDurationSeconds` again corresponds to the time bad health was sustained

_Test fresh install_
- [x] Install from develop and enable AppTP
- [x] Go to diagnostics screen and create some simulate some BAD_HEALT, GOOD_HEALTH
- [x] With AppTP enabled, Update from this branch
- [x] Launch the app, verify AppTP is enabled automatically (that means the db table update is correct)
- [x] Go to diagnostics screen
- [x] click on `BAD HEALTH` button
- [x] filter logcat by `m_atp_bad_health_resolved|m_atp_did_` and wait for couple VPN restarts
- [x] click on `GOOD_HEALTH` button
- [x] wait until the `m_atp_bad_health_resolved_itself_c` appears 
- [x] verify the `m_atp_bad_health_resolved_itself_c` contains the `badHealthDurationSeconds` and that the duration corresponds with the time the bad health was sustained
- [x] repeat from step 4/ above and verify `badHealthDurationSeconds` again corresponds to the time bad health was sustained

