### PR TITLE
Fix bug in AppTP restore default protections

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ManageAppsProtectionViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ManageAppsProtectionViewModel.kt
@@ -16,8 +16,7 @@
 
 package com.duckduckgo.mobile.android.vpn.apps
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
@@ -25,18 +24,12 @@ import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageScreen
 import com.duckduckgo.mobile.android.vpn.model.BucketizedVpnTracker
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
-import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository.TimeWindow
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit.DAYS
 import javax.inject.Inject
@@ -47,15 +40,39 @@ class ManageAppsProtectionViewModel @Inject constructor(
     private val excludedApps: TrackingProtectionAppsRepository,
     private val appTrackersRepository: AppTrackerBlockingStatsRepository,
     private val pixel: DeviceShieldPixels,
-    private val vpnStateMonitor: VpnStateMonitor,
     private val dispatcherProvider: DispatcherProvider
-) : ViewModel() {
+) : ViewModel(), DefaultLifecycleObserver {
 
     private val command = Channel<Command>(1, BufferOverflow.DROP_OLDEST)
     internal fun commands(): Flow<Command> = command.receiveAsFlow()
-    private val manualChanges: MutableList<String> = mutableListOf()
-
+    private val currentManualProtections = mutableListOf<Pair<String, Boolean>>()
+    private val refreshSnapshot = MutableStateFlow(System.currentTimeMillis())
+    private val entryProtectionSnapshot = mutableListOf<Pair<String, Boolean>>()
+    private var latestSnapshot = 0L
     private val defaultTimeWindow = TimeWindow(5, DAYS)
+
+    private fun MutableStateFlow<Long>.refresh() {
+        viewModelScope.launch {
+            emit(System.currentTimeMillis())
+        }
+    }
+
+    init {
+        excludedApps.manuallyExcludedApps()
+            .combine(refreshSnapshot.asStateFlow()) { excludedApps, timestamp -> ManualProtectionSnapshot(timestamp, excludedApps) }
+            .flowOn(dispatcherProvider.io())
+            .onEach {
+                if (latestSnapshot != it.timestamp) {
+                    latestSnapshot = it.timestamp
+                    entryProtectionSnapshot.clear()
+                    entryProtectionSnapshot.addAll(it.snapshot)
+                }
+                currentManualProtections.clear()
+                currentManualProtections.addAll(it.snapshot)
+            }
+            .flowOn(dispatcherProvider.main())
+            .launchIn(viewModelScope)
+    }
 
     internal suspend fun getProtectedApps() = excludedApps.getAppsAndProtectionInfo().map { ViewState(it) }
 
@@ -96,10 +113,9 @@ class ManageAppsProtectionViewModel @Inject constructor(
         packageName: String,
         report: Boolean
     ) {
-        recordManualChange(packageName)
         pixel.didDisableAppProtectionFromApps()
         viewModelScope.launch {
-            excludedApps.manuallyExcludedApp(packageName)
+            excludedApps.manuallyExcludeApp(packageName)
             pixel.didSubmitManuallyDisableAppProtectionDialog()
             if (report) {
                 command.send(Command.LaunchFeedback(ReportBreakageScreen.IssueDescriptionForm(appName, packageName)))
@@ -112,36 +128,49 @@ class ManageAppsProtectionViewModel @Inject constructor(
     fun onAppProtectionEnabled(
         packageName: String
     ) {
-        recordManualChange(packageName)
         pixel.didEnableAppProtectionFromApps()
         viewModelScope.launch {
             excludedApps.manuallyEnabledApp(packageName)
         }
     }
 
-    private fun recordManualChange(packageName: String) {
-        if (manualChanges.contains(packageName)) {
-            manualChanges.remove(packageName)
-        } else {
-            manualChanges.add(packageName)
-        }
-    }
-
     fun restoreProtectedApps() {
         pixel.restoreDefaultProtectionList()
-        manualChanges.clear()
         viewModelScope.launch {
             excludedApps.restoreDefaultProtectedList()
+            // as product wanted to restart VPN as soon as we restored protections, we need to refresh the snapshot here
+            refreshSnapshot.refresh()
             command.send(Command.RestartVpn)
         }
     }
 
-    fun userMadeChanges() = manualChanges.isNotEmpty()
+    fun userMadeChanges(): Boolean {
+        // User made changes when the manual protections entry snapshot is different from the current snapshot
+        if (currentManualProtections.size != entryProtectionSnapshot.size) return true
 
-    fun onLeavingScreen() {
+        currentManualProtections.forEach { protection ->
+            entryProtectionSnapshot.firstOrNull { it.first == protection.first }?.let { match ->
+                if (match.second != protection.second) return true
+            }
+        }
+
+        return false
+    }
+
+    fun canRestoreDefaults() = currentManualProtections.isNotEmpty()
+
+    override fun onResume(owner: LifecycleOwner) {
+        super.onResume(owner)
+        refreshSnapshot.refresh()
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        onLeavingScreen()
+    }
+
+    private fun onLeavingScreen() {
         viewModelScope.launch {
             if (userMadeChanges()) {
-                manualChanges.clear()
                 command.send(Command.RestartVpn)
             }
         }
@@ -193,12 +222,12 @@ class ManageAppsProtectionViewModel @Inject constructor(
             command.send(Command.LaunchAllAppsProtection)
         }
     }
-
-    companion object DeviceShieldPixelParameter {
-        private const val PACKAGE_NAME = "packageName"
-        private const val EXCLUDING_REASON = "reason"
-    }
 }
+
+private data class ManualProtectionSnapshot(
+    val timestamp: Long,
+    val snapshot: List<Pair<String, Boolean>>
+)
 
 internal data class ViewState(val excludedApps: List<TrackingProtectionAppInfo>)
 internal sealed class Command {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/ManageRecentAppsProtectionActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/ManageRecentAppsProtectionActivity.kt
@@ -81,6 +81,13 @@ class ManageRecentAppsProtectionActivity :
 
         bindViews()
         observeViewModel()
+
+        lifecycle.addObserver(viewModel)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        lifecycle.removeObserver(viewModel)
     }
 
     private fun bindViews() {
@@ -176,11 +183,6 @@ class ManageRecentAppsProtectionActivity :
             supportFragmentManager,
             ManuallyEnableAppProtectionDialog.TAG_MANUALLY_EXCLUDE_APPS_ENABLE
         )
-    }
-
-    override fun onPause() {
-        viewModel.onLeavingScreen()
-        super.onPause()
     }
 
     override fun onBackPressed() {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionExclusionListActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionExclusionListActivity.kt
@@ -88,6 +88,13 @@ class TrackingProtectionExclusionListActivity :
         observeViewModel()
 
         deviceShieldPixels.didShowExclusionListActivity()
+
+        lifecycle.addObserver(viewModel)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        lifecycle.removeObserver(viewModel)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -97,7 +104,8 @@ class TrackingProtectionExclusionListActivity :
 
     override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
         val restoreDefault = menu?.findItem(R.id.restoreDefaults)
-        restoreDefault?.isEnabled = viewModel.userMadeChanges()
+        // onPrepareOptionsMenu is called when overflow menu is being displayed, that's why this can be an imperative call
+        restoreDefault?.isEnabled = viewModel.canRestoreDefaults()
 
         return super.onPrepareOptionsMenu(menu)
     }
@@ -183,6 +191,7 @@ class TrackingProtectionExclusionListActivity :
                 command.position
             )
             is Command.LaunchFeedback -> reportBreakage.launch(command.reportBreakageScreen)
+            else -> { /* noop */ }
         }
     }
 
@@ -210,11 +219,6 @@ class TrackingProtectionExclusionListActivity :
             supportFragmentManager,
             ManuallyEnableAppProtectionDialog.TAG_MANUALLY_EXCLUDE_APPS_ENABLE
         )
