### PR TITLE
we no longer need to prepopulate tracker entities

### DIFF
--- a/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallback.kt
+++ b/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallback.kt
@@ -57,12 +57,6 @@ internal class VpnDatabaseCallback(
         }
     }
 
-    override fun onOpen(db: SupportSQLiteDatabase) {
-        ioThread {
-            prepopulateTrackerEntities()
-        }
-    }
-
     private fun prepopulateUUID() {
         val uuid = UUID.randomUUID().toString()
         vpnDatabase.get().vpnStateDao().insert(VpnState(uuid = uuid))


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1157893581871903/1201722332762154

### Description
Background
In [✓ AppTP: Crash after merging company signals](https://app.asana.com/0/1157893581871903/1201711685020952) we added a method to prepopulate the vpn database with a list of trackers to solve the crash.

Remove the prepopulation method as we no longer need it.

### Steps to test this PR
Usual smoke tests