### PR TITLE
Scan media files after download

### DIFF
--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadCallback.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadCallback.kt
@@ -87,7 +87,8 @@ class FileDownloadCallback @Inject constructor(
     private val downloadsRepository: DownloadsRepository,
     private val pixel: Pixel,
     private val dispatchers: DispatcherProvider,
-    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val mediaScanner: MediaScanner,
 ) : DownloadCallback, DownloadStateListener {
 
     private val command = Channel<DownloadCommand>(1, BufferOverflow.DROP_OLDEST)
@@ -120,6 +121,7 @@ class FileDownloadCallback @Inject constructor(
         )
         appCoroutineScope.launch(dispatchers.io()) {
             downloadsRepository.update(downloadId = downloadId, downloadStatus = FINISHED, contentLength = contentLength)
+            mediaScanner.scan(file)
             downloadsRepository.getDownloadItem(downloadId)?.let {
                 command.send(
                     DownloadCommand.ShowDownloadSuccessMessage(
@@ -142,6 +144,7 @@ class FileDownloadCallback @Inject constructor(
         )
         appCoroutineScope.launch(dispatchers.io()) {
             downloadsRepository.update(fileName = file.name, downloadStatus = FINISHED, contentLength = file.length())
+            mediaScanner.scan(file)
             command.send(
                 DownloadCommand.ShowDownloadSuccessMessage(
                     messageId = R.string.downloadsDownloadFinishedMessage,

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/MediaScanner.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/MediaScanner.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.downloads.impl
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.io.File
+import javax.inject.Inject
+
+interface MediaScanner {
+    /**
+     * Triggers the Media Store scanner so that the newly added [File] is immediately visible to the user.
+     */
+    fun scan(file: File)
+}
+
+@ContributesBinding(AppScope::class)
+class MediaScannerImpl @Inject constructor(
+    private val context: Context,
+) : MediaScanner {
+    override fun scan(file: File) {
+        val mediaScanIntent = Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE)
+        mediaScanIntent.data = Uri.fromFile(file)
+        context.sendBroadcast(mediaScanIntent)
+    }
+}

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/FileDownloadCallbackTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/FileDownloadCallbackTest.kt
@@ -57,6 +57,8 @@ class FileDownloadCallbackTest {
 
     private val mockFileDownloadNotificationManager: FileDownloadNotificationManager = mock()
 
+    private val mockMediaScanner: MediaScanner = mock()
+
     private lateinit var callback: FileDownloadCallback
 
     @Before
@@ -66,7 +68,8 @@ class FileDownloadCallbackTest {
             downloadsRepository = mockDownloadsRepository,
             pixel = mockPixel,
             dispatchers = coroutineRule.testDispatcherProvider,
-            appCoroutineScope = TestScope()
+            appCoroutineScope = TestScope(),
+            mediaScanner = mockMediaScanner,
         )
     }
 
@@ -97,6 +100,7 @@ class FileDownloadCallbackTest {
         callback.onSuccess(item.downloadId, updatedContentLength, file, "type")
 
         verify(mockPixel).fire(DownloadsPixelName.DOWNLOAD_REQUEST_SUCCEEDED)
+        verify(mockMediaScanner).scan(file)
         verify(mockDownloadsRepository).update(
             downloadId = item.downloadId,
             downloadStatus = FINISHED,
@@ -121,6 +125,7 @@ class FileDownloadCallbackTest {
         callback.onSuccess(file = file, mimeType = mimeType)
 
         verify(mockPixel).fire(DownloadsPixelName.DOWNLOAD_REQUEST_SUCCEEDED)
+        verify(mockMediaScanner).scan(file)
         verify(mockDownloadsRepository).update(
             fileName = item.fileName,
             downloadStatus = FINISHED,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202798538526983/f

### Description
Ensure we scan the media folder so that downloaded media files immediately appear to the user when trying to open from apps other than the DDG browser

### Steps to test this PR

_Before_
- [x] install from develop
- [x] search anything from SERP and go to images
- [x] long press in an image and download
- [x] open a 3rd party app to see downloads, eg. Files
- expected
  - [x] the recently downloaded image should appear
- actual
  - [x] the recently downloaded image does not appear

_After_
- [x] install from this branch
- [x] search anything from SERP and go to images
- [x] long press in an image and download
- [x] open a 3rd party app to see downloads, eg. Files
- [x] verify the recently downloaded image should appear

