### PR TITLE
Fix update bug for autofill

### DIFF
--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -89,7 +89,8 @@ class SecureStoreBackedAutofillStore(
             return
         }
 
-        val matchingCredentials = secureStorage.websiteLoginDetailsWithCredentialsForDomain(url).firstOrNull()
+        val matchingCredentials =
+            secureStorage.websiteLoginDetailsWithCredentialsForDomain(url).firstOrNull()?.filter { it.details.username == credentials.username }
         if (matchingCredentials.isNullOrEmpty()) {
             Timber.w("Cannot update credentials as no credentials were found for %s", url)
             return

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.store
 
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.autofill.InternalTestUserChecker
+import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult
 import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.*
 import com.duckduckgo.securestorage.api.SecureStorage
@@ -25,8 +26,10 @@ import com.duckduckgo.securestorage.api.WebsiteLoginDetails
 import com.duckduckgo.securestorage.api.WebsiteLoginDetailsWithCredentials
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -71,7 +74,7 @@ class SecureStoreBackedAutofillStoreTest {
     @Test
     fun whenStoreContainsMatchingUsernameEntriesButNoneMatchingUrlThenNoMatch() = runTest {
         setupTesteeWithInternalTestUserTrue()
-        storeCredentials("https://example.com", "username", "password")
+        storeCredentials(1, "https://example.com", "username", "password")
         val result = testee.containsCredentials("foo.com", "username", "password")
         assertNotMatch(result)
     }
@@ -79,7 +82,7 @@ class SecureStoreBackedAutofillStoreTest {
     @Test
     fun whenStoreContainsDomainButDifferentCredentialsThenUrlMatch() = runTest {
         setupTesteeWithInternalTestUserTrue()
-        storeCredentials("https://example.com", "username", "password")
+        storeCredentials(1, "https://example.com", "username", "password")
         val result = testee.containsCredentials("example.com", "differentUsername", "differentPassword")
         assertUrlOnlyMatch(result)
     }
@@ -87,7 +90,7 @@ class SecureStoreBackedAutofillStoreTest {
     @Test
     fun whenStoreContainsDomainAndUsernameButDifferentPassword() = runTest {
         setupTesteeWithInternalTestUserTrue()
-        storeCredentials("https://example.com", "username", "password")
+        storeCredentials(1, "https://example.com", "username", "password")
         val result = testee.containsCredentials("example.com", "username", "differentPassword")
         assertUsernameMatch(result)
     }
@@ -95,9 +98,115 @@ class SecureStoreBackedAutofillStoreTest {
     @Test
     fun whenStoreContainsMatchingDomainAndUsernameAndPassword() = runTest {
         setupTesteeWithInternalTestUserTrue()
-        storeCredentials("https://example.com", "username", "password")
+        storeCredentials(1, "https://example.com", "username", "password")
         val result = testee.containsCredentials("example.com", "username", "password")
         assertExactMatch(result)
+    }
+
+    @Test
+    fun whenNoCredentialsForUrlStoredThenGetCredentialsReturnNothing() = runTest {
+        storeCredentials(1, "url.com", "username1", "password123")
+
+        assertEquals(0, testee.getCredentials("https://example.com").size)
+    }
+
+    @Test
+    fun whenNoCredentialsSavedThenGetAllCredentialsReturnNothing() = runTest {
+        assertEquals(0, testee.getAllCredentials().first().size)
+    }
+
+    @Test
+    fun whenPasswordIsUpdatedForUrlThenUpdatedOnlyMatchingCredential() = runTest {
+        val url = "https://example.com"
+        storeCredentials(1, url, "username1", "password123")
+        storeCredentials(2, url, "username2", "password456")
+        storeCredentials(3, url, "username3", "password789")
+        val credentials = LoginCredentials(
+            domain = url,
+            username = "username1",
+            password = "newpassword",
+            id = 1
+        )
+
+        testee.updateCredentials(url, credentials)
+
+        testee.getCredentials(url).run {
+            this.assertHasLoginCredentials(url, "username1", "newpassword")
+            this.assertHasLoginCredentials(url, "username2", "password456")
+            this.assertHasLoginCredentials(url, "username3", "password789")
+        }
+    }
+
+    @Test
+    fun whenPasswordIsUpdatedThenUpdatedOnlyMatchingCredential() = runTest {
+        val url = "https://example.com"
+        storeCredentials(1, url, "username1", "password123")
+        storeCredentials(2, url, "username2", "password456")
+        storeCredentials(3, url, "username3", "password789")
+        val credentials = LoginCredentials(
+            domain = url,
+            username = "username1",
+            password = "newpassword",
+            id = 1
+        )
+
+        testee.updateCredentials(credentials)
+
+        testee.getCredentials(url).run {
+            this.assertHasLoginCredentials(url, "username1", "newpassword")
+            this.assertHasLoginCredentials(url, "username2", "password456")
+            this.assertHasLoginCredentials(url, "username3", "password789")
+        }
+    }
+
+    @Test
+    fun whenSaveCredentialsThenReturnSavedOnGetCredentials() = runTest {
+        val url = "https://example.com"
+        val credentials = LoginCredentials(
+            domain = url,
+            username = "username1",
+            password = "password"
+        )
+        testee.saveCredentials(url, credentials)
+
+        assertEquals(credentials, testee.getCredentials(url).get(0))
+    }
+
+    @Test
+    fun whenPasswordIsDeletedThenRemoveCredentialFromStore() = runTest {
+        val url = "https://example.com"
+        storeCredentials(1, url, "username1", "password123")
+        storeCredentials(2, url, "username2", "password456")
+        storeCredentials(3, url, "username3", "password789")
+        testee.deleteCredentials(1)
+
+        testee.getCredentials(url).run {
+            this.assertHasNoLoginCredentials(url, "username1", "password123")
+            this.assertHasLoginCredentials(url, "username2", "password456")
+            this.assertHasLoginCredentials(url, "username3", "password789")
+        }
+    }
+
+    private fun List<LoginCredentials>.assertHasNoLoginCredentials(
+        url: String,
+        username: String,
+        password: String
+    ) {
+        val result = this.filter {
+            it.domain == url && it.username == username && it.password == password
+        }
+        assertEquals(0, result.size)
+    }
+
+    private fun List<LoginCredentials>.assertHasLoginCredentials(
+        url: String,
+        username: String,
+        password: String
+    ) {
+        val result = this.filter {
+            it.domain == url && it.username == username && it.password == password
+        }
+        assertEquals(1, result.size)
     }
 
     private fun setupTesteeWithInternalTestUserTrue() {
@@ -127,57 +236,70 @@ class SecureStoreBackedAutofillStoreTest {
     }
 
     private suspend fun storeCredentials(
+        id: Int,
         domain: String,
         username: String,
         password: String
     ) {
-        val details = WebsiteLoginDetails(domain, username)
+        val details = WebsiteLoginDetails(domain, username, id)
         val credentials = WebsiteLoginDetailsWithCredentials(details, password)
         secureStore.addWebsiteLoginDetailsWithCredentials(credentials)
     }
 
     private class FakeSecureStore : SecureStorage {
 
-        private val credentials = mutableMapOf<String, WebsiteLoginDetailsWithCredentials>()
+        private val credentials = mutableListOf<WebsiteLoginDetailsWithCredentials>()
 
         override suspend fun addWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials) {
-            credentials[websiteLoginDetailsWithCredentials.details.domain!!] = websiteLoginDetailsWithCredentials
+            credentials.add(websiteLoginDetailsWithCredentials)
         }
 
         override suspend fun websiteLoginDetailsForDomain(domain: String): Flow<List<WebsiteLoginDetails>> {
             return flow {
-                emit(credentials[domain]?.let { listOf(it.details) } ?: emptyList())
+                emit(
+                    credentials.filter {
+                        it.details.domain == domain
+                    }.map {
+                        it.details
+                    }
+                )
             }
         }
 
         override suspend fun websiteLoginDetails(): Flow<List<WebsiteLoginDetails>> {
             return flow {
-                emit(credentials.values.map { it.details })
+                emit(credentials.map { it.details })
             }
         }
 
         override suspend fun getWebsiteLoginDetailsWithCredentials(id: Int): WebsiteLoginDetailsWithCredentials {
-            return credentials.values.first { it.details.id == id }
+            return credentials.first { it.details.id == id }
         }
 
         override suspend fun websiteLoginDetailsWithCredentialsForDomain(domain: String): Flow<List<WebsiteLoginDetailsWithCredentials>> {
             return flow {
-                emit(credentials[domain]?.let { listOf(it) } ?: emptyList())
+                emit(
+                    credentials.filter {
+                        it.details.domain == domain
+                    }
+                )
             }
         }
 
         override suspend fun websiteLoginDetailsWithCredentials(): Flow<List<WebsiteLoginDetailsWithCredentials>> {
             return flow {
-                emit(credentials.values.toList())
+                emit(credentials)
             }
         }
 
         override suspend fun updateWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials) {
-            credentials[websiteLoginDetailsWithCredentials.details.domain!!] = websiteLoginDetailsWithCredentials
+            credentials.indexOfFirst { it.details.id == websiteLoginDetailsWithCredentials.details.id }.also {
+                credentials[it] = websiteLoginDetailsWithCredentials
+            }
         }
 
         override suspend fun deleteWebsiteLoginDetailsWithCredentials(id: Int) {
-            credentials.values.removeAll { it.details.id == id }
+            credentials.removeAll { it.details.id == id }
         }
 
         override fun canAccessSecureStorage(): Boolean = true


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202611392391295/f

### Description
This PR includes:
- Fix for logic when updating credentials for a specific domain url
- Add more tests for class SecureStoreBackedAutofillStore


### Steps to test this PR

_Updating credentials from browser_
- [ ] Save a few credentials for trello.com
- [ ] Refresh trello.com and fill login with existing credentials but update the password used
- [ ] Confirm that update bottom sheet is shown
- [ ] Update the password
- [ ] Refresh page and confirm that when autofill bottom sheet is shown, usernames shown are correct.
- [ ] Confirm in autofill management that password updated was updated correctly.

