### PR TITLE
Revert "Replaced liveTabs with flowTabs."

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.app.trackerdetection.EntityLookup
 import org.mockito.kotlin.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -233,13 +234,7 @@ class TabDataRepositoryTest {
 
         testee.addDefaultTab()
 
-        val job = launch {
-            testee.flowTabs.collect {
-                assertEquals(1, it.size)
-            }
-        }
-        job.cancel()
-        db.close()
+        assertTrue(testee.liveTabs.blockingObserve()?.size == 1)
     }
 
     @Test
@@ -250,13 +245,7 @@ class TabDataRepositoryTest {
 
         testee.addDefaultTab()
 
-        val job = launch {
-            testee.flowTabs.collect {
-                assertEquals(1, it.size)
-            }
-        }
-        job.cancel()
-        db.close()
+        assertTrue(testee.liveTabs.blockingObserve()?.size == 1)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -27,10 +27,7 @@ import android.view.View
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.DialogFragment
-import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.Observer
-import androidx.lifecycle.flowWithLifecycle
-import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.bookmarks.ui.BookmarksActivity
 import com.duckduckgo.app.browser.BrowserViewModel.Command
 import com.duckduckgo.app.browser.BrowserViewModel.Command.Query
@@ -66,7 +63,6 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
-import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
@@ -129,8 +125,6 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
 
     @VisibleForTesting
     var destroyedByBackPress: Boolean = false
-
-    private val tabsJob = ConflatedJob()
 
     @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -318,20 +312,19 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
                 if (it != null) selectTab(it)
             }
         )
-
-        tabsJob += lifecycleScope.launch {
-            viewModel.tabs
-                .flowWithLifecycle(lifecycle, STARTED).collect {
-                    clearStaleTabs(it)
-                    launch { viewModel.onTabsUpdated(it) }
-                }
-        }
+        viewModel.tabs.observe(
+            this,
+            Observer {
+                clearStaleTabs(it)
+                launch { viewModel.onTabsUpdated(it) }
+            }
+        )
     }
 
     private fun removeObservers() {
         viewModel.command.removeObservers(this)
         viewModel.selectedTab.removeObservers(this)
-        tabsJob.cancel()
+        viewModel.tabs.removeObservers(this)
     }
 
     private fun clearStaleTabs(updatedTabs: List<TabEntity>?) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -175,13 +175,12 @@ import com.duckduckgo.app.browser.remotemessage.asMessage
 import com.duckduckgo.app.global.view.launchDefaultAppActivity
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.statistics.isFireproofExperimentEnabled
-import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import javax.inject.Provider
-import kotlinx.coroutines.flow.cancellable
+import kotlinx.android.synthetic.main.include_cta.*
 
 class BrowserTabFragment :
     Fragment(),
@@ -325,8 +324,6 @@ class BrowserTabFragment :
 
     private lateinit var omnibarQuickAccessAdapter: FavoritesQuickAccessAdapter
     private lateinit var omnibarQuickAccessItemTouchHelper: ItemTouchHelper
-
-    private val tabsJob = ConflatedJob()
 
     private val viewModel: BrowserTabViewModel by lazy {
         val viewModel = ViewModelProvider(this, viewModelFactory).get(BrowserTabViewModel::class.java)
@@ -600,11 +597,14 @@ class BrowserTabFragment :
     }
 
     private fun addTabsObserver() {
-        tabsJob += lifecycleScope.launch {
-            viewModel.tabs.cancellable().collect {
-                decorator.renderTabIcon(it)
+        viewModel.tabs.observe(
+            viewLifecycleOwner,
+            Observer<List<TabEntity>> {
+                it?.let {
+                    decorator.renderTabIcon(it)
+                }
             }
-        }
+        )
     }
 
     private fun fragmentIsVisible(): Boolean {
@@ -951,7 +951,7 @@ class BrowserTabFragment :
 
     private fun openInNewBackgroundTab() {
         appBarLayout.setExpanded(true, true)
-        tabsJob.cancel()
+        viewModel.tabs.removeObservers(this)
         decorator.incrementTabs()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -442,7 +442,7 @@ class BrowserTabViewModel(
     val privacyGradeViewState: MutableLiveData<PrivacyGradeViewState> = MutableLiveData()
 
     var skipHome = false
-    val tabs: Flow<List<TabEntity>> = tabRepository.flowTabs
+    val tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
     val survey: LiveData<Survey> = ctaViewModel.surveyLiveData
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
     private var refreshOnViewVisible = MutableStateFlow(true)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -48,7 +48,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -94,7 +93,7 @@ class BrowserViewModel(
     private val currentViewState: ViewState
         get() = viewState.value!!
 
-    var tabs: Flow<List<TabEntity>> = tabRepository.flowTabs
+    var tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
     var selectedTab: LiveData<TabEntity> = tabRepository.liveSelectedTab
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -402,7 +402,7 @@ class CtaViewModel @Inject constructor(
         }
     }
 
-    private fun forceStopFireButtonPulseAnimationFlow() = tabRepository.flowTabs
+    private fun forceStopFireButtonPulseAnimationFlow() = tabRepository.flowTabs.distinctUntilChanged()
         .map { tabs ->
             if (tabs.size >= MAX_TABS_OPEN_FIRE_EDUCATION) return@map true
             return@map false

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -43,6 +43,9 @@ abstract class TabsDao {
     @Query("select * from tabs where deletable is 0 order by position")
     abstract fun flowTabs(): Flow<List<TabEntity>>
 
+    @Query("select * from tabs where deletable is 0 order by position")
+    abstract fun liveTabs(): LiveData<List<TabEntity>>
+
     @Query("select * from tabs where deletable is 1 order by position")
     abstract fun flowDeletableTabs(): Flow<List<TabEntity>>
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -51,7 +51,9 @@ class TabDataRepository @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) : TabRepository {
 
-    override val flowTabs: Flow<List<TabEntity>> = tabsDao.flowTabs().distinctUntilChanged()
+    override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs()
+
+    override val flowTabs: Flow<List<TabEntity>> = tabsDao.flowTabs()
 
     private val childTabClosedSharedFlow = MutableSharedFlow<String>()
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -24,6 +24,11 @@ import kotlinx.coroutines.flow.SharedFlow
 
 interface TabRepository {
 
+    /**
+     * @return the tabs that are NOT marked as deletable in the DB
+     */
+    val liveTabs: LiveData<List<TabEntity>>
+
     val flowTabs: Flow<List<TabEntity>>
 
     val childClosedTabs: SharedFlow<String>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1201921632645241

### Description
This PR reverts a bug introduced in the previous release, that messes up with the tab positioning in the Tab Switcher

### Steps to test this PR

_Check tab ordering in tab switcher_
- [x] Open the browser
- [x] Create multiple tabs (at least more than 8 tabs, so you need to scroll when opening the tabs screen)
- [x] Open tab switcher screen
- [x] Notice the focus is on the current selected tab

Reverts duckduckgo/Android#1757
Fixes https://github.com/duckduckgo/Android/issues/1785