### PR TITLE
AppTP: Crash in DetectOriginatingAppPackageModern.getPackageIdForUid

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/DetectOriginatingAppPackageModern.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/DetectOriginatingAppPackageModern.kt
@@ -51,7 +51,15 @@ class DetectOriginatingAppPackageModern(
     }
 
     private fun getPackageIdForUid(uid: Int): String {
-        val packages = packageManager.getPackagesForUid(uid)
+        val packages: Array<String>?
+
+        try {
+            packages = packageManager.getPackagesForUid(uid)
+        } catch (e: SecurityException) {
+            Timber.e(e, "Failed to get package ID for UID: $uid due to security violation.")
+            return OriginatingAppPackageIdentifierStrategy.UNKNOWN
+        }
+
         if (packages.isNullOrEmpty()) {
             Timber.w("Failed to get package ID for UID: $uid")
             return OriginatingAppPackageIdentifierStrategy.UNKNOWN

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/requestingapp/DetectOriginatingAppPackageModernTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/requestingapp/requestingapp/DetectOriginatingAppPackageModernTest.kt
@@ -95,6 +95,16 @@ class DetectOriginatingAppPackageModernTest {
         verify(packageManager).getPackagesForUid(-1)
     }
 
+    @Test
+    fun whenGetPackagesForUidThrowsSecurityExceptionThenReturnUnknown() {
+        val connection = aConnectionInfo(sourcePort = 40123)
+
+        whenever(packageManager.getPackagesForUid(any())).thenThrow(SecurityException())
+
+        val packageId = testee.resolvePackageId(connection)
+        assertEquals("unknown", packageId)
+    }
+
     private fun captureDestinationAddress() {
         verify(connectivityManager).getConnectionOwnerUid(any(), any(), addressCaptor.capture())
     }


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202299726914755/f

### Description
Updated getPackageIdForUid to return unknown in case of SecurityException.

### Steps to test this PR

Could not reproduce. Might need another user profile on device.

### NO UI changes
