### PR TITLE
Add sharedPrefs flipper-plugin that considers Harmony prefs

### DIFF
--- a/app-tracking-protection/vpn-internal/build.gradle
+++ b/app-tracking-protection/vpn-internal/build.gradle
@@ -74,6 +74,9 @@ dependencies {
     implementation AndroidX.room.rxJava2
     implementation AndroidX.room.ktx
 
+    implementation "com.frybits.harmony:harmony:_"
+    implementation "com.facebook.flipper:flipper:_"
+
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
     testImplementation AndroidX.archCore.testing

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/flipper/PreferencesFlipperPlugin.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/flipper/PreferencesFlipperPlugin.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.vpn.internal.flipper
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
+import android.preference.PreferenceManager
+import androidx.core.content.edit
+import com.duckduckgo.di.scopes.AppScope
+import com.facebook.flipper.core.FlipperConnection
+import com.facebook.flipper.core.FlipperObject
+import com.facebook.flipper.core.FlipperPlugin
+import com.facebook.flipper.core.FlipperReceiver
+import com.frybits.harmony.getHarmonySharedPreferences
+import com.squareup.anvil.annotations.ContributesMultibinding
+import java.io.File
+import javax.inject.Inject
+
+private const val XML_SUFFIX = ".xml"
+private const val SHARED_PREFS_DIR = "shared_prefs"
+private const val HARMONY_PREFS_DIR = "harmony_prefs"
+
+@ContributesMultibinding(AppScope::class)
+class PreferencesFlipperPlugin @Inject constructor(context: Context) : FlipperPlugin {
+
+    private var connection: FlipperConnection? = null
+
+    private val onSharedPreferenceChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
+        val descriptor = this.sharedPreferences[sharedPreferences] ?: return@OnSharedPreferenceChangeListener
+
+        connection?.send(
+            "sharedPreferencesChange",
+            FlipperObject.Builder()
+                .put("preferences", descriptor.name)
+                .put("name", key)
+                .put("deleted", !sharedPreferences.contains(key))
+                .put("time", System.currentTimeMillis())
+                .put("value", sharedPreferences.all[key])
+                .build()
+        )
+    }
+
+    private lateinit var sharedPreferences: Map<SharedPreferences, SharedPreferencesDescriptor>
+
+    init {
+        val descriptors = buildDescriptorForAllPrefsFiles(context)
+        val prefs = HashMap<SharedPreferences, SharedPreferencesDescriptor>(descriptors.size)
+        descriptors.forEach { descriptor ->
+            descriptor.getSharedPreferences(context).run {
+                registerOnSharedPreferenceChangeListener(onSharedPreferenceChangeListener)
+                prefs[this] = descriptor
+            }
+        }
+        sharedPreferences = prefs
+    }
+
+    override fun getId(): String = "Preferences"
+
+    override fun onConnect(connection: FlipperConnection?) {
+        this.connection = connection
+
+        connection!!.receive(
+            "getAllSharedPreferences"
+        ) { _, responder ->
+            val builder = FlipperObject.Builder()
+            for ((key, value) in sharedPreferences.entries) {
+                builder.put(value.name, key.asFlipperObject())
+            }
+            responder.success(builder.build())
+        }
+
+        connection.receive(
+            "getSharedPreferences",
+            FlipperReceiver { params, responder ->
+                val name = params.getString("name")
+                if (name != null) {
+                    responder.success(getFlipperObjectFor(name))
+                }
+            }
+        )
+
+        connection.receive(
+            "setSharedPreference",
+            FlipperReceiver { params, responder ->
+                val sharedPreferencesName = params.getString("sharedPreferencesName")
+                val preferenceName = params.getString("preferenceName")
+                val sharedPrefs = getSharedPreferencesFor(sharedPreferencesName)
+                val originalValue = sharedPrefs.all[preferenceName]
+                sharedPrefs.edit {
+                    when (originalValue) {
+                        is Boolean -> {
+                            putBoolean(preferenceName, params.getBoolean("preferenceValue"))
+                        }
+                        is Long -> {
+                            putLong(preferenceName, params.getLong("preferenceValue"))
+                        }
+                        is Int -> {
+                            putInt(preferenceName, params.getInt("preferenceValue"))
+                        }
+                        is Float -> {
+                            putFloat(preferenceName, params.getFloat("preferenceValue"))
+                        }
+                        is String -> {
+                            putString(preferenceName, params.getString("preferenceValue"))
+                        }
+                        else -> {
+                            throw IllegalArgumentException("Type not supported: $preferenceName")
+                        }
+                    }
+                }
+                responder.success(getFlipperObjectFor(sharedPreferencesName))
+            }
+        )
+
+        connection.receive(
+            "deleteSharedPreference",
+            FlipperReceiver { params, responder ->
+                val sharedPreferencesName = params.getString("sharedPreferencesName")
+                val preferenceName = params.getString("preferenceName")
+                getSharedPreferencesFor(sharedPreferencesName).edit {
+                    remove(preferenceName)
+                }
+                responder.success(getFlipperObjectFor(sharedPreferencesName))
+            }
+        )
+
+    }
+
+    override fun onDisconnect() {
+        this.connection = null
+    }
+
+    override fun runInBackground(): Boolean = false
+
+    private data class SharedPreferencesDescriptor(
+        val name: String,
+        val mode: Int
+    ) {
+        fun getSharedPreferences(context: Context): SharedPreferences {
+            return if (mode == Context.MODE_MULTI_PROCESS) {
+                context.getHarmonySharedPreferences(name)
+            } else {
+                context.getSharedPreferences(name, mode)
+            }
+        }
+    }
+
+    private fun getFlipperObjectFor(name: String): FlipperObject {
+        return getSharedPreferencesFor(name).asFlipperObject()
+    }
+
+    private fun SharedPreferences.asFlipperObject(): FlipperObject {
+        return FlipperObject.Builder().apply {
+            all.forEach { entry ->
+                entry.key?.let {
+                    put(it, entry.value)
+                }
+            }
+        }.build()
+    }
+
+    private fun getSharedPreferencesFor(name: String): SharedPreferences {
+        return sharedPreferences.entries.first { it.value.name == name }.key
+    }
+
+    companion object {
+        private fun buildDescriptorForAllPrefsFiles(context: Context): List<SharedPreferencesDescriptor> {
+            // shared prefs
+            val dir = File(context.applicationInfo.dataDir, SHARED_PREFS_DIR)
+            val list = dir.list { _, name -> name.endsWith(XML_SUFFIX) }
+            val descriptors: MutableList<SharedPreferencesDescriptor> = ArrayList()
+            if (list != null) {
+                for (each in list) {
+                    val prefName = each.substring(0, each.indexOf(XML_SUFFIX))
+                    descriptors.add(SharedPreferencesDescriptor(prefName, Context.MODE_PRIVATE))
+                }
+            }
+
+            // default shared prefs
+            descriptors.add(SharedPreferencesDescriptor(getDefaultSharedPreferencesName(context), Context.MODE_PRIVATE))
+
+            // Harmony prefs go at the end to ensure they'll override the shared prefs
+            context.harmonyPrefsFolder().list()?.forEach { prefName ->
+                descriptors.add(SharedPreferencesDescriptor(prefName, Context.MODE_MULTI_PROCESS))
+            }
+
+            return descriptors
+        }
+
+        private fun getDefaultSharedPreferencesName(context: Context): String {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                PreferenceManager.getDefaultSharedPreferencesName(context)
+            } else {
+                context.packageName + "_preferences"
+            }
+        }
+    }
+}
+
+private fun Context.harmonyPrefsFolder(): File {
+    return File(filesDir, HARMONY_PREFS_DIR).apply {
+        if (!exists()) mkdirs()
+    }
+}

--- a/app/src/internal/java/com/duckduckgo/app/flipper/FlipperInitializer.kt
+++ b/app/src/internal/java/com/duckduckgo/app/flipper/FlipperInitializer.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.core.FlipperPlugin
 import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
-import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.soloader.SoLoader
 import com.squareup.anvil.annotations.ContributesMultibinding
 import timber.log.Timber
@@ -51,7 +50,6 @@ class FlipperInitializer @Inject constructor(
 
             // Common device plugins
             addPlugin(DatabasesFlipperPlugin(context))
-            addPlugin(SharedPreferencesFlipperPlugin(context))
 
             start()
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202290988165053/f

### Description
Create a flipper plugin that supports both sharedPreferences and Harmony shared preferences (used for multi-process)

### Steps to test this PR
- [x] build and install from this branch
- [x] launch the app
- [x] launch flipper app
- [x] verify the `com.duckduckgo.mobile.atp.cohort.prefs` appears under shared preferences
- [x] verify the `com.duckduckgo.mobile.android.device.shield.pixels` appears under shared preferences

