### PR TITLE
Fix dark mode bug for fireproof sites settings

### DIFF
--- a/app/src/main/res/layout/view_fireproof_website_settings_selection.xml
+++ b/app/src/main/res/layout/view_fireproof_website_settings_selection.xml
@@ -34,7 +34,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textSize="16sp"
-            android:textColor="@color/gray90"
+            android:textColor="?attr/normalTextColor"
+            style="@style/TextAppearance.DuckDuckGo.Body1"
             android:text="@string/fireproofWebsiteSettingSelectionTitle"/>
     <TextView
             android:id="@+id/fireproofWebsiteUserSetting"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202561047873902/f

### Description
- Fix color used for fireproof sites selection title

### Steps to test this PR

_Fireproof site looks good in dark mode_
- [x] Change to dark mode
- [x] Open Settings -> Fireproof sites
- [x] Verify page looks OK on dark mode

### UI changes
| Before  | After |
| ------ | ----- |
|![Screenshot_20220713-142902](https://user-images.githubusercontent.com/2943941/178734667-020a9e8f-fc52-4ca6-ae23-b7d33e351edf.png)|![Screenshot_20220713-142503](https://user-images.githubusercontent.com/2943941/178734532-81880989-a353-49d2-9bb7-8b58f3d441fd.png)|
|![Screenshot_20220713-142824](https://user-images.githubusercontent.com/2943941/178734784-e1be311f-bec6-4280-9d0e-cc70702e4a58.png)|![Screenshot_20220713-142442](https://user-images.githubusercontent.com/2943941/178734818-e2a9cbca-feec-440a-8c59-008e6df2f46f.png)|


