### PR TITLE
Fix dependency injection hierarchy for fragments 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/di/component/AppEnjoymentDialogFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/AppEnjoymentDialogFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.browser.rating.ui.AppEnjoymentDialogFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface AppEnjoymentDialogFragmentComponent : AndroidInjector<AppEnjoymentDial
     interface Factory : AndroidInjector.Factory<AppEnjoymentDialogFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface AppEnjoymentDialogFragmentComponentProvider {
     fun provideAppEnjoymentDialogFragmentComponentFactory(): AppEnjoymentDialogFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class AppEnjoymentDialogFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/BrokenSiteNegativeFeedbackFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/BrokenSiteNegativeFeedbackFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.feedback.ui.negative.brokensite.BrokenSiteNegativeFeedbackFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface BrokenSiteNegativeFeedbackFragmentComponent : AndroidInjector<BrokenSi
     interface Factory : AndroidInjector.Factory<BrokenSiteNegativeFeedbackFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface BrokenSiteNegativeFeedbackFragmentComponentProvider {
     fun provideBrokenSiteNegativeFeedbackFragmentComponentFactory(): BrokenSiteNegativeFeedbackFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class BrokenSiteNegativeFeedbackFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/BrowserTabFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/BrowserTabFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.browser.BrowserTabFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
@@ -39,13 +39,13 @@ interface BrowserTabFragmentComponent : AndroidInjector<BrowserTabFragment> {
     interface Factory : AndroidInjector.Factory<BrowserTabFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface BrowserTabFragmentComponentProvider {
     fun provideBrowserTabFragmentComponentFactory(): BrowserTabFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class BrowserTabFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/DefaultBrowserPageComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/DefaultBrowserPageComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPage
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface DefaultBrowserPageComponent : AndroidInjector<DefaultBrowserPage> {
     interface Factory : AndroidInjector.Factory<DefaultBrowserPage>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface DefaultBrowserPageComponentProvider {
     fun provideDefaultBrowserPageComponentFactory(): DefaultBrowserPageComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class DefaultBrowserPageBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/DownloadConfirmationFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/DownloadConfirmationFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.browser.DownloadConfirmationFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface DownloadConfirmationFragmentComponent : AndroidInjector<DownloadConfir
     interface Factory : AndroidInjector.Factory<DownloadConfirmationFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface DownloadConfirmationFragmentComponentProvider {
     fun provideDownloadConfirmationFragmentComponentFactory(): DownloadConfirmationFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class DownloadConfirmationFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/EmailProtectionNotSupportedFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/EmailProtectionNotSupportedFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.email.ui.EmailProtectionNotSupportedFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface EmailProtectionNotSupportedFragmentComponent : AndroidInjector<EmailPr
     interface Factory : AndroidInjector.Factory<EmailProtectionNotSupportedFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface EmailProtectionNotSupportedFragmentComponentProvider {
     fun provideEmailProtectionNotSupportedFragmentComponentFactory(): EmailProtectionNotSupportedFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class EmailProtectionNotSupportedFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/EmailProtectionSignInFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/EmailProtectionSignInFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.email.ui.EmailProtectionSignInFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface EmailProtectionSignInFragmentComponent : AndroidInjector<EmailProtecti
     interface Factory : AndroidInjector.Factory<EmailProtectionSignInFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface EmailProtectionSignInFragmentComponentProvider {
     fun provideEmailProtectionSignInFragmentComponentFactory(): EmailProtectionSignInFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class EmailProtectionSignInFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/EmailProtectionSignOutFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/EmailProtectionSignOutFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.email.ui.EmailProtectionSignOutFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface EmailProtectionSignOutFragmentComponent : AndroidInjector<EmailProtect
     interface Factory : AndroidInjector.Factory<EmailProtectionSignOutFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface EmailProtectionSignOutFragmentComponentProvider {
     fun provideEmailProtectionSignOutFragmentComponentFactory(): EmailProtectionSignOutFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class EmailProtectionSignOutFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/GiveFeedbackDialogFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/GiveFeedbackDialogFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.browser.rating.ui.GiveFeedbackDialogFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface GiveFeedbackDialogFragmentComponent : AndroidInjector<GiveFeedbackDial
     interface Factory : AndroidInjector.Factory<GiveFeedbackDialogFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface GiveFeedbackDialogFragmentComponentProvider {
     fun provideGiveFeedbackDialogFragmentComponentFactory(): GiveFeedbackDialogFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class GiveFeedbackDialogFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/InitialFeedbackFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/InitialFeedbackFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.feedback.ui.initial.InitialFeedbackFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface InitialFeedbackFragmentComponent : AndroidInjector<InitialFeedbackFrag
     interface Factory : AndroidInjector.Factory<InitialFeedbackFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface InitialFeedbackFragmentComponentProvider {
     fun provideInitialFeedbackFragmentComponentFactory(): InitialFeedbackFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class InitialFeedbackFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/MainReasonNegativeFeedbackFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/MainReasonNegativeFeedbackFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.feedback.ui.negative.mainreason.MainReasonNegativeFeedbackFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface MainReasonNegativeFeedbackFragmentComponent : AndroidInjector<MainReas
     interface Factory : AndroidInjector.Factory<MainReasonNegativeFeedbackFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface MainReasonNegativeFeedbackFragmentComponentProvider {
     fun provideMainReasonNegativeFeedbackFragmentComponentFactory(): MainReasonNegativeFeedbackFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class MainReasonNegativeFeedbackFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/PositiveFeedbackLandingFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/PositiveFeedbackLandingFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.feedback.ui.positive.initial.PositiveFeedbackLandingFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface PositiveFeedbackLandingFragmentComponent : AndroidInjector<PositiveFee
     interface Factory : AndroidInjector.Factory<PositiveFeedbackLandingFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface PositiveFeedbackLandingFragmentComponentProvider {
     fun providePositiveFeedbackLandingFragmentComponentFactory(): PositiveFeedbackLandingFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class PositiveFeedbackLandingFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/RateAppDialogFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/RateAppDialogFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.browser.rating.ui.RateAppDialogFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface RateAppDialogFragmentComponent : AndroidInjector<RateAppDialogFragment
     interface Factory : AndroidInjector.Factory<RateAppDialogFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface RateAppDialogFragmentComponentProvider {
     fun provideRateAppDialogFragmentComponentFactory(): RateAppDialogFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class RateAppDialogFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/ShareOpenEndedFeedbackFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/ShareOpenEndedFeedbackFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.feedback.ui.negative.openended.ShareOpenEndedFeedbackFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface ShareOpenEndedFeedbackFragmentComponent : AndroidInjector<ShareOpenEnd
     interface Factory : AndroidInjector.Factory<ShareOpenEndedFeedbackFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface ShareOpenEndedFeedbackFragmentComponentProvider {
     fun provideShareOpenEndedFeedbackFragmentComponentFactory(): ShareOpenEndedFeedbackFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class ShareOpenEndedFeedbackFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/SiteLocationPermissionDialogComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/SiteLocationPermissionDialogComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.location.ui.SiteLocationPermissionDialog
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface SiteLocationPermissionDialogComponent : AndroidInjector<SiteLocationPe
     interface Factory : AndroidInjector.Factory<SiteLocationPermissionDialog>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface SiteLocationPermissionDialogComponentProvider {
     fun provideSiteLocationPermissionDialogComponentFactory(): SiteLocationPermissionDialogComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class SiteLocationPermissionDialogBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/SubReasonNegativeFeedbackFragmentComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/SubReasonNegativeFeedbackFragmentComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.feedback.ui.negative.subreason.SubReasonNegativeFeedbackFragment
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface SubReasonNegativeFeedbackFragmentComponent : AndroidInjector<SubReason
     interface Factory : AndroidInjector.Factory<SubReasonNegativeFeedbackFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface SubReasonNegativeFeedbackFragmentComponentProvider {
     fun provideSubReasonNegativeFeedbackFragmentComponentFactory(): SubReasonNegativeFeedbackFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class SubReasonNegativeFeedbackFragmentBindingModule {
     @Binds
     @IntoMap

--- a/app/src/main/java/com/duckduckgo/app/di/component/WelcomePageComponent.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/component/WelcomePageComponent.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.di.component
 
 import com.duckduckgo.app.onboarding.ui.page.WelcomePage
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -38,13 +38,13 @@ interface WelcomePageComponent : AndroidInjector<WelcomePage> {
     interface Factory : AndroidInjector.Factory<WelcomePage>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface WelcomePageComponentProvider {
     fun provideWelcomePageComponentFactory(): WelcomePageComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class WelcomePageBindingModule {
     @Binds
     @IntoMap

--- a/vpn-main/src/main/java/com/duckduckgo/mobile/android/vpn/di/DeviceShieldActivityFeedFragmentComponent.kt
+++ b/vpn-main/src/main/java/com/duckduckgo/mobile/android/vpn/di/DeviceShieldActivityFeedFragmentComponent.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.mobile.android.vpn.di
 
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldActivityFeedFragment
 import com.squareup.anvil.annotations.ContributesTo
@@ -38,13 +38,13 @@ interface DeviceShieldActivityFeedFragmentComponent : AndroidInjector<DeviceShie
     interface Factory : AndroidInjector.Factory<DeviceShieldActivityFeedFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface DeviceShieldActivityFeedFragmentComponentProvider {
     fun provideDeviceShieldActivityFeedFragmentComponentFactory(): DeviceShieldActivityFeedFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class DeviceShieldActivityFeedFragmentBindingModule {
     @Binds
     @IntoMap

--- a/vpn-main/src/main/java/com/duckduckgo/mobile/android/vpn/di/DeviceShieldFragmentComponent.kt
+++ b/vpn-main/src/main/java/com/duckduckgo/mobile/android/vpn/di/DeviceShieldFragmentComponent.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.mobile.android.vpn.di
 
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.vpn.ui.report.DeviceShieldFragment
 import com.squareup.anvil.annotations.ContributesTo
@@ -38,13 +38,13 @@ interface DeviceShieldFragmentComponent : AndroidInjector<DeviceShieldFragment> 
     interface Factory : AndroidInjector.Factory<DeviceShieldFragment>
 }
 
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 interface DeviceShieldFragmentComponentProvider {
     fun deviceShieldFragmentComponentFactory(): DeviceShieldFragmentComponent.Factory
 }
 
 @Module
-@ContributesTo(AppScope::class)
+@ContributesTo(ActivityScope::class)
 abstract class DeviceShieldFragmentComponentBindingModule {
     @Binds
     @IntoMap


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202049355677833/f

### Description
fix nesting hierarchy for fragments by:
Change from @ContributesTo(AppScope::class) to @ContributesTo(ActivityScope::class) on *FragmentComponentProvider
Change from @ContributesTo(AppScope::class) to @ContributesTo(ActivityScope::class) on *FragmentBindingModule

### Steps to test this PR

- [x] Quickly open all known fragments / pages of the app and see that no crash happens.
