### PR TITLE
Autofill engine: support saving and updating last updated time and notes along with credentials

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
@@ -43,6 +43,12 @@ interface AutofillStore {
     suspend fun getCredentials(rawUrl: String): List<LoginCredentials>
 
     /**
+     * Find saved credential for the given id
+     * @param id of the saved credential
+     */
+    suspend fun getCredentialsWithId(id: Int): LoginCredentials?
+
+    /**
      * Save the given credentials for the given URL
      * @param rawUrl Can be a full, unmodified URL taken from the URL bar (containing subdomains, query params etc...)
      * @param credentials The credentials to be saved. The ID can be null.

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/di/AutofillModule.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/di/AutofillModule.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.autofill.InternalTestUserChecker
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.autofill.store.InternalTestUserStore
 import com.duckduckgo.autofill.store.RealInternalTestUserStore
+import com.duckduckgo.autofill.store.RealLastUpdatedTimeProvider
 import com.duckduckgo.autofill.store.SecureStoreBackedAutofillStore
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.securestorage.api.SecureStorage
@@ -43,6 +44,6 @@ class AutofillModule {
         context: Context,
         internalTestUserChecker: InternalTestUserChecker
     ): AutofillStore {
-        return SecureStoreBackedAutofillStore(secureStorage, context, internalTestUserChecker)
+        return SecureStoreBackedAutofillStore(secureStorage, context, internalTestUserChecker, RealLastUpdatedTimeProvider())
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
@@ -31,8 +31,8 @@ import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ActivityAutofillSettingsBinding
 import com.duckduckgo.autofill.ui.AutofillSettingsActivityLauncher
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.*
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialModeState.Editing
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialModeState.Viewing
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Editing
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Viewing
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementDisabledMode
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementCredentialsMode
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementLockedMode
@@ -153,7 +153,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
             title = credentials.domainTitle ?: credentials.domain
             supportFragmentManager.commit {
                 setReorderingAllowed(true)
-                replace(R.id.fragment_container_view, AutofillManagementCredentialsMode.instance(credentials))
+                replace(R.id.fragment_container_view, AutofillManagementCredentialsMode.instance())
             }
         }
     }
@@ -184,8 +184,8 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
     }
 
     override fun onBackPressed() {
-        when (viewModel.viewState.value.credentialModeState) {
-            Editing -> viewModel.onExitEditMode(true)
+        when (viewModel.viewState.value.credentialMode) {
+            is Editing -> viewModel.onCancelEditMode()
             is Viewing -> viewModel.onExitViewMode()
             else -> super.onBackPressed()
         }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/LastUpdatedTimeProvider.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/LastUpdatedTimeProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.store
+
+interface LastUpdatedTimeProvider {
+    fun getInMillis(): Long
+}
+
+class RealLastUpdatedTimeProvider : LastUpdatedTimeProvider {
+    override fun getInMillis(): Long = System.currentTimeMillis()
+}

--- a/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorage.kt
+++ b/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorage.kt
@@ -60,7 +60,7 @@ interface SecureStorage {
      * @throws [SecureStorageException] if something went wrong while trying to perform the action. See type to get more info on the cause.
      */
     @Throws(SecureStorageException::class)
-    suspend fun getWebsiteLoginDetailsWithCredentials(id: Int): WebsiteLoginDetailsWithCredentials
+    suspend fun getWebsiteLoginDetailsWithCredentials(id: Int): WebsiteLoginDetailsWithCredentials?
 
     /**
      * This method returns the [WebsiteLoginDetailsWithCredentials] with the [domain] stored in the [SecureStorage].

--- a/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
+++ b/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
@@ -63,9 +63,9 @@ class RealSecureStorage @Inject constructor(
             }
         }
 
-    override suspend fun getWebsiteLoginDetailsWithCredentials(id: Int): WebsiteLoginDetailsWithCredentials =
+    override suspend fun getWebsiteLoginDetailsWithCredentials(id: Int): WebsiteLoginDetailsWithCredentials? =
         withContext(dispatchers.io()) {
-            secureStorageRepository.getWebsiteLoginCredentialsForId(id).toCredentials()
+            secureStorageRepository.getWebsiteLoginCredentialsForId(id)?.toCredentials()
         }
 
     override suspend fun websiteLoginDetailsWithCredentialsForDomain(domain: String): Flow<List<WebsiteLoginDetailsWithCredentials>> =

--- a/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/SecureStorageRepository.kt
+++ b/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/SecureStorageRepository.kt
@@ -28,7 +28,7 @@ interface SecureStorageRepository {
 
     suspend fun websiteLoginCredentialsForDomain(domain: String): Flow<List<WebsiteLoginCredentialsEntity>>
 
-    suspend fun getWebsiteLoginCredentialsForId(id: Int): WebsiteLoginCredentialsEntity
+    suspend fun getWebsiteLoginCredentialsForId(id: Int): WebsiteLoginCredentialsEntity?
 
     suspend fun websiteLoginCredentials(): Flow<List<WebsiteLoginCredentialsEntity>>
 
@@ -50,7 +50,7 @@ class RealSecureStorageRepository constructor(
     override suspend fun websiteLoginCredentials(): Flow<List<WebsiteLoginCredentialsEntity>> =
         websiteLoginCredentialsDao.websiteLoginCredentials()
 
-    override suspend fun getWebsiteLoginCredentialsForId(id: Int): WebsiteLoginCredentialsEntity =
+    override suspend fun getWebsiteLoginCredentialsForId(id: Int): WebsiteLoginCredentialsEntity? =
         websiteLoginCredentialsDao.getWebsiteLoginCredentialsById(id)
 
     override suspend fun updateWebsiteLoginCredentials(websiteLoginCredentials: WebsiteLoginCredentialsEntity) =

--- a/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/db/WebsiteLoginCredentialsDao.kt
+++ b/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/db/WebsiteLoginCredentialsDao.kt
@@ -40,7 +40,7 @@ interface WebsiteLoginCredentialsDao {
     fun websiteLoginCredentialsByDomain(domain: String): Flow<List<WebsiteLoginCredentialsEntity>>
 
     @Query("select * from website_login_credentials where id = :id")
-    fun getWebsiteLoginCredentialsById(id: Int): WebsiteLoginCredentialsEntity
+    fun getWebsiteLoginCredentialsById(id: Int): WebsiteLoginCredentialsEntity?
 
     @Delete
     fun delete(loginCredentials: WebsiteLoginCredentialsEntity)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202666734291055/f

### Description
This PR includes:
- Saving of last updated time upon saving of the credential
- Update of last updated time (UI and DB) when saving edits to a credential
- Update of notes and domain title(UI and DB) when saving edits to a credential
- Move reference to currently being edited credential from the CredentialModeFragment to the ViewModel removing any reference to the state from the fragment.


### Steps to test this PR

_Save credential saves last updated time_
- [x] Open a website
- [x] Save credential
- [x] Go to autofill management screen and open the credential you saved
- [x] Confirm that last updated time is displayed and is correct

_Updating credentials persists_
- [x] Go to autofill management screen and select any saved credential
- [x] Select edit from the context menu
- [x] Update all fields
- [x] Press the check icon to save the changes
- [x] Confirm that view mode contains all updated data and the last updated time is updated. If you changed the domain, it is possible that the icon in the toolbar will not show if we haven't loaded the icon yet. For icons that already exist, it should change automatically.
- [x] Exit autofill management screen and comeback
- [x] Confirm that edited credentials is persisted
