### PR TITLE
Integrate AppTP with remote config 1/N

### DIFF
--- a/app/src/internal/java/com/duckduckgo/app/flipper/FlipperInitializer.kt
+++ b/app/src/internal/java/com/duckduckgo/app/flipper/FlipperInitializer.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.core.FlipperPlugin
 import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.soloader.SoLoader
 import com.squareup.anvil.annotations.ContributesMultibinding
 import timber.log.Timber
@@ -48,6 +49,7 @@ class FlipperInitializer @Inject constructor(
 
             // Common device plugins
             addPlugin(DatabasesFlipperPlugin(context))
+            addPlugin(SharedPreferencesFlipperPlugin(context))
 
             start()
         }

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggle.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggle.kt
@@ -34,4 +34,25 @@ interface FeatureToggle {
  */
 interface FeatureName {
     val value: String
+
+    companion object {
+        /**
+         * Utility function to create a [FeatureName] from the passed in [block] lambda
+         * instead of using the anonymous `object : FeatureName` syntax.
+         *
+         * Usage:
+         *
+         * ```kotlin
+         * val feature = FeatureName {
+         *
+         * }
+         * ```
+         */
+        inline operator fun invoke(crossinline block: () -> String): FeatureName {
+            return object : FeatureName {
+                override val value: String
+                    get() = block()
+            }
+        }
+    }
 }

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeaturePlugin.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeaturePlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 DuckDuckGo
+ * Copyright (c) 2022 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,23 @@ package com.duckduckgo.privacy.config.api
 
 import com.duckduckgo.feature.toggles.api.FeatureName
 
-/** List of [FeatureName] that belong to the Privacy Configuration */
-enum class PrivacyFeatureName(override val value: String) : FeatureName {
-    ContentBlockingFeatureName("contentBlocking"),
-    GpcFeatureName("gpc"),
-    HttpsFeatureName("https"),
-    TrackerAllowlistFeatureName("trackerAllowlist"),
-    DrmFeatureName("eme"),
-    AmpLinksFeatureName("ampLinks"),
-    TrackingParametersFeatureName("trackingParameters"),
-    AutofillFeatureName("autofill"),
+/**
+ * Implement this interface and contribute it as a multibinding to get called upon downloading remote privacy config
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * @ContributesMultibinding(AppScope::class)
+ * class MuFeaturePlugin @Inject constructor(...) : PrivacyFeaturePlugin {
+ *
+ * }
+ * ```
+ */
+interface PrivacyFeaturePlugin {
+    fun store(
+        name: FeatureName,
+        jsonString: String
+    ): Boolean
+
+    val featureName: FeatureName
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -19,9 +19,9 @@ package com.duckduckgo.privacy.config.impl
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.privacy.config.api.privacyFeatureValueOf
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.PrivacyConfig
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
@@ -58,10 +58,8 @@ class RealPrivacyConfigPersister @Inject constructor(
                 unprotectedTemporaryRepository.updateAll(jsonPrivacyConfig.unprotectedTemporary)
                 jsonPrivacyConfig.features.forEach { feature ->
                     feature.value?.let { jsonObject ->
-                        privacyFeaturePluginPoint.getPlugins().forEach { plugin ->
-                            privacyFeatureValueOf(feature.key)?.let {
-                                plugin.store(it, jsonObject.toString())
-                            }
+                        privacyFeaturePluginPoint.getPlugins().firstOrNull { feature.key == it.featureName.value }?.let { featurePlugin ->
+                            featurePlugin.store(FeatureName { feature.key }, jsonObject.toString())
                         }
                     }
                 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
@@ -26,7 +26,7 @@ import com.duckduckgo.di.DaggerSet
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.duckduckgo.privacy.config.impl.network.PrivacyConfigService
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePluginPoint
 import com.duckduckgo.privacy.config.store.ALL_MIGRATIONS
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/PrivacyFeatureNameUtil.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/PrivacyFeatureNameUtil.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features
+
+import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+
+/**
+ * Convenience method to get the [PrivacyFeatureName] from its [String] value
+ */
+fun privacyFeatureValueOf(value: String): PrivacyFeatureName? {
+    return PrivacyFeatureName.values().find { it.value == value }
+}

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPlugin.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.privacy.config.impl.features.amplinks
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.*
 import com.duckduckgo.privacy.config.store.features.amplinks.AmpLinksRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -32,7 +34,9 @@ class AmpLinksPlugin @Inject constructor(
     private val privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository
 ) : PrivacyFeaturePlugin {
 
-    override fun store(name: PrivacyFeatureName, jsonString: String): Boolean {
+    override fun store(name: FeatureName, jsonString: String): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = privacyFeatureValueOf(name.value)
         if (name == featureName) {
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<AmpLinksFeature> =

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/autofill/AutofillPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/autofill/AutofillPlugin.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.privacy.config.impl.features.autofill
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.AutofillExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
@@ -35,9 +37,11 @@ class AutofillPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: PrivacyFeatureName,
+        name: FeatureName,
         jsonString: String
     ): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = privacyFeatureValueOf(name.value)
         if (name == featureName) {
             val autofillExceptions = mutableListOf<AutofillExceptionEntity>()
             val moshi = Moshi.Builder().build()

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingPlugin.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.privacy.config.impl.features.contentblocking
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.ContentBlockingExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
@@ -35,9 +37,11 @@ class ContentBlockingPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: PrivacyFeatureName,
+        name: FeatureName,
         jsonString: String
     ): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = privacyFeatureValueOf(name.value)
         if (name == featureName) {
             val contentBlockingExceptions = mutableListOf<ContentBlockingExceptionEntity>()
             val moshi = Moshi.Builder().build()

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmPlugin.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.privacy.config.impl.features.drm
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.DrmExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
@@ -35,9 +37,11 @@ class DrmPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: PrivacyFeatureName,
+        name: FeatureName,
         jsonString: String
     ): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = privacyFeatureValueOf(name.value)
         if (name == featureName) {
             val drmExceptions = mutableListOf<DrmExceptionEntity>()
             val moshi = Moshi.Builder().build()

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.privacy.config.impl.features.gpc
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.GpcExceptionEntity
 import com.duckduckgo.privacy.config.store.GpcHeaderEnabledSiteEntity
 import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
@@ -36,9 +38,11 @@ class GpcPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: PrivacyFeatureName,
+        name: FeatureName,
         jsonString: String
     ): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = privacyFeatureValueOf(name.value)
         if (name == featureName) {
             val gpcExceptions = mutableListOf<GpcExceptionEntity>()
             val gpcHeaders = mutableListOf<GpcHeaderEnabledSiteEntity>()

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.privacy.config.impl.features.https
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
@@ -35,9 +37,11 @@ class HttpsPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: PrivacyFeatureName,
+        name: FeatureName,
         jsonString: String
     ): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = privacyFeatureValueOf(name.value)
         if (name == featureName) {
             val httpsExceptions = mutableListOf<HttpsExceptionEntity>()
             val moshi = Moshi.Builder().build()

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/TrackerAllowlistPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/TrackerAllowlistPlugin.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.privacy.config.impl.features.trackerallowlist
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.TrackerAllowlistEntity
 import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
@@ -35,9 +37,11 @@ class TrackerAllowlistPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: PrivacyFeatureName,
+        name: FeatureName,
         jsonString: String
     ): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = privacyFeatureValueOf(name.value)
         if (name == featureName) {
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<TrackerAllowlistFeature> =

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersPlugin.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.privacy.config.impl.features.trackingparameters
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.*
 import com.duckduckgo.privacy.config.store.features.trackingparameters.TrackingParametersRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -32,7 +34,9 @@ class TrackingParametersPlugin @Inject constructor(
     private val privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository
 ) : PrivacyFeaturePlugin {
 
-    override fun store(name: PrivacyFeatureName, jsonString: String): Boolean {
+    override fun store(name: FeatureName, jsonString: String): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = privacyFeatureValueOf(name.value)
         if (name == featureName) {
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<TrackingParametersFeature> =

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeaturePluginPoint.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeaturePluginPoint.kt
@@ -18,16 +18,7 @@ package com.duckduckgo.privacy.config.impl.plugins
 
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.di.DaggerSet
-import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-
-interface PrivacyFeaturePlugin {
-    fun store(
-        name: PrivacyFeatureName,
-        jsonString: String
-    ): Boolean
-
-    val featureName: PrivacyFeatureName
-}
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 
 class PrivacyFeaturePluginPoint(
     private val privacyFeatures: DaggerSet<PrivacyFeaturePlugin>

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
@@ -20,9 +20,10 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.PrivacyConfig
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
@@ -168,7 +169,7 @@ class RealPrivacyConfigPersisterTest {
         var count = 0
 
         override fun store(
-            name: PrivacyFeatureName,
+            name: FeatureName,
             jsonString: String
         ): Boolean {
             count++
@@ -176,7 +177,7 @@ class RealPrivacyConfigPersisterTest {
         }
 
         override val featureName: PrivacyFeatureName =
-            PrivacyFeatureName.ContentBlockingFeatureName
+            PrivacyFeatureName.GpcFeatureName
     }
 
     companion object {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/ReferenceTestUtilities.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/ReferenceTestUtilities.kt
@@ -26,7 +26,7 @@ import com.duckduckgo.privacy.config.impl.features.https.HttpsPlugin
 import com.duckduckgo.privacy.config.impl.features.trackerallowlist.TrackerAllowlistPlugin
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
-import com.duckduckgo.privacy.config.impl.plugins.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigDisabledReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigDisabledReferenceTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.FileUtilities
-import com.duckduckgo.privacy.config.api.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigEnabledReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigEnabledReferenceTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.FileUtilities
-import com.duckduckgo.privacy.config.api.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigMissingReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigMissingReferenceTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.FileUtilities
-import com.duckduckgo.privacy.config.api.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202005414608950/f

### Description
First stack PR to integrate AppTP with remote privacy config.

This PR generalised a bit the `RealPrivacyConfigPersister` and the `PrivacyFeaturePlugin` so they don't depend on the `PrivacyFeatureName` but rather in the `FeatureName`.

The reason is that by depending on the base `FeatureName` interface, we can now place the privacy features in other modules other than the `privacy-config-xxx` modules.

### Steps to test this PR

_Smoke tests on privacy config_
- [x] fresh install from this branch
- [x] open the app
- [x] inspect the `privacy_config` db and verify the configurations are correct
- [x] inspect the `com.duckduckgo.privacy.config.store.toggles` shared prefs and verify all toggles are ON except for `trackingParameters` that should be OFF