-    }
-
-    override fun onPause() {
-        viewModel.onLeavingScreen()
-        super.onPause()
     }
 
     override fun onBackPressed() {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
@@ -143,7 +143,7 @@ constructor(
                     excludedAppsRepository.manuallyEnabledApp(packageName)
                 } else {
                     deviceShieldPixels.didDisableAppProtectionFromDetail()
-                    excludedAppsRepository.manuallyExcludedApp(packageName)
+                    excludedAppsRepository.manuallyExcludeApp(packageName)
                 }
             }
             command.send(Command.RestartVpn)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201703612758403/f

### Description
Fix the issue with restore default protections.

I had to change a bit the aproach in the `ManageAppsProtectionViewModel`.
* The view model listens for `manuallyExcludedApps` and updates two lists
  * `entryProtectionSnapshot` -> the snapshot of the manually excluded apps when the screen is first in the foreground
    * this is updated only once (*), when the screen is first shown
  * `currentManualProtections` -> manually excluded apps, updated every time they change
* When the user leaves the screen, the view model compares both the `entryProtectionSnapshot` and the `currentManualProtections` and restarts the VPN if they're different (so that exclusion take effect)
* (*) the `entryProtectionSnapshot` also need to be updated when restoring the protections (call to `restoreProtectedApps()`)
  * when the user restores default protections, the VPN is restarted right away (and not when leaving the screen)
  * this means the `entryProtectionSnapshot` need to be udpated, to avoid triggering another unnecessary restart when leaving the screen
  * the update is controlled by the `refreshSnapshot.refres()` extension function
    * it is a basic timestamp-based refresh mechanism

