### PR TITLE
Wrap shortcut creation in a runCatching

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -76,7 +76,7 @@ class AppShortcutCreator @Inject constructor(private val context: Context) {
         shortcutList.add(buildBookmarksShortcut(context))
 
         val shortcutManager = context.getSystemService(ShortcutManager::class.java)
-        shortcutManager.dynamicShortcuts = shortcutList
+        kotlin.runCatching { shortcutManager.dynamicShortcuts = shortcutList }
     }
 
     @RequiresApi(Build.VERSION_CODES.N_MR1)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/276630244458377/1202055094426961/f

### Description
Wraps the call interacting with `ShortcutManager` in a `runCatching` block. There are times when this call will fail with an `IllegalStateException`. When this happens, we don't want a crash but can silently swallow the exception given the low-importance of app shortcuts being registered.

### Steps to test this PR
1. Test the app starts as normal
2. Tests the app shortcuts are created as normal (ie, that you can long press on the app icon and use the shortcuts)
