### PR TITLE
Make CookieManager lazy

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -32,6 +32,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.accessibility.AccessibilityManager
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
+import com.duckduckgo.app.browser.cookies.CookieManagerProvider
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.app.browser.logindetection.DOMLoginDetector
@@ -73,6 +74,7 @@ class BrowserWebViewClientTest {
     private val specialUrlDetector: SpecialUrlDetector = mock()
     private val requestInterceptor: RequestInterceptor = mock()
     private val listener: WebViewClientListener = mock()
+    private val cookieManagerProvider: CookieManagerProvider = mock()
     private val cookieManager: CookieManager = mock()
     private val loginDetector: DOMLoginDetector = mock()
     private val offlinePixelCountDataStore: OfflinePixelCountDataStore = mock()
@@ -99,7 +101,7 @@ class BrowserWebViewClientTest {
             requestInterceptor,
             offlinePixelCountDataStore,
             uncaughtExceptionRepository,
-            cookieManager,
+            cookieManagerProvider,
             loginDetector,
             dosDetector,
             gpc,
@@ -112,6 +114,7 @@ class BrowserWebViewClientTest {
         )
         testee.webViewClientListener = listener
         whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)
+        whenever(cookieManagerProvider.get()).thenReturn(cookieManager)
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.browser.cookies
 
 import android.content.Context
-import android.webkit.CookieManager
 import android.webkit.WebView
 import androidx.core.net.toUri
 import androidx.room.Room
@@ -43,7 +42,8 @@ class AppThirdPartyCookieManagerTest {
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
 
-    private val cookieManager = CookieManager.getInstance()
+    private val cookieManagerProvider = DefaultCookieManagerProvider()
+    private val cookieManager = cookieManagerProvider.get()
     private lateinit var db: AppDatabase
     private lateinit var authCookiesAllowedDomainsDao: AuthCookiesAllowedDomainsDao
     private lateinit var authCookiesAllowedDomainsRepository: AuthCookiesAllowedDomainsRepository
@@ -61,7 +61,7 @@ class AppThirdPartyCookieManagerTest {
             AuthCookiesAllowedDomainsRepository(authCookiesAllowedDomainsDao, coroutinesTestRule.testDispatcherProvider)
         webView = TestWebView(InstrumentationRegistry.getInstrumentation().targetContext)
 
-        testee = AppThirdPartyCookieManager(cookieManager, authCookiesAllowedDomainsRepository)
+        testee = AppThirdPartyCookieManager(cookieManagerProvider, authCookiesAllowedDomainsRepository)
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
@@ -23,6 +23,7 @@ import androidx.test.annotation.UiThreadTest
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.browser.*
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
+import com.duckduckgo.app.browser.cookies.CookieManagerProvider
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.privacy.config.api.Gpc
@@ -47,6 +48,7 @@ class UrlExtractingWebViewClientTest {
     private lateinit var testee: UrlExtractingWebViewClient
 
     private val requestInterceptor: RequestInterceptor = mock()
+    private val cookieManagerProvider: CookieManagerProvider = mock()
     private val cookieManager: CookieManager = mock()
     private val gpc: Gpc = mock()
     private val trustedCertificateStore: TrustedCertificateStore = mock()
@@ -62,13 +64,14 @@ class UrlExtractingWebViewClientTest {
             webViewHttpAuthStore,
             trustedCertificateStore,
             requestInterceptor,
-            cookieManager,
+            cookieManagerProvider,
             gpc,
             thirdPartyCookieManager,
             TestScope(),
             coroutinesTestRule.testDispatcherProvider,
             urlExtractor
         )
+        whenever(cookieManagerProvider.get()).thenReturn(cookieManager)
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
@@ -19,11 +19,11 @@ package com.duckduckgo.app.referencetests
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.os.Build
-import android.webkit.CookieManager
 import androidx.core.net.toUri
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.FileUtilities
+import com.duckduckgo.app.browser.cookies.DefaultCookieManagerProvider
 import com.duckduckgo.app.fire.CookieManagerRemover
 import com.duckduckgo.app.fire.GetCookieHostsToPreserve
 import com.duckduckgo.app.fire.RemoveCookies
@@ -61,7 +61,8 @@ class FireproofingReferenceTest(private val testCase: TestCase) {
 
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
     private val db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
-    private val cookieManager = CookieManager.getInstance()
+    private val cookieManagerProvider = DefaultCookieManagerProvider()
+    private val cookieManager = cookieManagerProvider.get()
     private val fireproofWebsiteDao = db.fireproofWebsiteDao()
     private val mockPixel = mock<Pixel>()
     private val mockOfflinePixelCountDataStore = mock<OfflinePixelCountDataStore>()
@@ -98,9 +99,9 @@ class FireproofingReferenceTest(private val testCase: TestCase) {
             DefaultDispatcherProvider()
         )
 
-        val removeCookiesStrategy = RemoveCookies(CookieManagerRemover(cookieManager), sqlCookieRemover)
+        val removeCookiesStrategy = RemoveCookies(CookieManagerRemover(cookieManagerProvider), sqlCookieRemover)
 
-        testee = WebViewCookieManager(cookieManager, "duckduckgo.com", removeCookiesStrategy, DefaultDispatcherProvider())
+        testee = WebViewCookieManager(cookieManagerProvider, "duckduckgo.com", removeCookiesStrategy, DefaultDispatcherProvider())
 
         fireproofedSites.map { url ->
             fireproofWebsiteDao.insert(FireproofWebsiteEntity(url.toUri().domain().orEmpty()))

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -29,6 +29,7 @@ import androidx.core.net.toUri
 import com.duckduckgo.app.accessibility.AccessibilityManager
 import com.duckduckgo.app.browser.certificates.rootstore.CertificateValidationState
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
+import com.duckduckgo.app.browser.cookies.CookieManagerProvider
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.app.browser.logindetection.DOMLoginDetector
@@ -54,7 +55,7 @@ class BrowserWebViewClient(
     private val requestInterceptor: RequestInterceptor,
     private val offlinePixelCountDataStore: OfflinePixelCountDataStore,
     private val uncaughtExceptionRepository: UncaughtExceptionRepository,
-    private val cookieManager: CookieManager,
+    private val cookieManagerProvider: CookieManagerProvider,
     private val loginDetector: DOMLoginDetector,
     private val dosDetector: DosDetector,
     private val gpc: Gpc,
@@ -269,7 +270,7 @@ class BrowserWebViewClient(
 
     private fun flushCookies() {
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            cookieManager.flush()
+            cookieManagerProvider.get().flush()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/cookies/CookieManagerProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/cookies/CookieManagerProvider.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.cookies
+
+import android.webkit.CookieManager
+
+interface CookieManagerProvider {
+    fun get(): CookieManager
+}
+
+class DefaultCookieManagerProvider : CookieManagerProvider {
+
+    @Volatile
+    private var instance: CookieManager? = null
+
+    override fun get(): CookieManager =
+        instance ?: synchronized(this) {
+            instance ?: CookieManager.getInstance().also { instance = it }
+        }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.browser.cookies
 
 import android.net.Uri
-import android.webkit.CookieManager
 import android.webkit.WebView
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.cookies.db.AuthCookieAllowedDomainEntity
@@ -36,7 +35,7 @@ interface ThirdPartyCookieManager {
 }
 
 class AppThirdPartyCookieManager(
-    private val cookieManager: CookieManager,
+    private val cookieManagerProvider: CookieManagerProvider,
     private val authCookiesAllowedDomainsRepository: AuthCookiesAllowedDomainsRepository
 ) : ThirdPartyCookieManager {
 
@@ -64,10 +63,10 @@ class AppThirdPartyCookieManager(
         withContext(Dispatchers.Main) {
             if (domain != null && hasUserIdCookie()) {
                 Timber.d("Cookies enabled for $uri")
-                cookieManager.setAcceptThirdPartyCookies(webView, true)
+                cookieManagerProvider.get().setAcceptThirdPartyCookies(webView, true)
             } else {
                 Timber.d("Cookies disabled for $uri")
-                cookieManager.setAcceptThirdPartyCookies(webView, false)
+                cookieManagerProvider.get().setAcceptThirdPartyCookies(webView, false)
             }
             domain?.let { deleteHost(it) }
         }
@@ -91,7 +90,7 @@ class AppThirdPartyCookieManager(
     }
 
     private fun hasUserIdCookie(): Boolean {
-        return cookieManager.getCookie(GOOGLE_ACCOUNTS_URL)?.split(";")?.firstOrNull {
+        return cookieManagerProvider.get().getCookie(GOOGLE_ACCOUNTS_URL)?.split(";")?.firstOrNull {
             it.contains(USER_ID_COOKIE)
         } != null
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.browser.di
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.pm.PackageManager
-import android.webkit.CookieManager
 import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.accessibility.AccessibilityManager
 import com.duckduckgo.app.browser.*
@@ -27,6 +26,8 @@ import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.addtohome.AddToHomeSystemCapabilityDetector
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
 import com.duckduckgo.app.browser.cookies.AppThirdPartyCookieManager
+import com.duckduckgo.app.browser.cookies.CookieManagerProvider
+import com.duckduckgo.app.browser.cookies.DefaultCookieManagerProvider
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsRepository
 import com.duckduckgo.app.browser.defaultbrowsing.AndroidDefaultBrowserDetector
@@ -110,7 +111,7 @@ class BrowserModule {
         requestInterceptor: RequestInterceptor,
         offlinePixelCountDataStore: OfflinePixelCountDataStore,
         uncaughtExceptionRepository: UncaughtExceptionRepository,
-        cookieManager: CookieManager,
+        cookieManagerProvider: CookieManagerProvider,
         loginDetector: DOMLoginDetector,
         dosDetector: DosDetector,
         gpc: Gpc,
@@ -129,7 +130,7 @@ class BrowserModule {
             requestInterceptor,
             offlinePixelCountDataStore,
             uncaughtExceptionRepository,
-            cookieManager,
+            cookieManagerProvider,
             loginDetector,
             dosDetector,
             gpc,
@@ -147,7 +148,7 @@ class BrowserModule {
         webViewHttpAuthStore: WebViewHttpAuthStore,
         trustedCertificateStore: TrustedCertificateStore,
         requestInterceptor: RequestInterceptor,
-        cookieManager: CookieManager,
+        cookieManagerProvider: CookieManagerProvider,
         gpc: Gpc,
         thirdPartyCookieManager: ThirdPartyCookieManager,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
@@ -158,7 +159,7 @@ class BrowserModule {
             webViewHttpAuthStore,
             trustedCertificateStore,
             requestInterceptor,
-            cookieManager,
+            cookieManagerProvider,
             gpc,
             thirdPartyCookieManager,
             appCoroutineScope,
@@ -249,11 +250,11 @@ class BrowserModule {
 
     @Provides
     fun cookieManager(
-        cookieManager: CookieManager,
+        cookieManagerProvider: CookieManagerProvider,
         removeCookies: RemoveCookies,
         dispatcherProvider: DispatcherProvider
     ): DuckDuckGoCookieManager {
-        return WebViewCookieManager(cookieManager, AppUrl.Url.COOKIES, removeCookies, dispatcherProvider)
+        return WebViewCookieManager(cookieManagerProvider, AppUrl.Url.COOKIES, removeCookies, dispatcherProvider)
     }
 
     @Provides
@@ -291,15 +292,15 @@ class BrowserModule {
 
     @Provides
     fun cookieManagerRemover(
-        cookieManager: CookieManager
+        cookieManagerProvider: CookieManagerProvider
     ): CookieManagerRemover {
-        return CookieManagerRemover(cookieManager)
+        return CookieManagerRemover(cookieManagerProvider)
     }
 
     @SingleInstanceIn(AppScope::class)
     @Provides
-    fun webViewCookieManager(): CookieManager {
-        return CookieManager.getInstance()
+    fun webViewCookieManagerProvider(): CookieManagerProvider {
+        return DefaultCookieManagerProvider()
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -388,10 +389,10 @@ class BrowserModule {
     @SingleInstanceIn(AppScope::class)
     @Provides
     fun thirdPartyCookieManager(
-        cookieManager: CookieManager,
+        cookieManagerProvider: CookieManagerProvider,
         authCookiesAllowedDomainsRepository: AuthCookiesAllowedDomainsRepository
     ): ThirdPartyCookieManager {
-        return AppThirdPartyCookieManager(cookieManager, authCookiesAllowedDomainsRepository)
+        return AppThirdPartyCookieManager(cookieManagerProvider, authCookiesAllowedDomainsRepository)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
@@ -27,6 +27,7 @@ import androidx.core.net.toUri
 import com.duckduckgo.app.browser.RequestInterceptor
 import com.duckduckgo.app.browser.certificates.rootstore.CertificateValidationState
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
+import com.duckduckgo.app.browser.cookies.CookieManagerProvider
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.app.global.DispatcherProvider
@@ -38,7 +39,7 @@ class UrlExtractingWebViewClient(
     private val webViewHttpAuthStore: WebViewHttpAuthStore,
     private val trustedCertificateStore: TrustedCertificateStore,
     private val requestInterceptor: RequestInterceptor,
-    private val cookieManager: CookieManager,
+    private val cookieManagerProvider: CookieManagerProvider,
     private val gpc: Gpc,
     private val thirdPartyCookieManager: ThirdPartyCookieManager,
     private val appCoroutineScope: CoroutineScope,
@@ -76,7 +77,7 @@ class UrlExtractingWebViewClient(
     }
 
     private fun flushCookies() {
-        appCoroutineScope.launch(dispatcherProvider.io()) { cookieManager.flush() }
+        appCoroutineScope.launch(dispatcherProvider.io()) { cookieManagerProvider.get().flush() }
     }
 
     @WorkerThread

--- a/app/src/main/java/com/duckduckgo/app/fire/CookieRemover.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/CookieRemover.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.app.fire
 import android.database.DatabaseErrorHandler
 import android.database.DefaultDatabaseErrorHandler
 import android.database.sqlite.SQLiteDatabase
-import android.webkit.CookieManager
+import com.duckduckgo.app.browser.cookies.CookieManagerProvider
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.ExceptionPixel
@@ -34,10 +34,10 @@ interface CookieRemover {
     suspend fun removeCookies(): Boolean
 }
 
-class CookieManagerRemover(private val cookieManager: CookieManager) : CookieRemover {
+class CookieManagerRemover(private val cookieManagerProvider: CookieManagerProvider) : CookieRemover {
     override suspend fun removeCookies(): Boolean {
         suspendCoroutine<Unit> { continuation ->
-            cookieManager.removeAllCookies {
+            cookieManagerProvider.get().removeAllCookies {
                 Timber.v("All cookies removed; restoring DDG cookies")
                 continuation.resume(Unit)
             }

--- a/app/src/main/java/com/duckduckgo/app/fire/DuckDuckGoCookieManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DuckDuckGoCookieManager.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.app.fire
 
-import android.webkit.CookieManager
+import com.duckduckgo.app.browser.cookies.CookieManagerProvider
 import com.duckduckgo.app.global.DispatcherProvider
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -29,7 +29,7 @@ interface DuckDuckGoCookieManager {
 }
 
 class WebViewCookieManager(
-    private val cookieManager: CookieManager,
+    private val cookieManager: CookieManagerProvider,
     private val host: String,
     private val removeCookies: RemoveCookiesStrategy,
     private val dispatcher: DispatcherProvider
@@ -44,7 +44,7 @@ class WebViewCookieManager(
         // These cookies are not stored in a personally identifiable way. For example, the large size setting is stored as 's=l.'
         // More info in https://duckduckgo.com/privacy
         val ddgCookies = getDuckDuckGoCookies()
-        if (cookieManager.hasCookies()) {
+        if (cookieManager.get().hasCookies()) {
             removeCookies.removeCookies()
             storeDuckDuckGoCookies(ddgCookies)
         }
@@ -63,7 +63,7 @@ class WebViewCookieManager(
 
     private suspend fun storeCookie(cookie: String) {
         suspendCoroutine<Unit> { continuation ->
-            cookieManager.setCookie(host, cookie) { success ->
+            cookieManager.get().setCookie(host, cookie) { success ->
                 Timber.v("Cookie $cookie stored successfully: $success")
                 continuation.resume(Unit)
             }
@@ -71,10 +71,10 @@ class WebViewCookieManager(
     }
 
     private fun getDuckDuckGoCookies(): List<String> {
-        return cookieManager.getCookie(host)?.split(";").orEmpty()
+        return cookieManager.get().getCookie(host)?.split(";").orEmpty()
     }
 
     override fun flush() {
-        cookieManager.flush()
+        cookieManager.get().flush()
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/fire/WebViewCookieManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/WebViewCookieManagerTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.fire
 import android.webkit.CookieManager
 import android.webkit.ValueCallback
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.browser.cookies.CookieManagerProvider
 import kotlinx.coroutines.test.runTest
 import org.mockito.kotlin.*
 import kotlinx.coroutines.Dispatchers
@@ -40,11 +41,12 @@ class WebViewCookieManagerTest {
     val coroutineRule = CoroutineTestRule()
 
     private val removeCookieStrategy = mock<RemoveCookiesStrategy>()
+    private val cookieManagerProvider = mock<CookieManagerProvider>()
     private val cookieManager = mock<CookieManager>()
     private val ddgCookie = Cookie(DDG_HOST, "da=abc")
     private val externalHostCookie = Cookie("example.com", "dz=zyx")
     private val testee: WebViewCookieManager = WebViewCookieManager(
-        cookieManager,
+        cookieManagerProvider,
         DDG_HOST,
         removeCookieStrategy,
         coroutineRule.testDispatcherProvider
@@ -52,6 +54,7 @@ class WebViewCookieManagerTest {
 
     @Before
     fun setup() {
+        whenever(cookieManagerProvider.get()).thenReturn(cookieManager)
         whenever(cookieManager.setCookie(any(), any(), any())).then {
             (it.getArgument(2) as ValueCallback<Boolean>).onReceiveValue(true)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202085579672992/f

### Description
This makes the CookieManager dependency lazy (In a similar way to: https://github.com/duckduckgo/Android/pull/1775) which should address some related crashes.

### Steps to test this PR

_Feature 1_
- [x] Verify that the app opens without error.
- [x] Visit a site.
- [x] Use the fire button.
- [x] Open a first party cloaked link on: https://privacy-test-pages.glitch.me/privacy-protections/amp/
