### PR TITLE
Improve autofill list UX

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/domain/app/LoginCredentials.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/domain/app/LoginCredentials.kt
@@ -34,6 +34,6 @@ data class LoginCredentials(
 ) : Parcelable {
     override fun toString(): String {
         return "LoginCredentials(id=$id, domain=$domain, username=$username, password=********," +
-            " domainTitle= $domainTitle, lastUpdatedMillis=$lastUpdatedMillis, notes=$notes"
+            " domainTitle=$domainTitle, lastUpdatedMillis=$lastUpdatedMillis, notes=$notes"
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillDomainFormatter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillDomainFormatter.kt
@@ -29,6 +29,11 @@ interface AutofillDomainFormatter {
 @ContributesBinding(FragmentScope::class)
 class AutofillDomainFormatterDomainNameOnly @Inject constructor() : AutofillDomainFormatter {
     override fun extractDomain(domain: String?): String? {
-        return domain?.toUri()?.baseHost
+        val domain = domain?.toUri()?.baseHost
+        return if (domain.isNullOrBlank()) {
+            null
+        } else {
+            domain
+        }
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillDomainFormatter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillDomainFormatter.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill
+
+import androidx.core.net.toUri
+import com.duckduckgo.app.global.baseHost
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface AutofillDomainFormatter {
+    fun extractDomain(domain: String?): String?
+}
+
+@ContributesBinding(AppScope::class)
+class AutofillDomainFormatterDomainNameOnly @Inject constructor() : AutofillDomainFormatter {
+    override fun extractDomain(domain: String?): String? {
+        return domain?.toUri()?.baseHost
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillDomainFormatter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillDomainFormatter.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.autofill
 
 import androidx.core.net.toUri
 import com.duckduckgo.app.global.baseHost
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -26,7 +26,7 @@ interface AutofillDomainFormatter {
     fun extractDomain(domain: String?): String?
 }
 
-@ContributesBinding(AppScope::class)
+@ContributesBinding(FragmentScope::class)
 class AutofillDomainFormatterDomainNameOnly @Inject constructor() : AutofillDomainFormatter {
     override fun extractDomain(domain: String?): String? {
         return domain?.toUri()?.baseHost

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillCharacterValidator.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillCharacterValidator.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.autofill.ui.credential.management
 
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -24,7 +24,7 @@ interface AutofillCharacterValidator {
     fun isLetter(character: Char): Boolean
 }
 
-@ContributesBinding(AppScope::class)
+@ContributesBinding(FragmentScope::class)
 class LatinCharacterValidator @Inject constructor() : AutofillCharacterValidator {
 
     override fun isLetter(character: Char): Boolean {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillCharacterValidator.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillCharacterValidator.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface AutofillCharacterValidator {
+    fun isLetter(character: Char): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class LatinCharacterValidator @Inject constructor() : AutofillCharacterValidator {
+
+    override fun isLetter(character: Char): Boolean {
+        return character in 'a'..'z' || character in 'A'..'Z'
+    }
+
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialGrouper.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialGrouper.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem
+import javax.inject.Inject
+
+class CredentialGrouper @Inject constructor(
+    private val initialExtractor: InitialExtractor,
+    private val sorter: CredentialListSorter
+) {
+
+    fun group(unsortedCredentials: List<LoginCredentials>): List<ListItem> {
+        val groups = mutableListOf<ListItem>()
+
+        val sorted = sorter.sort(unsortedCredentials)
+
+        sorted.forEach { credential ->
+            val initial = initialExtractor.extractInitial(credential)
+
+            if (shouldAddNewGroup(groups, initial)) {
+                groups.add(ListItem.GroupHeading(initial))
+            }
+
+            groups.add(ListItem.Credential(credential))
+        }
+
+        return groups
+    }
+
+    private fun shouldAddNewGroup(groups: List<ListItem>, initial: Char): Boolean {
+        return !groups.contains(ListItem.GroupHeading(initial))
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractor.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractor.kt
@@ -24,6 +24,8 @@ import javax.inject.Inject
 
 interface InitialExtractor {
     fun extractInitial(loginCredentials: LoginCredentials): Char
+    fun extractInitialFromTitle(loginCredentials: LoginCredentials): Char?
+    fun extractInitialFromDomain(loginCredentials: LoginCredentials): Char?
 }
 
 @ContributesBinding(FragmentScope::class)
@@ -32,7 +34,7 @@ class CredentialInitialExtractor @Inject constructor(
 ) : InitialExtractor {
 
     override fun extractInitial(loginCredentials: LoginCredentials): Char {
-        val initial = loginCredentials.extractTitleInitial() ?: loginCredentials.extractDomainInitial()
+        val initial = extractInitialFromTitle(loginCredentials) ?: extractInitialFromDomain(loginCredentials)
 
         if (initial == null || !initial.isLetter()) {
             return INITIAL_CHAR_FOR_NON_LETTERS
@@ -41,12 +43,12 @@ class CredentialInitialExtractor @Inject constructor(
         return initial.uppercaseChar()
     }
 
-    private fun LoginCredentials.extractTitleInitial(): Char? {
-        return this.domainTitle?.firstOrNull()
+    override fun extractInitialFromTitle(loginCredentials: LoginCredentials): Char? {
+        return loginCredentials.domainTitle?.firstOrNull()?.uppercaseChar()
     }
 
-    private fun LoginCredentials.extractDomainInitial(): Char? {
-        return domainFormatter.extractDomain(this.domain)?.firstOrNull()
+    override fun extractInitialFromDomain(loginCredentials: LoginCredentials): Char? {
+        return domainFormatter.extractDomain(loginCredentials.domain)?.firstOrNull()?.uppercaseChar()
     }
 
     private fun Char.isLetter(): Boolean {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractor.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractor.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.autofill.ui.credential.management
 
 import com.duckduckgo.autofill.AutofillDomainFormatter
 import com.duckduckgo.autofill.domain.app.LoginCredentials
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -26,7 +26,7 @@ interface InitialExtractor {
     fun extractInitial(loginCredentials: LoginCredentials): Char
 }
 
-@ContributesBinding(AppScope::class)
+@ContributesBinding(FragmentScope::class)
 class CredentialInitialExtractor @Inject constructor(
     private val domainFormatter: AutofillDomainFormatter
 ) : InitialExtractor {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractor.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractor.kt
@@ -30,13 +30,14 @@ interface InitialExtractor {
 
 @ContributesBinding(FragmentScope::class)
 class CredentialInitialExtractor @Inject constructor(
-    private val domainFormatter: AutofillDomainFormatter
+    private val domainFormatter: AutofillDomainFormatter,
+    private val characterValidator: AutofillCharacterValidator
 ) : InitialExtractor {
 
     override fun extractInitial(loginCredentials: LoginCredentials): Char {
         val initial = extractInitialFromTitle(loginCredentials) ?: extractInitialFromDomain(loginCredentials)
 
-        if (initial == null || !initial.isLetter()) {
+        if (initial == null || !characterValidator.isLetter(initial)) {
             return INITIAL_CHAR_FOR_NON_LETTERS
         }
 
@@ -49,10 +50,6 @@ class CredentialInitialExtractor @Inject constructor(
 
     override fun extractInitialFromDomain(loginCredentials: LoginCredentials): Char? {
         return domainFormatter.extractDomain(loginCredentials.domain)?.firstOrNull()?.uppercaseChar()
-    }
-
-    private fun Char.isLetter(): Boolean {
-        return this in 'a'..'z' || this in 'A'..'Z'
     }
 
     companion object {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractor.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractor.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import com.duckduckgo.autofill.AutofillDomainFormatter
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface InitialExtractor {
+    fun extractInitial(loginCredentials: LoginCredentials): Char
+}
+
+@ContributesBinding(AppScope::class)
+class CredentialInitialExtractor @Inject constructor(
+    private val domainFormatter: AutofillDomainFormatter
+) : InitialExtractor {
+
+    override fun extractInitial(loginCredentials: LoginCredentials): Char {
+        val initial = loginCredentials.extractTitleInitial() ?: loginCredentials.extractDomainInitial()
+
+        if (initial == null || !initial.isLetter()) {
+            return INITIAL_CHAR_FOR_NON_LETTERS
+        }
+
+        return initial.uppercaseChar()
+    }
+
+    private fun LoginCredentials.extractTitleInitial(): Char? {
+        return this.domainTitle?.firstOrNull()
+    }
+
+    private fun LoginCredentials.extractDomainInitial(): Char? {
+        return domainFormatter.extractDomain(this.domain)?.firstOrNull()
+    }
+
+    private fun Char.isLetter(): Boolean {
+        return this in 'a'..'z' || this in 'A'..'Z'
+    }
+
+    companion object {
+        const val INITIAL_CHAR_FOR_NON_LETTERS = '#'
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialListSorter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialListSorter.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.autofill.ui.credential.management
 
 import com.duckduckgo.autofill.AutofillDomainFormatter
 import com.duckduckgo.autofill.domain.app.LoginCredentials
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -26,7 +26,7 @@ interface CredentialListSorter {
     fun sort(credentials: List<LoginCredentials>): List<LoginCredentials>
 }
 
-@ContributesBinding(AppScope::class)
+@ContributesBinding(FragmentScope::class)
 class CredentialListSorterByTitleAndDomain @Inject constructor(
     private val domainFormatter: AutofillDomainFormatter
 ) : CredentialListSorter {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialListSorter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/CredentialListSorter.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import com.duckduckgo.autofill.AutofillDomainFormatter
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface CredentialListSorter {
+    fun sort(credentials: List<LoginCredentials>): List<LoginCredentials>
+}
+
+@ContributesBinding(AppScope::class)
+class CredentialListSorterByTitleAndDomain @Inject constructor(
+    private val domainFormatter: AutofillDomainFormatter
+) : CredentialListSorter {
+
+    override fun sort(credentials: List<LoginCredentials>): List<LoginCredentials> {
+        return credentials.sortedWith(
+            compareBy(
+                titleSort(),
+                domainSort()
+            )
+        )
+    }
+
+    private fun titleSort(): (LoginCredentials) -> Comparable<*>? = { it.domainTitle }
+    private fun domainSort(): (LoginCredentials) -> Comparable<*>? = { domainFormatter.extractDomain(it.domain) }
+
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementListModeBinding
 import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel
+import com.duckduckgo.autofill.ui.credential.management.CredentialGrouper
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import dagger.android.support.AndroidSupportInjection
@@ -49,6 +50,9 @@ class AutofillManagementListMode : Fragment() {
 
     @Inject
     lateinit var viewModelFactory: FragmentViewModelFactory
+
+    @Inject
+    lateinit var credentialGrouper: CredentialGrouper
 
     val viewModel by lazy {
         ViewModelProvider(requireActivity(), viewModelFactory)[AutofillSettingsViewModel::class.java]
@@ -122,7 +126,9 @@ class AutofillManagementListMode : Fragment() {
 
     private fun configureRecyclerView() {
         adapter = AutofillManagementRecyclerAdapter(
-            this, faviconManager,
+            this,
+            faviconManager = faviconManager,
+            grouper = credentialGrouper,
             onCredentialSelected = this::onCredentialsSelected,
             onCopyUsername = this::onCopyUsername,
             onCopyPassword = this::onCopyPassword,

--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
@@ -16,28 +16,34 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context="com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementListMode">
 
     <TextView
         android:id="@+id/enabledToggleLabel"
-        android:layout_width="0dp"
-        app:layout_constraintStart_toStartOf="parent"
         style="@style/TextAppearance.AppCompat.Title"
-        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginStart="@dimen/keyline_4"
+        android:layout_marginTop="30dp"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="@string/credentialManagementAutofillToggleLabel" />
+        android:text="@string/credentialManagementAutofillToggleLabel"
+        app:layout_constraintEnd_toStartOf="@id/enabledToggle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/enabledToggle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toEndOf="@id/enabledToggleLabel"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:layout_marginStart="@dimen/keyline_4"
+        android:gravity="center_vertical"
+        android:layout_marginEnd="@dimen/keyline_4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/enabledToggleLabel"
+        app:layout_constraintTop_toTopOf="@id/enabledToggleLabel" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/logins"

--- a/autofill/autofill-impl/src/main/res/layout/item_row_autofill_credentials_management_screen_header.xml
+++ b/autofill/autofill-impl/src/main/res/layout/item_row_autofill_credentials_management_screen_header.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2022 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp"
+    android:textSize="14sp"
+    android:id="@+id/groupHeader"
+    android:textColor="?attr/colorAccent"
+    android:text="hello world" />

--- a/autofill/autofill-impl/src/main/res/layout/item_row_autofill_credentials_management_screen_header.xml
+++ b/autofill/autofill-impl/src/main/res/layout/item_row_autofill_credentials_management_screen_header.xml
@@ -14,12 +14,11 @@
   ~ limitations under the License.
   -->
 
-<TextView
+<com.duckduckgo.mobile.android.ui.view.SectionHeaderTextView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/groupHeader"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_margin="16dp"
-    android:textSize="14sp"
-    android:id="@+id/groupHeader"
-    android:textColor="?attr/colorAccent"
-    android:text="hello world" />
+    tools:text="hello world" />

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillDomainFormatterDomainNameOnlyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillDomainFormatterDomainNameOnlyTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -61,8 +62,27 @@ class AutofillDomainFormatterDomainNameOnlyTest {
         assertEquals("example.com", result)
     }
 
-    fun whenDomainContainsSubdomainThatIsNotWwwThenSubdomainStripped() {
+    @Test
+    fun whenDomainContainsSubdomainThatIsNotWwwThenSubdomainNotStripped() {
         val result = testee.extractDomain("login.example.com")
-        assertEquals("example.com", result)
+        assertEquals("login.example.com", result)
+    }
+
+    @Test
+    fun whenDomainIsNullThenThenFormattedAsNull() {
+        val result = testee.extractDomain(null)
+        assertNull(result)
+    }
+
+    @Test
+    fun whenDomainIsEmptyStringThenThenFormattedAsNull() {
+        val result = testee.extractDomain("")
+        assertNull(result)
+    }
+
+    @Test
+    fun whenDomainIsBlankStringThenThenFormattedAsNull() {
+        val result = testee.extractDomain("  ")
+        assertNull(result)
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillDomainFormatterDomainNameOnlyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillDomainFormatterDomainNameOnlyTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AutofillDomainFormatterDomainNameOnlyTest {
+    private val testee = AutofillDomainFormatterDomainNameOnly()
+
+    @Test
+    fun whenSimpleDomainThenNoChanges() {
+        val result = testee.extractDomain("example.com")
+        assertEquals("example.com", result)
+    }
+
+    @Test
+    fun whenDomainStartsHttpThenSchemaStripped() {
+        val result = testee.extractDomain("http://example.com")
+        assertEquals("example.com", result)
+    }
+
+    @Test
+    fun whenDomainStartsHttpsThenSchemaStripped() {
+        val result = testee.extractDomain("https://example.com")
+        assertEquals("example.com", result)
+    }
+
+    @Test
+    fun whenDomainContainsWwwSubdomainThenSubdomainStripped() {
+        val result = testee.extractDomain("www.example.com")
+        assertEquals("example.com", result)
+    }
+
+    @Test
+    fun whenDomainContainsWwwSubdomainAndHttpSchemaThenBothStripped() {
+        val result = testee.extractDomain("http://www.example.com")
+        assertEquals("example.com", result)
+    }
+
+    @Test
+    fun whenDomainContainsWwwSubdomainAndHttpsSchemaThenBothStripped() {
+        val result = testee.extractDomain("https://www.example.com")
+        assertEquals("example.com", result)
+    }
+
+    fun whenDomainContainsSubdomainThatIsNotWwwThenSubdomainStripped() {
+        val result = testee.extractDomain("login.example.com")
+        assertEquals("example.com", result)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialGrouperTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialGrouperTest.kt
@@ -112,6 +112,25 @@ class CredentialGrouperTest {
         grouped[8].assertIsGroupHeading('S')
     }
 
+    @Test
+    fun whenListContainsAnEntryWithAMissingDomainAndTitleThenGroupedIntoPlaceholder() {
+        val credentials = listOf(
+            creds(domain = "amazon.com", title = "Smile Amazon"),
+            creds(domain = "example.com"),
+            creds(domain = null, title = null),
+            creds(domain = "null", title = "Title"),
+        )
+        val grouped = testee.group(credentials)
+
+        grouped.assertNumberOfHeadings(expected = 4)
+        grouped.assertTotalSize(expected = 8)
+        grouped[0].assertIsGroupHeading('#')
+        grouped[1].assertIsCredential(expectedDomain = null)
+        grouped[2].assertIsGroupHeading('E')
+        grouped[4].assertIsGroupHeading('S')
+        grouped[6].assertIsGroupHeading('T')
+    }
+
     private fun List<ListItem>.assertNumberOfHeadings(expected: Int) {
         assertEquals(expected, this.count { it is GroupHeading })
     }
@@ -125,7 +144,7 @@ class CredentialGrouperTest {
         assertEquals(expectedInitial, (this as GroupHeading).initial)
     }
 
-    private fun ListItem.assertIsCredential(expectedDomain: String) {
+    private fun ListItem.assertIsCredential(expectedDomain: String?) {
         assertTrue(this is Credential)
         assertEquals(expectedDomain, (this as Credential).credentials.domain)
     }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialGrouperTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialGrouperTest.kt
@@ -29,11 +29,16 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class CredentialGrouperTest {
 
-    private val initialExtractor = CredentialInitialExtractor(AutofillDomainFormatterDomainNameOnly())
+    private val characterValidator = LatinCharacterValidator()
+
+    private val initialExtractor = CredentialInitialExtractor(
+        domainFormatter = AutofillDomainFormatterDomainNameOnly(),
+        characterValidator = characterValidator
+    )
 
     private val testee = CredentialGrouper(
         initialExtractor = initialExtractor,
-        sorter = CredentialListSorterByTitleAndDomain(initialExtractor)
+        sorter = CredentialListSorterByTitleAndDomain(initialExtractor, characterValidator)
     )
 
     @Test
@@ -88,7 +93,7 @@ class CredentialGrouperTest {
     }
 
     @Test
-    fun whenTrickyThen() {
+    fun whenCombinationOfDomainsAndTitlesThenGroupsTakenFromTitlesWhenTheyExist() {
         val credentials = listOf(
             creds(domain = "energy.com"),
             creds(domain = "amazon.com", title = "Smile Amazon"),

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialGrouperTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialGrouperTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.AutofillDomainFormatterDomainNameOnly
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem
+import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem.Credential
+import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem.GroupHeading
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CredentialGrouperTest {
+
+    private val initialExtractor: InitialExtractor = object : InitialExtractor {
+        override fun extractInitial(loginCredentials: LoginCredentials): Char {
+            val data = loginCredentials.domainTitle ?: loginCredentials.domain
+            return data?.firstOrNull() ?: '#'
+        }
+    }
+
+    private val domainFormatter = AutofillDomainFormatterDomainNameOnly()
+
+    private val testee = CredentialGrouper(initialExtractor, CredentialListSorterByTitleAndDomain(domainFormatter))
+
+    @Test
+    fun whenEmptyListInThenEmptyListOut() {
+        val credentials = emptyList<LoginCredentials>()
+        val grouped = testee.group(credentials)
+        assertTrue(grouped.isEmpty())
+    }
+
+    @Test
+    fun whenSingleCredentialThenInitialAdded() {
+        val credentials = listOf(
+            creds("example.com")
+        )
+        val grouped = testee.group(credentials)
+
+        grouped.assertTotalSize(expected = 2)
+        grouped.assertNumberOfHeadings(expected = 1)
+        grouped[0].assertIsGroupHeading('e')
+        grouped[1].assertIsCredential("example.com")
+    }
+
+    @Test
+    fun whenMultipleCredentialsWithSameInitialThenOnlyOneGroupAdded() {
+        val credentials = listOf(
+            creds("example.com"),
+            creds("energy.com"),
+            creds("elastic.com"),
+        )
+        val grouped = testee.group(credentials)
+
+        grouped.assertNumberOfHeadings(expected = 1)
+        grouped.assertTotalSize(expected = 4)
+        grouped[0].assertIsGroupHeading('e')
+    }
+
+    @Test
+    fun whenCredentialsWithDifferentInitialsThenMultipleGroupsAdded() {
+        val credentials = listOf(
+            creds("example.com"),
+            creds("foo.com"),
+            creds("bar.com"),
+            creds("energy.com"),
+        )
+        val grouped = testee.group(credentials)
+
+        grouped.assertNumberOfHeadings(expected = 3)
+        grouped.assertTotalSize(expected = 7)
+        grouped[0].assertIsGroupHeading('b')
+        grouped[2].assertIsGroupHeading('e')
+        grouped[5].assertIsGroupHeading('f')
+    }
+
+    private fun List<ListItem>.assertNumberOfHeadings(expected: Int) {
+        assertEquals(expected, this.count { it is GroupHeading })
+    }
+
+    private fun List<ListItem>.assertTotalSize(expected: Int) {
+        assertEquals(expected, this.size)
+    }
+
+    private fun ListItem.assertIsGroupHeading(expectedInitial: Char) {
+        assertTrue(this is GroupHeading)
+        assertEquals(expectedInitial, (this as GroupHeading).initial)
+    }
+
+    private fun ListItem.assertIsCredential(expectedDomain: String) {
+        assertTrue(this is Credential)
+        assertEquals(expectedDomain, (this as Credential).credentials.domain)
+    }
+
+    private fun creds(domain: String? = null, title: String? = null): LoginCredentials {
+        return LoginCredentials(domain = domain, domainTitle = title, username = null, password = null)
+    }
+
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractorTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.AutofillDomainFormatterDomainNameOnly
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.autofill.ui.credential.management.CredentialInitialExtractor.Companion.INITIAL_CHAR_FOR_NON_LETTERS
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CredentialInitialExtractorTest {
+
+    private val testee = CredentialInitialExtractor(AutofillDomainFormatterDomainNameOnly())
+
+    @Test
+    fun whenMissingTitleAndDomainThenPlaceholderChar() {
+        val result = testee.extractInitial(creds(title = null, domain = null))
+        result.assertIsPlaceholder()
+    }
+
+    @Test
+    fun whenEmptyStringTitleAndEmptyStringDomainThenPlaceholderChar() {
+        val result = testee.extractInitial(creds(title = "", domain = ""))
+        result.assertIsPlaceholder()
+    }
+
+    @Test
+    fun whenMissingTitleThenDomainInitialUsed() {
+        val loginCredentials = creds(title = null, domain = "example.com")
+        val result = testee.extractInitial(loginCredentials)
+        assertEquals('E', result)
+    }
+
+    @Test
+    fun whenTitleIsPresentThenTitleInitialIsUsedAndDomainIsIgnored() {
+        val loginCredentials = creds(title = "A website", domain = "example.com")
+        val result = testee.extractInitial(loginCredentials)
+        assertEquals('A', result)
+    }
+
+    @Test
+    fun whenTitleStartsWithANumberThenPlaceholderChar() {
+        val loginCredentials = creds(title = "123 website")
+        val result = testee.extractInitial(loginCredentials)
+        result.assertIsPlaceholder()
+    }
+
+    @Test
+    fun whenTitleStartsWithASpecialCharacterThenPlaceholderChar() {
+        val loginCredentials = creds(title = "$123 website")
+        val result = testee.extractInitial(loginCredentials)
+        result.assertIsPlaceholder()
+    }
+
+    @Test
+    fun whenTitleStartsWithANonLatinLetterThenPlaceholderChar() {
+        val loginCredentials = creds(title = "À website")
+        val result = testee.extractInitial(loginCredentials)
+        result.assertIsPlaceholder()
+    }
+
+    private fun Char.assertIsPlaceholder() {
+        assertEquals(INITIAL_CHAR_FOR_NON_LETTERS, this)
+    }
+
+    private fun creds(title: String? = null, domain: String? = null): LoginCredentials {
+        return LoginCredentials(
+            domainTitle = title,
+            domain = domain,
+            username = "",
+            password = ""
+        )
+    }
+
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialInitialExtractorTest.kt
@@ -27,7 +27,10 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class CredentialInitialExtractorTest {
 
-    private val testee = CredentialInitialExtractor(AutofillDomainFormatterDomainNameOnly())
+    private val testee = CredentialInitialExtractor(
+        domainFormatter = AutofillDomainFormatterDomainNameOnly(),
+        characterValidator = LatinCharacterValidator()
+    )
 
     @Test
     fun whenMissingTitleAndDomainThenPlaceholderChar() {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialListSorterTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialListSorterTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.AutofillDomainFormatterDomainNameOnly
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CredentialListSorterTest {
+
+    private val testee = CredentialListSorterByTitleAndDomain(AutofillDomainFormatterDomainNameOnly())
+    private val list = mutableListOf<LoginCredentials>()
+
+    @Test
+    fun whenListIsEmptyThenReturnEmptyList() {
+        val result = testee.sort(emptyList())
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun whenTitleStartsWithANumberThenSortedBeforeLetters() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(credsWithTitle("1"))
+                it.add(credsWithTitle("A"))
+                it.add(credsWithTitle("2"))
+                it.add(credsWithTitle("B"))
+            }
+        )
+        sorted.assertTitleOrder("1", "2", "A", "B")
+    }
+
+    @Test
+    fun whenTitleStartsWithACharacterThenSortedBeforeLetters() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(credsWithTitle("1"))
+                it.add(credsWithTitle("$"))
+                it.add(credsWithTitle("2"))
+                it.add(credsWithTitle("A"))
+            }
+        )
+        sorted.assertTitleOrder("$", "1", "2", "A")
+    }
+
+    @Test
+    fun whenTitleMissingThenSortedBeforeLetters() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(credsWithTitle("A"))
+                it.add(credsWithTitle("B"))
+                it.add(credsWithTitle("C"))
+                it.add(credsWithTitle(null))
+            }
+        )
+        sorted.assertTitleOrder(null, "A", "B", "C")
+    }
+
+    @Test
+    fun whenTitlesAllMissingThenDomainUsedInstead() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(credsWithDomain("a.com"))
+                it.add(credsWithDomain("c.com"))
+                it.add(credsWithDomain("b.com"))
+            }
+        )
+        sorted.assertDomainOrder("a.com", "b.com", "c.com")
+    }
+
+    @Test
+    fun whenTitlesEqualThenDomainUsedAsSecondarySort() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(creds("a.com", "Website"))
+                it.add(creds("c.com", "Website"))
+                it.add(creds("b.com", "Website"))
+            }
+        )
+        sorted.assertDomainOrder("a.com", "b.com", "c.com")
+    }
+
+    @Test
+    fun whenTitlesDifferThenDomainSortingNotUsed() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(creds("a.com", "2. Website"))
+                it.add(creds("c.com", "1. Website"))
+                it.add(creds("b.com", "3. Website"))
+            }
+        )
+        sorted.assertTitleOrder("1. Website", "2. Website", "3. Website")
+        sorted.assertDomainOrder("c.com", "a.com", "b.com")
+    }
+
+    @Test
+    fun whenComparingDomainsThenHttpSchemaIgnored() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(credsWithDomain("http://b.com"))
+                it.add(credsWithDomain("a.com"))
+            }
+        )
+        sorted.assertDomainOrder("a.com", "http://b.com")
+    }
+
+    @Test
+    fun whenComparingDomainsThenHttpsSchemaIgnored() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(credsWithDomain("https://b.com"))
+                it.add(credsWithDomain("a.com"))
+            }
+        )
+        sorted.assertDomainOrder("a.com", "https://b.com")
+    }
+
+    @Test
+    fun whenComparingDomainsThenWwwSubdomainIgnored() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(credsWithDomain("www.a.com"))
+                it.add(credsWithDomain("http://b.com"))
+                it.add(credsWithDomain("c.com"))
+            }
+        )
+        sorted.assertDomainOrder("www.a.com", "http://b.com", "c.com")
+    }
+
+    @Test
+    fun whenComparingDomainsThenMissingDomainSortedFirst() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(credsWithDomain("http://b.com"))
+                it.add(credsWithDomain("c.com"))
+                it.add(credsWithDomain(null))
+            }
+        )
+        sorted.assertDomainOrder(null, "http://b.com", "c.com")
+    }
+
+    @Test
+    fun whenComparingDomainsThenInvalidDomainInitialUsedForSort() {
+        val sorted = testee.sort(
+            list.also {
+                it.add(credsWithDomain("http://b.com"))
+                it.add(credsWithDomain("c.com"))
+                it.add(credsWithDomain("an invalid domain"))
+                it.add(credsWithDomain("invalid domain"))
+            }
+        )
+        sorted.assertDomainOrder("an invalid domain", "http://b.com", "c.com", "invalid domain",)
+    }
+
+    private fun List<LoginCredentials>.assertTitleOrder(vararg titles: String?) {
+        assertEquals("Wrong number of titles", titles.size, this.size)
+        titles.forEachIndexed { index, title ->
+            assertEquals("Title wrong at position $index", title, this[index].domainTitle)
+        }
+    }
+
+    private fun List<LoginCredentials>.assertDomainOrder(vararg domains: String?) {
+        assertEquals("Wrong number of domains", domains.size, this.size)
+        domains.forEachIndexed { index, domain ->
+            assertEquals("Domain wrong at position $index", domain, this[index].domain)
+        }
+    }
+
+    private fun creds(domain: String?, title: String?): LoginCredentials {
+        return LoginCredentials(domainTitle = title, domain = domain, username = null, password = null)
+    }
+
+    private fun credsWithTitle(title: String?): LoginCredentials {
+        return LoginCredentials(domainTitle = title, domain = null, username = null, password = null)
+    }
+
+    private fun credsWithDomain(domain: String?): LoginCredentials {
+        return LoginCredentials(domain = domain, domainTitle = null, username = null, password = null)
+    }
+
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialListSorterTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/CredentialListSorterTest.kt
@@ -26,7 +26,8 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class CredentialListSorterTest {
 
-    private val testee = CredentialListSorterByTitleAndDomain(AutofillDomainFormatterDomainNameOnly())
+    private val domainFormatter = AutofillDomainFormatterDomainNameOnly()
+    private val testee = CredentialListSorterByTitleAndDomain(CredentialInitialExtractor(domainFormatter))
     private val list = mutableListOf<LoginCredentials>()
 
     @Test
@@ -170,6 +171,21 @@ class CredentialListSorterTest {
         sorted.assertDomainOrder("an invalid domain", "http://b.com", "c.com", "invalid domain",)
     }
 
+    @Test
+    fun whenThen() {
+        val credentials = listOf(
+            creds(domain = "energy.com"),
+            creds(domain = "amazon.co.uk", title = "Smile Amazon"),
+            creds(domain = "example.com", title = "c"),
+            creds(domain = "aaa.com"),
+            creds(domain = "bar.com"),
+        )
+
+        val sorted = testee.sort(credentials)
+        sorted.assertDomainOrder("aaa.com", "bar.com", "example.com", "energy.com", "amazon.co.uk")
+        sorted.assertTitleOrder(null, null, "c", null, "Smile Amazon")
+    }
+
     private fun List<LoginCredentials>.assertTitleOrder(vararg titles: String?) {
         assertEquals("Wrong number of titles", titles.size, this.size)
         titles.forEachIndexed { index, title ->
@@ -184,7 +200,7 @@ class CredentialListSorterTest {
         }
     }
 
-    private fun creds(domain: String?, title: String?): LoginCredentials {
+    private fun creds(domain: String? = null, title: String? = null): LoginCredentials {
         return LoginCredentials(domainTitle = title, domain = domain, username = null, password = null)
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/LatinCharacterValidatorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/LatinCharacterValidatorTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LatinCharacterValidatorTest {
+
+    private val testee = LatinCharacterValidator()
+
+    @Test
+    fun whenLowercaseLetterAStartOfRangeThenIsClassedAsLetter() {
+        assertTrue(testee.isLetter('a'))
+    }
+
+    @Test
+    fun whenLowercaseLetterAtEndOfRangeThenIsClassedAsLetter() {
+        assertTrue(testee.isLetter('z'))
+    }
+
+    @Test
+    fun whenUpperLetterAtStartOfRangeThenIsClassedAsLetter() {
+        assertTrue(testee.isLetter('A'))
+    }
+
+    @Test
+    fun whenUpperLetterAtEndOfRangeThenIsClassedAsLetter() {
+        assertTrue(testee.isLetter('Z'))
+    }
+
+    @Test
+    fun whenNumberThenNotClassedAsLetter() {
+        assertFalse(testee.isLetter('1'))
+    }
+
+    @Test
+    fun whenCharacterThenNotClassedAsLetter() {
+        assertFalse(testee.isLetter('$'))
+    }
+
+    @Test
+    fun whenNonLatinCharacterThenNotClassedAsLetter() {
+        assertFalse(testee.isLetter('à'))
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: 
- [Management screen (List view): sort entries alphabetically](https://app.asana.com/0/1202630133908322/1202630133908322/f)
- [Management screen (List view): add visual groupings to the credential list view](https://app.asana.com/0/1202630133908323/1202630133908323/f)

### Description
Sorts the list of credentials and adds the visual groupings between them in the credential management screen.

### Steps to test this PR

- [x] Add a few logins from a few different sites (e.g., Amazon, Trello)
- [x] Visit the cred management screen
- [x] verify the entries are grouped appropriately
- [x] verify the entries are sorted by the rules specified in [Management screen (List view): sort entries alphabetically](https://app.asana.com/0/1202630133908322/1202630133908322/f)
- [x] Edit an entry to have a numerical domain (e.g., `192.168.0.1`); verify it is grouped into the `#` grouping
- [x] Edit an entry to have `http` and `https` prefixes; verify this isn't used when deciding the grouping
- [x] Edit an entry to have a `www` prefix in the domain (e.g., `www.trello.com`); verify is grouped into `T` and not `W`


### UI changes

![list-light](https://user-images.githubusercontent.com/1336281/181486490-4494b7de-4fdc-424c-96a3-7f712b859d53.png)
![list-dark](https://user-images.githubusercontent.com/1336281/181486499-b75f0dc8-d17c-450b-93ab-93e864c45e60.png)

