### PR TITLE
Use post to load extracted new tab AMP links

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -424,7 +424,7 @@ class BrowserWebViewClientTest {
     fun whenAmpLinkDetectedAndIsForMainFrameThenReturnTrueAndLoadExtractedUrl() = runTest {
         whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.ExtractedAmpLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
-        val mockWebView = mock<WebView>()
+        val mockWebView = getImmediatelyInvokedMockWebView()
         assertTrue(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
         verify(mockWebView).loadUrl(EXAMPLE_URL)
         verify(listener).startProcessingTrackingLink()
@@ -438,6 +438,12 @@ class BrowserWebViewClientTest {
         assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
         verify(mockWebView, never()).loadUrl(EXAMPLE_URL)
         verify(listener, never()).startProcessingTrackingLink()
+    }
+
+    @Test
+    fun whenAmpLinkDetectedAndIsForMainFrameAndIsOpenedInNewTabThenReturnTrueAndLoadExtractedUrl() = runTest {
+        whenever(listener.linkOpenedInNewTab()).thenReturn(true)
+        whenAmpLinkDetectedAndIsForMainFrameThenReturnTrueAndLoadExtractedUrl()
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -160,9 +160,11 @@ class BrowserWebViewClient(
                 }
                 is SpecialUrlDetector.UrlType.ExtractedAmpLink -> {
                     if (isForMainFrame) {
-                        webViewClientListener?.startProcessingTrackingLink()
-                        Timber.d("AMP link detection: Loading extracted URL: ${urlType.extractedUrl}")
-                        webView.loadUrl(urlType.extractedUrl)
+                        webViewClientListener?.let { listener ->
+                            listener.startProcessingTrackingLink()
+                            Timber.d("AMP link detection: Loading extracted URL: ${urlType.extractedUrl}")
+                            loadUrl(listener, webView, urlType.extractedUrl)
+                        }
                         return true
                     }
                     false
@@ -186,12 +188,12 @@ class BrowserWebViewClient(
 
                         if (parameterStrippedType is SpecialUrlDetector.UrlType.AppLink) {
                             webViewClientListener?.let { listener ->
-                                loadCleanedUrl(listener, webView, urlType)
+                                loadUrl(listener, webView, urlType.cleanedUrl)
                                 return listener.handleAppLink(parameterStrippedType, isForMainFrame)
                             }
                         } else {
                             webViewClientListener?.let { listener ->
-                                loadCleanedUrl(listener, webView, urlType)
+                                loadUrl(listener, webView, urlType.cleanedUrl)
                             }
                             return true
                         }
@@ -208,17 +210,17 @@ class BrowserWebViewClient(
         }
     }
 
-    private fun loadCleanedUrl(
+    private fun loadUrl(
         listener: WebViewClientListener,
         webView: WebView,
-        urlType: TrackingParameterLink
+        url: String
     ) {
         if (listener.linkOpenedInNewTab()) {
             webView.post {
-                webView.loadUrl(urlType.cleanedUrl)
+                webView.loadUrl(url)
             }
         } else {
-            webView.loadUrl(urlType.cleanedUrl)
+            webView.loadUrl(url)
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202329383243646/f

### Description
This PR fixes an exception that occurs when clicking on an AMP link that opens in a new tab.

### Steps to test this PR

_Test pages_
- [x] Build the app and visit https://privacy-test-pages.glitch.me/privacy-protections/amp/.
- [x] Click through the first 3 links (The 4th link is an unrelated regression, will be fixed in a follow-up PR).
- [x] Verify that the expected URLs are loaded.

_Links that open in a new tab_
- [x] Log into Gmail in the browser and send yourself this link: https://www.google.com/amp/s/example.edu.
- [x] Click on the link.
- [x] Verify that the link opens in a new tab correctly and that the address is https://example.edu.

_Pasting into the search bar_
- [x] Paste https://www.google.com/amp/s/example.edu into the search bar.
- [x] Verify that link opens correctly and that the address is https://example.edu.

_Opening from another app_
- [x] Go to the Gmail app and open the link you sent to yourself using the DDG browser.
- [x] Verify that link opens correctly and that the address is https://example.edu.
