### PR TITLE
Expose autofill dialogs as DialogFragment to simplify API

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1593,7 +1593,7 @@ class BrowserTabFragment :
         Timber.v("onCredentialsAvailable. %d creds to choose from", credentials.size)
         val url = webView?.url ?: return
         val dialog = credentialAutofillDialogFactory.autofillSelectCredentialsDialog(url, credentials)
-        showDialogHidingPrevious(dialog.asDialogFragment(), CredentialAutofillPickerDialog.TAG)
+        showDialogHidingPrevious(dialog, CredentialAutofillPickerDialog.TAG)
     }
 
     private fun showAutofillDialogSaveCredentials(currentUrl: String, credentials: LoginCredentials) {
@@ -1601,7 +1601,7 @@ class BrowserTabFragment :
         if (url != currentUrl) return
 
         val dialog = credentialAutofillDialogFactory.autofillSavingCredentialsDialog(url, credentials)
-        showDialogHidingPrevious(dialog.asDialogFragment(), CredentialSavePickerDialog.TAG)
+        showDialogHidingPrevious(dialog, CredentialSavePickerDialog.TAG)
     }
 
     private fun showAutofillDialogUpdateCredentials(currentUrl: String, credentials: LoginCredentials) {
@@ -1609,7 +1609,7 @@ class BrowserTabFragment :
         if (url != currentUrl) return
 
         val dialog = credentialAutofillDialogFactory.autofillSavingUpdateCredentialsDialog(url, credentials)
-        showDialogHidingPrevious(dialog.asDialogFragment(), CredentialUpdateExistingCredentialsDialog.TAG)
+        showDialogHidingPrevious(dialog, CredentialUpdateExistingCredentialsDialog.TAG)
     }
 
     private fun showDialogHidingPrevious(dialog: DialogFragment, tag: String) {

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/AutofillCredentialDialogs.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/AutofillCredentialDialogs.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.autofill.domain.app.LoginCredentials
 /**
  * Dialog which can be shown when user is required to select which saved credential to autofill
  */
-interface CredentialAutofillPickerDialog : DialogFragmentType {
+interface CredentialAutofillPickerDialog {
 
     companion object {
         const val TAG = "CredentialAutofillPickerDialog"
@@ -36,7 +36,7 @@ interface CredentialAutofillPickerDialog : DialogFragmentType {
 /**
  * Dialog which can be shown to prompt user to save credentials or not
  */
-interface CredentialSavePickerDialog : DialogFragmentType {
+interface CredentialSavePickerDialog {
 
     companion object {
         const val TAG = "CredentialSavePickerDialog"
@@ -49,7 +49,7 @@ interface CredentialSavePickerDialog : DialogFragmentType {
 /**
  * Dialog which can be shown to prompt user to update existing saved credentials or not
  */
-interface CredentialUpdateExistingCredentialsDialog : DialogFragmentType {
+interface CredentialUpdateExistingCredentialsDialog {
 
     companion object {
         const val TAG = "CredentialUpdateExistingCredentialsDialog"
@@ -60,22 +60,14 @@ interface CredentialUpdateExistingCredentialsDialog : DialogFragmentType {
 }
 
 /**
- * A workaround caused by modularization:
- * clients using these dialogs will know them by their interface but will also need to know they are DialogFragments to show them
- */
-interface DialogFragmentType {
-    fun asDialogFragment(): DialogFragment
-}
-
-/**
  * Factory used to get instances of the various autofill dialogs
  */
 interface CredentialAutofillDialogFactory {
 
-    fun autofillSelectCredentialsDialog(url: String, credentials: List<LoginCredentials>): CredentialAutofillPickerDialog
+    fun autofillSelectCredentialsDialog(url: String, credentials: List<LoginCredentials>): DialogFragment
 
-    fun autofillSavingCredentialsDialog(url: String, credentials: LoginCredentials): CredentialSavePickerDialog
+    fun autofillSavingCredentialsDialog(url: String, credentials: LoginCredentials): DialogFragment
 
-    fun autofillSavingUpdateCredentialsDialog(url: String, credentials: LoginCredentials): CredentialUpdateExistingCredentialsDialog
+    fun autofillSavingUpdateCredentialsDialog(url: String, credentials: LoginCredentials): DialogFragment
 
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/CredentialAutofillDialogAndroidFactory.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/CredentialAutofillDialogAndroidFactory.kt
@@ -16,10 +16,8 @@
 
 package com.duckduckgo.autofill.ui
 
+import androidx.fragment.app.DialogFragment
 import com.duckduckgo.autofill.CredentialAutofillDialogFactory
-import com.duckduckgo.autofill.CredentialAutofillPickerDialog
-import com.duckduckgo.autofill.CredentialSavePickerDialog
-import com.duckduckgo.autofill.CredentialUpdateExistingCredentialsDialog
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment
 import com.duckduckgo.autofill.ui.credential.updating.AutofillUpdatingExistingCredentialsDialogFragment
@@ -31,15 +29,15 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 class CredentialAutofillDialogAndroidFactory @Inject constructor() : CredentialAutofillDialogFactory {
 
-    override fun autofillSelectCredentialsDialog(url: String, credentials: List<LoginCredentials>): CredentialAutofillPickerDialog {
+    override fun autofillSelectCredentialsDialog(url: String, credentials: List<LoginCredentials>): DialogFragment {
         return AutofillSelectCredentialsDialogFragment.instance(url, credentials)
     }
 
-    override fun autofillSavingCredentialsDialog(url: String, credentials: LoginCredentials): CredentialSavePickerDialog {
+    override fun autofillSavingCredentialsDialog(url: String, credentials: LoginCredentials): DialogFragment {
         return AutofillSavingCredentialsDialogFragment.instance(url, credentials)
     }
 
-    override fun autofillSavingUpdateCredentialsDialog(url: String, credentials: LoginCredentials): CredentialUpdateExistingCredentialsDialog {
+    override fun autofillSavingUpdateCredentialsDialog(url: String, credentials: LoginCredentials): DialogFragment {
         return AutofillUpdatingExistingCredentialsDialogFragment.instance(url, credentials)
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
@@ -21,7 +21,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -118,8 +117,6 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
     private fun getOriginalUrl() = arguments?.getString(CredentialSavePickerDialog.KEY_URL)!!
 
     private fun showOnboarding() = viewModel.showOnboarding()
-
-    override fun asDialogFragment(): DialogFragment = this
 
     companion object {
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
@@ -22,7 +22,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
@@ -114,8 +113,6 @@ class AutofillSelectCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
     private fun getAvailableCredentials() = arguments?.getParcelableArrayList<LoginCredentials>(CredentialAutofillPickerDialog.KEY_CREDENTIALS)!!
 
     private fun getOriginalUrl() = arguments?.getString(CredentialAutofillPickerDialog.KEY_URL)!!
-
-    override fun asDialogFragment(): DialogFragment = this
 
     companion object {
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
@@ -21,7 +21,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -112,8 +111,6 @@ class AutofillUpdatingExistingCredentialsDialogFragment : BottomSheetDialogFragm
     private fun getCredentialsToSave() = arguments?.getParcelable<LoginCredentials>(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIALS)!!
 
     private fun getOriginalUrl() = arguments?.getString(CredentialUpdateExistingCredentialsDialog.KEY_URL)!!
-
-    override fun asDialogFragment(): DialogFragment = this
 
     companion object {
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202722378440328/f 

### Description
Simplification of the way we create and show the DialogFragments in autofill.

### Steps to test this PR

(Make sure you build using `internal` variant)

- [ ] Visit a site with a login (e.g., trello.com/login)
- [ ] Attempt a login; verify the save dialog still shows and works correctly
- [ ] Save the login. Refresh the page and verify you are prompted to use the saved login when tapping on the email field
- [ ] Choose to autofill. Change the password and hit log in button; Verify the update password dialog still shows 
