### PR TITLE
Autofill: Fix net.sqlcipher.database.SQLiteException in WebsiteLoginCredentialsDao

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -36,7 +36,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_ANIMATION
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.autofill.InternalTestUserChecker
+import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.macos_api.MacOsWaitlist
@@ -78,7 +78,7 @@ class SettingsViewModel @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val emailManager: EmailManager,
     private val macOsWaitlist: MacOsWaitlist,
-    private val internalTestUserChecker: InternalTestUserChecker,
+    private val autofillStore: AutofillStore,
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : ViewModel(), DefaultLifecycleObserver {
 
@@ -167,7 +167,7 @@ class SettingsViewModel @Inject constructor(
                     appTrackingProtectionWaitlistState = atpRepository.getState(),
                     emailAddress = emailManager.getEmailAddress(),
                     macOsWaitlistState = macOsWaitlist.getWaitlistState(),
-                    showAutofill = internalTestUserChecker.isInternalTestUser
+                    showAutofill = autofillStore.autofillAvailable
                 )
             )
         }

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -34,7 +34,7 @@ import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.autofill.InternalTestUserChecker
+import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.macos_api.MacOsWaitlist
 import com.duckduckgo.macos_api.MacWaitlistState
@@ -106,7 +106,7 @@ class SettingsViewModelTest {
     private lateinit var mockMacOsWaitlist: MacOsWaitlist
 
     @Mock
-    private lateinit var internalTestUserChecker: InternalTestUserChecker
+    private lateinit var autofillStore: AutofillStore
 
     @Mock
     private lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
@@ -147,7 +147,7 @@ class SettingsViewModelTest {
             mockAppBuildConfig,
             mockEmailManager,
             mockMacOsWaitlist,
-            internalTestUserChecker,
+            autofillStore,
             vpnFeaturesRegistry,
         )
     }
