### PR TITLE
Monitor network switches and set underlying networks in internal builds

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/network/connection/ConnectionMonitor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/network/connection/ConnectionMonitor.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.network.connection
+
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.HandlerThread
+import android.os.Message
+import com.duckduckgo.mobile.android.vpn.network.connection.Messages.MSG_ADD_ALL_NETWORKS
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+
+class ConnectionMonitor @AssistedInject constructor(
+    private val connectivityManager: ConnectivityManager?,
+    private val networkRequestHandlerFactory: NetworkRequestHandler.Factory,
+    @Assisted private val networkConnectionListener: NetworkConnectionListener,
+) : NetworkCallback() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(networkConnectionListener: NetworkConnectionListener): ConnectionMonitor
+    }
+
+    private var handlerThread: HandlerThread? = null
+    private var networkHandler: NetworkRequestHandler? = null
+
+    private val networkRequest: NetworkRequest = NetworkRequest.Builder()
+        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        .build()
+
+    override fun onAvailable(network: Network) {
+        Timber.d("onAvailable $network")
+        handleNetworkChange()
+    }
+
+    override fun onLost(network: Network) {
+        Timber.d("onLost $network")
+        handleNetworkChange()
+    }
+
+    fun onStartMonitoring() {
+        Timber.d("onStartMonitoring")
+        connectivityManager?.registerNetworkCallback(networkRequest, this)
+        // just in case it is called twice without calling onStopMonitoring()
+        tearDownNetworkHandler()
+
+        val handler = HandlerThread(NetworkRequestHandler::class.java.simpleName).apply { start() }
+        handlerThread = handler
+        networkHandler = networkRequestHandlerFactory.create(handler.looper, networkConnectionListener)
+    }
+
+    fun onSopMonitoring() {
+        Timber.d("onSopMonitoring")
+        connectivityManager?.safeUnregisterNetworkCallback(this)
+        tearDownNetworkHandler()
+    }
+
+    private fun tearDownNetworkHandler() {
+        handlerThread?.quitSafely()
+        handlerThread = null
+        networkHandler?.removeCallbacksAndMessages(null)
+        networkHandler = null
+    }
+
+    private fun handleNetworkChange() {
+        buildMessage(MSG_ADD_ALL_NETWORKS).run {
+            networkHandler?.removeMessages(this.what, null)
+            networkHandler?.sendMessage(this)
+        }
+    }
+
+    private fun buildMessage(what: Messages): Message {
+        val message = Message.obtain()
+        message.what = what.ordinal
+        return message
+    }
+
+    private fun ConnectivityManager.safeUnregisterNetworkCallback(networkCallback: NetworkCallback) {
+        kotlin.runCatching {
+            unregisterNetworkCallback(networkCallback)
+        }.onFailure {
+            Timber.e(it, "Error unregistering the network callback")
+        }
+    }
+
+}
+
+interface NetworkConnectionListener {
+    fun onNetworkDisconnected()
+    fun onNetworkConnected(networks: LinkedHashSet<Network>)
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/network/connection/NetworkRequestHandler.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/network/connection/NetworkRequestHandler.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.network.connection
+
+import android.annotation.SuppressLint
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build.VERSION_CODES
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+
+class NetworkRequestHandler @AssistedInject constructor(
+    private val connectivityManager: ConnectivityManager?,
+    private val appBuildConfig: AppBuildConfig,
+    @Assisted looper: Looper,
+    @Assisted private val networkConnectionListener: NetworkConnectionListener
+) : Handler(looper) {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            looper: Looper,
+            networkConnectionListener: NetworkConnectionListener
+        ): NetworkRequestHandler
+    }
+
+    var currentNetworks: LinkedHashSet<Network> = linkedSetOf()
+
+    override fun handleMessage(msg: Message) {
+        when (msg.what) {
+            Messages.MSG_ADD_ALL_NETWORKS.ordinal -> updateAllNetworks()
+            else -> {}
+        }
+    }
+
+    @SuppressLint("NewApi")
+    private fun updateAllNetworks() {
+        val newActiveNetwork = if (appBuildConfig.sdkInt >= VERSION_CODES.M) {
+            connectivityManager?.activeNetwork
+        } else {
+            null
+        }
+        val newNetworks = createNetworksSet(newActiveNetwork)
+        val didNetworksChange = !currentNetworks.toTypedArray().contentEquals(newNetworks.toTypedArray())
+        currentNetworks = newNetworks
+
+        Timber.d("networks: $newNetworks")
+
+        if (didNetworksChange && newNetworks.isNotEmpty()) {
+            networkConnectionListener.onNetworkConnected(newNetworks)
+        } else if (newNetworks.isEmpty()) {
+            networkConnectionListener.onNetworkDisconnected()
+        } else {
+            Timber.d("Networks didn't chance...noop")
+        }
+    }
+
+    private fun createNetworksSet(newActiveNetwork: Network?): LinkedHashSet<Network> {
+        return linkedSetOf<Network>().apply {
+            // first element of the list must be the active network
+            newActiveNetwork?.let { network ->
+                if (network.hasInternet() && !network.isVPN()) {
+                    add(network)
+                }
+            }
+
+            connectivityManager?.allNetworks?.forEach { network ->
+                if (network.hasInternet() && !network.isVPN()) {
+                    add(network)
+                }
+            }
+        }
+    }
+
+    private fun Network.hasInternet(): Boolean {
+        return connectivityManager?.getNetworkCapabilities(this)?.hasCapability(
+            NetworkCapabilities.NET_CAPABILITY_INTERNET
+        ) ?: false
+    }
+
+    private fun Network.isVPN(): Boolean {
+        return connectivityManager?.getNetworkCapabilities(this)?.hasTransport(
+            NetworkCapabilities.TRANSPORT_VPN
+        ) ?: false
+    }
+}
+
+enum class Messages {
+    // add all available networks as underlying vpn networks
+    MSG_ADD_ALL_NETWORKS,
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -237,7 +237,8 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
         }
 
         connectionMonitor?.onSopMonitoring()
