### PR TITLE
ensure status notifications are posted to a silent channel

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
@@ -93,7 +93,7 @@ class DeviceShieldNotificationsDebugReceiverRegister @Inject constructor(
                     val deviceShieldNotification =
                         deviceShieldNotificationFactory.weeklyNotificationFactory.createWeeklyDeviceShieldNotification(weekly)
 
-                    deviceShieldAlertNotificationBuilder.buildDeviceShieldNotification(
+                    deviceShieldAlertNotificationBuilder.buildStatusNotification(
                         context,
                         deviceShieldNotification,
                         weeklyNotificationPressedHandler
@@ -103,7 +103,7 @@ class DeviceShieldNotificationsDebugReceiverRegister @Inject constructor(
                     dailyNotificationPressedHandler.notificationVariant = daily
                     val deviceShieldNotification = deviceShieldNotificationFactory.dailyNotificationFactory.createDailyDeviceShieldNotification(daily)
 
-                    deviceShieldAlertNotificationBuilder.buildDeviceShieldNotification(
+                    deviceShieldAlertNotificationBuilder.buildStatusNotification(
                         context, deviceShieldNotification, dailyNotificationPressedHandler
                     )
                 } else {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldNotificationScheduler.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldNotificationScheduler.kt
@@ -181,7 +181,7 @@ class DeviceShieldNotificationScheduler(
 
             if (!deviceShieldNotification.hidden) {
                 val notification =
-                    deviceShieldAlertNotificationBuilder.buildDeviceShieldNotification(context, deviceShieldNotification, notificationPressedHandler)
+                    deviceShieldAlertNotificationBuilder.buildStatusNotification(context, deviceShieldNotification, notificationPressedHandler)
                 deviceShieldPixels.didShowDailyNotification(deviceShieldNotification.notificationVariant)
                 notificationManager.notify(VPN_DAILY_NOTIFICATION_ID, notification)
                 Timber.v("Vpn Daily notification is now shown")
@@ -210,7 +210,7 @@ class DeviceShieldNotificationScheduler(
 
             if (!deviceShieldNotification.hidden) {
                 Timber.v("Vpn Daily notification won't be shown because there is no data to show")
-                val notification = deviceShieldAlertNotificationBuilder.buildDeviceShieldNotification(
+                val notification = deviceShieldAlertNotificationBuilder.buildStatusNotification(
                     context, deviceShieldNotification, notificationPressedHandler
                 )
                 deviceShieldPixels.didShowWeeklyNotification(deviceShieldNotification.notificationVariant)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1201775937180777

### Description
Some devices are not respecting the silent notification flag. This PR fixes that, creating a new channel that is always silent.

### Steps to test this PR

- [ ] Enable AppTp
- [ ] Check that the status notification is shown
- [ ] Doesn't make noise
- [ ] It's placed in the silent notifications group