### PR TITLE
Try-catch registerNetworkCallback

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
@@ -147,9 +147,9 @@ class NetworkTypeCollector @Inject constructor(
 
     override fun onVpnStarted(coroutineScope: CoroutineScope) {
         (context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?)?.let {
-            it.registerNetworkCallback(wifiNetworkRequest, wifiNetworkCallback)
-            it.registerNetworkCallback(cellularNetworkRequest, cellularNetworkCallback)
-            it.registerNetworkCallback(privateDnsRequest, privateDnsCallback)
+            it.safeRegisterNetworkCallback(wifiNetworkRequest, wifiNetworkCallback)
+            it.safeRegisterNetworkCallback(cellularNetworkRequest, cellularNetworkCallback)
+            it.safeRegisterNetworkCallback(privateDnsRequest, privateDnsCallback)
         }
     }
 
@@ -239,6 +239,14 @@ class NetworkTypeCollector @Inject constructor(
             unregisterNetworkCallback(networkCallback)
         }.onFailure {
             Timber.e(it, "Error unregistering the network callback")
+        }
+    }
+
+    private fun ConnectivityManager.safeRegisterNetworkCallback(networkRequest: NetworkRequest, networkCallback: NetworkCallback) {
+        kotlin.runCatching {
+            registerNetworkCallback(networkRequest, networkCallback)
+        }.onFailure {
+            Timber.e(it, "Error registering the network callback")
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1202331659918964/f

### Description
The `registerNetworkCallback` can throw SecurityException. According to [this issue](https://issuetracker.google.com/issues/175055271) that should have been solved, but we see crashes. I found [examples](https://github.com/microsoft/cpp_client_telemetry/pull/798/files) of code that try-catch the registering. We already do so for the call to unregister, so it make sense to have it symetric anyway.

### Steps to test this PR
Nothing to test
