### PR TITLE
fixed crash when trying to grab info from uninstalled apps

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/TrackingProtectionAppsRepository.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/TrackingProtectionAppsRepository.kt
@@ -36,11 +36,11 @@ import timber.log.Timber
 import javax.inject.Inject
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 
 interface TrackingProtectionAppsRepository {
+
     /** @return the list of installed apps and information about its excluded state */
-    suspend fun getProtectedApps(): Flow<List<TrackingProtectionAppInfo>>
+    suspend fun getAppsAndProtectionInfo(): Flow<List<TrackingProtectionAppInfo>>
 
     /** @return the list of installed apps currently excluded */
     suspend fun getExclusionAppsList(): List<String>
@@ -70,7 +70,7 @@ class RealTrackingProtectionAppsRepository @Inject constructor(
 
     private var installedApps: Sequence<ApplicationInfo> = emptySequence()
 
-    override suspend fun getProtectedApps(): Flow<List<TrackingProtectionAppInfo>> {
+    override suspend fun getAppsAndProtectionInfo(): Flow<List<TrackingProtectionAppInfo>> {
         return appTrackerRepository.getAppExclusionListFlow()
             .combine(appTrackerRepository.getManualAppExclusionListFlow()) { ddgExclusionList, manualList ->
                 Timber.d("getProtectedApps flow")

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageAppListViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageAppListViewModel.kt
@@ -38,7 +38,7 @@ class ReportBreakageAppListViewModel @Inject constructor(
     internal fun commands(): Flow<ReportBreakageAppListView.Command> = command.receiveAsFlow()
 
     internal suspend fun getInstalledApps(): Flow<ReportBreakageAppListView.State> {
-        return trackingProtectionAppsRepository.getProtectedApps()
+        return trackingProtectionAppsRepository.getAppsAndProtectionInfo()
             .combine(selectedAppFlow.asStateFlow()) { apps, selectedApp ->
                 val installedApps = apps.map { InstalledApp(it.packageName, it.name) }
                 selectedApp?.let { appSelected ->

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageAppListViewModelTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageAppListViewModelTest.kt
@@ -76,7 +76,7 @@ class ReportBreakageAppListViewModelTest {
 
     @Test
     fun whenGetInstalledAppsAndNoInstalledAppsThenEmitNoItem() = runTest {
-        whenever(trackingProtectionAppsRepository.getProtectedApps()).thenReturn(protectedAppsChannel.receiveAsFlow())
+        whenever(trackingProtectionAppsRepository.getAppsAndProtectionInfo()).thenReturn(protectedAppsChannel.receiveAsFlow())
         viewModel.getInstalledApps().test {
             expectNoEvents()
         }
@@ -84,7 +84,7 @@ class ReportBreakageAppListViewModelTest {
 
     @Test
     fun whenGetInstalledAppsThenEmitState() = runTest {
-        whenever(trackingProtectionAppsRepository.getProtectedApps()).thenReturn(protectedAppsChannel.receiveAsFlow())
+        whenever(trackingProtectionAppsRepository.getAppsAndProtectionInfo()).thenReturn(protectedAppsChannel.receiveAsFlow())
         viewModel.getInstalledApps().test {
             protectedAppsChannel.send(listOf(appWithoutIssues))
             assertEquals(
@@ -99,7 +99,7 @@ class ReportBreakageAppListViewModelTest {
 
     @Test
     fun whenGetInstalledAppsAndSelectedAppThenEmitState() = runTest {
-        whenever(trackingProtectionAppsRepository.getProtectedApps()).thenReturn(protectedAppsChannel.receiveAsFlow())
+        whenever(trackingProtectionAppsRepository.getAppsAndProtectionInfo()).thenReturn(protectedAppsChannel.receiveAsFlow())
         viewModel.getInstalledApps().test {
             viewModel.onAppSelected(InstalledApp(packageName = appWithIssues.packageName, name = appWithIssues.name))
             protectedAppsChannel.send(listOf(appWithoutIssues, appWithIssues))
@@ -116,7 +116,7 @@ class ReportBreakageAppListViewModelTest {
 
     @Test
     fun whenGetInstalledAppsAndUnknownSelectedAppThenEmitState() = runTest {
-        whenever(trackingProtectionAppsRepository.getProtectedApps()).thenReturn(protectedAppsChannel.receiveAsFlow())
+        whenever(trackingProtectionAppsRepository.getAppsAndProtectionInfo()).thenReturn(protectedAppsChannel.receiveAsFlow())
         viewModel.getInstalledApps().test {
             viewModel.onAppSelected(InstalledApp(packageName = "unknown.package.name", name = appWithIssues.name))
             protectedAppsChannel.send(listOf(appWithoutIssues, appWithIssues))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1202185118693825/f

### Description

### Steps to test this PR

_Reproduce crash (install from develop)_
- [x] Enable AppTP
- [x] Have it block some trackers in an app
- [x] Uninstall the app
- [x] Open Recent Apps from the Trackers Screen
- [x] App should crash

_Crash fix (install from this branch)_
- [x] Enable AppTP
- [x] Have it block some trackers in an app
- [x] Uninstall the app
- [x] Open Recent Apps from the Trackers Screen
- [x] List should appear without the app just uninstalled
