### PR TITLE
Remove api dependencies from privacy-config-api and vpn-api modules

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4188,7 +4188,7 @@ class BrowserTabViewModelTest {
 
     private fun givenUrlCannotUseGpc(url: String) {
         val exceptions = CopyOnWriteArrayList<GpcException>().apply { add(GpcException(url)) }
-        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName), any())).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName.value), any())).thenReturn(true)
         whenever(mockGpcRepository.isGpcEnabled()).thenReturn(true)
         whenever(mockGpcRepository.exceptions).thenReturn(exceptions)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/email/EmailInjectorJsTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/EmailInjectorJsTest.kt
@@ -47,7 +47,7 @@ class EmailInjectorJsTest {
         testee =
             EmailInjectorJs(mockEmailManager, DuckDuckGoUrlDetector(), mockDispatcherProvider, mockFeatureToggle, javascriptInjector, mockAutofill)
 
-        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName)).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName.value)).thenReturn(true)
         whenever(mockAutofill.isAnException(any())).thenReturn(false)
     }
 
@@ -68,7 +68,7 @@ class EmailInjectorJsTest {
     @Test
     @SdkSuppress(minSdkVersion = 24)
     fun whenInjectAddressAndFeatureIsDisabledThenJsCodeNotInjected() {
-        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName)).thenReturn(false)
+        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName.value)).thenReturn(false)
 
         val address = "address"
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))
@@ -123,7 +123,7 @@ class EmailInjectorJsTest {
     @SdkSuppress(minSdkVersion = 24)
     fun whenNotifyWebAppSignEventAndUrlIsFromDuckDuckGoAndFeatureIsDisabledAndEmailIsNotSignedInThenDoNotEvaluateJsCode() {
         whenever(mockEmailManager.isSignedIn()).thenReturn(false)
-        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName)).thenReturn(false)
+        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName.value)).thenReturn(false)
 
         val jsToEvaluate = getNotifySignOutJsToEvaluate()
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))
@@ -138,7 +138,7 @@ class EmailInjectorJsTest {
     @SdkSuppress(minSdkVersion = 24)
     fun whenNotifyWebAppSignEventAndUrlIsFromDuckDuckGoAndFeatureIsEnabledAndEmailIsNotSignedInThenEvaluateJsCode() {
         whenever(mockEmailManager.isSignedIn()).thenReturn(false)
-        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName)).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName.value)).thenReturn(true)
 
         val jsToEvaluate = getNotifySignOutJsToEvaluate()
         val webView = spy(WebView(InstrumentationRegistry.getInstrumentation().targetContext))

--- a/app/src/androidTest/java/com/duckduckgo/app/fakes/FeatureToggleFake.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fakes/FeatureToggleFake.kt
@@ -16,12 +16,11 @@
 
 package com.duckduckgo.app.fakes
 
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 
 class FeatureToggleFake : FeatureToggle {
     override fun isFeatureEnabled(
-        featureName: FeatureName,
+        featureName: String,
         defaultValue: Boolean
     ): Boolean = true
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
@@ -44,14 +44,14 @@ class HttpsUpgraderTest {
     @Before
     fun before() {
         whenever(mockHttpsBloomFilterFactory.create()).thenReturn(bloomFilter)
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName)).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName.value)).thenReturn(true)
         testee = HttpsUpgraderImpl(mockHttpsBloomFilterFactory, mockBloomFalsePositiveListDao, mockUserAllowlistDao, mockFeatureToggle, mockHttps)
         testee.reloadData()
     }
 
     @Test
     fun whenFeatureIsDisableTheShouldNotUpgrade() {
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName)).thenReturn(false)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName.value)).thenReturn(false)
         bloomFilter.add("www.local.url")
         assertFalse(testee.shouldUpgrade(Uri.parse("http://www.local.url")))
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/HttpsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/HttpsReferenceTest.kt
@@ -169,7 +169,7 @@ class HttpsReferenceTest(private val testCase: TestCase) {
         val isEnabled = httpsFeature?.state == "enabled"
         val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(config?.unprotectedTemporary ?: emptyList())
 
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName, isEnabled)).thenReturn(isEnabled)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName.value, isEnabled)).thenReturn(isEnabled)
         whenever(mockHttpsRepository.exceptions).thenReturn(CopyOnWriteArrayList(httpsExceptions))
         whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptionsUnprotectedTemporary)
 

--- a/app/src/androidTestPlay/java/com/duckduckgo/app/integration/HttpsEmbeddedDataIntegrationTest.kt
+++ b/app/src/androidTestPlay/java/com/duckduckgo/app/integration/HttpsEmbeddedDataIntegrationTest.kt
@@ -55,7 +55,7 @@ class HttpsEmbeddedDataIntegrationTest {
 
     @Before
     fun before() {
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName)).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName.value)).thenReturn(true)
 
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -50,7 +50,7 @@ class BrokenSiteSubmitter(
 ) : BrokenSiteSender {
 
     override fun submitBrokenSiteFeedback(brokenSite: BrokenSite) {
-        val isGpcEnabled = (featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName) && gpc.isEnabled()).toString()
+        val isGpcEnabled = (featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value) && gpc.isEnabled()).toString()
         val absoluteUrl = Uri.parse(brokenSite.siteUrl).absoluteString
 
         appCoroutineScope.launch(dispatcherProvider.io()) {

--- a/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/useragent/UserAgentProvider.kt
@@ -78,7 +78,7 @@ class UserAgentProvider constructor(
 
         val isDomainInUserAllowList = isHostInUserAllowedList(host)
 
-        if (isDomainInUserAllowList || !toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName) || shouldUseDefaultUserAgent) {
+        if (isDomainInUserAllowList || !toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName.value) || shouldUseDefaultUserAgent) {
             return if (isDesktop) {
                 defaultUserAgent.get().replace(AgentRegex.platform, desktopPrefix)
             } else {

--- a/app/src/main/java/com/duckduckgo/app/email/EmailInjector.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailInjector.kt
@@ -90,7 +90,7 @@ class EmailInjectorJs(
         }
     }
 
-    private fun isFeatureEnabled() = featureToggle.isFeatureEnabled(PrivacyFeatureName.AutofillFeatureName, defaultValue = true)
+    private fun isFeatureEnabled() = featureToggle.isFeatureEnabled(PrivacyFeatureName.AutofillFeatureName.value, defaultValue = true)
 
     private fun isDuckDuckGoUrl(url: String?): Boolean = (url != null && urlDetector.isDuckDuckGoEmailUrl(url))
 

--- a/app/src/main/java/com/duckduckgo/app/email/EmailJavascriptInterface.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailJavascriptInterface.kt
@@ -47,7 +47,7 @@ class EmailJavascriptInterface(
         return (url != null && urlDetector.isDuckDuckGoEmailUrl(url))
     }
 
-    private fun isFeatureEnabled() = featureToggle.isFeatureEnabled(PrivacyFeatureName.AutofillFeatureName, defaultValue = true)
+    private fun isFeatureEnabled() = featureToggle.isFeatureEnabled(PrivacyFeatureName.AutofillFeatureName.value, defaultValue = true)
 
     @JavascriptInterface
     fun isSignedIn(): String {

--- a/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModel.kt
@@ -52,7 +52,7 @@ class GlobalPrivacyControlViewModel @Inject constructor(
     init {
         _viewState.value = ViewState(
             globalPrivacyControlEnabled = gpc.isEnabled(),
-            globalPrivacyControlFeatureEnabled = featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName, true)
+            globalPrivacyControlFeatureEnabled = featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, true)
         )
         pixel.fire(SETTINGS_DO_NOT_SELL_SHOWN)
     }

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -78,7 +78,7 @@ class HttpsUpgraderImpl @Inject constructor(
     override fun shouldUpgrade(uri: Uri): Boolean {
         val host = uri.host ?: return false
 
-        if (!toggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName)) {
+        if (!toggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName.value)) {
             Timber.d("https is disabled in the remote config and so $host is not upgradable")
             return false
         }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -161,7 +161,7 @@ class SettingsViewModel @Inject constructor(
                     automaticallyClearData = AutomaticallyClearData(automaticallyClearWhat, automaticallyClearWhen, automaticallyClearWhenEnabled),
                     appIcon = settingsDataStore.appIcon,
                     selectedFireAnimation = settingsDataStore.selectedFireAnimation,
-                    globalPrivacyControlEnabled = gpc.isEnabled() && featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName) == true,
+                    globalPrivacyControlEnabled = gpc.isEnabled() && featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value),
                     appLinksSettingType = getAppLinksSettingsState(settingsDataStore.appLinksEnabled, settingsDataStore.showAppLinksPrompt),
                     appTrackingProtectionEnabled = TrackerBlockingVpnService.isServiceRunning(appContext),
                     appTrackingProtectionWaitlistState = atpRepository.getState(),

--- a/app/src/test/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
@@ -60,7 +60,7 @@ class UserAgentProviderTest {
     @Before
     fun before() {
         whenever(deviceInfo.majorAppVersion).thenReturn("5")
-        whenever(toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName)).thenReturn(true)
+        whenever(toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName.value)).thenReturn(true)
         whenever(userAgentRepository.defaultExceptions).thenReturn(defaultExceptions)
         whenever(userAgentRepository.omitApplicationExceptions).thenReturn(applicationExceptions)
         whenever(userAgentRepository.omitVersionExceptions).thenReturn(versionExceptions)
@@ -174,7 +174,7 @@ class UserAgentProviderTest {
 
     @Test
     fun whenFeatureIsDisabledThenUaIsDefault() {
-        whenever(toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName)).thenReturn(false)
+        whenever(toggle.isFeatureEnabled(PrivacyFeatureName.UserAgentFeatureName.value)).thenReturn(false)
         testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
         val actual = testee.userAgent(DOMAIN)
         assertTrue("$actual does not match expected regex", ValidationRegex.default.matches(actual))

--- a/app/src/test/java/com/duckduckgo/app/email/EmailJavascriptInterfaceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/email/EmailJavascriptInterfaceTest.kt
@@ -60,7 +60,7 @@ class EmailJavascriptInterfaceTest {
             mockAutofill
         ) { counter++ }
 
-        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName)).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName.value)).thenReturn(true)
         whenever(mockAutofill.isAnException(any())).thenReturn(false)
     }
 
