### PR TITLE
Address remaining comments on MVP autofill

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -193,7 +193,6 @@ import com.duckduckgo.autofill.CredentialUpdateExistingCredentialsDialog.Compani
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.*
 import com.duckduckgo.autofill.ui.ExistingCredentialMatchDetector
-import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.voice.api.VoiceSearchLauncher
 import com.duckduckgo.voice.api.VoiceSearchLauncher.Source.BROWSER
@@ -331,9 +330,6 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var printInjector: PrintInjector
-
-    @Inject
-    lateinit var deviceAuthenticator: DeviceAuthenticator
 
     @Inject
     lateinit var credentialAutofillDialogFactory: CredentialAutofillDialogFactory
@@ -1580,20 +1576,18 @@ class BrowserTabFragment :
     }
 
     private fun configureWebViewForAutofill(it: DuckDuckGoWebView) {
-        if (deviceAuthenticator.hasValidDeviceAuthentication()) {
-            browserAutofill.addJsInterface(it, autofillCallback)
+        browserAutofill.addJsInterface(it, autofillCallback)
 
-            setFragmentResultListener(RESULT_KEY_CREDENTIAL_PICKER) { _, result ->
-                autofillCredentialsSelectionResultHandler.processAutofillCredentialSelectionResult(result, this, viewModel)
-            }
+        setFragmentResultListener(RESULT_KEY_CREDENTIAL_PICKER) { _, result ->
+            autofillCredentialsSelectionResultHandler.processAutofillCredentialSelectionResult(result, this, viewModel)
+        }
 
-            setFragmentResultListener(RESULT_KEY_CREDENTIAL_RESULT_SAVE) { _, result ->
-                autofillCredentialsSelectionResultHandler.processSaveCredentialsResult(result, viewModel)
-            }
+        setFragmentResultListener(RESULT_KEY_CREDENTIAL_RESULT_SAVE) { _, result ->
+            autofillCredentialsSelectionResultHandler.processSaveCredentialsResult(result, viewModel)
+        }
 
-            setFragmentResultListener(RESULT_KEY_CREDENTIAL_RESULT_UPDATE) { _, result ->
-                autofillCredentialsSelectionResultHandler.processUpdateCredentialsResult(result, viewModel)
-            }
+        setFragmentResultListener(RESULT_KEY_CREDENTIAL_RESULT_UPDATE) { _, result ->
+            autofillCredentialsSelectionResultHandler.processUpdateCredentialsResult(result, viewModel)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.autofill.jsbridge.request.SupportedAutofillInputSubType.PA
 import com.duckduckgo.autofill.jsbridge.request.SupportedAutofillInputSubType.USERNAME
 import com.duckduckgo.autofill.jsbridge.response.AutofillResponseWriter
 import com.duckduckgo.autofill.store.AutofillStore
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
@@ -67,6 +68,7 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
     private val autofillResponseWriter: AutofillResponseWriter,
     private val emailManager: EmailManager,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val deviceAuthenticator: DeviceAuthenticator,
     private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider(),
     private val currentUrlProvider: UrlProvider = WebViewUrlProvider(dispatcherProvider)
 ) : AutofillJavascriptInterface {
@@ -105,19 +107,28 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
         }
     }
 
-    private fun filterRequestedSubtypes(request: AutofillDataRequest, credentials: List<LoginCredentials>): List<LoginCredentials> {
+    private fun filterRequestedSubtypes(
+        request: AutofillDataRequest,
+        credentials: List<LoginCredentials>
+    ): List<LoginCredentials> {
         return when (request.subType) {
             USERNAME -> credentials.filterNot { it.username.isNullOrBlank() }
             PASSWORD -> credentials.filterNot { it.password.isNullOrBlank() }
         }
     }
 
-    private fun handleUnknownRequestMainType(request: AutofillDataRequest, url: String) {
+    private fun handleUnknownRequestMainType(
+        request: AutofillDataRequest,
+        url: String
+    ) {
         Timber.w("Autofill type %s unsupported", request.mainType)
         callback?.noCredentialsAvailable(url)
     }
 
-    override suspend fun getRuntimeConfiguration(rawJs: String, url: String?): String {
+    override suspend fun getRuntimeConfiguration(
+        rawJs: String,
+        url: String?
+    ): String {
         Timber.v("BrowserAutofill: getRuntimeConfiguration called")
 
         val contentScope = autofillResponseWriter.generateContentScope()
@@ -145,7 +156,7 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
     private fun determineIfEmailAvailable(): Boolean = emailManager.isSignedIn()
 
     // in the future, we'll also tie this into feature toggles and remote config
-    private fun determineIfAutofillEnabled(): Boolean = autofillStore.autofillEnabled
+    private fun determineIfAutofillEnabled(): Boolean = autofillStore.autofillEnabled && deviceAuthenticator.hasValidDeviceAuthentication()
 
     private suspend fun determineIfCredentialsAvailable(url: String?): Boolean {
         return if (url == null) {
@@ -214,5 +225,4 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
             }
         }
     }
-
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/InlineBrowserAutofill.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/InlineBrowserAutofill.kt
@@ -38,6 +38,7 @@ class InlineBrowserAutofill @Inject constructor(
 
     override fun addJsInterface(webView: WebView, callback: Callback) {
         Timber.v("Injecting BrowserAutofill interface")
+        // Adding the interface regardless if the feature is available or not
         webView.addJavascriptInterface(autofillInterface, AutofillJavascriptInterface.INTERFACE_NAME)
         autofillInterface.webView = webView
         autofillInterface.callback = callback

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillClipboardInteractor.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillClipboardInteractor.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import com.duckduckgo.di.scopes.ActivityScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface AutofillClipboardInteractor {
+    fun copyToClipboard(toCopy: String)
+}
+
+@ContributesBinding(ActivityScope::class)
+class RealAutofillClipboardInteractor @Inject constructor(
+    context: Context
+) : AutofillClipboardInteractor {
+    private val clipboardManager by lazy { context.getSystemService(ClipboardManager::class.java) }
+
+    override fun copyToClipboard(toCopy: String) {
+        clipboardManager.setPrimaryClip(ClipData.newPlainText("", toCopy))
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -16,10 +16,6 @@
 
 package com.duckduckgo.autofill.ui.credential.management
 
-import android.annotation.SuppressLint
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
@@ -34,11 +30,10 @@ import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
 
-@SuppressLint("StaticFieldLeak")
 @ContributesViewModel(ActivityScope::class)
 class AutofillSettingsViewModel @Inject constructor(
-    private val applicationContext: Context,
     private val autofillStore: AutofillStore,
+    private val clipboardInteractor: AutofillClipboardInteractor
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -48,12 +43,12 @@ class AutofillSettingsViewModel @Inject constructor(
     val commands: StateFlow<List<Command>> = _commands
 
     fun onCopyUsername(username: String?) {
-        username?.copyToClipboard()
+        username?.let { clipboardInteractor.copyToClipboard(it) }
         addCommand(ShowUserUsernameCopied())
     }
 
     fun onCopyPassword(password: String?) {
-        password?.copyToClipboard()
+        password?.let { clipboardInteractor.copyToClipboard(it) }
         addCommand(ShowUserPasswordCopied())
     }
 
@@ -92,14 +87,6 @@ class AutofillSettingsViewModel @Inject constructor(
             val updatedList = currentCommands.filterNot { it.id == command.id }
             _commands.value = updatedList
         }
-    }
-
-    private fun String.copyToClipboard() {
-        clipboardManager().setPrimaryClip(ClipData.newPlainText("", this))
-    }
-
-    private fun clipboardManager(): ClipboardManager {
-        return applicationContext.getSystemService(ClipboardManager::class.java)
     }
 
     fun observeCredentials() {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.autofill.jsbridge.request.SupportedAutofillInputSubType.PA
 import com.duckduckgo.autofill.jsbridge.request.SupportedAutofillInputSubType.USERNAME
 import com.duckduckgo.autofill.jsbridge.response.AutofillResponseWriter
 import com.duckduckgo.autofill.store.AutofillStore
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -55,14 +56,14 @@ class AutofillStoredBackJavascriptInterfaceTest {
     private val autofillResponseWriter: AutofillResponseWriter = mock()
     private val emailManager: EmailManager = mock()
     private val currentUrlProvider: UrlProvider = mock()
+    private val deviceAuthenticator: DeviceAuthenticator = mock()
     private val coroutineScope: CoroutineScope = TestScope()
 
     private val testWebView = WebView(getApplicationContext())
-
-    private lateinit var testee: AutofillJavascriptInterface
+    private lateinit var testee: AutofillStoredBackJavascriptInterface
 
     @Before
-    fun setup() = runTest {
+    fun setUp() = runTest {
         testee = AutofillStoredBackJavascriptInterface(
             requestParser = requestParser,
             autofillStore = autofillStore,
@@ -72,12 +73,19 @@ class AutofillStoredBackJavascriptInterfaceTest {
             coroutineScope = coroutineScope,
             currentUrlProvider = currentUrlProvider,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
+            deviceAuthenticator = deviceAuthenticator
         )
         testee.callback = TestCallback
         testee.webView = testWebView
 
         whenever(currentUrlProvider.currentUrl(testWebView)).thenReturn("https://example.com")
         whenever(requestParser.parseAutofillDataRequest(any())).thenReturn(AutofillDataRequest(CREDENTIALS, USERNAME))
+        whenever(autofillResponseWriter.generateContentScope()).thenReturn("")
+        whenever(autofillResponseWriter.generateEmptyResponseGetAutofillData()).thenReturn("")
+        whenever(autofillResponseWriter.generateResponseGetAutofillData(any())).thenReturn("")
+        whenever(autofillResponseWriter.generateResponseGetAvailableInputTypes(any(), any())).thenReturn("")
+        whenever(autofillResponseWriter.generateUserPreferences(any(), any())).thenReturn("")
+        whenever(autofillResponseWriter.generateUserUnprotectedDomains()).thenReturn("")
     }
 
     @Test
@@ -216,13 +224,95 @@ class AutofillStoredBackJavascriptInterfaceTest {
         assertCredentialsContains({ it.password }, "password1", "password2", "password3")
     }
 
-    private fun assertCredentialsContains(property: (LoginCredentials) -> String?, vararg expected: String?) {
+    @Test
+    fun whenAutofillEnabledButNoDeviceAuthThenConfigurationUserPrefsCredentialsIsFalse() = runTest {
+        val url = "example.com"
+        whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(false)
+        whenever(autofillStore.autofillEnabled).thenReturn(true)
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateUserPreferences(false)
+    }
+
+    @Test
+    fun whenAutofillNotEnabledThenConfigurationUserPrefsCredentialsIsFalse() = runTest {
+        val url = "example.com"
+        whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
+        whenever(autofillStore.autofillEnabled).thenReturn(false)
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateUserPreferences(false)
+    }
+
+    @Test
+    fun whenAutofillEnabledWithDeviceAuthThenConfigurationUserPrefsCredentialsIsTrue() = runTest {
+        val url = "example.com"
+        whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
+        whenever(autofillStore.autofillEnabled).thenReturn(true)
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateUserPreferences(true)
+    }
+
+    @Test
+    fun whenNoCredentialsForUrlThenConfigurationInputTypeCredentialsIsFalse() = runTest {
+        val url = "example.com"
+        whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateResponseGetAvailableInputTypes(credentialsAvailable = false, emailAvailable = false)
+    }
+
+    @Test
+    fun whenWithCredentialsForUrlThenConfigurationInputTypeCredentialsIsTrue() = runTest {
+        val url = "example.com"
+        whenever(autofillStore.getCredentials(url)).thenReturn(
+            listOf(
+                LoginCredentials(
+                    id = 1,
+                    domain = url,
+                    username = "username",
+                    password = "password"
+                )
+            )
+        )
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateResponseGetAvailableInputTypes(credentialsAvailable = true, emailAvailable = false)
+    }
+
+    @Test
+    fun whenEmailIsSignedInThenConfigurationInputTypeEmailIsTrue() = runTest {
+        val url = "example.com"
+        whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
+        whenever(emailManager.isSignedIn()).thenReturn(true)
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateResponseGetAvailableInputTypes(credentialsAvailable = false, emailAvailable = true)
+    }
+
+    private fun assertCredentialsContains(
+        property: (LoginCredentials) -> String?,
+        vararg expected: String?
+    ) {
         val numberExpected = expected.size
         val numberMatched = TestCallback.credentials?.filter { expected.contains(property(it)) }?.count()
         assertEquals("Wrong number of matched properties. Expected $numberExpected but found $numberMatched", numberExpected, numberMatched)
     }
 
-    private fun loginCredential(username: String?, password: String?) = LoginCredentials(0, "example.com", username, password)
+    private fun loginCredential(
+        username: String?,
+        password: String?
+    ) = LoginCredentials(0, "example.com", username, password)
 
     private suspend fun setupRequestForSubTypeUsername() {
         whenever(requestParser.parseAutofillDataRequest(any())).thenReturn(AutofillDataRequest(CREDENTIALS, USERNAME))
@@ -260,13 +350,14 @@ class AutofillStoredBackJavascriptInterfaceTest {
             this.credentials = credentials
         }
 
-        override suspend fun onCredentialsAvailableToSave(currentUrl: String, credentials: LoginCredentials) {
-
+        override suspend fun onCredentialsAvailableToSave(
+            currentUrl: String,
+            credentials: LoginCredentials
+        ) {
         }
 
         override fun noCredentialsAvailable(originalUrl: String) {
             credentialsAvailable = false
         }
     }
-
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -16,9 +16,8 @@
 
 package com.duckduckgo.autofill.ui.credential.management
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command
@@ -27,18 +26,21 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import kotlin.reflect.KClass
 
-@RunWith(AndroidJUnit4::class)
 @ExperimentalCoroutinesApi
 class AutofillSettingsViewModelTest {
 
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
     private val mockStore: AutofillStore = mock()
-    private val testee = AutofillSettingsViewModel(InstrumentationRegistry.getInstrumentation().targetContext, mockStore)
+    private val clipboardInteractor: AutofillClipboardInteractor = mock()
+    private val testee = AutofillSettingsViewModel(mockStore, clipboardInteractor)
 
     @Test
     fun whenUserEnablesAutofillThenViewStateUpdatedToReflectChange() = runTest {
@@ -59,6 +61,8 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenUserCopiesPasswordThenCommandIssuedToShowChange() = runTest {
         testee.onCopyPassword("hello")
+
+        verify(clipboardInteractor).copyToClipboard("hello")
         testee.commands.test {
             awaitItem().first().assertCommandType(ShowUserPasswordCopied::class)
         }
@@ -67,6 +71,8 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenUserCopiesUsernameThenCommandIssuedToShowChange() = runTest {
         testee.onCopyUsername("username")
+
+        verify(clipboardInteractor).copyToClipboard("username")
         testee.commands.test {
             awaitItem().first().assertCommandType(ShowUserUsernameCopied::class)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202621847351497/f

### Description
This PR includes:
- Remove injected context in ActivityScoped AutofillManagement Screen ViewModel
- Move device auth check from browser fragment into AutofillJavascript to have a single place that defines availability of autofill. This also fixes the issue where when device auth is removed from device anduser attempts to autofill aftyer refreshing website. Previously, autofill is still enabled (bottom sheet is shown) but can't autofill since no device auth is available. Now that is fixed.

### Steps to test this PR

_Clipboard changes_
- [x] Add a new credential
- [x] Go to autofill management 
- [x] Copy username and password and verify that they are being copied correctly.

_Auth check changes_
- [x] Enrol device auth in device
- [x] Save a credential for a website
- [x] Attempt to autofill the website with previously saved credential. 
- [x] Confirm that this works
- [x] Remove device auth for device
- [x] Refresh page and attempt to autofill
- [x] Confirm that autofill bottom sheet doesn't show.

