### PR TITLE
Integrate device authentication to autofill

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -59,6 +59,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.waitlist.trackerprotection.ui.AppTPWaitlistActivity
 import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.autofill.ui.AutofillSettingsActivityLauncher
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.macos_api.MacWaitlistState
 import com.duckduckgo.macos_api.MacWaitlistState.*
@@ -98,6 +99,9 @@ class SettingsActivity :
 
     @Inject
     lateinit var autofillSettingsActivityLauncher: AutofillSettingsActivityLauncher
+
+    @Inject
+    lateinit var deviceAuthenticator: DeviceAuthenticator
 
     private val defaultBrowserChangeListener = OnCheckedChangeListener { _, isChecked ->
         viewModel.onDefaultBrowserToggled(isChecked)
@@ -153,7 +157,12 @@ class SettingsActivity :
         with(viewsPrivacy) {
             globalPrivacyControlSetting.setOnClickListener { viewModel.onGlobalPrivacyControlClicked() }
             fireproofWebsites.setOnClickListener { viewModel.onFireproofWebsitesClicked() }
-            autofill.setOnClickListener { viewModel.onAutofillSettingsClick() }
+            if (deviceAuthenticator.hasValidDeviceAuthentication()) {
+                autofill.isEnabled = true
+                autofill.setOnClickListener { viewModel.onAutofillSettingsClick() }
+            } else {
+                autofill.isEnabled = false
+            }
             locationPermissions.setOnClickListener { viewModel.onLocationClicked() }
             automaticallyClearWhatSetting.setOnClickListener { viewModel.onAutomaticallyClearWhatClicked() }
             automaticallyClearWhenSetting.setOnClickListener { viewModel.onAutomaticallyClearWhenClicked() }

--- a/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AuthLauncher.kt
+++ b/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AuthLauncher.kt
@@ -29,7 +29,7 @@ import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Error
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Failed
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Success
-import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import timber.log.Timber
 import javax.inject.Inject
@@ -48,7 +48,7 @@ interface AuthLauncher {
     )
 }
 
-@ContributesBinding(ActivityScope::class)
+@ContributesBinding(AppScope::class)
 class RealAuthLauncher @Inject constructor(
     private val context: Context,
     private val appBuildConfig: AppBuildConfig

--- a/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticator.kt
+++ b/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticator.kt
@@ -23,11 +23,11 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features
-import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
-@ContributesBinding(ActivityScope::class)
+@ContributesBinding(AppScope::class)
 class RealDeviceAuthenticator @Inject constructor(
     private val deviceAuthChecker: SupportedDeviceAuthChecker,
     private val appBuildConfig: AppBuildConfig,

--- a/modules/autofill/autofill-impl/build.gradle
+++ b/modules/autofill/autofill-impl/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(path: ':common-ui')
     implementation project(path: ':autofill-api')
     implementation project(path: ':secure-storage-api')
+    implementation project(path: ':device-auth-api')
     api project(path: ':autofill-store')
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 

--- a/modules/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
+++ b/modules/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
@@ -32,6 +32,9 @@ import com.duckduckgo.autofill.ui.AutofillSettingsActivityLauncher
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.*
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementEditMode
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementViewMode
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
@@ -41,6 +44,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class AutofillManagementActivity : DuckDuckGoActivity() {
@@ -50,15 +54,26 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
 
     private var inEditMode: Boolean = false
 
+    @Inject
+    lateinit var deviceAuthenticator: DeviceAuthenticator
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
-        if (savedInstanceState == null) {
-            showViewMode()
-        }
+        // TODO implement reauth when app is backgrounded
+        deviceAuthenticator.authenticate(AUTOFILL, this) {
+            if (it == AuthResult.Success) {
+                if (savedInstanceState == null) {
+                    showViewMode()
+                }
 
-        observeViewModel()
+                observeViewModel()
+            } else {
+                // TODO show locked autofill UI once available
+                finish()
+            }
+        }
     }
 
     private fun observeViewModel() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202418883857448/f
PR depends on: https://github.com/duckduckgo/Android/pull/1994

### Description
This PR integrates the device auth flow into the autofill flow.

This doesn't include the full flow in management page since the page will likely change in implementation since it is still in the MVP stage. Will address this in https://app.asana.com/0/0/1202418883857449/f

### Steps to test this PR

_User has device auth enrolled on device_
- [x] Open a website with log in.
- [x] Saves credentials without needing to do any authentication.
- [x] Log out and attempt to login using saved credentials.
- [x] Authentication using whatever is enrolled to the device (Fingerprint, faceid, pin, password or pattern) should be required **everytime** when trying to autofill a login.
- [x] Open the management screen in settings. 
- [x] Authentication should be required every time.

_User has no device auth enrolled on device_
- [x] Open a website with log in.
- [x] Save credential should not be shown.
- [x] If a credential was previously saved, no prompt to autofill should be shown.
- [x] Management link in settings should be disabled.
