### PR TITLE
AnrSupervisor will not run if debugger is attached

### DIFF
--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrSupervisor.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrSupervisor.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.anr
 
+import android.os.Debug
 import android.os.Handler
 import android.os.Looper
 import com.duckduckgo.app.anrs.store.AnrsDatabase
@@ -36,7 +37,7 @@ class AnrSupervisor @Inject constructor(
 
     override fun onOpen(isFreshLaunch: Boolean) {
         synchronized(anrSupervisorRunnable) {
-            if (anrSupervisorRunnable.isStopped) {
+            if (!Debug.isDebuggerConnected() && anrSupervisorRunnable.isStopped) {
                 executor.execute(anrSupervisorRunnable)
             }
         }
@@ -81,7 +82,7 @@ class AnrSupervisorRunnable @Inject constructor(
                     callback.wait(ANR_THRESHOLD_MILLIS)
 
                     if (callback.isCalled) {
-                        Timber.d("UI Thread responded withint ${ANR_THRESHOLD_MILLIS}ms")
+                        Timber.d("UI Thread responded within ${ANR_THRESHOLD_MILLIS}ms")
                     } else {
                         val e = AnrException(handler.looper.thread)
                         Timber.e("ANR Detected: ${e.threadStateMap}")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201861300112042/f

### Description
The `ANR Supervisor` is prone to false negatives when the debugger is attached, especially if stepping through code on the main thread for instance.

### Steps to test this PR

Suggested logcat filter: `AnrSupervisor checking for ANRs`

1. Run (not debug) the project, and ensure you **do see** the log lines above
2. Debug (not run) the project, and ensure you **do not** see the log lines