@@ -130,7 +130,7 @@ class EmailJavascriptInterfaceTest {
     @Test
     fun whenShowTooltipAndFeatureDisabledThenLambdaNotCalled() {
         whenever(mockWebView.url).thenReturn(NON_EMAIL_URL)
-        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName)).thenReturn(false)
+        whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName.value)).thenReturn(false)
 
         testee.showTooltip()
 

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -160,7 +160,7 @@ class SettingsViewModelTest {
 
     @Test
     fun whenStartIfGpcToggleDisabledAndGpcEnabledThenGpgDisabled() = runTest {
-        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName), any())).thenReturn(false)
+        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName.value), any())).thenReturn(false)
         whenever(mockGpc.isEnabled()).thenReturn(true)
 
         testee.start()
@@ -173,7 +173,7 @@ class SettingsViewModelTest {
 
     @Test
     fun whenStartIfGpcToggleEnabledAndGpcDisabledThenGpgDisabled() = runTest {
-        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName), any())).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName.value), any())).thenReturn(true)
         whenever(mockGpc.isEnabled()).thenReturn(false)
         testee.start()
 
@@ -185,7 +185,7 @@ class SettingsViewModelTest {
 
     @Test
     fun whenStartIfGpcToggleEnabledAndGpcEnabledThenGpgEnabled() = runTest {
-        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName), any())).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName.value), any())).thenReturn(true)
         whenever(mockGpc.isEnabled()).thenReturn(true)
         testee.start()
 

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggle.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggle.kt
@@ -24,35 +24,7 @@ interface FeatureToggle {
      * @throws [IllegalArgumentException] if the feature is not implemented
      */
     fun isFeatureEnabled(
-        featureName: FeatureName,
+        featureName: String,
         defaultValue: Boolean = true
     ): Boolean
-}
-
-/**
- * Each feature toggle created needs a [FeatureName] which can be implemented using this interface
- */
-interface FeatureName {
-    val value: String
-
-    companion object {
-        /**
-         * Utility function to create a [FeatureName] from the passed in [block] lambda
-         * instead of using the anonymous `object : FeatureName` syntax.
-         *
-         * Usage:
-         *
-         * ```kotlin
-         * val feature = FeatureName {
-         *
-         * }
-         * ```
-         */
-        inline operator fun invoke(crossinline block: () -> String): FeatureName {
-            return object : FeatureName {
-                override val value: String
-                    get() = block()
-            }
-        }
-    }
 }

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureTogglesPlugin.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureTogglesPlugin.kt
@@ -28,7 +28,7 @@ interface FeatureTogglesPlugin {
      * know the featureName. [defaultValue] if the plugin knows featureName but is not set
      */
     fun isEnabled(
-        featureName: FeatureName,
+        featureName: String,
         defaultValue: Boolean
     ): Boolean?
 }

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealFeatureTogglesImpl.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealFeatureTogglesImpl.kt
@@ -21,7 +21,6 @@ import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.feature.toggles.api.FeatureTogglesPlugin
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import dagger.SingleInstanceIn
@@ -32,14 +31,14 @@ class RealFeatureToggleImpl @Inject constructor(private val featureTogglesPlugin
     FeatureToggle {
 
     override fun isFeatureEnabled(
-        featureName: FeatureName,
+        featureName: String,
         defaultValue: Boolean
     ): Boolean {
         featureTogglesPluginPoint.getPlugins().forEach { plugin ->
             plugin.isEnabled(featureName, defaultValue)?.let { return it }
         }
 
-        throw IllegalArgumentException("Unknown feature: ${featureName.value}")
+        throw IllegalArgumentException("Unknown feature: $featureName")
     }
 }
 

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealFeatureToggleImplTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealFeatureToggleImplTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.feature.toggles.impl
 
 import com.duckduckgo.app.global.plugins.PluginPoint
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.feature.toggles.api.FeatureTogglesPlugin
 import org.junit.Assert.*
 import org.junit.Test
@@ -29,22 +28,22 @@ class RealFeatureToggleImplTest {
 
     @Test
     fun whenFeatureNameCanBeHandledByPluginThenReturnTheCorrectValue() {
-        val result = testee.isFeatureEnabled(TrueFeatureName(), false)
+        val result = testee.isFeatureEnabled(TrueFeatureName().value, false)
         assertNotNull(result)
         assertTrue(result)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun whenFeatureNameCannotBeHandledByAnyPluginThenThrowException() {
-        testee.isFeatureEnabled(NullFeatureName(), false)
+        testee.isFeatureEnabled(NullFeatureName().value, false)
     }
 
     class FakeTruePlugin : FeatureTogglesPlugin {
         override fun isEnabled(
-            featureName: FeatureName,
+            featureName: String,
             defaultValue: Boolean
         ): Boolean? {
-            return if (featureName is TrueFeatureName) {
+            return if (featureName == TrueFeatureName().value) {
                 true
             } else {
                 null
@@ -58,6 +57,6 @@ class RealFeatureToggleImplTest {
         }
     }
 
-    data class TrueFeatureName(override val value: String = "true") : FeatureName
-    data class NullFeatureName(override val value: String = "null") : FeatureName
+    data class TrueFeatureName(val value: String = "true")
+    data class NullFeatureName(val value: String = "null")
 }

--- a/privacy-config/privacy-config-api/build.gradle
+++ b/privacy-config/privacy-config-api/build.gradle
@@ -27,9 +27,6 @@ java {
 }
 
 dependencies {
-
-    implementation project(path: ':feature-toggles-api')
-
     implementation Google.dagger
     implementation Kotlin.stdlib.jdk7
 }

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -16,10 +16,8 @@
 
 package com.duckduckgo.privacy.config.api
 
-import com.duckduckgo.feature.toggles.api.FeatureName
-
-/** List of [FeatureName] that belong to the Privacy Configuration */
-enum class PrivacyFeatureName(override val value: String) : FeatureName {
+/** List of [PrivacyFeatureName] that belong to the Privacy Configuration */
+enum class PrivacyFeatureName(val value: String) {
     ContentBlockingFeatureName("contentBlocking"),
     GpcFeatureName("gpc"),
     HttpsFeatureName("https"),

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeaturePlugin.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeaturePlugin.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.privacy.config.api
 
-import com.duckduckgo.feature.toggles.api.FeatureName
-
 /**
  * Implement this interface and contribute it as a multibinding to get called upon downloading remote privacy config
  *
@@ -32,15 +30,15 @@ import com.duckduckgo.feature.toggles.api.FeatureName
  */
 interface PrivacyFeaturePlugin {
     /**
-     * @return `true` when the feature config was stored, otherwise `false`
+     * @return `true` when the feature was stored, otherwise `false`
      */
     fun store(
-        name: FeatureName,
+        featureName: String,
         jsonString: String
     ): Boolean
 
     /**
-     * @return the [FeatureName] of this feature
+     * @return the [featureName] of this feature
      */
-    val featureName: FeatureName
+    val featureName: String
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.privacy.config.impl
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.store.PrivacyConfig
@@ -58,8 +57,8 @@ class RealPrivacyConfigPersister @Inject constructor(
                 unprotectedTemporaryRepository.updateAll(jsonPrivacyConfig.unprotectedTemporary)
                 jsonPrivacyConfig.features.forEach { feature ->
                     feature.value?.let { jsonObject ->
-                        privacyFeaturePluginPoint.getPlugins().firstOrNull { feature.key == it.featureName.value }?.let { featurePlugin ->
-                            featurePlugin.store(FeatureName { feature.key }, jsonObject.toString())
+                        privacyFeaturePluginPoint.getPlugins().firstOrNull { feature.key == it.featureName }?.let { featurePlugin ->
+                            featurePlugin.store(featurePlugin.featureName, jsonObject.toString())
                         }
                     }
                 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -58,7 +58,7 @@ class RealPrivacyConfigPersister @Inject constructor(
                 jsonPrivacyConfig.features.forEach { feature ->
                     feature.value?.let { jsonObject ->
                         privacyFeaturePluginPoint.getPlugins().firstOrNull { feature.key == it.featureName }?.let { featurePlugin ->
-                            featurePlugin.store(featurePlugin.featureName, jsonObject.toString())
+                            featurePlugin.store(feature.key, jsonObject.toString())
                         }
                     }
                 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPlugin.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.impl.features.amplinks
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
@@ -34,10 +33,9 @@ class AmpLinksPlugin @Inject constructor(
     private val privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository
 ) : PrivacyFeaturePlugin {
 
-    override fun store(name: FeatureName, jsonString: String): Boolean {
-        @Suppress("NAME_SHADOWING")
-        val name = privacyFeatureValueOf(name.value)
-        if (name == featureName) {
+    override fun store(featureName: String, jsonString: String): Boolean {
+        val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
+        if (privacyFeature.value == this.featureName) {
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<AmpLinksFeature> =
                 moshi.adapter(AmpLinksFeature::class.java)
@@ -62,11 +60,11 @@ class AmpLinksPlugin @Inject constructor(
 
             ampLinksRepository.updateAll(exceptions, ampLinkFormats, ampKeywords)
             val isEnabled = ampLinksFeature?.state == "enabled"
-            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, ampLinksFeature?.minSupportedVersion))
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(this.featureName, isEnabled, ampLinksFeature?.minSupportedVersion))
             return true
         }
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.AmpLinksFeatureName
+    override val featureName: String = PrivacyFeatureName.AmpLinksFeatureName.value
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPlugin.kt
@@ -34,6 +34,7 @@ class AmpLinksPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(featureName: String, jsonString: String): Boolean {
+        @Suppress("NAME_SHADOWING")
         val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
         if (privacyFeature.value == this.featureName) {
             val moshi = Moshi.Builder().build()

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/RealAmpLinks.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/RealAmpLinks.kt
@@ -50,7 +50,7 @@ class RealAmpLinks @Inject constructor(
     }
 
     override fun extractCanonicalFromAmpLink(url: String): AmpLinkType? {
-        if (!featureToggle.isFeatureEnabled(PrivacyFeatureName.AmpLinksFeatureName)) return null
+        if (!featureToggle.isFeatureEnabled(PrivacyFeatureName.AmpLinksFeatureName.value)) return null
         if (url == lastExtractedUrl) return null
 
         val extractedUrl = extractCanonical(url)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/autofill/AutofillPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/autofill/AutofillPlugin.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.impl.features.autofill
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
@@ -37,12 +36,12 @@ class AutofillPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: FeatureName,
+        featureName: String,
         jsonString: String
     ): Boolean {
         @Suppress("NAME_SHADOWING")
-        val name = privacyFeatureValueOf(name.value)
-        if (name == featureName) {
+        val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
+        if (privacyFeature.value == this.featureName) {
             val autofillExceptions = mutableListOf<AutofillExceptionEntity>()
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<AutofillFeature> =
@@ -54,11 +53,11 @@ class AutofillPlugin @Inject constructor(
             }
             autofillRepository.updateAll(autofillExceptions)
             val isEnabled = httpsFeature?.state == "enabled"
-            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, httpsFeature?.minSupportedVersion))
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(this.featureName, isEnabled, httpsFeature?.minSupportedVersion))
             return true
         }
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.AutofillFeatureName
+    override val featureName: String = PrivacyFeatureName.AutofillFeatureName.value
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingPlugin.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.impl.features.contentblocking
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
@@ -37,12 +36,12 @@ class ContentBlockingPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: FeatureName,
+        featureName: String,
         jsonString: String
     ): Boolean {
         @Suppress("NAME_SHADOWING")
-        val name = privacyFeatureValueOf(name.value)
-        if (name == featureName) {
+        val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
+        if (privacyFeature.value == this.featureName) {
             val contentBlockingExceptions = mutableListOf<ContentBlockingExceptionEntity>()
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<ContentBlockingFeature> =
@@ -54,11 +53,11 @@ class ContentBlockingPlugin @Inject constructor(
             }
             contentBlockingRepository.updateAll(contentBlockingExceptions)
             val isEnabled = contentBlockingFeature?.state == "enabled"
-            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, contentBlockingFeature?.minSupportedVersion))
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(this.featureName, isEnabled, contentBlockingFeature?.minSupportedVersion))
             return true
         }
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.ContentBlockingFeatureName
+    override val featureName: String = PrivacyFeatureName.ContentBlockingFeatureName.value
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlocking.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlocking.kt
@@ -36,7 +36,7 @@ class RealContentBlocking @Inject constructor(
 ) : ContentBlocking {
 
     override fun isAnException(url: String): Boolean {
-        return if (featureToggle.isFeatureEnabled(PrivacyFeatureName.ContentBlockingFeatureName, true) == true) {
+        return if (featureToggle.isFeatureEnabled(PrivacyFeatureName.ContentBlockingFeatureName.value, true)) {
             unprotectedTemporary.isAnException(url) || matches(url)
         } else {
             false

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmPlugin.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.impl.features.drm
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
@@ -37,12 +36,12 @@ class DrmPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: FeatureName,
+        featureName: String,
         jsonString: String
     ): Boolean {
         @Suppress("NAME_SHADOWING")
-        val name = privacyFeatureValueOf(name.value)
-        if (name == featureName) {
+        val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
+        if (privacyFeature.value == this.featureName) {
             val drmExceptions = mutableListOf<DrmExceptionEntity>()
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<DrmFeature> =
@@ -54,11 +53,11 @@ class DrmPlugin @Inject constructor(
             }
             drmRepository.updateAll(drmExceptions)
             val isEnabled = drmFeature?.state == "enabled"
-            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, drmFeature?.minSupportedVersion))
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(this.featureName, isEnabled, drmFeature?.minSupportedVersion))
             return true
         }
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.DrmFeatureName
+    override val featureName: String = PrivacyFeatureName.DrmFeatureName.value
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrm.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrm.kt
@@ -50,7 +50,7 @@ class RealDrm @Inject constructor(
     }
 
     private fun shouldEnableDrmForUri(uri: Uri): Boolean {
-        val isFeatureEnabled = featureToggle.isFeatureEnabled(PrivacyFeatureName.DrmFeatureName, defaultValue = true)
+        val isFeatureEnabled = featureToggle.isFeatureEnabled(PrivacyFeatureName.DrmFeatureName.value, defaultValue = true)
         return isFeatureEnabled && domainsThatAllowDrm(uri.baseHost)
     }
 

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPlugin.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.impl.features.gpc
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
@@ -38,12 +37,12 @@ class GpcPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: FeatureName,
+        featureName: String,
         jsonString: String
     ): Boolean {
         @Suppress("NAME_SHADOWING")
-        val name = privacyFeatureValueOf(name.value)
-        if (name == featureName) {
+        val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
+        if (privacyFeature.value == this.featureName) {
             val gpcExceptions = mutableListOf<GpcExceptionEntity>()
             val gpcHeaders = mutableListOf<GpcHeaderEnabledSiteEntity>()
             val moshi = Moshi.Builder().build()
@@ -59,11 +58,11 @@ class GpcPlugin @Inject constructor(
             }
             gpcRepository.updateAll(gpcExceptions, gpcHeaders)
             val isEnabled = gpcFeature?.state == "enabled"
-            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, gpcFeature?.minSupportedVersion))
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(this.featureName, isEnabled, gpcFeature?.minSupportedVersion))
             return true
         }
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.GpcFeatureName
+    override val featureName: String = PrivacyFeatureName.GpcFeatureName.value
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
@@ -80,7 +80,7 @@ class RealGpc @Inject constructor(
     }
 
     private fun isFeatureEnabled(): Boolean {
-        return featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName)
+        return featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value)
     }
 
     private fun containsGpcHeader(headers: Map<String, String>): Boolean {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.impl.features.https
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
@@ -37,12 +36,12 @@ class HttpsPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: FeatureName,
+        featureName: String,
         jsonString: String
     ): Boolean {
         @Suppress("NAME_SHADOWING")
-        val name = privacyFeatureValueOf(name.value)
-        if (name == featureName) {
+        val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
+        if (privacyFeature.value == this.featureName) {
             val httpsExceptions = mutableListOf<HttpsExceptionEntity>()
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<HttpsFeature> =
@@ -54,11 +53,11 @@ class HttpsPlugin @Inject constructor(
             }
             httpsRepository.updateAll(httpsExceptions)
             val isEnabled = httpsFeature?.state == "enabled"
-            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, httpsFeature?.minSupportedVersion))
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(this.featureName, isEnabled, httpsFeature?.minSupportedVersion))
             return true
         }
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.HttpsFeatureName
+    override val featureName: String = PrivacyFeatureName.HttpsFeatureName.value
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
@@ -40,7 +40,7 @@ class RealTrackerAllowlist @Inject constructor(
         documentURL: String,
         url: String
     ): Boolean {
-        return if (featureToggle.isFeatureEnabled(PrivacyFeatureName.TrackerAllowlistFeatureName, true)) {
+        return if (featureToggle.isFeatureEnabled(PrivacyFeatureName.TrackerAllowlistFeatureName.value, true)) {
             trackerAllowlistRepository.exceptions
                 .filter { UriString.sameOrSubdomain(url, it.domain) }
                 .map { matches(url, documentURL, it) }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/TrackerAllowlistPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/TrackerAllowlistPlugin.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.impl.features.trackerallowlist
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
@@ -37,12 +36,12 @@ class TrackerAllowlistPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: FeatureName,
+        featureName: String,
         jsonString: String
     ): Boolean {
         @Suppress("NAME_SHADOWING")
-        val name = privacyFeatureValueOf(name.value)
-        if (name == featureName) {
+        val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
+        if (privacyFeature.value == this.featureName) {
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<TrackerAllowlistFeature> =
                 moshi.adapter(TrackerAllowlistFeature::class.java)
@@ -55,11 +54,11 @@ class TrackerAllowlistPlugin @Inject constructor(
             }
             trackerAllowlistRepository.updateAll(exceptions)
             val isEnabled = trackerAllowlistFeature?.state == "enabled"
-            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, trackerAllowlistFeature?.minSupportedVersion))
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(this.featureName, isEnabled, trackerAllowlistFeature?.minSupportedVersion))
             return true
         }
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.TrackerAllowlistFeatureName
+    override val featureName: String = PrivacyFeatureName.TrackerAllowlistFeatureName.value
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/RealTrackingParameters.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/RealTrackingParameters.kt
@@ -60,7 +60,7 @@ class RealTrackingParameters @Inject constructor(
     }
 
     override fun cleanTrackingParameters(initiatingUrl: String?, url: String): String? {
-        if (!featureToggle.isFeatureEnabled(PrivacyFeatureName.TrackingParametersFeatureName)) return null
+        if (!featureToggle.isFeatureEnabled(PrivacyFeatureName.TrackingParametersFeatureName.value)) return null
         if (isAnException(initiatingUrl, url)) return null
 
         val trackingParameters = trackingParametersRepository.parameters

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersPlugin.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.impl.features.trackingparameters
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
@@ -34,10 +33,9 @@ class TrackingParametersPlugin @Inject constructor(
     private val privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository
 ) : PrivacyFeaturePlugin {
 
-    override fun store(name: FeatureName, jsonString: String): Boolean {
-        @Suppress("NAME_SHADOWING")
-        val name = privacyFeatureValueOf(name.value)
-        if (name == featureName) {
+    override fun store(featureName: String, jsonString: String): Boolean {
+        val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
+        if (privacyFeature.value == this.featureName) {
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<TrackingParametersFeature> =
                 moshi.adapter(TrackingParametersFeature::class.java)
@@ -57,11 +55,11 @@ class TrackingParametersPlugin @Inject constructor(
 
             trackingParametersRepository.updateAll(exceptions, parameters)
             val isEnabled = trackingParametersFeature?.state == "enabled"
-            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, trackingParametersFeature?.minSupportedVersion))
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(this.featureName, isEnabled, trackingParametersFeature?.minSupportedVersion))
             return true
         }
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.TrackingParametersFeatureName
+    override val featureName: String = PrivacyFeatureName.TrackingParametersFeatureName.value
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.privacy.config.impl.features.useragent
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
@@ -37,12 +36,12 @@ class UserAgentPlugin @Inject constructor(
 ) : PrivacyFeaturePlugin {
 
     override fun store(
-        name: FeatureName,
+        featureName: String,
         jsonString: String
     ): Boolean {
         @Suppress("NAME_SHADOWING")
-        val name = privacyFeatureValueOf(name.value)
-        if (name == featureName) {
+        val privacyFeature = privacyFeatureValueOf(featureName) ?: return false
+        if (privacyFeature.value == this.featureName) {
             val userAgentExceptions = mutableListOf<UserAgentExceptionEntity>()
             val moshi = Moshi.Builder().build()
             val jsonAdapter: JsonAdapter<UserAgentFeature> =
@@ -73,11 +72,11 @@ class UserAgentPlugin @Inject constructor(
 
             userAgentRepository.updateAll(userAgentExceptions)
             val isEnabled = userAgentFeature?.state == "enabled"
-            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(name, isEnabled, userAgentFeature?.minSupportedVersion))
+            privacyFeatureTogglesRepository.insert(PrivacyFeatureToggles(this.featureName, isEnabled, userAgentFeature?.minSupportedVersion))
             return true
         }
         return false
     }
 
-    override val featureName: PrivacyFeatureName = PrivacyFeatureName.UserAgentFeatureName
+    override val featureName: String = PrivacyFeatureName.UserAgentFeatureName.value
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeatureTogglesPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeatureTogglesPlugin.kt
@@ -19,8 +19,7 @@ package com.duckduckgo.privacy.config.impl.plugins
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureTogglesPlugin
-import com.duckduckgo.feature.toggles.api.FeatureName
-import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
@@ -32,12 +31,14 @@ class PrivacyFeatureTogglesPlugin @Inject constructor(
 ) : FeatureTogglesPlugin {
 
     override fun isEnabled(
-        featureName: FeatureName,
+        featureName: String,
         defaultValue: Boolean
     ): Boolean? {
-        return if (featureName is PrivacyFeatureName) {
-            privacyFeatureTogglesRepository.get(featureName, defaultValue) &&
-                appBuildConfig.versionCode >= privacyFeatureTogglesRepository.getMinSupportedVersion(featureName)
+        @Suppress("NAME_SHADOWING")
+        val privacyFeatureName = privacyFeatureValueOf(featureName)
+        return if (privacyFeatureName != null) {
+            privacyFeatureTogglesRepository.get(privacyFeatureName, defaultValue) &&
+                appBuildConfig.versionCode >= privacyFeatureTogglesRepository.getMinSupportedVersion(privacyFeatureName)
         } else {
             null
         }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeatureTogglesPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeatureTogglesPlugin.kt
@@ -35,12 +35,8 @@ class PrivacyFeatureTogglesPlugin @Inject constructor(
         defaultValue: Boolean
     ): Boolean? {
         @Suppress("NAME_SHADOWING")
-        val privacyFeatureName = privacyFeatureValueOf(featureName)
-        return if (privacyFeatureName != null) {
-            privacyFeatureTogglesRepository.get(privacyFeatureName, defaultValue) &&
-                appBuildConfig.versionCode >= privacyFeatureTogglesRepository.getMinSupportedVersion(privacyFeatureName)
-        } else {
-            null
-        }
+        val privacyFeatureName = privacyFeatureValueOf(featureName) ?: return null
+        return privacyFeatureTogglesRepository.get(privacyFeatureName, defaultValue) &&
+            appBuildConfig.versionCode >= privacyFeatureTogglesRepository.getMinSupportedVersion(privacyFeatureName)
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
@@ -20,7 +20,6 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.plugins.PluginPoint
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
@@ -169,15 +168,15 @@ class RealPrivacyConfigPersisterTest {
         var count = 0
 
         override fun store(
-            name: FeatureName,
+            featureName: String,
             jsonString: String
         ): Boolean {
             count++
             return true
         }
 
-        override val featureName: PrivacyFeatureName =
-            PrivacyFeatureName.GpcFeatureName
+        override val featureName: String =
+            PrivacyFeatureName.GpcFeatureName.value
     }
 
     companion object {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpFormatReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpFormatReferenceTest.kt
@@ -51,7 +51,7 @@ class AmpFormatReferenceTest(private val testCase: TestCase) {
         mockAmpLinks()
         testee = RealAmpLinks(mockRepository, mockFeatureToggle, mockUnprotectedTemporary)
         whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(false)
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.AmpLinksFeatureName, true)).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.AmpLinksFeatureName.value, true)).thenReturn(true)
     }
 
     companion object {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpKeywordReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpKeywordReferenceTest.kt
@@ -50,7 +50,7 @@ class AmpKeywordReferenceTest(private val testCase: TestCase) {
         mockAmpLinks()
         testee = RealAmpLinks(mockRepository, mockFeatureToggle, mockUnprotectedTemporary)
         whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(false)
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.AmpLinksFeatureName, true)).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.AmpLinksFeatureName.value, true)).thenReturn(true)
     }
 
     companion object {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPluginTest.kt
@@ -43,22 +43,22 @@ class AmpLinksPluginTest {
     @Test
     fun whenFeatureNameDoesNotMatchAmpLinksThenReturnFalse() {
         PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
-            Assert.assertFalse(testee.store(it, EMPTY_JSON_STRING))
+            Assert.assertFalse(testee.store(it.value, EMPTY_JSON_STRING))
         }
     }
 
     @Test
     fun whenFeatureNameMatchesAmpLinksThenReturnTrue() {
-        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+        assertTrue(testee.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
     }
 
     @Test
     fun whenFeatureNameMatchesAmpLinksAndIsEnabledThenStoreFeatureEnabled() {
         val jsonString = FileUtilities.loadText(AmpLinksPluginTest::class.java.classLoader!!, "json/amp_links.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, null))
     }
 
     @Test
@@ -68,25 +68,25 @@ class AmpLinksPluginTest {
             "json/amp_links_disabled.json"
         )
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, false, null))
     }
 
     @Test
     fun whenFeatureNameMatchesAmpLinksAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
         val jsonString = FileUtilities.loadText(AmpLinksPluginTest::class.java.classLoader!!, "json/amp_links_min_supported_version.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, 1234))
     }
 
     @Test
     fun whenFeatureNameMatchesAmpLinksThenUpdateAllExistingValues() {
         val jsonString = FileUtilities.loadText(AmpLinksPluginTest::class.java.classLoader!!, "json/amp_links.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
         val exceptionArgumentCaptor = argumentCaptor<List<AmpLinkExceptionEntity>>()
         val ampLinkFormatArgumentCaptor = argumentCaptor<List<AmpLinkFormatEntity>>()
@@ -117,6 +117,7 @@ class AmpLinksPluginTest {
 
     companion object {
         private val FEATURE_NAME = PrivacyFeatureName.AmpLinksFeatureName
+        private val FEATURE_NAME_VALUE = FEATURE_NAME.value
         private const val EMPTY_JSON_STRING = "{}"
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/autofill/AutofillPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/autofill/AutofillPluginTest.kt
@@ -42,53 +42,54 @@ class AutofillPluginTest {
     @Test
     fun whenFeatureNameDoesNotMatchHttpsThenReturnFalse() {
         PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
-            assertFalse(testee.store(it, EMPTY_JSON_STRING))
+            assertFalse(testee.store(it.value, EMPTY_JSON_STRING))
         }
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsThenReturnTrue() {
-        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+        assertTrue(testee.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsAndIsEnabledThenStoreFeatureEnabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/autofill.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, null))
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsAndIsNotEnabledThenStoreFeatureDisabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/autofill_disabled.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, false, null))
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/autofill_min_supported_version.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, 1234))
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsThenUpdateAllExistingExceptions() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/autofill.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
         verify(mockAutofillRepository).updateAll(ArgumentMatchers.anyList())
     }
 
     companion object {
         private val FEATURE_NAME = PrivacyFeatureName.AutofillFeatureName
+        private val FEATURE_NAME_VALUE = PrivacyFeatureName.AutofillFeatureName.value
         private const val EMPTY_JSON_STRING = "{}"
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingPluginTest.kt
@@ -42,53 +42,54 @@ class ContentBlockingPluginTest {
     @Test
     fun whenFeatureNameDoesNotMatchContentBlockingThenReturnFalse() {
         PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
-            assertFalse(testee.store(it, EMPTY_JSON_STRING))
+            assertFalse(testee.store(it.value, EMPTY_JSON_STRING))
         }
     }
 
     @Test
     fun whenFeatureNameMatchesContentBlockingThenReturnTrue() {
-        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+        assertTrue(testee.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
     }
 
     @Test
     fun whenFeatureNameMatchesContentBlockingAndIsEnabledThenStoreFeatureEnabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/content_blocking.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, null))
     }
 
     @Test
     fun whenFeatureNameMatchesContentBlockingAndIsNotEnabledThenStoreFeatureDisabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/content_blocking_disabled.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, false, null))
     }
 
     @Test
     fun whenFeatureNameMatchesContentBlockingAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/content_blocking_min_supported_version.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, 1234))
     }
 
     @Test
     fun whenFeatureNameMatchesContentBlockingThenUpdateAllExistingExceptions() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/content_blocking.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
         verify(mockContentBlockingRepository).updateAll(anyList())
     }
 
     companion object {
         private val FEATURE_NAME = PrivacyFeatureName.ContentBlockingFeatureName
+        private val FEATURE_NAME_VALUE = FEATURE_NAME.value
         private const val EMPTY_JSON_STRING = "{}"
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
@@ -98,7 +98,7 @@ class RealContentBlockingTest {
     private fun givenFeatureIsEnabled() {
         whenever(
             mockFeatureToggle.isFeatureEnabled(
-                PrivacyFeatureName.ContentBlockingFeatureName, true
+                PrivacyFeatureName.ContentBlockingFeatureName.value, true
             )
         )
             .thenReturn(true)
@@ -107,7 +107,7 @@ class RealContentBlockingTest {
     private fun givenFeatureIsDisabled() {
         whenever(
             mockFeatureToggle.isFeatureEnabled(
-                PrivacyFeatureName.ContentBlockingFeatureName, true
+                PrivacyFeatureName.ContentBlockingFeatureName.value, true
             )
         )
             .thenReturn(false)

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/DrmPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/DrmPluginTest.kt
@@ -42,53 +42,54 @@ class DrmPluginTest {
     @Test
     fun whenFeatureNameDoesNotMatchEmeThenReturnFalse() {
         PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
-            assertFalse(testee.store(it, EMPTY_JSON_STRING))
+            assertFalse(testee.store(it.value, EMPTY_JSON_STRING))
         }
     }
 
     @Test
     fun whenFeatureNameMatchesEmeThenReturnTrue() {
-        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+        assertTrue(testee.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
     }
 
     @Test
     fun whenFeatureNameMatchesEmeAndIsEnabledThenStoreFeatureEnabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/drm.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, null))
     }
 
     @Test
     fun whenFeatureNameMatchesEmeAndIsNotEnabledThenStoreFeatureDisabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/drm_disabled.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, false, null))
     }
 
     @Test
     fun whenFeatureNameMatchesEmeAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/drm_min_supported_version.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, 1234))
     }
 
     @Test
     fun whenFeatureNameMatchesEmeThenUpdateAllExistingExceptions() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/drm.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
         verify(mockDrmRepository).updateAll(anyList())
     }
 
     companion object {
         private val FEATURE_NAME = PrivacyFeatureName.DrmFeatureName
+        private val FEATURE_NAME_VALUE = FEATURE_NAME.value
         private const val EMPTY_JSON_STRING = "{}"
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
@@ -92,7 +92,7 @@ class RealDrmTest {
     }
 
     private fun giveFeatureIsEnabled() {
-        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.DrmFeatureName), any())).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.DrmFeatureName.value), any())).thenReturn(true)
     }
 
     private fun givenUrlIsInExceptionList() {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/GpcPluginTest.kt
@@ -42,53 +42,54 @@ class GpcPluginTest {
     @Test
     fun whenFeatureNameDoesNotMatchGpcThenReturnFalse() {
         PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
-            assertFalse(testee.store(it, EMPTY_JSON_STRING))
+            assertFalse(testee.store(it.value, EMPTY_JSON_STRING))
         }
     }
 
     @Test
     fun whenFeatureNameMatchesGpcThenReturnTrue() {
-        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+        assertTrue(testee.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
     }
 
     @Test
     fun whenFeatureNameMatchesGpcAndIsEnabledThenStoreFeatureEnabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/gpc.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, null))
     }
 
     @Test
     fun whenFeatureNameMatchesGpcAndIsNotEnabledThenStoreFeatureDisabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/gpc_disabled.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, false, null))
     }
 
     @Test
     fun whenFeatureNameMatchesGpcAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/gpc_min_supported_version.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, 1234))
     }
 
     @Test
     fun whenFeatureNameMatchesGpcThenUpdateAllExistingExceptionsAndHeaders() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/gpc.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
         verify(mockGpcRepository).updateAll(anyList(), anyList())
     }
 
     companion object {
         private val FEATURE_NAME = PrivacyFeatureName.GpcFeatureName
+        private val FEATURE_NAME_VALUE = FEATURE_NAME.value
         private const val EMPTY_JSON_STRING = "{}"
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
@@ -216,19 +216,19 @@ class RealGpcTest {
     }
 
     private fun givenFeatureAndGpcAreEnabled() {
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName, true))
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, true))
             .thenReturn(true)
         whenever(mockGpcRepository.isGpcEnabled()).thenReturn(true)
     }
 
     private fun givenFeatureIsEnabledButGpcIsNot() {
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName, true))
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, true))
             .thenReturn(true)
         whenever(mockGpcRepository.isGpcEnabled()).thenReturn(false)
     }
 
     private fun givenFeatureIsNotEnabledButGpcIsEnabled() {
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName, true))
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, true))
             .thenReturn(false)
         whenever(mockGpcRepository.isGpcEnabled()).thenReturn(true)
     }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPluginTest.kt
