### PR TITLE
Move UA exceptions to remote config

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.browser.useragent.provideUserAgentOverridePluginPoint
 import com.duckduckgo.app.fakes.FeatureToggleFake
 import com.duckduckgo.app.fakes.UserAgentFake
+import com.duckduckgo.app.fakes.UserAllowListRepositoryFake
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.surrogates.ResourceSurrogates
@@ -64,8 +65,16 @@ class WebViewRequestInterceptorTest {
     private val mockWebBackForwardList: WebBackForwardList = mock()
     private val fakeUserAgent: UserAgent = UserAgentFake()
     private val fakeToggle: FeatureToggle = FeatureToggleFake()
-    private val userAgentProvider: UserAgentProvider =
-        UserAgentProvider({ DEFAULT }, mock(), provideUserAgentOverridePluginPoint(), fakeUserAgent, fakeToggle)
+    private val fakeUserAllowListRepository = UserAllowListRepositoryFake()
+    private val userAgentProvider: UserAgentProvider = UserAgentProvider(
+        { "" },
+        mock(),
+        provideUserAgentOverridePluginPoint(),
+        fakeUserAgent,
+        fakeToggle,
+        fakeUserAllowListRepository,
+        coroutinesTestRule.testDispatcherProvider
+    )
 
     private var webView: WebView = mock()
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
@@ -25,13 +25,17 @@ import androidx.test.annotation.UiThreadTest
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.browser.useragent.provideUserAgentOverridePluginPoint
+import com.duckduckgo.app.fakes.FeatureToggleFake
+import com.duckduckgo.app.fakes.UserAgentFake
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.surrogates.ResourceSurrogates
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.trackerdetection.TrackerDetector
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
+import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.Gpc
+import com.duckduckgo.privacy.config.api.UserAgent
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
 import org.mockito.kotlin.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -41,7 +45,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.MockitoAnnotations
 
 @ExperimentalCoroutinesApi
 class WebViewRequestInterceptorTest {
@@ -59,14 +62,16 @@ class WebViewRequestInterceptorTest {
     private val mockPrivacyProtectionCountDao: PrivacyProtectionCountDao = mock()
     private val mockGpc: Gpc = mock()
     private val mockWebBackForwardList: WebBackForwardList = mock()
-    private val userAgentProvider: UserAgentProvider = UserAgentProvider({ DEFAULT }, mock(), provideUserAgentOverridePluginPoint())
+    private val fakeUserAgent: UserAgent = UserAgentFake()
+    private val fakeToggle: FeatureToggle = FeatureToggleFake()
+    private val userAgentProvider: UserAgentProvider =
+        UserAgentProvider({ DEFAULT }, mock(), provideUserAgentOverridePluginPoint(), fakeUserAgent, fakeToggle)
 
     private var webView: WebView = mock()
 
     @UiThreadTest
     @Before
     fun setup() {
-        MockitoAnnotations.openMocks(this)
         configureUserAgent()
         configureStack()
 

--- a/app/src/androidTest/java/com/duckduckgo/app/fakes/FeatureToggleFake.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fakes/FeatureToggleFake.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fakes
+
+import com.duckduckgo.feature.toggles.api.FeatureName
+import com.duckduckgo.feature.toggles.api.FeatureToggle
+
+class FeatureToggleFake : FeatureToggle {
+    override fun isFeatureEnabled(
+        featureName: FeatureName,
+        defaultValue: Boolean
+    ): Boolean = true
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/fakes/UserAgentFake.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fakes/UserAgentFake.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fakes
+
+import com.duckduckgo.privacy.config.api.UserAgent
+
+class UserAgentFake : UserAgent {
+    override fun isAnApplicationException(url: String): Boolean = false
+
+    override fun isAVersionException(url: String): Boolean = false
+
+    override fun isADefaultException(url: String): Boolean = false
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/fakes/UserAllowListRepositoryFake.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fakes/UserAllowListRepositoryFake.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fakes
+
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
+
+class UserAllowListRepositoryFake : UserAllowListRepository {
+    override fun isDomainInUserAllowList(domain: String): Boolean = false
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
@@ -20,13 +20,16 @@ import android.webkit.WebSettings
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.browser.useragent.provideUserAgentOverridePluginPoint
+import com.duckduckgo.app.fakes.FeatureToggleFake
+import com.duckduckgo.app.fakes.UserAgentFake
 import com.duckduckgo.app.global.device.ContextDeviceInfo
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.feature.toggles.api.FeatureToggle
+import com.duckduckgo.privacy.config.api.UserAgent
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mock
-import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class ApiRequestInterceptorTest {
@@ -35,18 +38,21 @@ class ApiRequestInterceptorTest {
 
     private lateinit var userAgentProvider: UserAgentProvider
 
-    @Mock private lateinit var appBuildConfig: AppBuildConfig
+    private val appBuildConfig: AppBuildConfig = mock()
+
+    private val fakeUserAgent: UserAgent = UserAgentFake()
+    private val fakeToggle: FeatureToggle = FeatureToggleFake()
 
     @Before
     fun before() {
-        MockitoAnnotations.openMocks(this)
-
         whenever(appBuildConfig.versionName).thenReturn("name")
 
         userAgentProvider = UserAgentProvider(
             { WebSettings.getDefaultUserAgent(InstrumentationRegistry.getInstrumentation().context) },
             ContextDeviceInfo(InstrumentationRegistry.getInstrumentation().context),
-            provideUserAgentOverridePluginPoint()
+            provideUserAgentOverridePluginPoint(),
+            fakeUserAgent,
+            fakeToggle
         )
 
         testee = ApiRequestInterceptor(

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
@@ -18,30 +18,36 @@ package com.duckduckgo.app.global.api
 
 import android.webkit.WebSettings
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.browser.useragent.provideUserAgentOverridePluginPoint
 import com.duckduckgo.app.fakes.FeatureToggleFake
 import com.duckduckgo.app.fakes.UserAgentFake
+import com.duckduckgo.app.fakes.UserAllowListRepositoryFake
 import com.duckduckgo.app.global.device.ContextDeviceInfo
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.UserAgent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@ExperimentalCoroutinesApi
 class ApiRequestInterceptorTest {
 
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
     private lateinit var testee: ApiRequestInterceptor
-
     private lateinit var userAgentProvider: UserAgentProvider
-
     private val appBuildConfig: AppBuildConfig = mock()
-
     private val fakeUserAgent: UserAgent = UserAgentFake()
     private val fakeToggle: FeatureToggle = FeatureToggleFake()
+    private val fakeUserAllowListRepository = UserAllowListRepositoryFake()
 
     @Before
     fun before() {
@@ -52,7 +58,9 @@ class ApiRequestInterceptorTest {
             ContextDeviceInfo(InstrumentationRegistry.getInstrumentation().context),
             provideUserAgentOverridePluginPoint(),
             fakeUserAgent,
-            fakeToggle
+            fakeToggle,
+            fakeUserAllowListRepository,
+            coroutinesTestRule.testDispatcherProvider
         )
 
         testee = ApiRequestInterceptor(

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.browser.useragent.provideUserAgentOverridePluginPoint
 import com.duckduckgo.app.fakes.FeatureToggleFake
 import com.duckduckgo.app.fakes.UserAgentFake
+import com.duckduckgo.app.fakes.UserAllowListRepositoryFake
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
@@ -98,8 +99,16 @@ class DomainsReferenceTest(private val testCase: TestCase) {
     private val mockPrivacyProtectionCountDao: PrivacyProtectionCountDao = mock()
     private val fakeUserAgent: UserAgent = UserAgentFake()
     private val fakeToggle: FeatureToggle = FeatureToggleFake()
-    private val userAgentProvider: UserAgentProvider =
-        UserAgentProvider({ "" }, mock(), provideUserAgentOverridePluginPoint(), fakeUserAgent, fakeToggle)
+    private val fakeUserAllowListRepository = UserAllowListRepositoryFake()
+    private val userAgentProvider: UserAgentProvider = UserAgentProvider(
+        { "" },
+        mock(),
+        provideUserAgentOverridePluginPoint(),
+        fakeUserAgent,
+        fakeToggle,
+        fakeUserAllowListRepository,
+        coroutinesTestRule.testDispatcherProvider
+    )
     private val mockGpc: Gpc = mock()
 
     companion object {

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -30,6 +30,8 @@ import com.duckduckgo.app.FileUtilities
 import com.duckduckgo.app.browser.WebViewRequestInterceptor
 import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.browser.useragent.provideUserAgentOverridePluginPoint
+import com.duckduckgo.app.fakes.FeatureToggleFake
+import com.duckduckgo.app.fakes.UserAgentFake
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
@@ -48,9 +50,11 @@ import com.duckduckgo.app.trackerdetection.api.TdsJson
 import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
 import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
+import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.TrackerAllowlist
+import com.duckduckgo.privacy.config.api.UserAgent
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import com.squareup.moshi.JsonAdapter
@@ -92,7 +96,10 @@ class DomainsReferenceTest(private val testCase: TestCase) {
     private var mockHttpsUpgrader: HttpsUpgrader = mock()
     private var mockRequest: WebResourceRequest = mock()
     private val mockPrivacyProtectionCountDao: PrivacyProtectionCountDao = mock()
-    private val userAgentProvider: UserAgentProvider = UserAgentProvider({ "" }, mock(), provideUserAgentOverridePluginPoint())
+    private val fakeUserAgent: UserAgent = UserAgentFake()
+    private val fakeToggle: FeatureToggle = FeatureToggleFake()
+    private val userAgentProvider: UserAgentProvider =
+        UserAgentProvider({ "" }, mock(), provideUserAgentOverridePluginPoint(), fakeUserAgent, fakeToggle)
     private val mockGpc: Gpc = mock()
 
     companion object {

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.browser.useragent.provideUserAgentOverridePluginPoint
 import com.duckduckgo.app.fakes.FeatureToggleFake
 import com.duckduckgo.app.fakes.UserAgentFake
+import com.duckduckgo.app.fakes.UserAllowListRepositoryFake
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
@@ -95,8 +96,16 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
     private val mockPrivacyProtectionCountDao: PrivacyProtectionCountDao = mock()
     private val fakeUserAgent: UserAgent = UserAgentFake()
     private val fakeToggle: FeatureToggle = FeatureToggleFake()
-    private val userAgentProvider: UserAgentProvider =
-        UserAgentProvider({ "" }, mock(), provideUserAgentOverridePluginPoint(), fakeUserAgent, fakeToggle)
+    private val fakeUserAllowListRepository = UserAllowListRepositoryFake()
+    private val userAgentProvider: UserAgentProvider = UserAgentProvider(
+        { "" },
+        mock(),
+        provideUserAgentOverridePluginPoint(),
+        fakeUserAgent,
+        fakeToggle,
+        fakeUserAllowListRepository,
+        coroutinesTestRule.testDispatcherProvider
+    )
     private val mockGpc: Gpc = mock()
 
     companion object {

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -29,6 +29,8 @@ import com.duckduckgo.app.FileUtilities
 import com.duckduckgo.app.browser.WebViewRequestInterceptor
 import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.browser.useragent.provideUserAgentOverridePluginPoint
+import com.duckduckgo.app.fakes.FeatureToggleFake
+import com.duckduckgo.app.fakes.UserAgentFake
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
@@ -47,9 +49,11 @@ import com.duckduckgo.app.trackerdetection.api.TdsJson
 import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
 import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
+import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.TrackerAllowlist
+import com.duckduckgo.privacy.config.api.UserAgent
 import org.mockito.kotlin.*
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -89,7 +93,10 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
     private var mockHttpsUpgrader: HttpsUpgrader = mock()
     private var mockRequest: WebResourceRequest = mock()
     private val mockPrivacyProtectionCountDao: PrivacyProtectionCountDao = mock()
-    private val userAgentProvider: UserAgentProvider = UserAgentProvider({ "" }, mock(), provideUserAgentOverridePluginPoint())
+    private val fakeUserAgent: UserAgent = UserAgentFake()
+    private val fakeToggle: FeatureToggle = FeatureToggleFake()
+    private val userAgentProvider: UserAgentProvider =
+        UserAgentProvider({ "" }, mock(), provideUserAgentOverridePluginPoint(), fakeUserAgent, fakeToggle)
     private val mockGpc: Gpc = mock()
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -82,9 +82,11 @@ import com.duckduckgo.downloads.impl.AndroidFileDownloader
 import com.duckduckgo.downloads.impl.DataUriDownloader
 import com.duckduckgo.downloads.impl.DownloadFileService
 import com.duckduckgo.downloads.impl.NetworkFileDownloader
+import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.privacy.config.api.TrackingParameters
+import com.duckduckgo.privacy.config.api.UserAgent
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
@@ -237,9 +239,11 @@ class BrowserModule {
     fun userAgentProvider(
         @Named("defaultUserAgent") defaultUserAgent: Provider<String>,
         deviceInfo: DeviceInfo,
-        userAgentInterceptorPluginPoint: PluginPoint<UserAgentInterceptor>
+        userAgentInterceptorPluginPoint: PluginPoint<UserAgentInterceptor>,
+        userAgent: UserAgent,
+        toggle: FeatureToggle
     ): UserAgentProvider {
-        return UserAgentProvider(defaultUserAgent, deviceInfo, userAgentInterceptorPluginPoint)
+        return UserAgentProvider(defaultUserAgent, deviceInfo, userAgentInterceptorPluginPoint, userAgent, toggle)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -65,6 +65,7 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
@@ -241,9 +242,19 @@ class BrowserModule {
         deviceInfo: DeviceInfo,
         userAgentInterceptorPluginPoint: PluginPoint<UserAgentInterceptor>,
         userAgent: UserAgent,
-        toggle: FeatureToggle
+        toggle: FeatureToggle,
+        userAllowListRepository: UserAllowListRepository,
+        dispatcher: DispatcherProvider,
     ): UserAgentProvider {
-        return UserAgentProvider(defaultUserAgent, deviceInfo, userAgentInterceptorPluginPoint, userAgent, toggle)
+        return UserAgentProvider(
+            defaultUserAgent,
+            deviceInfo,
+            userAgentInterceptorPluginPoint,
+            userAgent,
+            toggle,
+            userAllowListRepository,
+            dispatcher
+        )
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
@@ -71,8 +71,14 @@ class UserAgentProvider constructor(
         val host = url?.toUri()?.host
         val shouldUseDefaultUserAgent = if (host != null) userAgent.isADefaultException(host) else false
 
-        if (!toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName) || shouldUseDefaultUserAgent) {
-            return defaultUserAgent.get()
+        if (!toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName) ||
+            shouldUseDefaultUserAgent
+        ) {
+            return if (isDesktop) {
+                defaultUserAgent.get().replace(AgentRegex.platform, desktopPrefix)
+            } else {
+                defaultUserAgent.get()
+            }
         }
 
         val omitApplicationComponent = if (host != null) userAgent.isAnApplicationException(host) else false
@@ -134,14 +140,14 @@ class UserAgentProvider constructor(
         val webkitUntilEnd = Regex("(AppleWebKit/.*)")
         val safari = Regex("(Safari/[^ ]+) *")
         val version = Regex("(Version/[^ ]+) *")
+        val platform = Regex(".*Linux; Android \\d+")
     }
 
     companion object {
         const val SPACE = " "
-        const val defaultUA = "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/96.0.4664.104 Mobile Safari/537.36"
         val mobilePrefix = "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE})"
         val desktopPrefix = "Mozilla/5.0 (X11; Linux ${System.getProperty("os.arch")})"
-        val fallbackDefaultUA = "$mobilePrefix $defaultUA"
+        val fallbackDefaultUA = "$mobilePrefix AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/96.0.4664.104 Mobile Safari/537.36"
 
         val sitesThatShouldUseDesktopAgent = listOf(
             DesktopAgentSiteOnly("m.facebook.com", listOf("dialog", "sharer"))

--- a/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
@@ -71,9 +71,7 @@ class UserAgentProvider constructor(
         val host = url?.toUri()?.host
         val shouldUseDefaultUserAgent = if (host != null) userAgent.isADefaultException(host) else false
 
-        if (!toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName) ||
-            shouldUseDefaultUserAgent
-        ) {
+        if (!toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName) || shouldUseDefaultUserAgent) {
             return if (isDesktop) {
                 defaultUserAgent.get().replace(AgentRegex.platform, desktopPrefix)
             } else {

--- a/app/src/main/java/com/duckduckgo/app/privacy/db/UserAllowListRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/db/UserAllowListRepository.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.privacy.db
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface UserAllowListRepository {
+    fun isDomainInUserAllowList(domain: String): Boolean
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealUserAllowListRepository @Inject constructor(
+    private val userWhitelistDao: UserWhitelistDao,
+) : UserAllowListRepository {
+    override fun isDomainInUserAllowList(domain: String): Boolean = userWhitelistDao.contains(domain)
+}

--- a/app/src/main/java/com/duckduckgo/app/privacy/db/UserAllowListRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/db/UserAllowListRepository.kt
@@ -18,14 +18,12 @@ package com.duckduckgo.app.privacy.db
 
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
-import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 interface UserAllowListRepository {
     fun isDomainInUserAllowList(domain: String): Boolean
 }
 
-@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealUserAllowListRepository @Inject constructor(
     private val userWhitelistDao: UserWhitelistDao,

--- a/app/src/test/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
@@ -193,6 +193,13 @@ class UserAgentProviderTest {
         assertTrue("$actual does not match expected regex", ValidationRegex.converted.matches(actual))
     }
 
+    @Test
+    fun whenUserAgentShouldBeDefaultAndShouldUseDesktopAgentThenReturnDesktopUserAgent() {
+        testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
+        val actual = testee.userAgent(DEFAULT_DOMAIN, true)
+        assertTrue("$actual does not match expected regex", ValidationRegex.desktop_default.matches(actual))
+    }
+
     private fun getUserAgentProvider(
         defaultUserAgent: String,
         device: DeviceInfo,
@@ -237,6 +244,10 @@ class UserAgentProviderTest {
     private object ValidationRegex {
         val default = Regex(
             "Mozilla/5.0 \\(Linux; Android .*? Nexus 6P Build/OPM3.171019.014\\) AppleWebKit/[.0-9]+" +
+                " \\(KHTML, like Gecko\\) Version/[.0-9]+ Chrome/[.0-9]+ Mobile Safari/[.0-9]+"
+        )
+        val desktop_default = Regex(
+            "Mozilla/5.0 \\(X11; Linux .*? Nexus 6P Build/OPM3.171019.014\\) AppleWebKit/[.0-9]+" +
                 " \\(KHTML, like Gecko\\) Version/[.0-9]+ Chrome/[.0-9]+ Mobile Safari/[.0-9]+"
         )
         val converted = Regex(

--- a/app/src/test/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
@@ -19,12 +19,23 @@ package com.duckduckgo.app.browser.useragent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.feature.toggles.api.FeatureToggle
+import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.api.UserAgent
+import com.duckduckgo.privacy.config.api.UserAgentException
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.RealUnprotectedTemporary
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.impl.features.useragent.RealUserAgent
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.concurrent.CopyOnWriteArrayList
 
 @RunWith(AndroidJUnit4::class)
 class UserAgentProviderTest {
@@ -32,10 +43,20 @@ class UserAgentProviderTest {
     private lateinit var testee: UserAgentProvider
 
     private var deviceInfo: DeviceInfo = mock()
+    private var userAgentRepository: UserAgentRepository = mock()
+    private var unprotectedTemporaryRepository: UnprotectedTemporaryRepository = mock()
+    private var unprotectedTemporary: UnprotectedTemporary = RealUnprotectedTemporary(unprotectedTemporaryRepository)
+    private var userAgent: UserAgent = RealUserAgent(userAgentRepository, unprotectedTemporary)
+    private var toggle: FeatureToggle = mock()
 
     @Before
     fun before() {
         whenever(deviceInfo.majorAppVersion).thenReturn("5")
+        whenever(toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName)).thenReturn(true)
+        whenever(userAgentRepository.defaultExceptions).thenReturn(defaultExceptions)
+        whenever(userAgentRepository.omitApplicationExceptions).thenReturn(applicationExceptions)
+        whenever(userAgentRepository.omitVersionExceptions).thenReturn(versionExceptions)
+        whenever(unprotectedTemporaryRepository.exceptions).thenReturn(unprotectedExceptions)
     }
 
     @Test
@@ -88,7 +109,7 @@ class UserAgentProviderTest {
     }
 
     @Test
-    fun whenSubdomsinDoesNotSupportApplicationThenUaOmitsApplicationComponent() {
+    fun whenSubdomainDoesNotSupportApplicationThenUaOmitsApplicationComponent() {
         testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
         val actual = testee.userAgent(NO_APPLICATION_SUBDOMAIN)
         assertTrue("$actual does not match expected regex", ValidationRegex.noApplication.matches(actual))
@@ -113,6 +134,42 @@ class UserAgentProviderTest {
         testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
         val actual = testee.userAgent(NO_VERSION_SUBDOMAIN)
         assertTrue("$actual does not match expected regex", ValidationRegex.noVersion.matches(actual))
+    }
+
+    @Test
+    fun whenDomainHasDefaultExceptionThenUaIsDefault() {
+        testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
+        val actual = testee.userAgent(DEFAULT_DOMAIN)
+        assertTrue("$actual does not match expected regex", ValidationRegex.default.matches(actual))
+    }
+
+    @Test
+    fun whenSubdomainHasDefaultExceptionThenUaIsDefault() {
+        testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
+        val actual = testee.userAgent(DEFAULT_SUBDOMAIN)
+        assertTrue("$actual does not match expected regex", ValidationRegex.default.matches(actual))
+    }
+
+    @Test
+    fun whenDomainInUnprotectedTemporaryThenUaIsDefault() {
+        testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
+        val actual = testee.userAgent(UNPROTECTED_DOMAIN)
+        assertTrue("$actual does not match expected regex", ValidationRegex.default.matches(actual))
+    }
+
+    @Test
+    fun whenSubdomainInUnprotectedTemporaryThenUaIsDefault() {
+        testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
+        val actual = testee.userAgent(UNPROTECTED_SUBDOMAIN)
+        assertTrue("$actual does not match expected regex", ValidationRegex.default.matches(actual))
+    }
+
+    @Test
+    fun whenFeatureIsDisabledThenUaIsDefault() {
+        whenever(toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName)).thenReturn(false)
+        testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
+        val actual = testee.userAgent(DOMAIN)
+        assertTrue("$actual does not match expected regex", ValidationRegex.default.matches(actual))
     }
 
     @Test
@@ -141,17 +198,25 @@ class UserAgentProviderTest {
         device: DeviceInfo,
         userAgentInterceptorPluginPoint: PluginPoint<UserAgentInterceptor> = provideUserAgentFakePluginPoint()
     ): UserAgentProvider {
-        return UserAgentProvider({ defaultUserAgent }, device, userAgentInterceptorPluginPoint)
+        return UserAgentProvider({ defaultUserAgent }, device, userAgentInterceptorPluginPoint, userAgent, toggle)
     }
 
     companion object {
         const val DOMAIN = "http://example.com"
-        const val NO_APPLICATION_DOMAIN = "http://cvs.com"
-        const val NO_APPLICATION_SUBDOMAIN = "http://subdomain.cvs.com"
-        const val NO_VERSION_DOMAIN = "http://ing.nl"
-        const val NO_VERSION_SUBDOMAIN = "http://subdomain.ing.nl"
+        const val NO_APPLICATION_DOMAIN = "http://application.com"
+        const val NO_APPLICATION_SUBDOMAIN = "http://subdomain.application.com"
+        const val NO_VERSION_DOMAIN = "http://version.com"
+        const val NO_VERSION_SUBDOMAIN = "http://subdomain.version.com"
+        const val DEFAULT_DOMAIN = "http://default.com"
+        const val DEFAULT_SUBDOMAIN = "http://subdomain.default.com"
+        const val UNPROTECTED_DOMAIN = "http://unprotected.com"
+        const val UNPROTECTED_SUBDOMAIN = "http://subdomain.unprotected.com"
         const val DESKTOP_ONLY_SITE = "http://m.facebook.com"
         const val DESKTOP_ONLY_SITE_EXCEPTION = "http://m.facebook.com/dialog/"
+        val applicationExceptions = CopyOnWriteArrayList(listOf(UserAgentException(domain = "application.com", reason = "reason")))
+        val versionExceptions = CopyOnWriteArrayList(listOf(UserAgentException(domain = "version.com", reason = "reason")))
+        val defaultExceptions = CopyOnWriteArrayList(listOf(UserAgentException(domain = "default.com", reason = "reason")))
+        val unprotectedExceptions = CopyOnWriteArrayList(listOf(UnprotectedTemporaryEntity(domain = "unprotected.com", reason = "reason")))
     }
 
     private object Agent {
@@ -170,6 +235,10 @@ class UserAgentProviderTest {
 
     // Some values will be dynamic based on OS/Architecture/Software versions, so we use Regex to validate values
     private object ValidationRegex {
+        val default = Regex(
+            "Mozilla/5.0 \\(Linux; Android .*? Nexus 6P Build/OPM3.171019.014\\) AppleWebKit/[.0-9]+" +
+                " \\(KHTML, like Gecko\\) Version/[.0-9]+ Chrome/[.0-9]+ Mobile Safari/[.0-9]+"
+        )
         val converted = Regex(
             "Mozilla/5.0 \\(Linux; Android .*?\\) AppleWebKit/[.0-9]+" +
                 " \\(KHTML, like Gecko\\) Version/[.0-9]+ Chrome/[.0-9]+ Mobile DuckDuckGo/5 Safari/[.0-9]+"

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -28,4 +28,5 @@ enum class PrivacyFeatureName(override val value: String) : FeatureName {
     AmpLinksFeatureName("ampLinks"),
     TrackingParametersFeatureName("trackingParameters"),
     AutofillFeatureName("autofill"),
+    UserAgentFeatureName("customUserAgent"),
 }

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UserAgent.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UserAgent.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.api
+
+/** Public interface for the User Agent feature */
+interface UserAgent {
+    /**
+     * This method takes a [url] and returns `true` or `false` depending if the [url] is in the
+     * application exceptions list
+     * @return a `true` if the given [url] if the url is in the application exceptions list and `false`
+     * otherwise.
+     */
+    fun isAnApplicationException(url: String): Boolean
+    /**
+     * This method takes a [url] and returns `true` or `false` depending if the [url] is in the
+     * version exceptions list
+     * @return a `true` if the given [url] if the url is in the version exceptions list and `false`
+     * otherwise.
+     */
+    fun isAVersionException(url: String): Boolean
+    /**
+     * This method takes a [url] and returns `true` or `false` depending if the [url] is in the
+     * default exceptions list
+     * @return a `true` if the given [url] if the url is in the default exceptions list and `false`
+     * otherwise.
+     */
+    fun isADefaultException(url: String): Boolean
+}
+
+/** Public data class for User Agent Exceptions */
+data class UserAgentException(
+    val domain: String,
+    val reason: String
+)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
@@ -54,6 +54,8 @@ import com.duckduckgo.privacy.config.store.features.trackingparameters.RealTrack
 import com.duckduckgo.privacy.config.store.features.trackingparameters.TrackingParametersRepository
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.RealUnprotectedTemporaryRepository
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
+import com.duckduckgo.privacy.config.store.features.useragent.RealUserAgentRepository
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.moshi.Moshi
 import dagger.Module
@@ -219,5 +221,15 @@ object DatabaseModule {
         dispatcherProvider: DispatcherProvider
     ): AutofillRepository {
         return RealAutofillRepository(database, coroutineScope, dispatcherProvider)
+    }
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideUserAgentRepository(
+        database: PrivacyConfigDatabase,
+        @AppCoroutineScope coroutineScope: CoroutineScope,
+        dispatcherProvider: DispatcherProvider
+    ): UserAgentRepository {
+        return RealUserAgentRepository(database, coroutineScope, dispatcherProvider)
     }
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.useragent
+
+import com.duckduckgo.app.global.UriString
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.UserAgent
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealUserAgent @Inject constructor(
+    private val userAgentRepository: UserAgentRepository,
+    private val unprotectedTemporary: UnprotectedTemporary
+): UserAgent {
+
+    override fun isAnApplicationException(url: String): Boolean {
+        return userAgentRepository.omitApplicationExceptions.any { UriString.sameOrSubdomain(url, it.domain) }
+    }
+
+    override fun isAVersionException(url: String): Boolean {
+        return userAgentRepository.omitVersionExceptions.any { UriString.sameOrSubdomain(url, it.domain) }
+    }
+
+    override fun isADefaultException(url: String): Boolean {
+        return unprotectedTemporary.isAnException(url) || userAgentRepository.defaultExceptions.any { UriString.sameOrSubdomain(url, it.domain) }
+    }
+}

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
@@ -22,11 +22,9 @@ import com.duckduckgo.privacy.config.api.UserAgent
 import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
 import com.squareup.anvil.annotations.ContributesBinding
-import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
-@SingleInstanceIn(AppScope::class)
 class RealUserAgent @Inject constructor(
     private val userAgentRepository: UserAgentRepository,
     private val unprotectedTemporary: UnprotectedTemporary

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
@@ -30,7 +30,7 @@ import javax.inject.Inject
 class RealUserAgent @Inject constructor(
     private val userAgentRepository: UserAgentRepository,
     private val unprotectedTemporary: UnprotectedTemporary
-): UserAgent {
+) : UserAgent {
 
     override fun isAnApplicationException(url: String): Boolean {
         return userAgentRepository.omitApplicationExceptions.any { UriString.sameOrSubdomain(url, it.domain) }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentFeature.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.useragent
+
+data class UserAgentFeature(
+    val state: String,
+    val minSupportedVersion: Int?,
+    val exceptions: List<UserAgentExceptionJson>,
+    val settings: UserAgentSettings
+)
+
+data class UserAgentExceptionJson(
+    val domain: String,
+    val reason: String
+)
+
+data class UserAgentSettings(
+    val omitApplicationSites: List<UserAgentExceptionJson>,
+    val omitVersionSites: List<UserAgentExceptionJson>
+)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
@@ -58,17 +58,18 @@ class UserAgentPlugin @Inject constructor(
             val applicationExceptionList = applicationList subtract versionList
             val versionExceptionList = versionList subtract applicationList
 
+            // Order matters, do not change it
             applicationAndVersionExceptionsList.forEach {
                 userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = true, omitVersion = true))
-            }
-            defaultExceptionList.forEach {
-                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = false))
             }
             applicationExceptionList.forEach {
                 userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = true, omitVersion = false))
             }
             versionExceptionList.forEach {
                 userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = true))
+            }
+            defaultExceptionList.forEach {
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = false))
             }
 
             userAgentRepository.updateAll(userAgentExceptions)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
@@ -55,10 +55,12 @@ class UserAgentPlugin @Inject constructor(
 
             val applicationAndVersionExceptionsList = applicationList intersect versionList
             val defaultExceptionList = (exceptionsList subtract applicationList) + (exceptionsList subtract versionList)
-            val applicationExceptionList = applicationList subtract versionList
-            val versionExceptionList = versionList subtract applicationList
+            val applicationExceptionList = applicationList subtract versionList subtract exceptionsList
+            val versionExceptionList = versionList subtract applicationList subtract exceptionsList
 
-            // Order matters, do not change it
+            defaultExceptionList.forEach {
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = false))
+            }
             applicationAndVersionExceptionsList.forEach {
                 userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = true, omitVersion = true))
             }
@@ -67,9 +69,6 @@ class UserAgentPlugin @Inject constructor(
             }
             versionExceptionList.forEach {
                 userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = true))
-            }
-            defaultExceptionList.forEach {
-                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = false))
             }
 
             userAgentRepository.updateAll(userAgentExceptions)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.useragent
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureName
+import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
+import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
+import com.duckduckgo.privacy.config.store.UserAgentExceptionEntity
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+
+@ContributesMultibinding(AppScope::class)
+class UserAgentPlugin @Inject constructor(
+    private val userAgentRepository: UserAgentRepository,
+    private val privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository
+) : PrivacyFeaturePlugin {
+
+    override fun store(
+        name: FeatureName,
+        jsonString: String
+    ): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = privacyFeatureValueOf(name.value)
+        if (name == featureName) {
+            val userAgentExceptions = mutableListOf<UserAgentExceptionEntity>()
+            val moshi = Moshi.Builder().build()
+            val jsonAdapter: JsonAdapter<UserAgentFeature> =
+                moshi.adapter(UserAgentFeature::class.java)
+
+            val userAgentFeature: UserAgentFeature? = jsonAdapter.fromJson(jsonString)
+            val exceptionsList = userAgentFeature?.exceptions.orEmpty()
+            val applicationList = userAgentFeature?.settings?.omitApplicationSites.orEmpty()
+            val versionList = userAgentFeature?.settings?.omitVersionSites.orEmpty()
+
+            val applicationAndVersionExceptionsList = applicationList intersect versionList
+            val defaultExceptionList = (exceptionsList subtract applicationList) + (exceptionsList subtract versionList)
+            val applicationExceptionList = applicationList subtract versionList
+            val versionExceptionList = versionList subtract applicationList
+
+            applicationAndVersionExceptionsList.forEach {
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = true, omitVersion = true))
+            }
+            defaultExceptionList.forEach {
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = false))
+            }
+            applicationExceptionList.forEach {
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = true, omitVersion = false))
+            }
+            versionExceptionList.forEach {
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = true))
+            }
+
+            userAgentRepository.updateAll(userAgentExceptions)
+            val isEnabled = userAgentFeature?.state == "enabled"
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, userAgentFeature?.minSupportedVersion))
+            return true
+        }
+        return false
+    }
+
+    override val featureName: PrivacyFeatureName = PrivacyFeatureName.UserAgentFeatureName
+}

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgentTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgentTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.useragent
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.privacy.config.api.UserAgentException
+import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.concurrent.CopyOnWriteArrayList
+
+@RunWith(AndroidJUnit4::class)
+class RealUserAgentTest {
+    private val mockUserAgentRepository: UserAgentRepository = mock()
+    private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
+    lateinit var testee: RealUserAgent
+
+    @Before
+    fun before() {
+        testee = RealUserAgent(mockUserAgentRepository, mockUnprotectedTemporary)
+    }
+
+    @Test
+    fun whenIsADefaultExceptionAndDomainIsListedInTheExceptionsListThenReturnTrue() {
+        givenThereAreExceptions()
+
+        assertTrue(testee.isADefaultException("http://www.example.com"))
+    }
+
+    @Test
+    fun whenIsADefaultExceptionWithSubdomainAndDomainIsListedInTheExceptionsListThenReturnTrue() {
+        givenThereAreExceptions()
+
+        assertTrue(testee.isADefaultException("http://test.example.com"))
+    }
+
+    @Test
+    fun whenIsADefaultExceptionAndDomainIsNotListedInTheExceptionsListThenReturnFalse() {
+        whenever(mockUserAgentRepository.defaultExceptions).thenReturn(CopyOnWriteArrayList())
+
+        assertFalse(testee.isADefaultException("http://test.example.com"))
+    }
+
+    @Test
+    fun whenIsADefaultExceptionAndDomainIsListedInTheUnprotectedTemporaryListThenReturnTrue() {
+        val url = "http://example.com"
+        whenever(mockUnprotectedTemporary.isAnException(url)).thenReturn(true)
+        whenever(mockUserAgentRepository.defaultExceptions).thenReturn(CopyOnWriteArrayList())
+
+        assertTrue(testee.isADefaultException(url))
+    }
+
+    @Test
+    fun whenIsAnApplicationExceptionAndDomainIsListedInTheExceptionsListThenReturnTrue() {
+        givenThereAreExceptions()
+
+        assertTrue(testee.isAnApplicationException("http://www.example.com"))
+    }
+
+    @Test
+    fun whenIsAnApplicationExceptionWithSubdomainAndDomainIsListedInTheExceptionsListThenReturnTrue() {
+        givenThereAreExceptions()
+
+        assertTrue(testee.isAnApplicationException("http://test.example.com"))
+    }
+
+    @Test
+    fun whenIsAnApplicationExceptionAndDomainIsNotListedInTheExceptionsListThenReturnFalse() {
+        whenever(mockUserAgentRepository.omitApplicationExceptions).thenReturn(CopyOnWriteArrayList())
+
+        assertFalse(testee.isAnApplicationException("http://test.example.com"))
+    }
+
+    @Test
+    fun whenIsAVersionExceptionAndDomainIsListedInTheExceptionsListThenReturnTrue() {
+        givenThereAreExceptions()
+
+        assertTrue(testee.isAVersionException("http://www.example.com"))
+    }
+
+    @Test
+    fun whenIsAVersionExceptionWithSubdomainAndDomainIsListedInTheExceptionsListThenReturnTrue() {
+        givenThereAreExceptions()
+
+        assertTrue(testee.isAVersionException("http://test.example.com"))
+    }
+
+    @Test
+    fun whenIsAVersionExceptionAndDomainIsNotListedInTheExceptionsListThenReturnFalse() {
+        whenever(mockUserAgentRepository.omitVersionExceptions).thenReturn(CopyOnWriteArrayList())
+
+        assertFalse(testee.isAVersionException("http://test.example.com"))
+    }
+
+    private fun givenThereAreExceptions() {
+        val exceptions =
+            CopyOnWriteArrayList<UserAgentException>().apply {
+                add(UserAgentException("example.com", "my reason here"))
+            }
+        whenever(mockUserAgentRepository.defaultExceptions).thenReturn(exceptions)
+        whenever(mockUserAgentRepository.omitApplicationExceptions).thenReturn(exceptions)
+        whenever(mockUserAgentRepository.omitVersionExceptions).thenReturn(exceptions)
+    }
+}

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPluginTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.useragent
+
+import com.duckduckgo.app.FileUtilities
+import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.store.PrivacyFeatureToggles
+import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
+import com.duckduckgo.privacy.config.store.UserAgentExceptionEntity
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class UserAgentPluginTest {
+    lateinit var testee: UserAgentPlugin
+
+    private val mockFeatureTogglesRepository: PrivacyFeatureTogglesRepository = mock()
+    private val mockUserAgentRepository: UserAgentRepository = mock()
+
+    @Before
+    fun before() {
+        testee = UserAgentPlugin(mockUserAgentRepository, mockFeatureTogglesRepository)
+    }
+
+    @Test
+    fun whenFeatureNameDoesNotMatchUserAgentThenReturnFalse() {
+        PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
+            assertFalse(testee.store(it, EMPTY_JSON_STRING))
+        }
+    }
+
+    @Test
+    fun whenFeatureNameMatchesUserAgentThenReturnTrue() {
+        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesUserAgentAndIsEnabledThenStoreFeatureEnabled() {
+        val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/useragent.json")
+
+        testee.store(FEATURE_NAME, jsonString)
+
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesUserAgentAndIsNotEnabledThenStoreFeatureDisabled() {
+        val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/useragent_disabled.json")
+
+        testee.store(FEATURE_NAME, jsonString)
+
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesUserAgentAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
+        val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/useragent_min_supported_version.json")
+
+        testee.store(FEATURE_NAME, jsonString)
+
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesUserAgentThenUpdateAllExistingExceptions() {
+        val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/useragent.json")
+        val exceptionsCaptor = argumentCaptor<List<UserAgentExceptionEntity>>()
+
+        testee.store(FEATURE_NAME, jsonString)
+
+        verify(mockUserAgentRepository).updateAll(exceptionsCaptor.capture())
+
+        val exceptions = exceptionsCaptor.firstValue
+
+        val default = exceptions.first { it.domain == "default.com" }
+        val application = exceptions.first { it.domain == "application.com" }
+        val version = exceptions.first { it.domain == "version.com" }
+        val duplicatedApplication = exceptions.first { it.domain == "duplicatedapplication.com" }
+        val duplicatedVersion = exceptions.first { it.domain == "duplicatedversion.com" }
+        val versionApplication = exceptions.first { it.domain == "versionapplication.com" }
+
+        assertFalse(default.omitApplication)
+        assertFalse(default.omitVersion)
+
+        assertTrue(application.omitApplication)
+        assertFalse(application.omitVersion)
+
+        assertTrue(version.omitVersion)
+        assertFalse(version.omitApplication)
+
+        assertFalse(duplicatedApplication.omitApplication)
+        assertFalse(duplicatedApplication.omitVersion)
+
+        assertFalse(duplicatedVersion.omitApplication)
+        assertFalse(duplicatedVersion.omitVersion)
+
+        assertTrue(versionApplication.omitApplication)
+        assertTrue(versionApplication.omitVersion)
+    }
+
+    companion object {
+        private val FEATURE_NAME = PrivacyFeatureName.UserAgentFeatureName
+        private const val EMPTY_JSON_STRING = "{}"
+    }
+}

--- a/privacy-config/privacy-config-impl/src/test/resources/json/useragent.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/useragent.json
@@ -1,0 +1,47 @@
+{
+  "state": "enabled",
+  "exceptions": [
+    {
+      "domain": "default.com",
+      "reason": "Site reports browser not supported"
+    },
+    {
+      "domain": "duplicatedversion.com",
+      "reason": "Site reports browser not supported"
+    },
+    {
+      "domain": "duplicatedapplication.com",
+      "reason": "Site reports browser not supported"
+    }
+  ],
+  "settings": {
+    "omitApplicationSites": [
+      {
+        "domain": "application.com",
+        "reason": "Site reports browser not supported"
+      },
+      {
+        "domain": "duplicatedapplication.com",
+        "reason": "Site reports browser not supported"
+      },
+      {
+        "domain": "versionapplication.com",
+        "reason": "Site reports browser not supported"
+      }
+    ],
+    "omitVersionSites": [
+      {
+        "domain": "version.com",
+        "reason": "Site reports browser not supported"
+      },
+      {
+        "domain": "duplicatedversion.com",
+        "reason": "Site reports browser not supported"
+      },
+      {
+        "domain": "versionapplication.com",
+        "reason": "Site reports browser not supported"
+      }
+    ]
+  }
+}

--- a/privacy-config/privacy-config-impl/src/test/resources/json/useragent_disabled.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/useragent_disabled.json
@@ -1,0 +1,23 @@
+{
+  "state": "disabled",
+  "exceptions": [
+    {
+      "domain": "cnn.com",
+      "reason": "Site reports browser not supported"
+    }
+  ],
+  "settings": {
+    "omitApplicationSites": [
+      {
+        "domain": "cvs.com",
+        "reason": "Site reports browser not supported"
+      }
+    ],
+    "omitVersionSites": [
+      {
+        "domain": "ing.nl",
+        "reason": "Site reports browser not supported"
+      }
+    ]
+  }
+}

--- a/privacy-config/privacy-config-impl/src/test/resources/json/useragent_min_supported_version.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/useragent_min_supported_version.json
@@ -1,0 +1,24 @@
+{
+  "state": "enabled",
+  "minSupportedVersion": 1234,
+  "exceptions": [
+    {
+      "domain": "cnn.com",
+      "reason": "Site reports browser not supported"
+    }
+  ],
+  "settings": {
+    "omitApplicationSites": [
+      {
+        "domain": "cvs.com",
+        "reason": "Site reports browser not supported"
+      }
+    ],
+    "omitVersionSites": [
+      {
+        "domain": "ing.nl",
+        "reason": "Site reports browser not supported"
+      }
+    ]
+  }
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
@@ -32,12 +32,13 @@ import com.duckduckgo.privacy.config.store.features.trackerallowlist.TrackerAllo
 import com.duckduckgo.privacy.config.store.features.amplinks.AmpLinksDao
 import com.duckduckgo.privacy.config.store.features.trackingparameters.TrackingParametersDao
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryDao
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentDao
 
 @TypeConverters(
     RuleTypeConverter::class,
 )
 @Database(
-    exportSchema = true, version = 8,
+    exportSchema = true, version = 9,
     entities = [
         TrackerAllowlistEntity::class,
         UnprotectedTemporaryEntity::class,
@@ -52,7 +53,8 @@ import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.Unprote
         AmpLinkExceptionEntity::class,
         TrackingParameterEntity::class,
         TrackingParameterExceptionEntity::class,
-        AutofillExceptionEntity::class
+        AutofillExceptionEntity::class,
+        UserAgentExceptionEntity::class,
     ]
 )
 abstract class PrivacyConfigDatabase : RoomDatabase() {
@@ -67,6 +69,7 @@ abstract class PrivacyConfigDatabase : RoomDatabase() {
     abstract fun ampLinksDao(): AmpLinksDao
     abstract fun trackingParametersDao(): TrackingParametersDao
     abstract fun autofillDao(): AutofillDao
+    abstract fun userAgentDao(): UserAgentDao
 }
 
 val MIGRATION_2_3 = object : Migration(2, 3) {

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.privacy.config.api.GpcHeaderEnabledSite
 import com.duckduckgo.privacy.config.api.HttpsException
 import com.duckduckgo.privacy.config.api.AmpLinkException
 import com.duckduckgo.privacy.config.api.TrackingParameterException
+import com.duckduckgo.privacy.config.api.UserAgentException
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -114,6 +115,18 @@ data class ContentBlockingExceptionEntity(
 
 fun ContentBlockingExceptionEntity.toContentBlockingException(): ContentBlockingException {
     return ContentBlockingException(domain = this.domain, reason = this.reason)
+}
+
+@Entity(tableName = "user_agent_exceptions")
+data class UserAgentExceptionEntity(
+    @PrimaryKey val domain: String,
+    val reason: String,
+    val omitApplication: Boolean,
+    val omitVersion: Boolean
+)
+
+fun UserAgentExceptionEntity.toUserAgentException(): UserAgentException {
+    return UserAgentException(domain = this.domain, reason = this.reason)
 }
 
 @Entity(tableName = "privacy_config")

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentDao.kt
@@ -38,11 +38,15 @@ abstract class UserAgentDao {
     @Query("select * from user_agent_exceptions where domain = :domain")
     abstract fun get(domain: String): UserAgentExceptionEntity
 
-    @Query("select * from user_agent_exceptions where omitApplication = 0 AND omitVersion = 0") abstract fun getDefaultExceptions(): List<UserAgentExceptionEntity>
+    @Query("select * from user_agent_exceptions where omitApplication = 0 AND omitVersion = 0")
+    abstract fun getDefaultExceptions(): List<UserAgentExceptionEntity>
 
-    @Query("select * from user_agent_exceptions where omitApplication = 1") abstract fun getApplicationExceptions(): List<UserAgentExceptionEntity>
+    @Query("select * from user_agent_exceptions where omitApplication = 1")
+    abstract fun getApplicationExceptions(): List<UserAgentExceptionEntity>
 
-    @Query("select * from user_agent_exceptions where omitVersion = 1") abstract fun getVersionExceptions(): List<UserAgentExceptionEntity>
+    @Query("select * from user_agent_exceptions where omitVersion = 1")
+    abstract fun getVersionExceptions(): List<UserAgentExceptionEntity>
 
-    @Query("delete from user_agent_exceptions") abstract fun deleteAll()
+    @Query("delete from user_agent_exceptions")
+    abstract fun deleteAll()
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentDao.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.useragent
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.privacy.config.store.UserAgentExceptionEntity
+
+@Dao
+abstract class UserAgentDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertAll(domains: List<UserAgentExceptionEntity>)
+
+    @Transaction
+    open fun updateAll(domains: List<UserAgentExceptionEntity>) {
+        deleteAll()
+        insertAll(domains)
+    }
+
+    @Query("select * from user_agent_exceptions where domain = :domain")
+    abstract fun get(domain: String): UserAgentExceptionEntity
+
+    @Query("select * from user_agent_exceptions where omitApplication = 0 AND omitVersion = 0") abstract fun getDefaultExceptions(): List<UserAgentExceptionEntity>
+
+    @Query("select * from user_agent_exceptions where omitApplication = 1") abstract fun getApplicationExceptions(): List<UserAgentExceptionEntity>
+
+    @Query("select * from user_agent_exceptions where omitVersion = 1") abstract fun getVersionExceptions(): List<UserAgentExceptionEntity>
+
+    @Query("delete from user_agent_exceptions") abstract fun deleteAll()
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentRepository.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.useragent
+
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.privacy.config.api.UserAgentException
+import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
+import com.duckduckgo.privacy.config.store.UserAgentExceptionEntity
+import com.duckduckgo.privacy.config.store.toUserAgentException
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+interface UserAgentRepository {
+    fun updateAll(exceptions: List<UserAgentExceptionEntity>)
+    val defaultExceptions: CopyOnWriteArrayList<UserAgentException>
+    val omitApplicationExceptions: CopyOnWriteArrayList<UserAgentException>
+    val omitVersionExceptions: CopyOnWriteArrayList<UserAgentException>
+}
+
+class RealUserAgentRepository(
+    val database: PrivacyConfigDatabase,
+    coroutineScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider
+) : UserAgentRepository {
+
+    private val userAgentDao: UserAgentDao = database.userAgentDao()
+    override val defaultExceptions = CopyOnWriteArrayList<UserAgentException>()
+    override val omitApplicationExceptions = CopyOnWriteArrayList<UserAgentException>()
+    override val omitVersionExceptions = CopyOnWriteArrayList<UserAgentException>()
+
+    init {
+        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+    }
+
+    override fun updateAll(exceptions: List<UserAgentExceptionEntity>) {
+        userAgentDao.updateAll(exceptions)
+        loadToMemory()
+    }
+
+    private fun loadToMemory() {
+        defaultExceptions.clear()
+        omitApplicationExceptions.clear()
+        omitVersionExceptions.clear()
+        userAgentDao.getDefaultExceptions().map { defaultExceptions.add(it.toUserAgentException()) }
+        userAgentDao.getApplicationExceptions().map { omitApplicationExceptions.add(it.toUserAgentException()) }
+        userAgentDao.getVersionExceptions().map { omitVersionExceptions.add(it.toUserAgentException()) }
+    }
+}

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/useragent/RealUserAgentRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/useragent/RealUserAgentRepositoryTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.useragent
+
+import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
+import com.duckduckgo.privacy.config.store.UserAgentExceptionEntity
+import com.duckduckgo.privacy.config.store.toUserAgentException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class RealUserAgentRepositoryTest {
+
+    @get:Rule var coroutineRule = CoroutineTestRule()
+
+    lateinit var testee: RealUserAgentRepository
+
+    private val mockDatabase: PrivacyConfigDatabase = mock()
+    private val mockUserAgentDao: UserAgentDao = mock()
+
+    @Before
+    fun before() {
+        whenever(mockDatabase.userAgentDao()).thenReturn(mockUserAgentDao)
+        testee =
+            RealUserAgentRepository(
+                mockDatabase, TestScope(), coroutineRule.testDispatcherProvider
+            )
+    }
+
+    @Test
+    fun whenRepositoryIsCreatedThenExceptionsLoadedIntoMemory() {
+        givenUserAgentDaoContainsExceptions()
+        val actual = userAgentException.toUserAgentException()
+        testee =
+            RealUserAgentRepository(
+                mockDatabase, TestScope(), coroutineRule.testDispatcherProvider
+            )
+
+        assertEquals(testee.omitApplicationExceptions.first(), actual)
+        assertEquals(testee.omitVersionExceptions.first(), actual)
+        assertEquals(testee.defaultExceptions.first(), actual)
+    }
+
+    @Test
+    fun whenUpdateAllThenUpdateAllCalled() =
+        runTest {
+            testee =
+                RealUserAgentRepository(
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider
+                )
+
+            testee.updateAll(listOf())
+
+            verify(mockUserAgentDao).updateAll(anyList())
+        }
+
+    @Test
+    fun whenUpdateAllThenPreviousExceptionsAreCleared() =
+        runTest {
+            givenUserAgentDaoContainsExceptions()
+            testee =
+                RealUserAgentRepository(
+                    mockDatabase, TestScope(), coroutineRule.testDispatcherProvider
+                )
+            assertEquals(1, testee.defaultExceptions.size)
+            assertEquals(1, testee.omitApplicationExceptions.size)
+            assertEquals(1, testee.omitVersionExceptions.size)
+            reset(mockUserAgentDao)
+
+            testee.updateAll(listOf())
+
+            assertEquals(0, testee.defaultExceptions.size)
+            assertEquals(0, testee.omitApplicationExceptions.size)
+            assertEquals(0, testee.omitVersionExceptions.size)
+        }
+
+    private fun givenUserAgentDaoContainsExceptions() {
+        whenever(mockUserAgentDao.getApplicationExceptions()).thenReturn(listOf(userAgentException))
+        whenever(mockUserAgentDao.getDefaultExceptions()).thenReturn(listOf(userAgentException))
+        whenever(mockUserAgentDao.getVersionExceptions()).thenReturn(listOf(userAgentException))
+    }
+
+    companion object {
+        val userAgentException = UserAgentExceptionEntity("example.com", "reason", omitApplication = false, omitVersion = false)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1202317386594677

### Description
This PR moves the hardcoded UA exception lists to the remote config.

### Steps to test this PR
Before you begin, using Charles or similar map the request to `https://staticcdn.duckduckgo.com/trackerblocking/config/v2/android-config.json` to return the json attached in the Asana task.

Our UA looks like `Mozilla/5.0 (Linux; Android 12) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/101.0.4951.61 Mobile DuckDuckGo/5 Safari/537.36`

Notice the application component: `DuckDuckGo/5`
and the version component: `Version/4.0`

_User Agent works as expected_
- [x] Install from this branch
- [x] In the logcat filter by useragent
- [x] Go to SERP
- [x] In the logcat you should see contain the version and application component
- [x] Go to `cvs.com`
- [x] In the logcat the UA should not contain the application component and include the version component
- [x] Go to `ing.nl` 
- [x] In the logcat the UA should not contain the version component and include the application component
- [x] Go to `marcos.com`
- [x] In the logcat the UA should not contain both the version component and the application component
- [x] Go to `facebook.com`
- [x] In the logcat the UA should be the desktop version `(X11; Linux aarch64)` instead of `(Linux; Android 12)`
- [x] The UA should also not contain the version component. The UA change will probably show twice, this is normal.
- [x] Go to `cnn.com`
- [x] The UA should be the default one from WebView, no application or version component should show up and extra information that we remove should be re-added.
- [x] Go to `chase.com`
- [x] The UA should be the default one from WebView, no application or version component should show up and extra information that we remove should be re-added.
- [x] Go to `sovietgames.ru`
- [x] The UA should be the default one from WebView, no application or version component should show up and extra information that we remove should be re-added.
- [x] Go to `cvs.com` and remove privacy protections. The website should reload.
- [x] The UA should be the default one from WebView, no application or version component should show up and extra information that we remove should be re-added.

_Disable User Agent_
- [x] Using Flipper or similar disable the UA toggle in shared preferences (or change the json to "disabled" and install the app again)
- [x] Reload the app
- [x] Go to SERP
- [x] The UA should be the default one from WebView, no application or version component should show up and extra information that we remove should be re-added.
- [x] Go to the options menu and select `Desktop Site`
- [x] The UA should be the default one from WebView but should contain the desktop portion instead of the mobile one `(X11; Linux aarch64)` instead of `(Linux; Android 12)`.

