### PR TITLE
Replace context.resources.getDrawable with ResourcesCompat.getDrawable

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
@@ -26,6 +26,7 @@ import android.content.IntentFilter
 import android.graphics.drawable.Drawable
 import android.view.ContextThemeWrapper
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.res.ResourcesCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.ui.Theming.Constants.BROADCAST_THEME_CHANGED
@@ -43,10 +44,10 @@ object Theming {
         context: Context,
         drawableId: Int,
         theme: DuckDuckGoTheme
-    ): Drawable {
+    ): Drawable? {
         val themeId: Int = THEME_MAP[Pair(R.style.AppTheme, theme)] ?: R.style.AppTheme_Light
-        return context.resources.getDrawable(
-            drawableId, ContextThemeWrapper(context, themeId).theme
+        return ResourcesCompat.getDrawable(
+            context.resources, drawableId, ContextThemeWrapper(context, themeId).theme
         )
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1202360890245126/f

### Description
Use `ResourcesCompat.getDrawable` instead of `context.resources.getDrawable` when getting `getThemedDrawable()`.

### Steps to test this PR

- [ ] Go to a site with trackers.
- [ ] Visit the privacy dashboard and click the "Trackers Blocked" item.
- [ ] Verify that the company icons are shown correctly.