### PR TITLE
Check and report VPN connectivity issues

### DIFF
--- a/common/src/main/java/com/duckduckgo/app/global/extensions/ContextExtensions.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/extensions/ContextExtensions.kt
@@ -22,6 +22,7 @@ import android.content.Context.ACTIVITY_SERVICE
 import android.os.Build.VERSION_CODES.R
 import android.provider.Settings
 import androidx.annotation.RequiresApi
+import timber.log.Timber
 import java.util.*
 
 @RequiresApi(R)
@@ -46,4 +47,10 @@ fun Context.isPrivateDnsActive(): Boolean {
 fun Context.getPrivateDnsServerName(): String? {
     val dnsMode = Settings.Global.getString(contentResolver, "private_dns_mode")
     return if ("hostname" == dnsMode) Settings.Global.getString(contentResolver, "private_dns_specifier") else null
+}
+
+fun Context.isAirplaneModeOn(): Boolean {
+    val airplaneMode = Settings.Global.getString(contentResolver, "airplane_mode_on")
+    Timber.v("airplane_mode_on $airplaneMode")
+    return airplaneMode == "1"
 }

--- a/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSetting.kt
+++ b/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSetting.kt
@@ -23,6 +23,7 @@ enum class AppTpSetting(override val value: String, override val defaultValue: B
     NetworkSwitchHandling("networkSwitchSupport"),
     SetActiveNetworkDns("setActiveNetworkDns"),
     VpnDdgBrowserTraffic("vpnDdgBrowserTraffic"),
+    ConnectivityChecks("connectivityChecks"),
     AlwaysSetDNS("alwaysSetDNS"),
 }
 

--- a/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
+++ b/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
@@ -124,6 +124,7 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
                 binding.badHealthMitigationToggle.isEnabled = isEnabled
                 binding.vpnUnderlyingNetworksToggle.isEnabled = isEnabled
                 binding.vpnAlwaysSetDNSToggle.isEnabled = isEnabled
+                binding.vpnConnectivityChecksToggle.isEnabled = isEnabled
                 binding.setActiveNetworkDnsToggle.isEnabled = isEnabled
                 binding.debugLoggingToggle.isEnabled = isEnabled
                 binding.transparencyModeToggle.isEnabled = isEnabled
@@ -249,6 +250,17 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
         with(AppTpSetting.SetActiveNetworkDns) {
             binding.setActiveNetworkDnsToggle.isChecked = appTpConfig.isEnabled(this)
             binding.setActiveNetworkDnsToggle.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    sendBroadcast(VpnRemoteFeatureReceiver.enableIntent(this))
+                } else {
+                    sendBroadcast(VpnRemoteFeatureReceiver.disableIntent(this))
+                }
+            }
+        }
+
+        with(AppTpSetting.ConnectivityChecks) {
+            binding.vpnConnectivityChecksToggle.isChecked = appTpConfig.isEnabled(this)
+            binding.vpnConnectivityChecksToggle.setOnCheckedChangeListener { _, isChecked ->
                 if (isChecked) {
                     sendBroadcast(VpnRemoteFeatureReceiver.enableIntent(this))
                 } else {

--- a/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
+++ b/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
@@ -116,6 +116,15 @@
                     android:theme="@style/SettingsSwitchTheme"
             />
 
+            <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/vpnConnectivityChecksToggle"
+                    style="@style/SettingsSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="VPN connectivity checks"
+                    android:theme="@style/SettingsSwitchTheme"
+            />
+
             <!-- Section Trackers -->
             <View style="@style/SettingsGroupDivider" />
             <TextView

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthStatsStore.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthStatsStore.kt
@@ -64,6 +64,7 @@ data class SimpleEvent(
         fun TUN_WRITE_IO_EXCEPTION() = build("TUN_WRITE_IO_EXCEPTION")
         fun TUN_READ_IO_EXCEPTION() = build("TUN_READ_IO_EXCEPTION")
         fun TUN_WRITE_IO_MEMORY_EXCEPTION() = build("TUN_WRITE_IO_EXCEPTION_NO_BUFFER_SPACE")
+        fun NO_NETWORK_CONNECTIVITY() = build("NO_NETWORK_CONNECTIVITY")
     }
 }
 

--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthStatsStore.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthStatsStore.kt
@@ -64,7 +64,7 @@ data class SimpleEvent(
         fun TUN_WRITE_IO_EXCEPTION() = build("TUN_WRITE_IO_EXCEPTION")
         fun TUN_READ_IO_EXCEPTION() = build("TUN_READ_IO_EXCEPTION")
         fun TUN_WRITE_IO_MEMORY_EXCEPTION() = build("TUN_WRITE_IO_EXCEPTION_NO_BUFFER_SPACE")
-        fun NO_NETWORK_CONNECTIVITY() = build("NO_NETWORK_CONNECTIVITY")
+        fun NO_VPN_CONNECTIVITY() = build("NO_VPN_CONNECTIVITY")
     }
 }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/ConnectivityChecksSettingPlugin.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/ConnectivityChecksSettingPlugin.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.feature.*
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.Moshi
+import timber.log.Timber
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AppTpSettingPlugin::class
+)
+class ConnectivityChecksSettingPlugin @Inject constructor(
+    private val appTpFeatureConfig: AppTpFeatureConfig,
+) : AppTpSettingPlugin {
+    private val jsonAdapter = Moshi.Builder().build().adapter(JsonConfigModel::class.java)
+
+    override fun store(name: SettingName, jsonString: String): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = appTpSettingValueOf(name.value)
+        if (name == settingName) {
+            Timber.d("Received configuration: $jsonString")
+            jsonAdapter.fromJson(jsonString)?.let { config ->
+                appTpFeatureConfig.edit { setEnabled(settingName, config.state == "enabled") }
+            }
+            return true
+        }
+
+        return false
+    }
+
+    override val settingName: SettingName = AppTpSetting.ConnectivityChecks
+
+    private data class JsonConfigModel(val state: String?)
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPHealthMonitor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPHealthMonitor.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.di.VpnCoroutineScope
 import com.duckduckgo.mobile.android.vpn.health.AppTPHealthMonitor.HealthState.BadHealth
 import com.duckduckgo.mobile.android.vpn.health.AppTPHealthMonitor.HealthState.GoodHealth
