### PR TITLE
Fix permission issues with API 29 related to scope-storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28" />
+        android:maxSdkVersion="29" />
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -32,6 +32,7 @@
         android:roundIcon="${appIconRound}"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="GoogleAppIndexingWarning">
         <meta-data
             android:name="android.webkit.WebView.MetricsOptOut"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2021,13 +2021,13 @@ class BrowserTabFragment :
         startActivityForResult(intent, REQUEST_CODE_CHOOSE_FILE)
     }
 
-    private fun minSdk29(): Boolean {
-        return appBuildConfig.sdkInt >= Build.VERSION_CODES.Q
+    private fun minSdk30(): Boolean {
+        return appBuildConfig.sdkInt >= Build.VERSION_CODES.R
     }
 
     @Suppress("NewApi") // we use appBuildConfig
     private fun hasWriteStoragePermission(): Boolean {
-        return minSdk29() ||
+        return minSdk30() ||
             ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202574319510580/f

### Description
Android 10 introduced scope-storage that require the `requestLegacyExternalStorage` set to `true` and request the `WRITE_EXTERNAL_STORAGE` permission to be able to directly create files in the `Downloads` folder.

### Steps to test this PR

_Bug repro and fix_
- [x] install from develop in device with API 29
- [x] download any file
- [x] expect the download to fail with `Permission denied` error
- [x] install from this branch in device with API 29
- [x] download any file
- [x] verify download succeeds
- [x] verify downloads in device with API 28 and API 30
