### PR TITLE
Autofill management: Better state handling 

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
@@ -191,7 +191,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
         when (viewModel.viewState.value.credentialMode) {
             is Editing -> viewModel.onCancelEditMode()
             is Viewing -> if (supportFragmentManager.backStackEntryCount > 1) {
-                viewModel.viewState.value.credentialMode
+                viewModel.onExitCredentialMode()
             } else {
                 super.onBackPressed()
             }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -60,8 +60,40 @@ class AutofillSettingsViewModel @Inject constructor(
         addCommand(ShowCredentialMode(credentials))
     }
 
-    fun onEditCredentials(loginCredentials: LoginCredentials) {
-        _viewState.value = viewState.value.copy(credentialMode = Editing(credentialsViewed = loginCredentials))
+    fun onEditCredentials(
+        credentials: LoginCredentials,
+        isFromViewMode: Boolean
+    ) {
+        if (!isFromViewMode) {
+            addCommand(ShowCredentialMode(credentials))
+        }
+        _viewState.value = viewState.value.copy(credentialMode = Editing(credentialsViewed = credentials, isFromViewMode = isFromViewMode))
+    }
+
+    fun onCancelEditMode() {
+        viewState.value.let { value ->
+            value.credentialMode.let {
+                // if not from view mode, it means edit mode was opened directly
+                if (it is Editing && it.isFromViewMode) {
+                    _viewState.value = value.copy(credentialMode = Viewing(credentialsViewed = it.credentialsViewed))
+                } else {
+                    onExitViewMode()
+                }
+            }
+        }
+    }
+
+    fun onExitViewMode() {
+        _viewState.value = viewState.value.copy(credentialMode = NotInCredentialMode)
+        addCommand(ExitCredentialMode)
+    }
+
+    fun allowSaveInEditMode(saveable: Boolean) {
+        _viewState.value.credentialMode.let { credentialMode ->
+            if (credentialMode is Editing) {
+                _viewState.value = _viewState.value.copy(credentialMode = credentialMode.copy(saveable = saveable))
+            }
+        }
     }
 
     fun launchDeviceAuth() {
@@ -70,17 +102,21 @@ class AutofillSettingsViewModel @Inject constructor(
 
     fun lock() {
         if (!viewState.value.isLocked) {
+            _viewState.value = viewState.value.copy(isLocked = true)
             addCommand(ShowLockedMode)
         }
     }
 
     fun unlock() {
+        addCommand(ExitLockedMode)
         _viewState.value = viewState.value.copy(isLocked = false, credentialMode = NotInCredentialMode)
-        addCommand(ShowListMode)
     }
 
     fun disabled() {
         _viewState.value = viewState.value.copy(isLocked = true, credentialMode = NotInCredentialMode)
+        // Remove backstack modes if they are present
+        addCommand(ExitCredentialMode)
+        addCommand(ExitLockedMode)
         addCommand(ShowDisabledMode)
     }
 
@@ -120,13 +156,13 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     fun updateCredentials(updatedCredentials: LoginCredentials) {
-        _viewState.value.credentialMode.credentialsViewed?.let {
+        _viewState.value.credentialMode.credentialsViewed?.let { originalCredentials ->
             viewModelScope.launch {
-                autofillStore.updateCredentials(updatedCredentials.copy(id = it.id))
-                autofillStore.getCredentialsWithId(it.id!!)?.let { credentials ->
+                autofillStore.updateCredentials(updatedCredentials.copy(id = originalCredentials.id))
+                autofillStore.getCredentialsWithId(originalCredentials.id!!)?.let { credentialsWithLastUpdatedTimeUpdated ->
                     _viewState.value = viewState.value.copy(
                         credentialMode = Viewing(
-                            credentialsViewed = credentials
+                            credentialsViewed = credentialsWithLastUpdatedTimeUpdated
                         )
                     )
                 }
@@ -144,25 +180,6 @@ class AutofillSettingsViewModel @Inject constructor(
         _viewState.value = viewState.value.copy(autofillEnabled = false)
     }
 
-    fun onCancelEditMode() {
-        viewState.value.credentialMode.credentialsViewed?.let {
-            _viewState.value = viewState.value.copy(credentialMode = Viewing(credentialsViewed = it))
-        }
-    }
-
-    fun onExitViewMode() {
-        _viewState.value = viewState.value.copy(credentialMode = NotInCredentialMode)
-        addCommand(ShowListMode)
-    }
-
-    fun allowSaveInEditMode(saveable: Boolean) {
-        _viewState.value.credentialMode.let { credentialMode ->
-            if (credentialMode is Editing) {
-                _viewState.value = _viewState.value.copy(credentialMode = credentialMode.copy(saveable = saveable))
-            }
-        }
-    }
-
     data class ViewState(
         val autofillEnabled: Boolean = true,
         val logins: List<LoginCredentials> = emptyList(),
@@ -174,7 +191,8 @@ class AutofillSettingsViewModel @Inject constructor(
         data class Viewing(override val credentialsViewed: LoginCredentials) : CredentialMode(credentialsViewed)
         data class Editing(
             override val credentialsViewed: LoginCredentials,
-            val saveable: Boolean = true
+            val saveable: Boolean = true,
+            val isFromViewMode: Boolean
         ) : CredentialMode(credentialsViewed)
 
         object NotInCredentialMode : CredentialMode(null)
@@ -184,9 +202,10 @@ class AutofillSettingsViewModel @Inject constructor(
         class ShowUserUsernameCopied : Command()
         class ShowUserPasswordCopied : Command()
         data class ShowCredentialMode(val credentials: LoginCredentials) : Command()
-        object ShowListMode : Command()
         object ShowDisabledMode : Command()
         object ShowLockedMode : Command()
         object LaunchDeviceAuth : Command()
+        object ExitCredentialMode : Command()
+        object ExitLockedMode : Command()
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -65,7 +65,8 @@ class AutofillSettingsViewModel @Inject constructor(
         isFromViewMode: Boolean
     ) {
         if (!isFromViewMode) {
-            addCommand(ShowCredentialMode(credentials, !isFromViewMode))
+            // On the event that Edit mode is launched directly, we don't treat it as starting view mode since atm we will show view mode when saved.
+            addCommand(ShowCredentialMode(credentials, false))
         }
         _viewState.value = viewState.value.copy(credentialMode = Editing(credentialsViewed = credentials, isFromViewMode = isFromViewMode))
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/FragmentUtils.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/FragmentUtils.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.commit
+import com.duckduckgo.autofill.impl.R
+
+fun FragmentManager.forceExitFragment(tag: String) {
+    commit {
+        findFragmentByTag(tag)?.let { this.remove(it) }
+        popBackStackImmediate()
+    }
+}
+
+fun FragmentManager.showFragment(
+    fragment: Fragment,
+    tag: String,
+    shouldAddToBackStack: Boolean
+) {
+    if (findFragmentByTag(tag) == null) {
+        commit {
+            setReorderingAllowed(true)
+            replace(R.id.fragment_container_view, fragment, tag)
+            if (shouldAddToBackStack) addToBackStack(tag)
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -100,7 +100,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(), MenuProvider {
         return when (menuItem.itemId) {
             R.id.view_menu_edit -> {
                 viewModel.viewState.value.credentialMode.credentialsViewed?.let {
-                    viewModel.onEditCredentials(it)
+                    viewModel.onEditCredentials(it, true)
                 }
                 true
             }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -108,7 +108,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(), MenuProvider {
                 viewModel.viewState.value.credentialMode.credentialsViewed?.let {
                     viewModel.onDeleteCredentials(it)
                 }
-                viewModel.onExitViewMode()
+                viewModel.onExitCredentialMode()
                 true
             }
             R.id.view_menu_save -> {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -217,7 +217,10 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(), MenuProvider {
                             populateFields(state.credentialMode.credentialsViewed)
                             showViewMode(state.credentialMode.credentialsViewed)
                         }
-                        is Editing -> showEditMode()
+                        is Editing -> {
+                            populateFields(state.credentialMode.credentialsViewed)
+                            showEditMode()
+                        }
                         else -> {
                         }
                     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -18,12 +18,10 @@ package com.duckduckgo.autofill.ui.credential.management.viewing
 
 import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.MenuProvider
@@ -43,11 +41,12 @@ import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewMode
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Viewing
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.ui.view.OutLinedTextInputView
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @InjectWith(FragmentScope::class)
-class AutofillManagementCredentialsMode : DuckDuckGoFragment(), MenuProvider {
+class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_autofill_management_edit_mode), MenuProvider {
 
     @Inject
     lateinit var faviconManager: FaviconManager
@@ -65,17 +64,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(), MenuProvider {
         ViewModelProvider(requireActivity(), viewModelFactory)[AutofillSettingsViewModel::class.java]
     }
 
-    private lateinit var binding: FragmentAutofillManagementEditModeBinding
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = FragmentAutofillManagementEditModeBinding.inflate(inflater, container, false)
-        requireActivity().addMenuProvider(this)
-        return binding.root
-    }
+    private val binding: FragmentAutofillManagementEditModeBinding by viewBinding()
 
     override fun onPrepareMenu(menu: Menu) {
         if (viewModel.viewState.value.credentialMode is Editing) {
@@ -124,6 +113,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(), MenuProvider {
         savedInstanceState: Bundle?
     ) {
         super.onViewCreated(view, savedInstanceState)
+        requireActivity().addMenuProvider(this)
         observeViewModel()
         binding.watchSaveState(saveStateWatcher) {
             viewModel.allowSaveInEditMode(it)
@@ -184,6 +174,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(), MenuProvider {
         updateToolbarForView(credentials)
         binding.apply {
             domainTitleEditText.visibility = View.GONE
+            lastUpdatedView.visibility = View.VISIBLE
             domainTitleEditText.isEditable = false
             usernameEditText.isEditable = false
             passwordEditText.isEditable = false
@@ -196,6 +187,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(), MenuProvider {
         updateToolbarForEdit()
         binding.apply {
             domainTitleEditText.visibility = View.VISIBLE
+            lastUpdatedView.visibility = View.GONE
             domainTitleEditText.isEditable = true
             usernameEditText.isEditable = true
             passwordEditText.isEditable = true
@@ -218,7 +210,9 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(), MenuProvider {
                             showViewMode(state.credentialMode.credentialsViewed)
                         }
                         is Editing -> {
-                            populateFields(state.credentialMode.credentialsViewed)
+                            if (!state.credentialMode.isFromViewMode) {
+                                populateFields(state.credentialMode.credentialsViewed)
+                            }
                             showEditMode()
                         }
                         else -> {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -136,7 +136,7 @@ class AutofillManagementListMode : DuckDuckGoFragment() {
     }
 
     private fun onCredentialsSelected(credentials: LoginCredentials) {
-        viewModel.onViewCredentials(credentials)
+        viewModel.onViewCredentials(credentials, false)
     }
 
     private fun onCopyUsername(credentials: LoginCredentials) {

--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_disabled.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_disabled.xml
@@ -17,6 +17,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?attr/colorPrimaryDark"
     android:fillViewport="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_edit_mode.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_edit_mode.xml
@@ -17,7 +17,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorPrimaryDark">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -31,8 +32,8 @@
             android:id="@+id/domainTitleEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/credentialManagementEditLoginTitleHint"
             android:layout_marginBottom="@dimen/keyline_5"
+            android:hint="@string/credentialManagementEditLoginTitleHint"
             android:visibility="gone"
             app:editable="true"
             app:endIconContentDescription="@string/credentialManagementEditButtonCopyUsername" />
@@ -77,9 +78,9 @@
             android:id="@+id/lastUpdatedView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_4"
             android:textAppearance="@style/TextAppearance.DuckDuckGo.Caption"
-            android:textColor="?attr/secondaryTextColor"
-            android:layout_marginTop="@dimen/keyline_4"/>
+            android:textColor="?attr/secondaryTextColor" />
 
     </LinearLayout>
 

--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
@@ -14,21 +14,21 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?attr/colorPrimaryDark"
     tools:context="com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementListMode">
 
     <TextView
         android:id="@+id/enabledToggleLabel"
         style="@style/TextAppearance.AppCompat.Title"
-        android:layout_marginStart="@dimen/keyline_4"
-        android:layout_marginTop="30dp"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_4"
+        android:layout_marginTop="30dp"
         android:text="@string/credentialManagementAutofillToggleLabel"
         app:layout_constraintEnd_toStartOf="@id/enabledToggle"
         app:layout_constraintStart_toStartOf="parent"
@@ -39,10 +39,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/keyline_4"
-        android:gravity="center_vertical"
         android:layout_marginEnd="@dimen/keyline_4"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:gravity="center_vertical"
         app:layout_constraintBottom_toBottomOf="@id/enabledToggleLabel"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/enabledToggleLabel" />
 
     <androidx.recyclerview.widget.RecyclerView

--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_locked.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_locked.xml
@@ -18,6 +18,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?attr/colorPrimaryDark"
     android:fillViewport="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -93,12 +93,27 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
-    fun whenOnViewCredentialsCalledThenShowCredentialViewingMode() = runTest {
+    fun whenOnViewCredentialsCalledFromListThenShowCredentialViewingMode() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials)
+        testee.onViewCredentials(credentials, false)
 
         testee.commands.test {
-            awaitItem().first().assertCommandType(ShowCredentialMode::class)
+            assertEquals(ShowCredentialMode(credentials, false), awaitItem().first())
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState.test {
+            assertEquals(CredentialMode.Viewing(credentials), this.awaitItem().credentialMode)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenOnViewCredentialsCalledFirstThenShowCredentialViewingMode() = runTest {
+        val credentials = someCredentials()
+        testee.onViewCredentials(credentials, true)
+
+        testee.commands.test {
+            assertEquals(ShowCredentialMode(credentials, true), awaitItem().first())
             cancelAndIgnoreRemainingEvents()
         }
         testee.viewState.test {
@@ -242,8 +257,8 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
-    fun whenOnExitViewModeThenExitCredentialMode() = runTest {
-        testee.onExitViewMode()
+    fun whenOnExitCredentialModeThenExitCredentialMode() = runTest {
+        testee.onExitCredentialMode()
 
         testee.viewState.test {
             assertEquals(CredentialMode.NotInCredentialMode, this.awaitItem().credentialMode)
@@ -262,7 +277,6 @@ class AutofillSettingsViewModelTest {
 
         testee.viewState.test {
             val finalResult = this.expectMostRecentItem()
-            assertEquals(CredentialMode.NotInCredentialMode, finalResult.credentialMode)
             assertTrue(finalResult.isLocked)
             cancelAndIgnoreRemainingEvents()
         }
@@ -282,7 +296,7 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenAllowSaveInEditModeSetToFalseThenUpdateViewStateToEditingSaveableFalse() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials)
+        testee.onViewCredentials(credentials, true)
         testee.onEditCredentials(credentials, true)
 
         testee.allowSaveInEditMode(false)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202659292537112/f

### Description
This PR includes:
- Adding support to launch edit mode directly through viewmodel
- Adding support to launch view mode autofill credential management 
- Fixing handling for config chnages / backgrounding for credential mode

### Steps to test this PR

_Autofill management works as expected!_
- [x] Save a few credentials
- [x] Open management through overflow and settings.
- [x] Verify that list mode is shown as expected.
- [x] Open a credential.
- [x] Verify that credential mode is displayed with correct values and aligned to design.
- [x] Select edit from context menu.
- [x] Verify that edit mode is displayed with correct values and aligned to design.
- [x] Press back. Verify that back button works as expected all the way to exiting the management screen.
- [x] Repeat the steps above and try saving in edit mode.
- [x] Verify that user is returned to view mode with saved values updated.
- [x] Repeat the steps above and try deleting. Verify that it works as expected.

_Handling back/config changes_
- [x] Save a few credentials
- [x] In list mode, try backgrounding app and changing config. Verify that state is retained correctly.
- [x] Press back and verify that backstack is as expected.
- [x] Go to credential view mode. Try backgrounding app and changing config. Verify that state is retained correctly.
- [x] Press back and verify that backstack is as expected.
- [x] Go to credential edit mode. Try backgrounding app and changing config. Verify that state is retained correctly.
- [x] Press back and verify that backstack is as expected.
- [x] In all pages, try backgrounding the app and cancelling the device auth. Verify that autofill management is exited.

