### PR TITLE
Update anvil to 2.4.0

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/Extensions.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/Extensions.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.anvil.compiler
+
+import com.squareup.anvil.annotations.ExperimentalAnvilApi
+import com.squareup.anvil.compiler.internal.reference.AnnotationReference
+import com.squareup.anvil.compiler.internal.reference.ClassReference
+import com.squareup.anvil.compiler.internal.reference.argumentAt
+
+@OptIn(ExperimentalAnvilApi::class)
+internal fun AnnotationReference.bindingKeyOrNull(): ClassReference? = argumentAt("bindingKey", 1)?.value()

--- a/app/src/main/java/com/duckduckgo/app/browser/httpauth/WebViewHttpAuthStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/httpauth/WebViewHttpAuthStore.kt
@@ -28,10 +28,8 @@ import com.duckduckgo.app.fire.DatabaseCleaner
 import com.duckduckgo.app.fire.DatabaseLocator
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -72,6 +70,10 @@ interface WebViewHttpAuthStore {
 @ContributesMultibinding(
     scope = AppScope::class,
     boundType = LifecycleObserver::class
+)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = WebViewHttpAuthStore::class
 )
 @SingleInstanceIn(AppScope::class)
 class RealWebViewHttpAuthStore @Inject constructor(
@@ -129,14 +131,4 @@ class RealWebViewHttpAuthStore @Inject constructor(
     override suspend fun cleanHttpAuthDatabase() {
         databaseCleaner.cleanDatabase(authDatabaseLocator.getDatabasePath())
     }
-}
-
-@Module
-@ContributesTo(AppScope::class)
-abstract class WebViewHttpAuthStoreModule {
-    @Binds
-    @SingleInstanceIn(AppScope::class)
-    abstract fun bindWebViewHttpAuthStore(
-        realWebViewHttpAuthStore: RealWebViewHttpAuthStore
-    ): WebViewHttpAuthStore
 }

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -30,10 +30,7 @@ import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.Https
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.squareup.anvil.annotations.ContributesBinding
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
-import dagger.multibindings.IntoSet
+import com.squareup.anvil.annotations.ContributesMultibinding
 import timber.log.Timber
 import java.util.concurrent.locks.ReentrantLock
 import javax.inject.Inject
@@ -57,6 +54,10 @@ interface HttpsUpgrader {
 @ContributesBinding(
     scope = AppScope::class,
     boundType = HttpsUpgrader::class
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = LifecycleObserver::class
 )
 class HttpsUpgraderImpl @Inject constructor(
     private val bloomFactory: HttpsBloomFilterFactory,
@@ -131,16 +132,4 @@ class HttpsUpgraderImpl @Inject constructor(
             bloomReloadLock.unlock()
         }
     }
-}
-
-@Module
-@ContributesTo(AppScope::class)
-abstract class HttpsUpgraderModule {
-
-    @SingleInstanceIn(AppScope::class)
-    @Binds
-    @IntoSet
-    abstract fun bindHttpsUpgraderLifecycleObserver(
-        httpsUpgraderImpl: HttpsUpgraderImpl
-    ): LifecycleObserver
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         kotlin_version = '1.6.21'
         spotless = "6.1.2"
-        anvil_version = "2.3.11-1-6-10"
+        anvil_version = "2.4.0"
         gradle_plugin = "7.0.4"
         min_sdk = 23
         target_sdk = 30

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
@@ -32,12 +32,8 @@ import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateCollectorPlugin
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.squareup.anvil.annotations.ContributesMultibinding
-import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.moshi.Moshi
-import dagger.Binds
-import dagger.Module
 import dagger.SingleInstanceIn
-import dagger.multibindings.IntoSet
 import com.duckduckgo.mobile.android.vpn.prefs.VpnPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -53,6 +49,10 @@ import javax.inject.Inject
 @ContributesMultibinding(
     scope = VpnScope::class,
     boundType = VpnStateCollectorPlugin::class
+)
+@ContributesMultibinding(
+    scope = VpnScope::class,
+    boundType = VpnServiceCallbacks::class
 )
 @SingleInstanceIn(VpnScope::class)
 class NetworkTypeCollector @Inject constructor(
@@ -259,13 +259,4 @@ class NetworkTypeCollector @Inject constructor(
         private const val FILENAME = "network.type.collector.file.v1"
         private const val NETWORK_INFO_KEY = "network.info.key"
     }
-}
-
-@Module
-@ContributesTo(VpnScope::class)
-abstract class NetworkTypeCollectorModule {
-    @Binds
-    @IntoSet
-    @SingleInstanceIn(VpnScope::class)
-    abstract fun NetworkTypeCollector.bind(): VpnServiceCallbacks
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
@@ -25,11 +25,7 @@ import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.squareup.anvil.annotations.ContributesBinding
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
-import dagger.SingleInstanceIn
-import dagger.multibindings.IntoSet
+import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
 import org.threeten.bp.LocalDate
 import org.threeten.bp.format.DateTimeFormatter
@@ -50,6 +46,10 @@ interface CohortStore {
 @ContributesBinding(
     scope = AppScope::class,
     boundType = CohortStore::class
+)
+@ContributesMultibinding(
+    scope = VpnScope::class,
+    boundType = VpnServiceCallbacks::class
 )
 class RealCohortStore @Inject constructor(
     private val context: Context
@@ -89,13 +89,4 @@ class RealCohortStore @Inject constructor(
         private const val FILENAME = "com.duckduckgo.mobile.atp.cohort.prefs"
         private const val KEY_COHORT_LOCAL_DATE = "KEY_COHORT_LOCAL_DATE"
     }
-}
-
-@Module
-@ContributesTo(VpnScope::class)
-abstract class CohortStoreModule {
-    @Binds
-    @IntoSet
-    @SingleInstanceIn(VpnScope::class)
-    abstract fun bindCohortStore(realCohortStore: RealCohortStore): VpnServiceCallbacks
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpSocketWriter.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpSocketWriter.kt
@@ -23,11 +23,8 @@ import com.duckduckgo.mobile.android.vpn.processor.tcp.TcpPacketProcessor.Pendin
 import com.duckduckgo.mobile.android.vpn.service.VpnMemoryCollectorPlugin
 import com.duckduckgo.mobile.android.vpn.service.VpnQueues
 import com.squareup.anvil.annotations.ContributesBinding
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
+import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
-import dagger.multibindings.IntoSet
 import timber.log.Timber
 import xyz.hexene.localvpn.ByteBufferPool
 import xyz.hexene.localvpn.Packet
@@ -55,6 +52,10 @@ interface TcpSocketWriter {
 @ContributesBinding(
     scope = VpnScope::class,
     boundType = TcpSocketWriter::class
+)
+@ContributesMultibinding(
+    scope = VpnScope::class,
+    boundType = VpnMemoryCollectorPlugin::class
 )
 class RealTcpSocketWriter @Inject constructor(
     @TcpNetworkSelector private val selector: Selector,
@@ -205,12 +206,4 @@ class RealTcpSocketWriter @Inject constructor(
         removalList.forEach { writeQueue.remove(it) }
         Timber.v("Cleaned up evicted TCBs. Removed %d", removalList.size)
     }
-}
-
-@Module
-@ContributesTo(VpnScope::class)
-abstract class TcpSocketWriterModule {
-    @Binds
-    @IntoSet
-    abstract fun bindTcpSocketWriterMemoryCollector(tcpSocketWriter: TcpSocketWriter): VpnMemoryCollectorPlugin
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/AppTrackerRecorder.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/AppTrackerRecorder.kt
@@ -23,10 +23,8 @@ import com.duckduckgo.mobile.android.vpn.model.VpnTracker
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
+import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.*
 import timber.log.Timber
@@ -41,6 +39,10 @@ interface AppTrackerRecorder {
 @ContributesMultibinding(
     scope = VpnScope::class,
     boundType = VpnServiceCallbacks::class,
+)
+@ContributesBinding(
+    scope = VpnScope::class,
+    boundType = AppTrackerRecorder::class,
 )
 @SingleInstanceIn(VpnScope::class)
 class BatchedAppTrackerRecorder @Inject constructor(vpnDatabase: VpnDatabase) : VpnServiceCallbacks, AppTrackerRecorder {
@@ -96,13 +98,4 @@ class BatchedAppTrackerRecorder @Inject constructor(vpnDatabase: VpnDatabase) : 
     companion object {
         private const val PERIODIC_INSERTION_FREQUENCY_MS: Long = 1_000
     }
-}
-
-@Module
-@ContributesTo(VpnScope::class)
-abstract class AppTrackerRecorderModule {
-
-    @Binds
-    @SingleInstanceIn(VpnScope::class)
-    abstract fun providesAppTrackerRecorder(batchedAppTrackerRecorder: BatchedAppTrackerRecorder): AppTrackerRecorder
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpChannelCache.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpChannelCache.kt
@@ -19,15 +19,16 @@ package com.duckduckgo.mobile.android.vpn.processor.udp
 import android.util.LruCache
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnMemoryCollectorPlugin
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Binds
-import dagger.Module
+import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
-import dagger.multibindings.IntoSet
 import timber.log.Timber
 import javax.inject.Inject
 
 @SingleInstanceIn(VpnScope::class)
+@ContributesMultibinding(
+    scope = VpnScope::class,
+    boundType = VpnMemoryCollectorPlugin::class
+)
 class UdpChannelCache @Inject constructor() : LruCache<String, UdpPacketProcessor.ChannelDetails>(500), VpnMemoryCollectorPlugin {
     override fun entryRemoved(
         evicted: Boolean,
@@ -46,12 +47,4 @@ class UdpChannelCache @Inject constructor() : LruCache<String, UdpPacketProcesso
             this["udpChannelCacheSize"] = size().toString()
         }
     }
-}
-
-@Module
-@ContributesTo(VpnScope::class)
-abstract class UdpChannelCacheModule {
-    @Binds
-    @IntoSet
-    abstract fun bindUdpChannelCacheMemoryCollector(udpChannelCache: UdpChannelCache): VpnMemoryCollectorPlugin
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 21 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202216477980438/f

### Description
Bump Anvil to 2.4.0
* This requires to update the anvil codegen

Incidentally modified the following classes now that anvil supports repeatable annotations
* WebViewHttpAuthStore
* HttpsUpgrader
* NetworkTypeCollector
* CohortStore
* TcpSocketWriter
* AppTrackerRecorder
* UdpChannelCache

### Steps to test this PR
_Build_
- [x] build passes

_Other classes_
- [x] install from this branch
- [x] filter logcat by `HttpsUpgrader|NetworkTypeCollector|CohortStore|AppTrackerRecorder`
- [x] launch the app
- [x] verify `Registering application lifecycle observer: com.duckduckgo.app.httpsupgrade.HttpsUpgraderImpl` appears in logcat
- [x] verify `VPN log: starting class com.duckduckgo.mobile.android.vpn.bugreport.NetworkTypeCollector callback` appears in logcat
- [x] verify `VPN log: starting class com.duckduckgo.mobile.android.vpn.cohort.RealCohortStore callback` appears in logcat

_Smoke tests_
- [x] install from this branch
- [x] launch app
- [x] test core browser features
- [x] enable AppTP
- [x] open apps that track
- [x] verify AppTP blocks trackers

_Code inspection_
For the following classes:
* WebViewHttpAuthStore
* HttpsUpgrader
* NetworkTypeCollector
* CohortStore
* TcpSocketWriter
* AppTrackerRecorder
* UdpChannelCache

- [x] verify the removed modules did the same that the newly added `ContributesBinding` and `ContributesMultibinding` annotations in the following classes
