### PR TITLE
Add IP packet type to health reports

### DIFF
--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthStatsStore.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthStatsStore.kt
@@ -48,6 +48,8 @@ data class SimpleEvent(
     companion object {
         fun build(type: String) = SimpleEvent(type = type, timestamp = System.currentTimeMillis())
 
+        fun TUN_READ_IPV4_PACKET() = build("TUN_READ_IPV4_PACKET")
+        fun TUN_READ_IPV6_PACKET() = build("TUN_READ_IPV6_PACKET")
         fun TUN_READ_UNKNOWN_PACKET() = build("TUN_READ_UNKNOWN_PACKET")
         fun TUN_READ() = build("TUN_READ")
         fun ADD_TO_DEVICE_TO_NETWORK_QUEUE() = build("ADD_TO_DEVICE_TO_NETWORK_QUEUE")

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
@@ -101,6 +101,20 @@ class HealthClassifier @Inject constructor(val applicationContext: Context) {
         return if (metricSummary.isInBadHealth()) BadHealth(metricSummary) else GoodHealth(metricSummary)
     }
 
+    fun determineHealthIpPackets(
+        ipv4PacketCount: Long,
+        ipv6PacketCount: Long
+    ): HealthState {
+        val rawMetrics = mutableMapOf<String, Metric>()
+        val metricSummary = RawMetricsSubmission("ipPacket-types", rawMetrics, informational = true)
+
+        // never trigger an alert for this. We just one the info
+        rawMetrics["ipv4"] = Metric(ipv4PacketCount.toString(), badHealthIf { false })
+        rawMetrics["ipv6"] = Metric(ipv6PacketCount.toString(), badHealthIf { false })
+
+        return if (metricSummary.isInBadHealth()) BadHealth(metricSummary) else GoodHealth(metricSummary)
+    }
+
     fun determineHealthMemory(): HealthState {
         val rawMetrics = mutableMapOf<String, Metric>()
         val metricSummary = RawMetricsSubmission("memory", rawMetrics, redacted = true)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthMetricCounter.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthMetricCounter.kt
@@ -30,6 +30,8 @@ import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.SOCKET_CHA
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.SOCKET_CHANNEL_READ_EXCEPTION
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.SOCKET_CHANNEL_WRITE_EXCEPTION
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_READ
+import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_READ_IPV4_PACKET
+import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_READ_IPV6_PACKET
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_READ_UNKNOWN_PACKET
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_WRITE_IO_EXCEPTION
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_WRITE_IO_MEMORY_EXCEPTION
@@ -60,6 +62,18 @@ class HealthMetricCounter @Inject constructor(
     fun clearAllMetrics() {
         coroutineScope.launch(databaseDispatcher) {
             db.clearAllTables()
+        }
+    }
+
+    fun onTunIpv4PacketReceived() {
+        coroutineScope.launch(databaseDispatcher) {
+            healthStatsDao.insertEvent(TUN_READ_IPV4_PACKET())
+        }
+    }
+
+    fun onTunIpv6PacketReceived() {
+        coroutineScope.launch(databaseDispatcher) {
+            healthStatsDao.insertEvent(TUN_READ_IPV6_PACKET())
         }
     }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -156,5 +156,6 @@ enum class DeviceShieldPixelNames(override val pixelName: String) : Pixel.PixelN
     ATP_DID_PRESS_WAITLIST_DIALOG_DISMISS("m_atp_ev_waitlist_dialog_dismiss_c"),
 
     ATP_RECEIVED_UNKNOWN_PACKET_PROTOCOL("m_atp_ev_unknown_packet_%d_c"),
+    ATP_RECEIVED_UNKNOWN_PACKET_PROTOCOL_DAILY("m_atp_ev_unknown_packet_%d_d"),
     ;
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -610,6 +610,7 @@ class RealDeviceShieldPixels @Inject constructor(
     }
 
     override fun sendUnknownPacketProtocol(protocol: Int) {
+        tryToFireDailyPixel(String.format(Locale.US, DeviceShieldPixelNames.ATP_RECEIVED_UNKNOWN_PACKET_PROTOCOL_DAILY.pixelName, protocol))
         firePixel(String.format(Locale.US, DeviceShieldPixelNames.ATP_RECEIVED_UNKNOWN_PACKET_PROTOCOL.pixelName, protocol))
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1201884340030491/f

### Description
More context in [this task](https://app.asana.com/0/1199371158290272/1201862327796575/f)

We want to add IPv6/4 traffic information to the breakage reports to see their impact.

### Steps to test this PR

_Test information is in reports_
- [ ] Set `DEFAULT_ALERT_SAMPLES` to `1` in `AppTPHealthMonitor` for this branch
- [ ] install from this branch
- [ ] go to diagnostics screen and simluate BAD health
- [ ] wait for bad health notification to appear
- [ ] verify the `m_atp_health_monitor_report` is sent and that `badHealthData` contains the `ipPacket-types` informational ipv4/6 metrics
- [ ] report breakage for any app
- [ ] verify the `m_atp_breakage_report` contains the bad health information and also contains the `ipPacket-types` informational ipv4/6 metrics
