### PR TITLE
Add a lint rule to not extend LifecycleObserver

### DIFF
--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/privacy/TrackerDataDevReceiver.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/privacy/TrackerDataDevReceiver.kt
@@ -38,7 +38,7 @@ class TrackerDataDevReceiver(
     context: Context,
     intentAction: String = DOWNLOAD_TDS_INTENT_ACTION,
     private val receiver: (Intent) -> Unit
-) : BroadcastReceiver(), LifecycleObserver {
+) : BroadcastReceiver() {
     init {
         context.registerReceiver(this, IntentFilter(intentAction))
     }

--- a/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
@@ -79,10 +79,6 @@ abstract class StoreModule {
     abstract fun bindUserStageStore(userStageStore: AppUserStageStore): UserStageStore
 
     @Binds
-    @IntoSet
-    abstract fun bindUserStageStoreObserver(userStageStore: UserStageStore): LifecycleObserver
-
-    @Binds
     abstract fun bindUserEventsStore(userEventsStore: AppUserEventsStore): UserEventsStore
 
     @Binds

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/UserStageStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/UserStageStore.kt
@@ -16,12 +16,11 @@
 
 package com.duckduckgo.app.onboarding.store
 
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.global.DispatcherProvider
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-interface UserStageStore : LifecycleObserver {
+interface UserStageStore {
     suspend fun getUserAppStage(): AppStage
     suspend fun stageCompleted(appStage: AppStage): AppStage
     suspend fun moveToStage(appStage: AppStage)

--- a/lint-rules/src/main/java/com/duckduckgo/lint/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/DuckDuckGoIssueRegistry.kt
@@ -20,12 +20,16 @@ import com.android.tools.lint.client.api.IssueRegistry
 import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
+import com.duckduckgo.lint.NoLifecycleObserverDetector.Companion.NO_LIFECYCLE_OBSERVER_ISSUE
 import com.duckduckgo.lint.NoSingletonDetector.Companion.NO_SINGLETON_ISSUE
 
 @Suppress("UnstableApiUsage")
 class DuckDuckGoIssueRegistry : IssueRegistry() {
     override val issues: List<Issue>
-        get() = listOf(NO_SINGLETON_ISSUE)
+        get() = listOf(
+            NO_SINGLETON_ISSUE,
+            NO_LIFECYCLE_OBSERVER_ISSUE,
+        )
 
     override val api: Int
         get() = CURRENT_API

--- a/lint-rules/src/main/java/com/duckduckgo/lint/NoLifecycleObserverDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/NoLifecycleObserverDetector.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UClass
+import java.util.*
+
+@Suppress("UnstableApiUsage")
+class NoLifecycleObserverDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes() = listOf(UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = NoInternalImportHandler(context)
+
+    internal class NoInternalImportHandler(private val context: JavaContext) : UElementHandler() {
+        override fun visitClass(node: UClass) {
+            if (node.extendsListTypes.any { it.className == "LifecycleObserver" }) {
+                context.report(NO_LIFECYCLE_OBSERVER_ISSUE, node, context.getNameLocation(node), "LifecycleObserver should not be directly extended")
+            }
+        }
+    }
+
+    companion object {
+        val NO_LIFECYCLE_OBSERVER_ISSUE = Issue.create("NoLifecycleObserver",
+            "The LifecycleObserver type should not be extended.",
+            """
+                The LifecycleObserver should not be used.
+                Use DefaultLifecycleObserver instead.
+            """.trimIndent(),
+            Category.CORRECTNESS, 10, ERROR,
+            Implementation(NoLifecycleObserverDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES))
+        )
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/NoLifecycleObserverTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/NoLifecycleObserverTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class NoLifecycleObserverTest {
+    @Test
+    fun whenLifecycleObserverExtendedThenFailWithError() {
+        lint()
+            .files(kt("""
+              package com.duckduckgo.lint
+    
+                class LifecycleObserver
+
+                class Duck : LifecycleObserver() {
+                    fun quack() {                    
+                    }
+                }
+            """).indented())
+            .issues(NoLifecycleObserverDetector.NO_LIFECYCLE_OBSERVER_ISSUE)
+            .run()
+            .expect("""
+                src/com/duckduckgo/lint/LifecycleObserver.kt:5: Error: LifecycleObserver should not be directly extended [NoLifecycleObserver]
+                  class Duck : LifecycleObserver() {
+                        ~~~~
+                1 errors, 0 warnings
+            """.trimMargin())
+    }
+
+    @Test
+    fun whenDefaultLifecycleObserverExtendedThenSucceed() {
+        lint()
+            .files(kt("""
+              package com.duckduckgo.lint
+    
+                class DefaultLifecycleObserver
+
+                class Duck : DefaultLifecycleObserver() {
+                    fun quack() {                    
+                    }
+                }
+            """).indented())
+            .allowCompilationErrors()
+            .issues(NoLifecycleObserverDetector.NO_LIFECYCLE_OBSERVER_ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenLifecycleObserverNotFoundThenSucceed() {
+        lint()
+            .files(kt("""
+              package com.duckduckgo.lint
+    
+                class Duck {
+                    fun quack() {                    
+                    }
+                }
+            """).indented())
+            .allowCompilationErrors()
+            .issues(NoLifecycleObserverDetector.NO_LIFECYCLE_OBSERVER_ISSUE)
+            .run()
+            .expectClean()
+    }
+}

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
@@ -47,7 +47,7 @@ class DeviceShieldNotificationsDebugReceiver(
     context: Context,
     intentAction: String = "notify",
     private val receiver: (Intent) -> Unit
-) : BroadcastReceiver(), LifecycleObserver {
+) : BroadcastReceiver() {
 
     init {
         context.registerReceiver(this, IntentFilter(intentAction))

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/report/PrivacyReportViewModel.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/ui/report/PrivacyReportViewModel.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.mobile.android.vpn.ui.report
 
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.global.DispatcherProvider
@@ -42,7 +41,7 @@ class PrivacyReportViewModel @Inject constructor(
     private val vpnFeatureRemover: VpnFeatureRemover,
     vpnStateMonitor: VpnStateMonitor,
     private val dispatchers: DispatcherProvider
-) : ViewModel(), LifecycleObserver {
+) : ViewModel() {
 
     val viewStateFlow = vpnStateMonitor.getStateFlow(AppTpVpnFeature.APPTP_VPN).combine(getReport()) { vpnState, trackersBlocked ->
         PrivacyReportView.ViewState(vpnState, trackersBlocked, shouldShowCTA())


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202643385187950/f

### Description
Ditto, no more extending `LifecycleObserver`

### Steps to test this PR

_Test lint rule_
- [x] Take any class and extend `LifecycleObserver`
- [x] run `./gradlew lint`
- [x] expect failure

