### PR TITLE
Fix leak in Settings

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -69,11 +69,13 @@ import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.sendThemeChangedBroadcast
 import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnOnboardingActivity
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTrackerActivity
 import com.duckduckgo.mobile.android.vpn.waitlist.store.WaitlistState
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -133,12 +135,16 @@ class SettingsActivity :
         configureInternalFeatures()
         configureAppLinksSettingVisibility()
         observeViewModel()
+
+        lifecycle.addObserver(viewModel)
     }
 
     override fun onStart() {
         super.onStart()
-        viewModel.start()
-        viewModel.startPollingAppTpEnableState()
+        viewModel.start(TrackerBlockingVpnService.isServiceRunning(this))
+        viewModel.startPollingAppTpEnableState {
+            TrackerBlockingVpnService.isServiceRunning(this)
+        }
     }
 
     private fun configureUiEventHandlers() {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.settings
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.*
@@ -42,7 +41,6 @@ import com.duckduckgo.macos_api.MacOsWaitlist
 import com.duckduckgo.macos_api.MacWaitlistState
 import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.store.ThemingDataStore
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnStore
 import com.duckduckgo.mobile.android.vpn.waitlist.store.AtpWaitlistStateRepository
 import com.duckduckgo.mobile.android.vpn.waitlist.store.WaitlistState
@@ -63,7 +61,6 @@ import javax.inject.Inject
 
 @ContributesViewModel(ActivityScope::class)
 class SettingsViewModel @Inject constructor(
-    private val appContext: Context,
     private val themingDataStore: ThemingDataStore,
     private val settingsDataStore: SettingsDataStore,
     private val defaultWebBrowserCapability: DefaultBrowserDetector,
@@ -77,9 +74,9 @@ class SettingsViewModel @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val emailManager: EmailManager,
     private val macOsWaitlist: MacOsWaitlist
-) : ViewModel(), LifecycleObserver {
+) : ViewModel(), DefaultLifecycleObserver {
 
-    private var deviceShieldStatePollingJob: Job? = null
+    private var appTpVpnStatePollingJob: Job? = null
 
     data class ViewState(
         val loading: Boolean = true,
@@ -136,7 +133,7 @@ class SettingsViewModel @Inject constructor(
         pixel.fire(SETTINGS_OPENED)
     }
 
-    fun start() {
+    fun start(isTrackerBlockingVpnServiceRunning: Boolean) {
         val defaultBrowserAlready = defaultWebBrowserCapability.isDefaultBrowser()
         val variant = variantManager.getVariant()
         val savedTheme = themingDataStore.theme
@@ -156,9 +153,9 @@ class SettingsViewModel @Inject constructor(
                     automaticallyClearData = AutomaticallyClearData(automaticallyClearWhat, automaticallyClearWhen, automaticallyClearWhenEnabled),
                     appIcon = settingsDataStore.appIcon,
                     selectedFireAnimation = settingsDataStore.selectedFireAnimation,
-                    globalPrivacyControlEnabled = gpc.isEnabled() && featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName) == true,
+                    globalPrivacyControlEnabled = gpc.isEnabled() && featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName),
                     appLinksSettingType = getAppLinksSettingsState(settingsDataStore.appLinksEnabled, settingsDataStore.showAppLinksPrompt),
-                    appTrackingProtectionEnabled = TrackerBlockingVpnService.isServiceRunning(appContext),
+                    appTrackingProtectionEnabled = isTrackerBlockingVpnServiceRunning,
                     appTrackingProtectionWaitlistState = atpRepository.getState(),
                     emailAddress = emailManager.getEmailAddress(),
                     macOsWaitlistState = macOsWaitlist.getWaitlistState()
@@ -171,23 +168,24 @@ class SettingsViewModel @Inject constructor(
     // We need to fix this. This logic as inside the start method but it messes with the unit tests
     // because when doing runningBlockingTest {} there is no delay and the tests crashes because this
     // becomes a while(true) without any delay
-    fun startPollingAppTpEnableState() {
-        viewModelScope.launch {
+    fun startPollingAppTpEnableState(vpnServiceChecker: () -> Boolean) {
+        appTpVpnStatePollingJob = viewModelScope.launch {
             while (isActive) {
-                val isDeviceShieldEnabled = TrackerBlockingVpnService.isServiceRunning(appContext)
-                if (currentViewState().appTrackingProtectionEnabled != isDeviceShieldEnabled) {
-                    viewState.value = currentViewState().copy(
-                        appTrackingProtectionEnabled = isDeviceShieldEnabled
-                    )
+                vpnServiceChecker().also {
+                    if (currentViewState().appTrackingProtectionEnabled != it) {
+                        viewState.value = currentViewState().copy(
+                            appTrackingProtectionEnabled = it
+                        )
+                    }
                 }
                 delay(1_000)
             }
         }
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    fun stopPollingDeviceShieldState() {
-        deviceShieldStatePollingJob?.cancel()
+    override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
+        appTpVpnStatePollingJob?.cancel()
     }
 
     fun viewState(): StateFlow<ViewState> {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201723066508937/f

### Description
This PR includes:
- Removal of the injected Context in SettingsViewModel since it causes a StaticFieldLeak of the Context
- Instead, pass the TrackerBlockingVpnService.isServiceRunning from the activity to the viewmodel through functions
- Cancel polling when Activity's onStop is called since it is resumed anyway onStart and we don't have to poll when the settings page is not visible.

### Steps to test this PR

_Verify appTP state gets updates_
- [ ] Open settings
- [ ] Enable app tp
- [ ] Ensure that app tp state in settings is changed to "Enabled"
- [ ] Background the app / press home/ go out of settings and back
- [ ] Ensure that app tp state in settings is still correct
- [ ] Disable app tp
- [ ]  Ensure that app tp state in settings is changed to "Disabled"

_Check leaks for settings page_
- [ ] Use a debug build
- [ ] Open settings page and change the theme 
- [ ] Background the app
- [ ] Wait for a few seconds and confirm that no leaks is detected
- [ ] Do the same when changing orientation and leaving the settings page

