### PR TITLE
solve race condition in vpn state query

### DIFF
--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnServiceStateStatsDao.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnServiceStateStatsDao.kt
@@ -30,10 +30,10 @@ interface VpnServiceStateStatsDao {
     @Query("SELECT strftime('%Y-%m-%d', timestamp) day, * FROM vpn_service_state_stats WHERE timestamp >= :startTime order by timestamp DESC")
     fun getServiceStateStatsSince(startTime: String): List<BucketizedVpnServiceStateStats>
 
-    @Query("SELECT * FROM vpn_service_state_stats ORDER BY timestamp DESC limit 1")
+    @Query("SELECT * FROM vpn_service_state_stats ORDER BY id DESC limit 1")
     fun getLastStateStats(): VpnServiceStateStats?
 
-    @Query("SELECT * FROM vpn_service_state_stats ORDER BY timestamp DESC limit 1")
+    @Query("SELECT * FROM vpn_service_state_stats ORDER BY id DESC limit 1")
     fun getStateStats(): Flow<VpnServiceStateStats?>
 
     @Query("SELECT COUNT(*) FROM vpn_service_state_stats WHERE state is 'ENABLED'")

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
@@ -42,10 +42,7 @@ import javax.inject.Inject
     boundType = VpnServiceCallbacks::class
 )
 @SingleInstanceIn(VpnScope::class)
-class VpnServiceStateLogger @Inject constructor(
-    private val dispatcherProvider: VpnDispatcherProvider,
-    private val vpnDatabase: VpnDatabase
-) : VpnServiceCallbacks {
+class VpnServiceStateLogger @Inject constructor(private val vpnDatabase: VpnDatabase) : VpnServiceCallbacks {
 
     private val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
@@ -31,8 +31,10 @@ import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.util.concurrent.Executors
 import javax.inject.Inject
 
 @ContributesMultibinding(
@@ -44,8 +46,11 @@ class VpnServiceStateLogger @Inject constructor(
     private val dispatcherProvider: VpnDispatcherProvider,
     private val vpnDatabase: VpnDatabase
 ) : VpnServiceCallbacks {
+
+    private val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+
     override fun onVpnStarted(coroutineScope: CoroutineScope) {
-        coroutineScope.launch(dispatcherProvider.io()) {
+        coroutineScope.launch(dispatcher) {
             Timber.d("VpnServiceStateLogge, new state ENABLED")
             vpnDatabase.vpnServiceStateDao().insert(VpnServiceStateStats(state = VpnServiceState.ENABLED))
         }
@@ -55,7 +60,7 @@ class VpnServiceStateLogger @Inject constructor(
         coroutineScope: CoroutineScope,
         vpnStopReason: VpnStopReason
     ) {
-        coroutineScope.launch(dispatcherProvider.io()) {
+        coroutineScope.launch(dispatcher) {
             Timber.d("VpnServiceStateLogge, new state DISABLED, reason $vpnStopReason")
             vpnDatabase.vpnServiceStateDao().insert(VpnServiceStateStats(state = VpnServiceState.DISABLED, stopReason = mapStopReason(vpnStopReason)))
         }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.mobile.android.vpn.stats
 
 import com.duckduckgo.di.scopes.VpnScope
-import com.duckduckgo.mobile.android.vpn.di.VpnDispatcherProvider
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceState
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceStateStats
 import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1174433894299346/1201913071568577

### Description
In [AppTP: Improve communication for AppTP disables](https://app.asana.com/0/1174433894299346/1201630444699765) we changed how the Trackers screen toggle receives its information. 

Before we polled the VpnService state every second, now we relay on a callback that tells us when the VPN as started / stopped.

After doing the change, we've seen cases where the toggle and the vpn state are out of sync. The toggle shows AppTP as disabled, but the VPN service is running.