@@ -42,53 +42,54 @@ class HttpsPluginTest {
     @Test
     fun whenFeatureNameDoesNotMatchHttpsThenReturnFalse() {
         PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
-            assertFalse(testee.store(it, EMPTY_JSON_STRING))
+            assertFalse(testee.store(it.value, EMPTY_JSON_STRING))
         }
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsThenReturnTrue() {
-        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+        assertTrue(testee.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsAndIsEnabledThenStoreFeatureEnabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/https.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, null))
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsAndIsNotEnabledThenStoreFeatureDisabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/https_disabled.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, false, null))
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/https_min_supported_version.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, 1234))
     }
 
     @Test
     fun whenFeatureNameMatchesHttpsThenUpdateAllExistingExceptions() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/https.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
         verify(mockHttpsRepository).updateAll(anyList())
     }
 
     companion object {
         private val FEATURE_NAME = PrivacyFeatureName.HttpsFeatureName
+        private val FEATURE_NAME_VALUE = FEATURE_NAME.value
         private const val EMPTY_JSON_STRING = "{}"
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/TrackerAllowlistPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/TrackerAllowlistPluginTest.kt
@@ -43,47 +43,47 @@ class TrackerAllowlistPluginTest {
     @Test
     fun whenFeatureNameDoesNotMatchTrackerAllowlistThenReturnFalse() {
         PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
-            assertFalse(testee.store(it, EMPTY_JSON_STRING))
+            assertFalse(testee.store(it.value, EMPTY_JSON_STRING))
         }
     }
 
     @Test
     fun whenFeatureNameMatchesTrackerAllowlistThenReturnTrue() {
-        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+        assertTrue(testee.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
     }
 
     @Test
     fun whenFeatureNameMatchesTrackerAllowlistAndIsEnabledThenStoreFeatureEnabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/tracker_allowlist.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, null))
     }
 
     @Test
     fun whenFeatureNameMatchesTrackerAllowlistAndIsNotEnabledThenStoreFeatureDisabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/tracker_allowlist_disabled.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, false, null))
     }
 
     @Test
     fun whenFeatureNameMatchesTrackerAllowlistAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/tracker_allowlist_min_supported_version.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, 1234))
     }
 
     @Test
     fun whenFeatureNameMatchesTrackerAllowlistThenUpdateAllExistingExceptions() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/tracker_allowlist.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
         argumentCaptor<List<TrackerAllowlistEntity>>().apply {
             verify(mockAllowlistRepository).updateAll(capture())
@@ -99,6 +99,7 @@ class TrackerAllowlistPluginTest {
 
     companion object {
         private val FEATURE_NAME = PrivacyFeatureName.TrackerAllowlistFeatureName
+        private val FEATURE_NAME_VALUE = FEATURE_NAME.value
         private const val EMPTY_JSON_STRING = "{}"
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParameterReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParameterReferenceTest.kt
@@ -52,7 +52,7 @@ class TrackingParameterReferenceTest(private val testCase: TestCase) {
         mockTrackingParameters()
         testee = RealTrackingParameters(mockRepository, mockFeatureToggle, mockUnprotectedTemporary, mockUserWhiteListRepository)
         whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(false)
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.TrackingParametersFeatureName, true)).thenReturn(true)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.TrackingParametersFeatureName.value, true)).thenReturn(true)
     }
 
     companion object {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersPluginTest.kt
@@ -43,22 +43,22 @@ class TrackingParametersPluginTest {
     @Test
     fun whenFeatureNameDoesNotMatchTrackingParametersThenReturnFalse() {
         PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
-            Assert.assertFalse(testee.store(it, EMPTY_JSON_STRING))
+            Assert.assertFalse(testee.store(it.value, EMPTY_JSON_STRING))
         }
     }
 
     @Test
     fun whenFeatureNameMatchesTrackingParametersThenReturnTrue() {
-        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+        assertTrue(testee.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
     }
 
     @Test
     fun whenFeatureNameMatchesTrackingParametersAndIsEnabledThenStoreFeatureEnabled() {
         val jsonString = FileUtilities.loadText(TrackingParametersPluginTest::class.java.classLoader!!, "json/tracking_parameters.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, null))
     }
 
     @Test
@@ -68,9 +68,9 @@ class TrackingParametersPluginTest {
             "json/tracking_parameters_disabled.json"
         )
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, false, null))
     }
 
     @Test
