### PR TITLE
Disable save in edit mode when all fields are empty

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -161,6 +161,14 @@ class AutofillSettingsViewModel @Inject constructor(
         addCommand(ShowListMode)
     }
 
+    fun allowSaveInEditMode(saveable: Boolean) {
+        _viewState.value.credentialMode.let { credentialMode ->
+            if (credentialMode is Editing) {
+                _viewState.value = _viewState.value.copy(credentialMode = credentialMode.copy(saveable = saveable))
+            }
+        }
+    }
+
     data class ViewState(
         val autofillEnabled: Boolean = true,
         val logins: List<LoginCredentials> = emptyList(),
@@ -170,7 +178,11 @@ class AutofillSettingsViewModel @Inject constructor(
 
     sealed class CredentialMode(open val credentialsViewed: LoginCredentials?) {
         data class Viewing(override val credentialsViewed: LoginCredentials) : CredentialMode(credentialsViewed)
-        data class Editing(override val credentialsViewed: LoginCredentials) : CredentialMode(credentialsViewed)
+        data class Editing(
+            override val credentialsViewed: LoginCredentials,
+            val saveable: Boolean = true
+        ) : CredentialMode(credentialsViewed)
+
         object NotInCredentialMode : CredentialMode(null)
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -60,6 +60,9 @@ class AutofillManagementCredentialsMode : Fragment(), MenuProvider {
     @Inject
     lateinit var lastUpdatedDateFormatter: LastUpdatedDateFormatter
 
+    @Inject
+    lateinit var saveStateWatcher: SaveStateWatcher
+
     val viewModel by lazy {
         ViewModelProvider(requireActivity(), viewModelFactory)[AutofillSettingsViewModel::class.java]
     }
@@ -83,7 +86,7 @@ class AutofillManagementCredentialsMode : Fragment(), MenuProvider {
 
     override fun onPrepareMenu(menu: Menu) {
         if (viewModel.viewState.value.credentialMode is Editing) {
-            menu.findItem(R.id.view_menu_save).isVisible = true
+            menu.findItem(R.id.view_menu_save).isVisible = (viewModel.viewState.value.credentialMode as Editing).saveable
             menu.findItem(R.id.view_menu_delete).isVisible = false
             menu.findItem(R.id.view_menu_edit).isVisible = false
         } else if (viewModel.viewState.value.credentialMode is Viewing) {
@@ -124,12 +127,16 @@ class AutofillManagementCredentialsMode : Fragment(), MenuProvider {
     ) {
         super.onViewCreated(view, savedInstanceState)
         observeViewModel()
+        binding.watchSaveState(saveStateWatcher) {
+            viewModel.allowSaveInEditMode(it)
+        }
         configureUiEventHandlers()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         resetToolbarOnExit()
+        binding.removeSaveStateWatcher(saveStateWatcher)
     }
 
     private fun resetToolbarOnExit() {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/SaveStateWatcher.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/SaveStateWatcher.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management.viewing
+
+import android.text.Editable
+import android.text.TextWatcher
+import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementEditModeBinding
+import javax.inject.Inject
+
+fun FragmentAutofillManagementEditModeBinding.watchSaveState(
+    saveStateWatcher: SaveStateWatcher,
+    saveStateUpdater: (Boolean) -> Unit = {}
+) {
+    saveStateWatcher.start(saveStateUpdater) {
+        domainTitleEditText.text.isEmpty() && domainEditText.text.isEmpty() &&
+            notesEditText.text.isEmpty() && passwordEditText.text.isEmpty() && usernameEditText.text.isEmpty()
+    }
+    domainEditText.addTextChangedListener(saveStateWatcher)
+    notesEditText.addTextChangedListener(saveStateWatcher)
+    usernameEditText.addTextChangedListener(saveStateWatcher)
+    passwordEditText.addTextChangedListener(saveStateWatcher)
+}
+
+fun FragmentAutofillManagementEditModeBinding.removeSaveStateWatcher(saveStateWatcher: SaveStateWatcher) {
+    domainTitleEditText.removeTextChangedListener(saveStateWatcher)
+    domainEditText.removeTextChangedListener(saveStateWatcher)
+    notesEditText.removeTextChangedListener(saveStateWatcher)
+    usernameEditText.removeTextChangedListener(saveStateWatcher)
+    passwordEditText.removeTextChangedListener(saveStateWatcher)
+}
+
+class SaveStateWatcher @Inject constructor() : TextWatcher {
+    private var _saveStateUpdater: (Boolean) -> Unit = {}
+    private var _allTextInputIsEmpty: () -> Boolean = { false }
+    fun start(
+        saveStateUpdater: (Boolean) -> Unit,
+        allTextInputIsEmpty: () -> Boolean
+    ) {
+        _saveStateUpdater = saveStateUpdater
+        _allTextInputIsEmpty = allTextInputIsEmpty
+    }
+
+    override fun beforeTextChanged(
+        s: CharSequence?,
+        start: Int,
+        count: Int,
+        after: Int
+    ) {
+    }
+
+    override fun onTextChanged(
+        s: CharSequence?,
+        start: Int,
+        before: Int,
+        count: Int
+    ) {
+    }
+
+    override fun afterTextChanged(s: Editable?) {
+        _saveStateUpdater(!_allTextInputIsEmpty())
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -245,6 +245,21 @@ class AutofillSettingsViewModelTest {
         }
     }
 
+    @Test
+    fun whenAllowSaveInEditModeSetToFalseThenUpdateViewStateToEditingSaveableFalse() = runTest {
+        val credentials = someCredentials()
+        testee.onViewCredentials(credentials)
+        testee.onEditCredentials()
+
+        testee.allowSaveInEditMode(false)
+
+        testee.viewState.test {
+            val finalResult = this.expectMostRecentItem()
+            assertEquals(CredentialMode.Editing(credentials, false), finalResult.credentialMode)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     private fun someCredentials(): LoginCredentials {
         return LoginCredentials(
             id = -1,

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/OutLinedTextInput.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/OutLinedTextInput.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.mobile.android.ui.view
 
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.text.TextWatcher
 import android.text.method.PasswordTransformationMethod
 import android.util.AttributeSet
 import android.view.View
@@ -35,6 +36,9 @@ import com.google.android.material.textfield.TextInputLayout.END_ICON_NONE
 interface OutlinedTextInput {
     var text: String
     var isEditable: Boolean
+
+    fun addTextChangedListener(textWatcher: TextWatcher)
+    fun removeTextChangedListener(textWatcher: TextWatcher)
 
     fun onAction(actionHandler: (Action) -> Unit)
 
@@ -113,6 +117,14 @@ class OutLinedTextInputView @JvmOverloads constructor(
                 }
             }
         }
+    }
+
+    override fun addTextChangedListener(textWatcher: TextWatcher) {
+        binding.internalEditText.addTextChangedListener(textWatcher)
+    }
+
+    override fun removeTextChangedListener(textWatcher: TextWatcher) {
+        binding.internalEditText.removeTextChangedListener(textWatcher)
     }
 
     override fun onAction(actionHandler: (Action) -> Unit) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202673680180939/f

### Description
- Add logic for hiding the save icon in Edit mode when all fields are set to empty.

### Steps to test this PR

_Remove all fields on edit mode_
- [x] Open a saved credential in credential management screen
- [x] Click edit from the overflow menu
- [x] Verify that the check icon is visible
- [x] Remove one field and verify that the check icon is still visible
- [x] Remove all fields and verify that the check icon disappears.