Repro steos:
1. enable AppTP
2. Go to App Tracking Protection screen → scroll down → Having problems with an App? → "Show all apps"
3. Change protection for any app
4. Navigate back and back into "All apps"
4. Click on overflow menu → "Restore default protected apps"
5. Expected: "Restore default protected apps" prompts to restore the default protections
6. Actual: Click has no effect, even when the menu item appears to be enabled to click

### Steps to test this PR
For all tets:
- [ ] install from this branch
- [ ] enable AppTP
- [ ] open several apps that contain trackers

_Test Recent apps_
- [ ] go to "app tracking protection" -> scroll down -> "having problems with an app?"
- [ ] change the protection for any app
- [ ] click in "show all apps"
- [ ] verify VPN restarts only once
- [ ] navigate back
- [ ] verify VPN does not restart
- [ ] change the protection for any app
- [ ] home the app
- [ ] verify VPN restarts only once
- [ ] navigate back to the app
- [ ] verify VPN does not restart
- [ ] change protection for any app
- [ ] navigate back
- [ ] verify VPN restarts only once
- [ ] click on "having problems with an app?"
- [ ] verify VPN does not restart

_Test All apps_
- [ ] go to "app tracking protection" -> scroll down -> "having problems with an app?" -> "all apps"
- [ ] change the protection for any app
- [ ] navigate back
- [ ] verify VPN restarts only once
- [ ] click on "show all apps"
- [ ] verify VPN does not restart
- [ ] click on overflow menu -> restore default protected apps -> restore
- [ ] verify the VPN restarts
- [ ] navigate back
- [ ] verify VPN does not restart
- [ ] click on "show all apps"


_Test bug fix_
- [ ] go to "app tracking protection" -> scroll down -> "having problems with an app?" -> "all apps"
- [ ] change protection for any app
- [ ] close app 
- [ ] verify VPN restarts only once
- [ ] reopen the app
- [ ] go to "app tracking protection" -> scroll down -> "having problems with an app?" -> "all apps"
- [ ] click on overflow menu -> restore default protected apps -> restore
- [ ] verify the VPN restarts

