### PR TITLE
Override Glide UA

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
@@ -45,11 +45,8 @@ class GlobalGlideModule : AppGlideModule() {
             .addInterceptor { chain: Interceptor.Chain ->
                 val request = chain.request()
 
-                val defaultUserAgent = getDefaultUserAgent(context)
-                Timber.d("Use default UA for Glide requests - $defaultUserAgent")
-
                 return@addInterceptor request.newBuilder()
-                    .header("User-Agent", defaultUserAgent)
+                    .header("User-Agent", getDefaultUserAgent(context))
                     .build().run {
                         chain.proceed(this)
                     }

--- a/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
@@ -24,9 +24,9 @@ import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.module.AppGlideModule
+import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.browser.certificates.rootstore.IsrgRootX1
 import com.duckduckgo.app.browser.certificates.rootstore.IsrgRootX2
-import com.duckduckgo.app.browser.useragent.DefaultUserAgentModule
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.tls.HandshakeCertificates
@@ -46,7 +46,7 @@ class GlobalGlideModule : AppGlideModule() {
                 val request = chain.request()
 
                 return@addInterceptor request.newBuilder()
-                    .header("User-Agent", getDefaultUserAgent(context))
+                    .header("User-Agent", getGlideUserAgent(context))
                     .build().run {
                         chain.proceed(this)
                     }
@@ -89,8 +89,8 @@ class GlobalGlideModule : AppGlideModule() {
         )
     }
 
-    private fun getDefaultUserAgent(context: Context): String {
-        // This is not great, but Glide Module can't be placed inside DI :|
-        return DefaultUserAgentModule().provideDefaultUserAgent(context)
+    private fun getGlideUserAgent(context: Context): String {
+        return "DuckDuckGo/${BuildConfig.VERSION_NAME.split(".").first()} " +
+            "(${context.applicationInfo.packageName}; Android API ${Build.VERSION.SDK_INT})"
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202472465643896/f

### Description
Override UA for Glide requests and use our default UA.

### Steps to test this PR

_Repro bug_
- [ ] Install from develop
- [ ] (ensure AppTP is disabled)
- [ ] open app
- [ ] Add example.com as bookmark
- [ ] Go to settings -> bookmearks
- [ ] Verify call `GET https://example.com/apple-touch-icon.png` DOES NOT have our default UA
- [ ] Verify call `GET https://example.com/favicon.png` DOES NOT have our default UA

_Test Fix
- [ ] Install from this branch
- [ ] (ensure AppTP is disabled)
- [ ] open app
- [ ] Add example.com as bookmark
- [ ] Go to settings -> bookmearks
- [ ] Verify call `GET https://example.com/apple-touch-icon.png` contains our default UA
- [ ] Verify call `GET https://example.com/favicon.png` contains our default UA

