### PR TITLE
AppTP: Slack upload fails consistently after VPN restart

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
@@ -92,6 +92,7 @@ class TcpDeviceToNetwork(
                 Timber.w(e, "Failed to process TCP device-to-network packet")
             } catch (e: InterruptedException) {
                 Timber.w(e, "Thread is interrupted")
+                return
             }
         }
     }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpNetworkToDevice.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpNetworkToDevice.kt
@@ -73,6 +73,7 @@ class TcpNetworkToDevice(
                 Timber.w(e, "Failed to process TCP network-to-device packet")
             } catch (e: InterruptedException) {
                 Timber.w(e, "Thread is interrupted")
+                return
             }
         }
     }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpPacketProcessor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpPacketProcessor.kt
@@ -242,6 +242,7 @@ private inline fun udpRunnable(crossinline block: () -> Unit): Runnable {
                 Timber.w(e, "Failed to process UDP network-to-device packet")
             } catch (e: InterruptedException) {
                 Timber.v("Thread interrupted")
+                break
             }
         }
     }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpPacketProcessor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/udp/UdpPacketProcessor.kt
@@ -242,7 +242,7 @@ private inline fun udpRunnable(crossinline block: () -> Unit): Runnable {
                 Timber.w(e, "Failed to process UDP network-to-device packet")
             } catch (e: InterruptedException) {
                 Timber.v("Thread interrupted")
-                break
+                return@Runnable
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1200905986587319/1202311975987092/f

### Description

Updated the code to stop packet processing when InterruptedException is caught. This ensures we won't have more threads processing packets after a VPN restart.

### Steps to test this PR

To reproduce the issue:
- fresh install from develop (internal build)
- enable App Tracking Protection
- go to Settings -> AppTP dev settings and tap on Protect all apps. This will ensure Slack is protected and also triggers a VPN restart
- open Slack and upload a photo
- notice it takes a long time and then fails.

To test the fix:
- fresh install from this branch (internal build)
- enable App Tracking Protection
- go to Settings -> AppTP dev settings and tap on Protect all apps. This will ensure Slack is protected and also triggers a VPN restart
- open Slack and upload a photo
- notice it works.


### NO UI changes
