### PR TITLE
Fix broken site reports

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteData.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteData.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.brokensite
 import android.net.Uri
 import com.duckduckgo.app.global.baseHost
 import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 
 data class BrokenSiteData(
     val url: String,
@@ -31,7 +32,9 @@ data class BrokenSiteData(
     companion object {
         fun fromSite(site: Site?): BrokenSiteData {
             val events = site?.trackingEvents
-            val blockedTrackers = events?.map { Uri.parse(it.trackerUrl).host }.orEmpty().distinct().joinToString(",")
+            val blockedTrackers = events?.filter { it.status == TrackerStatus.BLOCKED }
+                ?.map { Uri.parse(it.trackerUrl).host }
+                .orEmpty().distinct().joinToString(",")
             val upgradedHttps = site?.upgradedHttps ?: false
             val surrogates = site?.surrogates?.map { Uri.parse(it.name).baseHost }.orEmpty().distinct().joinToString(",")
             val url = site?.url.orEmpty()

--- a/app/src/test/java/com/duckduckgo/app/brokensite/BrokenSiteDataTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/BrokenSiteDataTest.kt
@@ -91,7 +91,7 @@ class BrokenSiteDataTest {
             categories = emptyList(),
             entity = null,
             surrogateId = null,
-            status = TrackerStatus.ALLOWED,
+            status = TrackerStatus.BLOCKED,
             type = TrackerType.OTHER
         )
         val anotherEvent = TrackingEvent(
@@ -105,7 +105,7 @@ class BrokenSiteDataTest {
         )
         site.trackerDetected(event)
         site.trackerDetected(anotherEvent)
-        assertEquals("www.tracker.com,www.anothertracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
+        assertEquals("www.tracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
     }
 
     @Test
@@ -117,7 +117,7 @@ class BrokenSiteDataTest {
             categories = emptyList(),
             entity = null,
             surrogateId = null,
-            status = TrackerStatus.ALLOWED,
+            status = TrackerStatus.BLOCKED,
             type = TrackerType.OTHER
         )
         val anotherEvent = TrackingEvent(
@@ -126,7 +126,7 @@ class BrokenSiteDataTest {
             categories = emptyList(),
             entity = null,
             surrogateId = null,
-            status = TrackerStatus.ALLOWED,
+            status = TrackerStatus.BLOCKED,
             type = TrackerType.OTHER
         )
         site.trackerDetected(event)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1202794100930314

### Description
After changing the trackers algorithm we broke broken sites a bit. We send the full list of domains that we intercept instead of only the ones that we blocked.

### Steps to test this PR

- [x] Install the app
- [x] Go to `play.google.com`
- [x] Go to the privacy dashboard
- [x] You should see `No tracking requests blocked`
- [x] Report the site as broken using the button on that scree
- [x] In the logcat filter by `Pixel sent: epbf`
- [x] The blockedTrackers parameter should be empty
- [x] Do the same but this time from `cnn.com`
- [x] The privacy dashboard should say this time `Requests blocked from loading`
- [x] The blockedTrackers parameter should not be empty
