### PR TITLE
Increase Upload Speeds

### DIFF
--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/TcpDeviceToNetwork.kt
@@ -288,7 +288,7 @@ class TcpDeviceToNetwork(
             val isLocalAddress = determineIfLocalIpAddress(packet)
             val requestingApp = determineRequestingApp(tcb, packet)
             val hostName = determineHostName(tcb, packet, payloadBuffer)
-            val requestType = determineIfTracker(tcb, packet, requestingApp, payloadBuffer, isLocalAddress)
+            val requestType = determineIfTracker(tcb, packet, requestingApp, payloadBuffer, isLocalAddress, hostName)
             val isATrackerRetryRequest = isARetryForRecentlyBlockedTracker(requestingApp, hostName, payloadSize)
             Timber.v(
                 "App %s attempting to send %d bytes to (%s). %s host=%s, localAddress=%s, retry=%s",
@@ -385,7 +385,8 @@ class TcpDeviceToNetwork(
         packet: Packet,
         requestingApp: OriginatingApp,
         payloadBuffer: ByteBuffer,
-        isLocalAddress: Boolean
+        isLocalAddress: Boolean,
+        hostName: String?
     ): RequestTrackerType {
         Timber.v("Determining if a tracker. Already determined? %s", tcb.trackerTypeDetermined)
         if (tcb.trackerTypeDetermined) {
@@ -394,7 +395,7 @@ class TcpDeviceToNetwork(
             )
         }
 
-        return trackerDetector.determinePacketType(tcb, packet, payloadBuffer, isLocalAddress, requestingApp)
+        return trackerDetector.determinePacketType(tcb, packet, payloadBuffer, isLocalAddress, requestingApp, hostName)
     }
 
     private fun determineIfLocalIpAddress(packet: Packet): Boolean {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/ByteArrayExtension.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/ByteArrayExtension.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.processor.tcp.hostname
+
+/**
+ * Searches for the provided sequence
+ * @param sequence to search for
+ * @param offset to start the search from
+ * @returns the index of this ByteArray after the sequence, or -1 if the sequence is empty or it was not found
+ */
+fun ByteArray.indexOf(sequence: ByteArray, offset: Int = 0): Int {
+    // sanity check
+    if (sequence.isEmpty() || offset >= this.size) {
+        return -1
+    }
+
+    var matchIdx = 0
+    for (i in offset until this.size) {
+        if (this[i] == sequence[matchIdx]) {
+            matchIdx++
+            if (matchIdx == sequence.size)
+                return i + 1
+        } else {
+            matchIdx = 0
+        }
+    }
+    return -1
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameExtractor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameExtractor.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.mobile.android.vpn.processor.tcp.hostname
 
 import timber.log.Timber
 import xyz.hexene.localvpn.TCB
-import java.nio.charset.StandardCharsets
 
 interface HostnameExtractor {
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameExtractor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameExtractor.kt
@@ -54,7 +54,7 @@ class AndroidHostnameExtractor(
             return
         }
 
-        host = hostnameHeaderExtractor.extract(String(payloadBytes, StandardCharsets.US_ASCII))
+        host = hostnameHeaderExtractor.extract(payloadBytes)
         if (host != null) {
             Timber.v("Found domain from plaintext headers: %s", host)
             tcb.hostName = host

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameExtractor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameExtractor.kt
@@ -47,16 +47,16 @@ class AndroidHostnameExtractor(
         tcb: TCB,
         payloadBytes: ByteArray
     ) {
-        var host = hostnameHeaderExtractor.extract(String(payloadBytes, StandardCharsets.US_ASCII))
+        var host = encryptedRequestHostExtractor.extract(payloadBytes)
         if (host != null) {
-            Timber.v("Found domain from plaintext headers: %s", host)
+            Timber.v("Found domain from encrypted headers: %s", host)
             tcb.hostName = host
             return
         }
 
-        host = encryptedRequestHostExtractor.extract(payloadBytes)
+        host = hostnameHeaderExtractor.extract(String(payloadBytes, StandardCharsets.US_ASCII))
         if (host != null) {
-            Timber.v("Found domain from encrypted headers: %s", host)
+            Timber.v("Found domain from plaintext headers: %s", host)
             tcb.hostName = host
             return
         }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameHeaderExtractor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameHeaderExtractor.kt
@@ -24,20 +24,17 @@ interface HostnameHeaderExtractor {
 class PlaintextHostHeaderExtractor : HostnameHeaderExtractor {
 
     override fun extract(payload: String): String? {
+        var hostIdx = payload.indexOf(HOST_HEADER_PREFIX)
+        if (hostIdx >= 0) {
+            hostIdx += HOST_HEADER_PREFIX.length
 
-        payload.split(NEWLINE_REGEX)
-            .map { it.trim() }
-            .forEach { line ->
-                if (line.startsWith(HOST_HEADER_PREFIX)) {
-                    return line.substring(HOST_HEADER_PREFIX.length)
-                }
-            }
+            return payload.substring(hostIdx, payload.indexOf("\r\n", hostIdx))
+        }
 
         return null
     }
 
     companion object {
-        private const val HOST_HEADER_PREFIX = "Host: "
-        private val NEWLINE_REGEX: Regex = "\\n".toRegex()
+        private const val HOST_HEADER_PREFIX = "\nHost: "
     }
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameHeaderExtractor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/HostnameHeaderExtractor.kt
@@ -16,25 +16,32 @@
 
 package com.duckduckgo.mobile.android.vpn.processor.tcp.hostname
 
+import java.nio.charset.StandardCharsets
+
 interface HostnameHeaderExtractor {
 
-    fun extract(payload: String): String?
+    fun extract(payload: ByteArray): String?
 }
 
 class PlaintextHostHeaderExtractor : HostnameHeaderExtractor {
 
-    override fun extract(payload: String): String? {
-        var hostIdx = payload.indexOf(HOST_HEADER_PREFIX)
+    override fun extract(payload: ByteArray): String? {
+        val hostIdx = payload.indexOf(HOST_HEADER_PREFIX)
         if (hostIdx >= 0) {
-            hostIdx += HOST_HEADER_PREFIX.length
-
-            return payload.substring(hostIdx, payload.indexOf("\r\n", hostIdx))
+            val hostEndIdx = payload.indexOf(CARRIAGE_RETURN, hostIdx)
+            if (hostEndIdx > hostIdx) {
+                val hostLen = hostEndIdx - hostIdx - CARRIAGE_RETURN.size
+                val hostname = String(payload, hostIdx, hostLen, StandardCharsets.US_ASCII)
+                if (hostname.isNotEmpty())
+                    return hostname
+            }
         }
 
         return null
     }
 
     companion object {
-        private const val HOST_HEADER_PREFIX = "\nHost: "
+        private val HOST_HEADER_PREFIX = "\nHost: ".toByteArray(StandardCharsets.US_ASCII)
+        private val CARRIAGE_RETURN = "\r\n".toByteArray(StandardCharsets.US_ASCII)
     }
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/VpnTrackerDetector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/VpnTrackerDetector.kt
@@ -73,7 +73,6 @@ class DomainBasedTrackerDetector(
             return RequestTrackerType.NotTracker(packet.ipHeader.destinationAddress.hostName)
         }
 
-        val payloadBytes = payloadBytesExtractor.extract(packet, payloadBuffer)
         if (hostname == null) {
             Timber.w("Failed to determine if packet is a tracker as hostname not extracted %s", tcb.ipAndPort)
             return RequestTrackerType.Undetermined
@@ -107,6 +106,7 @@ class DomainBasedTrackerDetector(
                 } else {
                     tcb.trackerHostName = trackerHostname
 
+                    val payloadBytes = payloadBytesExtractor.extract(packet, payloadBuffer)
                     when (tlsContentTypeExtractor.isTlsApplicationData(payloadBytes)) {
                         Undetermined -> {
                             Timber.v("Unable to determine TLS content type, fallback to blocking as if it were application data %s", tcb.ipAndPort)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/VpnTrackerDetector.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/processor/tcp/tracker/VpnTrackerDetector.kt
@@ -41,7 +41,8 @@ interface VpnTrackerDetector {
         packet: Packet,
         payloadBuffer: ByteBuffer,
         isLocalAddress: Boolean,
-        requestingApp: OriginatingApp
+        requestingApp: OriginatingApp,
+        hostname: String?
     ): RequestTrackerType
 }
 
@@ -60,7 +61,8 @@ class DomainBasedTrackerDetector(
         packet: Packet,
         payloadBuffer: ByteBuffer,
         isLocalAddress: Boolean,
-        requestingApp: OriginatingApp
+        requestingApp: OriginatingApp,
+        hostname: String?
     ): RequestTrackerType {
 
         if (isLocalAddress) {
@@ -72,7 +74,6 @@ class DomainBasedTrackerDetector(
         }
 
         val payloadBytes = payloadBytesExtractor.extract(packet, payloadBuffer)
-        val hostname = hostnameExtractor.extract(tcb, payloadBytes)
         if (hostname == null) {
             Timber.w("Failed to determine if packet is a tracker as hostname not extracted %s", tcb.ipAndPort)
             return RequestTrackerType.Undetermined

--- a/vpn/src/main/java/xyz/hexene/localvpn/TCB.java
+++ b/vpn/src/main/java/xyz/hexene/localvpn/TCB.java
@@ -69,7 +69,6 @@ public class TCB {
     public final Packet referencePacket;
 
     public final SocketChannel channel;
-    public boolean waitingForNetworkData;
 
     private static final int MAX_CACHE_SIZE = 500; // XXX: Is this ideal?
     private static final LRUCache<String, TCB> tcbCache =

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/ByteArrayExtensionTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/ByteArrayExtensionTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.processor.tcp.hostname
+
+import org.junit.Assert
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+class ByteArrayExtensionTest {
+    private val testee = "test_string".toByteArray(StandardCharsets.US_ASCII)
+    private val testeeSize = testee.size
+
+    @Test
+    fun whenEmptySequenceReturnNegative() {
+        Assert.assertEquals(-1, testee.indexOf("".toByteArray(StandardCharsets.US_ASCII)))
+    }
+
+    @Test
+    fun whenOffsetTooLargeReturnNegative() {
+        Assert.assertEquals(-1, testee.indexOf("test".toByteArray(StandardCharsets.US_ASCII), testeeSize))
+    }
+
+    @Test
+    fun whenSequenceFoundReturnIdx() {
+        Assert.assertEquals(4, testee.indexOf("test".toByteArray(StandardCharsets.US_ASCII)))
+    }
+
+    @Test
+    fun whenSequenceNotFoundReturnNegative() {
+        Assert.assertEquals(-1, testee.indexOf("tests".toByteArray(StandardCharsets.US_ASCII)))
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/PlaintextHostExtractorTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/PlaintextHostExtractorTest.kt
@@ -31,57 +31,67 @@ class PlaintextHostExtractorTest {
 
     @Test
     fun whenHostAvailableThenHostExtractedSuccessfully() {
-        val requestHostAvailable = prepareTestByteArray("""
+        val requestHostAvailable = prepareTestByteArray(
+            """
             GET / HTTP/1.1
             Host: example.com
             Connection: Keep-Alive
             Accept-Encoding: gzip
             User-Agent: okhttp/4.3.1
-        """)
+        """
+        )
         assertEquals("example.com", testee.extract(requestHostAvailable))
     }
 
     @Test
     fun whenHostAvailableInUnexpectedOrderThenHostExtractedSuccessfully() {
-        val requestHostAvailableOutOfOrder = prepareTestByteArray("""
+        val requestHostAvailableOutOfOrder = prepareTestByteArray(
+            """
             GET / HTTP/1.1
             Connection: Keep-Alive
             Accept-Encoding: gzip
             Host: example.com
             User-Agent: okhttp/4.3.1
-        """)
+        """
+        )
         assertEquals("example.com", testee.extract(requestHostAvailableOutOfOrder))
     }
 
     @Test
     fun whenHostMissingThenNulReturned() {
-        val requestHostMissing = prepareTestByteArray("""
+        val requestHostMissing = prepareTestByteArray(
+            """
             GET / HTTP/1.1
             Connection: Keep-Alive
             Accept-Encoding: gzip
             User-Agent: okhttp/4.3.1
-        """)
+        """
+        )
         assertNull(testee.extract(requestHostMissing))
     }
 
     @Test
     fun whenHostEmptyThenNulReturned() {
-        val requestHostEmpty = prepareTestByteArray("""
+        val requestHostEmpty = prepareTestByteArray(
+            """
             GET / HTTP/1.1
-            Host: 
+            Host:
             Connection: Keep-Alive
             Accept-Encoding: gzip
             User-Agent: okhttp/4.3.1
-        """)
+        """
+        )
         assertNull(testee.extract(requestHostEmpty))
     }
 
     @Test
     fun whenMalformedHTTPThenNulReturned() {
-        val requestMalformed = prepareTestByteArray("""
+        val requestMalformed = prepareTestByteArray(
+            """
             GET / HTTP/1.1
-            Host: 
-        """)
+            Host:
+        """
+        )
         assertNull(testee.extract(requestMalformed))
     }
 }

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/PlaintextHostExtractorTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/processor/tcp/hostname/PlaintextHostExtractorTest.kt
@@ -19,43 +19,69 @@ package com.duckduckgo.mobile.android.vpn.processor.tcp.hostname
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.nio.charset.StandardCharsets
 
 class PlaintextHostExtractorTest {
 
     private val testee = PlaintextHostHeaderExtractor()
 
+    fun prepareTestByteArray(testPayload: String): ByteArray {
+        return testPayload.trimIndent().replace("\n", "\r\n").toByteArray(StandardCharsets.US_ASCII)
+    }
+
     @Test
     fun whenHostAvailableThenHostExtractedSuccessfully() {
-        val requestHostAvailable = """
+        val requestHostAvailable = prepareTestByteArray("""
             GET / HTTP/1.1
             Host: example.com
             Connection: Keep-Alive
             Accept-Encoding: gzip
             User-Agent: okhttp/4.3.1
-        """.trimIndent()
+        """)
         assertEquals("example.com", testee.extract(requestHostAvailable))
     }
 
     @Test
     fun whenHostAvailableInUnexpectedOrderThenHostExtractedSuccessfully() {
-        val requestHostAvailableOutOfOrder = """
+        val requestHostAvailableOutOfOrder = prepareTestByteArray("""
             GET / HTTP/1.1
             Connection: Keep-Alive
             Accept-Encoding: gzip
             Host: example.com
             User-Agent: okhttp/4.3.1
-        """.trimIndent()
+        """)
         assertEquals("example.com", testee.extract(requestHostAvailableOutOfOrder))
     }
 
     @Test
     fun whenHostMissingThenNulReturned() {
-        val requestHostAvailableOutOfOrder = """
+        val requestHostMissing = prepareTestByteArray("""
             GET / HTTP/1.1
             Connection: Keep-Alive
             Accept-Encoding: gzip
             User-Agent: okhttp/4.3.1
-        """.trimIndent()
-        assertNull(testee.extract(requestHostAvailableOutOfOrder))
+        """)
+        assertNull(testee.extract(requestHostMissing))
+    }
+
+    @Test
+    fun whenHostEmptyThenNulReturned() {
+        val requestHostEmpty = prepareTestByteArray("""
+            GET / HTTP/1.1
+            Host: 
+            Connection: Keep-Alive
+            Accept-Encoding: gzip
+            User-Agent: okhttp/4.3.1
+        """)
+        assertNull(testee.extract(requestHostEmpty))
+    }
+
+    @Test
+    fun whenMalformedHTTPThenNulReturned() {
+        val requestMalformed = prepareTestByteArray("""
+            GET / HTTP/1.1
+            Host: 
+        """)
+        assertNull(testee.extract(requestMalformed))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/276630244458377/1202400910824455/f

### Description
This PR eliminates bottlenecks caused by hostname extraction. With the bottlenecks removed, our upload speeds can now reach ~300Mbps (up from ~100Mbps). Main changes were:

1. Do not extract the hostname twice
2. Avoid making copies of the payload - eliminate `ByteArray` to `String` conversion of the payload
3. Try TLS-based extraction first since most of the traffic is encrypted

### Steps to test this PR
- [x] install from this branch
- [x] smoke tests on AppTP
 - open apps that have trackers and verify it blocks
 - perform speed tests and verify the download is similar and upload is better than develop
 - downloads and uploads work as in develop