### PR TITLE
Remove queries to secure storage when autofill feature is disabled

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
@@ -159,7 +159,7 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
     private fun determineIfAutofillEnabled(): Boolean = autofillStore.autofillEnabled && deviceAuthenticator.hasValidDeviceAuthentication()
 
     private suspend fun determineIfCredentialsAvailable(url: String?): Boolean {
-        return if (url == null) {
+        return if (url == null || !determineIfAutofillEnabled()) {
             false
         } else {
             val savedCredentials = autofillStore.getCredentials(url)

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
@@ -263,6 +263,8 @@ class AutofillStoredBackJavascriptInterfaceTest {
     @Test
     fun whenNoCredentialsForUrlThenConfigurationInputTypeCredentialsIsFalse() = runTest {
         val url = "example.com"
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
+        whenever(autofillStore.autofillEnabled).thenReturn(true)
         whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
 
         testee.getRuntimeConfiguration("", url)
@@ -273,6 +275,8 @@ class AutofillStoredBackJavascriptInterfaceTest {
     @Test
     fun whenWithCredentialsForUrlThenConfigurationInputTypeCredentialsIsTrue() = runTest {
         val url = "example.com"
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
+        whenever(autofillStore.autofillEnabled).thenReturn(true)
         whenever(autofillStore.getCredentials(url)).thenReturn(
             listOf(
                 LoginCredentials(
@@ -287,6 +291,48 @@ class AutofillStoredBackJavascriptInterfaceTest {
         testee.getRuntimeConfiguration("", url)
 
         verify(autofillResponseWriter).generateResponseGetAvailableInputTypes(credentialsAvailable = true, emailAvailable = false)
+    }
+
+    @Test
+    fun whenWithCredentialsForUrlButNoDeviceAuthThenConfigurationInputTypeCredentialsIsFalse() = runTest {
+        val url = "example.com"
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(false)
+        whenever(autofillStore.autofillEnabled).thenReturn(true)
+        whenever(autofillStore.getCredentials(url)).thenReturn(
+            listOf(
+                LoginCredentials(
+                    id = 1,
+                    domain = url,
+                    username = "username",
+                    password = "password"
+                )
+            )
+        )
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateResponseGetAvailableInputTypes(credentialsAvailable = false, emailAvailable = false)
+    }
+
+    @Test
+    fun whenWithCredentialsForUrlButAutofillDisabledThenConfigurationInputTypeCredentialsIsFalse() = runTest {
+        val url = "example.com"
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
+        whenever(autofillStore.autofillEnabled).thenReturn(false)
+        whenever(autofillStore.getCredentials(url)).thenReturn(
+            listOf(
+                LoginCredentials(
+                    id = 1,
+                    domain = url,
+                    username = "username",
+                    password = "password"
+                )
+            )
+        )
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateResponseGetAvailableInputTypes(credentialsAvailable = false, emailAvailable = false)
     }
 
     @Test

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -52,13 +52,17 @@ class SecureStoreBackedAutofillStore(
         set(value) = prefs.edit { putBoolean(SHOW_SAVE_LOGIN_ONBOARDING, value) }
 
     override suspend fun getCredentials(rawUrl: String): List<LoginCredentials> {
-        Timber.i("Querying secure store for stored credentials. rawUrl: %s, extractedDomain:%s", rawUrl, rawUrl.extractSchemeAndDomain())
-        val url = rawUrl.extractSchemeAndDomain() ?: return emptyList()
+        return if (autofillEnabled) {
+            Timber.i("Querying secure store for stored credentials. rawUrl: %s, extractedDomain:%s", rawUrl, rawUrl.extractSchemeAndDomain())
+            val url = rawUrl.extractSchemeAndDomain() ?: return emptyList()
 
-        val storedCredentials = secureStorage.websiteLoginDetailsWithCredentialsForDomain(url).firstOrNull() ?: emptyList()
-        Timber.v("Found %d credentials for %s", storedCredentials.size, url)
+            val storedCredentials = secureStorage.websiteLoginDetailsWithCredentialsForDomain(url).firstOrNull() ?: emptyList()
+            Timber.v("Found %d credentials for %s", storedCredentials.size, url)
 
-        return storedCredentials.map { it.toLoginCredentials() }
+            storedCredentials.map { it.toLoginCredentials() }
+        } else {
+            emptyList()
+        }
     }
 
     override suspend fun getCredentialsWithId(id: Int): LoginCredentials? =

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -70,6 +70,15 @@ class SecureStoreBackedAutofillStoreTest {
     }
 
     @Test
+    fun whenInternalTestUserFalseThenGetCredentialsWithDomainReturnsEmpty() = runTest {
+        setupTesteeWithInternalTestUserFalse()
+        val url = "example.com"
+        storeCredentials(1, url, "username", "password")
+
+        assertTrue(testee.getCredentials(url).isEmpty())
+    }
+
+    @Test
     fun whenStoreEmptyThenNoMatch() = runTest {
         setupTesteeWithInternalTestUserTrue()
         val result = testee.containsCredentials("example.com", "username", "password")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202696748120680/f

### Description
This PR includes:
- In `AutofillStoredBackJavascriptInterface`, ensure that `AvailableInputTypes` json has `credentials` set to `false` if autofill is disabled (either through setting or when user is not internal tester). There's no real need to query for that data here since when `autofillCredentials` is set to `false`, the `credentials` field doesn't really matter.
- In `SecureStoreBackedAutofillStore`, `getCredentials(rawUrl: String`) returns `emptylist` when autofill is disabled. This is necessary since we call  SecureStoreBackedAutofillStore in the DuckDuckGoFaviconManager and we don't need the real Autofill data when the feature is not available at this point.

### Steps to test this PR

_Not internal user_
- [x] Use a non-internal build and ensure opt-in to internal test user hasn't been done for the user.
- [x] Open a login site
- [x] Verify that autofill doesn't work.
- [x] Verify that SecureStorage.websiteLoginDetailsWithCredentialsForDomain is not being called. Verify that no other calls to SecureStorage is being done through breakpoints  or any other ways.

_Is internal user and feature disabled in credential management_
- [x] Use an internal build and ensure opt-in to internal test user has been done for the user.
- [x] Go to credential management and disable the feature.
- [x] Open a login site
- [x] Verify that autofill doesn't work.
- [x] Verify that SecureStorage.websiteLoginDetailsWithCredentialsForDomain is not being called. Verify that no other calls to SecureStorage is being done through breakpoints or any other ways.
- [x] Verify the credential management still shows the saved credentials correctly.

_Is internal user_
- [x] Use a internal build and ensure opt-in to internal test user has been done for the user.
- [x] Open a login site
- [x] Verify that autofill works as expected.
- [ ] Verify that data is being shown for the user in the credential management screen.

_Check other features that maybe affected_
- [x] Confirm that favicons work as expected 
- [x] Confirm that email works as expected ( Adding an email -> gets to success page and autofill)
