### PR TITLE
Add delay before showing autofill save/update prompts

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/BrowserAutofill.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/BrowserAutofill.kt
@@ -56,7 +56,7 @@ interface BrowserAutofill {
  * Browser Autofill callbacks
  */
 interface Callback {
-    fun onCredentialsAvailableToInject(credentials: List<LoginCredentials>)
-    fun onCredentialsAvailableToSave(currentUrl: String, credentials: LoginCredentials)
+    suspend fun onCredentialsAvailableToInject(credentials: List<LoginCredentials>)
+    suspend fun onCredentialsAvailableToSave(currentUrl: String, credentials: LoginCredentials)
     fun noCredentialsAvailable(originalUrl: String)
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
@@ -144,7 +144,7 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
     fun storeFormData(data: String) {
         Timber.i("storeFormData called, credentials provided to be persisted")
 
-        getAutofillDataJob += coroutineScope.launch {
+        getAutofillDataJob += coroutineScope.launch(dispatcherProvider.default()) {
             val currentUrl = currentUrlProvider.currentUrl(webView) ?: return@launch
 
             val request = requestParser.parseStoreFormDataRequest(data).credentials

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/ExistingCredentialStoreInterrogatingMatchDetector.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/ExistingCredentialStoreInterrogatingMatchDetector.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.autofill.ui
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
@@ -26,6 +28,8 @@ class ExistingCredentialStoreInterrogatingMatchDetector @Inject constructor(priv
     ExistingCredentialMatchDetector {
 
     override suspend fun determine(currentUrl: String, username: String, password: String): AutofillStore.ContainsCredentialsResult {
-        return autofillStore.containsCredentials(currentUrl, username, password)
+        return withContext(Dispatchers.IO) {
+            autofillStore.containsCredentials(currentUrl, username, password)
+        }
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/ExistingCredentialStoreInterrogatingMatchDetector.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/ExistingCredentialStoreInterrogatingMatchDetector.kt
@@ -16,19 +16,23 @@
 
 package com.duckduckgo.autofill.ui
 
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
-class ExistingCredentialStoreInterrogatingMatchDetector @Inject constructor(private val autofillStore: AutofillStore) :
+class ExistingCredentialStoreInterrogatingMatchDetector @Inject constructor(
+    private val autofillStore: AutofillStore,
+    private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider()
+) :
     ExistingCredentialMatchDetector {
 
     override suspend fun determine(currentUrl: String, username: String, password: String): AutofillStore.ContainsCredentialsResult {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcherProvider.io()) {
             autofillStore.containsCredentials(currentUrl, username, password)
         }
     }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
@@ -131,12 +131,12 @@ class AutofillStoredBackJavascriptInterfaceTest {
         var credentials: List<LoginCredentials>? = null
         var credentialsAvailable: Boolean? = null
 
-        override fun onCredentialsAvailableToInject(credentials: List<LoginCredentials>) {
+        override suspend fun onCredentialsAvailableToInject(credentials: List<LoginCredentials>) {
             credentialsAvailable = true
             this.credentials = credentials
         }
 
-        override fun onCredentialsAvailableToSave(currentUrl: String, credentials: LoginCredentials) {
+        override suspend fun onCredentialsAvailableToSave(currentUrl: String, credentials: LoginCredentials) {
 
         }
 


### PR DESCRIPTION
Without this delay, the form submission / navigation web events can be blocked, meaning we save the credentials but the user is left on the form, needing to hit the submission button again.

<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202612639205162/f

### Description
As noted in the linked task, we can hit a problem with forms not submitting correctly if we immediately show a DialogFragment from the @Javainterface function. This is a strange problem, but also one hit on other platforms like iOS.

The workaround is to introduce a short delay before showing the DialogFragments for saving or updating a credential

Also included is a small tidy-up of coroutine usage around these areas, which weren't quite right before.

### Steps to test this PR

1. Visit https://trello.com/login
2. Enter credentials and hit login button
3. Verify save dialog is shown
4. Also verify the form was submitted (either you'll be logged in, or you'll at least see error message about incorrect login). On `develop`, the page wouldn't change and you'd have to tap login button again 
