### PR TITLE
Add ServiceWorkerLifecycleObserver to BrowserActivity lifecycle instead of Application

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.app.browser.databinding.IncludeOmnibarToolbarMockupBinding
 import com.duckduckgo.app.browser.rating.ui.AppEnjoymentDialogFragment
 import com.duckduckgo.app.browser.rating.ui.GiveFeedbackDialogFragment
 import com.duckduckgo.app.browser.rating.ui.RateAppDialogFragment
+import com.duckduckgo.app.browser.serviceworker.ServiceWorkerLifecycleObserver
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -108,6 +109,9 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
     lateinit var userEventsStore: UserEventsStore
 
     @Inject
+    lateinit var serviceWorkerLifecycleObserver: ServiceWorkerLifecycleObserver
+
+    @Inject
     @AppCoroutineScope
     lateinit var appCoroutineScope: CoroutineScope
 
@@ -141,6 +145,7 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
         instanceStateBundles = CombinedInstanceState(originalInstanceState = savedInstanceState, newInstanceState = newInstanceState)
 
         super.onCreate(savedInstanceState = newInstanceState, daggerInject = false)
+        lifecycle.addObserver(serviceWorkerLifecycleObserver)
         toolbarMockupBinding = IncludeOmnibarToolbarMockupBinding.bind(binding.root)
         setContentView(binding.root)
         viewModel.viewState.observe(this) {

--- a/app/src/main/java/com/duckduckgo/app/browser/serviceworker/ServiceWorkerLifecycleObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/serviceworker/ServiceWorkerLifecycleObserver.kt
@@ -23,18 +23,15 @@ import androidx.webkit.WebViewFeature
 import androidx.webkit.WebViewFeature.SERVICE_WORKER_BASIC_USAGE
 import com.duckduckgo.app.browser.RequestInterceptor
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
-import com.duckduckgo.di.scopes.AppScope
 import timber.log.Timber
 import javax.inject.Inject
-import dagger.SingleInstanceIn
 
-@SingleInstanceIn(AppScope::class)
 class ServiceWorkerLifecycleObserver @Inject constructor(
     private val requestInterceptor: RequestInterceptor,
     private val uncaughtExceptionRepository: UncaughtExceptionRepository,
 ) : DefaultLifecycleObserver {
-    override fun onStart(owner: LifecycleOwner) {
-        super.onStart(owner)
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
 
         if (WebViewFeature.isFeatureSupported(SERVICE_WORKER_BASIC_USAGE)) {
             try {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202712032214375/f

### Description
Another attempt to fix the crashes / anrs related to ServiceWorkerClient. Instead of setting the ServiceWorkerClient on application onStart() which might be too early in the process, we are delaying it to BrowserActivity's onCreate just before any webview is rendered.

### Steps to test this PR

- [x] Smoke test app
- [x] Load website with videos
- [x] Go to `http://privacy-test-pages.glitch.me/privacy-protections/request-blocking/` and make sure the service worker request is blocked (colour is not green)


