### PR TITLE
Ensure getApplicationInfo doesn't crash when app name not found

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/AppCategoryDetector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/AppCategoryDetector.kt
@@ -30,6 +30,8 @@ class RealAppCategoryDetector @Inject constructor(context: Context) : AppCategor
     private val packageManager = context.packageManager
 
     override fun getAppCategory(packageName: String): AppCategory {
-        return packageManager.getApplicationInfo(packageName, 0).parseAppCategory()
+        return runCatching {
+            packageManager.getApplicationInfo(packageName, 0).parseAppCategory()
+        }.getOrElse { AppCategory.Undefined }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202260283121034/f

### Description
`packageManager.getApplicationInfo` can throw `NameNotFoundException` but we were never catching that in the `AppCategoryDetector`.

The PR catches the exception and returns `AppCategory.Undefined` when it happens

### Steps to test this PR
Just code review
