### PR TITLE
Guard against duplicated byte buffer pool releases

### DIFF
--- a/vpn/src/test/java/xyz/hexene/localvpn/ByteBufferPoolTest.kt
+++ b/vpn/src/test/java/xyz/hexene/localvpn/ByteBufferPoolTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.hexene.localvpn
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class ByteBufferPoolTest {
+
+    @Test
+    fun whenAcquireThenReturnBuffer() {
+        assertNotNull(ByteBufferPool.acquire())
+    }
+
+    @Test
+    fun whenReleaseNullBufferThenReturn() {
+        assertEquals(ByteBufferPool.ENULL, ByteBufferPool.release(null))
+    }
+
+    @Test
+    fun whenReleaseBufferThenSuccess() {
+        assertEquals(0, ByteBufferPool.release(ByteBufferPool.acquire()))
+    }
+
+    @Test
+    fun whenReleaseSameBufferTwiceThenError() {
+        val buffer = ByteBufferPool.acquire()
+
+        assertEquals(0, ByteBufferPool.release(buffer))
+        assertEquals(ByteBufferPool.EEXIST, ByteBufferPool.release(buffer))
+    }
+
+    @Test
+    fun whenAcquireBufferThenIncrementAllocationCount() {
+        assertEquals(0, ByteBufferPool.allocations.get())
+
+        // new alloc, increment count
+        ByteBufferPool.acquire()
+        assertEquals(1, ByteBufferPool.allocations.get())
+
+        // new alloc, increment count
+        val b = ByteBufferPool.acquire()
+        assertEquals(2, ByteBufferPool.allocations.get())
+
+        // release, buffer back to pool
+        ByteBufferPool.release(b)
+        assertEquals(1, ByteBufferPool.allocations.get())
+
+        // new alloc, no count increment because poll should have one element
+        ByteBufferPool.acquire()
+        assertEquals(1, ByteBufferPool.allocations.get())
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201949747150726/f

### Description
Releasing the byte buffers that back the packets is a tedious process, and it can happen that we try to release the same buffer twice.

As the buffers a direct `ByteBuffers`, when released, they end up in a pool of available buffers, which is implemented by a linked queue. It can happen that the same buffer is released twice, resulting in a duplicated entry in the queue, eventually ending up in possible buffer corruption as it can be allocated twice.

This PR ensures that it won't be possible to release the same buffer twice.

### Steps to test this PR
Smoke tests in AppTP.

The newly added tests pass.

