### PR TITLE
Thread Safety for Selector Operations

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
@@ -60,7 +60,6 @@ import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.channels.CancelledKeyException
 import java.nio.channels.SelectionKey
-import java.nio.channels.SelectionKey.OP_READ
 import java.nio.channels.SelectionKey.OP_WRITE
 import java.nio.channels.Selector
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
@@ -247,9 +247,11 @@ class TcpDeviceToNetwork(
                     }
                 }
                 WaitToConnect -> {
-                    Timber.v("Not finished connecting yet to %s, will register for OP_CONNECT event", tcb.selectionKey)
+                    Timber.v("Not finished connecting yet to %s, will register for OP_CONNECT event", tcb.ipAndPort)
+                    synchronized(queues.selectorQueue) {
+                        queues.selectorQueue.offerLast(TcpSelectorOp(SelectionKey.OP_CONNECT, tcb))
+                    }
                     selector.wakeup()
-                    tcb.selectionKey = channel.register(selector, SelectionKey.OP_CONNECT, tcb)
                 }
                 else -> Timber.w("Unexpected action: %s", it)
             }
@@ -312,13 +314,6 @@ class TcpDeviceToNetwork(
                 return
             }
 
-            if (!tcb.waitingForNetworkData) {
-                Timber.v("Register for OP_READ and wait for network data. %s.", tcb.ipAndPort)
-                selector.wakeup()
-                tcb.selectionKey.interestOps(OP_READ)
-                tcb.waitingForNetworkData = true
-            }
-
             try {
                 val seqNumber = packet.tcpHeader.acknowledgementNumber
                 var ackNumber = increaseOrWraparound(packet.tcpHeader.sequenceNumber, payloadSize.toLong())
@@ -327,11 +322,13 @@ class TcpDeviceToNetwork(
                 }
                 tcb.acknowledgementNumberToClient = ackNumber
 
-                selector.wakeup()
-                tcb.channel.register(selector, OP_WRITE, tcb)
-
                 val writeData = PendingWriteData(payloadBuffer, tcb.channel, payloadSize, tcb, connectionParams, ackNumber, seqNumber)
                 socketWriter.addToWriteQueue(writeData, false)
+
+                synchronized(queues.selectorQueue) {
+                    queues.selectorQueue.offerLast(TcpSelectorOp(OP_WRITE, tcb))
+                }
+                selector.wakeup()
             } catch (e: IOException) {
                 val bytesUnwritten = payloadBuffer.remaining()
                 val bytesWritten = payloadSize - bytesUnwritten

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpPacketProcessor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpPacketProcessor.kt
@@ -231,7 +231,6 @@ constructor(
             queues.networkToDevice.offerFirst(buffer)
 
             try {
-                selectionKey.cancel()
                 channel.close()
             } catch (e: Exception) {
                 Timber.w(e, "Problem closing socket connection for %s", ipAndPort)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnQueues.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnQueues.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.mobile.android.vpn.service
 
 import android.os.SystemClock
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.processor.tcp.TcpSelectorOp
 import com.squareup.anvil.annotations.ContributesBinding
 import xyz.hexene.localvpn.Packet
 import java.nio.ByteBuffer
@@ -27,6 +28,7 @@ import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import dagger.SingleInstanceIn
+import java.util.*
 import kotlin.math.min
 
 interface VpnQueuesTimeLogger {
@@ -55,6 +57,8 @@ class VpnQueues @Inject constructor() : VpnQueuesTimeLogger {
     val udpDeviceToNetwork: BlockingQueue<Packet> = LoggingLinkedBlockingDeque()
 
     val networkToDevice: BlockingDeque<ByteBuffer> = LoggingLinkedBlockingDeque()
+
+    val selectorQueue: LinkedList<TcpSelectorOp> = LinkedList<TcpSelectorOp>()
 
     override fun millisSinceLastDeviceToNetworkWrite(): Long {
         return min(

--- a/vpn/src/main/java/xyz/hexene/localvpn/TCB.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/TCB.java
@@ -70,7 +70,6 @@ public class TCB {
 
     public final SocketChannel channel;
     public boolean waitingForNetworkData;
-    public SelectionKey selectionKey;
 
     private static final int MAX_CACHE_SIZE = 500; // XXX: Is this ideal?
     public static final LRUCache<String, TCB> tcbCache =

--- a/vpn/src/main/java/xyz/hexene/localvpn/TCB.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/TCB.java
@@ -19,7 +19,6 @@ package xyz.hexene.localvpn;
 import androidx.annotation.Nullable;
 import com.duckduckgo.mobile.android.vpn.processor.tcp.TcbState;
 import java.io.IOException;
-import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Iterator;
 import java.util.Map;


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202279501986195/1202454731900853/f

### Description
**Background**: We were changing channel keys' interest sets in two threads (`TcpNetworkToDevice` and `TcpDeviceToNetwork`), which is unsafe [[1]](http://rox-xmlrpc.sourceforge.net/niotut/) [[2]](https://stackoverflow.com/a/12824411). To get around the problem, we were using `sleep(10)` in between `select` operations. Without the `sleep`, a deadlock occurs between the two threads (where one is stuck on `register` and the other on `select`), indicating a thread-safety issue. There is a related discussion [here](https://stackoverflow.com/a/3191377) on the dangers of using `sleep` to make Selectors behave.

**This PR**: Fixes how we use the Selector by making sure all Selector-related operations are done on a single thread - `TcpDeviceToNetwork`. This eliminates the need to `sleep` in between `select` operations, thereby improving performance.

### Steps to test this PR
- [x] install from this branch
- [x] smoke tests on AppTP
 - open apps that have trackers and verify it blocks
 - perform speed tests and verify the download/upload perf is similar or better than develop. Ping should be much faster (in my testing it went from ~24ms to ~9ms).
 - downloads and uploads work as in develop