### PR TITLE
Migrate from @OnLifecycleEvent - statistics module

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.statistics.api
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.LifecycleOwner
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.InstantSchedulersRule
@@ -66,6 +67,7 @@ class RxPixelSenderTest {
     private lateinit var db: AppDatabase
     private lateinit var pendingPixelDao: PendingPixelDao
     private lateinit var testee: RxPixelSender
+    private val mockLifecycleOwner: LifecycleOwner = mock()
 
     @Before
     fun before() {
@@ -207,7 +209,7 @@ class RxPixelSenderTest {
         pendingPixelDao.insert(pixelEntity)
         givenFormFactor(DeviceInfo.FormFactor.PHONE)
 
-        testee.onAppForegrounded()
+        testee.onStart(mockLifecycleOwner)
 
         verify(api).fire(
             pixelEntity.pixelName, "phone", pixelEntity.atb, pixelEntity.additionalQueryParams, pixelEntity.encodedQueryParams
@@ -226,7 +228,7 @@ class RxPixelSenderTest {
         pendingPixelDao.insert(pixelEntity)
         givenFormFactor(DeviceInfo.FormFactor.PHONE)
 
-        testee.onAppForegrounded()
+        testee.onStart(mockLifecycleOwner)
 
         val pixels = pendingPixelDao.pixels().test().assertNoErrors().values().last()
         assertTrue(pixels.isEmpty())
@@ -244,7 +246,7 @@ class RxPixelSenderTest {
         pendingPixelDao.insert(pixelEntity)
         givenFormFactor(DeviceInfo.FormFactor.PHONE)
 
-        testee.onAppForegrounded()
+        testee.onStart(mockLifecycleOwner)
 
         val testObserver = pendingPixelDao.pixels().test()
         val pixels = testObserver.assertNoErrors().values().last()
@@ -263,7 +265,7 @@ class RxPixelSenderTest {
         pendingPixelDao.insert(pixelEntity, times = 5)
         givenFormFactor(DeviceInfo.FormFactor.PHONE)
 
-        testee.onAppForegrounded()
+        testee.onStart(mockLifecycleOwner)
 
         verify(api, times(5)).fire(
             pixelEntity.pixelName, "phone", pixelEntity.atb, pixelEntity.additionalQueryParams, pixelEntity.encodedQueryParams

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/AtbInitializer.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/AtbInitializer.kt
@@ -17,9 +17,8 @@
 package com.duckduckgo.app.statistics
 
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -42,10 +41,9 @@ class AtbInitializer(
     private val statisticsDataStore: StatisticsDataStore,
     private val statisticsUpdater: StatisticsUpdater,
     private val listeners: Set<AtbInitializerListener>
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-    fun initializeOnResume() {
+    override fun onResume(owner: LifecycleOwner) {
         appCoroutineScope.launch { initialize() }
     }
 

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelSender.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelSender.kt
@@ -16,9 +16,8 @@
 
 package com.duckduckgo.app.statistics.api
 
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.config.StatisticsLibraryConfig
@@ -31,7 +30,7 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
 
-interface PixelSender : LifecycleObserver {
+interface PixelSender : DefaultLifecycleObserver {
     fun sendPixel(
         pixelName: String,
         parameters: Map<String, String>,
@@ -60,8 +59,7 @@ class RxPixelSender constructor(
         if (statisticsLibraryConfig?.shouldFirePixelsAsDev() == true) 1 else null
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun onAppForegrounded() {
+    override fun onStart(owner: LifecycleOwner) {
         compositeDisposable.add(
             pendingPixelDao.pixels()
                 .flatMapIterable { it }
@@ -74,9 +72,7 @@ class RxPixelSender constructor(
         )
     }
 
-    @Suppress("unused")
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    fun onAppBackgrounded() {
+    override fun onStop(owner: LifecycleOwner) {
         compositeDisposable.clear()
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202260594569391/f

### Description
@OnLifecycleEvent is now deprecated. Updated code in statistics module to use `DefaultLifecycleObserver`

### Steps to test this PR

- Install from this branch
- Launch the app
- Check in the Logcat that the following Logs appear:

 - [ ] `Registering application lifecycle observer: com.duckduckgo.app.statistics.AtbInitializer`
 - [ ] `Registering application lifecycle observer: com.duckduckgo.app.statistics.api.RxPixelSender`
