### PR TITLE
AppTP: Disabling tracking protection issue on API 23

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -505,6 +505,9 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), N
 
             for (service in manager.getRunningServices(Int.MAX_VALUE)) {
                 if (TrackerBlockingVpnService::class.java.name == service.service.className) {
+                    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.M) {
+                        return service.started
+                    }
                     return true
                 }
             }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202236755602993/f

### Description
Fixed isServiceRunning on API 23.
On API 23 services are still reported as running up to 1 min after they're stopped. Changed the code to check the started property for this API version only.

### Steps to test this PR

- install from this branch on a device running Android M
- go to Settings and enable AppTP
- enable and disable AppTP and check it's indeed enabled / disabled
- check the Before / After videos attached on the Asana task.

### NO UI changes
