### PR TITLE
Remove ATB information from AppTP pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/api/AtpPixelRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/AtpPixelRemovalInterceptor.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import com.duckduckgo.app.global.AppUrl
+import com.duckduckgo.app.global.plugins.pixel.PixelInterceptorPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import okhttp3.Interceptor
+import okhttp3.Response
+import timber.log.Timber
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelInterceptorPlugin::class
+)
+class AtpPixelRemovalInterceptor @Inject constructor() : Interceptor, PixelInterceptorPlugin {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+        val pixel = chain.request().url.pathSegments.last()
+        val url = if (pixel.startsWith(PIXEL_PREFIX) && !PIXEL_EXCEPTIONS.contains(pixel)) {
+            chain.request().url.newBuilder()
+                .removeAllQueryParameters(AppUrl.ParamKey.ATB)
+                .build()
+        } else {
+            chain.request().url
+        }
+
+        Timber.d("Pixel interceptor: $url")
+
+        return chain.proceed(request.url(url).build())
+    }
+
+    companion object {
+        private const val PIXEL_PREFIX = "m_atp_"
+
+        // list here the pixels that except from this interceptor
+        private val PIXEL_EXCEPTIONS = listOf<String>()
+    }
+
+    override fun getInterceptor(): Interceptor {
+        return this
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/global/api/AtpPixelRemovalInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/api/AtpPixelRemovalInterceptorTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixelNames
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class AtpPixelRemovalInterceptorTest {
+    private lateinit var atpPixelRemovalInterceptor: AtpPixelRemovalInterceptor
+
+    @Before
+    fun setup() {
+        atpPixelRemovalInterceptor = AtpPixelRemovalInterceptor()
+    }
+
+    @Test
+    fun whenSendPixelTheRedactAtbInfoFromPixels() {
+        DeviceShieldPixelNames.values().map { it.pixelName }.forEach { pixelName ->
+            val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
+
+            val interceptedUrl = atpPixelRemovalInterceptor.intercept(FakeChain(pixelUrl)).request.url
+            assertTrue(interceptedUrl.queryParameter("atb") == null)
+            assertFalse(interceptedUrl.queryParameter("appVersion") == null)
+        }
+    }
+
+    companion object {
+        private const val PIXEL_TEMPLATE = "https://improving.duckduckgo.com/t/%s_android_phone?atb=v255-7zu&appVersion=5.74.0&test=1"
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1201931173358064/f

### Description
Remove ATB information from all AppTP pixels

### Steps to test this PR

_Test ATB info is gone_
- [ ] install from this branch
- [ ] filter logcat with `AtpPixelRemovalInterceptor`
- [ ] open app and enable AppTP
- [ ] verify that all `m_atp_` pixels do not carry the `atb` param
