### PR TITLE
Show snackbar when saving/updating credentials

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1630,7 +1630,12 @@ class BrowserTabFragment :
         showDialogHidingPrevious(dialog, CredentialUpdateExistingCredentialsDialog.TAG)
     }
 
-    private suspend fun showAuthenticationSavedOrUpdatedSnackbar(loginCredentials: LoginCredentials, @StringRes messageResourceId: Int) {
+    private suspend fun showAuthenticationSavedOrUpdatedSnackbar(
+        loginCredentials: LoginCredentials,
+        @StringRes messageResourceId: Int,
+        delay: Long = 200
+    ) {
+        delay(delay)
         withContext(Dispatchers.Main) {
             browserLayout.makeSnackbarWithNoBottomInset(messageResourceId, Snackbar.LENGTH_LONG)
                 .setAction(R.string.autofillSnackbarAction) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2682,14 +2682,14 @@ class BrowserTabViewModel @Inject constructor(
         command.postValue(CancelIncomingAutofillRequest(originalUrl))
     }
 
-    override fun saveCredentials(url: String, credentials: LoginCredentials) {
-        viewModelScope.launch {
+    override suspend fun saveCredentials(url: String, credentials: LoginCredentials): LoginCredentials? {
+        return withContext(appCoroutineScope.coroutineContext) {
             autofillStore.saveCredentials(url, credentials)
         }
     }
 
-    override fun updateCredentials(url: String, credentials: LoginCredentials) {
-        viewModelScope.launch {
+    override suspend fun updateCredentials(url: String, credentials: LoginCredentials): LoginCredentials? {
+        return withContext(appCoroutineScope.coroutineContext) {
             autofillStore.updateCredentials(url, credentials)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandler.kt
@@ -57,16 +57,16 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(private val 
         }
     }
 
-    fun processSaveCredentialsResult(result: Bundle, credentialSaver: AutofillCredentialSaver) {
-        val selectedCredentials = result.getParcelable<LoginCredentials>(CredentialSavePickerDialog.KEY_CREDENTIALS) ?: return
-        val originalUrl = result.getString(CredentialSavePickerDialog.KEY_URL) ?: return
-        credentialSaver.saveCredentials(originalUrl, selectedCredentials)
+    suspend fun processSaveCredentialsResult(result: Bundle, credentialSaver: AutofillCredentialSaver): LoginCredentials? {
+        val selectedCredentials = result.getParcelable<LoginCredentials>(CredentialSavePickerDialog.KEY_CREDENTIALS) ?: return null
+        val originalUrl = result.getString(CredentialSavePickerDialog.KEY_URL) ?: return null
+        return credentialSaver.saveCredentials(originalUrl, selectedCredentials)
     }
 
-    fun processUpdateCredentialsResult(result: Bundle, credentialSaver: AutofillCredentialSaver) {
-        val selectedCredentials = result.getParcelable<LoginCredentials>(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIALS) ?: return
-        val originalUrl = result.getString(CredentialUpdateExistingCredentialsDialog.KEY_URL) ?: return
-        credentialSaver.updateCredentials(originalUrl, selectedCredentials)
+    suspend fun processUpdateCredentialsResult(result: Bundle, credentialSaver: AutofillCredentialSaver): LoginCredentials? {
+        val selectedCredentials = result.getParcelable<LoginCredentials>(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIALS) ?: return null
+        val originalUrl = result.getString(CredentialUpdateExistingCredentialsDialog.KEY_URL) ?: return null
+        return credentialSaver.updateCredentials(originalUrl, selectedCredentials)
     }
 
     interface CredentialInjector {
@@ -75,7 +75,7 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(private val 
     }
 
     interface AutofillCredentialSaver {
-        fun saveCredentials(url: String, credentials: LoginCredentials)
-        fun updateCredentials(url: String, credentials: LoginCredentials)
+        suspend fun saveCredentials(url: String, credentials: LoginCredentials): LoginCredentials?
+        suspend fun updateCredentials(url: String, credentials: LoginCredentials): LoginCredentials?
     }
 }

--- a/app/src/main/res/values/string-untranslated.xml
+++ b/app/src/main/res/values/string-untranslated.xml
@@ -18,6 +18,9 @@
 
     <!-- Autofill -->
     <string name="autofillSettingsDisplayName">Autofill</string>
+    <string name="autofillSnackbarAction">View</string>
+    <string name="autofillLoginSavedSnackbarMessage">Login saved</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Login updated</string>
 
     <!-- We won't have a translation for this, to be used later. -->
     <string name="trackersOverviewEmpty">No tracking requests were blocked from loading on this page. If a company\'s requests are loaded, it can allow them to profile you.</string>

--- a/app/src/test/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandlerTest.kt
@@ -151,11 +151,11 @@ class AutofillCredentialsSelectionResultHandlerTest {
         verifyAuthenticatorNeverCalled()
     }
 
-    private fun verifySaveNeverCalled() {
+    private suspend fun verifySaveNeverCalled() {
         verify(credentialsSaver, never()).saveCredentials(any(), any())
     }
 
-    private fun verifyUpdateNeverCalled() {
+    private suspend fun verifyUpdateNeverCalled() {
         verify(credentialsSaver, never()).updateCredentials(any(), any())
     }
 

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
@@ -57,16 +57,17 @@ interface AutofillStore {
      * Save the given credentials for the given URL
      * @param rawUrl Can be a full, unmodified URL taken from the URL bar (containing subdomains, query params etc...)
      * @param credentials The credentials to be saved. The ID can be null.
-     * @return The ID of the saved credential if it saved successfully, otherwise null
+     * @return The saved credential if it saved successfully, otherwise null
      */
-    suspend fun saveCredentials(rawUrl: String, credentials: LoginCredentials): Long?
+    suspend fun saveCredentials(rawUrl: String, credentials: LoginCredentials): LoginCredentials?
 
     /**
      * Updates the credentials saved for the given URL
      * @param rawUrl Can be a full, unmodified URL taken from the URL bar (containing subdomains, query params etc...)
      * @param credentials The credentials to be updated. The ID can be null.
+     * @return The saved credential if it saved successfully, otherwise null
      */
-    suspend fun updateCredentials(rawUrl: String, credentials: LoginCredentials)
+    suspend fun updateCredentials(rawUrl: String, credentials: LoginCredentials): LoginCredentials?
 
     /**
      * Returns the full list of stored login credentials
@@ -81,8 +82,9 @@ interface AutofillStore {
     /**
      * Updates the given login credentials, replacing what was saved before for the credentials with the specified ID
      * @param credentials The ID of the given credentials must match a saved credential for it to be updated.
+     * @return The saved credential if it saved successfully, otherwise null
      */
-    suspend fun updateCredentials(credentials: LoginCredentials)
+    suspend fun updateCredentials(credentials: LoginCredentials): LoginCredentials?
 
     /**
      * Searches the saved login credentials for a match to the given URL, username and password

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/ui/AutofillSettingsActivityLauncher.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/ui/AutofillSettingsActivityLauncher.kt
@@ -18,11 +18,18 @@ package com.duckduckgo.autofill.ui
 
 import android.content.Context
 import android.content.Intent
+import com.duckduckgo.autofill.domain.app.LoginCredentials
 
 /**
  * Used to access an Intent which will launch the autofill settings activity
  * The activity is implemented in the impl module and is otherwise inaccessible from outside this module.
  */
 interface AutofillSettingsActivityLauncher {
-    fun intent(context: Context): Intent
+
+    /**
+     * Launch the Autofill management activity.
+     * Optionally, can provide LoginCredentials to jump directly into viewing mode.
+     * If no LoginCredentials provided, will show the list mode.
+     */
+    fun intent(context: Context, loginCredentials: LoginCredentials? = null): Intent
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
@@ -30,13 +30,11 @@ import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ActivityAutofillSettingsBinding
 import com.duckduckgo.autofill.ui.AutofillSettingsActivityLauncher
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.*
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Editing
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.NotInCredentialMode
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Viewing
-import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementDisabledMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.*
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementCredentialsMode
-import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementLockedMode
+import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementDisabledMode
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementListMode
+import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementLockedMode
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL
@@ -212,10 +210,12 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
         private const val TAG_CREDENTIAL = "tag_fragment_credential"
         private const val TAG_ALL_CREDENTIALS = "tag_fragment_all_credentials"
 
-        fun intent(
-            context: Context,
-            loginCredentials: LoginCredentials? = null
-        ): Intent {
+        /**
+         * Launch the Autofill management activity.
+         * Optionally, can provide LoginCredentials to jump directly into viewing mode.
+         * If no LoginCredentials provided, will show the list mode.
+         */
+        fun intent(context: Context, loginCredentials: LoginCredentials? = null): Intent {
             return Intent(context, AutofillManagementActivity::class.java).apply {
                 if (loginCredentials != null) {
                     putExtra(EXTRAS_CREDENTIALS_TO_VIEW, loginCredentials)
@@ -232,8 +232,8 @@ class AutofillSettingsModule {
     @Provides
     fun activityLauncher(): AutofillSettingsActivityLauncher {
         return object : AutofillSettingsActivityLauncher {
-            override fun intent(context: Context): Intent {
-                return AutofillManagementActivity.intent(context)
+            override fun intent(context: Context, loginCredentials: LoginCredentials?): Intent {
+                return AutofillManagementActivity.intent(context, loginCredentials)
             }
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -22,9 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.*
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Editing
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.NotInCredentialMode
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Viewing
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.*
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -20,7 +20,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autofill.InternalTestUserChecker
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult
-import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.*
+import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.ExactMatch
+import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.NoMatch
+import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.UrlOnlyMatch
+import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.UsernameMatch
 import com.duckduckgo.securestorage.api.SecureStorage
 import com.duckduckgo.securestorage.api.WebsiteLoginDetails
 import com.duckduckgo.securestorage.api.WebsiteLoginDetailsWithCredentials
@@ -176,10 +179,7 @@ class SecureStoreBackedAutofillStoreTest {
         storeCredentials(2, url, "username2", "password456")
         storeCredentials(3, url, "username3", "password789")
         val credentials = LoginCredentials(
-            domain = url,
-            username = "username1",
-            password = "newpassword",
-            id = 1
+            domain = url, username = "username1", password = "newpassword", id = 1
         )
 
         testee.updateCredentials(url, credentials)
@@ -199,10 +199,7 @@ class SecureStoreBackedAutofillStoreTest {
         storeCredentials(2, url, "username2", "password456")
         storeCredentials(3, url, "username3", "password789")
         val credentials = LoginCredentials(
-            domain = url,
-            username = "username1",
-            password = "newpassword",
-            id = 1
+            domain = url, username = "username1", password = "newpassword", id = 1
         )
 
         testee.updateCredentials(credentials)
@@ -219,9 +216,7 @@ class SecureStoreBackedAutofillStoreTest {
         setupTesteeWithAutofillAvailable()
         val url = "https://example.com"
         val credentials = LoginCredentials(
-            domain = url,
-            username = "username1",
-            password = "password"
+            domain = url, username = "username1", password = "password"
         )
         testee.saveCredentials(url, credentials)
 
@@ -253,11 +248,7 @@ class SecureStoreBackedAutofillStoreTest {
 
         assertEquals(
             LoginCredentials(
-                id = 1,
-                domain = url,
-                username = "username1",
-                password = "password123",
-                lastUpdatedMillis = DEFAULT_INITIAL_LAST_UPDATED
+                id = 1, domain = url, username = "username1", password = "password123", lastUpdatedMillis = DEFAULT_INITIAL_LAST_UPDATED
             ),
             testee.getCredentialsWithId(1)
         )
@@ -299,7 +290,10 @@ class SecureStoreBackedAutofillStoreTest {
         testee = SecureStoreBackedAutofillStore(secureStore, internalTestUserChecker, lastUpdatedTimeProvider, autofillPrefsStore)
     }
 
-    private fun setupTestee(isInternalUser: Boolean, canAccessSecureStorage: Boolean) {
+    private fun setupTestee(
+        isInternalUser: Boolean,
+        canAccessSecureStorage: Boolean
+    ) {
         internalTestUserChecker = FakeInternalTestUserChecker(isInternalUser)
         secureStore = FakeSecureStore(canAccessSecureStorage)
         testee = SecureStoreBackedAutofillStore(secureStore, internalTestUserChecker, lastUpdatedTimeProvider, autofillPrefsStore)
@@ -337,9 +331,11 @@ class SecureStoreBackedAutofillStoreTest {
 
         private val credentials = mutableListOf<WebsiteLoginDetailsWithCredentials>()
 
-        override suspend fun addWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials): Long {
+        override suspend fun addWebsiteLoginDetailsWithCredentials(
+            websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials
+        ): WebsiteLoginDetailsWithCredentials {
             credentials.add(websiteLoginDetailsWithCredentials)
-            return credentials.size.toLong()
+            return websiteLoginDetailsWithCredentials
         }
 
         override suspend fun websiteLoginDetailsForDomain(domain: String): Flow<List<WebsiteLoginDetails>> {
@@ -380,10 +376,13 @@ class SecureStoreBackedAutofillStoreTest {
             }
         }
 
-        override suspend fun updateWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials) {
+        override suspend fun updateWebsiteLoginDetailsWithCredentials(
+            websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials
+        ): WebsiteLoginDetailsWithCredentials {
             credentials.indexOfFirst { it.details.id == websiteLoginDetailsWithCredentials.details.id }.also {
                 credentials[it] = websiteLoginDetailsWithCredentials
             }
+            return websiteLoginDetailsWithCredentials
         }
 
         override suspend fun deleteWebsiteLoginDetailsWithCredentials(id: Long) {

--- a/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorage.kt
+++ b/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorage.kt
@@ -33,10 +33,12 @@ interface SecureStorage {
      * this is invoked, nothing will be done.
      *
      * @throws [SecureStorageException] if something went wrong while trying to perform the action. See type to get more info on the cause.
-     * @return The ID of the saved credential if it saved successfully, otherwise null
+     * @return The saved credential if it saved successfully, otherwise null
      */
     @Throws(SecureStorageException::class)
-    suspend fun addWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials): Long?
+    suspend fun addWebsiteLoginDetailsWithCredentials(
+        websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials
+    ): WebsiteLoginDetailsWithCredentials?
 
     /**
      * This method returns all [WebsiteLoginDetails] with the [domain] stored in the [SecureStorage].
@@ -96,9 +98,12 @@ interface SecureStorage {
      * If [canAccessSecureStorage] is false when this is invoked, nothing will be done.
      *
      * @throws [SecureStorageException] if something went wrong while trying to perform the action. See type to get more info on the cause.
+     * @return The updated credential if it saved successfully, otherwise null
      */
     @Throws(SecureStorageException::class)
-    suspend fun updateWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials)
+    suspend fun updateWebsiteLoginDetailsWithCredentials(
+        websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials
+    ): WebsiteLoginDetailsWithCredentials?
 
     /**
      * This method removes an existing [WebsiteLoginDetailsWithCredentials] associated with an [id] from the [SecureStorage].

--- a/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
+++ b/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
@@ -19,8 +19,8 @@ package com.duckduckgo.securestorage.impl
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.securestorage.api.SecureStorage
-import com.duckduckgo.securestorage.api.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.securestorage.api.WebsiteLoginDetails
+import com.duckduckgo.securestorage.api.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.securestorage.impl.encryption.EncryptionHelper.EncryptedString
 import com.duckduckgo.securestorage.store.SecureStorageRepository
 import com.duckduckgo.securestorage.store.db.WebsiteLoginCredentialsEntity
@@ -46,9 +46,12 @@ class RealSecureStorage @Inject constructor(
 
     override fun canAccessSecureStorage(): Boolean = l2DataTransformer.canProcessData() && secureStorageRepository != null
 
-    override suspend fun addWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials): Long? {
+    override suspend fun addWebsiteLoginDetailsWithCredentials(
+        websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials
+    ): WebsiteLoginDetailsWithCredentials? {
         return withContext(dispatchers.io()) {
-            return@withContext secureStorageRepository?.addWebsiteLoginCredential(websiteLoginDetailsWithCredentials.toDataEntity())
+            val savedCredential = secureStorageRepository?.addWebsiteLoginCredential(websiteLoginDetailsWithCredentials.toDataEntity())
+            return@withContext savedCredential?.toCredentials()
         }
     }
 
@@ -102,9 +105,11 @@ class RealSecureStorage @Inject constructor(
             }
         } else emptyFlow()
 
-    override suspend fun updateWebsiteLoginDetailsWithCredentials(websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials): Unit =
+    override suspend fun updateWebsiteLoginDetailsWithCredentials(
+        websiteLoginDetailsWithCredentials: WebsiteLoginDetailsWithCredentials
+    ): WebsiteLoginDetailsWithCredentials? =
         withContext(dispatchers.io()) {
-            secureStorageRepository?.updateWebsiteLoginCredentials(websiteLoginDetailsWithCredentials.toDataEntity())
+            secureStorageRepository?.updateWebsiteLoginCredentials(websiteLoginDetailsWithCredentials.toDataEntity())?.toCredentials()
         }
 
     override suspend fun deleteWebsiteLoginDetailsWithCredentials(id: Long): Unit =

--- a/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/SecureStorageRepository.kt
+++ b/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/SecureStorageRepository.kt
@@ -16,8 +16,8 @@
 
 package com.duckduckgo.securestorage.store
 
-import com.duckduckgo.securestorage.store.db.WebsiteLoginCredentialsEntity
 import com.duckduckgo.securestorage.store.db.WebsiteLoginCredentialsDao
+import com.duckduckgo.securestorage.store.db.WebsiteLoginCredentialsEntity
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -28,7 +28,7 @@ interface SecureStorageRepository {
         fun get(): SecureStorageRepository?
     }
 
-    suspend fun addWebsiteLoginCredential(websiteLoginCredentials: WebsiteLoginCredentialsEntity): Long
+    suspend fun addWebsiteLoginCredential(websiteLoginCredentials: WebsiteLoginCredentialsEntity): WebsiteLoginCredentialsEntity?
 
     suspend fun websiteLoginCredentialsForDomain(domain: String): Flow<List<WebsiteLoginCredentialsEntity>>
 
@@ -36,7 +36,7 @@ interface SecureStorageRepository {
 
     suspend fun websiteLoginCredentials(): Flow<List<WebsiteLoginCredentialsEntity>>
 
-    suspend fun updateWebsiteLoginCredentials(websiteLoginCredentials: WebsiteLoginCredentialsEntity)
+    suspend fun updateWebsiteLoginCredentials(websiteLoginCredentials: WebsiteLoginCredentialsEntity): WebsiteLoginCredentialsEntity?
 
     suspend fun deleteWebsiteLoginCredentials(id: Long)
 }
@@ -44,8 +44,9 @@ interface SecureStorageRepository {
 class RealSecureStorageRepository constructor(
     private val websiteLoginCredentialsDao: WebsiteLoginCredentialsDao
 ) : SecureStorageRepository {
-    override suspend fun addWebsiteLoginCredential(websiteLoginCredentials: WebsiteLoginCredentialsEntity): Long {
-        return websiteLoginCredentialsDao.insert(websiteLoginCredentials)
+    override suspend fun addWebsiteLoginCredential(websiteLoginCredentials: WebsiteLoginCredentialsEntity): WebsiteLoginCredentialsEntity? {
+        val newCredentialId = websiteLoginCredentialsDao.insert(websiteLoginCredentials)
+        return websiteLoginCredentialsDao.getWebsiteLoginCredentialsById(newCredentialId)
     }
 
     override suspend fun websiteLoginCredentialsForDomain(domain: String): Flow<List<WebsiteLoginCredentialsEntity>> =
@@ -57,8 +58,11 @@ class RealSecureStorageRepository constructor(
     override suspend fun getWebsiteLoginCredentialsForId(id: Long): WebsiteLoginCredentialsEntity? =
         websiteLoginCredentialsDao.getWebsiteLoginCredentialsById(id)
 
-    override suspend fun updateWebsiteLoginCredentials(websiteLoginCredentials: WebsiteLoginCredentialsEntity) =
+    override suspend fun updateWebsiteLoginCredentials(websiteLoginCredentials: WebsiteLoginCredentialsEntity): WebsiteLoginCredentialsEntity? {
+        val credentialId = websiteLoginCredentials.id
         websiteLoginCredentialsDao.update(websiteLoginCredentials)
+        return websiteLoginCredentialsDao.getWebsiteLoginCredentialsById(credentialId)
+    }
 
     override suspend fun deleteWebsiteLoginCredentials(id: Long) {
         websiteLoginCredentialsDao.delete(id)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202630343540915/f

### Description
Shows a snackbar after saving and updating login credentials. The snackbar has an action button letting you directly shortcut into viewing the credential.

### Steps to test this PR
- [x] Visit a site with a login form (e.g., https://trello.com/login)
- [x] Enter username + password and attempt login
- [x] When dialog appears offering to save credential, do it
- [x] Verify a snackbar shows indicating login **saved** message
- [x] Click the "view" action button
- [x] Authenticate, and verify you are viewing the correct login
- [x] Go back, and verify you jump straight back to the browser view (not settings)

- [x] Repeat the steps above, but this time **update** an existing credential by entering the same username already saved but with a different password
- [x] Verify the snackbar shows login **updated** message
- [x] Click the "view" action button
- [x] Authenticate, and verify you are viewing the correct login
- [ ] Go back, and verify you jump straight back to the browser view (not settings)

