### PR TITLE
Ignore non-http app links that are not for mainframe

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -62,6 +62,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.verifyNoInteractions
 
 @ExperimentalCoroutinesApi
 class BrowserWebViewClientTest {
@@ -359,8 +360,22 @@ class BrowserWebViewClientTest {
             whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
             whenever(webResourceRequest.isRedirect).thenReturn(false)
             whenever(listener.handleNonHttpAppLink(any())).thenReturn(true)
+            whenever(webResourceRequest.isForMainFrame).thenReturn(true)
             assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
             verify(listener).handleNonHttpAppLink(urlType)
+        }
+    }
+
+    @Test
+    fun whenNonHttpAppLinkDetectedAndIsNotForMainframeThenOnlyReturnTrue() = runTest {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.isRedirect).thenReturn(false)
+            whenever(listener.handleNonHttpAppLink(any())).thenReturn(true)
+            whenever(webResourceRequest.isForMainFrame).thenReturn(false)
+            assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+            verifyNoInteractions(listener)
         }
     }
 
@@ -370,6 +385,7 @@ class BrowserWebViewClientTest {
             val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
             whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
             whenever(listener.handleNonHttpAppLink(any())).thenReturn(true)
+            whenever(webResourceRequest.isForMainFrame).thenReturn(true)
             assertTrue(testee.shouldOverrideUrlLoading(webView, EXAMPLE_URL))
             verify(listener).handleNonHttpAppLink(urlType)
         }
@@ -382,6 +398,7 @@ class BrowserWebViewClientTest {
             whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
             whenever(webResourceRequest.isRedirect).thenReturn(false)
             whenever(listener.handleNonHttpAppLink(any())).thenReturn(false)
+            whenever(webResourceRequest.isForMainFrame).thenReturn(true)
             assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
             verify(listener).handleNonHttpAppLink(urlType)
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -139,8 +139,10 @@ class BrowserWebViewClient(
                 }
                 is SpecialUrlDetector.UrlType.NonHttpAppLink -> {
                     Timber.i("Found non-http app link for ${urlType.uriString}")
-                    webViewClientListener?.let { listener ->
-                        return listener.handleNonHttpAppLink(urlType)
+                    if (isForMainFrame) {
+                        webViewClientListener?.let { listener ->
+                            return listener.handleNonHttpAppLink(urlType)
+                        }
                     }
                     true
                 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201994777472691/f

### Description
This PR adds a check to ignore non-http app links that are not from mainframe.

### Steps to test this PR

- [x] Go to https://variety.com/feature/2022-oscars-best-documentary-feature-predictions-1235072004/.
- [x] Verify that the "Unable to open this type of link" toast is not shown.

### UI changes
Before

https://user-images.githubusercontent.com/3471025/183907792-9daac406-c139-4d87-8cae-705c5a91c9b9.mp4

After

https://user-images.githubusercontent.com/3471025/183907850-07d6c5dd-7764-4cd4-af44-81798ebabfb5.mp4


