### PR TITLE
Support logins with missing usernames

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -429,13 +429,8 @@ class BrowserTabFragment :
             val username = credentials.username
             val password = credentials.password
 
-            if (username == null) {
-                Timber.w("Not saving credentials with null username")
-                return
-            }
-
-            if (password == null) {
-                Timber.w("Not saving credentials with null password")
+            if (username == null && password == null) {
+                Timber.w("Not saving credentials with null username and password")
                 return
             }
 

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
@@ -78,7 +78,7 @@ interface AutofillStore {
      *
      * @return The match type, which might indicate there was an exact match, a partial match etc...
      */
-    suspend fun containsCredentials(rawUrl: String, username: String, password: String): ContainsCredentialsResult
+    suspend fun containsCredentials(rawUrl: String, username: String?, password: String?): ContainsCredentialsResult
 
     /**
      * Possible match types returned when searching for the presence of credentials

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/ui/ExistingCredentialMatchDetector.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/ui/ExistingCredentialMatchDetector.kt
@@ -25,5 +25,5 @@ import com.duckduckgo.autofill.store.AutofillStore
  * We can only show that prompt if we've first determined there is an existing partial match in need of an update.
  */
 interface ExistingCredentialMatchDetector {
-    suspend fun determine(currentUrl: String, username: String, password: String): AutofillStore.ContainsCredentialsResult
+    suspend fun determine(currentUrl: String, username: String?, password: String?): AutofillStore.ContainsCredentialsResult
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/ExistingCredentialStoreInterrogatingMatchDetector.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/ExistingCredentialStoreInterrogatingMatchDetector.kt
@@ -31,7 +31,7 @@ class ExistingCredentialStoreInterrogatingMatchDetector @Inject constructor(
 ) :
     ExistingCredentialMatchDetector {
 
-    override suspend fun determine(currentUrl: String, username: String, password: String): AutofillStore.ContainsCredentialsResult {
+    override suspend fun determine(currentUrl: String, username: String?, password: String?): AutofillStore.ContainsCredentialsResult {
         return withContext(dispatcherProvider.io()) {
             autofillStore.containsCredentials(currentUrl, username, password)
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
@@ -64,13 +64,13 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val binding = ContentAutofillSaveNewCredentialsBinding.inflate(inflater, container, false)
-        configureViews(binding)
+        configureViews(binding, getCredentialsToSave())
         return binding.root
     }
 
-    private fun configureViews(binding: ContentAutofillSaveNewCredentialsBinding) {
+    private fun configureViews(binding: ContentAutofillSaveNewCredentialsBinding, credentials: LoginCredentials) {
         configureSiteDetails(binding)
-        configureTitles(binding)
+        configureTitles(binding, credentials)
         configureCloseButtons(binding)
         configureSaveButton(binding)
     }
@@ -91,9 +91,13 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
         binding.cancelButton.setOnClickListener { (dialog as BottomSheetDialog).animateClosed() }
     }
 
-    private fun configureTitles(binding: ContentAutofillSaveNewCredentialsBinding) {
+    private fun configureTitles(binding: ContentAutofillSaveNewCredentialsBinding, credentials: LoginCredentials) {
+        val resources = viewModel.determineTextResources(credentials)
+
+        binding.dialogTitle.text = getString(resources.title)
+        binding.saveLoginButton.text = getString(resources.ctaButton)
+
         if (!showOnboarding()) {
-            binding.dialogTitle.text = getString(R.string.saveLoginDialogTitle)
             binding.onboardingSubtitle.gone()
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
@@ -16,8 +16,11 @@
 
 package com.duckduckgo.autofill.ui.credential.saving
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
@@ -31,4 +34,45 @@ class AutofillSavingCredentialsViewModel @Inject constructor() : ViewModel() {
     fun showOnboarding(): Boolean {
         return autofillStore.showOnboardingWhenOfferingToSaveLogin
     }
+
+    fun determineTextResources(credentials: LoginCredentials): DisplayStringResourceIds {
+        val title: Int = determineTitle(credentials)
+        val ctaButton: Int = determineCtaButtonText(credentials)
+
+        return DisplayStringResourceIds(
+            title = title,
+            ctaButton = ctaButton
+        )
+    }
+
+    @StringRes
+    private fun determineTitle(credentials: LoginCredentials): Int {
+        if (showOnboarding()) {
+            return R.string.saveLoginDialogFirstTimeOnboardingExplanationTitle
+        }
+
+        return if (credentials.username == null) {
+            R.string.saveLoginMissingUsernameDialogTitle
+        } else {
+            R.string.saveLoginDialogTitle
+        }
+    }
+
+    @StringRes
+    private fun determineCtaButtonText(credentials: LoginCredentials): Int {
+        if (showOnboarding()) {
+            return R.string.saveLoginDialogButtonSave
+        }
+
+        return if (credentials.username == null) {
+            R.string.saveLoginMissingUsernameDialogButtonSave
+        } else {
+            R.string.saveLoginDialogButtonSave
+        }
+    }
+
+    data class DisplayStringResourceIds(
+        @StringRes val title: Int,
+        @StringRes val ctaButton: Int
+    )
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
@@ -87,7 +87,12 @@ class AutofillSelectCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
     }
 
     private fun configureAdapter(): CredentialsPickerRecyclerAdapter {
-        return CredentialsPickerRecyclerAdapter(this, faviconManager, getAvailableCredentials()) { selectedCredentials ->
+        return CredentialsPickerRecyclerAdapter(
+            lifecycleOwner = this,
+            faviconManager = faviconManager,
+            credentialTextExtractor = CredentialTextExtractor(requireContext()),
+            credentials = getAvailableCredentials()
+        ) { selectedCredentials ->
             val result = Bundle().also {
                 it.putBoolean(CredentialAutofillPickerDialog.KEY_CANCELLED, false)
                 it.putString(CredentialAutofillPickerDialog.KEY_URL, getOriginalUrl())

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/CredentialTextExtractor.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/CredentialTextExtractor.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.selecting
+
+import android.content.Context
+import com.duckduckgo.app.global.extractDomain
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.R
+
+class CredentialTextExtractor(private val applicationContext: Context) {
+
+    fun usernameOrPlaceholder(credentials: LoginCredentials): String {
+        credentials.username.let { username ->
+            return if (username.isNullOrBlank()) {
+                buildPlaceholderForSite(credentials.domain)
+            } else {
+                username
+            }
+        }
+    }
+
+    private fun buildPlaceholderForSite(domain: String?): String {
+        return if (domain.isNullOrBlank()) {
+            missingUsernameAndSitePlaceholder()
+        } else {
+            val domainName = domain.extractDomain() ?: return missingUsernameAndSitePlaceholder()
+            applicationContext.getString(R.string.useSavedLoginDialogMissingUsernameButtonText, domainName)
+        }
+    }
+
+    private fun missingUsernameAndSitePlaceholder(): String {
+        return applicationContext.getString(R.string.useSavedLoginDialogMissingUsernameMissingDomainButtonText)
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/CredentialsPickerRecyclerAdapter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/CredentialsPickerRecyclerAdapter.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.mobile.android.ui.view.show
 class CredentialsPickerRecyclerAdapter(
     val lifecycleOwner: LifecycleOwner,
     val faviconManager: FaviconManager,
+    val credentialTextExtractor: CredentialTextExtractor,
     private val credentials: List<LoginCredentials>,
     private val onCredentialSelected: (credentials: LoginCredentials) -> Unit
 ) : Adapter<CredentialsViewHolder>() {
@@ -60,11 +61,11 @@ class CredentialsPickerRecyclerAdapter(
 
         val button = when (buttonType) {
             is UseCredentialPrimaryButton -> useCredentialPrimaryButton.also {
-                it.text = credentials.username
+                it.text = credentialTextExtractor.usernameOrPlaceholder(credentials)
                 it.setOnClickListener { onCredentialSelected(credentials) }
             }
             is UseCredentialSecondaryButton -> useCredentialSecondaryButton.also {
-                it.text = credentials.username
+                it.text = credentialTextExtractor.usernameOrPlaceholder(credentials)
                 it.setOnClickListener { onCredentialSelected(credentials) }
             }
             is ShowMoreButton -> moreOptionsButton.also {

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
@@ -69,6 +69,7 @@
         android:id="@+id/dialogTitle"
         style="@style/AutofillDialogHeadlineStyle"
         android:text="@string/saveLoginDialogFirstTimeOnboardingExplanationTitle"
+        android:breakStrategy="balanced"
         app:layout_constraintEnd_toEndOf="@id/guidelineEnd"
         app:layout_constraintStart_toStartOf="@id/guidelineStart"
         app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer" />

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
@@ -68,7 +68,7 @@
     <TextView
         android:id="@+id/dialogTitle"
         style="@style/AutofillDialogHeadlineStyle"
-        android:text="@string/saveLoginDialogFirstTimeExplanationTitle"
+        android:text="@string/saveLoginDialogFirstTimeOnboardingExplanationTitle"
         app:layout_constraintEnd_toEndOf="@id/guidelineEnd"
         app:layout_constraintStart_toStartOf="@id/guidelineStart"
         app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer" />

--- a/autofill/autofill-impl/src/main/res/values/autofill-impl-strings-untranslated.xml
+++ b/autofill/autofill-impl/src/main/res/values/autofill-impl-strings-untranslated.xml
@@ -29,7 +29,7 @@
     <string name="saveLoginMissingUsernameDialogButtonSave">Save Password</string>
     <string name="saveLoginDialogNotNow">Not Now</string>
     <string name="saveLoginDialogOnboardingExplanationSubtitle">Logins are stored securely on this device only, and can be managed from the Autofill menu in Settings.</string>
-    <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Do you want DuckDuckGo\nto save your Login?</string>
+    <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Do you want DuckDuckGo to save your Login?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">More Options</string>
 
     <string name="useSavedLoginDialogTitle">Use Saved Login?</string>

--- a/autofill/autofill-impl/src/main/res/values/autofill-impl-strings-untranslated.xml
+++ b/autofill/autofill-impl/src/main/res/values/autofill-impl-strings-untranslated.xml
@@ -24,13 +24,17 @@
     <string name="managementDisabledModeTitle">Secure your device to use Autofill</string>
 
     <string name="saveLoginDialogTitle">Save Login?</string>
+    <string name="saveLoginMissingUsernameDialogTitle">Save Password?</string>
     <string name="saveLoginDialogButtonSave">Save Login</string>
+    <string name="saveLoginMissingUsernameDialogButtonSave">Save Password</string>
     <string name="saveLoginDialogNotNow">Not Now</string>
     <string name="saveLoginDialogOnboardingExplanationSubtitle">Logins are stored securely on this device only, and can be managed from the Autofill menu in Settings.</string>
-    <string name="saveLoginDialogFirstTimeExplanationTitle">Do you want DuckDuckGo\nto save your Login?</string>
+    <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Do you want DuckDuckGo\nto save your Login?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">More Options</string>
 
     <string name="useSavedLoginDialogTitle">Use Saved Login?</string>
+    <string name="useSavedLoginDialogMissingUsernameButtonText">Login for %s</string>
+    <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Login for site</string>
 
     <string name="updateLoginDialogTitle">Update Password?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Update Password</string>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.saving
+
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.R
+import com.duckduckgo.autofill.store.AutofillStore
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AutofillSavingCredentialsViewModelTest {
+
+    private val mockStore: AutofillStore = mock()
+    private val testee = AutofillSavingCredentialsViewModel().also { it.autofillStore = mockStore }
+
+    @Test
+    fun whenShowingOnboardingThenTitleResourceIsAlwaysOnboardingTitle() {
+        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(true)
+        val expectedResource = R.string.saveLoginDialogFirstTimeOnboardingExplanationTitle
+
+        assertEquals(expectedResource, testee.determineTextResources(usernamePresent()).title)
+        assertEquals(expectedResource, testee.determineTextResources(usernameMissing()).title)
+    }
+
+    @Test
+    fun whenShowingOnboardingAndUsernamePresentThenCtaButtonResourceIsSaveLogin() {
+        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(true)
+        val expectedResource = R.string.saveLoginDialogButtonSave
+        assertEquals(expectedResource, testee.determineTextResources(usernamePresent()).ctaButton)
+    }
+
+    @Test
+    fun whenShowingOnboardingAndUsernameMissingThenCtaButtonResourceIsSaveLogin() {
+        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(true)
+        val expectedResource = R.string.saveLoginDialogButtonSave
+        assertEquals(expectedResource, testee.determineTextResources(usernameMissing()).ctaButton)
+    }
+
+    @Test
+    fun whenNotShowingOnboardingAndUsernamePresentThenTitleResourceIsSaveLogin() {
+        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
+        val expectedResource = R.string.saveLoginDialogTitle
+        assertEquals(expectedResource, testee.determineTextResources(usernamePresent()).title)
+    }
+
+    @Test
+    fun whenNotShowingOnboardingAndUsernamePresentThenCtaButtonResourceIsSaveLogin() {
+        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
+        val expectedResource = R.string.saveLoginDialogButtonSave
+        assertEquals(expectedResource, testee.determineTextResources(usernamePresent()).ctaButton)
+    }
+
+    @Test
+    fun whenNotShowingOnboardingAndUsernameMissingThenTitleResourceIsSavePassword() {
+        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
+        val expectedResource = R.string.saveLoginMissingUsernameDialogTitle
+        assertEquals(expectedResource, testee.determineTextResources(usernameMissing()).title)
+    }
+
+    @Test
+    fun whenNotShowingOnboardingAndUsernameMissingThenCtaButtonResourceIsSavePassword() {
+        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
+        val expectedResource = R.string.saveLoginMissingUsernameDialogButtonSave
+        assertEquals(expectedResource, testee.determineTextResources(usernameMissing()).ctaButton)
+    }
+
+    private fun usernamePresent() = loginCredentialsWithUsername(username = "foo")
+    private fun usernameMissing() = loginCredentialsWithUsername(username = null)
+
+    private fun loginCredentialsWithUsername(username: String?): LoginCredentials {
+        return LoginCredentials(username = username, password = "bar", domain = "example.com")
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/selecting/CredentialTextExtractorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/selecting/CredentialTextExtractorTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.selecting
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(AndroidJUnit4::class)
+class CredentialTextExtractorTest {
+
+    private val context: Context = RuntimeEnvironment.getApplication()
+    private val testee = CredentialTextExtractor(context)
+
+    @Test
+    fun whenMissingUsernameWithDomainPresentThenDomainUsedInString() {
+        val result = testee.usernameOrPlaceholder(missingUsername())
+        assertEquals("Login for example.com", result)
+    }
+
+    @Test
+    fun whenMissingUsernameAndMissingDomainThenPlaceholderUsedString() {
+        val result = testee.usernameOrPlaceholder(missingUsernameAndDomain())
+        assertEquals("Login for site", result)
+    }
+
+    private fun missingUsername(): LoginCredentials {
+        return credentials(username = null)
+    }
+
+    private fun missingUsernameAndDomain(): LoginCredentials {
+        return credentials(username = null, domain = null)
+    }
+
+    private fun credentials(username: String? = "username", password: String? = "pw", domain: String? = "example.com"): LoginCredentials {
+        return LoginCredentials(username = username, password = password, domain = domain)
+    }
+
+}

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -123,8 +123,8 @@ class SecureStoreBackedAutofillStore(
 
     override suspend fun containsCredentials(
         rawUrl: String,
-        username: String,
-        password: String
+        username: String?,
+        password: String?
     ): ContainsCredentialsResult {
         val url = rawUrl.extractSchemeAndDomain() ?: return NoMatch
         val credentials = secureStorage.websiteLoginDetailsWithCredentialsForDomain(url).firstOrNull() ?: return NoMatch


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202630343540911/f

### Description
Supports savings logins without usernames. This includes accepting the login, the "save" dialog and the "choose login" dialog when autofilling.

### Steps to test this PR

#### Saving a credential without a username (no previous credentials ever saved)
**Setup**
I don't have a suggestion for a site which only saves the password, so need to hack this unless you know one. 
In `BrowserTabFragment.onCredentialsAvailableToSave()`, add this as the first line of the function to fake the username coming through as `null` 
👉 `val credentials = credentials.copy(username = null)`

- [x] Visit a site and attempt a login with the hack above in place (e.g., https://trello.com/login)
- [x] Verify the onboarding dialog shows
- [x] Verify the title ends "save your Login"
- [x] Verify the subtitle starts "Logins are..."
- [x] Verify the main CTA is "Save Login"
- [x] Save the credential
- [x] Visit credential management, and verify it has saved the password but not the username


#### Saving a credential without a username (no onboarding)

**Setup**
- Ensure the hack from the previous test case is still in place.
- Ensure a previous login was saved (so onboarding dialog not shown)

**Instructions**
- [x] Delete the existing login from credential management for trello
- [x] Visit a site with a login and attempt to log in (e.g., https://trello.com/login)
- [x] Verify the save dialog shows
- [x] Verify the title is "Save **Password**?"
- [x] Verify there is no onboarding subtitle
- [x] Verify the main CTA is "Save **Password**"
- [x] Save the credential
- [x] Visit credential management, and verify it has saved the password but not the username



#### Testing Autofilling into a site with username missing
Easiest way to test this scenario is to manually edit an existing login; edit it by manually deleting the username and save. (or keep the incomplete entry created from the hack above if you have one saved already) 

- [x] Load a site which shows username and password (e.g., https://trello.com/login)
- [x] Tap on the username field; verify no prompt is shown yet
- [x] Tap on the password field; verify prompt is shown
- [x] Verify the text on the CTA is "Login for trello.com"
- [x] Accept autofill; verify only the password field is populated
