### PR TITLE
Ensure new/different privacy config plugins get configuration

### DIFF
--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -16,11 +16,15 @@
 
 package com.duckduckgo.privacy.config.impl
 
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
+import androidx.core.content.edit
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
+import com.duckduckgo.privacy.config.impl.di.ConfigPersisterPreferences
 import com.duckduckgo.privacy.config.store.PrivacyConfig
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
@@ -34,6 +38,8 @@ interface PrivacyConfigPersister {
     suspend fun persistPrivacyConfig(jsonPrivacyConfig: JsonPrivacyConfig)
 }
 
+private const val PRIVACY_SIGNATURE_KEY = "plugin_signature"
+
 @WorkerThread
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
@@ -42,16 +48,20 @@ class RealPrivacyConfigPersister @Inject constructor(
     private val privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository,
     private val unprotectedTemporaryRepository: UnprotectedTemporaryRepository,
     private val privacyConfigRepository: PrivacyConfigRepository,
-    private val database: PrivacyConfigDatabase
+    private val database: PrivacyConfigDatabase,
+    @ConfigPersisterPreferences private val persisterPreferences: SharedPreferences,
 ) : PrivacyConfigPersister {
 
     override suspend fun persistPrivacyConfig(jsonPrivacyConfig: JsonPrivacyConfig) {
         val privacyConfig = privacyConfigRepository.get()
         val newVersion = jsonPrivacyConfig.version
         val previousVersion = privacyConfig?.version ?: 0
+        val currentPluginHashCode = privacyFeaturePluginPoint.signature()
+        val previousPluginHashCode = persisterPreferences.getSignature()
 
-        if (newVersion >= previousVersion) {
+        if (newVersion > previousVersion || (newVersion == previousVersion && currentPluginHashCode != previousPluginHashCode)) {
             database.runInTransaction {
+                persisterPreferences.setSignature(currentPluginHashCode)
                 privacyFeatureTogglesRepository.deleteAll()
                 privacyConfigRepository.insert(PrivacyConfig(version = jsonPrivacyConfig.version, readme = jsonPrivacyConfig.readme))
                 unprotectedTemporaryRepository.updateAll(jsonPrivacyConfig.unprotectedTemporary)
@@ -65,4 +75,19 @@ class RealPrivacyConfigPersister @Inject constructor(
             }
         }
     }
+
+    private fun SharedPreferences.getSignature(): Int {
+        return getInt(PRIVACY_SIGNATURE_KEY, 0)
+    }
+
+    private fun SharedPreferences.setSignature(value: Int) {
+        edit {
+            putInt(PRIVACY_SIGNATURE_KEY, value)
+        }
+    }
+}
+
+@VisibleForTesting
+fun PluginPoint<PrivacyFeaturePlugin>.signature(): Int {
+    return this.getPlugins().sumOf { it.featureName.hashCode() }
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/ConfigPersisterPreferences.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/ConfigPersisterPreferences.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.di
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import javax.inject.Qualifier
+
+/** Identifies a coroutine scope type that is scope to the app lifecycle */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+annotation class ConfigPersisterPreferences

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.privacy.config.impl.di
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.AppUrl
@@ -86,6 +87,12 @@ object NetworkModule {
 @Module
 @ContributesTo(AppScope::class)
 object DatabaseModule {
+
+    @Provides
+    @ConfigPersisterPreferences
+    fun providePrivacyConfigPersisterPreferences(context: Context): SharedPreferences {
+        return context.getSharedPreferences("com.duckduckgo.privacy.config.persister.preferences.v1", Context.MODE_PRIVATE)
+    }
 
     @SingleInstanceIn(AppScope::class)
     @Provides

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
@@ -16,9 +16,12 @@
 
 package com.duckduckgo.privacy.config.impl
 
+import android.content.SharedPreferences
+import androidx.core.content.edit
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.global.api.InMemorySharedPreferences
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
@@ -40,6 +43,7 @@ import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -56,11 +60,17 @@ class RealPrivacyConfigPersisterTest {
     private lateinit var db: PrivacyConfigDatabase
     private lateinit var privacyRepository: PrivacyConfigRepository
     private lateinit var unprotectedTemporaryRepository: UnprotectedTemporaryRepository
-    private val pluginPoint = FakePrivacyFeaturePluginPoint()
+    private val pluginPoint = FakePrivacyFeaturePluginPoint(listOf(FakePrivacyFeaturePlugin()))
+    private lateinit var sharedPreferences: SharedPreferences
 
     @Before
     fun before() {
         prepareDb()
+        sharedPreferences = InMemorySharedPreferences().apply {
+            edit {
+                putInt("plugin_signature", pluginPoint.signature())
+            }
+        }
 
         testee =
             RealPrivacyConfigPersister(
@@ -68,7 +78,8 @@ class RealPrivacyConfigPersisterTest {
                 mockTogglesRepository,
                 unprotectedTemporaryRepository,
                 privacyRepository,
-                db
+                db,
+                sharedPreferences
             )
     }
 
@@ -87,6 +98,17 @@ class RealPrivacyConfigPersisterTest {
             RealUnprotectedTemporaryRepository(
                 db, TestScope(), coroutineRule.testDispatcherProvider
             )
+    }
+
+    @Test
+    fun whenPluginPointSignatureThenReturnUniqueSignature() {
+        assertEquals(pluginPoint.signature(), pluginPoint.signature())
+    }
+
+    @Test
+    fun whenDifferentPluginPointsThenReturnDifferentSignatures() {
+        val differentPluginPoint = FakePrivacyFeaturePluginPoint(listOf(FakePrivacyFeaturePlugin(), FakePrivacyFeaturePlugin()))
+        assertNotEquals(pluginPoint.signature(), differentPluginPoint.signature())
     }
 
     @Test
@@ -128,8 +150,32 @@ class RealPrivacyConfigPersisterTest {
         }
 
     @Test
-    fun whenPersistPrivacyConfigAndVersionIsEqualsThanPreviousOneStoredThenStoreNewConfig() =
+    fun whenPersistPrivacyConfigAndVersionIsLowerThanPreviousOneAndDifferentPluginsThenStoreNewConfig() =
         runTest {
+            sharedPreferences.edit().putInt("plugin_signature", 0)
+            privacyRepository.insert(PrivacyConfig(version = 3, readme = "readme"))
+
+            testee.persistPrivacyConfig(getJsonPrivacyConfig())
+
+            assertEquals(3, privacyRepository.get()!!.version)
+            verify(mockTogglesRepository, never()).deleteAll()
+        }
+
+    @Test
+    fun whenPersistPrivacyConfigAndVersionIsEqualsThanPreviousOneStoredThenDoNothing() =
+        runTest {
+            privacyRepository.insert(PrivacyConfig(version = 2, readme = "readme"))
+
+            testee.persistPrivacyConfig(getJsonPrivacyConfig())
+
+            assertEquals(2, privacyRepository.get()!!.version)
+            verify(mockTogglesRepository, never()).deleteAll()
+        }
+
+    @Test
+    fun whenPersistPrivacyConfigAndVersionIsEqualsThanPreviousOneStoredAndDifferentPluginsThenUpdateConfig() =
+        runTest {
+            sharedPreferences.edit().putInt("plugin_signature", 0)
             privacyRepository.insert(PrivacyConfig(version = 2, readme = "readme"))
 
             testee.persistPrivacyConfig(getJsonPrivacyConfig())
@@ -148,6 +194,17 @@ class RealPrivacyConfigPersisterTest {
             assertEquals(2, privacyRepository.get()!!.version)
         }
 
+    @Test
+    fun whenPersistPrivacyConfigAndVersionIsHigherThanPreviousOneStoredAndDifferentPluginsThenStoreNewConfig() =
+        runTest {
+            sharedPreferences.edit().putInt("plugin_signature", 0)
+            privacyRepository.insert(PrivacyConfig(version = 1, readme = "readme"))
+
+            testee.persistPrivacyConfig(getJsonPrivacyConfig())
+
+            assertEquals(2, privacyRepository.get()!!.version)
+        }
+
     private fun getJsonPrivacyConfig(): JsonPrivacyConfig {
         return JsonPrivacyConfig(
             version = 2,
@@ -157,10 +214,9 @@ class RealPrivacyConfigPersisterTest {
         )
     }
 
-    class FakePrivacyFeaturePluginPoint : PluginPoint<PrivacyFeaturePlugin> {
-        val plugin = FakePrivacyFeaturePlugin()
+    class FakePrivacyFeaturePluginPoint(private val plugins: List<PrivacyFeaturePlugin>) : PluginPoint<PrivacyFeaturePlugin> {
         override fun getPlugins(): Collection<PrivacyFeaturePlugin> {
-            return listOf(plugin)
+            return plugins
         }
     }
 

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigDisabledReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigDisabledReferenceTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.FileUtilities
+import com.duckduckgo.app.global.api.InMemorySharedPreferences
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
@@ -81,7 +82,8 @@ class PrivacyConfigDisabledReferenceTest(private val testCase: TestCase) {
             mockTogglesRepository,
             referenceTestUtilities.unprotectedTemporaryRepository,
             referenceTestUtilities.privacyRepository,
-            db
+            db,
+            InMemorySharedPreferences()
         )
     }
 

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigEnabledReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigEnabledReferenceTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.FileUtilities
+import com.duckduckgo.app.global.api.InMemorySharedPreferences
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
@@ -80,7 +81,8 @@ class PrivacyConfigEnabledReferenceTest(private val testCase: TestCase) {
             mockTogglesRepository,
             referenceTestUtilities.unprotectedTemporaryRepository,
             referenceTestUtilities.privacyRepository,
-            db
+            db,
+            InMemorySharedPreferences()
         )
     }
 

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigGlobalExceptionsReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigGlobalExceptionsReferenceTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.FileUtilities
+import com.duckduckgo.app.global.api.InMemorySharedPreferences
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
@@ -119,7 +120,8 @@ class PrivacyConfigGlobalExceptionsReferenceTest(private val testCase: TestCase)
             mockTogglesRepository,
             referenceTestUtilities.unprotectedTemporaryRepository,
             referenceTestUtilities.privacyRepository,
-            db
+            db,
+            InMemorySharedPreferences()
         )
         privacyConfigPersister.persistPrivacyConfig(
             referenceTestUtilities.getJsonPrivacyConfig(

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigLocalExceptionsReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigLocalExceptionsReferenceTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.FileUtilities
+import com.duckduckgo.app.global.api.InMemorySharedPreferences
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
@@ -117,7 +118,8 @@ class PrivacyConfigLocalExceptionsReferenceTest(private val testCase: TestCase) 
             mockTogglesRepository,
             referenceTestUtilities.unprotectedTemporaryRepository,
             referenceTestUtilities.privacyRepository,
-            db
+            db,
+            InMemorySharedPreferences()
         )
         privacyConfigPersister.persistPrivacyConfig(
             referenceTestUtilities.getJsonPrivacyConfig(

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigMissingReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/privacyconfig/PrivacyConfigMissingReferenceTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.privacyconfig
 import androidx.room.Room
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.FileUtilities
+import com.duckduckgo.app.global.api.InMemorySharedPreferences
 import com.duckduckgo.privacy.config.impl.features.privacyFeatureValueOf
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.ReferenceTestUtilities
@@ -82,7 +83,8 @@ class PrivacyConfigMissingReferenceTest(private val testCase: TestCase) {
             mockTogglesRepository,
             referenceTestUtilities.unprotectedTemporaryRepository,
             referenceTestUtilities.privacyRepository,
-            db
+            db,
+            InMemorySharedPreferences()
         )
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202765110225461/f

### Description
This is related to [this asana task](https://app.asana.com/0/1202552961248957/1202738585521624/f).

We want to ensure that changes in privacy config plugins trigger a config update when version is `==` to current version.

This covers the scenario where existing configuration in the current version is not given to a newly added plugin.


The table truth should be the following
| version / signature | `=` | `!=` |
| `<` | noop | noop |
| `==` | noop | update |
| `>` | update | update |

### Steps to test this PR
See steps in [this task](https://app.asana.com/0/1202552961248957/1202738585521624/f)
Alternatively, do the following:
- [x] from this branch, comment out the `ContributesMultibinding` line in the `AdClickAttributionPlugin`
- [x] (remove the `build-cache` folder to ensure no cache issues)
- [x] build and fresh install
- [x] verify the adclick.db is empty
- [x] re-add the `ContributesMultibinding` line in the `AdClickAttributionPlugin`
- [x] (remove the `build-cache` folder to ensure no cache issues)
- [x] build and update
- [x] verify the adclick.db is no longer empty
