### PR TITLE
Add atb param to pixels only when needed

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
@@ -23,15 +23,14 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.InstantSchedulersRule
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.device.DeviceInfo
+import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_DASHBOARD_OPENED
 import com.duckduckgo.app.statistics.Variant
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.config.StatisticsLibraryConfig
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.model.PixelEntity
-import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_DASHBOARD_OPENED
-import com.duckduckgo.app.statistics.config.StatisticsLibraryConfig
 import com.duckduckgo.app.statistics.store.PendingPixelDao
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
-import org.mockito.kotlin.*
 import io.reactivex.Completable
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -40,6 +39,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.concurrent.TimeoutException
 
 class RxPixelSenderTest {
@@ -98,7 +104,7 @@ class RxPixelSenderTest {
 
         testee.sendPixel(PRIVACY_DASHBOARD_OPENED.pixelName, emptyMap(), emptyMap())
 
-        verify(api).fire(eq("mp"), eq("phone"), eq("atbvariant"), any(), any(), any())
+        verify(api).fire(eq("mp"), eq("phone"), any(), any(), any())
     }
 
     @Test
@@ -108,7 +114,7 @@ class RxPixelSenderTest {
 
         testee.sendPixel(PRIVACY_DASHBOARD_OPENED.pixelName, emptyMap(), emptyMap())
 
-        verify(api).fire(eq("mp"), eq("tablet"), eq(""), any(), any(), any())
+        verify(api).fire(eq("mp"), eq("tablet"), any(), any(), any())
     }
 
     @Test
@@ -118,7 +124,7 @@ class RxPixelSenderTest {
 
         testee.sendPixel(PRIVACY_DASHBOARD_OPENED.pixelName, emptyMap(), emptyMap())
 
-        verify(api).fire(eq("mp"), eq("phone"), eq(""), any(), any(), any())
+        verify(api).fire(eq("mp"), eq("phone"), any(), any(), any())
     }
 
     @Test
@@ -133,7 +139,7 @@ class RxPixelSenderTest {
         val expectedParams = mapOf("param1" to "value1", "param2" to "value2", "appVersion" to "1.0.0")
         testee.sendPixel(PRIVACY_DASHBOARD_OPENED.pixelName, params, emptyMap())
 
-        verify(api).fire("mp", "phone", "atbvariant", expectedParams, emptyMap())
+        verify(api).fire("mp", "phone", expectedParams, emptyMap())
     }
 
     @Test
@@ -147,7 +153,7 @@ class RxPixelSenderTest {
         testee.sendPixel(PRIVACY_DASHBOARD_OPENED.pixelName, emptyMap(), emptyMap())
 
         val expectedParams = mapOf("appVersion" to "1.0.0")
-        verify(api).fire("mp", "phone", "atbvariant", expectedParams, emptyMap())
+        verify(api).fire("mp", "phone", expectedParams, emptyMap())
     }
 
     @Test
@@ -212,7 +218,7 @@ class RxPixelSenderTest {
         testee.onStart(mockLifecycleOwner)
 
         verify(api).fire(
-            pixelEntity.pixelName, "phone", pixelEntity.atb, pixelEntity.additionalQueryParams, pixelEntity.encodedQueryParams
+            pixelEntity.pixelName, "phone", pixelEntity.additionalQueryParams, pixelEntity.encodedQueryParams
         )
     }
 
@@ -268,7 +274,7 @@ class RxPixelSenderTest {
         testee.onStart(mockLifecycleOwner)
 
         verify(api, times(5)).fire(
-            pixelEntity.pixelName, "phone", pixelEntity.atb, pixelEntity.additionalQueryParams, pixelEntity.encodedQueryParams
+            pixelEntity.pixelName, "phone", pixelEntity.additionalQueryParams, pixelEntity.encodedQueryParams
         )
     }
 
@@ -288,7 +294,7 @@ class RxPixelSenderTest {
     }
 
     private fun givenApiSendPixelSucceeds() {
-        whenever(api.fire(any(), any(), any(), any(), any(), any())).thenReturn(Completable.complete())
+        whenever(api.fire(any(), any(), any(), any(), any())).thenReturn(Completable.complete())
     }
 
     private fun givenVariant(variant: Variant) {
@@ -304,11 +310,11 @@ class RxPixelSenderTest {
     }
 
     private fun givenPixelApiSucceeds() {
-        whenever(api.fire(any(), any(), any(), anyOrNull(), any(), any())).thenReturn(Completable.complete())
+        whenever(api.fire(any(), any(), anyOrNull(), any(), any())).thenReturn(Completable.complete())
     }
 
     private fun givenPixelApiFails() {
-        whenever(api.fire(any(), any(), any(), anyOrNull(), any(), any())).thenReturn(Completable.error(TimeoutException()))
+        whenever(api.fire(any(), any(), anyOrNull(), any(), any())).thenReturn(Completable.error(TimeoutException()))
     }
 
     private fun PendingPixelDao.insert(

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelAddAtbQueryParamInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelAddAtbQueryParamInterceptor.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import androidx.annotation.VisibleForTesting
+import com.duckduckgo.app.global.AppUrl
+import com.duckduckgo.app.global.plugins.pixel.PixelInterceptorPlugin
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.store.StatisticsDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelInterceptorPlugin::class
+)
+class PixelAddAtbQueryParamInterceptor @Inject constructor(
+    private val statisticsDataStore: StatisticsDataStore,
+    private val variantManager: VariantManager,
+) : Interceptor, PixelInterceptorPlugin {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+        val pixel = chain.request().url.pathSegments.last()
+
+        val url = if (PIXELS_SET.contains(getPixelName(pixel))) {
+            chain.request().url.newBuilder().addQueryParameter(AppUrl.ParamKey.ATB, getAtbInfo()).build()
+        } else {
+            chain.request().url
+        }
+
+        return chain.proceed(request.url(url).build())
+    }
+
+    override fun getInterceptor(): Interceptor = this
+
+    private fun getPixelName(pixel: String): String {
+        val suffixIndex = pixel.indexOf(PIXEL_PLATFORM_SUFFIX).takeIf { it > 0 } ?: 0
+        return pixel.substring(0, suffixIndex)
+    }
+
+    private fun getAtbInfo() = statisticsDataStore.atb?.formatWithVariant(variantManager.getVariant()) ?: ""
+
+    companion object {
+        private const val PIXEL_PLATFORM_SUFFIX = "_android"
+
+        @VisibleForTesting
+        internal val PIXELS_SET = setOf(
+            AppPixelName.PRIVACY_DASHBOARD_OPENED.pixelName,
+            AppPixelName.PRIVACY_DASHBOARD_SCORECARD.pixelName,
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelEmailRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelEmailRemovalInterceptor.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.global.api
 
 import androidx.annotation.VisibleForTesting
-import com.duckduckgo.app.global.AppUrl
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import okhttp3.Interceptor
@@ -29,7 +28,6 @@ class PixelEmailRemovalInterceptor : Interceptor {
         val pixel = chain.request().url.pathSegments.last()
         val url = if (pixels.contains(pixel.substringBefore("_android_"))) {
             chain.request().url.newBuilder()
-                .removeAllQueryParameters(AppUrl.ParamKey.ATB)
                 .removeAllQueryParameters(Pixel.PixelParameter.APP_VERSION)
                 .build()
         } else {

--- a/app/src/test/java/com/duckduckgo/app/global/api/PixelAddAtbQueryParamInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/api/PixelAddAtbQueryParamInterceptorTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import com.duckduckgo.app.global.api.PixelAddAtbQueryParamInterceptor.Companion.PIXELS_SET
+import com.duckduckgo.app.statistics.Variant
+import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.model.Atb
+import com.duckduckgo.app.statistics.store.StatisticsDataStore
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class PixelAddAtbQueryParamInterceptorTest {
+
+    private lateinit var pixelAddAtbQueryParamInterceptor: PixelAddAtbQueryParamInterceptor
+    private val mockStatisticsDataStore: StatisticsDataStore = mock()
+    private val mockVariantManager: VariantManager = mock()
+
+    @Before
+    fun setup() {
+        pixelAddAtbQueryParamInterceptor = PixelAddAtbQueryParamInterceptor(
+            mockStatisticsDataStore,
+            mockVariantManager
+        )
+    }
+
+    @Test
+    fun whenSendPixelWithNameInSetThenAddAtbInfo() {
+        givenVariant()
+        givenAtbVariant()
+        PIXELS_SET.forEach { pixelName ->
+            val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
+
+            val result = pixelAddAtbQueryParamInterceptor.intercept(FakeChain(pixelUrl)).request.url
+
+            assertNotNull(result.queryParameter("atb"))
+        }
+    }
+
+    @Test
+    fun whenSendPixelWithNameNotInSetThenDoNotAddAtbInfo() {
+        givenVariant()
+        givenAtbVariant()
+
+        val pixelName = "pixel_name"
+        assertTrue(!PIXELS_SET.contains(pixelName))
+
+        val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
+
+        val result = pixelAddAtbQueryParamInterceptor.intercept(FakeChain(pixelUrl)).request.url
+
+        assertNull(result.queryParameter("atb"))
+    }
+
+    private fun givenVariant() {
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("variant", filterBy = { true }))
+    }
+
+    private fun givenAtbVariant() {
+        whenever(mockStatisticsDataStore.atb).thenReturn(Atb("atb"))
+    }
+
+    companion object {
+        private const val PIXEL_TEMPLATE = "https://improving.duckduckgo.com/t/%s_android_phone?appVersion=5.132.1"
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/global/api/PixelEmailRemovalInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/api/PixelEmailRemovalInterceptorTest.kt
@@ -36,7 +36,6 @@ class PixelEmailRemovalInterceptorTest {
             val removalExpected = PixelEmailRemovalInterceptor.pixels.contains(pixelName)
 
             val interceptedUrl = pixelEmailRemovalInterceptor.intercept(FakeChain(pixelUrl)).request.url
-            assertEquals(removalExpected, interceptedUrl.queryParameter("atb") == null)
             assertEquals(removalExpected, interceptedUrl.queryParameter("appVersion") == null)
         }
     }

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelSender.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelSender.kt
@@ -99,7 +99,6 @@ class RxPixelSender constructor(
         return api.fire(
             pixelName,
             getDeviceFactor(),
-            getAtbInfo(),
             addDeviceParametersTo(parameters),
             encodedParameters,
             devMode = shouldFirePixelsAsDev
@@ -127,7 +126,6 @@ class RxPixelSender constructor(
             return api.fire(
                 this.pixelName,
                 getDeviceFactor(),
-                this.atb,
                 this.additionalQueryParams,
                 this.encodedQueryParams,
                 devMode = shouldFirePixelsAsDev

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelService.kt
@@ -30,7 +30,6 @@ interface PixelService {
     fun fire(
         @Path("pixelName") pixelName: String,
         @Path("formFactor") formFactor: String,
-        @Query(AppUrl.ParamKey.ATB) atb: String,
         @QueryMap additionalQueryParams: Map<String, String> = emptyMap(),
         @QueryMap(encoded = true) encodedQueryParams: Map<String, String> = emptyMap(),
         @Query(AppUrl.ParamKey.DEV_MODE) devMode: Int? = if (BuildConfig.DEBUG) 1 else null


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202771046815554/f

### Description
Removed atb param added by default to all pixels. Added interceptor to include atb param for specific pixels.

### Steps to test this PR

- fresh install from this branch
- open logcat and filter by `Pixel url request: https://improving.duckduckgo.com`
- open the app, navigate to a url
- open the privacy dashboard
- open the scorecard
- check in logcat the no pixel urls contain the `atb` param apart the ones starting with `mp_android` or `mp_c_android` [WIP, not the real pixels]

### NO UI changes
