### PR TITLE
Add ipv6, private DNS and network switching handling to AppTP internal settings

### DIFF
--- a/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureName.kt
+++ b/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureName.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 DuckDuckGo
+ * Copyright (c) 2022 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-}
+package com.duckduckgo.mobile.android.vpn.feature
 
-apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+import com.duckduckgo.feature.toggles.api.FeatureName
 
-dependencies {
-    implementation project(path: ':feature-toggles-api')
-
-    implementation Kotlin.stdlib.jdk7
-    implementation AndroidX.core.ktx
-    implementation KotlinX.coroutines.core
-
+sealed class AppTpFeatureName(override val value: String) : FeatureName {
+    data class Ipv6Support(override val value: String = "ipv6Support") : AppTpFeatureName(value)
+    data class PrivateDnsSupport(override val value: String = "privateDnsSupport") : AppTpFeatureName(value)
+    data class NetworkSwitchingHandling(override val value: String = "networkSwitchingHandling") : AppTpFeatureName(value)
 }

--- a/vpn-internal/build.gradle
+++ b/vpn-internal/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation project(path: ':common')
     implementation project(path: ':common-ui')
     implementation project(path: ':appbuildconfig-api')
+    implementation project(path: ':feature-toggles-api')
 
     implementation Kotlin.stdlib.jdk7
 

--- a/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
+++ b/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
@@ -23,8 +23,11 @@ import android.widget.CompoundButton
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureName
 import com.duckduckgo.mobile.android.vpn.health.AppHealthMonitor
 import com.duckduckgo.mobile.android.vpn.health.BadHealthMitigationFeature
+import com.duckduckgo.mobile.android.vpn.store.RealVpnFeatureToggleStore
+import com.duckduckgo.mobile.android.vpn.store.VpnFeatureToggles
 import com.duckduckgo.vpn.internal.databinding.ActivityVpnInternalSettingsBinding
 import com.duckduckgo.vpn.internal.feature.bugreport.VpnBugReporter
 import com.duckduckgo.vpn.internal.feature.logs.DebugLoggingReceiver
@@ -46,6 +49,8 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var badHealthMitigationFeature: BadHealthMitigationFeature
+
+    private val vpnFeatureToggleStore = RealVpnFeatureToggleStore(this)
 
     private val binding: ActivityVpnInternalSettingsBinding by viewBinding()
     private var transparencyModeDebugReceiver: TransparencyModeDebugReceiver? = null
@@ -91,6 +96,7 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
         setupDeleteTrackingHistory()
         setupViewDiagnosticsView()
         setupBadHealthMonitoring()
+        setupConfigSection()
     }
 
     override fun onDestroy() {
@@ -165,6 +171,24 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
 
         binding.badHealthMitigationToggle.isChecked = badHealthMitigationFeature.isEnabled
         binding.badHealthMitigationToggle.setOnCheckedChangeListener(badHealthMitigationFeatureToggle)
+    }
+
+    private fun setupConfigSection() {
+        binding.ipv6SupportToggle.isChecked = vpnFeatureToggleStore.get(AppTpFeatureName.Ipv6Support().value, false) ?: false
+        binding.ipv6SupportToggle.setOnCheckedChangeListener { _, isChecked ->
+            vpnFeatureToggleStore.insert(VpnFeatureToggles(AppTpFeatureName.Ipv6Support().value, isChecked))
+        }
+
+        binding.privateDnsToggle.isChecked = vpnFeatureToggleStore.get(AppTpFeatureName.PrivateDnsSupport().value, false) ?: false
+        binding.privateDnsToggle.setOnCheckedChangeListener { _, isChecked ->
+            vpnFeatureToggleStore.insert(VpnFeatureToggles(AppTpFeatureName.PrivateDnsSupport().value, isChecked))
+        }
+
+        binding.vpnUnderlyingNetworksToggle.isChecked = vpnFeatureToggleStore.get(AppTpFeatureName.NetworkSwitchingHandling().value, false)
+            ?: false
+        binding.vpnUnderlyingNetworksToggle.setOnCheckedChangeListener { _, isChecked ->
+            vpnFeatureToggleStore.insert(VpnFeatureToggles(AppTpFeatureName.NetworkSwitchingHandling().value, isChecked))
+        }
     }
 
     private fun setupDebugLogging() {

--- a/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
+++ b/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
@@ -54,6 +54,52 @@
             android:orientation="vertical"
         >
 
+            <!-- Section Config -->
+            <TextView
+                android:id="@+id/sectionConfigTitle"
+                style="@style/SettingsSectionTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Config"
+            />
+
+            <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/ipv6SupportToggle"
+                    style="@style/SettingsSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="IPv6 Support"
+                    android:theme="@style/SettingsSwitchTheme"
+            />
+
+            <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/privateDnsToggle"
+                    style="@style/SettingsSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Private DNS support"
+                    android:theme="@style/SettingsSwitchTheme"
+            />
+
+            <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/vpnUnderlyingNetworksToggle"
+                    style="@style/SettingsSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Network Switching handling"
+                    android:theme="@style/SettingsSwitchTheme"
+            />
+
+            <!-- Section Trackers -->
+            <View style="@style/SettingsGroupDivider" />
+            <TextView
+                android:id="@+id/sectionTrackersTitle"
+                style="@style/SettingsSectionTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Trackers"
+            />
+
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/transparencyModeToggle"
                 style="@style/SettingsSwitch"
@@ -71,6 +117,25 @@
                 android:text="App/Tracker exception rules"
             />
 
+            <TextView
+                    android:id="@+id/delete_tracking_history"
+                    style="@style/SettingsItemClickable"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:text="Delete Tracking History"
+            />
+
+            <!-- Section Logging -->
+            <View style="@style/SettingsGroupDivider" />
+
+            <TextView
+                    android:id="@+id/sectionTrackersLogging"
+                    style="@style/SettingsSectionTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Logging"
+            />
+
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/debug_logging_toggle"
                 style="@style/SettingsSwitch"
@@ -80,20 +145,22 @@
                 android:theme="@style/SettingsSwitchTheme"
             />
 
+            <!-- Section Diagnostics -->
+            <View style="@style/SettingsGroupDivider" />
+
+            <TextView
+                    android:id="@+id/sectionDiagnosticsTitle"
+                    style="@style/SettingsSectionTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Diagnostics"
+            />
+
             <com.duckduckgo.vpn.internal.feature.ui.SettingsToggleOptionWithLoadingState
                 android:id="@+id/apptp_bugreport"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:title="Generate AppTP bugreport"
-            />
-
-
-            <TextView
-                android:id="@+id/delete_tracking_history"
-                style="@style/SettingsItemClickable"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                android:text="Delete Tracking History"
             />
 
             <TextView
@@ -102,6 +169,18 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 android:text="View Diagnostics Data"/>
+
+
+            <!-- Section Health -->
+            <View style="@style/SettingsGroupDivider" />
+
+            <TextView
+                    android:id="@+id/sectionHealthTitle"
+                    style="@style/SettingsSectionTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Health"
+            />
 
             <androidx.appcompat.widget.SwitchCompat
                     android:id="@+id/badHealthMonitorToggle"

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnFeatureToggleStore.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnFeatureToggleStore.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.store
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+interface VpnFeatureToggleStore {
+    fun deleteAll()
+
+    fun get(
+        featureName: String,
+        defaultValue: Boolean
+    ): Boolean?
+
+    fun insert(toggle: VpnFeatureToggles)
+}
+
+class RealVpnFeatureToggleStore(private val context: Context) : VpnFeatureToggleStore {
+    private val preferences: SharedPreferences
+        get() = context.getSharedPreferences(FILENAME, Context.MODE_MULTI_PROCESS)
+
+    override fun deleteAll() {
+        preferences.edit().clear().apply()
+    }
+
+    override fun get(featureName: String, defaultValue: Boolean): Boolean? {
+        return if (preferences.contains(featureName)) {
+            preferences.getBoolean(featureName, defaultValue)
+        } else {
+            null
+        }
+    }
+
+    override fun insert(toggle: VpnFeatureToggles) {
+        preferences.edit { putBoolean(toggle.featureName, toggle.enabled) }
+    }
+
+    companion object {
+        const val FILENAME = "com.duckduckgo.vpn.atp.config.store.toggles"
+    }
+}
+
+data class VpnFeatureToggles(
+    val featureName: String,
+    val enabled: Boolean,
+)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureToggleRepository.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureToggleRepository.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature
+
+import android.content.Context
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.BuildFlavor
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.store.RealVpnFeatureToggleStore
+import com.duckduckgo.mobile.android.vpn.store.VpnFeatureToggleStore
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+
+// marker interface to use delegate pattern
+interface AppTpFeatureToggleRepository : VpnFeatureToggleStore
+
+class RealAppTpFeatureToggleRepository constructor(
+    private val vpnFeatureToggleStore: VpnFeatureToggleStore,
+    private val appBuildConfig: AppBuildConfig,
+) : AppTpFeatureToggleRepository, VpnFeatureToggleStore by vpnFeatureToggleStore {
+
+    override fun get(featureName: String, defaultValue: Boolean): Boolean? {
+        val delegateValue = vpnFeatureToggleStore.get(featureName, defaultValue) ?: return null
+
+        // Ensure production builds have all these feature disabled for now
+        return (appBuildConfig.flavor == BuildFlavor.INTERNAL) && delegateValue
+    }
+}
+
+@ContributesTo(AppScope::class)
+@Module
+class AppTpFeatureToggleRepositoryModule {
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideAppTpFeatureToggleRepository(context: Context, appBuildConfig: AppBuildConfig): AppTpFeatureToggleRepository {
+        val store = RealVpnFeatureToggleStore(context)
+        return RealAppTpFeatureToggleRepository(store, appBuildConfig)
+    }
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPlugin.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPlugin.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
+import com.duckduckgo.feature.toggles.api.FeatureTogglesPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class AppTpFeatureTogglesPlugin @Inject constructor(
+    private val appTpFeatureToggleRepository: AppTpFeatureToggleRepository,
+) : FeatureTogglesPlugin {
+    override fun isEnabled(featureName: FeatureName, defaultValue: Boolean): Boolean? {
+        return if (featureName is AppTpFeatureName) {
+            return appTpFeatureToggleRepository.get(featureName.value, defaultValue)
+        } else {
+            null
+        }
+    }
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/FeatureToggleExtensions.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/FeatureToggleExtensions.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature
+
+import com.duckduckgo.feature.toggles.api.FeatureToggle
+
+internal fun FeatureToggle.isNetworkSwitchingHandlingEnabled(): Boolean {
+    return isFeatureEnabled(AppTpFeatureName.NetworkSwitchingHandling(), false) == true
+}
+internal fun FeatureToggle.isIpv6SupportEnabled(): Boolean {
+    return isFeatureEnabled(AppTpFeatureName.Ipv6Support(), false) == true
+}
+internal fun FeatureToggle.isPrivateDnsSupportEnabled(): Boolean {
+    return isFeatureEnabled(AppTpFeatureName.PrivateDnsSupport(), false) == true
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -35,8 +35,10 @@ import android.system.OsConstants.AF_INET6
 import androidx.core.content.ContextCompat
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.appbuildconfig.api.BuildFlavor.INTERNAL
+import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.mobile.android.vpn.apps.TrackingProtectionAppsRepository
+import com.duckduckgo.mobile.android.vpn.feature.isPrivateDnsSupportEnabled
+import com.duckduckgo.mobile.android.vpn.feature.isNetworkSwitchingHandlingEnabled
 import com.duckduckgo.mobile.android.vpn.network.connection.ConnectionMonitor
 import com.duckduckgo.mobile.android.vpn.network.connection.NetworkConnectionListener
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
@@ -117,6 +119,8 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
 
     @Inject lateinit var connectionMonitorFactory: ConnectionMonitor.Factory
     private var connectionMonitor: ConnectionMonitor? = null
+
+    @Inject lateinit var featureToggle: FeatureToggle
 
     private val vpnStateServiceConnection = object : ServiceConnection {
         override fun onServiceConnected(
@@ -268,7 +272,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
                 addDnsServer("1.1.1.1").also { Timber.i("Using custom DNS server (1.1.1.1)") }
             }
             vpnPreferences.privateDns?.let { privateDnsName ->
-                if (appBuildConfig.flavor == INTERNAL) {
+                if (featureToggle.isPrivateDnsSupportEnabled()) {
                     Timber.v("Setting private DNS: $privateDnsName")
                     InetAddress.getAllByName(privateDnsName).forEach { addr -> addDnsServer(addr) }
                 }
@@ -503,30 +507,28 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
 
     @SuppressLint("NewApi")
     override fun onNetworkDisconnected() {
-        // for now just in internal builds to ensure it doesn't have side effects
-        if (appBuildConfig.flavor != INTERNAL) return
-
-        // TODO maybe at some point show the user?
-        Timber.w("No network")
-        if (appBuildConfig.sdkInt >= 22) {
-            setUnderlyingNetworks(null)
+        if (featureToggle.isNetworkSwitchingHandlingEnabled()) {
+            // TODO maybe at some point show the user?
+            Timber.w("No network")
+            if (appBuildConfig.sdkInt >= 22) {
+                setUnderlyingNetworks(null)
+            }
         }
     }
 
     @SuppressLint("NewApi")
     override fun onNetworkConnected(networks: LinkedHashSet<Network>) {
-        // for now just in internal builds to ensure it doesn't have side effects
-        if (appBuildConfig.flavor != INTERNAL) return
-
-        if (appBuildConfig.sdkInt >= 22) {
-            Timber.w("set underlying networks: $networks")
-            if (networks.isEmpty()) {
-                // this should never happen. If networks.isEmpty() onNetworkDisconnected() should be called instead.
-                // just safeguard
-                Timber.w("onNetworkConnected called with empty networks...setting underlying networks to default")
-                setUnderlyingNetworks(null)
-            } else {
-                setUnderlyingNetworks(networks.toTypedArray())
+        if (featureToggle.isNetworkSwitchingHandlingEnabled()) {
+            if (appBuildConfig.sdkInt >= 22) {
+                Timber.w("set underlying networks: $networks")
+                if (networks.isEmpty()) {
+                    // this should never happen. If networks.isEmpty() onNetworkDisconnected() should be called instead.
+                    // just safeguard
+                    Timber.w("onNetworkConnected called with empty networks...setting underlying networks to default")
+                    setUnderlyingNetworks(null)
+                } else {
+                    setUnderlyingNetworks(networks.toTypedArray())
+                }
             }
         }
     }

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPluginTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPluginTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature
+
+import com.duckduckgo.feature.toggles.api.FeatureName
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AppTpFeatureTogglesPluginTest {
+
+    private val appTpFeatureToggleRepository: AppTpFeatureToggleRepository = mock()
+    private lateinit var plugin: AppTpFeatureTogglesPlugin
+
+    @Before
+    fun setup() {
+        plugin = AppTpFeatureTogglesPlugin(appTpFeatureToggleRepository)
+    }
+
+    @Test
+    fun whenIsEnabledCalledOnAppTpFeatureNameThenReturnRepositoryValue() {
+        whenever(appTpFeatureToggleRepository.get(AppTpFeatureName.Ipv6Support().value, false)).thenReturn(null)
+        assertNull(plugin.isEnabled(AppTpFeatureName.Ipv6Support(), false))
+
+        whenever(appTpFeatureToggleRepository.get(AppTpFeatureName.Ipv6Support().value, false)).thenReturn(true)
+        assertEquals(true, plugin.isEnabled(AppTpFeatureName.Ipv6Support(), false))
+
+        whenever(appTpFeatureToggleRepository.get(AppTpFeatureName.Ipv6Support().value, false)).thenReturn(false)
+        assertEquals(false, plugin.isEnabled(AppTpFeatureName.Ipv6Support(), false))
+    }
+
+    @Test
+    fun whenIsEnabledCalledOnOtherFeatureNameThenReturnRepositoryNull() {
+        assertNull(plugin.isEnabled(TestFeatureName(), false))
+    }
+}
+
+class TestFeatureName(override val value: String = "test") : FeatureName

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/RealAppTpFeatureToggleRepositoryTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/RealAppTpFeatureToggleRepositoryTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature
+
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.BuildFlavor
+import com.duckduckgo.mobile.android.vpn.store.VpnFeatureToggleStore
+import com.duckduckgo.mobile.android.vpn.store.VpnFeatureToggles
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealAppTpFeatureToggleRepositoryTest {
+
+    private val appBuildConfig: AppBuildConfig = mock()
+    private val vpnFeatureToggleStore: VpnFeatureToggleStore = mock()
+
+    private lateinit var repository: RealAppTpFeatureToggleRepository
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+
+        repository = RealAppTpFeatureToggleRepository(vpnFeatureToggleStore, appBuildConfig)
+    }
+
+    @Test
+    fun whenDeleteAllThenDelegate() {
+        repository.deleteAll()
+
+        verify(vpnFeatureToggleStore).deleteAll()
+    }
+
+    @Test
+    fun whenInsertThenDelegate() {
+        repository.insert(VpnFeatureToggles("feature", false))
+
+        verify(vpnFeatureToggleStore).insert(VpnFeatureToggles("feature", false))
+    }
+
+    @Test
+    fun whenGetFeatureAndPlayBuildThenReturnFalseOrNull() {
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.PLAY)
+
+        whenever(vpnFeatureToggleStore.get("feature", false)).thenReturn(null)
+        assertNull(repository.get("feature", false))
+
+        whenever(vpnFeatureToggleStore.get("feature", false)).thenReturn(true)
+        assertEquals(false, repository.get("feature", false))
+
+        whenever(vpnFeatureToggleStore.get("feature", false)).thenReturn(false)
+        assertEquals(false, repository.get("feature", false))
+    }
+
+    @Test
+    fun whenGetFeatureAndFdroidBuildThenReturnFalseOrNull() {
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.FDROID)
+
+        whenever(vpnFeatureToggleStore.get("feature", false)).thenReturn(null)
+        assertNull(repository.get("feature", false))
+
+        whenever(vpnFeatureToggleStore.get("feature", false)).thenReturn(true)
+        assertEquals(false, repository.get("feature", false))
+
+        whenever(vpnFeatureToggleStore.get("feature", false)).thenReturn(false)
+        assertEquals(false, repository.get("feature", false))
+    }
+
+    @Test
+    fun whenGetFeatureAndInternalBuildThenReturnFalseOrValue() {
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.INTERNAL)
+
+        whenever(vpnFeatureToggleStore.get("feature", false)).thenReturn(null)
+        assertNull(repository.get("feature", false))
+
+        whenever(vpnFeatureToggleStore.get("feature", false)).thenReturn(true)
+        assertEquals(true, repository.get("feature", false))
+
+        whenever(vpnFeatureToggleStore.get("feature", false)).thenReturn(false)
+        assertEquals(false, repository.get("feature", false))
+    }
+}

--- a/vpn/vpn-build.gradle
+++ b/vpn/vpn-build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation project(path: ':common-ui')
     implementation project(path: ':statistics')
     implementation project(path: ':appbuildconfig-api')
+    implementation project(path: ':feature-toggles-api')
 
     implementation Kotlin.stdlib.jdk7
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1201967142475482/f

### Description
Some of the current AppTP features are only available in internal builds:
* IP6 support
* network switching handling
* private DNS handling

However internal users are not able to enable/disable them, making it hard to know whether they cause side (breakage) effects.

This PR adds entries in the AppTP internal settings screen for those features. And does that in a way that in the future is ready to integrate with [remote privacy config](https://app.asana.com/0/1199371158290272/1201967142475463/f)

### Steps to test this PR

_Test the feature enable/disable
- [x] install INTERNAL build
- [x] filter logcat by `set underlying networks|No network
- [x] enable AppTP
- [x] switch beteen WIFI <> CELLULAR and vicecersa
- [x] verify that logcat doesn't print any message
- [x] go to AppTP internal settings and toggle `Network Switching handling` ON
- [x] switch between WIFI<>CELLULAR and viceversa
- [x] verify the logcat messages DO appear
- [x] go to AppTP internal settings and toggle `Network Switching handling` OFF
- [x] clear logcat
- [x] filter logcat by `Dropping ipv6 packet to`
- [x] switch to CELLULAR connection
- [x] open instagram
- [x] verify that messages DO appear in the logcat
- [x] close instagram
- [x] go to AppTP internal settings and toggle `IPv6 support` ON
- [x] clear logcat
- [x] open instagram
- [x] verify that messages DO NOT appear in the logcat
- [x] go to AppTP internal settings and toggle `IPv6 support` OFF
- [x] clear logcat
- [x] disable and re-enable AppTP
- [x] filter logcat by `Setting private DNS`
- [x] go to Android settings and configure private DNS to `one.one.one.one`
- [x] verify logcat messags DO NOT appear
- [x] go to AppTP internal settings and toggle `private DNS support` ON
- [x] disable and re-enable AppTP
- [x] verify logcat messags DO appear

- [x] repeat the tests above for PLAY build
- [x] verify it behaves as if the feature toggle was OFF

