### PR TITLE
Fix logic for set autofillEnabled

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/di/AutofillModule.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/di/AutofillModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import com.duckduckgo.autofill.InternalTestUserChecker
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.autofill.store.InternalTestUserStore
+import com.duckduckgo.autofill.store.RealAutofillPrefsStore
 import com.duckduckgo.autofill.store.RealInternalTestUserStore
 import com.duckduckgo.autofill.store.RealLastUpdatedTimeProvider
 import com.duckduckgo.autofill.store.SecureStoreBackedAutofillStore
@@ -44,6 +45,11 @@ class AutofillModule {
         context: Context,
         internalTestUserChecker: InternalTestUserChecker
     ): AutofillStore {
-        return SecureStoreBackedAutofillStore(secureStorage, context, internalTestUserChecker, RealLastUpdatedTimeProvider())
+        return SecureStoreBackedAutofillStore(
+            secureStorage,
+            internalTestUserChecker,
+            RealLastUpdatedTimeProvider(),
+            RealAutofillPrefsStore(context)
+        )
     }
 }

--- a/autofill/autofill-store/build.gradle
+++ b/autofill/autofill-store/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation JakeWharton.timber
 
     // Testing dependencies
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
     testImplementation AndroidX.test.ext.junit
     testImplementation Testing.robolectric

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.store
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+interface AutofillPrefsStore {
+    var isEnabled: Boolean
+    var showOnboardingWhenOfferingToSaveLogin: Boolean
+}
+
+class RealAutofillPrefsStore constructor(
+    private val applicationContext: Context
+) : AutofillPrefsStore {
+
+    private val prefs: SharedPreferences by lazy {
+        applicationContext.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+    }
+
+    override var isEnabled: Boolean
+        get() = prefs.getBoolean(AUTOFILL_ENABLED, true)
+        set(value) = prefs.edit {
+            putBoolean(AUTOFILL_ENABLED, value)
+        }
+
+    override var showOnboardingWhenOfferingToSaveLogin: Boolean
+        get() = prefs.getBoolean(SHOW_SAVE_LOGIN_ONBOARDING, true)
+        set(value) = prefs.edit { putBoolean(SHOW_SAVE_LOGIN_ONBOARDING, value) }
+
+    companion object {
+        const val FILENAME = "com.duckduckgo.autofill.store.autofill_store"
+        const val AUTOFILL_ENABLED = "autofill_enabled"
+        const val SHOW_SAVE_LOGIN_ONBOARDING = "autofill_show_onboardind_saved_login"
+    }
+}

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.autofill.store
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autofill.InternalTestUserChecker
 import com.duckduckgo.autofill.domain.app.LoginCredentials
@@ -35,24 +33,55 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class SecureStoreBackedAutofillStoreTest {
 
-    private val context: Context = getApplicationContext()
     private val lastUpdatedTimeProvider = object : LastUpdatedTimeProvider {
         override fun getInMillis(): Long = UPDATED_INITIAL_LAST_UPDATED
     }
+
+    @Mock
+    private lateinit var autofillPrefsStore: AutofillPrefsStore
     private lateinit var testee: SecureStoreBackedAutofillStore
     private lateinit var internalTestUserChecker: FakeInternalTestUserChecker
     private lateinit var secureStore: FakeSecureStore
 
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        whenever(autofillPrefsStore.isEnabled).thenReturn(true)
+        whenever(autofillPrefsStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(true)
+    }
+
+    @Test
+    fun whenAutofillUnavailableAndPrefsAreAllTrueThenReturnTrueForAutofillEnabledAndShowOnboardingWhenOfferingToSaveLogin() {
+        setupTestee(isInternalUser = false, canAccessSecureStorage = false)
+
+        assertTrue(testee.autofillEnabled)
+        assertTrue(testee.showOnboardingWhenOfferingToSaveLogin)
+    }
+
+    @Test
+    fun whenAutofillAvailableAndPrefsAreAllFalseThenReturnFalseForAutofillEnabledAndShowOnboardingWhenOfferingToSaveLogin() {
+        setupTesteeWithAutofillAvailable()
+        whenever(autofillPrefsStore.isEnabled).thenReturn(false)
+        whenever(autofillPrefsStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
+
+        assertFalse(testee.autofillEnabled)
+        assertFalse(testee.showOnboardingWhenOfferingToSaveLogin)
+    }
+
     @Test
     fun whenInternalTestUserTrueThenReturnAutofillEnabled() {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         assertTrue(testee.autofillAvailable)
     }
 
@@ -88,14 +117,14 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenStoreEmptyThenNoMatch() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         val result = testee.containsCredentials("example.com", "username", "password")
         assertNotMatch(result)
     }
 
     @Test
     fun whenStoreContainsMatchingUsernameEntriesButNoneMatchingUrlThenNoMatch() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         storeCredentials(1, "https://example.com", "username", "password")
         val result = testee.containsCredentials("foo.com", "username", "password")
         assertNotMatch(result)
@@ -103,7 +132,7 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenStoreContainsDomainButDifferentCredentialsThenUrlMatch() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         storeCredentials(1, "https://example.com", "username", "password")
         val result = testee.containsCredentials("example.com", "differentUsername", "differentPassword")
         assertUrlOnlyMatch(result)
@@ -111,7 +140,7 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenStoreContainsDomainAndUsernameButDifferentPassword() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         storeCredentials(1, "https://example.com", "username", "password")
         val result = testee.containsCredentials("example.com", "username", "differentPassword")
         assertUsernameMatch(result)
@@ -119,7 +148,7 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenStoreContainsMatchingDomainAndUsernameAndPassword() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         storeCredentials(1, "https://example.com", "username", "password")
         val result = testee.containsCredentials("example.com", "username", "password")
         assertExactMatch(result)
@@ -127,7 +156,7 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenNoCredentialsForUrlStoredThenGetCredentialsReturnNothing() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         storeCredentials(1, "url.com", "username1", "password123")
 
         assertEquals(0, testee.getCredentials("https://example.com").size)
@@ -135,13 +164,13 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenNoCredentialsSavedThenGetAllCredentialsReturnNothing() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         assertEquals(0, testee.getAllCredentials().first().size)
     }
 
     @Test
     fun whenPasswordIsUpdatedForUrlThenUpdatedOnlyMatchingCredential() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         val url = "https://example.com"
         storeCredentials(1, url, "username1", "password123")
         storeCredentials(2, url, "username2", "password456")
