### PR TITLE
Add internal features to protect all apps or restore default protections

### DIFF
--- a/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
+++ b/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
@@ -160,6 +160,31 @@
                     android:text="Delete Tracking History"
             />
 
+            <!-- Section Protection -->
+            <View style="@style/SettingsGroupDivider" />
+
+            <TextView
+                    android:id="@+id/sectionAppProtection"
+                    style="@style/SettingsSectionTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="App Protections"
+            />
+
+            <TextView
+                    android:id="@+id/protectAllApps"
+                    style="@style/SettingsItemClickable"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:text="Protect all apps"/>
+
+            <TextView
+                    android:id="@+id/restoreDefaultAppProtections"
+                    style="@style/SettingsItemClickable"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:text="Restore default protections"/>
+
             <!-- Section Logging -->
             <View style="@style/SettingsGroupDivider" />
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202290988165066/f

### Description
This PR adds couple internal options in the "AppTP dev settings" to:
* protect all apps
* restore default protections

To keep the PR simple as this is convenience internal feature for testing, the following limitations/cases are not tackled:
* when protecting or restoring protections the screen may flicker a bit, this is because we automatically restart the VPN for the config changes to take affect, and the Internal settings activity has a banner that appears when VPN is OFF and goes away when OFF
* `Protect all apps` option has no effect on Games. This is because games are detected at runtime
* If the user unprotects an app that is not in the exclusion list, clicking on `Protect all apps` will not undo this change
  * This is becasue the implementation purposely compares the (remote) exclusion list with the (manual) overrides and not the state of the installed apps
  * The user will have to first `restore defaults` and then `protect all apps`

As it is an internal feature, we also don't add unit tests 🤷 

### Steps to test this PR

_Protect all apps / restore default protections_
- [x] fresh install from this branch
- [x] enable AppTP
- [x] go to settings -> AppTP dev settings
- [x] In `APP PROTECTIONS` section
- [x] verify `protect all apps` is enabled and `restore default protections` is disabled
- [x] click on `protect all apps`
- [x] verify VPN is restart, `protect all apps` becomes disabled and `restore default protections` becomes enabled
- [x] verify the `vpn_app_tracker_manual_exclusion_list` db table in the `vpn.db` db should contain all package IDs of the `vpn_app_tracker_exclusion_list` db table set to `1`
- [x] click on `restore default protections`
- [x] verify the `vpn_app_tracker_manual_exclusion_list` is cleared, VPN restarts, `protect all apps` becomes enabled and `restore default protections` becomes disabled