@@ -80,16 +80,16 @@ class TrackingParametersPluginTest {
             "json/tracking_parameters_min_supported_version.json"
         )
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, 1234))
     }
 
     @Test
     fun whenFeatureNameMatchesTrackingParametersThenUpdateAllExistingValues() {
         val jsonString = FileUtilities.loadText(TrackingParametersPluginTest::class.java.classLoader!!, "json/tracking_parameters.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
         val exceptionArgumentCaptor = argumentCaptor<List<TrackingParameterExceptionEntity>>()
         val trackingParameterArgumentCaptor = argumentCaptor<List<TrackingParameterEntity>>()
@@ -113,6 +113,7 @@ class TrackingParametersPluginTest {
 
     companion object {
         private val FEATURE_NAME = PrivacyFeatureName.TrackingParametersFeatureName
+        private val FEATURE_NAME_VALUE = FEATURE_NAME.value
         private const val EMPTY_JSON_STRING = "{}"
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPluginTest.kt
@@ -43,40 +43,40 @@ class UserAgentPluginTest {
     @Test
     fun whenFeatureNameDoesNotMatchUserAgentThenReturnFalse() {
         PrivacyFeatureName.values().filter { it != FEATURE_NAME }.forEach {
-            assertFalse(testee.store(it, EMPTY_JSON_STRING))
+            assertFalse(testee.store(it.value, EMPTY_JSON_STRING))
         }
     }
 
     @Test
     fun whenFeatureNameMatchesUserAgentThenReturnTrue() {
-        assertTrue(testee.store(FEATURE_NAME, EMPTY_JSON_STRING))
+        assertTrue(testee.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
     }
 
     @Test
     fun whenFeatureNameMatchesUserAgentAndIsEnabledThenStoreFeatureEnabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/useragent.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, null))
     }
 
     @Test
     fun whenFeatureNameMatchesUserAgentAndIsNotEnabledThenStoreFeatureDisabled() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/useragent_disabled.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, false, null))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, false, null))
     }
 
     @Test
     fun whenFeatureNameMatchesUserAgentAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/useragent_min_supported_version.json")
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
-        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME, true, 1234))
+        verify(mockFeatureTogglesRepository).insert(PrivacyFeatureToggles(FEATURE_NAME_VALUE, true, 1234))
     }
 
     @Test
