### PR TITLE
Exclude VPN routes to fix wi-fi calling

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnRoutes.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnRoutes.kt
@@ -31,6 +31,21 @@ class VpnRoutes {
          *   - link-local address range
          *   - multicast address range
          *   - broadcast address
+         *   - T-mobile wi-fi calling
+         *      - 66.94.2.0/24  -> 66.94.2.255
+         *      - 66.94.6.0/23  -> 66.94.7.255
+         *      - 66.94.8.0/22  -> 66.94.11.255
+         *      - 208.54.0.0/16 -> 208.54.255.255
+         *   - Verizon wi-fi calling
+         *      - 66.174.0.0/16 -> 66.174.255.255
+         *      - 69.82.0.0/15  -> 69.83.255.255
+         *      - 69.96.0.0/13  -> 69.103.255.255
+         *      - 70.192.0.0/11 -> 70.223.255.255
+         *      - 72.96.0.0/9   -> 72.127.255.255
+         *      - 75.192.0.0/9  -> 75.255.255.255
+         *      - 97.0.0.0/10   -> 97.63.255.255
+         *      - 97.128.0.0/9  -> 97.255.255.255
+         *      - 174.192.0.0/9 -> 174.255.255.255
          */
         val includedRoutes: List<Route> = listOf(
             Route(address = "0.0.0.0", maskWidth = 5, lowAddress = "0.0.0.0", highAddress = "7.255.255.255"),
@@ -40,7 +55,66 @@ class VpnRoutes {
             Route(address = "12.0.0.0", maskWidth = 6, lowAddress = "12.0.0.0", highAddress = "15.255.255.255"),
             Route(address = "16.0.0.0", maskWidth = 4, lowAddress = "16.0.0.0", highAddress = "31.255.255.255"),
             Route(address = "32.0.0.0", maskWidth = 3, lowAddress = "32.0.0.0", highAddress = "63.255.255.255"),
-            Route(address = "64.0.0.0", maskWidth = 2, lowAddress = "64.0.0.0", highAddress = "127.255.255.255"),
+            Route(address = "64.0.0.0", maskWidth = 7, lowAddress = "64.0.0.0", highAddress = "65.255.255.255"),
+            Route(address = "66.0.0.0", maskWidth = 10, lowAddress = "66.0.0.0", highAddress = "66.63.255.255"),
+            Route(address = "66.64.0.0", maskWidth = 12, lowAddress = "66.64.0.0", highAddress = "66.79.255.255"),
+            Route(address = "66.80.0.0", maskWidth = 13, lowAddress = "66.80.0.0", highAddress = "66.87.255.255"),
+            Route(address = "66.88.0.0", maskWidth = 14, lowAddress = "66.88.0.0", highAddress = "66.91.255.255"),
+            Route(address = "66.92.0.0", maskWidth = 15, lowAddress = "66.92.0.0", highAddress = "66.93.255.255"),
+            Route(address = "66.94.0.0", maskWidth = 23, lowAddress = "66.94.0.0", highAddress = "66.94.1.255"),
+            // Excluded range: 66.94.2.0 -> 66.94.2.255
+            Route(address = "66.94.3.0", maskWidth = 24, lowAddress = "66.94.3.0", highAddress = "66.94.3.255"),
+            Route(address = "66.94.4.0", maskWidth = 23, lowAddress = "66.94.4.0", highAddress = "66.94.5.255"),
+            // Excluded range: 66.94.6.0 -> 66.94.7.255
+            // Excluded range: 66.94.8.0 -> 66.94.11.255
+            Route(address = "66.94.12.0", maskWidth = 22, lowAddress = "66.94.12.0", highAddress = "66.94.15.255"),
+            Route(address = "66.94.16.0", maskWidth = 20, lowAddress = "66.94.16.0", highAddress = "66.94.31.255"),
+            Route(address = "66.94.32.0", maskWidth = 19, lowAddress = "66.94.32.0", highAddress = "66.94.63.255"),
+            Route(address = "66.94.64.0", maskWidth = 18, lowAddress = "66.94.64.0", highAddress = "66.94.127.255"),
+            Route(address = "66.94.128.0", maskWidth = 17, lowAddress = "66.94.128.0", highAddress = "66.94.255.255"),
+            Route(address = "66.95.0.0", maskWidth = 16, lowAddress = "66.95.0.0", highAddress = "66.95.255.255"),
+            Route(address = "66.96.0.0", maskWidth = 11, lowAddress = "66.96.0.0", highAddress = "66.127.255.255"),
+            Route(address = "66.128.0.0", maskWidth = 11, lowAddress = "66.128.0.0", highAddress = "66.159.255.255"),
+            Route(address = "66.160.0.0", maskWidth = 13, lowAddress = "66.160.0.0", highAddress = "66.167.255.255"),
+            Route(address = "66.168.0.0", maskWidth = 14, lowAddress = "66.168.0.0", highAddress = "66.171.255.255"),
+            Route(address = "66.172.0.0", maskWidth = 15, lowAddress = "66.172.0.0", highAddress = "66.173.255.255"),
+            // Excluded range: 66.174.0.0 -> 66.174.255.255
+            Route(address = "66.175.0.0", maskWidth = 16, lowAddress = "66.175.0.0", highAddress = "66.175.255.255"),
+            Route(address = "66.176.0.0", maskWidth = 12, lowAddress = "66.176.0.0", highAddress = "66.191.255.255"),
+            Route(address = "66.192.0.0", maskWidth = 10, lowAddress = "66.192.0.0", highAddress = "66.255.255.255"),
+            Route(address = "67.0.0.0", maskWidth = 8, lowAddress = "67.0.0.0", highAddress = "67.255.255.255"),
+            Route(address = "68.0.0.0", maskWidth = 8, lowAddress = "68.0.0.0", highAddress = "68.255.255.255"),
+            Route(address = "69.0.0.0", maskWidth = 10, lowAddress = "69.0.0.0", highAddress = "69.63.255.255"),
+            Route(address = "69.64.0.0", maskWidth = 12, lowAddress = "69.64.0.0", highAddress = "69.79.255.255"),
+            Route(address = "69.80.0.0", maskWidth = 15, lowAddress = "69.80.0.0", highAddress = "69.81.255.255"),
+            // Excluded range: 69.82.0.0 -> 69.83.255.255
+            Route(address = "69.84.0.0", maskWidth = 14, lowAddress = "69.84.0.0", highAddress = "69.87.255.255"),
+            Route(address = "69.88.0.0", maskWidth = 13, lowAddress = "69.88.0.0", highAddress = "69.95.255.255"),
+            // Excluded range: 69.96.0.0 -> 69.103.255.255
+            Route(address = "69.104.0.0", maskWidth = 13, lowAddress = "69.104.0.0", highAddress = "69.111.255.255"),
+            Route(address = "69.112.0.0", maskWidth = 12, lowAddress = "69.112.0.0", highAddress = "69.127.255.255"),
+            Route(address = "69.128.0.0", maskWidth = 9, lowAddress = "69.128.0.0", highAddress = "69.255.255.255"),
+            Route(address = "70.0.0.0", maskWidth = 9, lowAddress = "70.0.0.0", highAddress = "70.127.255.255"),
+            Route(address = "70.128.0.0", maskWidth = 10, lowAddress = "70.128.0.0", highAddress = "70.191.255.255"),
+            // Excluded range: 70.192.0.0 -> 70.223.255.255
+            Route(address = "70.224.0.0", maskWidth = 11, lowAddress = "70.224.0.0", highAddress = "70.255.255.255"),
+            Route(address = "71.0.0.0", maskWidth = 8, lowAddress = "71.0.0.0", highAddress = "71.255.255.255"),
+            // Excluded range: 72.0.0.0 -> 72.127.255.255
+            Route(address = "72.128.0.0", maskWidth = 9, lowAddress = "72.128.0.0", highAddress = "72.255.255.255"),
+            Route(address = "73.0.0.0", maskWidth = 8, lowAddress = "73.0.0.0", highAddress = "73.255.255.255"),
+            Route(address = "74.0.0.0", maskWidth = 8, lowAddress = "74.0.0.0", highAddress = "74.255.255.255"),
+            Route(address = "75.0.0.0", maskWidth = 9, lowAddress = "75.0.0.0", highAddress = "75.127.255.255"),
+            // Excluded range: 75.128.0.0 -> 75.255.255.255
+            Route(address = "76.0.0.0", maskWidth = 6, lowAddress = "76.0.0.0", highAddress = "79.255.255.255"),
+            Route(address = "80.0.0.0", maskWidth = 4, lowAddress = "80.0.0.0", highAddress = "95.255.255.255"),
+            Route(address = "96.0.0.0", maskWidth = 8, lowAddress = "96.0.0.0", highAddress = "96.255.255.255"),
+            // Excluded range: 97.0.0.0 -> 97.63.255.255
+            Route(address = "97.64.0.0", maskWidth = 10, lowAddress = "97.64.0.0", highAddress = "97.127.255.255"),
+            // Excluded range: 97.128.0.0 -> 97.255.255.255
+            Route(address = "98.0.0.0", maskWidth = 7, lowAddress = "98.0.0.0", highAddress = "99.255.255.255"),
+            Route(address = "100.0.0.0", maskWidth = 6, lowAddress = "100.0.0.0", highAddress = "103.255.255.255"),
+            Route(address = "104.0.0.0", maskWidth = 5, lowAddress = "104.0.0.0", highAddress = "111.255.255.255"),
+            Route(address = "112.0.0.0", maskWidth = 4, lowAddress = "112.0.0.0", highAddress = "127.255.255.255"),
             Route(address = "128.0.0.0", maskWidth = 3, lowAddress = "128.0.0.0", highAddress = "159.255.255.255"),
             Route(address = "160.0.0.0", maskWidth = 5, lowAddress = "160.0.0.0", highAddress = "167.255.255.255"),
             Route(address = "168.0.0.0", maskWidth = 8, lowAddress = "168.0.0.0", highAddress = "168.255.255.255"),
@@ -60,7 +134,10 @@ class VpnRoutes {
             Route(address = "172.64.0.0", maskWidth = 10, lowAddress = "172.64.0.0", highAddress = "172.127.255.255"),
             Route(address = "172.128.0.0", maskWidth = 9, lowAddress = "172.128.0.0", highAddress = "172.255.255.255"),
             Route(address = "173.0.0.0", maskWidth = 8, lowAddress = "173.0.0.0", highAddress = "173.255.255.255"),
-            Route(address = "174.0.0.0", maskWidth = 7, lowAddress = "174.0.0.0", highAddress = "175.255.255.255"),
+            Route(address = "174.0.0.0", maskWidth = 9, lowAddress = "174.0.0.0", highAddress = "174.127.255.255"),
+            Route(address = "174.128.0.0", maskWidth = 10, lowAddress = "174.128.0.0", highAddress = "174.191.255.255"),
+            // Excluded range: 174.192.0.0 -> 174.255.255.255
+            Route(address = "175.0.0.0", maskWidth = 8, lowAddress = "175.0.0.0", highAddress = "175.255.255.255"),
             Route(address = "176.0.0.0", maskWidth = 4, lowAddress = "176.0.0.0", highAddress = "191.255.255.255"),
             Route(address = "192.0.0.0", maskWidth = 9, lowAddress = "192.0.0.0", highAddress = "192.127.255.255"),
             Route(address = "192.128.0.0", maskWidth = 11, lowAddress = "192.128.0.0", highAddress = "192.159.255.255"),
@@ -75,7 +152,19 @@ class VpnRoutes {
             Route(address = "194.0.0.0", maskWidth = 7, lowAddress = "194.0.0.0", highAddress = "195.255.255.255"),
             Route(address = "196.0.0.0", maskWidth = 6, lowAddress = "196.0.0.0", highAddress = "199.255.255.255"),
             Route(address = "200.0.0.0", maskWidth = 5, lowAddress = "200.0.0.0", highAddress = "207.255.255.255"),
-            Route(address = "208.0.0.0", maskWidth = 4, lowAddress = "208.0.0.0", highAddress = "223.255.255.255"),
+            Route(address = "208.0.0.0", maskWidth = 11, lowAddress = "208.0.0.0", highAddress = "208.31.255.255"),
+            Route(address = "208.32.0.0", maskWidth = 12, lowAddress = "208.32.0.0", highAddress = "208.47.255.255"),
+            Route(address = "208.48.0.0", maskWidth = 14, lowAddress = "208.48.0.0", highAddress = "208.51.255.255"),
+            Route(address = "208.52.0.0", maskWidth = 15, lowAddress = "208.52.0.0", highAddress = "208.53.255.255"),
+            // Excluded range: 208.54.0.0 -> 208.54.255.255
+            Route(address = "208.55.0.0", maskWidth = 16, lowAddress = "208.55.0.0", highAddress = "208.55.255.255"),
+            Route(address = "208.56.0.0", maskWidth = 13, lowAddress = "208.56.0.0", highAddress = "208.63.255.255"),
+            Route(address = "208.64.0.0", maskWidth = 10, lowAddress = "208.64.0.0", highAddress = "208.127.255.255"),
+            Route(address = "208.128.0.0", maskWidth = 9, lowAddress = "208.128.0.0", highAddress = "208.255.255.255"),
+            Route(address = "209.0.0.0", maskWidth = 8, lowAddress = "209.0.0.0", highAddress = "209.255.255.255"),
+            Route(address = "210.0.0.0", maskWidth = 7, lowAddress = "210.0.0.0", highAddress = "211.255.255.255"),
+            Route(address = "212.0.0.0", maskWidth = 6, lowAddress = "212.0.0.0", highAddress = "215.255.255.255"),
+            Route(address = "216.0.0.0", maskWidth = 5, lowAddress = "216.0.0.0", highAddress = "223.255.255.255"),
             // Excluded range: 224.0.0.0 -> 239.255.255.255
             Route(address = "240.0.0.0", maskWidth = 5, lowAddress = "240.0.0.0", highAddress = "247.255.255.255"),
             Route(address = "248.0.0.0", maskWidth = 6, lowAddress = "248.0.0.0", highAddress = "251.255.255.255"),

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/service/VpnRoutesTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/service/VpnRoutesTest.kt
@@ -25,6 +25,27 @@ import java.net.InetAddress
 class VpnRoutesTest {
 
     @Test
+    fun `all t-mobile wifi calling addresses are excluded from VPN`() {
+        assertNoRoutes(findRoutes("66.94.2.0", "66.94.2.255"))
+        assertNoRoutes(findRoutes("66.94.6.0", "66.94.7.255"))
+        assertNoRoutes(findRoutes("66.94.8.0", "66.94.11.255"))
+        assertNoRoutes(findRoutes("208.54.0.0", "208.54.255.255"))
+    }
+
+    @Test
+    fun `all verizon wifi calling addresses are excluded from VPN`() {
+        assertNoRoutes(findRoutes("66.174.0.0", "66.174.255.255"))
+        assertNoRoutes(findRoutes("69.82.0.0", "69.83.255.255"))
+        assertNoRoutes(findRoutes("69.96.0.0", "69.103.255.255"))
+        assertNoRoutes(findRoutes("70.192.0.0", "70.223.255.255"))
+        assertNoRoutes(findRoutes("72.96.0.0", "72.127.255.255"))
+        assertNoRoutes(findRoutes("75.192.0.0", "75.255.255.255"))
+        assertNoRoutes(findRoutes("97.0.0.0", "97.63.255.255"))
+        assertNoRoutes(findRoutes("97.128.0.0", "97.191.255.255"))
+        assertNoRoutes(findRoutes("174.192.0.0", "174.255.255.255"))
+    }
+
+    @Test
     fun `all private local addresses in 10·x·x·x range are excluded from VPN`() {
         val fromRange = "10.0.0.0"
         val toRange = "10.255.255.255"
@@ -77,8 +98,108 @@ class VpnRoutesTest {
     }
 
     @Test
-    fun `all addresses between private 10·x·x·x range and link local range go through VPN`() {
+    fun `all addresses between private 10·x·x·x range and wifi calling range go through VPN`() {
         val fromRange = "11.0.0.0"
+        val toRange = "66.94.1.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 66·94·3·0 range and wifi calling range go through VPN`() {
+        val fromRange = "66.94.3.0"
+        val toRange = "66.94.5.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 66·94·12·0 range and wifi calling range go through VPN`() {
+        val fromRange = "66.94.12.0"
+        val toRange = "66.173.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 66·175·0·0 range and wifi calling range go through VPN`() {
+        val fromRange = "66.175.0.0"
+        val toRange = "69.81.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 69·84·0·0 range and wifi calling range go through VPN`() {
+        val fromRange = "69.84.0.0"
+        val toRange = "69.95.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 69·104·0·0 range and wifi calling range go through VPN`() {
+        val fromRange = "69.104.0.0"
+        val toRange = "70.191.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 70·224·0·0 range and wifi calling range go through VPN`() {
+        val fromRange = "70.224.0.0"
+        val toRange = "71.255.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 72·128·0·0 range and wifi calling range go through VPN`() {
+        val fromRange = "72.128.0.0"
+        val toRange = "75.127.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 76·0·0·0 range and wifi calling range go through VPN`() {
+        val fromRange = "76.0.0.0"
+        val toRange = "96.255.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 97·64·0·0 range and wifi calling range go through VPN`() {
+        val fromRange = "97.64.0.0"
+        val toRange = "97.127.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 98·0·0·0 range and wifi calling range go through VPN`() {
+        val fromRange = "98.0.0.0"
         val toRange = "169.253.255.255"
         val routes = findRoutes(fromRange, toRange)
         assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
@@ -97,8 +218,18 @@ class VpnRoutesTest {
     }
 
     @Test
-    fun `all addresses between private 172 range and private 192 range go through VPN`() {
+    fun `all addresses between private 172 range and 174·191·255·255 range go through VPN`() {
         val fromRange = "172.32.0.0"
+        val toRange = "174.191.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 175·0·0·0 range and private 192 range go through VPN`() {
+        val fromRange = "175.0.0.0"
         val toRange = "192.167.255.255"
         val routes = findRoutes(fromRange, toRange)
         assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
@@ -107,8 +238,18 @@ class VpnRoutesTest {
     }
 
     @Test
-    fun `all addresses between private 192 range and multicast range go through VPN`() {
+    fun `all addresses between private 192 range and 208·53·255·255 go through VPN`() {
         val fromRange = "192.169.0.0"
+        val toRange = "208.53.255.255"
+        val routes = findRoutes(fromRange, toRange)
+        assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)
+        assertIpLesserOrEqualTo(toRange, routes.last().highAddress)
+        assertNoGaps(routes)
+    }
+
+    @Test
+    fun `all addresses between 208·55·0·0 range and multicast range go through VPN`() {
+        val fromRange = "208.55.0.0"
         val toRange = "223.255.255.255"
         val routes = findRoutes(fromRange, toRange)
         assertIpGreaterOrEqualTo(fromRange, routes.first().lowAddress)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201438077555953/f

### Description
There seems to be a bug in some OEMs that breaks wi-fi calling when there's an active android VPN.

Samsung seems to be one of the OEMs affected. As Samsung footprint is very high amongst our users, we fix this issue by adding exclusion routes to the t-mobile and verizon ePDG servers.

### Steps to test this PR
Perform smoke tests for AppTP

Verify that the `VpnRoutes` contain the following routes:
* T-mobile wi-fi calling
 * 66.94.2.0/24  -> 66.94.2.255
 * 66.94.6.0/23  -> 66.94.7.255
 * 66.94.8.0/22  -> 66.94.11.255 
 * 208.54.0.0/16 -> 208.54.255.255
* Verizon wi-fi calling
 * 66.174.0.0/16 -> 66.174.255.255
 * 69.82.0.0/15  -> 69.83.255.255
 * 69.96.0.0/13  -> 69.103.255.255
 * 70.192.0.0/11 -> 70.223.255.255
 * 72.96.0.0/9   -> 72.127.255.255
 * 75.192.0.0/9  -> 75.255.255.255
 * 97.0.0.0/10   -> 97.63.255.255
 * 97.128.0.0/9  -> 97.255.255.255
 * 174.192.0.0/9 -> 174.255.255.255


