### PR TITLE
Detect and set private DNS in AppTP

### DIFF
--- a/common/src/main/java/com/duckduckgo/app/global/extensions/ContextExtensions.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/extensions/ContextExtensions.kt
@@ -20,6 +20,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.Context.ACTIVITY_SERVICE
 import android.os.Build.VERSION_CODES.R
+import android.provider.Settings
 import androidx.annotation.RequiresApi
 import java.util.*
 
@@ -34,4 +35,15 @@ fun Context.historicalExitReasonsByProcessName(
         .filter { it.processName == name }
         .take(n)
         .map { "[${Date(it.timestamp)} - Reason: ${it.reason}: ${it.description}" }
+}
+
+fun Context.isPrivateDnsActive(): Boolean {
+    var dnsMode = Settings.Global.getString(contentResolver, "private_dns_mode")
+    if (dnsMode == null) dnsMode = "off"
+    return "off" != dnsMode
+}
+
+fun Context.getPrivateDnsServerName(): String? {
+    val dnsMode = Settings.Global.getString(contentResolver, "private_dns_mode")
+    return if ("hostname" == dnsMode) Settings.Global.getString(contentResolver, "private_dns_specifier") else null
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/dns/PrivateDnsSettingMonitor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/dns/PrivateDnsSettingMonitor.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.dns
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.di.scopes.VpnScope
+import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
+import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
+import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dummy.ui.VpnPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ContributesMultibinding(VpnScope::class)
+class PrivateDnsSettingMonitor @Inject constructor(
+    private val context: Context,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val vpnPreferences: VpnPreferences,
+) : VpnServiceCallbacks {
+
+    private val vpnSharedPreferencesListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (vpnPreferences.isPrivateDnsKey(key)) {
+            appCoroutineScope.launch {
+                TrackerBlockingVpnService.restartVpnService(context)
+            }
+        }
+    }
+
+    override fun onVpnStarted(coroutineScope: CoroutineScope) {
+        vpnPreferences.registerOnSharedPreferenceChangeListener(vpnSharedPreferencesListener)
+    }
+
+    override fun onVpnStopped(coroutineScope: CoroutineScope, vpnStopReason: VpnStateMonitor.VpnStopReason) {
+        vpnPreferences.unregisterOnSharedPreferenceChangeListener(vpnSharedPreferencesListener)
+    }
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
+import java.net.InetAddress
 import java.nio.channels.DatagramChannel
 import java.nio.channels.SocketChannel
 import java.util.concurrent.ExecutorService
@@ -266,6 +267,12 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
             if (vpnPreferences.isCustomDnsServerSet()) {
                 addDnsServer("1.1.1.1").also { Timber.i("Using custom DNS server (1.1.1.1)") }
             }
+            vpnPreferences.privateDns?.let { privateDnsName ->
+                if (appBuildConfig.flavor == INTERNAL) {
+                    Timber.v("Setting private DNS: $privateDnsName")
+                    InetAddress.getAllByName(privateDnsName).forEach { addr -> addDnsServer(addr) }
+                }
+            }
 
             // Can either route all apps through VPN and exclude a few (better for prod), or exclude all apps and include a few (better for dev)
             val limitingToTestApps = false
@@ -397,7 +404,6 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
 
     companion object {
 
-        const val ACTION_VPN_REMINDER = "com.duckduckgo.vpn.internaltesters.reminder"
         const val ACTION_VPN_REMINDER_RESTART = "com.duckduckgo.vpn.internaltesters.reminder.restart"
 
         const val VPN_REMINDER_NOTIFICATION_ID = 999

--- a/vpn/src/main/java/dummy/ui/VpnPreferences.kt
+++ b/vpn/src/main/java/dummy/ui/VpnPreferences.kt
@@ -18,6 +18,7 @@ package dummy.ui
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -29,20 +30,33 @@ class VpnPreferences @Inject constructor(
 ) {
 
     fun updateDebugLoggingPreference(enabled: Boolean) {
-        prefs().edit { putBoolean(PREFS_KEY_DEBUG_LOGGING, enabled) }
+        preferences.edit { putBoolean(PREFS_KEY_DEBUG_LOGGING, enabled) }
     }
 
-    fun getDebugLoggingPreference(): Boolean = prefs().getBoolean(PREFS_KEY_DEBUG_LOGGING, appBuildConfig.isDebug)
+    fun getDebugLoggingPreference(): Boolean = preferences.getBoolean(PREFS_KEY_DEBUG_LOGGING, appBuildConfig.isDebug)
 
     fun useCustomDnsServer(dnsServer: Boolean) {
-        prefs().edit { putBoolean(PREFS_KEY_DNS_SERVER, dnsServer) }
+        preferences.edit { putBoolean(PREFS_KEY_DNS_SERVER, dnsServer) }
     }
 
-    fun isCustomDnsServerSet(): Boolean = prefs().getBoolean(PREFS_KEY_DNS_SERVER, false)
+    fun isCustomDnsServerSet(): Boolean = preferences.getBoolean(PREFS_KEY_DNS_SERVER, false)
 
-    private fun prefs(): SharedPreferences {
-        return applicationContext.getSharedPreferences(PREFS_FILENAME, Context.MODE_PRIVATE)
+    var privateDns: String?
+        get() = preferences.getString("private_dns", null)
+        set(value) = preferences.edit { putString("private_dns", value) }
+
+    fun isPrivateDnsKey(key: String) = key == "private_dns"
+
+    fun registerOnSharedPreferenceChangeListener(listener: OnSharedPreferenceChangeListener) {
+        preferences.registerOnSharedPreferenceChangeListener(listener)
     }
+
+    fun unregisterOnSharedPreferenceChangeListener(listener: OnSharedPreferenceChangeListener) {
+        preferences.unregisterOnSharedPreferenceChangeListener(listener)
+    }
+
+    private val preferences: SharedPreferences
+        get() = applicationContext.getSharedPreferences(PREFS_FILENAME, Context.MODE_PRIVATE)
 
     companion object {
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201931173358074/f

### Description
Try to fix the issues with private DNS settings.

When users go to Android settings and set the private DNS, the systems expects to use DoT[H] however the VPN default DNS will not support it. And that will create issues in certain cases.

The PR listens for the `private_dns_mode` setting and adds those as well to the VPN configuration.

This is done for now in internal builds only to give it some bake time


### Steps to test this PR

_Check private DNS is added to VPN config in internal builds_
- [x] install from this branch the internal flavor
- [x] Enable AppTP and filter logcat by `Setting private DNS`
- [x] Go to Android setting `Private DNS`, configure it to `manual` and set it to `one.one.one.one`
- [x] Click `save`
- [x] Verify the `Setting private DNS:...` log appears in the console
- [x] Go to diagnostics screen and verify the DNS(es) also appear in there
- [x] Repeate this test using the play flavor
- [x] verify the `Setting private DNS:...` log does not appear and that in diagnostics no additional DNS appears

Repeat this tests above for both WIFI and CELLULAR connections. The one difference may be that in CELLULAR you may also see IPv6 DNS addresses.

