### PR TITLE
Migrate privacy config to LifecycleObserver

### DIFF
--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserver.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserver.kt
@@ -18,8 +18,7 @@ package com.duckduckgo.privacy.config.impl.observers
 
 import android.content.Context
 import androidx.annotation.WorkerThread
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -47,12 +46,10 @@ class LocalPrivacyConfigObserver @Inject constructor(
     private val privacyConfigPersister: PrivacyConfigPersister,
     @AppCoroutineScope val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider
-) : LifecycleEventObserver {
+) : DefaultLifecycleObserver {
 
-    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-        if (event == Lifecycle.Event.ON_CREATE) {
-            coroutineScope.launch(dispatcherProvider.io()) { loadPrivacyConfig() }
-        }
+    override fun onCreate(owner: LifecycleOwner) {
+        coroutineScope.launch(dispatcherProvider.io()) { loadPrivacyConfig() }
     }
 
     private suspend fun loadPrivacyConfig() {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserver.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserver.kt
@@ -19,8 +19,9 @@ package com.duckduckgo.privacy.config.impl.observers
 import android.content.Context
 import androidx.annotation.WorkerThread
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -37,18 +38,20 @@ import dagger.SingleInstanceIn
 
 @WorkerThread
 @SingleInstanceIn(AppScope::class)
-@ContributesMultibinding(AppScope::class)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = LifecycleObserver::class
+)
 class LocalPrivacyConfigObserver @Inject constructor(
     private val context: Context,
     private val privacyConfigPersister: PrivacyConfigPersister,
     @AppCoroutineScope val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider
-) : LifecycleObserver {
+) : LifecycleEventObserver {
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-    fun storeLocalPrivacyConfig() {
-        coroutineScope.launch(dispatcherProvider.io()) {
-            loadPrivacyConfig()
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        if (event == Lifecycle.Event.ON_CREATE) {
+            coroutineScope.launch(dispatcherProvider.io()) { loadPrivacyConfig() }
         }
     }
 

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/workers/RemoteConfigDownloadWorker.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/workers/RemoteConfigDownloadWorker.kt
@@ -18,8 +18,9 @@ package com.duckduckgo.privacy.config.impl.workers
 
 import android.content.Context
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -30,10 +31,11 @@ import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.impl.PrivacyConfigDownloader
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.withContext
-import timber.log.Timber
+import dagger.SingleInstanceIn
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 class PrivacyConfigDownloadWorker(
     context: Context,
@@ -54,19 +56,24 @@ class PrivacyConfigDownloadWorker(
     }
 }
 
-@ContributesMultibinding(AppScope::class)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = LifecycleObserver::class
+)
+@SingleInstanceIn(AppScope::class)
 class PrivacyConfigDownloadWorkerScheduler @Inject constructor(
     private val workManager: WorkManager
-) : LifecycleObserver {
+) : LifecycleEventObserver {
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-    fun scheduleRemoteConfigDownload() {
-        Timber.v("Scheduling remote config worker")
-        val workerRequest = PeriodicWorkRequestBuilder<PrivacyConfigDownloadWorker>(1, TimeUnit.HOURS)
-            .addTag(PRIVACY_CONFIG_DOWNLOADER_WORKER_TAG)
-            .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
-            .build()
-        workManager.enqueueUniquePeriodicWork(PRIVACY_CONFIG_DOWNLOADER_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, workerRequest)
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        if (event == Lifecycle.Event.ON_CREATE) {
+            Timber.v("Scheduling remote config worker")
+            val workerRequest = PeriodicWorkRequestBuilder<PrivacyConfigDownloadWorker>(1, TimeUnit.HOURS)
+                .addTag(PRIVACY_CONFIG_DOWNLOADER_WORKER_TAG)
+                .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+                .build()
+            workManager.enqueueUniquePeriodicWork(PRIVACY_CONFIG_DOWNLOADER_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, workerRequest)
+        }
     }
 
     companion object {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/workers/RemoteConfigDownloadWorker.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/workers/RemoteConfigDownloadWorker.kt
@@ -17,8 +17,7 @@
 package com.duckduckgo.privacy.config.impl.workers
 
 import android.content.Context
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
@@ -63,17 +62,15 @@ class PrivacyConfigDownloadWorker(
 @SingleInstanceIn(AppScope::class)
 class PrivacyConfigDownloadWorkerScheduler @Inject constructor(
     private val workManager: WorkManager
-) : LifecycleEventObserver {
+) : DefaultLifecycleObserver {
 
-    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-        if (event == Lifecycle.Event.ON_CREATE) {
-            Timber.v("Scheduling remote config worker")
-            val workerRequest = PeriodicWorkRequestBuilder<PrivacyConfigDownloadWorker>(1, TimeUnit.HOURS)
-                .addTag(PRIVACY_CONFIG_DOWNLOADER_WORKER_TAG)
-                .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
-                .build()
-            workManager.enqueueUniquePeriodicWork(PRIVACY_CONFIG_DOWNLOADER_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, workerRequest)
-        }
+    override fun onCreate(owner: LifecycleOwner) {
+        Timber.v("Scheduling remote config worker")
+        val workerRequest = PeriodicWorkRequestBuilder<PrivacyConfigDownloadWorker>(1, TimeUnit.HOURS)
+            .addTag(PRIVACY_CONFIG_DOWNLOADER_WORKER_TAG)
+            .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+            .build()
+        workManager.enqueueUniquePeriodicWork(PRIVACY_CONFIG_DOWNLOADER_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, workerRequest)
     }
 
     companion object {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserverTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserverTest.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.privacy.config.impl.observers
 
 import android.content.Context
 import android.content.res.Resources
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.FileUtilities.loadResource
@@ -42,6 +44,7 @@ class LocalPrivacyConfigObserverTest {
 
     private val mockPrivacyConfigPersister: PrivacyConfigPersister = mock()
     private val mockContext: Context = mock()
+    private val lifecycleOwner: LifecycleOwner = mock()
     lateinit var testee: LocalPrivacyConfigObserver
 
     @Before
@@ -60,7 +63,7 @@ class LocalPrivacyConfigObserverTest {
         runTest {
             givenLocalPrivacyConfigFileExists()
 
-            testee.storeLocalPrivacyConfig()
+            testee.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
 
             verify(mockPrivacyConfigPersister).persistPrivacyConfig(any())
         }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserverTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserverTest.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.privacy.config.impl.observers
 
 import android.content.Context
 import android.content.res.Resources
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
@@ -63,7 +62,7 @@ class LocalPrivacyConfigObserverTest {
         runTest {
             givenLocalPrivacyConfigFileExists()
 
-            testee.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
+            testee.onCreate(lifecycleOwner)
 
             verify(mockPrivacyConfigPersister).persistPrivacyConfig(any())
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1202260594569388

### Description
This PR migrates the privacy config module to LifecycleEventObserver

### Steps to test this PR

_Observers still work_
- [x] Put your phone in flight mode
- [x] Launch the app
- [x] Check the `privacy_config` table in the `privacy_config.db`, the version value should be `1652275711516`
- [x] Kill the app
- [x] Remove your phone from flight mode
- [x] Launch the app
- [x] Check the `privacy_config` table in the `privacy_config.db`, the version value should **not** be `1652275711516`. As of 25th of May the value should be `1653049801643` but that can change. The important thing is that the value should be updated.
