### PR TITLE
Remove the atb param from ad click pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptor.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import androidx.annotation.VisibleForTesting
+import com.duckduckgo.adclick.impl.pixels.AdClickPixelName
+import com.duckduckgo.app.global.AppUrl
+import com.duckduckgo.app.global.plugins.pixel.PixelInterceptorPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelInterceptorPlugin::class
+)
+class PixelAdClickAttributionRemovalInterceptor @Inject constructor() : Interceptor, PixelInterceptorPlugin {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+        val pixel = chain.request().url.pathSegments.last()
+
+        val url = if (PIXELS_SET.contains(getPixelName(pixel))) {
+            chain.request().url.newBuilder()
+                .removeAllQueryParameters(AppUrl.ParamKey.ATB)
+                .build()
+        } else {
+            chain.request().url
+        }
+
+        return chain.proceed(request.url(url).build())
+    }
+
+    override fun getInterceptor(): Interceptor = this
+
+    private fun getPixelName(pixel: String): String {
+        val suffixIndex = pixel.indexOf(PIXEL_PLATFORM_SUFFIX).takeIf { it > 0 } ?: 0
+        return pixel.substring(0, suffixIndex)
+    }
+
+    companion object {
+        private const val PIXEL_PLATFORM_SUFFIX = "_android"
+
+        @VisibleForTesting
+        internal val PIXELS_SET = setOf(
+            AdClickPixelName.AD_CLICK_DETECTED.pixelName,
+            AdClickPixelName.AD_CLICK_ACTIVE.pixelName,
+        )
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptorTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.api
+
+import com.duckduckgo.adclick.impl.pixels.AdClickPixelName
+import com.duckduckgo.app.global.api.PixelAdClickAttributionRemovalInterceptor.Companion.PIXELS_SET
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class PixelAdClickAttributionRemovalInterceptorTest {
+    private lateinit var interceptor: PixelAdClickAttributionRemovalInterceptor
+
+    @Before
+    fun setup() {
+        interceptor = PixelAdClickAttributionRemovalInterceptor()
+    }
+
+    @Test
+    fun whenSendPixelTheRemoveAtbInfoFromDefinedPixels() {
+        AdClickPixelName.values().map { it.pixelName }.forEach { pixelName ->
+            val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
+            val removalExpected = PIXELS_SET.contains(pixelName)
+
+            val interceptedUrl = interceptor.intercept(FakeChain(pixelUrl)).request.url
+
+            assertEquals(removalExpected, interceptedUrl.queryParameter("atb") == null)
+        }
+    }
+
+    companion object {
+        private const val PIXEL_TEMPLATE = "https://improving.duckduckgo.com/t/%s_android_phone?atb=v337-7&appVersion=5.132.1&test=1"
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202783564212781/f

### Description
Added interceptor to remove atb param from ad click pixels.

### Steps to test this PR

- fresh install from this branch
- open logcat and filter by `Pixel url request: https://improving.duckduckgo.com/t/m_ad_click_`
- open the app, search for `PlayStation`
- click on one of the ads from `onbuy.com`
- check in logcat than you see the `m_ad_click_detected` and `m_ad_click_active` pixles with no atb params.

### NO UI changes
