### PR TITLE
Decouple AppTP and VPN enable/disable states

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.settings
 
-import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
@@ -41,6 +40,7 @@ import com.duckduckgo.macos_api.MacOsWaitlist
 import com.duckduckgo.macos_api.MacWaitlistState
 import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.store.ThemingDataStore
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnStore
 import com.duckduckgo.mobile.android.vpn.waitlist.AppTrackingProtectionWaitlistDataStore
 import com.duckduckgo.mobile.android.vpn.waitlist.store.AtpWaitlistStateRepository
@@ -85,9 +85,6 @@ class SettingsViewModelTest {
     @Mock
     private lateinit var mockFireAnimationLoader: FireAnimationLoader
 
-    @Mock
-    lateinit var mockContext: Context
-
     private lateinit var appTPRepository: AtpWaitlistStateRepository
 
     @Mock
@@ -110,6 +107,9 @@ class SettingsViewModelTest {
 
     @Mock
     private lateinit var internalTestUserChecker: InternalTestUserChecker
+
+    @Mock
+    private lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     private lateinit var appTrackingProtectionWaitlistDataStore: FakeAppTrackingProtectionWaitlistDataStore
 
@@ -134,7 +134,6 @@ class SettingsViewModelTest {
         whenever(mockAppBuildConfig.versionCode).thenReturn(1)
 
         testee = SettingsViewModel(
-            mockContext,
             mockThemeSettingsDataStore,
             mockAppSettingsDataStore,
             mockDefaultBrowserDetector,
@@ -148,7 +147,8 @@ class SettingsViewModelTest {
             mockAppBuildConfig,
             mockEmailManager,
             mockMacOsWaitlist,
-            internalTestUserChecker
+            internalTestUserChecker,
+            vpnFeaturesRegistry,
         )
     }
 

--- a/common-test/src/main/java/com/duckduckgo/app/global/api/InMemorySharedPreferences.kt
+++ b/common-test/src/main/java/com/duckduckgo/app/global/api/InMemorySharedPreferences.kt
@@ -25,6 +25,7 @@ class InMemorySharedPreferences : SharedPreferences, SharedPreferences.Editor {
     private val longMap = mutableMapOf<String, Long>()
     private val floatMap = mutableMapOf<String, Float>()
     private val booleanMap = mutableMapOf<String, Boolean>()
+    private val listeners = mutableListOf<SharedPreferences.OnSharedPreferenceChangeListener>()
 
     private val maps = listOf<MutableMap<String, *>>(
         stringSetMap,
@@ -73,51 +74,60 @@ class InMemorySharedPreferences : SharedPreferences, SharedPreferences.Editor {
         return this
     }
 
-    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
-        TODO("Not yet implemented")
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+        listeners += listener
     }
 
-    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
-        TODO("Not yet implemented")
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+        listeners -= listener
     }
 
     override fun putString(key: String, value: String?): SharedPreferences.Editor {
         stringMap[key] = value
+        notifyListeners(key)
         return this
     }
 
     override fun putStringSet(key: String, values: MutableSet<String>?): SharedPreferences.Editor {
         stringSetMap[key] = values
+        notifyListeners(key)
         return this
     }
 
     override fun putInt(key: String, value: Int): SharedPreferences.Editor {
         intMap[key] = value
+        notifyListeners(key)
         return this
     }
 
     override fun putLong(key: String, value: Long): SharedPreferences.Editor {
         longMap[key] = value
+        notifyListeners(key)
         return this
     }
 
     override fun putFloat(key: String, value: Float): SharedPreferences.Editor {
         floatMap[key] = value
+        notifyListeners(key)
         return this
     }
 
     override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor {
         booleanMap[key] = value
+        notifyListeners(key)
         return this
     }
 
     override fun remove(key: String): SharedPreferences.Editor {
         maps.forEach { it.remove(key) }
+        notifyListeners(key)
         return this
     }
 
     override fun clear(): SharedPreferences.Editor {
+        val keys = maps.flatMap { it.keys }.toSet()
         maps.forEach { it.clear() }
+        keys.forEach { notifyListeners(it) }
         return this
     }
 
@@ -126,5 +136,9 @@ class InMemorySharedPreferences : SharedPreferences, SharedPreferences.Editor {
     }
 
     override fun apply() {
+    }
+
+    private fun notifyListeners(key: String) {
+        listeners.forEach { it.onSharedPreferenceChanged(this, key) }
     }
 }

--- a/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistry.kt
+++ b/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistry.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Use this class to register features that required VPN access.
+ *
+ * Registering a feature will cause the VPN to be enabled.
+ * Unregistering a feature will cause the VPN to be disabled IF no other feature is registered.
+ */
+interface VpnFeaturesRegistry {
+
+    /**
+     * Call this method to register a feature that requires VPN access.
+     * If the VPN is not enabled, it will be enabled.
+     */
+    fun registerFeature(feature: VpnFeature)
+
+    /**
+     * Call this method to unregister a feature that requires VPN access.
+     * If the VPN will be disabled if and only if this is the last registered feature.
+     */
+    fun unregisterFeature(feature: VpnFeature)
+
+    /**
+     * @return `true` if this feature is registered, `false` otherwise.
+     */
+    fun isFeatureRegistered(feature: VpnFeature): Boolean
+
+    /**
+     * Refreshing the feature will cause the VPN to be stopped/restarted if it is enabled and the feature is already registered.
+     */
+    suspend fun refreshFeature(feature: VpnFeature)
+
+    /**
+     * Subscribe to this flow to get changes of the VPN feature registrations.
+     * The flow is a hot flow with no cache, ie. only emits new values upon subscription.
+     *
+     * When a VPN feature is (re)registered it will emit a pair with the name of the feature and `true`
+     * When a VPN feature is (re)unregistered it will emit a pair with the name of the feature and `false`
+     */
+    fun registryChanges(): Flow<Pair<String, Boolean>>
+}
+
+interface VpnFeature {
+    val featureName: String
+}

--- a/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProvider.kt
+++ b/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProvider.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.prefs
+
+import android.content.SharedPreferences
+
+interface VpnSharedPreferencesProvider {
+    /**
+     * Returns an instance of Shared preferences
+     * @param name Name of the shared preferences
+     * @param multiprocess `true` if the shared preferences will be accessed from several processes else `false`
+     * @param migrate `true` if the shared preferences existed prior to use the [VpnSharedPreferencesProvider], else `false`
+     */
+    fun getSharedPreferences(name: String, multiprocess: Boolean = false, migrate: Boolean = false): SharedPreferences
+}

--- a/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/state/VpnStateMonitor.kt
+++ b/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/state/VpnStateMonitor.kt
@@ -15,12 +15,18 @@
  */
 
 package com.duckduckgo.mobile.android.vpn.state
+import com.duckduckgo.mobile.android.vpn.VpnFeature
 import kotlinx.coroutines.flow.Flow
 
 interface VpnStateMonitor {
-    fun getStateFlow(): Flow<VpnState>
-    fun getState(): VpnState
 
+    /**
+     * Returns a flow of VPN changes for the given [vpnFeature]
+     * It follows the following truth table:
+     * * when the VPN is disabled the flow will emit a [VpnState.DISABLED]
+     * * else it will return the state of the feature
+     */
+    fun getStateFlow(vpnFeature: VpnFeature): Flow<VpnState>
     data class VpnState(
         val state: VpnRunningState,
         val stopReason: VpnStopReason? = null

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/AppTpVpnFeature.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/AppTpVpnFeature.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn
+
+enum class AppTpVpnFeature(override val featureName: String) : VpnFeature {
+    APPTP_VPN("APP_TP_VPN"),
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
+import kotlinx.coroutines.flow.*
+import timber.log.Timber
+import java.util.UUID
+
+private const val PREFS_FILENAME = "com.duckduckgo.mobile.android.vpn.feature.registry.v1"
+private const val IS_INITIALIZED = "IS_INITIALIZED"
+
+internal class VpnFeaturesRegistryImpl(
+    private val vpnServiceWrapper: VpnServiceWrapper,
+    sharedPreferencesProvider: VpnSharedPreferencesProvider,
+) : VpnFeaturesRegistry, SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private val preferences = sharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME, multiprocess = true, migrate = false)
+    private val registryInitialValue = Pair("", false)
+    private val _registry = MutableStateFlow(registryInitialValue)
+
+    private var isInitialized: Boolean
+        get() = preferences.getBoolean(IS_INITIALIZED, false)
+        set(value) = preferences.edit(commit = true) { putBoolean(IS_INITIALIZED, value) }
+
+    init {
+        // we don't need to unregister the listener
+        preferences.registerOnSharedPreferenceChangeListener(this)
+    }
+
+    @Synchronized
+    override fun registerFeature(feature: VpnFeature) {
+        if (!isInitialized) {
+            Timber.d("Initializing VpnFeaturesRegistry")
+            isInitialized = true
+        }
+
+        if (!vpnServiceWrapper.isServiceRunning()) {
+            Timber.d("no features registered, start the service")
+            // there's not a registered feature, so we need to start the VPN too
+            vpnServiceWrapper.startService()
+        }
+        Timber.d("(re)registering feature")
+        preferences.edit(commit = true) {
+            // we use random UUID to force change listener to be called
+            putString(feature.featureName, UUID.randomUUID().toString())
+        }
+    }
+
+    @Synchronized
+    override fun unregisterFeature(feature: VpnFeature) {
+        if (!isInitialized) {
+            Timber.d("Initializing VpnFeaturesRegistry, auto-registering AppTP")
+            isInitialized = true
+            vpnServiceWrapper.stopService()
+            return
+        }
+
+        if (registeredFeatures().size == 1 && preferences.contains(feature.featureName)) {
+            Timber.d("$feature is the last registered feature, stopping VPN")
+            // this is the last feature registered for VPN usage, stop the service
+            vpnServiceWrapper.stopService()
+        }
+
+        Timber.d("$feature removal")
+        preferences.edit(commit = true) {
+            remove(feature.featureName)
+        }
+    }
+
+    override fun isFeatureRegistered(feature: VpnFeature): Boolean {
+        val isRegistered = registeredFeatures().contains(feature.featureName) ||
+            (!isInitialized && vpnServiceWrapper.isServiceRunning())
+
+        if (isRegistered && !isInitialized) {
+            Timber.v("isFeatureRegistered($feature) - should be registered as we're not initialised ")
+            preferences.edit(commit = true) {
+                // we use random UUID to force change listener to be called
+                putString(feature.featureName, UUID.randomUUID().toString())
+            }
+            isInitialized = true
+        }
+
+        Timber.v("isFeatureRegistered($feature) = $isRegistered")
+        return isRegistered && vpnServiceWrapper.isServiceRunning()
+    }
+
+    override suspend fun refreshFeature(feature: VpnFeature) {
+        if (!isInitialized) {
+            Timber.d("Initializing VpnFeaturesRegistry, attempting to restart VPN service")
+            isInitialized = true
+
+            vpnServiceWrapper.restartVpnService()
+        } else if (!preferences.all.contains(feature.featureName)) {
+            Timber.e("The $feature is not registered for VPN usage")
+        } else {
+            vpnServiceWrapper.restartVpnService()
+        }
+    }
+
+    override fun registryChanges(): Flow<Pair<String, Boolean>> {
+        return _registry.asStateFlow()
+            .filter {
+                Timber.v("change $it")
+                it != registryInitialValue && it.first != IS_INITIALIZED
+            }
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+        Timber.d("onSharedPreferenceChanged($key)")
+        _registry.update { Pair(key, sharedPreferences.contains(key)) }
+    }
+
+    private fun registeredFeatures(): Map<String, Any?> {
+        return preferences.all.filter { it.key != IS_INITIALIZED }
+    }
+}
+
+/**
+ * This class is here purely to wrap TrackerBlockingVpnService static calls that deal with enable/disable VPN, so that we can
+ * unit test the [VpnFeaturesRegistryImpl] class.
+ *
+ * The class is marked as open to be able to mock it in tests.
+ */
+internal open class VpnServiceWrapper(private val context: Context) {
+    open suspend fun restartVpnService() {
+        TrackerBlockingVpnService.restartVpnService(context)
+    }
+
+    open fun stopService() {
+        TrackerBlockingVpnService.stopService(context)
+    }
+
+    open fun startService() {
+        TrackerBlockingVpnService.startService(context)
+    }
+
+    open fun isServiceRunning(): Boolean {
+        return TrackerBlockingVpnService.isServiceRunning(context)
+    }
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/NewAppBroadcastReceiver.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/NewAppBroadcastReceiver.kt
@@ -25,7 +25,8 @@ import androidx.annotation.WorkerThread
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.VpnScope
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.service.goAsync
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
@@ -46,7 +47,8 @@ class NewAppBroadcastReceiver @Inject constructor(
     private val applicationContext: Context,
     private val appCategoryDetector: AppCategoryDetector,
     private val appTrackerRepository: AppTrackerRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : BroadcastReceiver(), VpnServiceCallbacks {
 
     @MainThread
@@ -66,7 +68,7 @@ class NewAppBroadcastReceiver @Inject constructor(
         goAsync(pendingResult) {
             if (isGame(packageName) || isInExclusionList(packageName)) {
                 Timber.i("Newly installed package $packageName is in exclusion list, disabling/re-enabling vpn")
-                TrackerBlockingVpnService.restartVpnService(applicationContext)
+                vpnFeaturesRegistry.refreshFeature(AppTpVpnFeature.APPTP_VPN)
             } else {
                 Timber.i("Newly installed package $packageName not in exclusion list")
             }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/ManageRecentAppsProtectionActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/ManageRecentAppsProtectionActivity.kt
@@ -30,14 +30,15 @@ import com.duckduckgo.mobile.android.ui.view.addClickableLink
 import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.apps.Command
 import com.duckduckgo.mobile.android.vpn.apps.ManageAppsProtectionViewModel
 import com.duckduckgo.mobile.android.vpn.apps.TrackingProtectionAppInfo
 import com.duckduckgo.mobile.android.vpn.apps.ViewState
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageContract
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityManageRecentAppsProtectionBinding
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.facebook.shimmer.ShimmerFrameLayout
 import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_LONG
 import com.google.android.material.snackbar.Snackbar
@@ -57,6 +58,8 @@ class ManageRecentAppsProtectionActivity :
     @Inject
     @AppCoroutineScope
     lateinit var appCoroutineScope: CoroutineScope
+
+    @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     private val binding: ActivityManageRecentAppsProtectionBinding by viewBinding()
 
@@ -162,7 +165,7 @@ class ManageRecentAppsProtectionActivity :
     private fun restartVpn() {
         // we use the app coroutine scope to ensure this call outlives the Activity
         appCoroutineScope.launch {
-            TrackerBlockingVpnService.restartVpnService(applicationContext)
+            vpnFeaturesRegistry.refreshFeature(AppTpVpnFeature.APPTP_VPN)
         }
     }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionExclusionListActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionExclusionListActivity.kt
@@ -31,7 +31,9 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.apps.Command
 import com.duckduckgo.mobile.android.vpn.apps.ManageAppsProtectionViewModel
 import com.duckduckgo.mobile.android.vpn.apps.TrackingProtectionAppInfo
@@ -39,7 +41,6 @@ import com.duckduckgo.mobile.android.vpn.apps.ViewState
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageContract
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityTrackingProtectionExclusionListBinding
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.facebook.shimmer.ShimmerFrameLayout
 import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_LONG
 import com.google.android.material.snackbar.Snackbar
@@ -62,6 +63,8 @@ class TrackingProtectionExclusionListActivity :
 
     @Inject
     lateinit var deviceShieldPixels: DeviceShieldPixels
+
+    @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     private val binding: ActivityTrackingProtectionExclusionListBinding by viewBinding()
 
@@ -198,7 +201,7 @@ class TrackingProtectionExclusionListActivity :
     private fun restartVpn() {
         // we use the app coroutine scope to ensure this call outlives the Activity
         appCoroutineScope.launch {
-            TrackerBlockingVpnService.restartVpnService(applicationContext)
+            vpnFeaturesRegistry.refreshFeature(AppTpVpnFeature.APPTP_VPN)
         }
     }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerExclusionListUpdateWorker.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerExclusionListUpdateWorker.kt
@@ -23,7 +23,8 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExclusionListMetadata
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerSystemAppOverrideListMetadata
@@ -43,6 +44,7 @@ class AppTrackerExclusionListUpdateWorker(
     lateinit var appTrackerListDownloader: AppTrackerListDownloader
     @Inject
     lateinit var vpnDatabase: VpnDatabase
+    @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     override suspend fun doWork(): Result {
         return withContext(Dispatchers.IO) {
@@ -79,7 +81,7 @@ class AppTrackerExclusionListUpdateWorker(
                     sysAppsOverrides.overridePackages, AppTrackerSystemAppOverrideListMetadata(eTag = updatedEtag)
                 )
 
-                TrackerBlockingVpnService.restartVpnService(applicationContext)
+                vpnFeaturesRegistry.refreshFeature(AppTpVpnFeature.APPTP_VPN)
 
                 return Result.success()
             }
@@ -108,7 +110,7 @@ class AppTrackerExclusionListUpdateWorker(
                 vpnDatabase.vpnAppTrackerBlockingDao()
                     .updateExclusionList(exclusionList.excludedPackages, AppTrackerExclusionListMetadata(eTag = exclusionList.etag.value))
 
-                TrackerBlockingVpnService.restartVpnService(applicationContext)
+                vpnFeaturesRegistry.refreshFeature(AppTpVpnFeature.APPTP_VPN)
 
                 return Result.success()
             }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
@@ -21,6 +21,10 @@ import android.content.res.Resources
 import android.net.ConnectivityManager
 import androidx.room.Room
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistryImpl
+import com.duckduckgo.mobile.android.vpn.VpnServiceWrapper
+import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.remote_config.*
 import com.duckduckgo.mobile.android.vpn.store.*
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerRepository
@@ -96,5 +100,14 @@ object VpnAppModule {
     @Provides
     fun provideAppHealthTriggersRepository(appHealthDatabase: AppHealthDatabase): AppHealthTriggersRepository {
         return AppHealthTriggersRepositoryImpl(appHealthDatabase)
+    }
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun provideVpnFeaturesRegistry(
+        context: Context,
+        sharedPreferencesProvider: VpnSharedPreferencesProvider,
+    ): VpnFeaturesRegistry {
+        return VpnFeaturesRegistryImpl(VpnServiceWrapper(context), sharedPreferencesProvider)
     }
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldRetentionPixelSender.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldRetentionPixelSender.kt
@@ -16,21 +16,21 @@
 
 package com.duckduckgo.mobile.android.vpn.pixels
 
-import android.content.Context
 import com.duckduckgo.app.statistics.api.RefreshRetentionAtbPlugin
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class)
 class DeviceShieldRetentionPixelSender @Inject constructor(
-    private val context: Context,
     private val deviceShieldPixels: DeviceShieldPixels,
+    private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : RefreshRetentionAtbPlugin {
 
     override fun onSearchRetentionAtbRefreshed() {
-        if (TrackerBlockingVpnService.isServiceRunning(context)) {
+        if (vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)) {
             deviceShieldPixels.deviceShieldEnabledOnSearch()
         } else {
             deviceShieldPixels.deviceShieldDisabledOnSearch()
@@ -38,7 +38,7 @@ class DeviceShieldRetentionPixelSender @Inject constructor(
     }
 
     override fun onAppRetentionAtbRefreshed() {
-        if (TrackerBlockingVpnService.isServiceRunning(context)) {
+        if (vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)) {
             deviceShieldPixels.deviceShieldEnabledOnAppLaunch()
         } else {
             deviceShieldPixels.deviceShieldDisabledOnAppLaunch()

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldStatusReporting.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldStatusReporting.kt
@@ -27,8 +27,9 @@ import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.dao.VpnServiceStateStatsDao
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceState
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -82,16 +83,18 @@ class DeviceShieldStatusReporting(
 
 @ContributesWorker(AppScope::class)
 class DeviceShieldStatusReportingWorker(
-    private val context: Context,
+    context: Context,
     params: WorkerParameters
 ) : CoroutineWorker(context, params) {
     @Inject
     lateinit var deviceShieldPixels: DeviceShieldPixels
     @Inject
     lateinit var vpnServiceStateStatsDao: VpnServiceStateStatsDao
+    @Inject
+    lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     override suspend fun doWork(): Result {
-        if (TrackerBlockingVpnService.isServiceRunning(context)) {
+        if (vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)) {
             deviceShieldPixels.reportEnabled()
         } else {
             deviceShieldPixels.reportDisabled()

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProvider.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProvider.kt
@@ -26,16 +26,6 @@ import com.squareup.anvil.annotations.ContributesBinding
 import timber.log.Timber
 import javax.inject.Inject
 
-interface VpnSharedPreferencesProvider {
-    /**
-     * Returns an instance of Shared preferences
-     * @param name Name of the shared preferences
-     * @param multiprocess `true` if the shared preferences will be accessed from several processes else `false`
-     * @param migrate `true` if the shared preferences existed prior to use the [VpnSharedPreferencesProvider], else `false`
-     */
-    fun getSharedPreferences(name: String, multiprocess: Boolean = false, migrate: Boolean = false): SharedPreferences
-}
-
 private const val MIGRATED_TO_HARMONY = "migrated_to_harmony"
 
 @ContributesBinding(AppScope::class)

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -495,7 +495,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
         // For backwards compatibility, it will still return the caller's own services.
         // So for us it's still valid because we don't need to know third party services, just ours.
         @Suppress("DEPRECATION")
-        fun isServiceRunning(context: Context): Boolean {
+        internal fun isServiceRunning(context: Context): Boolean {
             val manager = kotlin.runCatching {
                 context.getSystemService(ACTIVITY_SERVICE) as ActivityManager
             }.getOrElse {
@@ -513,7 +513,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
             return false
         }
 
-        fun startService(context: Context) {
+        internal fun startService(context: Context) {
             val applicationContext = context.applicationContext
 
             if (isServiceRunning(applicationContext)) return
@@ -523,7 +523,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
             }
         }
 
-        fun stopService(context: Context) {
+        internal fun stopService(context: Context) {
             val applicationContext = context.applicationContext
 
             if (!isServiceRunning(applicationContext)) return
@@ -533,7 +533,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
             }
         }
 
-        suspend fun restartVpnService(
+        internal suspend fun restartVpnService(
             context: Context,
             forceGc: Boolean = false
         ) = withContext(Dispatchers.Default) {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnReminderReceiver.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnReminderReceiver.kt
@@ -21,9 +21,10 @@ import android.content.Context
 import android.content.Intent
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.di.scopes.ReceiverScope
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService.Companion.ACTION_VPN_REMINDER_RESTART
-import com.duckduckgo.mobile.android.vpn.ui.notification.ReminderNotificationPressedHandler
 import dagger.android.AndroidInjection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -38,11 +39,7 @@ class VpnReminderReceiver : BroadcastReceiver() {
     @Inject
     lateinit var deviceShieldPixels: DeviceShieldPixels
 
-    @Inject
-    lateinit var notificationPressedHandler: ReminderNotificationPressedHandler
-
-    @Inject
-    lateinit var reminderManager: VpnReminderReceiverManager
+    @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     override fun onReceive(
         context: Context,
@@ -57,7 +54,7 @@ class VpnReminderReceiver : BroadcastReceiver() {
             Timber.v("Vpn will restart because the user asked it")
             deviceShieldPixels.enableFromReminderNotification()
             goAsync(pendingResult) {
-                TrackerBlockingVpnService.startService(context)
+                vpnFeaturesRegistry.registerFeature(AppTpVpnFeature.APPTP_VPN)
             }
         } else {
             Timber.w("VpnReminderReceiver: unknown action")

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnReminderReceiverManager.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnReminderReceiverManager.kt
@@ -21,6 +21,8 @@ import android.content.SharedPreferences
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.edit
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.prefs.PREFS_FILENAME
 import com.duckduckgo.mobile.android.vpn.prefs.PREFS_KEY_REMINDER_NOTIFICATION_SHOWN
@@ -37,11 +39,12 @@ interface VpnReminderReceiverManager {
 class AndroidVpnReminderReceiverManager @Inject constructor(
     private val deviceShieldPixels: DeviceShieldPixels,
     private val notificationManager: NotificationManagerCompat,
-    private val deviceShieldAlertNotificationBuilder: DeviceShieldAlertNotificationBuilder
+    private val deviceShieldAlertNotificationBuilder: DeviceShieldAlertNotificationBuilder,
+    private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : VpnReminderReceiverManager {
 
     override fun showReminderNotificationIfVpnDisabled(context: Context) {
-        if (TrackerBlockingVpnService.isServiceRunning(context)) {
+        if (vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)) {
             Timber.v("Vpn is already running, nothing to show")
         } else {
             Timber.v("Vpn is not running, showing reminder notification")

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/RealVpnStateMonitor.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/RealVpnStateMonitor.kt
@@ -16,7 +16,10 @@
 
 package com.duckduckgo.mobile.android.vpn.service.state
 
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.VpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceState.DISABLED
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceState.ENABLED
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceStateStats
@@ -29,22 +32,35 @@ import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnState
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
+import timber.log.Timber
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
-class RealVpnStateMonitor @Inject constructor(val database: VpnDatabase) : VpnStateMonitor {
+class RealVpnStateMonitor @Inject constructor(
+    private val database: VpnDatabase,
+    private val vpnFeaturesRegistry: VpnFeaturesRegistry,
+    private val dispatcherProvider: DispatcherProvider
+) : VpnStateMonitor {
 
-    override fun getStateFlow(): Flow<VpnState> {
-        return database.vpnServiceStateDao().getStateStats().map {
-            mapState(it)
-        }
-    }
+    override fun getStateFlow(vpnFeature: VpnFeature): Flow<VpnState> {
+        return database.vpnServiceStateDao().getStateStats().map { mapState(it) }
+            .onEach { Timber.v("service $it") }
+            .combine(
+                vpnFeaturesRegistry.registryChanges()
+                    .filter { it.first == vpnFeature.featureName }
+                    .onStart { emit(vpnFeature.featureName to vpnFeaturesRegistry.isFeatureRegistered(vpnFeature)) }
+                    .onEach { Timber.v("feature $it") }
+            ) { vpnState, feature ->
+                val isFeatureEnabled = feature.second
+                val isVpnEnabled = vpnState.state == VpnRunningState.ENABLED
 
-    override fun getState(): VpnState {
-        val lastState = database.vpnServiceStateDao().getLastStateStats()
-        return mapState(lastState)
+                if (!isVpnEnabled) vpnState
+                else if (isFeatureEnabled) VpnState(VpnRunningState.ENABLED)
+                else VpnState(VpnRunningState.DISABLED)
+            }.flowOn(dispatcherProvider.io())
+            .onEach { Timber.v("$it") }
+            .distinctUntilChanged()
     }
 
     private fun mapState(lastState: VpnServiceStateStats?): VpnState {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingActivity.kt
@@ -34,10 +34,11 @@ import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityVpnOnboardingBinding
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.Command.CheckVPNPermission
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.Command.LaunchVPN
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.Command.RequestVPNPermission
@@ -59,6 +60,8 @@ class VpnOnboardingActivity : DuckDuckGoActivity(), AppTPVpnConflictDialog.Liste
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     private val viewModel: VpnOnboardingViewModel by bindViewModel()
     private val binding: ActivityVpnOnboardingBinding by viewBinding()
@@ -243,7 +246,7 @@ class VpnOnboardingActivity : DuckDuckGoActivity(), AppTPVpnConflictDialog.Liste
     }
 
     private fun startVpn() {
-        TrackerBlockingVpnService.startService(this)
+        vpnFeaturesRegistry.registerFeature(AppTpVpnFeature.APPTP_VPN)
         showEnabledState()
         viewModel.onAppTpEnabled()
     }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/report/PrivacyReportViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/report/PrivacyReportViewModel.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.formatters.time.model.dateOfLastHour
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.feature.removal.VpnFeatureRemover
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnState
@@ -43,7 +44,7 @@ class PrivacyReportViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider
 ) : ViewModel(), LifecycleObserver {
 
-    val viewStateFlow = vpnStateMonitor.getStateFlow().combine(getReport()) { vpnState, trackersBlocked ->
+    val viewStateFlow = vpnStateMonitor.getStateFlow(AppTpVpnFeature.APPTP_VPN).combine(getReport()) { vpnState, trackersBlocked ->
         PrivacyReportView.ViewState(vpnState, trackersBlocked, shouldShowCTA())
     }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
@@ -38,12 +38,13 @@ import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageContract
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageScreen
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityApptpCompanyTrackersActivityBinding
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.DeviceShieldFAQActivity
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.AppTPCompanyTrackersViewModel.Command
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.AppTPCompanyTrackersViewModel.ViewState
@@ -64,6 +65,8 @@ class AppTPCompanyTrackersActivity : DuckDuckGoActivity() {
     @Inject
     @AppCoroutineScope
     lateinit var appCoroutineScope: CoroutineScope
+
+    @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     private val binding: ActivityApptpCompanyTrackersActivityBinding by viewBinding()
     private val viewModel: AppTPCompanyTrackersViewModel by bindViewModel()
@@ -181,7 +184,7 @@ class AppTPCompanyTrackersActivity : DuckDuckGoActivity() {
     private fun restartVpn() {
         // we use the app coroutine scope to ensure this call outlives the Activity
         appCoroutineScope.launch {
-            TrackerBlockingVpnService.restartVpnService(applicationContext)
+            vpnFeaturesRegistry.refreshFeature(AppTpVpnFeature.APPTP_VPN)
         }
     }
 

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -41,13 +41,14 @@ import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.apps.ui.ManageRecentAppsProtectionActivity
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageContract
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageScreen
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityDeviceShieldActivityBinding
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnRunningState
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnState
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason.REVOKED
@@ -80,6 +81,8 @@ class DeviceShieldTrackerActivity :
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     private val binding: ActivityDeviceShieldActivityBinding by viewBinding()
 
@@ -377,12 +380,12 @@ class DeviceShieldTrackerActivity :
 
     private fun startVPN() {
         quietlyToggleAppTpSwitch(true)
-        TrackerBlockingVpnService.startService(this)
+        vpnFeaturesRegistry.registerFeature(AppTpVpnFeature.APPTP_VPN)
     }
 
     private fun stopDeviceShield() {
         quietlyToggleAppTpSwitch(false)
-        TrackerBlockingVpnService.stopService(this)
+        vpnFeaturesRegistry.unregisterFeature(AppTpVpnFeature.APPTP_VPN)
     }
 
     private fun quietlyToggleAppTpSwitch(state: Boolean) {

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.formatters.time.model.dateOfLastWeek
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.feature.removal.VpnFeatureRemover
 import com.duckduckgo.mobile.android.vpn.network.VpnDetector
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
@@ -56,7 +57,7 @@ class DeviceShieldTrackerActivityViewModel @Inject constructor(
     private var lastVpnRequestTime = -1L
 
     internal suspend fun getRunningState(): Flow<VpnState> = withContext(dispatcherProvider.io()) {
-        return@withContext vpnStateMonitor.getStateFlow()
+        return@withContext vpnStateMonitor.getStateFlow(AppTpVpnFeature.APPTP_VPN)
     }
 
     internal suspend fun getTrackingAppsCount(): Flow<TrackingAppCount> = withContext(dispatcherProvider.io()) {

--- a/vpn/src/main/java/dummy/ui/VpnControllerViewModel.kt
+++ b/vpn/src/main/java/dummy/ui/VpnControllerViewModel.kt
@@ -16,7 +16,6 @@
 
 package dummy.ui
 
-import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
@@ -24,9 +23,10 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedRepository
 import com.duckduckgo.app.trackerdetection.db.WebTrackerBlocked
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.model.VpnState
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.stats.DataStats
 import kotlinx.coroutines.flow.map
@@ -36,12 +36,12 @@ import javax.inject.Inject
 class VpnControllerViewModel @Inject constructor(
     private val appTrackerBlockedRepository: AppTrackerBlockingStatsRepository,
     private val webTrackersBlockedRepository: WebTrackersBlockedRepository,
-    private val applicationContext: Context,
+    private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : ViewModel() {
 
     fun getRunningTimeUpdates(startTime: () -> String): LiveData<VpnRunningStatus> {
         return appTrackerBlockedRepository.getRunningTimeMillis(startTime)
-            .map { timeRunning -> VpnRunningStatus(timeRunning, TrackerBlockingVpnService.isServiceRunning(applicationContext)) }
+            .map { timeRunning -> VpnRunningStatus(timeRunning, vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)) }
             .asLiveData()
     }
 

--- a/vpn/src/main/java/dummy/ui/VpnDiagnosticsActivity.kt
+++ b/vpn/src/main/java/dummy/ui/VpnDiagnosticsActivity.kt
@@ -39,7 +39,9 @@ import com.duckduckgo.app.global.formatters.time.model.TimePassed
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.ui.view.rightDrawable
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityVpnDiagnosticsBinding
 import com.duckduckgo.mobile.android.vpn.health.AppTPHealthMonitor
 import com.duckduckgo.mobile.android.vpn.health.AppTPHealthMonitor.Companion.SLIDING_WINDOW_DURATION_MS
@@ -64,7 +66,6 @@ import com.duckduckgo.mobile.android.vpn.health.SimpleEvent.Companion.TUN_WRITE_
 import com.duckduckgo.mobile.android.vpn.health.UserHealthSubmission
 import com.duckduckgo.mobile.android.vpn.network.util.getSystemActiveNetworkDefaultDns
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
-import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.squareup.moshi.Moshi
 import dagger.android.AndroidInjection
@@ -106,6 +107,8 @@ class VpnDiagnosticsActivity : DuckDuckGoActivity(), CoroutineScope by MainScope
     @Inject lateinit var deviceShieldPixels: DeviceShieldPixels
 
     @Inject lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     private val moshi = Moshi.Builder().build()
 
@@ -185,9 +188,9 @@ class VpnDiagnosticsActivity : DuckDuckGoActivity(), CoroutineScope by MainScope
             updateStatus()
         }
 
-        binding.startVpnButton.setOnClickListener { TrackerBlockingVpnService.startService(this) }
+        binding.startVpnButton.setOnClickListener { vpnFeaturesRegistry.registerFeature(AppTpVpnFeature.APPTP_VPN) }
 
-        binding.stopVpnButton.setOnClickListener { TrackerBlockingVpnService.stopService(this) }
+        binding.stopVpnButton.setOnClickListener { vpnFeaturesRegistry.unregisterFeature(AppTpVpnFeature.APPTP_VPN) }
 
         binding.simulateGoodHealth.setOnClickListener {
             appTPHealthMonitor.simulateGoodHealthState()

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImplTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImplTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import app.cash.turbine.test
+import com.duckduckgo.app.global.api.InMemorySharedPreferences
+import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.*
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class VpnFeaturesRegistryImplTest {
+
+    private val sharedPreferencesProvider: VpnSharedPreferencesProvider = mock()
+    private lateinit var vpnServiceWrapper: TestVpnServiceWrapper
+
+    private lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
+
+    @Before
+    fun setup() {
+        val prefs = InMemorySharedPreferences()
+        vpnServiceWrapper = TestVpnServiceWrapper()
+
+        whenever(
+            sharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.mobile.android.vpn.feature.registry.v1"), eq(true), eq(false))
+        ).thenReturn(prefs)
+
+        vpnFeaturesRegistry = VpnFeaturesRegistryImpl(vpnServiceWrapper, sharedPreferencesProvider)
+    }
+
+    @Test
+    fun whenRegisterFeatureThenFeatureIsRegistered() {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+
+        assertTrue(vpnFeaturesRegistry.isFeatureRegistered(TestVpnFeatures.FOO))
+    }
+
+    @Test
+    fun whenRegisterFeatureTheVpnIsRunning() {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+
+        assertTrue(vpnServiceWrapper.isServiceRunning())
+    }
+
+    @Test
+    fun whenRegisterMultipleFeaturesThenFeaturesAreRegistered() {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.BAR)
+
+        assertTrue(vpnFeaturesRegistry.isFeatureRegistered(TestVpnFeatures.FOO))
+        assertTrue(vpnFeaturesRegistry.isFeatureRegistered(TestVpnFeatures.BAR))
+    }
+
+    @Test
+    fun whenUnregisterFeatureThenFeatureIsUnregistered() {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+        vpnFeaturesRegistry.unregisterFeature(TestVpnFeatures.FOO)
+
+        assertFalse(vpnFeaturesRegistry.isFeatureRegistered(TestVpnFeatures.FOO))
+    }
+
+    @Test
+    fun whenUnregisterLastFeatureThenVpnIsNotRunning() {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.BAR)
+        vpnFeaturesRegistry.unregisterFeature(TestVpnFeatures.FOO)
+        vpnFeaturesRegistry.unregisterFeature(TestVpnFeatures.BAR)
+
+        assertFalse(vpnServiceWrapper.isServiceRunning())
+    }
+
+    @Test
+    fun whenUnregisterFeatureAndOtherFeaturesStillRegisteredThenVpnIsRunning() {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.BAR)
+        vpnFeaturesRegistry.unregisterFeature(TestVpnFeatures.FOO)
+
+        assertTrue(vpnServiceWrapper.isServiceRunning())
+    }
+
+    @Test
+    fun whenRefreshUnregisteredFeatureThenRestartVpn() = runTest {
+        vpnFeaturesRegistry.refreshFeature(TestVpnFeatures.FOO)
+
+        assertEquals(1, vpnServiceWrapper.restartCount)
+    }
+
+    @Test
+    fun whenRefreshUnregisteredFeatureAfterInitialisationThenNoop() = runTest {
+        vpnFeaturesRegistry.refreshFeature(TestVpnFeatures.FOO)
+        vpnFeaturesRegistry.refreshFeature(TestVpnFeatures.FOO)
+
+        assertEquals(1, vpnServiceWrapper.restartCount)
+    }
+
+    @Test
+    fun whenRefreshRegisteredFeatureThenRestartVpn() = runTest {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+        vpnFeaturesRegistry.refreshFeature(TestVpnFeatures.FOO)
+
+        assertEquals(1, vpnServiceWrapper.restartCount)
+    }
+
+    @Test
+    fun whenRegisterFeatureThenEmitChange() = runTest {
+        vpnFeaturesRegistry.registryChanges().test {
+            vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+            vpnFeaturesRegistry.registerFeature(TestVpnFeatures.BAR)
+            assertEquals(TestVpnFeatures.FOO.featureName to true, awaitItem())
+            assertEquals(TestVpnFeatures.BAR.featureName to true, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUnregisterNotRegisterFeatureThenNoEmission() = runTest {
+        vpnFeaturesRegistry.registryChanges().test {
+            vpnFeaturesRegistry.unregisterFeature(TestVpnFeatures.FOO)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun whenUnregisterRegisteredFeatureThenEmitChange() = runTest {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+        vpnFeaturesRegistry.registryChanges().test {
+            vpnFeaturesRegistry.unregisterFeature(TestVpnFeatures.FOO)
+            assertEquals(TestVpnFeatures.FOO.featureName to true, awaitItem())
+            assertEquals(TestVpnFeatures.FOO.featureName to false, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private enum class TestVpnFeatures(override val featureName: String) : VpnFeature {
+        FOO("FOO"),
+        BAR("BAR"),
+    }
+
+    private class TestVpnServiceWrapper : VpnServiceWrapper(InstrumentationRegistry.getInstrumentation().context) {
+        private var isRunning = false
+        var restartCount = 0
+
+        override suspend fun restartVpnService() {
+            restartCount++
+        }
+
+        override fun stopService() {
+            isRunning = false
+        }
+
+        override fun startService() {
+            isRunning = true
+        }
+
+        override fun isServiceRunning(): Boolean {
+            return isRunning
+        }
+    }
+}

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModelTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModelTest.kt
@@ -30,9 +30,6 @@ import com.duckduckgo.mobile.android.vpn.model.VpnTracker
 import com.duckduckgo.mobile.android.vpn.network.VpnDetector
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
-import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnRunningState.ENABLED
-import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnState
-import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason.UNKNOWN
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTrackerActivityViewModel.ViewEvent
@@ -129,7 +126,6 @@ class DeviceShieldTrackerActivityViewModelTest {
 
     @Test
     fun whenLaunchExcludedAppsViewEventThenCommandIsLaunchExcludedApps() = runBlocking {
-        whenever(vpnStateMonitor.getState()).thenReturn(VpnState(ENABLED, UNKNOWN))
         viewModel.commands().test {
             viewModel.onViewEvent(DeviceShieldTrackerActivityViewModel.ViewEvent.LaunchExcludedApps)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1202551193613496/f

### Description
See context in [asana task](https://app.asana.com/0/1202279501986195/1202551193613496/f)

### Steps to test this PR

_Fresh install_
- [x] fresh install from this branch
- [x] enable AppTP when going through onboarding
- [x] go to Settings -> App tracking protection screen
- [x] verify AppTP is enabled
- [x] Toggle AppTP OFF
- [x] verify AppTP is disabled
- [x] go back to Settings
- [x] verify AppTP appears as disabled
- [x] in the browser, open new tabs until the AppTP banner apperas in new tab
- [x] verify AppTP is disabled
- [x] tab on the banner to go to App tracking protection screen
- [x] enable AppTP
- [x] go back to new tab and verify the banner shows AppTP enabled
- [x] install another VPN app and enabled it
- [x] back to our browser, verify AppTP is disabled and the reason in both new tab and AppTP screen is `A VPN app on your device disabled App Tracking Protection`
- [x] in App tracking protection screen, enable AppTP
- [x] verify AppTP is enabled
- [x] kill the VPN process (this can be done from IDE logcat)
- [x] verify AppTP is is re-enabled

_App update_
- [x] fresh install from develop branch
- [x] enable AppTP and update from this branch
- [x] launch AppTP and verify is enabled
- [x] repeat tests in previous section