@@ -84,7 +84,7 @@ class UserAgentPluginTest {
         val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/useragent.json")
         val exceptionsCaptor = argumentCaptor<List<UserAgentExceptionEntity>>()
 
-        testee.store(FEATURE_NAME, jsonString)
+        testee.store(FEATURE_NAME_VALUE, jsonString)
 
         verify(mockUserAgentRepository).updateAll(exceptionsCaptor.capture())
 
@@ -118,6 +118,7 @@ class UserAgentPluginTest {
 
     companion object {
         private val FEATURE_NAME = PrivacyFeatureName.UserAgentFeatureName
+        private val FEATURE_NAME_VALUE = FEATURE_NAME.value
         private const val EMPTY_JSON_STRING = "{}"
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeatureTogglesPluginTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/plugins/PrivacyFeatureTogglesPluginTest.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.privacy.config.impl.plugins
 
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
 import org.mockito.kotlin.mock
@@ -49,7 +48,7 @@ class PrivacyFeatureTogglesPluginTest {
 
     @Test
     fun whenIsEnabledAndFeatureIsNotAPrivacyFeatureThenReturnNull() = runTest {
-        assertNull(testee.isEnabled(NonPrivacyFeature(), true))
+        assertNull(testee.isEnabled(NonPrivacyFeature().value, true))
     }
 
     @Test
@@ -57,7 +56,7 @@ class PrivacyFeatureTogglesPluginTest {
         runTest {
             givenPrivacyFeatureIsEnabled()
 
-            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName, true)
+            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName.value, true)
 
             assertTrue(isEnabled!!)
         }
@@ -67,7 +66,7 @@ class PrivacyFeatureTogglesPluginTest {
         runTest {
             givenPrivacyFeatureIsDisabled()
 
-            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName, true)
+            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName.value, true)
 
             assertFalse(isEnabled!!)
         }
@@ -79,7 +78,7 @@ class PrivacyFeatureTogglesPluginTest {
             givenPrivacyFeatureReturnsDefaultValue(defaultValue)
 
             val isEnabled =
-                testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName, defaultValue)
+                testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName.value, defaultValue)
 
             assertEquals(defaultValue, isEnabled)
         }