@@ -164,7 +193,7 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenPasswordIsUpdatedThenUpdatedOnlyMatchingCredential() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         val url = "https://example.com"
         storeCredentials(1, url, "username1", "password123")
         storeCredentials(2, url, "username2", "password456")
@@ -187,7 +216,7 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenSaveCredentialsThenReturnSavedOnGetCredentials() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         val url = "https://example.com"
         val credentials = LoginCredentials(
             domain = url,
@@ -201,7 +230,7 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenPasswordIsDeletedThenRemoveCredentialFromStore() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         val url = "https://example.com"
         storeCredentials(1, url, "username1", "password123")
         storeCredentials(2, url, "username2", "password456")
@@ -217,7 +246,7 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenCredentialWithIdIsStoredTheReturnCredentialsOnGetCredentialsWithId() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         val url = "https://example.com"
         storeCredentials(1, url, "username1", "password123")
         storeCredentials(2, url, "username2", "password456")
@@ -236,7 +265,7 @@ class SecureStoreBackedAutofillStoreTest {
 
     @Test
     fun whenNoCredentialStoredTheReturnNullOnGetCredentialsWithId() = runTest {
-        setupTesteeWithAutofillEnabledAndAvailable()
+        setupTesteeWithAutofillAvailable()
         assertNull(testee.getCredentialsWithId(1))
     }
 
@@ -264,16 +293,16 @@ class SecureStoreBackedAutofillStoreTest {
         assertEquals(1, result.size)
     }
 
-    private fun setupTesteeWithAutofillEnabledAndAvailable() {
+    private fun setupTesteeWithAutofillAvailable() {
         internalTestUserChecker = FakeInternalTestUserChecker(true)
         secureStore = FakeSecureStore(true)
-        testee = SecureStoreBackedAutofillStore(secureStore, context, internalTestUserChecker, lastUpdatedTimeProvider)
+        testee = SecureStoreBackedAutofillStore(secureStore, internalTestUserChecker, lastUpdatedTimeProvider, autofillPrefsStore)
     }
 
     private fun setupTestee(isInternalUser: Boolean, canAccessSecureStorage: Boolean) {
         internalTestUserChecker = FakeInternalTestUserChecker(isInternalUser)
         secureStore = FakeSecureStore(canAccessSecureStorage)
-        testee = SecureStoreBackedAutofillStore(secureStore, context, internalTestUserChecker, lastUpdatedTimeProvider)
+        testee = SecureStoreBackedAutofillStore(secureStore, internalTestUserChecker, lastUpdatedTimeProvider, autofillPrefsStore)
     }
 
     private fun assertNotMatch(result: ContainsCredentialsResult) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202768144082716/f

### Description
This PR includes:
- Fix incorrect loging for autofillEnabled. Previously when setting, it takes into account the incoming value, isInternalTestUser and canAccessSecureStorage which is incorrect since autofillEnabled is only used primarily for the user controlled toggled.
- Additional tests for the incorrect logic

### Steps to test this PR

_Enable and disable works as expected_
- [ ] Use an internal build with autofill available
- [ ] Verify that autofill prompt is shown when logging in a website
- [ ] Verify autofill management entry points are visible in settings and overflow
- [ ] Disable autofill in credential management
- [ ] Verify that autofill prompt is not shown when logging in a website

