### PR TITLE
Set TCP sockets as SO_REUSEADDR

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.mobile.android.vpn.service
 
+import android.annotation.SuppressLint
 import android.app.ActivityManager
 import android.app.Service
 import android.content.ComponentName
@@ -26,12 +27,14 @@ import android.content.pm.PackageManager
 import android.net.VpnService
 import android.os.Binder
 import android.os.Build
+import android.os.Build.VERSION_CODES
 import android.os.IBinder
 import android.os.Parcel
 import android.os.ParcelFileDescriptor
 import android.system.OsConstants.AF_INET6
 import androidx.core.content.ContextCompat
 import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.mobile.android.vpn.apps.TrackingProtectionAppsRepository
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.processor.TunPacketReader
@@ -52,6 +55,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
+import java.net.StandardSocketOptions
 import java.nio.channels.DatagramChannel
 import java.nio.channels.SocketChannel
 import java.util.concurrent.ExecutorService
@@ -103,6 +107,8 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
     @Inject
     lateinit var tunPacketWriterFactory: TunPacketWriter.Factory
     private var vpnStateServiceReference: IBinder? = null
+
+    @Inject lateinit var appBuildConfig: AppBuildConfig
 
     private val vpnStateServiceConnection = object : ServiceConnection {
         override fun onServiceConnected(
@@ -485,8 +491,12 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
         }
     }
 
+    @SuppressLint("NewApi") // because we use the appBuildConfig.sdkInt IDE doesn't detect it
     override fun createSocketChannel(): SocketChannel {
         return SocketChannel.open().also { channel ->
+            if (appBuildConfig.sdkInt >= VERSION_CODES.N) {
+                channel.setOption(StandardSocketOptions.SO_REUSEADDR, true)
+            }
             channel.configureBlocking(false)
             protect(channel.socket())
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201814931393813/f

### Description
Set the TCP sockets as SO_REUSEADDR to avoid connection failures due to stale sockets in TIME_WAIT state

### Steps to test this PR
smoke tests for AppTP