-import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.NO_NETWORK_CONNECTIVITY
+import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.NO_VPN_CONNECTIVITY
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.REMOVE_FROM_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.REMOVE_FROM_TCP_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.REMOVE_FROM_UDP_DEVICE_TO_NETWORK_QUEUE
@@ -140,7 +140,7 @@ class AppTPHealthMonitor @Inject constructor(
         healthStates += sampleTunWriteNoMemoryExceptions(timeWindow, tunWriteIOMemoryExceptionsAlerts)
         healthStates += sampleBufferAllocations(timeWindow, bufferAllocationsAlerts)
         healthStates += sampleIpPackets(timeWindow, ipPacketCounts)
-        healthStates += sampleNetworkConnectivityEvents(timeWindow, noNetworkConnectivityAlert)
+        healthStates += sampleVpnConnectivityEvents(timeWindow, noNetworkConnectivityAlert)
 
         /*
          * useful for testing notifications; can trigger good or bad health from diagnostics screen
@@ -196,12 +196,12 @@ class AppTPHealthMonitor @Inject constructor(
         return state
     }
 
-    private fun sampleNetworkConnectivityEvents(
+    private fun sampleVpnConnectivityEvents(
         timeWindow: Long,
         healthAlerts: HealthRule
     ): HealthState {
-        val noConnectivityStats = healthMetricCounter.getStat(NO_NETWORK_CONNECTIVITY(), timeWindow)
-        val state = healthClassifier.determineHealthNetworkConnectivity(noConnectivityStats)
+        val noConnectivityStats = healthMetricCounter.getStat(NO_VPN_CONNECTIVITY(), timeWindow)
+        val state = healthClassifier.determineHealthVpnConnectivity(noConnectivityStats)
         healthAlerts.updateAlert(state)
         return state
     }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
@@ -45,6 +45,15 @@ class HealthClassifier @Inject constructor(val applicationContext: Context) {
         return if (metricSummary.isInBadHealth()) BadHealth(metricSummary) else GoodHealth(metricSummary)
     }
 
+    fun determineHealthNetworkConnectivity(connectivityEvents: Long): HealthState {
+        val rawMetrics = mutableMapOf<String, Metric>()
+        val metricSummary = RawMetricsSubmission("no-connectivity-events", rawMetrics)
+
+        rawMetrics["events"] = Metric(connectivityEvents.toString(), badHealthIf { connectivityEvents >= 2 }, isCritical = true)
+
+        return if (metricSummary.isInBadHealth()) BadHealth(metricSummary) else GoodHealth(metricSummary)
+    }
+
     fun determineHealthSocketChannelReadExceptions(readExceptions: Long): HealthState {
         val rawMetrics = mutableMapOf<String, Metric>()
         val metricSummary = RawMetricsSubmission("socket-readExceptions", rawMetrics)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthClassifier.kt
@@ -45,9 +45,9 @@ class HealthClassifier @Inject constructor(val applicationContext: Context) {
         return if (metricSummary.isInBadHealth()) BadHealth(metricSummary) else GoodHealth(metricSummary)
     }
 
-    fun determineHealthNetworkConnectivity(connectivityEvents: Long): HealthState {
+    fun determineHealthVpnConnectivity(connectivityEvents: Long): HealthState {
         val rawMetrics = mutableMapOf<String, Metric>()
-        val metricSummary = RawMetricsSubmission("no-connectivity-events", rawMetrics)
+        val metricSummary = RawMetricsSubmission("vpn-no-connectivity-events", rawMetrics)
 
         rawMetrics["events"] = Metric(connectivityEvents.toString(), badHealthIf { connectivityEvents >= 2 }, isCritical = true)
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthMetricCounter.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthMetricCounter.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.mobile.android.vpn.di.VpnCoroutineScope
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.ADD_TO_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.ADD_TO_TCP_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.ADD_TO_UDP_DEVICE_TO_NETWORK_QUEUE
+import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.NO_NETWORK_CONNECTIVITY
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.REMOVE_FROM_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.REMOVE_FROM_TCP_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.REMOVE_FROM_UDP_DEVICE_TO_NETWORK_QUEUE
@@ -141,6 +142,12 @@ class HealthMetricCounter @Inject constructor(
     fun onTunWriteIOExceptionNoBufferSpace() {
         coroutineScope.launch(databaseDispatcher) {
             healthStatsDao.insertEvent(TUN_WRITE_IO_MEMORY_EXCEPTION())
+        }
+    }
+
+    fun onNoNetworkConnectivity() {
+        coroutineScope.launch(databaseDispatcher) {
+            healthStatsDao.insertEvent(NO_NETWORK_CONNECTIVITY())
         }
     }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthMetricCounter.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/HealthMetricCounter.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.mobile.android.vpn.di.VpnCoroutineScope
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.ADD_TO_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.ADD_TO_TCP_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.ADD_TO_UDP_DEVICE_TO_NETWORK_QUEUE
-import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.NO_NETWORK_CONNECTIVITY
+import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.NO_VPN_CONNECTIVITY
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.REMOVE_FROM_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.REMOVE_FROM_TCP_DEVICE_TO_NETWORK_QUEUE
 import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.REMOVE_FROM_UDP_DEVICE_TO_NETWORK_QUEUE
@@ -145,9 +145,9 @@ class HealthMetricCounter @Inject constructor(
         }
     }
 
-    fun onNoNetworkConnectivity() {
+    fun onVpnConnectivityError() {
         coroutineScope.launch(databaseDispatcher) {
-            healthStatsDao.insertEvent(NO_NETWORK_CONNECTIVITY())
+            healthStatsDao.insertEvent(NO_VPN_CONNECTIVITY())
         }
     }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/NetworkConnectivityHealthHandler.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/NetworkConnectivityHealthHandler.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.health
+
+import android.content.Context
+import android.net.ConnectivityManager
+import com.duckduckgo.app.global.extensions.isAirplaneModeOn
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.utils.ConflatedJob
+import com.duckduckgo.di.scopes.VpnScope
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
+import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
+import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.nio.channels.SocketChannel
+import javax.inject.Inject
+import javax.inject.Provider
+
+private const val WWW_DUCKDUCKGO_COM = "www.duckduckgo.com"
+
+@ContributesMultibinding(VpnScope::class)
+class NetworkConnectivityHealthHandler @Inject constructor(
+    private val context: Context,
+    private val pixel: Pixel,
+    private val healthMetricCounter: HealthMetricCounter,
+    private val appTpFeatureConfig: AppTpFeatureConfig,
+    private val trackerBlockingVpnService: Provider<TrackerBlockingVpnService>,
+) : VpnServiceCallbacks {
+    private val connectivityManager = context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val job = ConflatedJob()
+
+    override fun onVpnStarted(coroutineScope: CoroutineScope) {
+        if (!appTpFeatureConfig.isEnabled(AppTpSetting.ConnectivityChecks)) {
+            Timber.d("AppTpSetting.ConnectivityChecks is disabled")
+            return
+        }
+
+        job += coroutineScope.launch {
+            while (isActive) {
+                delay(10_000)
+                if (!hasVpnConnectivity() && !context.isAirplaneModeOn()) {
+                    if (hasDeviceConnectivity()) {
+                        Timber.d("Active VPN network does not have connectivity")
+                        pixel.enqueueFire(PixelName { "m_atp_report_no_vpn_connectivity_c" })
+                        healthMetricCounter.onNoNetworkConnectivity()
+                    } else {
+                        Timber.d("Device doesn't have connectivity either")
+                        pixel.enqueueFire(PixelName { "m_atp_report_no_device_connectivity_c" })
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onVpnStopped(coroutineScope: CoroutineScope, vpnStopReason: VpnStateMonitor.VpnStopReason) {
+        job.cancel()
+    }
+
+    private fun hasVpnConnectivity(): Boolean {
+        connectivityManager.activeNetwork?.let { activeNetwork ->
+            var socket: Socket? = null
+            try {
+                socket = activeNetwork.socketFactory.createSocket()
+                socket.connect(InetSocketAddress(WWW_DUCKDUCKGO_COM, 443), 5000)
+                Timber.v("Validated $activeNetwork VPN network has connectivity to $WWW_DUCKDUCKGO_COM")
+                return true
+            } catch (t: Throwable) {
+                Timber.e(t, "No connectivity for network $activeNetwork")
+                return false
+            } finally {
+                runCatching { socket?.close() }
+            }
+        }
+
+        // default to "has connectivity"
+        return true
+    }
+
+    private fun hasDeviceConnectivity(): Boolean {
+        connectivityManager.activeNetwork?.let { activeNetwork ->
+            var socket: Socket? = null
+            try {
+                socket = SocketChannel.open().socket()
+                trackerBlockingVpnService.get().protect(socket)
+                socket.connect(InetSocketAddress(WWW_DUCKDUCKGO_COM, 443), 5000)
+                Timber.v("Validated $activeNetwork device network has connectivity to $WWW_DUCKDUCKGO_COM")
+                return true
+            } catch (t: Throwable) {
+                Timber.e(t, "No connectivity for network $activeNetwork")
+                return false
+            } finally {
+                runCatching { socket?.close() }
+            }
+        }
+
+        // default to "has connectivity"
+        return true
+    }
+
+    private fun PixelName(block: () -> String): Pixel.PixelName {
+        return object : Pixel.PixelName {
+            override val pixelName: String
+                get() = block()
+        }
+    }
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/NetworkConnectivityHealthHandler.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/health/NetworkConnectivityHealthHandler.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
 import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixelNames
 import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
@@ -59,7 +60,7 @@ class NetworkConnectivityHealthHandler @Inject constructor(
                 if (!hasVpnConnectivity() && !context.isAirplaneModeOn()) {
                     if (hasDeviceConnectivity()) {
                         Timber.d("Active VPN network does not have connectivity")
-                        pixel.enqueueFire(PixelName { "m_atp_report_no_vpn_connectivity_c" })
+                        pixel.enqueueFire(DeviceShieldPixelNames.ATP_REPORT_VPN_CONNECTIVITY_ERROR)
                         if (appTpFeatureConfig.isEnabled(AppTpSetting.ConnectivityChecks)) {
                             Timber.d("AppTpSetting.ConnectivityChecks is enabled, logging health event")
                             healthMetricCounter.onVpnConnectivityError()
@@ -68,7 +69,7 @@ class NetworkConnectivityHealthHandler @Inject constructor(
                         }
                     } else {
                         Timber.d("Device doesn't have connectivity either")
-                        pixel.enqueueFire(PixelName { "m_atp_report_no_device_connectivity_c" })
+                        pixel.enqueueFire(DeviceShieldPixelNames.ATP_REPORT_DEVICE_CONNECTIVITY_ERROR)
                     }
                 }
             }
@@ -118,12 +119,5 @@ class NetworkConnectivityHealthHandler @Inject constructor(
 
         // default to "has connectivity"
         return true
-    }
-
-    private fun PixelName(block: () -> String): Pixel.PixelName {
-        return object : Pixel.PixelName {
-            override val pixelName: String
-                get() = block()
-        }
     }
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -185,5 +185,8 @@ enum class DeviceShieldPixelNames(override val pixelName: String) : Pixel.PixelN
     ATP_DID_SHOW_MANAGE_RECENT_APP_SETTINGS_ACTIVITY_UNIQUE("m_atp_imp_manage_recent_app_settings_activity_u"),
     ATP_DID_SHOW_MANAGE_RECENT_APP_SETTINGS_ACTIVITY_DAILY("m_atp_imp_manage_recent_app_settings_activity_d"),
     ATP_DID_SHOW_MANAGE_RECENT_APP_SETTINGS_ACTIVITY_("m_atp_imp_manage_recent_app_settings_activity_c"),
+
+    ATP_REPORT_DEVICE_CONNECTIVITY_ERROR("m_atp_report_no_device_connectivity_c"),
+    ATP_REPORT_VPN_CONNECTIVITY_ERROR("m_atp_report_no_vpn_connectivity_c"),
     ;
 }

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureConfigImplTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureConfigImplTest.kt
@@ -64,6 +64,8 @@ class AppTpFeatureConfigImplTest {
                 AppTpSetting.NetworkSwitchHandling -> assertFalse(config.isEnabled(setting))
                 AppTpSetting.SetActiveNetworkDns -> assertFalse(config.isEnabled(setting))
                 AppTpSetting.AlwaysSetDNS -> assertFalse(config.isEnabled(setting))
+                AppTpSetting.VpnDdgBrowserTraffic -> assertFalse(config.isEnabled(setting))
+                AppTpSetting.ConnectivityChecks -> assertFalse(config.isEnabled(setting))
             }
         }
     }

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSettingTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSettingTest.kt
@@ -33,6 +33,7 @@ class AppTpSettingTest {
                 AppTpSetting.SetActiveNetworkDns -> assertFalse(setting.defaultValue)
                 AppTpSetting.AlwaysSetDNS -> assertFalse(setting.defaultValue)
                 AppTpSetting.VpnDdgBrowserTraffic -> assertFalse(setting.defaultValue)
+                AppTpSetting.ConnectivityChecks -> assertFalse(setting.defaultValue)
                 else -> throw java.lang.IllegalStateException("Missing AppTpSetting default checks")
             }
         }

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/BadHealthMitigationSettingPluginTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/BadHealthMitigationSettingPluginTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.feature.SettingName
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class BadHealthMitigationSettingPluginTest {
+
+    private lateinit var featureConfig: BadHealthMitigationSettingPlugin
+    private val appTpFeatureConfig: AppTpFeatureConfig = mock()
+    private val appTpFeatureConfigEditor: AppTpFeatureConfig.Editor = mock()
+    private val jsonEnabled = """
+        {
+          "state": "enabled",
+          "settings": {}
+        }
+    """.trimIndent()
+    private val jsonDisabled = """
+        {
+          "state": "disabled",
+          "settings": {}
+        }
+    """.trimIndent()
+
+    @Before
+    fun setup() {
+        whenever(appTpFeatureConfig.edit()).thenReturn(appTpFeatureConfigEditor)
+        featureConfig = BadHealthMitigationSettingPlugin(appTpFeatureConfig)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndEnabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.BadHealthMitigation, enabled = true, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndDisabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonDisabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.BadHealthMitigation, enabled = false, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithIncorrectSettingThenDoNotStoreAndReturnFalse() {
+        val settingName = SettingName { "wrongSettingName" }
+        val result = featureConfig.store(settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor, never()).setEnabled(any(), any(), any())
+        assertFalse(result)
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/ConnectivityChecksSettingPluginTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/ConnectivityChecksSettingPluginTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.feature.SettingName
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class ConnectivityChecksSettingPluginTest {
+
+    private lateinit var featureConfig: ConnectivityChecksSettingPlugin
+    private val appTpFeatureConfig: AppTpFeatureConfig = mock()
+    private val appTpFeatureConfigEditor: AppTpFeatureConfig.Editor = mock()
+    private val jsonEnabled = """
+        {
+          "state": "enabled",
+          "settings": {}
+        }
+    """.trimIndent()
+    private val jsonDisabled = """
+        {
+          "state": "disabled",
+          "settings": {}
+        }
+    """.trimIndent()
+
+    @Before
+    fun setup() {
+        whenever(appTpFeatureConfig.edit()).thenReturn(appTpFeatureConfigEditor)
+        featureConfig = ConnectivityChecksSettingPlugin(appTpFeatureConfig)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndEnabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.ConnectivityChecks, enabled = true, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndDisabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonDisabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.ConnectivityChecks, enabled = false, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithIncorrectSettingThenDoNotStoreAndReturnFalse() {
+        val settingName = SettingName { "wrongSettingName" }
+        val result = featureConfig.store(settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor, never()).setEnabled(any(), any(), any())
+        assertFalse(result)
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/Ipv6PrivacySettingPluginTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/Ipv6PrivacySettingPluginTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.feature.SettingName
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class Ipv6PrivacySettingPluginTest {
+
+    private lateinit var featureConfig: Ipv6PrivacySettingPlugin
+    private val appTpFeatureConfig: AppTpFeatureConfig = mock()
+    private val appTpFeatureConfigEditor: AppTpFeatureConfig.Editor = mock()
+    private val jsonEnabled = """
+        {
+          "state": "enabled",
+          "settings": {}
+        }
+    """.trimIndent()
+    private val jsonDisabled = """
+        {
+          "state": "disabled",
+          "settings": {}
+        }
+    """.trimIndent()
+
+    @Before
+    fun setup() {
+        whenever(appTpFeatureConfig.edit()).thenReturn(appTpFeatureConfigEditor)
+        featureConfig = Ipv6PrivacySettingPlugin(appTpFeatureConfig)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndEnabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.Ipv6Support, enabled = true, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndDisabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonDisabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.Ipv6Support, enabled = false, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithIncorrectSettingThenDoNotStoreAndReturnFalse() {
+        val settingName = SettingName { "wrongSettingName" }
+        val result = featureConfig.store(settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor, never()).setEnabled(any(), any(), any())
+        assertFalse(result)
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/NetworkSwitchSettingPluginTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/NetworkSwitchSettingPluginTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.feature.SettingName
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class NetworkSwitchSettingPluginTest {
+
+    private lateinit var featureConfig: NetworkSwitchingSettingPlugin
+    private val appTpFeatureConfig: AppTpFeatureConfig = mock()
+    private val appTpFeatureConfigEditor: AppTpFeatureConfig.Editor = mock()
+    private val jsonEnabled = """
+        {
+          "state": "enabled",
+          "settings": {}
+        }
+    """.trimIndent()
+    private val jsonDisabled = """
+        {
+          "state": "disabled",
+          "settings": {}
+        }
+    """.trimIndent()
+
+    @Before
+    fun setup() {
+        whenever(appTpFeatureConfig.edit()).thenReturn(appTpFeatureConfigEditor)
+        featureConfig = NetworkSwitchingSettingPlugin(appTpFeatureConfig)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndEnabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.NetworkSwitchHandling, enabled = true, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndDisabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonDisabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.NetworkSwitchHandling, enabled = false, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithIncorrectSettingThenDoNotStoreAndReturnFalse() {
+        val settingName = SettingName { "wrongSettingName" }
+        val result = featureConfig.store(settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor, never()).setEnabled(any(), any(), any())
+        assertFalse(result)
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/PrivateDnsSettingPluginTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/PrivateDnsSettingPluginTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.feature.SettingName
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class PrivateDnsSettingPluginTest {
+
+    private lateinit var featureConfig: PrivateDnsSettingPlugin
+    private val appTpFeatureConfig: AppTpFeatureConfig = mock()
+    private val appTpFeatureConfigEditor: AppTpFeatureConfig.Editor = mock()
+    private val jsonEnabled = """
+        {
+          "state": "enabled",
+          "settings": {}
+        }
+    """.trimIndent()
+    private val jsonDisabled = """
+        {
+          "state": "disabled",
+          "settings": {}
+        }
+    """.trimIndent()
+
+    @Before
+    fun setup() {
+        whenever(appTpFeatureConfig.edit()).thenReturn(appTpFeatureConfigEditor)
+        featureConfig = PrivateDnsSettingPlugin(appTpFeatureConfig)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndEnabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.PrivateDnsSupport, enabled = true, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndDisabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonDisabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.PrivateDnsSupport, enabled = false, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithIncorrectSettingThenDoNotStoreAndReturnFalse() {
+        val settingName = SettingName { "wrongSettingName" }
+        val result = featureConfig.store(settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor, never()).setEnabled(any(), any(), any())
+        assertFalse(result)
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/SetActiveNetworkSettingPluginTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/SetActiveNetworkSettingPluginTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.feature.SettingName
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class SetActiveNetworkSettingPluginTest {
+
+    private lateinit var featureConfig: SetActiveNetworkSettingPlugin
+    private val appTpFeatureConfig: AppTpFeatureConfig = mock()
+    private val appTpFeatureConfigEditor: AppTpFeatureConfig.Editor = mock()
+    private val jsonEnabled = """
+        {
+          "state": "enabled",
+          "settings": {}
+        }
+    """.trimIndent()
+    private val jsonDisabled = """
+        {
+          "state": "disabled",
+          "settings": {}
+        }
+    """.trimIndent()
+
+    @Before
+    fun setup() {
+        whenever(appTpFeatureConfig.edit()).thenReturn(appTpFeatureConfigEditor)
+        featureConfig = SetActiveNetworkSettingPlugin(appTpFeatureConfig)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndEnabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.SetActiveNetworkDns, enabled = true, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithCorrectSettingAndDisabledThenStoreAndReturnTrue() {
+        val result = featureConfig.store(featureConfig.settingName, jsonDisabled)
+
+        verify(appTpFeatureConfigEditor).setEnabled(AppTpSetting.SetActiveNetworkDns, enabled = false, isManualOverride = false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenStoreWithIncorrectSettingThenDoNotStoreAndReturnFalse() {
+        val settingName = SettingName { "wrongSettingName" }
+        val result = featureConfig.store(settingName, jsonEnabled)
+
+        verify(appTpFeatureConfigEditor, never()).setEnabled(any(), any(), any())
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1202061499094755/f

### Description
Periodically check whether the VPN has network connectivity and report when it does not but the device continues having connectivity

### Steps to test this PR

_Test connectivity checks doesn't trigger health alert when device has no connection_
- [x] Install from this branch in an EMULATOR
- [x] launch app and enable AppTP
- [x] filter logcat `NetworkConnectivityHealthHandler|enqueue`
- [x] verify network connectivity checks happen every 10s or so trying to connect to www.duckduckgo.com
- [x] disable WIFI in your computer
- [x] verify connectivity exceptions happen and that the message `Device doesn't have connectivity either` appears in the logcat
- [x] verify `m_atp_report_no_device_connectivity_c` pixel is enqueued
- [x] go to the diagnostics screen and wait for at least 1min
- [x] verify bad health is not triggered
- [x] re-enable WIFI in the computer
- [x] verify the connectivity checks come back to succeeding

_Test connectivity checks trigger health alert when only VPN has no connection_
- [x] Go to `TunPacketReader` class and comment out the `queues.tcpDeviceToNetwork.offer(packet)` line 114
- [x] Find the `transparencyModeBugFixForAndroid12()` method and modified to `return VpnExclusionList.isDdgApp(appInfo.packageName)` so that DDG browser traffic always go through the VPN
- [x] re-build and install the app in an EMULATOR
- [x] launch the app and enable AppTP
- [x] filter logcat `NetworkConnectivityHealthHandler|enqueue`
- [x] verify the `m_atp_report_no_vpn_connectivity_c` pixel is sent
- [x] go to diagnostics screen
- [x] verify it shows VPN is in bad health
- [x] wait some time
- [x] verify eventually the VPN process is killed and restarted
