### PR TITLE
Update tracking parameter removal reference tests

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -304,7 +304,7 @@ class BrowserWebViewClientTest {
     @Test
     fun whenShouldOverrideThrowsExceptionThenRecordException() = runTest {
         val exception = RuntimeException()
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenThrow(exception)
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenThrow(exception)
         testee.shouldOverrideUrlLoading(webView, "")
         verify(uncaughtExceptionRepository).recordUncaughtException(exception, UncaughtExceptionSource.SHOULD_OVERRIDE_REQUEST)
     }
@@ -313,7 +313,7 @@ class BrowserWebViewClientTest {
     fun whenAppLinkDetectedAndIsHandledThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
-            whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
             whenever(webResourceRequest.isRedirect).thenReturn(false)
             whenever(webResourceRequest.isForMainFrame).thenReturn(true)
             whenever(listener.handleAppLink(any(), any())).thenReturn(true)
@@ -326,7 +326,7 @@ class BrowserWebViewClientTest {
     fun whenAppLinkDetectedAndIsNotHandledThenReturnFalse() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
-            whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
             whenever(webResourceRequest.isRedirect).thenReturn(false)
             whenever(webResourceRequest.isForMainFrame).thenReturn(true)
             whenever(listener.handleAppLink(any(), any())).thenReturn(false)
@@ -338,7 +338,8 @@ class BrowserWebViewClientTest {
     @Test
     fun whenAppLinkDetectedAndListenerIsNullThenReturnFalse() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL))
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+                .thenReturn(SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL))
             testee.webViewClientListener = null
             assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
             verify(listener, never()).handleAppLink(any(), any())
@@ -349,7 +350,7 @@ class BrowserWebViewClientTest {
     fun whenNonHttpAppLinkDetectedAndIsHandledThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
-            whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
             whenever(webResourceRequest.isRedirect).thenReturn(false)
             whenever(listener.handleNonHttpAppLink(any())).thenReturn(true)
             assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
@@ -361,7 +362,7 @@ class BrowserWebViewClientTest {
     fun whenNonHttpAppLinkDetectedAndIsHandledOnApiLessThan24ThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
-            whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
             whenever(listener.handleNonHttpAppLink(any())).thenReturn(true)
             assertTrue(testee.shouldOverrideUrlLoading(webView, EXAMPLE_URL))
             verify(listener).handleNonHttpAppLink(urlType)
@@ -372,7 +373,7 @@ class BrowserWebViewClientTest {
     fun whenNonHttpAppLinkDetectedAndIsNotHandledThenReturnFalse() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
-            whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
             whenever(webResourceRequest.isRedirect).thenReturn(false)
             whenever(listener.handleNonHttpAppLink(any())).thenReturn(false)
             assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
@@ -384,7 +385,7 @@ class BrowserWebViewClientTest {
     fun whenNonHttpAppLinkDetectedAndIsNotHandledOnApiLessThan24ThenReturnFalse() = runTest {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
-            whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(urlType)
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
             whenever(listener.handleNonHttpAppLink(any())).thenReturn(false)
             assertFalse(testee.shouldOverrideUrlLoading(webView, EXAMPLE_URL))
             verify(listener).handleNonHttpAppLink(urlType)
@@ -394,7 +395,7 @@ class BrowserWebViewClientTest {
     @Test
     fun whenNonHttpAppLinkDetectedAndListenerIsNullThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(
                 SpecialUrlDetector.UrlType.NonHttpAppLink(
                     EXAMPLE_URL,
                     Intent(),
@@ -410,7 +411,7 @@ class BrowserWebViewClientTest {
     @Test
     fun whenNonHttpAppLinkDetectedAndListenerIsNullOnApiLessThan24ThenReturnTrue() = runTest {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(
                 SpecialUrlDetector.UrlType.NonHttpAppLink(
                     EXAMPLE_URL,
                     Intent(),
@@ -425,7 +426,8 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenAmpLinkDetectedAndIsForMainFrameThenReturnTrueAndLoadExtractedUrl() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.ExtractedAmpLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.ExtractedAmpLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
         val mockWebView = getImmediatelyInvokedMockWebView()
         assertTrue(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
@@ -435,7 +437,8 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenAmpLinkDetectedAndIsNotForMainFrameThenReturnFalse() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.ExtractedAmpLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.ExtractedAmpLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(false)
         val mockWebView = mock<WebView>()
         assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
@@ -451,7 +454,8 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenCloakedAmpLinkDetectedAndIsForMainFrameThenHandleCloakedAmpLink() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.CloakedAmpLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.CloakedAmpLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
         assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
         verify(listener).handleCloakedAmpLink(EXAMPLE_URL)
@@ -459,7 +463,8 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenCloakedAmpLinkDetectedAndIsNotForMainFrameThenReturnFalse() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.CloakedAmpLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.CloakedAmpLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(false)
         assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
         verify(listener, never()).handleCloakedAmpLink(any())
@@ -467,7 +472,8 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenTrackingParametersDetectedAndIsForMainFrameThenReturnTrueAndLoadCleanedUrl() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
         val mockWebView = getImmediatelyInvokedMockWebView()
         assertTrue(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
@@ -483,7 +489,8 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenTrackingParametersDetectedAndIsNotForMainFrameThenReturnFalse() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(false)
         val mockWebView = mock<WebView>()
         assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
@@ -493,9 +500,10 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenTrackingParametersDetectedAndIsForMainFrameAndIsAppLinkAndAppLinkIsHandledThenReturnTrueAndLoadCleanedUrl() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         val appLink = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
-        whenever(specialUrlDetector.processUrl(anyString())).thenReturn(appLink)
+        whenever(specialUrlDetector.processUrl(anyString(), anyString())).thenReturn(appLink)
         whenever(listener.handleAppLink(any(), any())).thenReturn(true)
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
         val mockWebView = getImmediatelyInvokedMockWebView()
@@ -513,9 +521,10 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenTrackingParametersDetectedAndIsForMainFrameAndIsAppLinkAndAppLinkIsNotHandledThenReturnFalseAndLoadCleanedUrl() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         val appLink = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
-        whenever(specialUrlDetector.processUrl(anyString())).thenReturn(appLink)
+        whenever(specialUrlDetector.processUrl(anyString(), anyString())).thenReturn(appLink)
         whenever(listener.handleAppLink(any(), any())).thenReturn(false)
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
         val mockWebView = getImmediatelyInvokedMockWebView()
@@ -533,9 +542,10 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenTrackingParametersDetectedAndIsForMainFrameAndIsExtractedAmpLinkThenReturnTrueAndLoadExtractedUrl() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         val ampLink = SpecialUrlDetector.UrlType.ExtractedAmpLink(extractedUrl = EXAMPLE_URL)
-        whenever(specialUrlDetector.processUrl(anyString())).thenReturn(ampLink)
+        whenever(specialUrlDetector.processUrl(anyString(), anyString())).thenReturn(ampLink)
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
         val mockWebView = getImmediatelyInvokedMockWebView()
         assertTrue(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
@@ -551,9 +561,10 @@ class BrowserWebViewClientTest {
 
     @Test
     fun whenTrackingParametersDetectedAndIsForMainFrameAndIsAppLinkAndListenerIsNullThenReturnFalse() = runTest {
-        whenever(specialUrlDetector.determineType(any<Uri>())).thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         val appLink = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
-        whenever(specialUrlDetector.processUrl(anyString())).thenReturn(appLink)
+        whenever(specialUrlDetector.processUrl(anyString(), anyString())).thenReturn(appLink)
         testee.webViewClientListener = null
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
         val mockWebView = mock<WebView>()
@@ -562,6 +573,7 @@ class BrowserWebViewClientTest {
 
     private fun getImmediatelyInvokedMockWebView(): WebView {
         val mockWebView = mock<WebView>()
+        whenever(mockWebView.originalUrl).thenReturn(EXAMPLE_URL)
         whenever(mockWebView.post(any())).thenAnswer { invocation ->
             invocation.getArgument(0, Runnable::class.java).run()
             null
@@ -569,7 +581,11 @@ class BrowserWebViewClientTest {
         return mockWebView
     }
 
-    private class TestWebView(context: Context) : WebView(context)
+    private class TestWebView(context: Context) : WebView(context) {
+        override fun getOriginalUrl(): String {
+            return EXAMPLE_URL
+        }
+    }
 
     companion object {
         const val EXAMPLE_URL = "example.com"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -27,7 +27,6 @@ import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
 import androidx.core.net.toUri
 import com.duckduckgo.app.accessibility.AccessibilityManager
-import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.TrackingParameterLink
 import com.duckduckgo.app.browser.certificates.rootstore.CertificateValidationState
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
 import com.duckduckgo.app.browser.cookies.CookieManagerProvider
@@ -114,7 +113,7 @@ class BrowserWebViewClient(
                 return false
             }
 
-            return when (val urlType = specialUrlDetector.determineType(url)) {
+            return when (val urlType = specialUrlDetector.determineType(initiatingUrl = webView.originalUrl, uri = url)) {
                 is SpecialUrlDetector.UrlType.Email -> {
                     webViewClientListener?.sendEmailRequested(urlType.emailAddress)
                     true
@@ -187,7 +186,10 @@ class BrowserWebViewClient(
                             listener.startProcessingTrackingLink()
                             Timber.d("Loading parameter cleaned URL: ${urlType.cleanedUrl}")
 
-                            return when (val parameterStrippedType = specialUrlDetector.processUrl(urlType.cleanedUrl)) {
+                            return when (
+                                val parameterStrippedType =
+                                    specialUrlDetector.processUrl(initiatingUrl = webView.originalUrl, uriString = urlType.cleanedUrl)
+                            ) {
                                 is SpecialUrlDetector.UrlType.AppLink -> {
                                     loadUrl(listener, webView, urlType.cleanedUrl)
                                     listener.handleAppLink(parameterStrippedType, isForMainFrame)

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -32,9 +32,9 @@ import timber.log.Timber
 import java.net.URISyntaxException
 
 interface SpecialUrlDetector {
-    fun determineType(uri: Uri): UrlType
+    fun determineType(initiatingUrl: String?, uri: Uri): UrlType
     fun determineType(uriString: String?): UrlType
-    fun processUrl(uriString: String): UrlType
+    fun processUrl(initiatingUrl: String?, uriString: String): UrlType
 
     sealed class UrlType {
         class Web(val webAddress: String) : UrlType()
@@ -68,7 +68,7 @@ class SpecialUrlDetectorImpl(
     private val trackingParameters: TrackingParameters
 ) : SpecialUrlDetector {
 
-    override fun determineType(uri: Uri): UrlType {
+    override fun determineType(initiatingUrl: String?, uri: Uri): UrlType {
         val uriString = uri.toString()
 
         return when (val scheme = uri.scheme) {
@@ -77,7 +77,7 @@ class SpecialUrlDetectorImpl(
             MAILTO_SCHEME -> buildEmail(uriString)
             SMS_SCHEME -> buildSms(uriString)
             SMSTO_SCHEME -> buildSmsTo(uriString)
-            HTTP_SCHEME, HTTPS_SCHEME, DATA_SCHEME -> processUrl(uriString)
+            HTTP_SCHEME, HTTPS_SCHEME, DATA_SCHEME -> processUrl(initiatingUrl, uriString)
             JAVASCRIPT_SCHEME, ABOUT_SCHEME, FILE_SCHEME, SITE_SCHEME -> UrlType.SearchQuery(uriString)
             null -> UrlType.SearchQuery(uriString)
             else -> checkForIntent(scheme, uriString)
@@ -95,8 +95,8 @@ class SpecialUrlDetectorImpl(
 
     private fun buildSmsTo(uriString: String): UrlType = UrlType.Sms(uriString.removePrefix("$SMSTO_SCHEME:").truncate(SMS_MAX_LENGTH))
 
-    override fun processUrl(uriString: String): UrlType {
-        trackingParameters.cleanTrackingParameters(uriString)?.let { cleanedUrl ->
+    override fun processUrl(initiatingUrl: String?, uriString: String): UrlType {
+        trackingParameters.cleanTrackingParameters(initiatingUrl = initiatingUrl, url = uriString)?.let { cleanedUrl ->
             return UrlType.TrackingParameterLink(cleanedUrl = cleanedUrl)
         }
 
@@ -198,7 +198,7 @@ class SpecialUrlDetectorImpl(
     override fun determineType(uriString: String?): UrlType {
         if (uriString == null) return UrlType.Web("")
 
-        return determineType(Uri.parse(uriString))
+        return determineType(initiatingUrl = null, uri = Uri.parse(uriString))
     }
 
     private fun String.truncate(maxLength: Int): String = if (this.length > maxLength) this.substring(0, maxLength) else this

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -22,6 +22,7 @@ import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.os.Build
+import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.*
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.EMAIL_MAX_LENGTH
@@ -360,9 +361,11 @@ class SpecialUrlDetectorImplTest {
 
     @Test
     fun whenUrlIsTrackingParameterLinkThenTrackingParameterLinkTypeDetected() {
-        whenever(mockTrackingParameters.cleanTrackingParameters(anyString())).thenReturn("https://www.example.com/query.html")
+        whenever(mockTrackingParameters.cleanTrackingParameters(initiatingUrl = anyString(), url = anyString()))
+            .thenReturn("https://www.example.com/query.html")
         val expected = TrackingParameterLink::class
-        val actual = testee.determineType("https://www.example.com/query.html?utm_example=something")
+        val actual =
+            testee.determineType(initiatingUrl = "https://www.example.com", uri = "https://www.example.com/query.html?utm_example=something".toUri())
         assertEquals(expected, actual::class)
         assertEquals("https://www.example.com/query.html", (actual as TrackingParameterLink).cleanedUrl)
     }

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/TrackingParameters.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/TrackingParameters.kt
@@ -19,18 +19,17 @@ package com.duckduckgo.privacy.config.api
 /** Public interface for the Tracking Parameters feature */
 interface TrackingParameters {
     /**
-     * This method takes a [url] and returns `true` or `false` depending if the [url] is in the
-     * tracking parameters exceptions list
-     * @return `true` if the given [url] is in the tracking parameters exceptions list and `false`
-     * otherwise.
+     * This method takes an optional [initiatingUrl] and a [url]. It returns `true` or `false` depending if the [url] or [initiatingUrl]
+     * is in the tracking parameters exceptions list.
+     * @return `true` if the given [url] or [initiatingUrl] is in the tracking parameters exceptions list and `false` otherwise.
      */
-    fun isAnException(url: String): Boolean
+    fun isAnException(initiatingUrl: String?, url: String): Boolean
 
     /**
-     * This method takes a [url] and returns a [String] containing the cleaned URL with tracking parameters removed.
+     * This method takes an optional [initiatingUrl] and a [url] and returns a [String] containing the cleaned URL with tracking parameters removed.
      * @return the URL [String] or `null` if the [url] does not contain tracking parameters.
      */
-    fun cleanTrackingParameters(url: String): String?
+    fun cleanTrackingParameters(initiatingUrl: String?, url: String): String?
 
     /** The last tracking parameter cleaned URL. */
     var lastCleanedUrl: String?

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/RealTrackingParameters.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/RealTrackingParameters.kt
@@ -48,19 +48,20 @@ class RealTrackingParameters @Inject constructor(
 
     override var lastCleanedUrl: String? = null
 
-    override fun isAnException(url: String): Boolean {
-        return matches(url) ||
+    override fun isAnException(initiatingUrl: String?, url: String): Boolean {
+        return matches(initiatingUrl) || matches(url) ||
             unprotectedTemporary.isAnException(url) ||
             userWhiteListRepository.userWhiteList.contains(url.toUri().domain())
     }
 
-    private fun matches(url: String): Boolean {
+    private fun matches(url: String?): Boolean {
+        if (url == null) return false
         return trackingParametersRepository.exceptions.any { UriString.sameOrSubdomain(url, it.domain) }
     }
 
-    override fun cleanTrackingParameters(url: String): String? {
+    override fun cleanTrackingParameters(initiatingUrl: String?, url: String): String? {
         if (!featureToggle.isFeatureEnabled(PrivacyFeatureName.TrackingParametersFeatureName)) return null
-        if (isAnException(url)) return null
+        if (isAnException(initiatingUrl, url)) return null
 
         val trackingParameters = trackingParametersRepository.parameters
 

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParameterReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParameterReferenceTest.kt
@@ -74,7 +74,7 @@ class TrackingParameterReferenceTest(private val testCase: TestCase) {
 
     @Test
     fun whenReferenceTestRunsItReturnsTheExpectedResult() {
-        val cleanedUrl = testee.cleanTrackingParameters(testCase.testURL)
+        val cleanedUrl = testee.cleanTrackingParameters(initiatingUrl = testCase.initiatorURL, url = testCase.testURL)
         if (cleanedUrl != null) {
             assertEquals(testCase.expectURL, cleanedUrl)
         } else {
@@ -94,7 +94,7 @@ class TrackingParameterReferenceTest(private val testCase: TestCase) {
         jsonObject.keys().forEach { key ->
             val trackingParametersFeature: TrackingParametersFeature? = jsonAdapter.fromJson(jsonObject.get(key).toString())
             exceptions.addAll(trackingParametersFeature!!.exceptions)
-            trackingParameters.addAll(trackingParametersFeature.settings.parameters.map { it.toRegex(RegexOption.IGNORE_CASE) })
+            trackingParameters.addAll(trackingParametersFeature.settings.parameters.map { it.toRegex() })
         }
         whenever(mockRepository.exceptions).thenReturn(exceptions)
         whenever(mockRepository.parameters).thenReturn(trackingParameters)
@@ -103,6 +103,7 @@ class TrackingParameterReferenceTest(private val testCase: TestCase) {
     data class TestCase(
         val name: String,
         val testURL: String,
+        val initiatorURL: String,
         val expectURL: String,
         val exceptPlatforms: List<String>
     )

--- a/privacy-config/privacy-config-impl/src/test/resources/reference_tests/trackingparameters/tracking_parameters_matching_tests.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/reference_tests/trackingparameters/tracking_parameters_matching_tests.json
@@ -1,55 +1,124 @@
 {
     "trackingParameters": {
-        "name": "Tracking parameters are able to be removed from a URL",
+        "name": "Tracking parameters protection",
         "desc": "Those tests use config_reference.json",
         "referenceConfig": "config_reference.json",
         "tests": [
             {
-                "name": "Remove utm tracking parameters from URL",
-                "testURL": "http://www.example.com/test.html?utm_source=test&utm_medium=test&utm_campaign=test&utm_term=test&utm_content=test",
-                "expectURL": "http://www.example.com/test.html",
-                "exceptPlatforms": []
-            },
-            {
-                "name": "Remove fbclid parameter and retain other parameters",
-                "testURL": "http://www.example.com/test.html?fbclid=test&q=test&id=5",
-                "expectURL": "http://www.example.com/test.html?q=test&id=5",
-                "exceptPlatforms": []
-            },
-            {
-                "name": "Retain all non tracking parameters",
+                "name": "Non-tracking parameters are not removed",
                 "testURL": "http://www.example.com/test.html?q=test&id=5",
                 "expectURL": "http://www.example.com/test.html?q=test&id=5",
                 "exceptPlatforms": []
             },
             {
-                "name": "Don't remove parameters because domain is in exceptions list",
-                "testURL": "http://example2.com/test.html?gclid=test&fbclid=test",
-                "expectURL": "http://example2.com/test.html?gclid=test&fbclid=test",
+                "name": "Parameters with values that match tracking parameter names are not removed",
+                "testURL": "http://www.example.com/test.html?a=utm_test&b=regexp&c=gclid&d=fbclid",
+                "expectURL": "http://www.example.com/test.html?a=utm_test&b=regexp&c=gclid&d=fbclid",
                 "exceptPlatforms": []
             },
             {
-                "name": "Remove 2 tracking parameters and retain other parameters",
-                "testURL": "http://www.example.com/test.html?utm_source=test&utm_medium=test&q=test&id=5",
+                "name": "Plain-text tracking paramters are removed",
+                "testURL": "http://example.com/?a=123&gclid=test&fbclid=value&b=456",
+                "expectURL": "http://example.com/?a=123&b=456",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "When plain-text tracking parameters are removed, other parameters are preserved",
+                "testURL": "http://www.example.com/test.html?fbclid=test&q=test&id=5",
                 "expectURL": "http://www.example.com/test.html?q=test&id=5",
                 "exceptPlatforms": []
             },
             {
-                "name": "Param is in URL path",
-                "testURL": "http://gclid.example.com/fbclid=123",
-                "expectURL": "http://gclid.example.com/fbclid=123",
+                "name": "Parameters similar to plain-text tracking parameters are not removed",
+                "testURL": "http://www.example.com/test.html?fbclid1=test",
+                "expectURL": "http://www.example.com/test.html?fbclid1=test",
                 "exceptPlatforms": []
             },
             {
-                "name": "Param has no value",
-                "testURL": "http://www.example.com/test.html?fbclid&gclid",
+                "name": "Parameters case insensitively matching plain-text tracking parameters are not removed",
+                "testURL": "http://www.example.com/test.html?FBCLID=test",
+                "expectURL": "http://www.example.com/test.html?FBCLID=test",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Tracking parameters that match a regular expression are removed",
+                "testURL": "http://www.example.com/test.html?utm_source=test&utm_medium=test&utm_campaign=test&utm_term=test&utm_content=test",
                 "expectURL": "http://www.example.com/test.html",
                 "exceptPlatforms": []
             },
             {
-                "name": "Param ALMOST matches",
-                "testURL": "http://www.example.com/test.html?fbclid1=test",
-                "expectURL": "http://www.example.com/test.html?fbclid1=test",
+                "name": "Tracking parameters that only case-insensitively match a regular expressions are not removed",
+                "testURL": "http://www.example.com/test.html?utm_NOPE=test",
+                "expectURL": "http://www.example.com/test.html?utm_NOPE=test",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Tracking parameters only literally matching regular expression are not removed",
+                "testURL": "http://www.example.com/test.html?reg*exp=test&regexp=test",
+                "expectURL": "http://www.example.com/test.html?reg*exp=test",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Duplicate plain-text tracking parameters are removed",
+                "testURL": "http://www.example.com/test.html?gclid=123&gclid=456&test=test&gclid=789",
+                "expectURL": "http://www.example.com/test.html?test=test",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Duplicate non-tracking parameters are not removed",
+                "testURL": "http://www.example.com/test.html?test=123&test=456&utm_source=test&test=789",
+                "expectURL": "http://www.example.com/test.html?test=123&test=456&test=789",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Remaining parameter order is preserved after tracking parameters are removed",
+                "testURL": "http://www.example.com/test.html?ZEBRA=zzz&zebra=ZZZ&utm_source=test&alpca=BBB&alpca=bbb",
+                "expectURL": "http://www.example.com/test.html?ZEBRA=zzz&zebra=ZZZ&alpca=BBB&alpca=bbb",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Tracking parameters are not removed when request domain is in exceptions list",
+                "testURL": "http://allowlisted.com/test.html?gclid=test&fbclid=test",
+                "expectURL": "http://allowlisted.com/test.html?gclid=test&fbclid=test",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Tracking parameters are not removed when request domain is subdomain of domain in exceptions list",
+                "testURL": "http://subdomain.allowlisted.com/test.html?gclid=test&fbclid=test",
+                "expectURL": "http://subdomain.allowlisted.com/test.html?gclid=test&fbclid=test",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Tracking parameters are removed when request + initiator domain are not in exceptions list",
+                "testURL": "http://example.com/test.html?gclid=test&fbclid=test",
+                "initiatorURL": "http://example.com/",
+                "expectURL": "http://example.com/test.html",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Tracking parameters are not removed when the initiator domain is in exceptions list",
+                "testURL": "http://example.com/test.html?gclid=test&fbclid=test",
+                "initiatorURL": "http://allowlisted.com/",
+                "expectURL": "http://example.com/test.html?gclid=test&fbclid=test",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Tracking parameters are not removed when initiator domain is subdomain of domain in exceptions list",
+                "testURL": "http://example.com/test.html?gclid=test&fbclid=test",
+                "initiatorURL": "http://subdomain.allowlisted.com/",
+                "expectURL": "http://example.com/test.html?gclid=test&fbclid=test",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Tracking parameters are removed even if other parts of the URL match a tracking parameter name",
+                "testURL": "http://gclid.example.com/gclid/gclid?a=123&gclid=456",
+                "expectURL": "http://gclid.example.com/gclid/gclid?a=123",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Tracking parameters are removed correctly even when some parameters have no value",
+                "testURL": "http://www.example.com/test.html?a=123&fbclid&gclid&regexp&utm_tracker&b=456",
+                "expectURL": "http://www.example.com/test.html?a=123&b=456",
                 "exceptPlatforms": []
             }
         ]

--- a/privacy-config/privacy-config-impl/src/test/resources/reference_tests/trackingparameters/tracking_parameters_reference.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/reference_tests/trackingparameters/tracking_parameters_reference.json
@@ -3,33 +3,16 @@
         "state": "enabled",
         "exceptions": [
             {
-                "domain": "example2.com",
+                "domain": "allowlisted.com",
                 "reason": "site breakage"
             }
         ],
         "settings": {
             "parameters": [
-                "utm_[a-zA-Z]*",
+                "utm_[a-z]+",
+                "reg*exp",
                 "gclid",
-                "fbclid",
-                "fb_action_ids",
-                "fb_action_types",
-                "fb_source",
-                "fb_ref",
-                "ga_source",
-                "ga_medium",
-                "ga_term",
-                "ga_content",
-                "ga_campaign",
-                "ga_place",
-                "action_object_map",
-                "action_type_map",
-                "action_ref_map",
-                "gs_l",
-                "mkt_tok",
-                "hmb_campaign",
-                "hmb_source",
-                "hmb_medium"
+                "fbclid"
             ]
         }
     }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackingparameters/TrackingParametersRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackingparameters/TrackingParametersRepository.kt
@@ -62,7 +62,7 @@ class RealTrackingParametersRepository(
 
         parameters.clear()
         trackingParametersDao.getAllTrackingParameters().map {
-            parameters.add(it.parameter.toRegex(RegexOption.IGNORE_CASE))
+            parameters.add(it.parameter.toRegex())
         }
     }
 }

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackingparameters/RealTrackingParametersRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackingparameters/RealTrackingParametersRepositoryTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.privacy.config.store.features.trackingparameters
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.privacy.config.store.*
 import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -30,6 +31,7 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@ExperimentalCoroutinesApi
 class RealTrackingParametersRepositoryTest {
 
     @get:Rule


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202431148390057/f

### Description
This PR adds updated tracking parameter removal reference tests and associated code changes.

Changes:
- Parameter removal is now case-sensitive.
- Values are no longer decoded when rebuilding the URI.
- An initiator URL is now passed from the `BrowserWebViewClient`. This is used for exception checking.

### Steps to test this PR

- [x] Privacy reference tests should pass.
- [x] Go to http://privacy-test-pages.glitch.me/privacy-protections/query-parameters/.
- [x] Verify that the links provide the expected result.
- [x] General browsing sanity check.
