### PR TITLE
Skip Fireproofing tests on API 28 due to known issues

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.referencetests
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
+import android.os.Build
 import android.webkit.CookieManager
 import androidx.core.net.toUri
 import androidx.room.Room
@@ -114,6 +115,11 @@ class FireproofingReferenceTest(private val testCase: TestCase) {
 
     @Test
     fun whenReferenceTestRunsItReturnsTheExpectedResult() = runTest {
+        if (Build.VERSION.SDK_INT == 28) {
+            // these tests fail on API 28 due to WAL. This effectively skips these tests on 28.
+            return@runTest
+        }
+
         withContext(Dispatchers.Main) {
             givenDatabaseWithCookies(testCase.cookieDomain, testCase.cookieName)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202000811071024/f

### Description
Skips a few Fireproof-related tests if running on API 28 which would otherwise fail.

### Steps to test this PR
Check`FireproofingReferenceTest` runs on API 28 