@@ -90,7 +89,7 @@ class PrivacyFeatureTogglesPluginTest {
             givenPrivacyFeatureIsEnabled()
             givenAppVersionIsEqualToMinSupportedVersion()
 
-            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName, true)
+            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName.value, true)
 
             assertTrue(isEnabled!!)
         }
@@ -101,7 +100,7 @@ class PrivacyFeatureTogglesPluginTest {
             givenPrivacyFeatureIsEnabled()
             givenAppVersionIsGreaterThanMinSupportedVersion()
 
-            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName, true)
+            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName.value, true)
 
             assertTrue(isEnabled!!)
         }
@@ -112,7 +111,7 @@ class PrivacyFeatureTogglesPluginTest {
             givenPrivacyFeatureIsEnabled()
             givenAppVersionIsSmallerThanMinSupportedVersion()
 
-            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName, true)
+            val isEnabled = testee.isEnabled(PrivacyFeatureName.ContentBlockingFeatureName.value, true)
 
             assertFalse(isEnabled!!)
         }
@@ -171,5 +170,5 @@ class PrivacyFeatureTogglesPluginTest {
         whenever(mockAppBuildConfig.versionCode).thenReturn(123)
     }
 
-    data class NonPrivacyFeature(override val value: String = "test") : FeatureName
+    data class NonPrivacyFeature(val value: String = "test")
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/GpcHeaderReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/GpcHeaderReferenceTest.kt
@@ -109,7 +109,7 @@ class GpcHeaderReferenceTest(private val testCase: TestCase) {
         val isEnabled = gpcFeature?.state == "enabled"
         val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(config?.unprotectedTemporary ?: emptyList())
 
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName, isEnabled)).thenReturn(isEnabled)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, isEnabled)).thenReturn(isEnabled)
         whenever(mockGpcRepository.exceptions).thenReturn(CopyOnWriteArrayList(gpcExceptions))
         whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptionsUnprotectedTemporary)
     }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/GpcJavascriptReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/GpcJavascriptReferenceTest.kt
