### PR TITLE
Revert back to production endpoint for AppTP blocklist.json

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListService.kt
@@ -24,7 +24,7 @@ import retrofit2.Call
 import retrofit2.http.GET
 
 interface AppTrackerListService {
-    @GET("https://staticcdn.duckduckgo.com/trackerblocking/atp/beta/blocklist.json")
+    @GET("https://staticcdn.duckduckgo.com/trackerblocking/appTB/1.0/blocklist.json")
     fun appTrackerBlocklist(): Call<JsonAppBlockingList>
 
     @GET("https://staticcdn.duckduckgo.com/trackerblocking/appTB/1.0/apps-unprotected-temporary.json")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1202122946916649/f

### Description
[This task](https://app.asana.com/0/414730916066338/1201619168694507/f) mistakenly left the `blocklist.json` in beta endpoint.

Revert back to production endpoint

### Steps to test this PR
- [ ] fresh install
- [ ] launch app and enable ApptP
- [ ] verify `vpn_app_tracker_blocking_list` db table in `vpn.db` is populated
