### PR TITLE
Dismiss download in progress notifications on app close

### DIFF
--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloadCallManager.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloadCallManager.kt
@@ -16,8 +16,10 @@
 
 package com.duckduckgo.downloads.impl
 
+import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import okhttp3.ResponseBody
 import retrofit2.Call
@@ -31,9 +33,16 @@ interface UrlFileDownloadCallManager {
     fun remove(downloadId: Long)
 }
 
-@ContributesBinding(AppScope::class)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = UrlFileDownloadCallManager::class
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = BrowserLifecycleObserver::class
+)
 @SingleInstanceIn(AppScope::class)
-class RealUrlFileDownloadCallManager @Inject constructor() : UrlFileDownloadCallManager {
+class RealUrlFileDownloadCallManager @Inject constructor() : UrlFileDownloadCallManager, BrowserLifecycleObserver {
     private val callsMap = ConcurrentHashMap<Long, Call<ResponseBody>>()
 
     /**
@@ -53,5 +62,11 @@ class RealUrlFileDownloadCallManager @Inject constructor() : UrlFileDownloadCall
     override fun add(downloadId: Long, call: Call<ResponseBody>) {
         Timber.d("Adding download $downloadId")
         callsMap[downloadId] = call
+    }
+
+    override fun onExit() {
+        // this callback will only be called when the AppTP process is enabled and the user swipe closes the app :shrug:
+        // to be consistent with the behavior when AppTP process is disabled, we want to cancel downloads
+        callsMap.keys.forEach { remove(it) }
     }
 }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloader.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloader.kt
@@ -132,7 +132,7 @@ class UrlFileDownloader @Inject constructor(
                 sink.write(buffer, didRead)
                 val fakeProgress = floor(calculateFakeProgress(progressSteps) * 100.0).toInt().also { progressSteps += 0.0001 }
                 val calculatedProgress = (totalRead * 100 / contentLength).coerceAtLeast(0L)
-                val progress = if (calculatedProgress == 0L) fakeProgress else calculatedProgress
+                val progress = if (calculatedProgress < 0L) fakeProgress else calculatedProgress
                 downloadCallback.onProgress(downloadId, fileName, progress.toInt())
             }
             true


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202612974845126/f

### Description
When the app is closed all ongoing downloads are cancelled, but the in progress notifications linger.

This PR ensures the download in progress notifications are also cancelled.

### Steps to test this PR

_Test bug fix_
- Install from https://github.com/duckduckgo/Android/pull/2039
- open app and start downloading several files from http://ipv4.download.thinkbroadband.com
- close the app
- expected: download in progress notifications should be dismissed
- actual:   download in progress notifications are NOT dismissed
- install from this branch
- open app and start downloading several files from http://ipv4.download.thinkbroadband.com
- close the app
- [x] verify download in progress notifications are dismissed

