### PR TITLE
Save page title (extracted domain) along with credentials

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillDomainFormatter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillDomainFormatter.kt
@@ -23,13 +23,13 @@ import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 interface AutofillDomainFormatter {
-    fun extractDomain(domain: String?): String?
+    fun extractDomain(url: String?): String?
 }
 
 @ContributesBinding(AppScope::class)
 class AutofillDomainFormatterDomainNameOnly @Inject constructor() : AutofillDomainFormatter {
-    override fun extractDomain(domain: String?): String? {
-        val domain = domain?.toUri()?.baseHost
+    override fun extractDomain(url: String?): String? {
+        val domain = url?.toUri()?.baseHost
         return if (domain.isNullOrBlank()) {
             null
         } else {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementRecyclerAdapter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementRecyclerAdapter.kt
@@ -68,8 +68,8 @@ class AutofillManagementRecyclerAdapter(
     private fun onBindViewHolderCredential(position: Int, viewHolder: CredentialsViewHolder) {
         val item = listItems[position] as ListItem.Credential
         with(viewHolder.binding) {
-            title.text = item.credentials.username
-            subtitle.text = titleExtractor.extract(item.credentials)
+            title.text = titleExtractor.extract(item.credentials)
+            subtitle.text = item.credentials.username
             root.setOnClickListener { onCredentialSelected(item.credentials) }
             updateFavicon(item.credentials)
         }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
@@ -59,6 +59,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
     private val emailManager: EmailManager = mock()
     private val currentUrlProvider: UrlProvider = mock()
     private val deviceAuthenticator: DeviceAuthenticator = mock()
+    private val autofillDomainFormatter: AutofillDomainFormatter = AutofillDomainFormatterDomainNameOnly()
     private val coroutineScope: CoroutineScope = TestScope()
 
     private val testWebView = WebView(getApplicationContext())
@@ -77,7 +78,8 @@ class AutofillStoredBackJavascriptInterfaceTest {
             coroutineScope = coroutineScope,
             currentUrlProvider = currentUrlProvider,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
-            deviceAuthenticator = deviceAuthenticator
+            deviceAuthenticator = deviceAuthenticator,
+            autofillDomainFormatter = autofillDomainFormatter
         )
         testee.callback = testCallback
         testee.webView = testWebView


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202630343540910/f 

### Description
When saving a credential, the title will be populated alongside the usual URL, username and password.

### Steps to test this PR
- [x] Visit a login page and attempt to sign in (e.g., https://trello.com/login)
- [x] Choose to save the credential
- [x] Visit the credential management page and verify the title has been pre-populated with just the domain (e.g., trello.com)
- [x] Manually edit the title; verify it updates successfully
