### PR TITLE
Remove 'Edit' option from Fireproof Sites

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsiteAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsiteAdapter.kt
@@ -21,6 +21,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
+import android.widget.TextView
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
@@ -38,6 +39,7 @@ import com.duckduckgo.app.fire.fireproofwebsite.data.website
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.isFireproofExperimentEnabled
 import com.duckduckgo.mobile.android.ui.menu.PopupMenu
+import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -242,6 +244,7 @@ sealed class FireproofWebSiteViewHolder(itemView: View) : RecyclerView.ViewHolde
             val popupMenu = PopupMenu(layoutInflater, R.layout.popup_window_edit_delete_menu)
             val view = popupMenu.contentView
             popupMenu.apply {
+                view.findViewById<TextView>(R.id.edit).gone()
                 onMenuItemClicked(view.findViewById(R.id.delete)) { deleteEntity(entity) }
             }
             popupMenu.show(binding.root, anchor)

--- a/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsiteAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsiteAdapter.kt
@@ -243,10 +243,8 @@ sealed class FireproofWebSiteViewHolder(itemView: View) : RecyclerView.ViewHolde
         ) {
             val popupMenu = PopupMenu(layoutInflater, R.layout.popup_window_edit_delete_menu)
             val view = popupMenu.contentView
-            popupMenu.apply {
-                view.findViewById<TextView>(R.id.edit).gone()
-                onMenuItemClicked(view.findViewById(R.id.delete)) { deleteEntity(entity) }
-            }
+            view.findViewById<TextView>(R.id.edit).gone()
+            popupMenu.onMenuItemClicked(view.findViewById(R.id.delete)) { deleteEntity(entity) }
             popupMenu.show(binding.root, anchor)
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202170635398721/f

### Description
We are showing by mistake an 'Edit' option in overflow menu for a Fireproof Site. It is removed now

### Steps to test this PR

_Feature 1_
- Install from this branch
- Go to Settings > Fireproof Sites and make sure you have 1 or more fireproof sites added
- Tap on fireproof site overflow menu
- [x] Check 'Delete' option is showing
- [x] Check 'Edit' option is **not** showing

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20220428-173559_DuckDuckGo](https://user-images.githubusercontent.com/20798495/165792082-444b0529-bc37-4ad5-9f78-3d113aad9f4a.jpg) | ![Screenshot_20220428-173532_DuckDuckGo](https://user-images.githubusercontent.com/20798495/165792042-2ff0662c-c370-43bd-8070-1e29c1b0d6b8.jpg) |
