### PR TITLE
Migrate prefs to harmony when necessary

### DIFF
--- a/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProviderImplTest.kt
+++ b/vpn/src/androidTest/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProviderImplTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.prefs
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+
+class VpnSharedPreferencesProviderImplTest {
+
+    private val context: Context = InstrumentationRegistry.getInstrumentation().context.applicationContext
+    private lateinit var prefs: SharedPreferences
+    private lateinit var vpnPreferencesProvider: VpnSharedPreferencesProvider
+    private lateinit var NAME: String
+
+    @Before
+    fun setup() {
+        NAME = UUID.randomUUID().toString()
+        prefs = context.getSharedPreferences(NAME, MODE_PRIVATE)
+        vpnPreferencesProvider = VpnSharedPreferencesProviderImpl(context)
+    }
+
+    @Test
+    fun whenGetMultiprocessPreferencesThenMigrateToHarmony() {
+        prefs.edit(commit = true) { putBoolean("bool", true) }
+        prefs.edit(commit = true) { putString("string", "true") }
+        prefs.edit(commit = true) { putInt("int", 1) }
+        prefs.edit(commit = true) { putFloat("float", 1f) }
+        prefs.edit(commit = true) { putLong("long", 1L) }
+
+        val harmony = vpnPreferencesProvider.getSharedPreferences(NAME, multiprocess = true, migrate = true)
+
+        assertEquals(true, harmony.getBoolean("bool", false))
+        assertEquals("true", harmony.getString("string", "false"))
+        assertEquals(1, harmony.getInt("int", 0))
+        assertEquals(1f, harmony.getFloat("float", 0f))
+        assertEquals(1L, harmony.getLong("long", 0L))
+    }
+
+    @Test
+    fun whenGetMultiprocessPreferencesAndMigrateIsFalseThenDoNotMigrateToHarmony() {
+        prefs.edit(commit = true) { putBoolean("bool", true) }
+        prefs.edit(commit = true) { putString("string", "true") }
+        prefs.edit(commit = true) { putInt("int", 1) }
+        prefs.edit(commit = true) { putFloat("float", 1f) }
+        prefs.edit(commit = true) { putLong("long", 1L) }
+
+        val harmony = vpnPreferencesProvider.getSharedPreferences(NAME, multiprocess = true)
+
+        assertNotEquals(true, harmony.getBoolean("bool", false))
+        assertNotEquals("true", harmony.getString("string", "false"))
+        assertNotEquals(1, harmony.getInt("int", 0))
+        assertNotEquals(1f, harmony.getFloat("float", 0f))
+        assertNotEquals(1L, harmony.getLong("long", 0L))
+    }
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
@@ -55,7 +55,7 @@ class RealCohortStore @Inject constructor(
 
     private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
-    private val preferences = sharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true)
+    private val preferences = sharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = true)
 
     override fun getCohortStoredLocalDate(): LocalDate? {
         return preferences.getString(KEY_COHORT_LOCAL_DATE, null)?.let {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -403,7 +403,7 @@ class RealDeviceShieldPixels @Inject constructor(
     vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
 ) : DeviceShieldPixels {
 
-    private val preferences = vpnSharedPreferencesProvider.getSharedPreferences(DS_PIXELS_PREF_FILE, multiprocess = true)
+    private val preferences = vpnSharedPreferencesProvider.getSharedPreferences(DS_PIXELS_PREF_FILE, multiprocess = true, migrate = true)
 
     override fun deviceShieldEnabledOnSearch() {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_ENABLE_UPON_SEARCH_DAILY)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProvider.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProvider.kt
@@ -19,24 +19,75 @@ package com.duckduckgo.mobile.android.vpn.prefs
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.duckduckgo.di.scopes.AppScope
 import com.frybits.harmony.getHarmonySharedPreferences
 import com.squareup.anvil.annotations.ContributesBinding
+import timber.log.Timber
 import javax.inject.Inject
 
 interface VpnSharedPreferencesProvider {
-    fun getSharedPreferences(name: String, multiprocess: Boolean = false): SharedPreferences
+    /**
+     * Returns an instance of Shared preferences
+     * @param name Name of the shared preferences
+     * @param multiprocess `true` if the shared preferences will be accessed from several processes else `false`
+     * @param migrate `true` if the shared preferences existed prior to use the [VpnSharedPreferencesProvider], else `false`
+     */
+    fun getSharedPreferences(name: String, multiprocess: Boolean = false, migrate: Boolean = false): SharedPreferences
 }
+
+private const val MIGRATED_TO_HARMONY = "migrated_to_harmony"
 
 @ContributesBinding(AppScope::class)
 class VpnSharedPreferencesProviderImpl @Inject constructor(
     private val context: Context
 ) : VpnSharedPreferencesProvider {
-    override fun getSharedPreferences(name: String, multiprocess: Boolean): SharedPreferences {
+    override fun getSharedPreferences(name: String, multiprocess: Boolean, migrate: Boolean): SharedPreferences {
         return if (multiprocess) {
-            context.getHarmonySharedPreferences(name)
+            if (migrate) {
+                Timber.v("Migrate and return preferences to Harmony")
+                return migrateToHarmonyIfNecessary(name)
+            } else {
+                Timber.v("Return Harmony preferences")
+                context.getHarmonySharedPreferences(name)
+            }
         } else {
             context.getSharedPreferences(name, MODE_PRIVATE)
         }
+    }
+
+    private fun migrateToHarmonyIfNecessary(name: String): SharedPreferences {
+        val origin = context.getSharedPreferences(name, MODE_PRIVATE)
+        val destination = context.getHarmonySharedPreferences(name)
+
+        if (destination.getBoolean(MIGRATED_TO_HARMONY, false)) return destination
+        Timber.v("Performing migration to Harmony")
+
+        val contents = origin.all
+
+        contents.keys.forEach { key ->
+            when (val originalValue = contents[key]) {
+                is Boolean -> {
+                    destination.edit { putBoolean(key, originalValue) }
+                }
+                is Long -> {
+                    destination.edit { putLong(key, originalValue) }
+                }
+                is Int -> {
+                    destination.edit { putInt(key, originalValue) }
+                }
+                is Float -> {
+                    destination.edit { putFloat(key, originalValue) }
+                }
+                is String -> {
+                    destination.edit { putString(key, originalValue) }
+                }
+                else -> Timber.w("Could not migrate $key from $name preferences")
+            }
+        }
+
+        destination.edit(commit = true) { putBoolean(MIGRATED_TO_HARMONY, true) }
+
+        return destination
     }
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -42,11 +43,14 @@ interface VpnStore {
 }
 
 @ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
 class SharedPreferencesVpnStore @Inject constructor(
     sharedPreferencesProvider: VpnSharedPreferencesProvider,
     private val dispatcherProvider: DispatcherProvider,
 ) : VpnStore {
-    private val preferences = sharedPreferencesProvider.getSharedPreferences(DEVICE_SHIELD_ONBOARDING_STORE_PREFS, multiprocess = true)
+    private val preferences = sharedPreferencesProvider.getSharedPreferences(
+        DEVICE_SHIELD_ONBOARDING_STORE_PREFS, multiprocess = true, migrate = true
+    )
 
     override fun onboardingDidShow() {
         preferences.edit { putBoolean(KEY_DEVICE_SHIELD_ONBOARDING_LAUNCHED, true) }

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortStoreTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortStoreTest.kt
@@ -39,7 +39,7 @@ class RealCohortStoreTest {
     fun setup() {
         val prefs = InMemorySharedPreferences()
         whenever(
-            sharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.mobile.atp.cohort.prefs"), eq(true))
+            sharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.mobile.atp.cohort.prefs"), eq(true), eq(true))
         ).thenReturn(prefs)
 
         cohortStore = RealCohortStore(sharedPreferencesProvider)

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
@@ -35,7 +35,7 @@ class RealDeviceShieldPixelsTest {
     fun setup() {
         val prefs = InMemorySharedPreferences()
         whenever(
-            sharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.mobile.android.device.shield.pixels"), eq(true))
+            sharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.mobile.android.device.shield.pixels"), eq(true), eq(true))
         ).thenReturn(prefs)
 
         deviceShieldPixels = RealDeviceShieldPixels(pixel, sharedPreferencesProvider)

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/SharedPreferencesVpnStoreTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/SharedPreferencesVpnStoreTest.kt
@@ -43,7 +43,7 @@ class SharedPreferencesVpnStoreTest {
     fun setup() {
         val prefs = InMemorySharedPreferences()
         whenever(
-            sharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.android.atp.onboarding.store"), eq(true))
+            sharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.android.atp.onboarding.store"), eq(true), eq(true))
         ).thenReturn(prefs)
 
         sharedPreferencesVpnStore = SharedPreferencesVpnStore(sharedPreferencesProvider, coroutineRule.testDispatcherProvider)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1199371158290272/1202279501986167/f

### Description
The Harmony multi process shared preferences creates the shared prefs file under a different folder and does not migrate previously existing shared preferences.

This causes a bug in DDG, to repro the bug:
* install from `5.124.0.1-nightly`
* launch app and enable AppTP
* update from develop
* launch app and go to Settings -> App Tracking Protection
* expected: AppTP screen is open
* actual: onboarding is shown again

This PR adds a migration to the `VpnSharedPreferencesProviderImpl` that is executed when shared prefs are returned using the provider

### Steps to test this PR

_Check migration_
- [ ] install form `5.124.0.1-nightly`
- [ ] launch app and enable AppTP
- [ ] update app from this branch
- [ ] launch app and go to Settings -> App tracking protection
- [ ] verify onboarding is now shown

(cohort and AppTP pixels are also migrated, but not tested as migration works the same in all instalces)