@@ -104,7 +104,7 @@ class GpcJavascriptReferenceTest(private val testCase: TestCase) {
         val isEnabled = gpcFeature?.state == "enabled"
         val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(config?.unprotectedTemporary ?: emptyList())
 
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName, isEnabled)).thenReturn(isEnabled)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, isEnabled)).thenReturn(isEnabled)
         whenever(mockGpcRepository.exceptions).thenReturn(CopyOnWriteArrayList(gpcExceptions))
         whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptionsUnprotectedTemporary)
     }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/gpc/GpcHeaderReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/gpc/GpcHeaderReferenceTest.kt
@@ -109,7 +109,7 @@ class GpcHeaderReferenceTest(private val testCase: TestCase) {
         val isEnabled = gpcFeature?.state == "enabled"
         val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(config?.unprotectedTemporary ?: emptyList())
 
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName, isEnabled)).thenReturn(isEnabled)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, isEnabled)).thenReturn(isEnabled)
         whenever(mockGpcRepository.exceptions).thenReturn(CopyOnWriteArrayList(gpcExceptions))
         whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptionsUnprotectedTemporary)
     }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/gpc/GpcJavascriptReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/gpc/GpcJavascriptReferenceTest.kt
@@ -104,7 +104,7 @@ class GpcJavascriptReferenceTest(private val testCase: TestCase) {
         val isEnabled = gpcFeature?.state == "enabled"
         val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(config?.unprotectedTemporary ?: emptyList())
 
-        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName, isEnabled)).thenReturn(isEnabled)
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, isEnabled)).thenReturn(isEnabled)
         whenever(mockGpcRepository.exceptions).thenReturn(CopyOnWriteArrayList(gpcExceptions))
         whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptionsUnprotectedTemporary)
     }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigDisabledReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigDisabledReferenceTest.kt
