### PR TITLE
Add support for IPv6 in internal builds only

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/TunPacketReader.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/TunPacketReader.kt
@@ -18,8 +18,12 @@ package com.duckduckgo.mobile.android.vpn.processor
 
 import android.os.ParcelFileDescriptor
 import android.os.Process
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.BuildFlavor
 import com.duckduckgo.mobile.android.vpn.health.HealthMetricCounter
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
+import com.duckduckgo.mobile.android.vpn.processor.packet.isIP4
+import com.duckduckgo.mobile.android.vpn.processor.packet.isIP6
 import com.duckduckgo.mobile.android.vpn.service.VpnQueues
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -36,6 +40,7 @@ class TunPacketReader @AssistedInject constructor(
     private val queues: VpnQueues,
     private val healthMetricCounter: HealthMetricCounter,
     private val deviceShieldPixels: DeviceShieldPixels,
+    private val appBuildConfig: AppBuildConfig,
 ) : Runnable {
 
     private var running = false
@@ -93,8 +98,13 @@ class TunPacketReader @AssistedInject constructor(
 
         bufferToNetwork.flip()
         val packet = Packet(bufferToNetwork)
-        if (packet.ip4Header.version.toInt() == 4) {
-            healthMetricCounter.onTunIpv4PacketReceived()
+        if (packet.isIP4() || isIP6AndInternalBuild(packet)) {
+            if (packet.isIP4()) {
+                healthMetricCounter.onTunIpv4PacketReceived()
+            }
+            if (packet.isIP6()) {
+                healthMetricCounter.onTunIpv6PacketReceived()
+            }
 
             if (packet.isUDP) {
                 queues.udpDeviceToNetwork.offer(packet)
@@ -104,13 +114,18 @@ class TunPacketReader @AssistedInject constructor(
                 healthMetricCounter.onWrittenToDeviceToNetworkQueue()
             } else {
                 healthMetricCounter.onTunUnknownPacketReceived()
-                deviceShieldPixels.sendUnknownPacketProtocol(packet.ip4Header.protocolNum.toInt())
+                deviceShieldPixels.sendUnknownPacketProtocol(packet.ipHeader.protocol.number)
                 ByteBufferPool.release(bufferToNetwork)
             }
         } else {
-            healthMetricCounter.onTunIpv6PacketReceived()
+            // this is temporary until we remove the isIP6AndInternalBuild() to make IP6 available in production builds
+            if (packet.isIP6()) healthMetricCounter.onTunIpv6PacketReceived()
             ByteBufferPool.release(bufferToNetwork)
         }
+    }
+
+    private fun isIP6AndInternalBuild(packet: Packet): Boolean {
+        return packet.isIP6() && appBuildConfig.flavor == BuildFlavor.INTERNAL
     }
 
     private fun byteBuffer(): ByteBuffer {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/packet/PacketExtension.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/packet/PacketExtension.kt
@@ -19,14 +19,32 @@ package com.duckduckgo.mobile.android.vpn.processor.packet
 import com.duckduckgo.mobile.android.vpn.processor.requestingapp.ConnectionInfo
 import xyz.hexene.localvpn.Packet
 
+fun Packet.totalHeaderSize(): Int {
+    return if (isTCP) {
+        ipHeader.headerLength + Packet.TCP_HEADER_SIZE
+    } else if (isUDP) {
+        ipHeader.headerLength + Packet.UDP_HEADER_SIZE
+    } else {
+        throw java.lang.IllegalArgumentException("Protocol not supported")
+    }
+}
+
 fun Packet.connectionInfo(): ConnectionInfo {
     return ConnectionInfo(
-        destinationAddress = ip4Header.destinationAddress,
+        destinationAddress = ipHeader.destinationAddress,
         destinationPort = extractDestinationPort(),
-        sourceAddress = ip4Header.sourceAddress,
+        sourceAddress = ipHeader.sourceAddress,
         sourcePort = extractSourcePort(),
-        protocolNumber = ip4Header.protocol.number
+        protocolNumber = ipHeader.protocol.number
     )
+}
+
+fun Packet.isIP4(): Boolean {
+    return ipHeader.version == 4
+}
+
+fun Packet.isIP6(): Boolean {
+    return ipHeader.version == 6
 }
 
 private fun Packet.extractSourcePort() =

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/DetectOriginatingAppPackageLegacy.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/DetectOriginatingAppPackageLegacy.kt
@@ -17,12 +17,12 @@
 package com.duckduckgo.mobile.android.vpn.processor.requestingapp
 
 import android.content.pm.PackageManager
+import com.duckduckgo.mobile.android.vpn.ProtocolVersion.TCP
+import com.duckduckgo.mobile.android.vpn.ProtocolVersion.UDP
 import com.duckduckgo.mobile.android.vpn.processor.requestingapp.DetectOriginatingAppPackageLegacy.NetworkFileSearchResult.Found
 import com.duckduckgo.mobile.android.vpn.processor.requestingapp.DetectOriginatingAppPackageLegacy.NetworkFileSearchResult.NotFound
 import kotlinx.coroutines.*
 import timber.log.Timber
-import xyz.hexene.localvpn.Packet.IP4Header.TransportProtocol.TCP
-import xyz.hexene.localvpn.Packet.IP4Header.TransportProtocol.UDP
 import java.io.File
 import java.util.concurrent.Executors
 import java.util.regex.Pattern

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
@@ -90,7 +90,7 @@ class TcpDeviceToNetwork(
 
         healthMetricCounter.onReadFromDeviceToNetworkQueue()
 
-        val destinationAddress = packet.ip4Header.destinationAddress
+        val destinationAddress = packet.ipHeader.destinationAddress
         val destinationPort = packet.tcpHeader.destinationPort
         val sourcePort = packet.tcpHeader.sourcePort
 
@@ -381,7 +381,7 @@ class TcpDeviceToNetwork(
         Timber.v("Determining if a tracker. Already determined? %s", tcb.trackerTypeDetermined)
         if (tcb.trackerTypeDetermined) {
             return if (tcb.isTracker) (RequestTrackerType.Tracker(tcb.trackerHostName)) else RequestTrackerType.NotTracker(
-                tcb.hostName ?: packet.ip4Header.destinationAddress.hostName
+                tcb.hostName ?: packet.ipHeader.destinationAddress.hostName
             )
         }
 
@@ -389,7 +389,7 @@ class TcpDeviceToNetwork(
     }
 
     private fun determineIfLocalIpAddress(packet: Packet): Boolean {
-        return localAddressDetector.isLocalAddress(packet.ip4Header.destinationAddress)
+        return localAddressDetector.isLocalAddress(packet.ipHeader.destinationAddress)
     }
 
     private fun determineRequestingApp(

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/PayloadBytesExtractor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/PayloadBytesExtractor.kt
@@ -32,8 +32,8 @@ class ConcretePayloadBytesExtractor : PayloadBytesExtractor {
         packet: Packet,
         payloadBuffer: ByteBuffer
     ): ByteArray {
-        val headerLength = packet.ip4Header.headerLength + packet.tcpHeader.headerLength
-        val payloadSize = packet.ip4Header.totalLength - headerLength
+        val headerLength = packet.ipHeader.headerLength + packet.tcpHeader.headerLength
+        val payloadSize = packet.ipHeader.totalLength - headerLength
         val newArray = ByteArray(payloadSize)
 
         if (payloadBuffer.hasArray()) {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/VpnTrackerDetector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/VpnTrackerDetector.kt
@@ -64,11 +64,11 @@ class DomainBasedTrackerDetector(
     ): RequestTrackerType {
 
         if (isLocalAddress) {
-            Timber.v("%s is a local address; not looking for trackers", packet.ip4Header.destinationAddress)
+            Timber.v("%s is a local address; not looking for trackers", packet.ipHeader.destinationAddress)
             tcb.trackerTypeDetermined = true
             tcb.isTracker = false
 
-            return RequestTrackerType.NotTracker(packet.ip4Header.destinationAddress.hostName)
+            return RequestTrackerType.NotTracker(packet.ipHeader.destinationAddress.hostName)
         }
 
         val payloadBytes = payloadBytesExtractor.extract(packet, payloadBuffer)

--- a/vpn/src/main/java/xyz/hexene/localvpn/IP4Header.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/IP4Header.java
@@ -21,9 +21,9 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 
 public class IP4Header implements IPHeader {
-    private byte version;
+    private final byte version;
     public byte IHL;
-    private int headerLength;
+    private final int headerLength;
     public short typeOfService;
     private int totalLength;
 
@@ -62,6 +62,11 @@ public class IP4Header implements IPHeader {
     @Override
     public TransportProtocol getProtocol() {
         return protocol;
+    }
+
+    @Override
+    public int getDefaultHeaderSize() {
+        return 20;
     }
 
     @Override

--- a/vpn/src/main/java/xyz/hexene/localvpn/IP4Header.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/IP4Header.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.hexene.localvpn;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+
+public class IP4Header implements IPHeader {
+    private byte version;
+    public byte IHL;
+    private int headerLength;
+    public short typeOfService;
+    private int totalLength;
+
+    public int identificationAndFlagsAndFragmentOffset;
+
+    public short TTL;
+    public final short protocolNum;
+    private TransportProtocol protocol;
+    public int headerChecksum;
+
+    private InetAddress sourceAddress;
+    private InetAddress destinationAddress;
+
+    public int optionsAndPadding;
+
+    @Override
+    public InetAddress getSourceAddress() {
+        return sourceAddress;
+    }
+
+    @Override
+    public void setSourceAddress(InetAddress address) {
+        this.sourceAddress = address;
+    }
+
+    @Override
+    public InetAddress getDestinationAddress() {
+        return destinationAddress;
+    }
+
+    @Override
+    public void setDestinationAddress(InetAddress address) {
+        this.destinationAddress = address;
+    }
+
+    @Override
+    public TransportProtocol getProtocol() {
+        return protocol;
+    }
+
+    @Override
+    public int getHeaderLength() {
+        return this.headerLength;
+    }
+
+    @Override
+    public int getTotalLength() {
+        return totalLength;
+    }
+
+    @Override
+    public void setTotalLength(int totalLength) {
+        this.totalLength = totalLength;
+    }
+
+    @Override
+    public int getVersion() {
+        return version;
+    }
+
+    IP4Header(ByteBuffer buffer) throws UnknownHostException {
+        byte versionAndIHL = buffer.get();
+        this.version = (byte) (versionAndIHL >> 4);
+        this.IHL = (byte) (versionAndIHL & 0x0F);
+        this.headerLength = this.IHL << 2;
+
+        this.typeOfService = Packet.BitUtils.getUnsignedByte(buffer.get());
+        this.totalLength = Packet.BitUtils.getUnsignedShort(buffer.getShort());
+
+        this.identificationAndFlagsAndFragmentOffset = buffer.getInt();
+
+        this.TTL = Packet.BitUtils.getUnsignedByte(buffer.get());
+        this.protocolNum = Packet.BitUtils.getUnsignedByte(buffer.get());
+        this.protocol = TransportProtocol.fromNumber(protocolNum);
+        this.headerChecksum = Packet.BitUtils.getUnsignedShort(buffer.getShort());
+
+        byte[] addressBytes = new byte[4];
+        buffer.get(addressBytes, 0, 4);
+        this.sourceAddress = InetAddress.getByAddress(addressBytes);
+
+        buffer.get(addressBytes, 0, 4);
+        this.destinationAddress = InetAddress.getByAddress(addressBytes);
+
+        // this.optionsAndPadding = buffer.getInt();
+    }
+
+    @Override
+    public void fillHeader(ByteBuffer buffer) {
+        buffer.put((byte) (this.version << 4 | this.IHL));
+        buffer.put((byte) this.typeOfService);
+        buffer.putShort((short) this.totalLength);
+
+        buffer.putInt(this.identificationAndFlagsAndFragmentOffset);
+
+        buffer.put((byte) this.TTL);
+        buffer.put((byte) this.protocol.getNumber());
+        buffer.putShort((short) this.headerChecksum);
+
+        buffer.put(this.sourceAddress.getAddress());
+        buffer.put(this.destinationAddress.getAddress());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("IP4Header{");
+        sb.append("version=").append(version);
+        sb.append(", IHL=").append(IHL);
+        sb.append(", typeOfService=").append(typeOfService);
+        sb.append(", totalLength=").append(totalLength);
+        sb.append(", identificationAndFlagsAndFragmentOffset=")
+                .append(identificationAndFlagsAndFragmentOffset);
+        sb.append(", TTL=").append(TTL);
+        sb.append(", protocol=").append(protocolNum).append(":").append(protocol);
+        sb.append(", headerChecksum=").append(headerChecksum);
+        sb.append(", sourceAddress=").append(sourceAddress.getHostAddress());
+        sb.append(", destinationAddress=").append(destinationAddress.getHostAddress());
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/vpn/src/main/java/xyz/hexene/localvpn/IP6Header.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/IP6Header.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.hexene.localvpn;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+
+public class IP6Header implements IPHeader {
+    /** Size of the IPv6 header in bytes. */
+    private static final int HEADER_SIZE_BYTES = 40;
+
+    // 4-bit long
+    private final int version;
+    // 8-bit long
+    private final int trafficClass;
+    // 20-bit long
+    private final int flowLabel;
+    // 16-bit long
+    private short payloadLength;
+    // 8-bit long
+    private final short nextHeader;
+    // 8-bit long
+    private final short hopLimit;
+    // 16 byte long
+    private InetAddress sourceAddress;
+    // 16 byte long
+    private InetAddress destinationAddress;
+
+    public IP6Header(ByteBuffer buffer) throws UnknownHostException {
+        byte versionAndHighTrafficClass = buffer.get();
+        this.version = versionAndHighTrafficClass >> 4;
+        byte lowTrafficClassAndFlowLabelHighNibble = buffer.get();
+        this.trafficClass =
+                versionAndHighTrafficClass & 0x0f
+                        | ((lowTrafficClassAndFlowLabelHighNibble & 0xf0) >> 4);
+        short lowFlowLabel = buffer.getShort();
+        this.flowLabel = (lowTrafficClassAndFlowLabelHighNibble & 0x0f) << 20 | lowFlowLabel;
+
+        this.payloadLength = buffer.getShort();
+        this.nextHeader = buffer.get();
+        this.hopLimit = buffer.get();
+
+        sourceAddress = getAddress(buffer);
+        destinationAddress = getAddress(buffer);
+    }
+
+    @Override
+    public InetAddress getSourceAddress() {
+        return sourceAddress;
+    }
+
+    @Override
+    public InetAddress getDestinationAddress() {
+        return destinationAddress;
+    }
+
+    @Override
+    public void setDestinationAddress(InetAddress address) {
+        this.destinationAddress = address;
+    }
+
+    @Override
+    public void setSourceAddress(InetAddress address) {
+        this.sourceAddress = address;
+    }
+
+    @Override
+    public TransportProtocol getProtocol() {
+        return TransportProtocol.fromNumber(this.nextHeader);
+    }
+
+    @Override
+    public int getHeaderLength() {
+        return HEADER_SIZE_BYTES;
+    }
+
+    @Override
+    public int getTotalLength() {
+        return this.payloadLength + HEADER_SIZE_BYTES;
+    }
+
+    @Override
+    public void setTotalLength(int length) {
+        this.payloadLength = (short) length;
+    }
+
+    @Override
+    public int getVersion() {
+        return version;
+    }
+
+    @Override
+    public void fillHeader(ByteBuffer buffer) {
+        buffer.put((byte) ((version << 4) | (trafficClass & 0xF0) >> 4));
+        buffer.put((byte) ((trafficClass & 0x0f) << 4 | (flowLabel & 0xf0000) >> 16));
+        buffer.putShort((short) (flowLabel & 0x0FFFF));
+        buffer.putShort(payloadLength);
+        buffer.put((byte) nextHeader);
+        buffer.put((byte) hopLimit);
+        buffer.put(sourceAddress.getAddress());
+        buffer.put(destinationAddress.getAddress());
+    }
+
+    private InetAddress getAddress(ByteBuffer buffer) throws UnknownHostException {
+        byte[] addressBytes = new byte[16];
+        buffer.get(addressBytes, 0, 16);
+        return InetAddress.getByAddress(addressBytes);
+    }
+
+    @Override
+    public String toString() {
+        return "IP6Header{"
+                + "version="
+                + version
+                + ", trafficClass="
+                + trafficClass
+                + ", flowLabel="
+                + flowLabel
+                + ", payloadLength="
+                + payloadLength
+                + ", nextHeader="
+                + nextHeader
+                + ", hopLimit="
+                + hopLimit
+                + ", sourceAddress="
+                + sourceAddress
+                + ", destinationAddress="
+                + destinationAddress
+                + '}';
+    }
+}

--- a/vpn/src/main/java/xyz/hexene/localvpn/IP6Header.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/IP6Header.java
@@ -85,6 +85,11 @@ public class IP6Header implements IPHeader {
     }
 
     @Override
+    public int getDefaultHeaderSize() {
+        return getHeaderLength();
+    }
+
+    @Override
     public int getHeaderLength() {
         return HEADER_SIZE_BYTES;
     }
@@ -96,7 +101,7 @@ public class IP6Header implements IPHeader {
 
     @Override
     public void setTotalLength(int length) {
-        this.payloadLength = (short) length;
+        this.payloadLength = (short) (length - HEADER_SIZE_BYTES);
     }
 
     @Override

--- a/vpn/src/main/java/xyz/hexene/localvpn/IPHeader.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/IPHeader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.hexene.localvpn;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+
+public interface IPHeader {
+    InetAddress getSourceAddress();
+
+    void setSourceAddress(InetAddress address);
+
+    InetAddress getDestinationAddress();
+
+    void setDestinationAddress(InetAddress address);
+
+    TransportProtocol getProtocol();
+
+    int getHeaderLength();
+
+    int getTotalLength();
+
+    void setTotalLength(int length);
+
+    int getVersion();
+
+    void fillHeader(ByteBuffer buffer);
+
+    /**
+     * Calculates checksums assuming the checksum is a 16-bit header field. This method is
+     * generalized to work for IP, ICMP, UDP, and TCP packets given the proper parameters.
+     */
+    static int computeChecksum(
+            ByteBuffer backingBuffer, int checksumOffset, int length, boolean update) {
+
+        ByteBuffer buffer = backingBuffer.duplicate();
+        buffer.position(0);
+
+        // Clear previous checksum
+        buffer.putShort(checksumOffset, (short) 0);
+
+        int ipLength = length;
+        int sum = 0;
+        while (ipLength > 0) {
+            sum += Packet.BitUtils.getUnsignedShort(buffer.getShort());
+            ipLength -= 2;
+        }
+        while (sum >> 16 > 0) sum = (sum & 0xFFFF) + (sum >> 16);
+
+        sum = ~sum;
+        if (update) {
+            backingBuffer.putShort(checksumOffset, (short) sum);
+        }
+
+        return sum;
+    }
+}

--- a/vpn/src/main/java/xyz/hexene/localvpn/IPHeader.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/IPHeader.java
@@ -30,6 +30,8 @@ public interface IPHeader {
 
     TransportProtocol getProtocol();
 
+    int getDefaultHeaderSize();
+
     int getHeaderLength();
 
     int getTotalLength();

--- a/vpn/src/main/java/xyz/hexene/localvpn/Packet.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/Packet.java
@@ -26,14 +26,15 @@ import java.nio.ByteBuffer;
 // TODO: Reduce public mutability
 public class Packet {
 
-    public static final int IP4_HEADER_SIZE = 20;
+    static final int IP4_HEADER_SIZE = 20;
     public static final int TCP_HEADER_SIZE = 20;
     public static final int UDP_HEADER_SIZE = 8;
-    public static final int TCP_OPTION_TYPE_MSS = 0x02;
-    public static final int TCP_OPTION_MSS_SIZE = 0x04;
-    public static final int TCP_MAX_SEGMENT_SIZE = BUFFER_SIZE - 40;
+    static final int TCP_OPTION_TYPE_MSS = 0x02;
+    static final int TCP_OPTION_MSS_SIZE = 0x04;
+    static final int TCP_MAX_SEGMENT_SIZE = BUFFER_SIZE - 40;
 
-    public IP4Header ip4Header;
+    private IP4Header ip4Header;
+    private final IP6Header ip6Header;
     public TCPHeader tcpHeader;
     public UDPHeader udpHeader;
     public ByteBuffer backingBuffer;
@@ -42,15 +43,37 @@ public class Packet {
     private boolean isUDP;
 
     public Packet(ByteBuffer buffer) throws UnknownHostException {
+        buffer.mark();
+
         this.ip4Header = new IP4Header(buffer);
-        if (this.ip4Header.protocol == IP4Header.TransportProtocol.TCP) {
+        TransportProtocol protocol;
+        if (ip4Header.getVersion() == 4) {
+            this.ip6Header = null;
+            protocol = ip4Header.getProtocol();
+        } else if (this.ip4Header.getVersion() == 6) {
+            this.ip4Header = null;
+            buffer.reset();
+            this.ip6Header = new IP6Header(buffer);
+            protocol = ip6Header.getProtocol();
+        } else {
+            // There's no proper net exception
+            throw new UnknownHostException("Wrong IP version");
+        }
+
+        if (protocol == TransportProtocol.TCP) {
             this.tcpHeader = new TCPHeader(buffer);
             this.isTCP = true;
-        } else if (ip4Header.protocol == IP4Header.TransportProtocol.UDP) {
+        } else if (protocol == TransportProtocol.UDP) {
             this.udpHeader = new UDPHeader(buffer);
             this.isUDP = true;
         }
         this.backingBuffer = buffer;
+    }
+
+    public IPHeader getIpHeader() {
+        if (this.ip4Header == null) return this.ip6Header;
+
+        return this.ip4Header;
     }
 
     @Override
@@ -73,9 +96,9 @@ public class Packet {
     }
 
     public void swapSourceAndDestination() {
-        InetAddress newSourceAddress = ip4Header.destinationAddress;
-        ip4Header.destinationAddress = ip4Header.sourceAddress;
-        ip4Header.sourceAddress = newSourceAddress;
+        InetAddress newSourceAddress = getIpHeader().getDestinationAddress();
+        getIpHeader().setDestinationAddress(getIpHeader().getSourceAddress());
+        getIpHeader().setSourceAddress(newSourceAddress);
 
         if (isUDP) {
             int newSourcePort = udpHeader.destinationPort;
@@ -91,9 +114,9 @@ public class Packet {
     public int tcpPayloadSize(boolean containsIpHeader) {
         if (isUDP) return 0;
 
-        int totalLength = ip4Header.totalLength;
+        int totalLength = getIpHeader().getTotalLength();
         int tcpHeaderLength = tcpHeader.headerLength;
-        int ipHeaderLength = containsIpHeader ? ip4Header.headerLength : 0;
+        int ipHeaderLength = containsIpHeader ? getIpHeader().getHeaderLength() : 0;
 
         return totalLength - (tcpHeaderLength + ipHeaderLength);
     }
@@ -133,7 +156,7 @@ public class Packet {
 
         int ip4TotalLength = IP4_HEADER_SIZE + headerLength + payloadSize;
         backingBuffer.putShort(2, (short) ip4TotalLength);
-        ip4Header.totalLength = ip4TotalLength;
+        getIpHeader().setTotalLength(ip4TotalLength);
 
         updateIP4Checksum();
     }
@@ -153,29 +176,17 @@ public class Packet {
 
         int ip4TotalLength = IP4_HEADER_SIZE + udpTotalLength;
         backingBuffer.putShort(2, (short) ip4TotalLength);
-        ip4Header.totalLength = ip4TotalLength;
+        getIpHeader().setTotalLength(ip4TotalLength);
 
         updateIP4Checksum();
     }
 
     private void updateIP4Checksum() {
-        ByteBuffer buffer = backingBuffer.duplicate();
-        buffer.position(0);
-
-        // Clear previous checksum
-        buffer.putShort(10, (short) 0);
-
-        int ipLength = ip4Header.headerLength;
-        int sum = 0;
-        while (ipLength > 0) {
-            sum += BitUtils.getUnsignedShort(buffer.getShort());
-            ipLength -= 2;
+        // IPv6 has no checksum
+        if (getIpHeader().getVersion() == 6) {
+            return;
         }
-        while (sum >> 16 > 0) sum = (sum & 0xFFFF) + (sum >> 16);
-
-        sum = ~sum;
-        ip4Header.headerChecksum = sum;
-        backingBuffer.putShort(10, (short) sum);
+        IPHeader.computeChecksum(backingBuffer, 10, getIpHeader().getHeaderLength(), true);
     }
 
     private void updateTCPChecksum(int payloadSize) {
@@ -184,17 +195,17 @@ public class Packet {
         int tcpLength = TCP_HEADER_SIZE + optionsSize + payloadSize;
 
         // Calculate pseudo-header checksum
-        ByteBuffer buffer = ByteBuffer.wrap(ip4Header.sourceAddress.getAddress());
+        ByteBuffer buffer = ByteBuffer.wrap(getIpHeader().getSourceAddress().getAddress());
         sum =
                 BitUtils.getUnsignedShort(buffer.getShort())
                         + BitUtils.getUnsignedShort(buffer.getShort());
 
-        buffer = ByteBuffer.wrap(ip4Header.destinationAddress.getAddress());
+        buffer = ByteBuffer.wrap(getIpHeader().getDestinationAddress().getAddress());
         sum +=
                 BitUtils.getUnsignedShort(buffer.getShort())
                         + BitUtils.getUnsignedShort(buffer.getShort());
 
-        sum += IP4Header.TransportProtocol.TCP.getNumber() + tcpLength;
+        sum += TransportProtocol.TCP.getNumber() + tcpLength;
 
         buffer = backingBuffer.duplicate();
         // Clear previous checksum
@@ -216,110 +227,9 @@ public class Packet {
     }
 
     private void fillHeader(ByteBuffer buffer) {
-        ip4Header.fillHeader(buffer);
+        getIpHeader().fillHeader(buffer);
         if (isUDP) udpHeader.fillHeader(buffer);
         else if (isTCP) tcpHeader.fillHeader(buffer);
-    }
-
-    public static class IP4Header {
-        public byte version;
-        public byte IHL;
-        public int headerLength;
-        public short typeOfService;
-        public int totalLength;
-
-        public int identificationAndFlagsAndFragmentOffset;
-
-        public short TTL;
-        public final short protocolNum;
-        public TransportProtocol protocol;
-        public int headerChecksum;
-
-        public InetAddress sourceAddress;
-        public InetAddress destinationAddress;
-
-        public int optionsAndPadding;
-
-        public enum TransportProtocol {
-            TCP(6),
-            UDP(17),
-            Other(0xFF);
-
-            private int protocolNumber;
-
-            TransportProtocol(int protocolNumber) {
-                this.protocolNumber = protocolNumber;
-            }
-
-            private static TransportProtocol numberToEnum(int protocolNumber) {
-                if (protocolNumber == 6) return TCP;
-                else if (protocolNumber == 17) return UDP;
-                else return Other;
-            }
-
-            public int getNumber() {
-                return this.protocolNumber;
-            }
-        }
-
-        private IP4Header(ByteBuffer buffer) throws UnknownHostException {
-            byte versionAndIHL = buffer.get();
-            this.version = (byte) (versionAndIHL >> 4);
-            this.IHL = (byte) (versionAndIHL & 0x0F);
-            this.headerLength = this.IHL << 2;
-
-            this.typeOfService = BitUtils.getUnsignedByte(buffer.get());
-            this.totalLength = BitUtils.getUnsignedShort(buffer.getShort());
-
-            this.identificationAndFlagsAndFragmentOffset = buffer.getInt();
-
-            this.TTL = BitUtils.getUnsignedByte(buffer.get());
-            this.protocolNum = BitUtils.getUnsignedByte(buffer.get());
-            this.protocol = TransportProtocol.numberToEnum(protocolNum);
-            this.headerChecksum = BitUtils.getUnsignedShort(buffer.getShort());
-
-            byte[] addressBytes = new byte[4];
-            buffer.get(addressBytes, 0, 4);
-            this.sourceAddress = InetAddress.getByAddress(addressBytes);
-
-            buffer.get(addressBytes, 0, 4);
-            this.destinationAddress = InetAddress.getByAddress(addressBytes);
-
-            // this.optionsAndPadding = buffer.getInt();
-        }
-
-        public void fillHeader(ByteBuffer buffer) {
-            buffer.put((byte) (this.version << 4 | this.IHL));
-            buffer.put((byte) this.typeOfService);
-            buffer.putShort((short) this.totalLength);
-
-            buffer.putInt(this.identificationAndFlagsAndFragmentOffset);
-
-            buffer.put((byte) this.TTL);
-            buffer.put((byte) this.protocol.getNumber());
-            buffer.putShort((short) this.headerChecksum);
-
-            buffer.put(this.sourceAddress.getAddress());
-            buffer.put(this.destinationAddress.getAddress());
-        }
-
-        @Override
-        public String toString() {
-            final StringBuilder sb = new StringBuilder("IP4Header{");
-            sb.append("version=").append(version);
-            sb.append(", IHL=").append(IHL);
-            sb.append(", typeOfService=").append(typeOfService);
-            sb.append(", totalLength=").append(totalLength);
-            sb.append(", identificationAndFlagsAndFragmentOffset=")
-                    .append(identificationAndFlagsAndFragmentOffset);
-            sb.append(", TTL=").append(TTL);
-            sb.append(", protocol=").append(protocolNum).append(":").append(protocol);
-            sb.append(", headerChecksum=").append(headerChecksum);
-            sb.append(", sourceAddress=").append(sourceAddress.getHostAddress());
-            sb.append(", destinationAddress=").append(destinationAddress.getHostAddress());
-            sb.append('}');
-            return sb.toString();
-        }
     }
 
     public static class TCPHeader {
@@ -464,16 +374,16 @@ public class Packet {
         }
     }
 
-    private static class BitUtils {
-        private static short getUnsignedByte(byte value) {
+    static class BitUtils {
+        static short getUnsignedByte(byte value) {
             return (short) (value & 0xFF);
         }
 
-        private static int getUnsignedShort(short value) {
+        static int getUnsignedShort(short value) {
             return value & 0xFFFF;
         }
 
-        private static long getUnsignedInt(int value) {
+        static long getUnsignedInt(int value) {
             return value & 0xFFFFFFFFL;
         }
     }

--- a/vpn/src/main/java/xyz/hexene/localvpn/TransportProtocol.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/TransportProtocol.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.hexene.localvpn;
+
+public enum TransportProtocol {
+    TCP(6),
+    UDP(17),
+    Other(0xFF);
+
+    private int protocolNumber;
+
+    TransportProtocol(int protocolNumber) {
+        this.protocolNumber = protocolNumber;
+    }
+
+    public static TransportProtocol fromNumber(int protocolNumber) {
+        if (protocolNumber == 6) return TCP;
+        else if (protocolNumber == 17) return UDP;
+        else return Other;
+    }
+
+    public int getNumber() {
+        return this.protocolNumber;
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/requestingapp/ConnectionInfoTestUtil.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/requestingapp/ConnectionInfoTestUtil.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.mobile.android.vpn.processor.requestingapp.requestingapp
 
 import com.duckduckgo.mobile.android.vpn.processor.requestingapp.ConnectionInfo
-import xyz.hexene.localvpn.Packet
+import xyz.hexene.localvpn.TransportProtocol
 import java.net.InetAddress
 
 internal fun aConnectionInfo(
@@ -30,4 +30,4 @@ internal fun aConnectionInfo(
 
 internal fun anInternalIpAddress(): String = "192.168.0.1"
 internal fun anExternalIpAddress(): String = "52.142.124.215"
-private fun aProtocol(): Int = Packet.IP4Header.TransportProtocol.TCP.number
+private fun aProtocol(): Int = TransportProtocol.TCP.number

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/requestingapp/OriginatingAppPackageIdentifierStrategyTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/requestingapp/OriginatingAppPackageIdentifierStrategyTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.mobile.android.vpn.processor.requestingapp.OriginatingAppP
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.junit.Test
-import xyz.hexene.localvpn.Packet
+import xyz.hexene.localvpn.TransportProtocol
 import java.net.InetAddress
 
 class OriginatingAppPackageIdentifierStrategyTest {
@@ -48,5 +48,5 @@ class OriginatingAppPackageIdentifierStrategyTest {
     private fun aConnectionInfo(): ConnectionInfo = ConnectionInfo(anAddress(), aPort(), anAddress(), aPort(), aProtocol())
     private fun anAddress(): InetAddress = InetAddress.getByName("192.168.0.1")
     private fun aPort(): Int = 80
-    private fun aProtocol(): Int = Packet.IP4Header.TransportProtocol.TCP.number
+    private fun aProtocol(): Int = TransportProtocol.TCP.number
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201928304609012/f

### Description
Add support for IPv6 traffic in AppTP.

See [this task](https://app.asana.com/0/488551667048375/1201928304609012/f) and [this other task](https://app.asana.com/0/488551667048375/1201862327796575) for full context.

### Steps to test this PR
_Best effort test_
* Testing if Ipv6 works is hard because it depends on external factors like the ISP.
* This why we enable it for internal builds only for now. Because we have some internal users that were hitting IPv6 issues and they already verified this improvement should work
* The best you can do is to switch to cellular network
* Filter logcat by `TcpNetworkToDevice`
* And see if you spot any IPv6 address in the logs

_Smoke tests for AppTP_
Repat smoke tests below for both PLAY and INTERNAL builds

- [x] install from this branch
- [x] enable AppTP
- [x] open apps that perform tracking attempts
- [x] verify blocking works as usual
- [x] open your most used apps, eg. twitter, insta, mail apps, etc
- [x] verify the continue working as usual
- [x] switch between WIFI and CELLULAR and vice versa
- [x] verify all works as expected, including tracker blocking
- [x] verify both update and fresh install
