### PR TITLE
Fix broken privacy test due to wrong view id

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
@@ -85,8 +85,8 @@ class RequestBlockingTest {
         IdlingRegistry.getInstance().register(idlingResourceForDisableProtections)
 
         onView(withId(R.id.browserMenu)).perform(click())
-        onView(isRoot()).perform(waitForView(withId(R.id.changeBrowserModeMenuItem)))
-        onView(withId(R.id.changeBrowserModeMenuItem)).perform(click())
+        onView(isRoot()).perform(waitForView(withId(R.id.privacyProtectionMenuItem)))
+        onView(withId(R.id.privacyProtectionMenuItem)).perform(click())
 
         val idlingResourceForScript: IdlingResource = WebViewIdlingResource(webView!!)
         IdlingRegistry.getInstance().register(idlingResourceForScript)

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
@@ -99,8 +99,8 @@ class SurrogatesTest {
         IdlingRegistry.getInstance().register(idlingResourceForDisableProtections)
 
         onView(withId(R.id.browserMenu)).perform(ViewActions.click())
-        onView(isRoot()).perform(waitForView(withId(R.id.changeBrowserModeMenuItem)))
-        onView(withId(R.id.changeBrowserModeMenuItem)).perform(ViewActions.click())
+        onView(isRoot()).perform(waitForView(withId(R.id.privacyProtectionMenuItem)))
+        onView(withId(R.id.privacyProtectionMenuItem)).perform(ViewActions.click())
 
         val idlingResourceForScript: IdlingResource = WebViewIdlingResource(webView!!)
         IdlingRegistry.getInstance().register(idlingResourceForScript)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202159825360139/f

### Description
This PR tries to fix 2 failing privacy tests after we renamed some views in the new menu.

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