@@ -96,7 +96,7 @@ class PrivacyConfigDisabledReferenceTest(private val testCase: TestCase) {
 
         verify(referenceTestUtilities.privacyFeatureTogglesRepository).insert(
             PrivacyFeatureToggles(
-                privacyFeatureValueOf(testCase.featureName)!!,
+                privacyFeatureValueOf(testCase.featureName)!!.value,
                 testCase.expectFeatureEnabled,
                 null
             )

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigEnabledReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigEnabledReferenceTest.kt
@@ -95,7 +95,7 @@ class PrivacyConfigEnabledReferenceTest(private val testCase: TestCase) {
 
         verify(referenceTestUtilities.privacyFeatureTogglesRepository).insert(
             PrivacyFeatureToggles(
-                privacyFeatureValueOf(testCase.featureName)!!,
+                privacyFeatureValueOf(testCase.featureName)!!.value,
                 testCase.expectFeatureEnabled,
                 null
             )

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigMissingReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigMissingReferenceTest.kt
@@ -96,7 +96,7 @@ class PrivacyConfigMissingReferenceTest(private val testCase: TestCase) {
         testee.persistPrivacyConfig(referenceTestUtilities.getJsonPrivacyConfig("reference_tests/privacyconfig/$referenceJsonFile"))
 
         verify(referenceTestUtilities.privacyFeatureTogglesRepository, never())
-            .insert(PrivacyFeatureToggles(privacyFeatureValueOf(testCase.featureName)!!, true, null))
+            .insert(PrivacyFeatureToggles(privacyFeatureValueOf(testCase.featureName)!!.value, true, null))
     }
 
     private fun prepareDb() {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/trackerallowlist/TrackerAllowlistReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/trackerallowlist/TrackerAllowlistReferenceTest.kt
@@ -64,7 +64,7 @@ class TrackerAllowlistReferenceTest(private val testCase: TestCase) {
     fun whenIsAnExceptionAnFeatureEnableThenReturnCorrectValues() {
         whenever(
             mockFeatureToggle.isFeatureEnabled(
-                PrivacyFeatureName.TrackerAllowlistFeatureName, true
+                PrivacyFeatureName.TrackerAllowlistFeatureName.value, true
             )
         )
             .thenReturn(true)
@@ -79,7 +79,7 @@ class TrackerAllowlistReferenceTest(private val testCase: TestCase) {
     fun whenIsAnExceptionAnFeatureDisabledThenReturnCorrectValues() {
         whenever(
             mockFeatureToggle.isFeatureEnabled(
-                PrivacyFeatureName.TrackerAllowlistFeatureName, true
+                PrivacyFeatureName.TrackerAllowlistFeatureName.value, true
             )
         )
             .thenReturn(false)

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyFeatureTogglesDataStore.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyFeatureTogglesDataStore.kt
@@ -52,9 +52,9 @@ class PrivacyFeatureTogglesSharedPreferences constructor(private val context: Co
 
     override fun insert(toggle: PrivacyFeatureToggles) {
         preferences.edit {
-            putBoolean(toggle.featureName.value, toggle.enabled)
+            putBoolean(toggle.featureName, toggle.enabled)
             toggle.minSupportedVersion?.let {
-                putInt("${toggle.featureName.value}$MIN_SUPPORTED_VERSION", it)
+                putInt("${toggle.featureName}$MIN_SUPPORTED_VERSION", it)
             }
         }
     }
@@ -70,7 +70,7 @@ class PrivacyFeatureTogglesSharedPreferences constructor(private val context: Co
 }
 
 data class PrivacyFeatureToggles(
-    val featureName: PrivacyFeatureName,
+    val featureName: String,
     val enabled: Boolean,
     val minSupportedVersion: Int?
 )

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/RealPrivacyFeatureTogglesRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/RealPrivacyFeatureTogglesRepositoryTest.kt
@@ -49,7 +49,7 @@ class RealPrivacyFeatureTogglesRepositoryTest {
 
     @Test
     fun whenInsertThenInsertCalled() {
-        val privacyFeatureToggle = PrivacyFeatureToggles(PrivacyFeatureName.GpcFeatureName, true, null)
+        val privacyFeatureToggle = PrivacyFeatureToggles(PrivacyFeatureName.GpcFeatureName.value, true, null)
         testee.insert(privacyFeatureToggle)
 
         verify(mockPrivacyFeatureTogglesDataStore).insert(privacyFeatureToggle)

--- a/vpn-api/build.gradle
+++ b/vpn-api/build.gradle
@@ -22,10 +22,7 @@ plugins {
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
-    implementation project(path: ':feature-toggles-api')
-
     implementation Kotlin.stdlib.jdk7
     implementation AndroidX.core.ktx
     implementation KotlinX.coroutines.core
-
 }

--- a/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureName.kt
+++ b/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureName.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.mobile.android.vpn.feature
 
-import com.duckduckgo.feature.toggles.api.FeatureName
-
-enum class AppTpFeatureName(override val value: String) : FeatureName {
+enum class AppTpFeatureName(val value: String) {
     AppTrackerProtection("appTrackerProtection"),
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPlugin.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPlugin.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.mobile.android.vpn.feature
 
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.feature.toggles.api.FeatureTogglesPlugin
 import com.duckduckgo.mobile.android.vpn.store.AppTpFeatureToggleRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -29,10 +28,11 @@ class AppTpFeatureTogglesPlugin @Inject constructor(
     private val appTpFeatureToggleRepository: AppTpFeatureToggleRepository,
     private val appBuildConfig: AppBuildConfig
 ) : FeatureTogglesPlugin {
-    override fun isEnabled(featureName: FeatureName, defaultValue: Boolean): Boolean? {
-        return if (featureName is AppTpFeatureName) {
-            return appTpFeatureToggleRepository.get(featureName, defaultValue) &&
-                appBuildConfig.versionCode >= appTpFeatureToggleRepository.getMinSupportedVersion(featureName)
+    override fun isEnabled(featureName: String, defaultValue: Boolean): Boolean? {
+        val appTpFeatureName = appTpFeatureValueOf(featureName)
+        return if (appTpFeatureName != null) {
+            return appTpFeatureToggleRepository.get(appTpFeatureName, defaultValue) &&
+                appBuildConfig.versionCode >= appTpFeatureToggleRepository.getMinSupportedVersion(appTpFeatureName)
         } else {
             null
         }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPlugin.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPlugin.kt
@@ -29,12 +29,8 @@ class AppTpFeatureTogglesPlugin @Inject constructor(
     private val appBuildConfig: AppBuildConfig
 ) : FeatureTogglesPlugin {
     override fun isEnabled(featureName: String, defaultValue: Boolean): Boolean? {
-        val appTpFeatureName = appTpFeatureValueOf(featureName)
-        return if (appTpFeatureName != null) {
-            return appTpFeatureToggleRepository.get(appTpFeatureName, defaultValue) &&
-                appBuildConfig.versionCode >= appTpFeatureToggleRepository.getMinSupportedVersion(appTpFeatureName)
-        } else {
-            null
-        }
+        val appTpFeatureName = appTpFeatureValueOf(featureName) ?: return null
+        return appTpFeatureToggleRepository.get(appTpFeatureName, defaultValue) &&
+            appBuildConfig.versionCode >= appTpFeatureToggleRepository.getMinSupportedVersion(appTpFeatureName)
     }
 }

--- a/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpPrivacyFeaturePlugin.kt
+++ b/vpn/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpPrivacyFeaturePlugin.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.mobile.android.vpn.feature
 
 import com.duckduckgo.di.DaggerSet
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
@@ -32,10 +31,10 @@ class AppTpPrivacyFeaturePlugin @Inject constructor(
 
     private val settings = plugins.sortedBy { it.settingName.value }
 
-    override fun store(name: FeatureName, jsonString: String): Boolean {
+    override fun store(featureName: String, jsonString: String): Boolean {
         @Suppress("NAME_SHADOWING")
-        val name = appTpFeatureValueOf(name.value)
-        if (name == featureName) {
+        val appTpFeature = appTpFeatureValueOf(featureName) ?: return false
+        if (appTpFeature.value == this.featureName) {
             val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
             val adapter: JsonAdapter<JsonAppTpFeatureConfig> = moshi.adapter(JsonAppTpFeatureConfig::class.java)
 
@@ -55,7 +54,7 @@ class AppTpPrivacyFeaturePlugin @Inject constructor(
         return false
     }
 
-    override val featureName: FeatureName = AppTpFeatureName.AppTrackerProtection
+    override val featureName: String = AppTpFeatureName.AppTrackerProtection.value
 }
 
 interface AppTpSettingPlugin {

--- a/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPluginTest.kt
+++ b/vpn/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureTogglesPluginTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.mobile.android.vpn.feature
 
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.feature.toggles.api.FeatureName
 import com.duckduckgo.mobile.android.vpn.store.AppTpFeatureToggleRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -45,15 +44,15 @@ class AppTpFeatureTogglesPluginTest {
     @Test
     fun whenIsEnabledCalledOnAppTpFeatureNameThenReturnRepositoryValue() {
         whenever(appTpFeatureToggleRepository.get(AppTpFeatureName.AppTrackerProtection, false)).thenReturn(true)
-        assertEquals(true, plugin.isEnabled(AppTpFeatureName.AppTrackerProtection, false))
+        assertEquals(true, plugin.isEnabled(AppTpFeatureName.AppTrackerProtection.value, false))
 
         whenever(appTpFeatureToggleRepository.get(AppTpFeatureName.AppTrackerProtection, false)).thenReturn(false)
-        assertEquals(false, plugin.isEnabled(AppTpFeatureName.AppTrackerProtection, false))
+        assertEquals(false, plugin.isEnabled(AppTpFeatureName.AppTrackerProtection.value, false))
     }
 
     @Test
     fun whenIsEnabledCalledOnOtherFeatureNameThenReturnRepositoryNull() {
-        assertNull(plugin.isEnabled(TestFeatureName(), false))
+        assertNull(plugin.isEnabled(TestFeatureName().value, false))
     }
 
     @Test
@@ -61,7 +60,7 @@ class AppTpFeatureTogglesPluginTest {
         runTest {
             givenAppTpFeatureIsEnabled()
 
-            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection, true)
+            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection.value, true)
 
             assertTrue(isEnabled!!)
         }
@@ -71,7 +70,7 @@ class AppTpFeatureTogglesPluginTest {
         runTest {
             givenAppTpFeatureIsDisabled()
 
-            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection, true)
+            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection.value, true)
 
             assertFalse(isEnabled!!)
         }
@@ -83,7 +82,7 @@ class AppTpFeatureTogglesPluginTest {
             givenAppTpFeatureReturnsDefaultValue(defaultValue)
 
             val isEnabled =
-                plugin.isEnabled(AppTpFeatureName.AppTrackerProtection, defaultValue)
+                plugin.isEnabled(AppTpFeatureName.AppTrackerProtection.value, defaultValue)
 
             assertEquals(defaultValue, isEnabled)
         }
@@ -94,7 +93,7 @@ class AppTpFeatureTogglesPluginTest {
             givenAppTpFeatureIsEnabled()
             givenAppVersionIsEqualToMinSupportedVersion()
 
-            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection, true)
+            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection.value, true)
 
             assertTrue(isEnabled!!)
         }
@@ -105,7 +104,7 @@ class AppTpFeatureTogglesPluginTest {
             givenAppTpFeatureIsEnabled()
             givenAppVersionIsGreaterThanMinSupportedVersion()
 
-            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection, true)
+            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection.value, true)
 
             assertTrue(isEnabled!!)
         }
@@ -116,7 +115,7 @@ class AppTpFeatureTogglesPluginTest {
             givenAppTpFeatureIsEnabled()
             givenAppVersionIsSmallerThanMinSupportedVersion()
 
-            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection, true)
+            val isEnabled = plugin.isEnabled(AppTpFeatureName.AppTrackerProtection.value, true)
 
             assertFalse(isEnabled!!)
         }
@@ -176,4 +175,4 @@ class AppTpFeatureTogglesPluginTest {
     }
 }
 
-class TestFeatureName(override val value: String = "test") : FeatureName
+class TestFeatureName(val value: String = "test")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1202666690958570

### Description
This PR removes the dependency from feature-toggles-api in the privacy-config-api and vpn-api modules. It removes FeatureName and swaps it to a String.

### Steps to test this PR

_Remote config_
- [x] All tests pass
- [x] Try a few remote features and make sure they work as expected, some examples below.
- [x] Install and launch from this branch
- [x] Filter by user agent in the logcat
- [x] Go to thingiverse.com
- [x] User agent should not include the word `DuckDuckGo`
- [x] Go to `welt.de`
- [x] Privacy grade should be solid black
- [x] Go to the privacy dashboard (click on the privacy grade)
- [x] There should be a message saying protections are temporarily disabled due to breakage
- [x] Check the toggles, privacy config and vpn DB to make sure the data inserted matches the date from `https://staticcdn.duckduckgo.com/trackerblocking/config/v1/android-config.json`

