### PR TITLE
Tolerate fingerprint-read failures before giving up on auth

### DIFF
--- a/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AuthLauncher.kt
+++ b/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AuthLauncher.kt
@@ -27,7 +27,6 @@ import androidx.fragment.app.FragmentActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Error
-import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Failed
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Success
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -106,8 +105,7 @@ class RealAuthLauncher @Inject constructor(
 
         override fun onAuthenticationFailed() {
             super.onAuthenticationFailed()
-            Timber.d("onAuthenticationFailed")
-            onResult(Failed)
+            Timber.v("onAuthenticationFailed")
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202592915624865/f

### Description
When authenticating with device auth, we should be tolerant of fingerprints not being read correctly the first time and wait for a total auth failure callback before we treat it as such.

### Steps to test this PR

- [ ] Visit a login site with a saved credential (e.g., https://trello.com/login)
- [ ] Choose saved login from bottom sheet dialog
- [ ] When challenged to authenticate, **use the wrong finger**
- [ ] Verify we keep waiting and allow the user to try again
- [ ] **Use the right finger** and verify auth is accepted