### PR TITLE
Remove lastSwitchTimestampMillis from breakage report

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
@@ -163,7 +163,8 @@ class NetworkTypeCollector @Inject constructor(
 
     private fun getNetworkInfoJsonObject(): JSONObject {
         updateSecondsSinceLastSwitch()
-        val info = currentNetworkInfo ?: return JSONObject()
+        // redact the lastSwitchTimestampMillis from the report
+        val info = currentNetworkInfo?.let { adapter.toJson(adapter.fromJson(it)?.copy(lastSwitchTimestampMillis = -999)) } ?: return JSONObject()
 
         return JSONObject(info)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201864646357756/f

### Description
Ditto

### Steps to test this PR
_Test lastSwitchTimestampMillis is redacted_
- [x] install from this branch
- [x] enable AppTP
- [x] switch network WIFI -> CELLULAR or vice-versa
- [x] report breakage for any app
- [x] ensure the `breakageMetadata` contains the `lastSwitchTimestampMillis` set to -999
