### PR TITLE
revert Configure sockets to use SO_REUSEADDR

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -28,7 +28,6 @@ import android.net.Network
 import android.net.VpnService
 import android.os.Binder
 import android.os.Build
-import android.os.Build.VERSION_CODES
 import android.os.IBinder
 import android.os.Parcel
 import android.os.ParcelFileDescriptor
@@ -61,7 +60,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
-import java.net.StandardSocketOptions
 import java.nio.channels.DatagramChannel
 import java.nio.channels.SocketChannel
 import java.util.concurrent.ExecutorService
@@ -537,12 +535,8 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
         }
     }
 
-    @SuppressLint("NewApi") // because we use the appBuildConfig.sdkInt IDE doesn't detect it
     override fun createSocketChannel(): SocketChannel {
         return SocketChannel.open().also { channel ->
-            if (appBuildConfig.sdkInt >= VERSION_CODES.N) {
-                channel.setOption(StandardSocketOptions.SO_REUSEADDR, true)
-            }
             channel.configureBlocking(false)
             protect(channel.socket())
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201949708149080/f

### Description
Reverting SO_REUSEADDR because we're seeing some increase in breakage and might be a candidate.

### Steps to test this PR
Smoke AppTP tests and code review

