### PR TITLE
Support other messages

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -429,6 +429,11 @@ class BrowserTabFragment :
         }
 
         override fun onPopUpHandled() {
+            // ToDo Replace with a proper action
+            Toast.makeText(context?.applicationContext, "Cookie Popup Handled!", Toast.LENGTH_LONG).show()
+        }
+
+        override fun onResultReceived(consentManaged: Boolean, optOutFailed: Boolean, selfTestFailed: Boolean?) {
             TODO("Not yet implemented")
         }
     }

--- a/autoconsent/autoconsent-api/src/main/java/com/duckduckgo/autoconsent/api/Autoconsent.kt
+++ b/autoconsent/autoconsent-api/src/main/java/com/duckduckgo/autoconsent/api/Autoconsent.kt
@@ -57,4 +57,9 @@ interface AutoconsentCallback {
      * This method is called whenever a popup is handled but not for the first time.
      */
     fun onPopUpHandled()
+
+    /**
+     * This method is called whenever autoconsent has a result to be sent
+     */
+    fun onResultReceived(consentManaged: Boolean, optOutFailed: Boolean, selfTestFailed: Boolean?)
 }

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentInterface.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentInterface.kt
@@ -33,7 +33,7 @@ class AutoconsentInterface(
         try {
             val parsedMessage = JSONObject(message)
             val type: String = parsedMessage.getString("type")
-            messageHandlerPlugins.getPlugins().firstOrNull { type == it.type }?.process(type, message, webView, autoconsentCallback)
+            messageHandlerPlugins.getPlugins().firstOrNull { it.supportedTypes.contains(type) }?.process(type, message, webView, autoconsentCallback)
         } catch (e: Exception) {
             Timber.d(e.localizedMessage)
         }

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/MessageHandlerPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/MessageHandlerPlugin.kt
@@ -28,5 +28,5 @@ import com.duckduckgo.di.scopes.AppScope
 @Suppress("unused")
 interface MessageHandlerPlugin {
     fun process(messageType: String, jsonString: String, webView: WebView, autoconsentCallback: AutoconsentCallback)
-    val type: String
+    val supportedTypes: List<String>
 }

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/EvalMessageHandlerPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/EvalMessageHandlerPlugin.kt
@@ -26,14 +26,12 @@ import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
-import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class)
-@SingleInstanceIn(AppScope::class)
 class EvalMessageHandlerPlugin @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider
