### PR TITLE
Adjust bad health detection thresholds

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandler.kt
@@ -297,10 +297,10 @@ class AppBadHealthStateHandler @Inject constructor(
     }
 
     companion object {
-        private const val FILENAME = "com.duckduckgo.mobile.android.vpn.app.health.state"
+        private const val FILENAME = "com.duckduckgo.mobile.vpn.bad.health.config.store"
         private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
         private const val INITIAL_BACKOFF: Long = 0
-        private const val INITIAL_BACKOFF_INCREMENT_SECONDS: Long = 30
+        private const val INITIAL_BACKOFF_INCREMENT_SECONDS: Long = 1
         private const val RESTART_BAKE_TIME_SECONDS = 45
 
         private const val MANUFACTURER_KEY = "manufacturer"

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPHealthMonitor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPHealthMonitor.kt
@@ -80,10 +80,11 @@ class AppTPHealthMonitor @Inject constructor(
         // how far back to look when obtaining health metrics
         const val SLIDING_WINDOW_DURATION_MS: Long = 60_000
 
-        private const val MONITORING_FREQUENCY_MS: Long = 30_000
+        private const val MONITORING_FREQUENCY_MS: Long = 3_000
         private const val OLD_METRIC_CLEANUP_FREQUENCY_MS: Long = 60_000
 
         private val TUN_READ_ALERT_SAMPLES: Int = (4.minutes.inWholeMilliseconds / MONITORING_FREQUENCY_MS).toInt()
+        private val DEFAULT_ALERT_SAMPLES: Int = (2.minutes.inWholeMilliseconds / MONITORING_FREQUENCY_MS).toInt()
     }
 
     private val now: Long
@@ -343,7 +344,7 @@ class AppTPHealthMonitor @Inject constructor(
 
     private abstract class HealthRule(
         open val name: String,
-        open var samplesToWaitBeforeAlerting: Int = 4
+        open var samplesToWaitBeforeAlerting: Int = DEFAULT_ALERT_SAMPLES
     ) {
         var badHealthSampleCount: Int = 0
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201862327796480/f

### Description
Lowerin the bad health detection thresholds to improve the time to repair. See [task](https://app.asana.com/0/1199371158290272/1201862327796480/f) for more dettails

### Steps to test this PR

_Test new thresholds_
- [x] on this branch, set `TUN_READ_ALERT_SAMPLES` in AppTPHealthMonitor to `1`
- [x] Install from this branch the internal build
- [x] Enable AppTP
- [x] Filter logcat by `AppBadHealthStateHandler|AppTPHealthMonitor`
- [x] Go to diagnostics settings
- [x] Click on `BAD HEALTH`
- [x] Verify the VPN restarts 3 consecutive times (`Restarting the VPN...` message) before the backoff kicks in (`Cancelled VPN restart` message)
- [x] Verify the this time the backoff kicks in and cancels the VPN restart (`Cancelled VPN restart` message)
- [x] Verify the VPN restarts 1 time 
- [x] ...
