### PR TITLE
Disable save prompt when autofill toggle disabled

### DIFF
--- a/modules/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/jsbridge/response/AutofillResponseWriter.kt
+++ b/modules/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/jsbridge/response/AutofillResponseWriter.kt
@@ -100,7 +100,7 @@ class AutofillJsonResponseWriter @Inject constructor(val moshi: Moshi) : Autofil
                       "inputType_creditCards": false,
                       "emailProtection": true,
                       "password_generation": false,
-                      "credentials_saving": true,
+                      "credentials_saving": $autofillCredentials,
                       "inlineIcon_credentials": $showInlineKeyIcon
                     }
                   }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202520205565765/f

### Description
Ensure we don't offer to save credentials when autofill global toggle disabled

### Steps to test this PR

#### Test change
- [ ] **Disable** autofill global toggle from settings
- [ ] Attempt a login that normally triggers a save (e.g., trello.com/login)
- [ ] Verify save prompt **is not shown**


#### Ensure no regression
- [ ] **Enable** autofill global toggle from settings
- [ ] Attempt a login that normally triggers a save (e.g., trello.com/login)
- [ ] Verify save prompt **is shown**