### PR TITLE
Allow Autofill viewmodel edit and delete to pass logincredentials

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -60,10 +60,8 @@ class AutofillSettingsViewModel @Inject constructor(
         addCommand(ShowCredentialMode(credentials))
     }
 
-    fun onEditCredentials() {
-        viewState.value.credentialMode.credentialsViewed?.let {
-            _viewState.value = viewState.value.copy(credentialMode = Editing(credentialsViewed = it))
-        }
+    fun onEditCredentials(loginCredentials: LoginCredentials) {
+        _viewState.value = viewState.value.copy(credentialMode = Editing(credentialsViewed = loginCredentials))
     }
 
     fun launchDeviceAuth() {
@@ -113,16 +111,12 @@ class AutofillSettingsViewModel @Inject constructor(
         }
     }
 
-    fun onDeleteCredentials() {
-        _viewState.value.credentialMode.credentialsViewed?.let {
-            val credentialsId = it.id ?: return
+    fun onDeleteCredentials(loginCredentials: LoginCredentials) {
+        val credentialsId = loginCredentials.id ?: return
 
-            viewModelScope.launch {
-                autofillStore.deleteCredentials(credentialsId)
-            }
+        viewModelScope.launch {
+            autofillStore.deleteCredentials(credentialsId)
         }
-
-        onExitViewMode()
     }
 
     fun updateCredentials(updatedCredentials: LoginCredentials) {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -103,11 +103,16 @@ class AutofillManagementCredentialsMode : Fragment(), MenuProvider {
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
         return when (menuItem.itemId) {
             R.id.view_menu_edit -> {
-                viewModel.onEditCredentials()
+                viewModel.viewState.value.credentialMode.credentialsViewed?.let {
+                    viewModel.onEditCredentials(it)
+                }
                 true
             }
             R.id.view_menu_delete -> {
-                viewModel.onDeleteCredentials()
+                viewModel.viewState.value.credentialMode.credentialsViewed?.let {
+                    viewModel.onDeleteCredentials(it)
+                }
+                viewModel.onExitViewMode()
                 true
             }
             R.id.view_menu_save -> {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -86,21 +86,9 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
-    fun whenUserDeletesCredentialsThenIsReturnedToListMode() = runTest {
-        testee.onDeleteCredentials()
-
-        testee.commands.test {
-            awaitItem().first().assertCommandType(ShowListMode::class)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun whenUserDeletesViewedCredentialsThenStoreDeletionCalled() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials)
-
-        testee.onDeleteCredentials()
+        testee.onDeleteCredentials(credentials)
         verify(mockStore).deleteCredentials(credentials.id!!)
     }
 
@@ -122,9 +110,8 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenOnEditCredentialsCalledThenShowCredentialEditingMode() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials)
 
-        testee.onEditCredentials()
+        testee.onEditCredentials(credentials)
 
         testee.viewState.test {
             assertEquals(CredentialMode.Editing(credentials), this.awaitItem().credentialMode)
@@ -186,8 +173,7 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenUpdateCredentialsCalledThenUpdateAutofillStore() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials)
-        testee.onEditCredentials()
+        testee.onEditCredentials(credentials)
 
         val updatedCredentials = credentials.copy(username = "helloworld123")
         whenever(mockStore.getCredentialsWithId(-1)).thenReturn(updatedCredentials)
@@ -203,8 +189,7 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenOnExitEditModeThenUpdateCredentialModeStateToViewing() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials)
-        testee.onEditCredentials()
+        testee.onEditCredentials(credentials)
 
         testee.onCancelEditMode()
 
@@ -230,7 +215,7 @@ class AutofillSettingsViewModelTest {
 
     @Test
     fun whenInEditModeAndChangedToDisabledThenUpdateNotInCredentialModeAndShowDisabledMode() = runTest {
-        testee.onEditCredentials()
+        testee.onEditCredentials(someCredentials())
         testee.disabled()
 
         testee.viewState.test {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202682552759994/f

### Description
This PR includes the viewmodel changes part for the task above. Changes include:
- ViewModel onDeleteCredentials and onEditCredentials now accepts the LoginCredentials instead of obtaining it from the Viewing/Editing CredentialMode.
- Update AutofillManagementCredentialsMode to obtain its own LoginCredentials from the ViewState when editing and deleting.

### Steps to test this PR

_Edit and delete still works!_
- [x] Open a saved credential in Credential management screen
- [x] Edit the credential and cancel edit.
- [x] Verify that credential goes back to viewing mode and data is reset.
- [x] Edit the credential again and save.
- [x] Verify that credential goes back to viewing mode and data is updated accordingly.
- [x]  Open another credential and delete it.
- [x] Verify that list mode is shown and credential is deleted.
