### PR TITLE
Add guard on long press handler to ensure DI initialization has happened

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2018,7 +2018,13 @@ class BrowserTabFragment :
     }
 
     fun onLongPressBackButton() {
-        viewModel.onUserLongPressedBack()
+        /*
+         It is possible that this can be invoked before Fragment is attached
+         If viewModelFactory isn't initialized, ignore long press
+         */
+        if (this::viewModelFactory.isInitialized) {
+            viewModel.onUserLongPressedBack()
+        }
     }
 
     private fun launchHideTipsDialog(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202348097691007/f

### Description
We noted a small number of crashes around `viewModelFactory` not being initialized when long press of back button happened. 

Theory on root cause is that there exists a small window whereby `BrowserActivity` has created the new fragment and reassigned `currentTab` to point to it, but the fragment hasn't been fully committed yet. Any interaction with the fragment in that window will result in similar crashes because the lazy `viewModel` will touch the uninitialized `viewModelFactory`.

This PR doesn't change the way the fragments are created (which is a bigger undertaking). Instead it just adds a guard in the long press handler to check for initialization, otherwise, it drops the long press event.