-        connectionMonitor = connectionMonitorFactory.create(this@TrackerBlockingVpnService).apply { onStartMonitoring() }
+        connectionMonitor = connectionMonitorFactory.create(this@TrackerBlockingVpnService, this@TrackerBlockingVpnService)
+            .apply { onStartMonitoring() }
     }
 
     private suspend fun establishVpnInterface() {

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/network/connection/NetworkRequestHandlerTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/network/connection/NetworkRequestHandlerTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.network.connection
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
+import android.net.NetworkCapabilities.TRANSPORT_VPN
+import android.net.NetworkCapabilities.TRANSPORT_WIFI
+import android.os.Build.VERSION_CODES.M
+import android.os.Build.VERSION_CODES.P
+import android.os.Handler
+import android.os.Message
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.mobile.android.vpn.network.connection.Messages.MSG_ADD_ALL_NETWORKS
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.whenever
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowNetworkCapabilities
+
+@RunWith(AndroidJUnit4::class)
+@Config(minSdk = M, maxSdk = P)
+class NetworkRequestHandlerTest {
+    @Mock lateinit var appBuildConfig: AppBuildConfig
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+    private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private lateinit var networkRequestHandler: NetworkRequestHandler
+    private lateinit var listener: Listener
+    private lateinit var networkCapabilities: NetworkCapabilities
+
+    @Before fun setup() {
+        MockitoAnnotations.openMocks(this)
+
+        listener = Listener()
+
+        networkCapabilities = ShadowNetworkCapabilities.newInstance()
+        shadowOf(connectivityManager).setNetworkCapabilities(connectivityManager.activeNetwork, networkCapabilities)
+
+        whenever(appBuildConfig.sdkInt).thenReturn(24)
+
+        networkRequestHandler = NetworkRequestHandler(connectivityManager, appBuildConfig, Handler().looper, listener)
+    }
+
+    @Test
+    fun whenNoNetworksThenCallOnNetworkDisconnected() {
+        val message = Message.obtain().apply {
+            what = MSG_ADD_ALL_NETWORKS.ordinal
+        }
+        networkRequestHandler.sendMessage(message)
+
+        assertTrue(listener.networks.isEmpty())
+    }
+
+    @Test
+    fun whenActiveNetworkNoInternetThenCallOnNetworkDisconnected() {
+        shadowOf(networkCapabilities).addTransportType(TRANSPORT_WIFI)
+
+        val message = Message.obtain().apply {
+            what = MSG_ADD_ALL_NETWORKS.ordinal
+        }
+        networkRequestHandler.sendMessage(message)
+
+        assertTrue(listener.networks.isEmpty())
+    }
+
+    @Test
+    fun whenActiveNetworkAndInternetThenCallOnNetworkConnected() {
+        shadowOf(networkCapabilities).addTransportType(TRANSPORT_WIFI)
+        shadowOf(networkCapabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+
+        val message = Message.obtain().apply {
+            what = MSG_ADD_ALL_NETWORKS.ordinal
+        }
+        networkRequestHandler.handleMessage(message)
+
+        assertEquals(1, listener.networks.size)
+        assertEquals(connectivityManager.activeNetwork, listener.networks.toTypedArray()[0])
+    }
+
+    @Test
+    fun whenMultipleNetworksAndInternetThenCallOnNetworkConnected() {
+        shadowOf(networkCapabilities).addTransportType(TRANSPORT_WIFI)
+        shadowOf(networkCapabilities).addTransportType(TRANSPORT_CELLULAR)
+        shadowOf(connectivityManager).setNetworkCapabilities(connectivityManager.allNetworks[1], networkCapabilities)
+
+        shadowOf(networkCapabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+
+        val message = Message.obtain().apply {
+            what = MSG_ADD_ALL_NETWORKS.ordinal
+        }
+        networkRequestHandler.handleMessage(message)
+
+        assertEquals(2, listener.networks.size)
+        assertEquals(connectivityManager.activeNetwork, listener.networks.toTypedArray()[0])
+    }
+
+    @Test
+    fun whenMultipleNetworksOnlyActiveHasInternetInternetThenCallOnNetworkConnected() {
+        shadowOf(networkCapabilities).addTransportType(TRANSPORT_WIFI)
+        shadowOf(networkCapabilities).addTransportType(TRANSPORT_CELLULAR)
+
+        shadowOf(networkCapabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+
+        val message = Message.obtain().apply {
+            what = MSG_ADD_ALL_NETWORKS.ordinal
+        }
+        networkRequestHandler.handleMessage(message)
+
+        assertEquals(1, listener.networks.size)
+        assertEquals(connectivityManager.activeNetwork, listener.networks.toTypedArray()[0])
+    }
+
+    @Test
+    fun whenNetworkIsVpnThenDoNotAddItToNetworkList() {
+        shadowOf(networkCapabilities).addTransportType(TRANSPORT_VPN)
+
+        shadowOf(networkCapabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+
+        val message = Message.obtain().apply {
+            what = MSG_ADD_ALL_NETWORKS.ordinal
+        }
+        networkRequestHandler.handleMessage(message)
+
+        assertTrue(listener.networks.isEmpty())
+    }
+
+    class Listener : NetworkConnectionListener {
+        var networks = linkedSetOf<Network>()
+
+        override fun onNetworkDisconnected() {
+            networks = linkedSetOf()
+        }
+
+        override fun onNetworkConnected(networks: LinkedHashSet<Network>) {
+            this.networks = networks
+        }
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/network/connection/NetworkRequestHandlerTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/network/connection/NetworkRequestHandlerTest.kt
@@ -25,12 +25,9 @@ import android.net.NetworkCapabilities.TRANSPORT_VPN
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.os.Build.VERSION_CODES.M
 import android.os.Build.VERSION_CODES.P
-import android.os.Handler
-import android.os.Message
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.mobile.android.vpn.network.connection.Messages.MSG_ADD_ALL_NETWORKS
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -64,15 +61,12 @@ class NetworkRequestHandlerTest {
 
         whenever(appBuildConfig.sdkInt).thenReturn(24)
 
-        networkRequestHandler = NetworkRequestHandler(connectivityManager, appBuildConfig, Handler().looper, listener)
+        networkRequestHandler = NetworkRequestHandler(connectivityManager, appBuildConfig, listener)
     }
 
     @Test
     fun whenNoNetworksThenCallOnNetworkDisconnected() {
-        val message = Message.obtain().apply {
-            what = MSG_ADD_ALL_NETWORKS.ordinal
-        }
-        networkRequestHandler.sendMessage(message)
+        networkRequestHandler.updateAllNetworks()
 
         assertTrue(listener.networks.isEmpty())
     }
@@ -81,10 +75,7 @@ class NetworkRequestHandlerTest {
     fun whenActiveNetworkNoInternetThenCallOnNetworkDisconnected() {
         shadowOf(networkCapabilities).addTransportType(TRANSPORT_WIFI)
 
-        val message = Message.obtain().apply {
-            what = MSG_ADD_ALL_NETWORKS.ordinal
-        }
-        networkRequestHandler.sendMessage(message)
+        networkRequestHandler.updateAllNetworks()
 
         assertTrue(listener.networks.isEmpty())
     }
@@ -94,10 +85,7 @@ class NetworkRequestHandlerTest {
         shadowOf(networkCapabilities).addTransportType(TRANSPORT_WIFI)
         shadowOf(networkCapabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
 
-        val message = Message.obtain().apply {
-            what = MSG_ADD_ALL_NETWORKS.ordinal
-        }
-        networkRequestHandler.handleMessage(message)
+        networkRequestHandler.updateAllNetworks()
 
         assertEquals(1, listener.networks.size)
         assertEquals(connectivityManager.activeNetwork, listener.networks.toTypedArray()[0])
@@ -111,10 +99,7 @@ class NetworkRequestHandlerTest {
 
         shadowOf(networkCapabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
 
-        val message = Message.obtain().apply {
-            what = MSG_ADD_ALL_NETWORKS.ordinal
-        }
-        networkRequestHandler.handleMessage(message)
+        networkRequestHandler.updateAllNetworks()
 
         assertEquals(2, listener.networks.size)
         assertEquals(connectivityManager.activeNetwork, listener.networks.toTypedArray()[0])
@@ -127,10 +112,7 @@ class NetworkRequestHandlerTest {
 
         shadowOf(networkCapabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
 
-        val message = Message.obtain().apply {
-            what = MSG_ADD_ALL_NETWORKS.ordinal
-        }
-        networkRequestHandler.handleMessage(message)
+        networkRequestHandler.updateAllNetworks()
 
         assertEquals(1, listener.networks.size)
         assertEquals(connectivityManager.activeNetwork, listener.networks.toTypedArray()[0])
@@ -142,10 +124,7 @@ class NetworkRequestHandlerTest {
 
         shadowOf(networkCapabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
 
-        val message = Message.obtain().apply {
-            what = MSG_ADD_ALL_NETWORKS.ordinal
-        }
-        networkRequestHandler.handleMessage(message)
+        networkRequestHandler.updateAllNetworks()
 
         assertTrue(listener.networks.isEmpty())
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201814931393750/f

### Description
To improve network hand-off, monitor the network switches and set underlying networks accordingly.
Do this only in internal builds for now to verify there's no side effects.

**Notes for the reviewer**
Why using a `Handler` in `NetworkRequestHandler`?
* For the same network switch, the `NetworkCallback`s can be called several times with slightly different values
* We want to ensure order of execution so we need a queue
* And also we want the creation of the underlying network set to happen in a background thread
* `HandlerThread` give us both the queue and the thread for free

### Steps to test this PR

_Test underlying networks are set only in internal builds_
- [x] on this branch, set `TUN_READ_ALERT_SAMPLES` in `AppTPHealthMonitor` to `1`
- [x] then install internal build from it
- [x] open all and enable appTP
- [x] filter logcat with `ConnectionMonitor|underlying|NetworkRequestHandler`
- [x] switch from WIFI -> CELLULAR (or vice-versa)
- [x] verify the `W/TrackerBlockingVpnService: set underlying networks:...` message appears
- [x] switch back from CELLULAR -> WIFI (or vice-verda)
- [x] verify the `W/TrackerBlockingVpnService: set underlying networks:...` message appears and the list of network IDs is different (or in different order)
- [x] Run the same test in PLAY or FDROID builds
- [x] Verify the `W/TrackerBlockingVpnService: set underlying networks:...` never appears

In addition, smoke AppTP tests

