### PR TITLE
Migrate from @OnLifecycleEvent: common-ui module

### DIFF
--- a/common-ui/build.gradle
+++ b/common-ui/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     implementation Kotlin.stdlib.jdk7
 
+    implementation JakeWharton.timber
     implementation AndroidX.appCompat
     implementation Google.android.material
     implementation AndroidX.constraintLayout

--- a/common-ui/build.gradle
+++ b/common-ui/build.gradle
@@ -38,7 +38,6 @@ dependencies {
 
     implementation Kotlin.stdlib.jdk7
 
-    implementation JakeWharton.timber
     implementation AndroidX.appCompat
     implementation Google.android.material
     implementation AndroidX.constraintLayout

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/FragmentViewBindingDelegate.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/FragmentViewBindingDelegate.kt
@@ -24,7 +24,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.viewbinding.ViewBinding
-import timber.log.Timber
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -47,10 +46,6 @@ class FragmentViewBindingDelegate<T : ViewBinding>(
         fragment.viewLifecycleOwnerLiveData.observe(fragment) { lifecycleOwner ->
             lifecycleOwner.lifecycle.addObserver(
                 object : DefaultLifecycleObserver {
-                    override fun onCreate(owner: LifecycleOwner) {
-                        Timber.d("Registering fragment lifecycle observer: ${fragment.javaClass.canonicalName}")
-                        super.onCreate(owner)
-                    }
                     override fun onDestroy(owner: LifecycleOwner) {
                         nullifyBindingHandler.post { binding = null }
                         super.onDestroy(owner)

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/FragmentViewBindingDelegate.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/viewbinding/FragmentViewBindingDelegate.kt
@@ -20,10 +20,11 @@ import android.os.Handler
 import android.os.Looper
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import androidx.viewbinding.ViewBinding
+import timber.log.Timber
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -45,10 +46,14 @@ class FragmentViewBindingDelegate<T : ViewBinding>(
     init {
         fragment.viewLifecycleOwnerLiveData.observe(fragment) { lifecycleOwner ->
             lifecycleOwner.lifecycle.addObserver(
-                object : LifecycleObserver {
-                    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-                    fun onDestroy() {
+                object : DefaultLifecycleObserver {
+                    override fun onCreate(owner: LifecycleOwner) {
+                        Timber.d("Registering fragment lifecycle observer: ${fragment.javaClass.canonicalName}")
+                        super.onCreate(owner)
+                    }
+                    override fun onDestroy(owner: LifecycleOwner) {
                         nullifyBindingHandler.post { binding = null }
+                        super.onDestroy(owner)
                     }
                 })
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202260594569384/f

### Description

@OnLifecycleEvent is now deprecated. Updated code in common-ui module to use `DefaultLifecycleObserver`

### Steps to test this PR

- Install from this branch
- Launch the app
- Open any fragment which uses viewBinding (e.g. Email Protection)
- Check in the Logcat that the following Logs appear:
  - [ ] Registering fragment lifecycle observer: com.duckduckgo.app.email.ui.EmailProtectionSignInFragment