@@ -42,7 +40,7 @@ class EvalMessageHandlerPlugin @Inject constructor(
     private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
 
     override fun process(messageType: String, jsonString: String, webView: WebView, autoconsentCallback: AutoconsentCallback) {
-        if (messageType == type) {
+        if (supportedTypes.contains(messageType)) {
             appCoroutineScope.launch(dispatcherProvider.main()) {
                 try {
                     val message: EvalMessage = parseMessage(jsonString) ?: return@launch
@@ -72,7 +70,7 @@ class EvalMessageHandlerPlugin @Inject constructor(
         """.trimIndent()
     }
 
-    override val type: String = "eval"
+    override val supportedTypes: List<String> = listOf("eval")
 
     private fun parseMessage(jsonString: String): EvalMessage? {
         val jsonAdapter: JsonAdapter<EvalMessage> = moshi.adapter(EvalMessage::class.java)

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPlugin.kt
@@ -31,7 +31,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
-import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.json.JSONObject
@@ -39,7 +38,6 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class)
-@SingleInstanceIn(AppScope::class)
 class InitMessageHandlerPlugin @Inject constructor(
     @AppCoroutineScope val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
@@ -50,7 +48,7 @@ class InitMessageHandlerPlugin @Inject constructor(
     private lateinit var rules: String
 
     override fun process(messageType: String, jsonString: String, webView: WebView, autoconsentCallback: AutoconsentCallback) {
-        if (messageType == type) {
+        if (supportedTypes.contains(messageType)) {
             appCoroutineScope.launch(dispatcherProvider.main()) {
                 try {
                     val message: InitMessage = parseMessage(jsonString) ?: return@launch
@@ -89,7 +87,7 @@ class InitMessageHandlerPlugin @Inject constructor(
         }
     }
 
-    override val type: String = "init"
+    override val supportedTypes: List<String> = listOf("init")
 
     private fun getAutoAction(): String? {
         return if (!repository.firstPopupHandled) null else "optOut"

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPlugin.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl.handlers
+
+import android.webkit.WebView
+import androidx.core.net.toUri
+import com.duckduckgo.autoconsent.api.AutoconsentCallback
+import com.duckduckgo.autoconsent.impl.MessageHandlerPlugin
+import com.duckduckgo.autoconsent.impl.adapters.JSONObjectAdapter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import timber.log.Timber
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class OptOutAndAutoconsentDoneMessageHandlerPlugin @Inject constructor() : MessageHandlerPlugin {
+
+    private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
+    private var selfTest = false
+
+    override fun process(messageType: String, jsonString: String, webView: WebView, autoconsentCallback: AutoconsentCallback) {
+        if (supportedTypes.contains(messageType)) {
+            when (messageType) {
+                OPT_OUT -> processOptOutResult(jsonString, autoconsentCallback)
+                RESULT_MESSAGE -> processAutoconsentDone(jsonString, webView, autoconsentCallback)
+                else -> return
+            }
+        }
+    }
+
+    override val supportedTypes: List<String> = listOf(OPT_OUT, RESULT_MESSAGE)
+
+    private fun processOptOutResult(jsonString: String, autoconsentCallback: AutoconsentCallback) {
+        try {
+            val message: OptOutResultMessage = parseOptOutMessage(jsonString) ?: return
+
+            if (!message.result) {
+                autoconsentCallback.onResultReceived(consentManaged = true, optOutFailed = true, selfTestFailed = null)
+            } else if (message.scheduleSelfTest) {
+                selfTest = true
+            }
+
+        } catch (e: Exception) {
+            Timber.d(e.localizedMessage)
+        }
+    }
+
+    private fun processAutoconsentDone(jsonString: String, webView: WebView, autoconsentCallback: AutoconsentCallback) {
+        try {
+            val message: AutoconsentDoneMessage = parseAutoconsentDoneMessage(jsonString) ?: return
+            val host: String = message.url.toUri().host ?: return
+
+            if (true) { // ToDo Store the host and check it doesn't exist
+                autoconsentCallback.onPopUpHandled()
+            }
+
+            if (selfTest) {
+                webView.evaluateJavascript("javascript:${ReplyHandler.constructReply("""{ "type": "selfTest" }""")}", null)
+            }
+            selfTest = false
+        } catch (e: Exception) {
+            Timber.d(e.localizedMessage)
+        }
+    }
+
+    private fun parseOptOutMessage(jsonString: String): OptOutResultMessage? {
+        val jsonAdapter: JsonAdapter<OptOutResultMessage> = moshi.adapter(OptOutResultMessage::class.java)
+        return jsonAdapter.fromJson(jsonString)
+    }
+
+    private fun parseAutoconsentDoneMessage(jsonString: String): AutoconsentDoneMessage? {
+        val jsonAdapter: JsonAdapter<AutoconsentDoneMessage> = moshi.adapter(AutoconsentDoneMessage::class.java)
+        return jsonAdapter.fromJson(jsonString)
+    }
+
+    data class OptOutResultMessage(val type: String, val cmp: String, val result: Boolean, val scheduleSelfTest: Boolean, val url: String)
+
+    data class AutoconsentDoneMessage(val type: String, val cmp: String, val url: String)
+
+    companion object {
+        const val OPT_OUT = "optOutResult"
+        const val RESULT_MESSAGE = "autoconsentDone"
+    }
+}

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/PopUpFoundMessageHandlerPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/PopUpFoundMessageHandlerPlugin.kt
@@ -27,13 +27,11 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.ui.view.DaxDialogListener
 import com.duckduckgo.mobile.android.ui.view.TypewriterDaxDialog
 import com.squareup.anvil.annotations.ContributesMultibinding
-import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class)
-@SingleInstanceIn(AppScope::class)
 class PopUpFoundMessageHandlerPlugin @Inject constructor(
     @AppCoroutineScope val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
@@ -41,7 +39,7 @@ class PopUpFoundMessageHandlerPlugin @Inject constructor(
 ) : MessageHandlerPlugin {
 
     override fun process(messageType: String, jsonString: String, webView: WebView, autoconsentCallback: AutoconsentCallback) {
-        if (messageType == type) {
+        if (supportedTypes.contains(messageType)) {
             if (repository.userSetting) {
                 return
             }
@@ -52,7 +50,7 @@ class PopUpFoundMessageHandlerPlugin @Inject constructor(
         }
     }
 
-    override val type: String = "popupFound"
+    override val supportedTypes: List<String> = listOf("popupFound")
 
     private fun getDialogFragment(webView: WebView): DialogFragment {
         val dialog = TypewriterDaxDialog.newInstance(

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/SelfTestResultMessageHandlerPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/SelfTestResultMessageHandlerPlugin.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl.handlers
+
+import android.webkit.WebView
+import com.duckduckgo.autoconsent.api.AutoconsentCallback
+import com.duckduckgo.autoconsent.impl.MessageHandlerPlugin
+import com.duckduckgo.autoconsent.impl.adapters.JSONObjectAdapter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import timber.log.Timber
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class SelfTestResultMessageHandlerPlugin @Inject constructor() : MessageHandlerPlugin {
+
+    private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
+
+    override fun process(messageType: String, jsonString: String, webView: WebView, autoconsentCallback: AutoconsentCallback) {
+        if (supportedTypes.contains(messageType)) {
+            try {
+                val message: SelfTestResultMessage = parseMessage(jsonString) ?: return
+                autoconsentCallback.onResultReceived(consentManaged = true, optOutFailed = false, selfTestFailed = message.result)
+            } catch (e: Exception) {
+                Timber.d(e.localizedMessage)
+            }
+        }
+    }
+
+    override val supportedTypes: List<String> = listOf("selfTestResult")
+
+    private fun parseMessage(jsonString: String): SelfTestResultMessage? {
+        val jsonAdapter: JsonAdapter<SelfTestResultMessage> = moshi.adapter(SelfTestResultMessage::class.java)
+        return jsonAdapter.fromJson(jsonString)
+    }
+
+    data class SelfTestResultMessage(val type: String, val cmp: String, val result: Boolean, val url: String)
+}

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
@@ -40,7 +40,7 @@ class FakeMessageHandlerPlugin : MessageHandlerPlugin {
         count++
     }
 
-    override val type: String = "fake"
+    override val supportedTypes: List<String> = listOf("fake")
 }
 
 class FakeRepository : AutoconsentSettingsRepository {

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/EvalMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/EvalMessageHandlerPluginTest.kt
@@ -56,10 +56,10 @@ class EvalMessageHandlerPluginTest {
     @Test
     fun whenProcessMessageIfDoesNotParseDoNothing() {
         val message = """
-            {"type":"${evalMessageHandlerPlugin.type}", id: "myId", "code": "42==42"}
+            {"type":"${evalMessageHandlerPlugin.supportedTypes.first()}", id: "myId", "code": "42==42"}
         """.trimIndent()
 
-        evalMessageHandlerPlugin.process(evalMessageHandlerPlugin.type, message, webView, mockCallback)
+        evalMessageHandlerPlugin.process(evalMessageHandlerPlugin.supportedTypes.first(), message, webView, mockCallback)
 
         assertNull(shadowOf(webView).lastEvaluatedJavascript)
     }
@@ -76,14 +76,14 @@ class EvalMessageHandlerPluginTest {
             }
         })();
         """.trimIndent()
-        evalMessageHandlerPlugin.process(evalMessageHandlerPlugin.type, message("42==42"), webView, mockCallback)
+        evalMessageHandlerPlugin.process(evalMessageHandlerPlugin.supportedTypes.first(), message("42==42"), webView, mockCallback)
 
         assertEquals(expected, shadowOf(webView).lastEvaluatedJavascript)
     }
 
     @Test
     fun whenProcessMessageThenAndEvalTrueThenCorrectEvalRespSent() {
-        evalMessageHandlerPlugin.process(evalMessageHandlerPlugin.type, message("42==42"), webView, mockCallback)
+        evalMessageHandlerPlugin.process(evalMessageHandlerPlugin.supportedTypes.first(), message("42==42"), webView, mockCallback)
 
         val shadow = shadowOf(webView)
         shadow.lastEvaluatedJavascriptCallback.onReceiveValue("true")
@@ -98,7 +98,7 @@ class EvalMessageHandlerPluginTest {
 
     @Test
     fun whenProcessMessageThenAndEvalFalseThenCorrectEvalRespSent() {
-        evalMessageHandlerPlugin.process(evalMessageHandlerPlugin.type, message("41==42"), webView, mockCallback)
+        evalMessageHandlerPlugin.process(evalMessageHandlerPlugin.supportedTypes.first(), message("41==42"), webView, mockCallback)
 
         val shadow = shadowOf(webView)
         shadow.lastEvaluatedJavascriptCallback.onReceiveValue("false")
@@ -113,7 +113,7 @@ class EvalMessageHandlerPluginTest {
 
     private fun message(code: String): String {
         return """
-            {"type":"${evalMessageHandlerPlugin.type}", "id": "myId", "code": "$code"}
+            {"type":"${evalMessageHandlerPlugin.supportedTypes.first()}", "id": "myId", "code": "$code"}
         """.trimIndent()
     }
 

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPluginTest.kt
@@ -55,10 +55,10 @@ class InitMessageHandlerPluginTest {
     @Test
     fun whenProcessIfCannotParseMessageThenDoNothing() {
         val message = """
-            {"type":"${initHandlerPlugin.type}", url: "http://www.example.com"}
+            {"type":"${initHandlerPlugin.supportedTypes.first()}", url: "http://www.example.com"}
         """.trimIndent()
 
-        initHandlerPlugin.process(initHandlerPlugin.type, message, webView, mockCallback)
+        initHandlerPlugin.process(initHandlerPlugin.supportedTypes.first(), message, webView, mockCallback)
 
         assertNull(shadowOf(webView).lastEvaluatedJavascript)
     }
@@ -66,10 +66,10 @@ class InitMessageHandlerPluginTest {
     @Test
     fun whenProcessIfNotUrlSchemaThenDoNothing() {
         val message = """
-            {"type":"${initHandlerPlugin.type}", "url": "ftp://www.example.com"}
+            {"type":"${initHandlerPlugin.supportedTypes.first()}", "url": "ftp://www.example.com"}
         """.trimIndent()
 
-        initHandlerPlugin.process(initHandlerPlugin.type, message, webView, mockCallback)
+        initHandlerPlugin.process(initHandlerPlugin.supportedTypes.first(), message, webView, mockCallback)
 
         assertNull(shadowOf(webView).lastEvaluatedJavascript)
     }
@@ -79,7 +79,7 @@ class InitMessageHandlerPluginTest {
         repository.userSetting = false
         repository.firstPopupHandled = true
 
-        initHandlerPlugin.process(initHandlerPlugin.type, message(), webView, mockCallback)
+        initHandlerPlugin.process(initHandlerPlugin.supportedTypes.first(), message(), webView, mockCallback)
 
         assertNull(shadowOf(webView).lastEvaluatedJavascript)
     }
@@ -89,7 +89,7 @@ class InitMessageHandlerPluginTest {
         repository.userSetting = false
         repository.firstPopupHandled = false
 
-        initHandlerPlugin.process(initHandlerPlugin.type, message(), webView, mockCallback)
+        initHandlerPlugin.process(initHandlerPlugin.supportedTypes.first(), message(), webView, mockCallback)
 
         assertTrue(shadowOf(webView).lastEvaluatedJavascript.isNotBlank())
     }
@@ -99,7 +99,7 @@ class InitMessageHandlerPluginTest {
         repository.userSetting = false
         repository.firstPopupHandled = false
 
-        initHandlerPlugin.process(initHandlerPlugin.type, message(), webView, mockCallback)
+        initHandlerPlugin.process(initHandlerPlugin.supportedTypes.first(), message(), webView, mockCallback)
 
         val shadow = shadowOf(webView)
         val result = shadow.lastEvaluatedJavascript
@@ -116,7 +116,7 @@ class InitMessageHandlerPluginTest {
         repository.userSetting = true
         repository.firstPopupHandled = true
 
-        initHandlerPlugin.process(initHandlerPlugin.type, message(), webView, mockCallback)
+        initHandlerPlugin.process(initHandlerPlugin.supportedTypes.first(), message(), webView, mockCallback)
 
         val shadow = shadowOf(webView)
         val result = shadow.lastEvaluatedJavascript
@@ -130,7 +130,7 @@ class InitMessageHandlerPluginTest {
 
     private fun message(): String {
         return """
-            {"type":"${initHandlerPlugin.type}", "url": "http://www.example.com"}
+            {"type":"${initHandlerPlugin.supportedTypes.first()}", "url": "http://www.example.com"}
         """.trimIndent()
     }
 

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPluginTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl.handlers
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.autoconsent.api.AutoconsentCallback
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.robolectric.Shadows
+
+@RunWith(AndroidJUnit4::class)
+class OptOutAndAutoconsentDoneMessageHandlerPluginTest {
+
+    private val mockCallback: AutoconsentCallback = mock()
+    private val webView: WebView = WebView(InstrumentationRegistry.getInstrumentation().targetContext)
+
+    private val handler = OptOutAndAutoconsentDoneMessageHandlerPlugin()
+
+    @Test
+    fun whenProcessIfMessageTypeIsNotIncludedInListThenDoNothing() {
+        handler.process("noMatching", "", webView, mockCallback)
+
+        verifyNoInteractions(mockCallback)
+        assertNull(Shadows.shadowOf(webView).lastEvaluatedJavascript)
+    }
+
+    @Test
+    fun whenProcessIfCannotParseMessageThenDoNothing() {
+        val message = """
+            {"type":"${handler.supportedTypes}", url: "http://www.example.com", "cmp: "test"}
+        """.trimIndent()
+
+        handler.process(handler.supportedTypes.first(), message, webView, mockCallback)
+
+        verifyNoInteractions(mockCallback)
+        assertNull(Shadows.shadowOf(webView).lastEvaluatedJavascript)
+    }
+
+    @Test
+    fun whenProcessOptOutIfResultIsFailsThenSendResultWithFailure() {
+        handler.process(getOptOut(), optOutMessage(result = false, selfTest = false), webView, mockCallback)
+
+        verify(mockCallback).onResultReceived(consentManaged = true, optOutFailed = true, selfTestFailed = null)
+    }
+
+    @Test
+    fun whenProcessAutoconsentDoneIfCannotGetHostTHenDoNothing() {
+        handler.process(getAutoconsentType(), autoconsentDoneMessage("noHost"), webView, mockCallback)
+
+        verifyNoInteractions(mockCallback)
+        assertNull(Shadows.shadowOf(webView).lastEvaluatedJavascript)
+    }
+
+    @Test
+    fun whenProcessOptOutWithSelfTestThenAutoconsentCallsEvaluateJavascript() {
+        val expected = """
+        javascript:(function() {
+            window.autoconsentMessageCallback({ "type": "selfTest" }, window.origin);
+        })();
+        """.trimIndent()
+
+        handler.process(getOptOut(), optOutMessage(result = true, selfTest = true), webView, mockCallback)
+        handler.process(getAutoconsentType(), autoconsentDoneMessage(), webView, mockCallback)
+
+        assertEquals(expected, Shadows.shadowOf(webView).lastEvaluatedJavascript)
+    }
+
+    private fun getOptOut(): String = handler.supportedTypes.first()
+
+    private fun getAutoconsentType(): String = handler.supportedTypes.last()
+
+    private fun optOutMessage(result: Boolean, selfTest: Boolean): String {
+        return """
+            {"type":"${getOptOut()}", "result": $result, "scheduleSelfTest": $selfTest, "cmp": "test", "url": "http://www.example.com"}
+        """.trimIndent()
+    }
+
+    private fun autoconsentDoneMessage(url: String = "http://www.example.com"): String {
+        return """
+            {"type":"${getAutoconsentType()}", "cmp": "test", "url": "$url"}
+        """.trimIndent()
+    }
+}

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/PopUpFoundMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/PopUpFoundMessageHandlerPluginTest.kt
@@ -54,7 +54,7 @@ class PopUpFoundMessageHandlerPluginTest {
     fun whenProcessIfSettingEnabledThenDoNothing() {
         repository.userSetting = true
 
-        popupFoundHandler.process(popupFoundHandler.type, "", webView, mockCallback)
+        popupFoundHandler.process(popupFoundHandler.supportedTypes.first(), "", webView, mockCallback)
 
         assertNull(Shadows.shadowOf(webView).lastEvaluatedJavascript)
     }
@@ -63,7 +63,7 @@ class PopUpFoundMessageHandlerPluginTest {
     fun whenProcessIfSettingDisabledThenCallCallback() {
         repository.userSetting = false
 
-        popupFoundHandler.process(popupFoundHandler.type, "", webView, mockCallback)
+        popupFoundHandler.process(popupFoundHandler.supportedTypes.first(), "", webView, mockCallback)
 
         verify(mockCallback).onFirstPopUpHandled(any(), any())
     }
@@ -72,7 +72,7 @@ class PopUpFoundMessageHandlerPluginTest {
     fun whenProcessIfSettingDisabledThenFistPopupHandledSetToTrue() {
         repository.userSetting = false
 
-        popupFoundHandler.process(popupFoundHandler.type, "", webView, mockCallback)
+        popupFoundHandler.process(popupFoundHandler.supportedTypes.first(), "", webView, mockCallback)
 
         assertTrue(repository.firstPopupHandled)
     }

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/SelfTestResultMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/SelfTestResultMessageHandlerPluginTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl.handlers
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.autoconsent.api.AutoconsentCallback
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+@RunWith(AndroidJUnit4::class)
+class SelfTestResultMessageHandlerPluginTest {
+
+    private val mockCallback: AutoconsentCallback = mock()
+    private val webView: WebView = WebView(InstrumentationRegistry.getInstrumentation().targetContext)
+
+    private val selfTestPlugin = SelfTestResultMessageHandlerPlugin()
+
+    @Test
+    fun whenProcessIfMessageTypeIsNotSelfTestThenDoNothing() {
+        selfTestPlugin.process("noMatching", "", webView, mockCallback)
+
+        verifyNoInteractions(mockCallback)
+    }
+
+    @Test
+    fun whenProcessIfCannotParseMessageThenDoNothing() {
+        val message = """
+            {"type":"${selfTestPlugin.supportedTypes.first()}", cmp: "test", "result": true, "url": "http://example.com"}
+        """.trimIndent()
+
+        selfTestPlugin.process(selfTestPlugin.supportedTypes.first(), message, webView, mockCallback)
+
+        verifyNoInteractions(mockCallback)
+    }
+
+    @Test
+    fun whenProcessThenCallDashboardWithCorrectParameters() {
+        val message = """
+            {"type":"${selfTestPlugin.supportedTypes.first()}", "cmp": "test", "result": true, "url": "http://example.com"}
+        """.trimIndent()
+
+        selfTestPlugin.process(selfTestPlugin.supportedTypes.first(), message, webView, mockCallback)
+
+        verify(mockCallback).onResultReceived(consentManaged = true, optOutFailed = false, selfTestFailed = true)
+
+        val anotherMessage = """
+            {"type":"${selfTestPlugin.supportedTypes}", "cmp": "test", "result": false, "url": "http://example.com"}
+        """.trimIndent()
+
+        selfTestPlugin.process(selfTestPlugin.supportedTypes.first(), anotherMessage, webView, mockCallback)
+
+        verify(mockCallback).onResultReceived(consentManaged = true, optOutFailed = false, selfTestFailed = false)
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1202768897662116

### Description
This PRs adds support for OptOut, selfTest and autoconsentDone

### Steps to test this PR

- [x] Install the app, go to SERP and get rid of the Dax dialogs by clicking hide and hide tips forever.
- [x] Go to `https://www.lufthansa.com/de/en/homepage`
- [x] New Dax dialog should show up and you should see the cookie popup behind it.
- [x] Click Manage Cookie Pop-ups
- [x] Dax dialog and cookie pop-up should disappear
- [x] You should see a toast with a random message
- [x] Refresh the page and you should not see anything related with cookies (Dax dialog, pop-up or toast)
- [x] Go to `http://privacy-test-pages.glitch.me/features/autoconsent/`
- [x] You should see a toast with a random message and the button in the site should say `I was clicked`
- [x] Refreshing the site should trigger the same behaviour, toast should show and button should way `I was clicked`