@@ -633,8 +633,8 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenIsInternalTestUserTheShowAutofillTrue() = runTest {
-        whenever(internalTestUserChecker.isInternalTestUser).thenReturn(true)
+    fun whenAutofillIsAvailableTheShowAutofillTrue() = runTest {
+        whenever(autofillStore.autofillAvailable).thenReturn(true)
         testee.start()
 
         testee.viewState().test {
@@ -643,8 +643,8 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun whenIsInternalTestUserTheShowAutofillFalse() = runTest {
-        whenever(internalTestUserChecker.isInternalTestUser).thenReturn(false)
+    fun whenAutofillIsNotAvailableTheShowAutofillFalse() = runTest {
+        whenever(autofillStore.autofillAvailable).thenReturn(false)
         testee.start()
 
         testee.viewState().test {

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
@@ -30,6 +30,11 @@ interface AutofillStore {
     var autofillEnabled: Boolean
 
     /**
+     * Determines if the autofill feature is available for the user
+     */
+    val autofillAvailable: Boolean
+
+    /**
      * Used to determine whether we show additional onboarding info when offering to save a login credential
      *
      * This will default to true, and remain true until after the first credential has been saved

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
@@ -47,7 +47,11 @@ interface AutofillJavascriptInterface {
     @JavascriptInterface
     fun getAutofillData(requestString: String)
 
-    suspend fun getRuntimeConfiguration(rawJs: String, url: String?): String
+    suspend fun getRuntimeConfiguration(
+        rawJs: String,
+        url: String?
+    ): String
+
     fun injectCredentials(credentials: LoginCredentials)
     fun injectNoCredentials()
 
@@ -57,7 +61,6 @@ interface AutofillJavascriptInterface {
     companion object {
         const val INTERFACE_NAME = "BrowserAutofill"
     }
-
 }
 
 @ContributesBinding(AppScope::class)
@@ -156,7 +159,8 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
     private fun determineIfEmailAvailable(): Boolean = emailManager.isSignedIn()
 
     // in the future, we'll also tie this into feature toggles and remote config
-    private fun determineIfAutofillEnabled(): Boolean = autofillStore.autofillEnabled && deviceAuthenticator.hasValidDeviceAuthentication()
+    private fun determineIfAutofillEnabled(): Boolean =
+        autofillStore.autofillAvailable && autofillStore.autofillEnabled && deviceAuthenticator.hasValidDeviceAuthentication()
 
     private suspend fun determineIfCredentialsAvailable(url: String?): Boolean {
         return if (url == null || !determineIfAutofillEnabled()) {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
@@ -230,6 +230,20 @@ class AutofillStoredBackJavascriptInterfaceTest {
         whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(false)
         whenever(autofillStore.autofillEnabled).thenReturn(true)
+        whenever(autofillStore.autofillAvailable).thenReturn(true)
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateUserPreferences(false)
+    }
+
+    @Test
+    fun whenAutofillUnavailableThenConfigurationUserPrefsCredentialsIsFalse() = runTest {
+        val url = "example.com"
+        whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(false)
+        whenever(autofillStore.autofillEnabled).thenReturn(true)
+        whenever(autofillStore.autofillAvailable).thenReturn(false)
 
         testee.getRuntimeConfiguration("", url)
 
@@ -242,6 +256,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
         whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
         whenever(autofillStore.autofillEnabled).thenReturn(false)
+        whenever(autofillStore.autofillAvailable).thenReturn(true)
 
         testee.getRuntimeConfiguration("", url)
 
@@ -254,6 +269,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
         whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
         whenever(autofillStore.autofillEnabled).thenReturn(true)
+        whenever(autofillStore.autofillAvailable).thenReturn(true)
 
         testee.getRuntimeConfiguration("", url)
 
@@ -265,6 +281,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
         val url = "example.com"
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
         whenever(autofillStore.autofillEnabled).thenReturn(true)
+        whenever(autofillStore.autofillAvailable).thenReturn(true)
         whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
 
         testee.getRuntimeConfiguration("", url)
@@ -277,6 +294,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
         val url = "example.com"
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
         whenever(autofillStore.autofillEnabled).thenReturn(true)
+        whenever(autofillStore.autofillAvailable).thenReturn(true)
         whenever(autofillStore.getCredentials(url)).thenReturn(
             listOf(
                 LoginCredentials(
@@ -298,6 +316,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
         val url = "example.com"
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(false)
         whenever(autofillStore.autofillEnabled).thenReturn(true)
+        whenever(autofillStore.autofillAvailable).thenReturn(true)
         whenever(autofillStore.getCredentials(url)).thenReturn(
             listOf(
                 LoginCredentials(
@@ -319,6 +338,29 @@ class AutofillStoredBackJavascriptInterfaceTest {
         val url = "example.com"
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
         whenever(autofillStore.autofillEnabled).thenReturn(false)
+        whenever(autofillStore.autofillAvailable).thenReturn(true)
+        whenever(autofillStore.getCredentials(url)).thenReturn(
+            listOf(
+                LoginCredentials(
+                    id = 1,
+                    domain = url,
+                    username = "username",
+                    password = "password"
+                )
+            )
+        )
+
+        testee.getRuntimeConfiguration("", url)
+
+        verify(autofillResponseWriter).generateResponseGetAvailableInputTypes(credentialsAvailable = false, emailAvailable = false)
+    }
+
+    @Test
+    fun whenWithCredentialsForUrlButAutofillUnavailableThenConfigurationInputTypeCredentialsIsFalse() = runTest {
+        val url = "example.com"
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
+        whenever(autofillStore.autofillEnabled).thenReturn(true)
+        whenever(autofillStore.autofillAvailable).thenReturn(false)
         whenever(autofillStore.getCredentials(url)).thenReturn(
             listOf(
                 LoginCredentials(

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -53,7 +53,7 @@ class SecureStoreBackedAutofillStore(
         }
 
     override val autofillAvailable: Boolean
-        get() = internalTestUserChecker.isInternalTestUser
+        get() = internalTestUserChecker.isInternalTestUser && secureStorage.canAccessSecureStorage()
 
     override var showOnboardingWhenOfferingToSaveLogin: Boolean
         get() = prefs.getBoolean(SHOW_SAVE_LOGIN_ONBOARDING, true)

--- a/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorage.kt
+++ b/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorage.kt
@@ -29,7 +29,8 @@ interface SecureStorage {
     fun canAccessSecureStorage(): Boolean
 
     /**
-     * This method adds a raw plaintext [WebsiteLoginDetailsWithCredentials] into the [SecureStorage].
+     * This method adds a raw plaintext [WebsiteLoginDetailsWithCredentials] into the [SecureStorage]. If [canAccessSecureStorage] is false when
+     * this is invoked, nothing will be done.
      *
      * @throws [SecureStorageException] if something went wrong while trying to perform the action. See type to get more info on the cause.
      */
@@ -39,6 +40,7 @@ interface SecureStorage {
     /**
      * This method returns all [WebsiteLoginDetails] with the [domain] stored in the [SecureStorage].
      * Only L1 encrypted data is returned by these function. This is best use when the need is only to access non-sensitive data.
+     * If [canAccessSecureStorage] is false when this is invoked, an empty flow will be emitted.
      *
      * @return Flow<List<WebsiteLoginDetails>> a flow emitting a List of plain text WebsiteLoginDetails stored in SecureStorage.
      */
@@ -47,6 +49,7 @@ interface SecureStorage {
     /**
      * This method returns all [WebsiteLoginDetails] stored in the [SecureStorage].
      * Only L1 encrypted data is returned by these function. This is best use when the need is only to access non-sensitive data.
+     * If [canAccessSecureStorage] is false when this is invoked, an empty flow will be emitted.
      *
      * @return Flow<List<WebsiteLoginDetails>> a flow containing a List of plain text WebsiteLoginDetails stored in SecureStorage.
      */
@@ -55,6 +58,7 @@ interface SecureStorage {
     /**
      * This method returns the [WebsiteLoginDetailsWithCredentials] with the [id] stored in the [SecureStorage].
      * This returns decrypted sensitive data (encrypted in L2). Use this only when sensitive data is needed to be accessed.
+     * If [canAccessSecureStorage] is false when this is invoked, null will be returned.
      *
      * @return [WebsiteLoginDetailsWithCredentials] containing the plaintext password
      * @throws [SecureStorageException] if something went wrong while trying to perform the action. See type to get more info on the cause.
@@ -65,6 +69,7 @@ interface SecureStorage {
     /**
      * This method returns the [WebsiteLoginDetailsWithCredentials] with the [domain] stored in the [SecureStorage].
      * This returns decrypted sensitive data (encrypted in L2). Use this only when sensitive data is needed to be accessed.
+     * If [canAccessSecureStorage] is false when this is invoked, an empty flow will be emitted.
      *
      * @return Flow<List<WebsiteLoginDetailsWithCredentials>> a flow emitting a List of plain text WebsiteLoginDetailsWithCredentials stored
      * in SecureStorage containing the plaintext password
@@ -76,6 +81,7 @@ interface SecureStorage {
     /**
      * This method returns all the [WebsiteLoginDetailsWithCredentials] stored in the [SecureStorage].
      * This returns decrypted sensitive data (encrypted in L2). Use this only when sensitive data is needed to be accessed.
+     * If [canAccessSecureStorage] is false when this is invoked, an empty flow will be emitted.
      *
      * @return Flow<List<WebsiteLoginDetailsWithCredentials>>  a flow emitting a List of plain text WebsiteLoginDetailsWithCredentials stored
      * in SecureStorage containing the plaintext password
@@ -86,6 +92,7 @@ interface SecureStorage {
 
     /**
      * This method updates an existing [WebsiteLoginDetailsWithCredentials] in the [SecureStorage].
+     * If [canAccessSecureStorage] is false when this is invoked, nothing will be done.
      *
      * @throws [SecureStorageException] if something went wrong while trying to perform the action. See type to get more info on the cause.
      */
@@ -94,6 +101,7 @@ interface SecureStorage {
 
     /**
      * This method removes an existing [WebsiteLoginDetailsWithCredentials] associated with an [id] from the [SecureStorage].
+     * If [canAccessSecureStorage] is false when this is invoked, nothing will be done.
      */
     suspend fun deleteWebsiteLoginDetailsWithCredentials(id: Int)
 }

--- a/secure-storage/secure-storage-impl/build.gradle
+++ b/secure-storage/secure-storage-impl/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     implementation "net.zetetic:android-database-sqlcipher:_"
 
+    testImplementation CashApp.turbine
     testImplementation project(path: ':common-test')
     testImplementation Testing.junit4
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"

--- a/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
+++ b/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
@@ -25,75 +25,91 @@ import com.duckduckgo.securestorage.impl.encryption.EncryptionHelper.EncryptedSt
 import com.duckduckgo.securestorage.store.SecureStorageRepository
 import com.duckduckgo.securestorage.store.db.WebsiteLoginCredentialsEntity
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
 class RealSecureStorage @Inject constructor(
-    private val secureStorageRepository: SecureStorageRepository,
+    private val secureStorageRepositoryFactory: SecureStorageRepository.Factory,
     private val dispatchers: DispatcherProvider,
     private val l2DataTransformer: L2DataTransformer
 ) : SecureStorage {
 
-    override fun canAccessSecureStorage(): Boolean = l2DataTransformer.canProcessData()
+    private val secureStorageRepository by lazy {
+        secureStorageRepositoryFactory.get()
+    }
+
+    override fun canAccessSecureStorage(): Boolean = l2DataTransformer.canProcessData() && secureStorageRepository != null
 
     override suspend fun addWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials) {
         withContext(dispatchers.io()) {
-            secureStorageRepository.addWebsiteLoginCredential(websiteLoginDetailsWithCredentials.toDataEntity())
+            secureStorageRepository?.addWebsiteLoginCredential(websiteLoginDetailsWithCredentials.toDataEntity())
         }
     }
 
-    override suspend fun websiteLoginDetailsForDomain(domain: String): Flow<List<WebsiteLoginDetails>> =
-        withContext(dispatchers.io()) {
-            secureStorageRepository.websiteLoginCredentialsForDomain(domain).map { list ->
-                list.map {
-                    it.toDetails()
+    override suspend fun websiteLoginDetailsForDomain(domain: String): Flow<List<WebsiteLoginDetails>> {
+        return if (secureStorageRepository != null) {
+            withContext(dispatchers.io()) {
+                secureStorageRepository!!.websiteLoginCredentialsForDomain(domain).map { list ->
+                    list.map {
+                        it.toDetails()
+                    }
                 }
             }
-        }
+        } else emptyFlow()
+    }
 
     override suspend fun websiteLoginDetails(): Flow<List<WebsiteLoginDetails>> =
-        withContext(dispatchers.io()) {
-            secureStorageRepository.websiteLoginCredentials().map { list ->
-                list.map {
-                    it.toDetails()
+        if (secureStorageRepository != null) {
+            withContext(dispatchers.io()) {
+                secureStorageRepository!!.websiteLoginCredentials().map { list ->
+                    list.map {
+                        it.toDetails()
+                    }
                 }
             }
-        }
+        } else emptyFlow()
 
     override suspend fun getWebsiteLoginDetailsWithCredentials(id: Int): WebsiteLoginDetailsWithCredentials? =
         withContext(dispatchers.io()) {
-            secureStorageRepository.getWebsiteLoginCredentialsForId(id)?.toCredentials()
+            secureStorageRepository?.getWebsiteLoginCredentialsForId(id)?.toCredentials()
         }
 
     override suspend fun websiteLoginDetailsWithCredentialsForDomain(domain: String): Flow<List<WebsiteLoginDetailsWithCredentials>> =
-        withContext(dispatchers.io()) {
-            secureStorageRepository.websiteLoginCredentialsForDomain(domain).map { list ->
-                list.map {
-                    it.toCredentials()
+        if (secureStorageRepository != null) {
+            withContext(dispatchers.io()) {
+                secureStorageRepository!!.websiteLoginCredentialsForDomain(domain).map { list ->
+                    list.map {
+                        it.toCredentials()
+                    }
                 }
             }
-        }
+        } else emptyFlow()
 
     override suspend fun websiteLoginDetailsWithCredentials(): Flow<List<WebsiteLoginDetailsWithCredentials>> =
-        withContext(dispatchers.io()) {
-            secureStorageRepository.websiteLoginCredentials().map { list ->
-                list.map {
-                    it.toCredentials()
+        if (secureStorageRepository != null) {
+            withContext(dispatchers.io()) {
+                secureStorageRepository!!.websiteLoginCredentials().map { list ->
+                    list.map {
+                        it.toCredentials()
+                    }
                 }
             }
+        } else emptyFlow()
+
+    override suspend fun updateWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials): Unit =
+        withContext(dispatchers.io()) {
+            secureStorageRepository?.updateWebsiteLoginCredentials(websiteLoginDetailsWithCredentials.toDataEntity())
         }
 
-    override suspend fun updateWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials) =
+    override suspend fun deleteWebsiteLoginDetailsWithCredentials(id: Int): Unit =
         withContext(dispatchers.io()) {
-            secureStorageRepository.updateWebsiteLoginCredentials(websiteLoginDetailsWithCredentials.toDataEntity())
-        }
-
-    override suspend fun deleteWebsiteLoginDetailsWithCredentials(id: Int) =
-        withContext(dispatchers.io()) {
-            secureStorageRepository.deleteWebsiteLoginCredentials(id)
+            secureStorageRepository?.deleteWebsiteLoginCredentials(id)
         }
 
     private fun WebsiteLoginDetailsWithCredentials.toDataEntity(): WebsiteLoginCredentialsEntity {

--- a/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorageRepositoryFactory.kt
+++ b/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorageRepositoryFactory.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.securestorage.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.securestorage.store.RealSecureStorageRepository
+import com.duckduckgo.securestorage.store.SecureStorageRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class RealSecureStorageRepositoryFactory @Inject constructor(
+    private val secureStorageDatabaseFactory: SecureStorageDatabaseFactory
+) : SecureStorageRepository.Factory {
+    override fun get(): SecureStorageRepository? {
+        val db = secureStorageDatabaseFactory.getDatabase()
+        return if (db != null) {
+            RealSecureStorageRepository(db.websiteLoginCredentialsDao())
+        } else null
+    }
+}

--- a/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/SecureStorageDatabaseFactory.kt
+++ b/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/SecureStorageDatabaseFactory.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.securestorage.impl
+
+import android.content.Context
+import androidx.room.Room
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.securestorage.store.db.ALL_MIGRATIONS
+import com.duckduckgo.securestorage.store.db.SecureStorageDatabase
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import net.sqlcipher.database.SupportFactory
+import javax.inject.Inject
+
+interface SecureStorageDatabaseFactory {
+    fun getDatabase(): SecureStorageDatabase?
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealSecureStorageDatabaseFactory @Inject constructor(
+    private val context: Context,
+    private val keyProvider: SecureStorageKeyProvider
+) : SecureStorageDatabaseFactory {
+    private var _database: SecureStorageDatabase? = null
+
+    @Synchronized
+    override fun getDatabase(): SecureStorageDatabase? {
+        // If we have already the DB instance then let's use it
+        if (_database != null) {
+            return _database
+        }
+
+        // If we can't access the keystore, it means that L1Key will be null. We don't want to encrypt the db with a null key.
+        return if (keyProvider.canAccessKeyStore()) {
+            // At this point, we are guaranteed that if l1key is null, it's because it hasn't been generated yet. Else, we always use the one stored.
+            _database = Room.databaseBuilder(
+                context,
+                SecureStorageDatabase::class.java,
+                "secure_storage_database_encrypted.db"
+            ).openHelperFactory(SupportFactory(keyProvider.getl1Key()))
+                .addMigrations(*ALL_MIGRATIONS)
+                .enableMultiInstanceInvalidation()
+                .build()
+            _database
+        } else {
+            null
+        }
+    }
+}

--- a/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/di/SecureStorageModule.kt
+++ b/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/di/SecureStorageModule.kt
@@ -17,25 +17,17 @@
 package com.duckduckgo.securestorage.impl.di
 
 import android.content.Context
-import androidx.room.Room
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.securestorage.impl.DerivedKeySecretFactory
 import com.duckduckgo.securestorage.impl.LegacyDerivedKeySecretFactory
 import com.duckduckgo.securestorage.impl.RealDerivedKeySecretFactory
-import com.duckduckgo.securestorage.impl.SecureStorageKeyProvider
 import com.duckduckgo.securestorage.store.RealSecureStorageKeyRepository
-import com.duckduckgo.securestorage.store.RealSecureStorageRepository
 import com.duckduckgo.securestorage.store.SecureStorageKeyRepository
-import com.duckduckgo.securestorage.store.SecureStorageRepository
-import com.duckduckgo.securestorage.store.db.ALL_MIGRATIONS
-import com.duckduckgo.securestorage.store.db.SecureStorageDatabase
-import com.duckduckgo.securestorage.store.db.WebsiteLoginCredentialsDao
 import com.duckduckgo.securestorage.store.keys.RealSecureStorageKeyStore
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
-import net.sqlcipher.database.SupportFactory
 import javax.inject.Named
 
 @Module
@@ -46,31 +38,6 @@ object SecureStorageModule {
     @SingleInstanceIn(AppScope::class)
     fun providesSecureStorageKeyStore(context: Context): SecureStorageKeyRepository =
         RealSecureStorageKeyRepository(RealSecureStorageKeyStore(context))
-
-    @Provides
-    @SingleInstanceIn(AppScope::class)
-    fun providesSecureStorageDatabase(
-        context: Context,
-        keyProvider: SecureStorageKeyProvider
-    ): SecureStorageDatabase {
-        return Room.databaseBuilder(
-            context,
-            SecureStorageDatabase::class.java,
-            "secure_storage_database_encrypted.db"
-        ).openHelperFactory(SupportFactory(keyProvider.getl1Key()))
-            .addMigrations(*ALL_MIGRATIONS)
-            .enableMultiInstanceInvalidation()
-            .build()
-    }
-
-    @Provides
-    fun providesWebsiteLoginCredentialsDao(db: SecureStorageDatabase): WebsiteLoginCredentialsDao {
-        return db.websiteLoginCredentialsDao()
-    }
-
-    @Provides
-    fun providesSecureStorageRepository(websiteLoginCredentialsDao: WebsiteLoginCredentialsDao): SecureStorageRepository =
-        RealSecureStorageRepository(websiteLoginCredentialsDao)
 }
 
 @Module
@@ -83,5 +50,4 @@ object SecureStorageKeyModule {
     @Provides
     @Named("DerivedKeySecretFactoryForLegacy")
     fun provideDerivedKeySecretFactoryForLegacy(): DerivedKeySecretFactory = LegacyDerivedKeySecretFactory()
-
 }

--- a/secure-storage/secure-storage-impl/src/test/java/com/duckduckgo/securestorage/impl/RealSecureStorageTest.kt
+++ b/secure-storage/secure-storage-impl/src/test/java/com/duckduckgo/securestorage/impl/RealSecureStorageTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.securestorage.impl
 
+import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.securestorage.api.WebsiteLoginDetails
 import com.duckduckgo.securestorage.api.WebsiteLoginDetailsWithCredentials
@@ -27,6 +28,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -35,16 +38,20 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 class RealSecureStorageTest {
     private lateinit var testee: RealSecureStorage
+
     @get:Rule
     @Suppress("unused")
     val coroutineRule = CoroutineTestRule()
+
     @Mock
     private lateinit var secureStorageRepository: SecureStorageRepository
+
     @Mock
     private lateinit var l2DataTransformer: L2DataTransformer
     private val testCredentials = WebsiteLoginDetailsWithCredentials(
@@ -77,7 +84,13 @@ class RealSecureStorageTest {
         whenever(l2DataTransformer.encrypt(any())).thenReturn(
             EncryptedString(expectedEncryptedData, expectedEncryptedIv)
         )
-        testee = RealSecureStorage(secureStorageRepository, coroutineRule.testDispatcherProvider, l2DataTransformer)
+        testee = RealSecureStorage(
+            object : SecureStorageRepository.Factory {
+                override fun get(): SecureStorageRepository = secureStorageRepository
+            },
+            coroutineRule.testDispatcherProvider,
+            l2DataTransformer
+        )
     }
 
     @Test
@@ -159,6 +172,93 @@ class RealSecureStorageTest {
         val result = testee.websiteLoginDetailsWithCredentialsForDomain("test.com").first()
 
         assertEquals(listOf(testCredentials), result)
+    }
+
+    @Test
+    fun whenNoSecureStorageRepositoryThenCanAccessSecureStorageFalse() {
+        setUpNoSecureStorageRepository()
+
+        assertFalse(testee.canAccessSecureStorage())
+    }
+
+    @Test
+    fun whenNoSecureStorageRepositoryAddCredentialsThenDoNothing() = runTest {
+        setUpNoSecureStorageRepository()
+
+        testee.addWebsiteLoginDetailsWithCredentials(testCredentials)
+
+        verifyNoInteractions(secureStorageRepository)
+    }
+
+    @Test
+    fun whenNoSecureStorageRepositoryGetCredentialsThenReturnNull() = runTest {
+        setUpNoSecureStorageRepository()
+
+        assertNull(testee.getWebsiteLoginDetailsWithCredentials(1))
+    }
+
+    @Test
+    fun whenNoSecureStorageRepositoryUpdateCredentialsThenDoNothing() = runTest {
+        setUpNoSecureStorageRepository()
+
+        testee.updateWebsiteLoginDetailsWithCredentials(testCredentials)
+
+        verifyNoInteractions(secureStorageRepository)
+    }
+
+    @Test
+    fun whenNoSecureStorageRepositoryDeleteCredentialsThenDoNothing() = runTest {
+        setUpNoSecureStorageRepository()
+
+        testee.deleteWebsiteLoginDetailsWithCredentials(1)
+
+        verifyNoInteractions(secureStorageRepository)
+    }
+
+    @Test
+    fun whenNoSecureStorageRepositoryGetWebsiteLoginDetailsForDomainThenFlowReturnsNothing() = runTest {
+        setUpNoSecureStorageRepository()
+
+        testee.websiteLoginDetailsForDomain("test").test {
+            this.awaitComplete()
+        }
+    }
+
+    @Test
+    fun whenNoSecureStorageRepositoryGetWebsiteLoginDetailsThenFlowReturnsNothing() = runTest {
+        setUpNoSecureStorageRepository()
+
+        testee.websiteLoginDetails().test {
+            this.awaitComplete()
+        }
+    }
+
+    @Test
+    fun whenNoSecureStorageRepositoryGetWebsiteCredentialsForDomainThenFlowReturnsNothing() = runTest {
+        setUpNoSecureStorageRepository()
+
+        testee.websiteLoginDetailsWithCredentialsForDomain("test").test {
+            this.awaitComplete()
+        }
+    }
+
+    @Test
+    fun whenNoSecureStorageRepositoryGetWebsiteCredentialsThenFlowReturnsNothing() = runTest {
+        setUpNoSecureStorageRepository()
+
+        testee.websiteLoginDetailsWithCredentials().test {
+            this.awaitComplete()
+        }
+    }
+
+    private fun setUpNoSecureStorageRepository() {
+        testee = RealSecureStorage(
+            object : SecureStorageRepository.Factory {
+                override fun get(): SecureStorageRepository? = null
+            },
+            coroutineRule.testDispatcherProvider,
+            l2DataTransformer
+        )
     }
 
     companion object {

--- a/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/SecureStorageRepository.kt
+++ b/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/SecureStorageRepository.kt
@@ -24,6 +24,10 @@ import kotlinx.coroutines.flow.Flow
  * This class is mainly responsible only for accessing and storing data into the DB.
  */
 interface SecureStorageRepository {
+    interface Factory {
+        fun get(): SecureStorageRepository?
+    }
+
     suspend fun addWebsiteLoginCredential(websiteLoginCredentials: WebsiteLoginCredentialsEntity)
 
     suspend fun websiteLoginCredentialsForDomain(domain: String): Flow<List<WebsiteLoginCredentialsEntity>>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202696696022583/f

### Description
This PR includes:
- Check SecureStorage.canAccessSecureStorage when determining if autofill is available. There's no point in enabling autofill if we can't decrypt/encrypt data correctly.
- Separate autofillEnabled and autofillAvailable since they are 2 separate things and have different side effects to the autofill feature.
- Handle scenarios where encryptedsharedprefs failed to load AND room database creation. We want to avoid encrypting / decrypting the database when the l1key is null. Moreover we don't want to automatically regenerate the L1key and use it to encrypt the database since it is possible that the encryptedsharedprefs failed and just can't access the already existing L1key.

### Steps to test this PR

_Autofill is not available for non-internal test user_
- [x] Use a non-internal build
- [x] Confirm that autofill isn't triggered when logging into any site
- [x] Confirm that autofill isn't available in settings

_Autofill is disabled via toggle_
- [x] Use an internal build and disabled autofill via credential management screen
- [x] Confirm that autofill isn't triggered when logging into any site
- [x] Confirm that autofill IS available in settings


_Autofill is works as expected_
- [x] Use an internal build and enable autofill via credential management screen
- [x] Confirm that autofill save dialog is show when logging in to a website
- [x] Confirm that autofill select dialog is shown logging in to a website
- [x] Confirm that credential management works as expected

_Simulated failure case_
- [x] Use an internal build
- [x] Confirm that autofill is triggered and is present in settings
- [x] Modify RealSecureStorageKeyStore and set encryptedPreferences to null
- [x] Re-run app and confirm that autofill is no longer available both when logging in and in settings
- [x] Verify no crash happens (previous crash point)
- [x] Remove changes in RealSecureStorageKeyStore
- [x] Re-run app and confirm that autofill is back and works as expected again