### PR TITLE
Fix issue where AppTP can't be turned off

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/network/RealVpnDetector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/network/RealVpnDetector.kt
@@ -16,13 +16,9 @@
 
 package com.duckduckgo.mobile.android.vpn.network
 
-import android.annotation.TargetApi
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import android.os.Build
-import androidx.annotation.RequiresApi
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -32,28 +28,11 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 class RealVpnDetector @Inject constructor(
     private val context: Context,
-    private val appBuildConfig: AppBuildConfig
 ) : VpnDetector {
 
     override fun isVpnDetected(): Boolean {
-        return if (appBuildConfig.sdkInt <= Build.VERSION_CODES.LOLLIPOP_MR1) {
-            detectVpnLollipop()
-        } else {
-            detectVpn()
-        }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.M)
-    private fun detectVpn(): Boolean {
         val connectivityManager = context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val activeNetwork = connectivityManager.activeNetwork
         return connectivityManager.getNetworkCapabilities(activeNetwork)?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ?: false
     }
-
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP_MR1)
-    private fun detectVpnLollipop(): Boolean {
-        val connectivityManager = context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        return connectivityManager.activeNetworkInfo?.type == ConnectivityManager.TYPE_VPN
-    }
-
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModel.kt
@@ -73,7 +73,7 @@ class DeviceShieldTrackerActivityViewModel @Inject constructor(
 
     internal fun onAppTPToggleSwitched(enabled: Boolean) {
         when {
-            vpnDetector.isVpnDetected() -> sendCommand(Command.ShowVpnConflictDialog)
+            enabled && vpnDetector.isVpnDetected() -> sendCommand(Command.ShowVpnConflictDialog)
             enabled == true -> sendCommand(Command.CheckVPNPermission)
             enabled == false -> sendCommand(Command.ShowDisableConfirmationDialog)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1201931173358115/f

### Description
But was introduced in #1763 where AppTP can't no longer be turned OFF

### Steps to test this PR

_Verify appTP can be turned off_
- [ ] install from this branch
- [ ] install another 3rd party VPN, eg. Netguard
- [ ] enable ApptP
- [ ] disable ApptP
- [ ] verify AppTP is disabled
- [ ] re-enable AppTP and verify it re-enables
- [ ] re-run the tests in #1763 to verify they also work (you'll need the 3rd party VPN for that)

