### PR TITLE
Remove usage of deprecated @OnLifecycleEvent on ServiceWorkerLifecycl…

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/serviceworker/ServiceWorkerLifecycleObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/serviceworker/ServiceWorkerLifecycleObserver.kt
@@ -18,9 +18,8 @@ package com.duckduckgo.app.browser.serviceworker
 
 import android.os.Build
 import android.webkit.ServiceWorkerController
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.browser.RequestInterceptor
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
 import com.duckduckgo.di.scopes.AppScope
@@ -32,10 +31,10 @@ import dagger.SingleInstanceIn
 class ServiceWorkerLifecycleObserver @Inject constructor(
     private val requestInterceptor: RequestInterceptor,
     private val uncaughtExceptionRepository: UncaughtExceptionRepository
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun setServiceWorkerClient() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             try {
                 ServiceWorkerController.getInstance().setServiceWorkerClient(


### PR DESCRIPTION
…eObserver

<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202478932608390/f

### Description
This just migrates away from usage of the deprecated @OnLifecycleEvent on ServiceWorkerLifecycleObserver. 

### Steps to test this PR

_Feature 1_
- [x] Sanity check app
- [x] Check that "com.duckduckgo.mobile.android.debug V/BrowserServiceWorkerClient$shouldInterceptRequest: Intercepting Service Worker resource" is logged in logcat when opening resources like videos on twitch
