### PR TITLE
Crash in NetworkFileDownloader

### DIFF
--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/NetworkFileDownloader.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/NetworkFileDownloader.kt
@@ -39,7 +39,8 @@ import javax.inject.Inject
 class NetworkFileDownloader @Inject constructor(
     private val context: Context,
     private val filenameExtractor: FilenameExtractor,
-    private val fileService: DownloadFileService
+    private val fileService: DownloadFileService,
+    private val appBuildConfig: AppBuildConfig
 ) {
 
     fun download(pendingDownload: PendingFileDownload, callback: DownloadCallback) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1201550925053703/f

### Description
Wrapped code in try/catch for Android 10 specific crash in NetworkFileDownloader.

### Steps to test this PR
Can't be reproduced. It happens only on Android 10 and it's very infrequent on Pixel devices -> only 0.23% in the last 30 days.
Instead of crashing, now we display a snackbar and a notification to inform the user about the failed download. See the 2 attached screenshots.

### UI changes
| Show snackbar  | Show notification |
| ------ | ----- |
![failed_to_download_snackbar](https://user-images.githubusercontent.com/7963079/164453881-b3950a7c-7ab3-4353-950f-8dbe94ac1f6d.png)|![failed_to_download_notification](https://user-images.githubusercontent.com/7963079/164453596-84bf52fd-daab-4709-8d4b-523109b354ca.png)|

