### PR TITLE
Get data from device for email settings page

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/email/EmailJavascriptInterface.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailJavascriptInterface.kt
@@ -47,6 +47,15 @@ class EmailJavascriptInterface(
     }
 
     @JavascriptInterface
+    fun getUserData(): String? {
+        return if (isUrlFromDuckDuckGoEmail()) {
+            emailManager.getUserData()
+        } else {
+            ""
+        }
+    }
+
+    @JavascriptInterface
     fun storeCredentials(
         token: String,
         username: String,

--- a/app/src/main/java/com/duckduckgo/app/email/EmailJavascriptInterface.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailJavascriptInterface.kt
@@ -47,7 +47,7 @@ class EmailJavascriptInterface(
     }
 
     @JavascriptInterface
-    fun getUserData(): String? {
+    fun getUserData(): String {
         return if (isUrlFromDuckDuckGoEmail()) {
             emailManager.getUserData()
         } else {

--- a/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
@@ -19,14 +19,13 @@ package com.duckduckgo.app.email
 import com.duckduckgo.app.email.api.EmailService
 import com.duckduckgo.app.email.db.EmailDataStore
 import com.duckduckgo.app.global.DispatcherProvider
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi.Builder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.json.JSONObject
 import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.*
@@ -43,7 +42,7 @@ interface EmailManager {
 
     fun signOut()
     fun getEmailAddress(): String?
-    fun getUserData(): String?
+    fun getUserData(): String
     fun waitlistState(): AppEmailManager.WaitlistState
     fun joinWaitlist(
         timestamp: Int,
@@ -103,17 +102,12 @@ class AppEmailManager(
         }
     }
 
-    data class UserData(val token: String?, val userName: String?, val nextAlias: String?)
-    var moshi = Builder().build()
-    var jsonAdapter: JsonAdapter<UserData> = moshi.adapter(UserData::class.java)
-
-    override fun getUserData(): String? {
-        var userData = UserData(
-            emailDataStore.emailToken,
-            emailDataStore.emailUsername,
-            emailDataStore.nextAlias?.replace(DUCK_EMAIL_DOMAIN, ""),
-        )
-        return jsonAdapter.toJson(userData)
+    override fun getUserData(): String {
+        return JSONObject().apply {
+            put("token", emailDataStore.emailToken)
+            put("userName", emailDataStore.emailUsername)
+            put("nextAlias", emailDataStore.nextAlias?.replace(DUCK_EMAIL_DOMAIN, ""))
+        }.toString()
     }
 
     override fun waitlistState(): WaitlistState {

--- a/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
@@ -104,9 +104,9 @@ class AppEmailManager(
 
     override fun getUserData(): String {
         return JSONObject().apply {
-            put("token", emailDataStore.emailToken)
-            put("userName", emailDataStore.emailUsername)
-            put("nextAlias", emailDataStore.nextAlias?.replace(DUCK_EMAIL_DOMAIN, ""))
+            put(TOKEN, emailDataStore.emailToken)
+            put(USERNAME, emailDataStore.emailUsername)
+            put(NEXT_ALIAS, emailDataStore.nextAlias?.replace(DUCK_EMAIL_DOMAIN, ""))
         }.toString()
     }
 
@@ -224,6 +224,9 @@ class AppEmailManager(
     companion object {
         const val DUCK_EMAIL_DOMAIN = "@duck.com"
         const val UNKNOWN_COHORT = "unknown"
+        const val TOKEN = "token"
+        const val USERNAME = "userName"
+        const val NEXT_ALIAS = "nextAlias"
     }
 
     private fun EmailDataStore.clearEmailData() {

--- a/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailManager.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.app.email
 import com.duckduckgo.app.email.api.EmailService
 import com.duckduckgo.app.email.db.EmailDataStore
 import com.duckduckgo.app.global.DispatcherProvider
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi.Builder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -41,6 +43,7 @@ interface EmailManager {
 
     fun signOut()
     fun getEmailAddress(): String?
+    fun getUserData(): String?
     fun waitlistState(): AppEmailManager.WaitlistState
     fun joinWaitlist(
         timestamp: Int,
@@ -98,6 +101,19 @@ class AppEmailManager(
         return emailDataStore.emailUsername?.let {
             "$it$DUCK_EMAIL_DOMAIN"
         }
+    }
+
+    data class UserData(val token: String?, val userName: String?, val nextAlias: String?)
+    var moshi = Builder().build()
+    var jsonAdapter: JsonAdapter<UserData> = moshi.adapter(UserData::class.java)
+
+    override fun getUserData(): String? {
+        var userData = UserData(
+            emailDataStore.emailToken,
+            emailDataStore.emailUsername,
+            emailDataStore.nextAlias?.replace(DUCK_EMAIL_DOMAIN, ""),
+        )
+        return jsonAdapter.toJson(userData)
     }
 
     override fun waitlistState(): WaitlistState {

--- a/app/src/test/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.email
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.email.AppEmailManager.Companion.DUCK_EMAIL_DOMAIN
 import com.duckduckgo.app.email.AppEmailManager.Companion.UNKNOWN_COHORT
@@ -39,6 +40,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -46,9 +48,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
 @FlowPreview
 @ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
 class AppEmailManagerTest {
 
     @get:Rule
@@ -385,6 +389,21 @@ class AppEmailManagerTest {
         assertFalse(testee.isEmailFeatureSupported())
     }
 
+    @Test
+    fun whenGetUserDataThenDataReceivedCorrectly() {
+        val expected = JSONObject().apply {
+            put(AppEmailManager.TOKEN, "token")
+            put(AppEmailManager.USERNAME, "user")
+            put(AppEmailManager.NEXT_ALIAS, "nextAlias")
+        }.toString()
+
+        mockEmailDataStore.emailToken = "token"
+        mockEmailDataStore.emailUsername = "user"
+        mockEmailDataStore.nextAlias = "nextAlias@duck.com"
+
+        assertEquals(expected, testee.getUserData())
+    }
+
     private fun givenUserIsInWaitlist() {
         mockEmailDataStore.waitlistTimestamp = 1234
         mockEmailDataStore.waitlistToken = "token"
@@ -396,7 +415,6 @@ class AppEmailManagerTest {
     }
 
     private fun givenNextAliasExists() {
-//        cachedAlias.set("alias")
         mockEmailDataStore.nextAlias = "alias"
     }
 

--- a/app/src/test/java/com/duckduckgo/app/email/EmailJavascriptInterfaceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/email/EmailJavascriptInterfaceTest.kt
@@ -85,6 +85,24 @@ class EmailJavascriptInterfaceTest {
     }
 
     @Test
+    fun whenGetUserDataAndUrlIsDuckDuckGoEmailThenGetUserDataCalled() {
+        whenever(mockWebView.url).thenReturn(DUCKDUCKGO_EMAIL_URL)
+
+        testee.getUserData()
+
+        verify(mockEmailManager).getUserData()
+    }
+
+    @Test
+    fun whenGetUserDataAndUrlIsNotDuckDuckGoEmailThenGetUserDataIsNotCalled() {
+        whenever(mockWebView.url).thenReturn(NON_EMAIL_URL)
+
+        testee.getUserData()
+
+        verify(mockEmailManager, never()).getUserData()
+    }
+
+    @Test
     fun whenShowTooltipThenLambdaCalled() {
         testee.showTooltip()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1201900580321807/f

### Description
Update to allow requesting user data from Android devices

### Steps to test this PR
1. Update `common/src/main/java/com/duckduckgo/app/global/AppUrl.kt` to have host value align with dev instance
2. Update autofill to https://github.com/duckduckgo/duckduckgo-autofill/pull/52
3. Build browser
4. Go to my dev instance
5. If needed, log in with production duck email username
6. See "Autofill" tab with duck email and private address generator
