### PR TITLE
use buildflavor to determine internal test user

### DIFF
--- a/modules/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/internal/RealInternalTestUserChecker.kt
+++ b/modules/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/internal/RealInternalTestUserChecker.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.autofill.internal
 
 import androidx.core.net.toUri
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.autofill.InternalTestUserChecker
 import com.duckduckgo.autofill.store.InternalTestUserStore
 import com.duckduckgo.di.scopes.AppScope
@@ -32,13 +34,14 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class RealInternalTestUserChecker @Inject constructor(
-    private val internalTestUserStore: InternalTestUserStore
+    private val internalTestUserStore: InternalTestUserStore,
+    private val appBuildConfig: AppBuildConfig
 ) : InternalTestUserChecker {
 
     private var verificationErrorDetected = false
 
     override val isInternalTestUser: Boolean
-        get() = internalTestUserStore.isVerifiedInternalTestUser
+        get() = appBuildConfig.isInternalBuild() || internalTestUserStore.isVerifiedInternalTestUser
 
     override fun verifyVerificationErrorReceived(url: String) {
         /**

--- a/modules/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/internal/RealInternalTestUserCheckerTest.kt
+++ b/modules/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/internal/RealInternalTestUserCheckerTest.kt
@@ -16,23 +16,34 @@
 
 package com.duckduckgo.autofill.internal
 
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.BuildFlavor.INTERNAL
+import com.duckduckgo.appbuildconfig.api.BuildFlavor.PLAY
 import com.duckduckgo.autofill.store.InternalTestUserStore
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class RealInternalTestUserCheckerTest {
+    @Mock
+    private lateinit var appBuildConfig: AppBuildConfig
     private lateinit var internalTestUserStore: InternalTestUserStore
     private lateinit var testee: RealInternalTestUserChecker
 
     @Before
     fun setUp() {
+        MockitoAnnotations.openMocks(this)
         internalTestUserStore = FakeInternalTestUserStore()
-        testee = RealInternalTestUserChecker(internalTestUserStore)
+        testee = RealInternalTestUserChecker(internalTestUserStore, appBuildConfig)
+
+        whenever(appBuildConfig.flavor).thenReturn(PLAY)
     }
 
     @Test
@@ -76,6 +87,23 @@ class RealInternalTestUserCheckerTest {
     @Test
     fun whenCompletedForValidButHttpUrlThenisInternalTestUser() {
         testee.verifyVerificationCompleted(VALID_TEST_HTTP_URL)
+
+        assertTrue(testee.isInternalTestUser)
+    }
+
+    @Test
+    fun whenUserBuildIsInternalNoValidationThenIsInternalTestUser() {
+        whenever(appBuildConfig.flavor).thenReturn(INTERNAL)
+
+        assertTrue(testee.isInternalTestUser)
+    }
+
+    @Test
+    fun whenUserBuildIsInternalAndErrorReceivedWhenValidatingThenIsInternalTestUser() {
+        whenever(appBuildConfig.flavor).thenReturn(INTERNAL)
+
+        testee.verifyVerificationErrorReceived(VALID_TEST_HTTPS_URL)
+        testee.verifyVerificationCompleted(VALID_TEST_HTTPS_URL)
 
         assertTrue(testee.isInternalTestUser)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202494823153095/f

### Description
This PR includes automatically making the user an internal test user when using an internal build.

### Steps to test this PR

_Internal build_
- [x] Use internal build
- [x] Verify that autofill is still available

_Internal build, failed verifications_
- [x] Use internal build
- [x] Open use-login.duckduckgo.com/patestsucceeded (without going through verifcation) this should show the error page.
- [x] Verify that autofill is still available

_Other builds_
- [x] Use any build that is not internal
- [x] Autofill should NOT be available.
- [x] Go through verification in use-login.duckduckgo.com
- [x] Verify that autofill is still available
