### PR TITLE
Redact netId values from breakage

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
@@ -209,7 +209,17 @@ class NetworkTypeCollector @Inject constructor(
     private fun getNetworkInfoJsonObject(): JSONObject {
         updateSecondsSinceLastSwitch()
         // redact the lastSwitchTimestampMillis from the report
-        val info = currentNetworkInfo?.let { adapter.toJson(adapter.fromJson(it)?.copy(lastSwitchTimestampMillis = -999)) } ?: return JSONObject()
+        val info = currentNetworkInfo?.let {
+            // Redact some values (set to -999) as they could be static values
+            val temp = adapter.fromJson(it)
+            adapter.toJson(
+                temp?.copy(
+                    lastSwitchTimestampMillis = -999,
+                    currentNetwork = temp.currentNetwork.copy(netId = -999),
+                    previousNetwork = temp.previousNetwork?.copy(netId = -999)
+                )
+            )
+        } ?: return JSONObject()
 
         return JSONObject(info)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202050072225379/f

### Description
Remove the `netId` value from breakage

### Steps to test this PR
- [x] intall from this branch
- [x] launch app and enable AppTP
- [x] report breakage for any app
- [x] verify the breakage_metadata -> networkInfo -> currentNetwork contains `netId` set to -999
