### PR TITLE
Only allow once cta per page load

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -133,7 +133,6 @@ import com.duckduckgo.privacy.config.api.*
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER_VALUE
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.duckduckgo.remote.messaging.api.Content
 import com.duckduckgo.remote.messaging.api.RemoteMessage

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2150,11 +2150,11 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenRefreshCtaIfCtaAlreadyExistedThenReturnThatCta() = runTest {
-        val cta = DaxBubbleCta.DaxIntroCta(mockOnboardingStore, mockAppInstallStore)
-        testee.ctaViewState.value = BrowserTabViewModel.CtaViewState(cta = cta)
+    fun whenRefreshCtaIfCtaAlreadyShownForCurrentPageThenReturnNull() = runTest {
+        setBrowserShowing(isBrowsing = true)
+        testee.hasCtaBeenShownForCurrentPage.set(true)
 
-        assertEquals(cta, testee.refreshCta())
+        assertNull(testee.refreshCta())
     }
 
     @Test
@@ -2191,6 +2191,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSurveyCtaDismissedAndNoOtherCtaPossibleCtaIsNull() = runTest {
+        setBrowserShowing(isBrowsing = false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
 
         givenShownCtas(CtaId.DAX_INTRO, CtaId.DAX_END)
@@ -2201,6 +2202,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSurveyCtaDismissedAndWidgetCtaIsPossibleThenNextCtaIsWidget() = runTest {
+        setBrowserShowing(isBrowsing = false)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
 
@@ -3800,6 +3802,13 @@ class BrowserTabViewModelTest {
         loadUrl(url = "www.example.com", isBrowserShowing = true)
         verify(mockAppLinksHandler).updatePreviousUrl("www.example.com")
         verify(mockAppLinksHandler).setUserQueryState(false)
+    }
+
+    @Test
+    fun whenPageChangedThenSetCtaBeenShownForCurrentPageToFalse() {
+        testee.hasCtaBeenShownForCurrentPage.set(true)
+        loadUrl(url = "www.example.com", isBrowserShowing = true)
+        assertFalse(testee.hasCtaBeenShownForCurrentPage.get())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -198,7 +198,7 @@ class BrowserWebViewClientTest {
     @Test
     fun whenOnPageStartedCalledThenInjectAutoconsentCalled() = runTest {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
-        verify(autoconsent).injectAutoconsent(webView)
+        verify(autoconsent).injectAutoconsent(webView, EXAMPLE_URL)
     }
 
     @UiThreadTest

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -250,7 +250,7 @@ class BrowserWebViewClient(
             Timber.v("onPageStarted webViewUrl: ${webView.url} URL: $url")
 
             url?.let {
-                autoconsent.injectAutoconsent(webView)
+                autoconsent.injectAutoconsent(webView, url)
                 adClickManager.detectAdDomain(url)
                 appCoroutineScope.launch(dispatcherProvider.default()) {
                     thirdPartyCookieManager.processUriForThirdPartyCookies(webView, url.toUri())

--- a/app/src/test/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/useragent/UserAgentProviderTest.kt
@@ -23,10 +23,10 @@ import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.api.UserAgent
 import com.duckduckgo.privacy.config.api.UserAgentException
 import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.RealUnprotectedTemporary
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.impl.features.useragent.RealUserAgent
 import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository

--- a/autoconsent/autoconsent-api/src/main/java/com/duckduckgo/autoconsent/api/Autoconsent.kt
+++ b/autoconsent/autoconsent-api/src/main/java/com/duckduckgo/autoconsent/api/Autoconsent.kt
@@ -21,9 +21,9 @@ import android.webkit.WebView
 /** Public interface for the Autoconsent (CMP) feature */
 interface Autoconsent {
     /**
-     * This method injects the JS code needed to run autoconsent. It requires a [WebView] instance.
+     * This method injects the JS code needed to run autoconsent. It requires a [WebView] instance and the URL where the code will be injected.
      */
-    fun injectAutoconsent(webView: WebView)
+    fun injectAutoconsent(webView: WebView, url: String)
     /**
      * This method adds the JS interface for autoconsent to create a bridge between JS and our client.
      * It requires a [WebView] instance and an [AutoconsentCallback].
@@ -75,4 +75,9 @@ interface AutoconsentCallback {
      * This method is called whenever autoconsent has a result to be sent
      */
     fun onResultReceived(consentManaged: Boolean, optOutFailed: Boolean, selfTestFailed: Boolean?)
+}
+
+/** List of [AutoconsentFeatureName] that belong to the Autoconsent feature */
+enum class AutoconsentFeatureName(val value: String) {
+    Autoconsent("autoconsent"),
 }

--- a/autoconsent/autoconsent-impl/build.gradle
+++ b/autoconsent/autoconsent-impl/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'kotlin-android-extensions'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
@@ -30,6 +29,10 @@ dependencies {
     implementation project(path: ':di')
     implementation project(path: ':common')
     implementation project(path: ':common-ui')
+    implementation project(path: ':privacy-config-api')
+    implementation project(path: ':feature-toggles-api')
+    implementation project(path: ':app-build-config-api')
+    implementation project(path: ':app-store')
     implementation project(path: ':autoconsent-api')
     implementation project(path: ':autoconsent-store')
 
@@ -49,6 +52,7 @@ dependencies {
     implementation AndroidX.core.ktx
     implementation AndroidX.lifecycle.viewModelKtx
     implementation AndroidX.lifecycle.runtimeKtx
+    implementation AndroidX.room.runtime
 
     // Testing dependencies
     testImplementation project(path: ':common-test')
@@ -59,7 +63,7 @@ dependencies {
     testImplementation AndroidX.test.ext.junit
     testImplementation "androidx.test:runner:_"
     testImplementation Testing.robolectric
-
+    testImplementation 'app.cash.turbine:turbine:_'
     testImplementation project(path: ':common-test')
 }
 

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeature.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeature.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl
+
+import com.duckduckgo.autoconsent.store.AutoconsentExceptionEntity
+
+data class AutoconsentFeature(
+    val state: String,
+    val minSupportedVersion: Int?,
+    val exceptions: List<AutoconsentExceptionEntity>,
+    val settings: Settings,
+)
+
+data class Settings(
+    val disabledCMPs: List<String>,
+)

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeatureNameUtil.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeatureNameUtil.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl
+
+import com.duckduckgo.autoconsent.api.AutoconsentFeatureName
+
+/**
+ * Convenience method to get the [AutoconsentFeatureName] from its [String] value
+ */
+fun autoconsentFeatureValueOf(value: String): AutoconsentFeatureName? {
+    return AutoconsentFeatureName.values().find { it.value == value }
+}

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeaturePlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeaturePlugin.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl
+
+import com.duckduckgo.autoconsent.api.AutoconsentFeatureName
+import com.duckduckgo.autoconsent.store.AutoconsentExceptionEntity
+import com.duckduckgo.autoconsent.store.AutoconsentFeatureToggleRepository
+import com.duckduckgo.autoconsent.store.AutoconsentFeatureToggles
+import com.duckduckgo.autoconsent.store.AutoconsentRepository
+import com.duckduckgo.autoconsent.store.DisabledCmpsEntity
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class AutoconsentFeaturePlugin @Inject constructor(
+    private val autoconsentRepository: AutoconsentRepository,
+    private val autoconsentFeatureToggleRepository: AutoconsentFeatureToggleRepository
+) : PrivacyFeaturePlugin {
+
+    override fun store(featureName: String, jsonString: String): Boolean {
+        val autoconsentFeatureName = autoconsentFeatureValueOf(featureName) ?: return false
+        if (autoconsentFeatureName.value == this.featureName) {
+            val moshi = Moshi.Builder().build()
+            val jsonAdapter: JsonAdapter<AutoconsentFeature> =
+                moshi.adapter(AutoconsentFeature::class.java)
+
+            val autoconsentFeature: AutoconsentFeature? = jsonAdapter.fromJson(jsonString)
+
+            val disabledCmps = autoconsentFeature?.settings?.disabledCMPs?.map {
+                DisabledCmpsEntity(it)
+            }.orEmpty()
+
+            val exceptions = autoconsentFeature?.exceptions?.map {
+                AutoconsentExceptionEntity(domain = it.domain, reason = it.reason)
+            }.orEmpty()
+
+            autoconsentRepository.updateAll(exceptions, disabledCmps)
+            val isEnabled = autoconsentFeature?.state == "enabled"
+            autoconsentFeatureToggleRepository.insert(
+                AutoconsentFeatureToggles(autoconsentFeatureName, isEnabled, autoconsentFeature?.minSupportedVersion)
+            )
+            return true
+        }
+        return false
+    }
+
+    override val featureName: String = AutoconsentFeatureName.Autoconsent.value
+}

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeatureTogglesPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeatureTogglesPlugin.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl
+
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.autoconsent.store.AutoconsentFeatureToggleRepository
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureTogglesPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class AutoconsentFeatureTogglesPlugin @Inject constructor(
+    private val autoconsentFeatureToggleRepository: AutoconsentFeatureToggleRepository,
+    private val appBuildConfig: AppBuildConfig
+) : FeatureTogglesPlugin {
+    override fun isEnabled(featureName: String, defaultValue: Boolean): Boolean? {
+        val autoconsentFeature = autoconsentFeatureValueOf(featureName) ?: return null
+        return autoconsentFeatureToggleRepository.get(autoconsentFeature, defaultValue) &&
+            appBuildConfig.versionCode >= autoconsentFeatureToggleRepository.getMinSupportedVersion(autoconsentFeature)
+    }
+}

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/AutoconsentFeaturePluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/AutoconsentFeaturePluginTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl
+
+import com.duckduckgo.app.FileUtilities
+import com.duckduckgo.autoconsent.api.AutoconsentFeatureName
+import com.duckduckgo.autoconsent.store.AutoconsentExceptionEntity
+import com.duckduckgo.autoconsent.store.AutoconsentFeatureToggleRepository
+import com.duckduckgo.autoconsent.store.AutoconsentFeatureToggles
+import com.duckduckgo.autoconsent.store.AutoconsentRepository
+import com.duckduckgo.autoconsent.store.DisabledCmpsEntity
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class AutoconsentFeaturePluginTest {
+
+    lateinit var plugin: AutoconsentFeaturePlugin
+
+    private val mockAutoconsentRepository: AutoconsentRepository = mock()
+    private val mockAutoconsentFeatureToggleRepository: AutoconsentFeatureToggleRepository = mock()
+
+    @Before
+    fun before() {
+        plugin = AutoconsentFeaturePlugin(mockAutoconsentRepository, mockAutoconsentFeatureToggleRepository)
+    }
+
+    @Test
+    fun whenFeatureNameDoesNotMatchAutoconsentFeatureNameValuesThenReturnFalse() {
+        AutoconsentFeatureName.values().filter { it != FEATURE_NAME }.forEach {
+            assertFalse(plugin.store(it.value, EMPTY_JSON_STRING))
+        }
+    }
+
+    @Test
+    fun whenFeatureNameMatchesAutoconsentThenReturnTrue() {
+        assertTrue(plugin.store(FEATURE_NAME_VALUE, EMPTY_JSON_STRING))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesAutoconsentAndIsEnabledThenStoreFeatureEnabled() {
+        val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/autoconsent.json")
+
+        plugin.store(FEATURE_NAME_VALUE, jsonString)
+
+        verify(mockAutoconsentFeatureToggleRepository).insert(AutoconsentFeatureToggles(FEATURE_NAME, true, null))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesAutoconsentAndIsNotEnabledThenStoreFeatureDisabled() {
+        val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/autoconsent_disabled.json")
+
+        plugin.store(FEATURE_NAME_VALUE, jsonString)
+
+        verify(mockAutoconsentFeatureToggleRepository).insert(AutoconsentFeatureToggles(FEATURE_NAME, false, null))
+    }
+
+    @Test
+    fun whenFeatureNameMatchesAutoconsentThenUpdateAllExistingLists() {
+        val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/autoconsent.json")
+
+        plugin.store(FEATURE_NAME_VALUE, jsonString)
+
+        val exceptions = argumentCaptor<List<AutoconsentExceptionEntity>>()
+        val disabledCmps = argumentCaptor<List<DisabledCmpsEntity>>()
+
+        verify(mockAutoconsentRepository).updateAll(exceptions = exceptions.capture(), disabledCmps = disabledCmps.capture())
+
+        val exceptionsEntity = exceptions.firstValue
+        assertEquals(2, exceptionsEntity.size)
+
+        val disabledCmpsEntity = disabledCmps.firstValue
+        assertEquals(1, disabledCmpsEntity.size)
+    }
+
+    @Test
+    fun whenFeatureNameMatchesAdClickAttributionAndHasMinSupportedVersionThenStoreMinSupportedVersion() {
+        val jsonString = FileUtilities.loadText(javaClass.classLoader!!, "json/autoconsent_min_supported_version.json")
+
+        plugin.store(FEATURE_NAME_VALUE, jsonString)
+
+        verify(mockAutoconsentFeatureToggleRepository).insert(AutoconsentFeatureToggles(FEATURE_NAME, true, 1234))
+    }
+
+    companion object {
+        private val FEATURE_NAME = AutoconsentFeatureName.Autoconsent
+        private val FEATURE_NAME_VALUE = FEATURE_NAME.value
+        private const val EMPTY_JSON_STRING = "{}"
+    }
+}

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/AutoconsentFeatureTogglesPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/AutoconsentFeatureTogglesPluginTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl
+
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.autoconsent.api.AutoconsentFeatureName.Autoconsent
+import com.duckduckgo.autoconsent.store.AutoconsentFeatureToggleRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class AutoconsentFeatureTogglesPluginTest {
+
+    private val autoconsentFeatureToggleRepository: AutoconsentFeatureToggleRepository = mock()
+    private lateinit var plugin: AutoconsentFeatureTogglesPlugin
+    private val mockAppBuildConfig: AppBuildConfig = mock()
+
+    @Before
+    fun setup() {
+        plugin = AutoconsentFeatureTogglesPlugin(autoconsentFeatureToggleRepository, mockAppBuildConfig)
+    }
+
+    @Test
+    fun whenIsEnabledCalledOnAutoconsentFeatureNameThenReturnRepositoryValue() {
+        whenever(autoconsentFeatureToggleRepository.get(Autoconsent, false)).thenReturn(true)
+        assertEquals(true, plugin.isEnabled(Autoconsent.value, false))
+
+        whenever(autoconsentFeatureToggleRepository.get(Autoconsent, false)).thenReturn(false)
+        assertEquals(false, plugin.isEnabled(Autoconsent.value, false))
+    }
+
+    @Test
+    fun whenIsEnabledCalledOnOtherFeatureNameThenReturnRepositoryNull() {
+        assertNull(plugin.isEnabled(TestFeatureName().value, false))
+    }
+
+    @Test
+    fun whenIsEnabledAndFeatureIsAutoconsentThenReturnTrueWhenEnabled() = runTest {
+        givenAutoconsentFeatureIsEnabled()
+
+        val isEnabled = plugin.isEnabled(Autoconsent.value, true)
+
+        assertTrue(isEnabled!!)
+    }
+
+    @Test
+    fun whenIsEnabledAndFeatureIsAutoconsentThenReturnFalseWhenDisabled() = runTest {
+        givenAutoconsentFeatureIsDisabled()
+
+        val isEnabled = plugin.isEnabled(Autoconsent.value, true)
+
+        assertFalse(isEnabled!!)
+    }
+
+    @Test
+    fun whenIsEnabledAndFeatureIsAutoconsentThenReturnDefaultValueIfFeatureDoesNotExist() = runTest {
+        givenAutoconsentFeatureReturnsDefaultValue(true)
+        assertTrue(plugin.isEnabled(Autoconsent.value, true)!!)
+
+        givenAutoconsentFeatureReturnsDefaultValue(false)
+        assertFalse(plugin.isEnabled(Autoconsent.value, false)!!)
+    }
+
+    @Test
+    fun whenIsEnabledAndFeatureIsAutoconsentAndAppVersionEqualToMinSupportedVersionThenReturnTrueWhenEnabled() = runTest {
+        givenAutoconsentFeatureIsEnabled()
+        givenAppVersionIsEqualToMinSupportedVersion()
+
+        val isEnabled = plugin.isEnabled(Autoconsent.value, true)
+
+        assertTrue(isEnabled!!)
+    }
+
+    @Test
+    fun whenIsEnabledAndFeatureIsAutoconsentAndAppVersionIsGreaterThanMinSupportedVersionThenReturnTrueWhenEnabled() = runTest {
+        givenAutoconsentFeatureIsEnabled()
+        givenAppVersionIsGreaterThanMinSupportedVersion()
+
+        val isEnabled = plugin.isEnabled(Autoconsent.value, true)
+
+        assertTrue(isEnabled!!)
+    }
+
+    @Test
+    fun whenIsEnabledAndFeatureAutoconsentAndAppVersionIsSmallerThanMinSupportedVersionThenReturnFalseWhenEnabled() = runTest {
+        givenAutoconsentFeatureIsEnabled()
+        givenAppVersionIsSmallerThanMinSupportedVersion()
+
+        val isEnabled = plugin.isEnabled(Autoconsent.value, true)
+
+        assertFalse(isEnabled!!)
+    }
+
+    private fun givenAutoconsentFeatureIsEnabled() {
+        whenever(autoconsentFeatureToggleRepository.get(Autoconsent, true)).thenReturn(true)
+    }
+
+    private fun givenAutoconsentFeatureIsDisabled() {
+        whenever(autoconsentFeatureToggleRepository.get(Autoconsent, true)).thenReturn(false)
+    }
+
+    private fun givenAutoconsentFeatureReturnsDefaultValue(defaultValue: Boolean) {
+        whenever(autoconsentFeatureToggleRepository.get(Autoconsent, defaultValue)).thenReturn(defaultValue)
+    }
+
+    private fun givenAppVersionIsEqualToMinSupportedVersion() {
+        whenever(autoconsentFeatureToggleRepository.getMinSupportedVersion(Autoconsent)).thenReturn(1234)
+        whenever(mockAppBuildConfig.versionCode).thenReturn(1234)
+    }
+
+    private fun givenAppVersionIsGreaterThanMinSupportedVersion() {
+        whenever(autoconsentFeatureToggleRepository.getMinSupportedVersion(Autoconsent)).thenReturn(1234)
+        whenever(mockAppBuildConfig.versionCode).thenReturn(5678)
+    }
+
+    private fun givenAppVersionIsSmallerThanMinSupportedVersion() {
+        whenever(autoconsentFeatureToggleRepository.getMinSupportedVersion(Autoconsent)).thenReturn(1234)
+        whenever(mockAppBuildConfig.versionCode).thenReturn(123)
+    }
+}
+
+class TestFeatureName(val value: String = "test")

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
@@ -17,9 +17,13 @@
 package com.duckduckgo.autoconsent.impl
 
 import android.webkit.WebView
+import androidx.core.net.toUri
+import com.duckduckgo.app.global.domain
 import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.app.userwhitelist.api.UserWhiteListRepository
 import com.duckduckgo.autoconsent.api.AutoconsentCallback
 import com.duckduckgo.autoconsent.store.AutoconsentSettingsRepository
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 
 class FakePluginPoint : PluginPoint<MessageHandlerPlugin> {
     val plugin = FakeMessageHandlerPlugin()
@@ -43,7 +47,15 @@ class FakeMessageHandlerPlugin : MessageHandlerPlugin {
     override val supportedTypes: List<String> = listOf("fake")
 }
 
-class FakeRepository : AutoconsentSettingsRepository {
+class FakeSettingsRepository : AutoconsentSettingsRepository {
     override var userSetting: Boolean = false
     override var firstPopupHandled: Boolean = false
 }
+
+class FakeUnprotected(private val exceptionList: List<String>) : UnprotectedTemporary {
+    override fun isAnException(url: String): Boolean {
+        return exceptionList.contains(url.toUri().domain())
+    }
+}
+
+class FakeUserAllowlist(override val userWhiteList: List<String>) : UserWhiteListRepository

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/EvalMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/EvalMessageHandlerPluginTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.autoconsent.impl.handlers.EvalMessageHandlerPlugin.EvalRes
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -44,7 +45,7 @@ class EvalMessageHandlerPluginTest {
     private val mockCallback: AutoconsentCallback = mock()
     private val webView: WebView = WebView(InstrumentationRegistry.getInstrumentation().targetContext)
 
-    private val evalMessageHandlerPlugin = EvalMessageHandlerPlugin(coroutineRule.testScope, coroutineRule.testDispatcherProvider)
+    private val evalMessageHandlerPlugin = EvalMessageHandlerPlugin(TestScope(), coroutineRule.testDispatcherProvider)
 
     @Test
     fun whenProcessMessageIfTypeNotEvalDoNothing() {

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/PopUpFoundMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/PopUpFoundMessageHandlerPluginTest.kt
@@ -20,7 +20,7 @@ import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.autoconsent.api.AutoconsentCallback
-import com.duckduckgo.autoconsent.impl.FakeRepository
+import com.duckduckgo.autoconsent.impl.FakeSettingsRepository
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -32,7 +32,7 @@ class PopUpFoundMessageHandlerPluginTest {
 
     private val mockCallback: AutoconsentCallback = mock()
     private val webView: WebView = WebView(InstrumentationRegistry.getInstrumentation().targetContext)
-    private val repository = FakeRepository()
+    private val repository = FakeSettingsRepository()
 
     private val popupFoundHandler = PopUpFoundMessageHandlerPlugin(repository)
 

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/ui/AutoconsentSettingsViewModelTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/ui/AutoconsentSettingsViewModelTest.kt
@@ -68,7 +68,7 @@ class AutoconsentSettingsViewModelTest {
     internal class FakeAutoconsent : Autoconsent {
         var test: Boolean = false
 
-        override fun injectAutoconsent(webView: WebView) {
+        override fun injectAutoconsent(webView: WebView, url: String) {
             // NO OP
         }
 

--- a/autoconsent/autoconsent-impl/src/test/resources/json/autoconsent.json
+++ b/autoconsent/autoconsent-impl/src/test/resources/json/autoconsent.json
@@ -1,0 +1,16 @@
+{
+  "state": "enabled",
+  "exceptions": [
+    {
+      "domain": "www.example.com",
+      "reason": "Cannot identify"
+    },
+    {
+      "domain": "weather.com",
+      "reason": "Broken autoconsent"
+    }
+  ],
+  "settings": {
+    "disabledCMPs": ["TestCmp"]
+  }
+}

--- a/autoconsent/autoconsent-impl/src/test/resources/json/autoconsent_disabled.json
+++ b/autoconsent/autoconsent-impl/src/test/resources/json/autoconsent_disabled.json
@@ -1,0 +1,16 @@
+{
+  "state": "disabled",
+  "exceptions": [
+    {
+      "domain": "www.example.com",
+      "reason": "Cannot identify"
+    },
+    {
+      "domain": "weather.com",
+      "reason": "Broken autoconsent"
+    }
+  ],
+  "settings": {
+    "disabledCMPs": ["TestCmp"]
+  }
+}

--- a/autoconsent/autoconsent-impl/src/test/resources/json/autoconsent_min_supported_version.json
+++ b/autoconsent/autoconsent-impl/src/test/resources/json/autoconsent_min_supported_version.json
@@ -1,0 +1,17 @@
+{
+  "state": "enabled",
+  "minSupportedVersion": 1234,
+  "exceptions": [
+    {
+      "domain": "www.example.com",
+      "reason": "Cannot identify"
+    },
+    {
+      "domain": "weather.com",
+      "reason": "Broken autoconsent"
+    }
+  ],
+  "settings": {
+    "disabledCMPs": ["TestCmp"]
+  }
+}

--- a/autoconsent/autoconsent-store/build.gradle
+++ b/autoconsent/autoconsent-store/build.gradle
@@ -1,19 +1,27 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
+    id 'kotlin-kapt'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation project(path: ':autoconsent-api')
+    implementation project(path: ':common')
 
     implementation AndroidX.core.ktx
     implementation KotlinX.coroutines.core
 
+    // Room
+    implementation AndroidX.room.runtime
+    implementation AndroidX.room.ktx
+    kapt AndroidX.room.compiler
+    testImplementation AndroidX.room.testing
+
     // Testing dependencies
     testImplementation Testing.junit4
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation AndroidX.test.ext.junit
     testImplementation Testing.robolectric
     testImplementation (KotlinX.coroutines.test) {
@@ -21,6 +29,7 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
+    testImplementation project(path: ':common-test')
 }
 
 android {

--- a/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentDao.kt
+++ b/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentDao.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.store
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Dao
+abstract class AutoconsentDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertDisabledCmps(disabledCmps: List<DisabledCmpsEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertExceptions(exceptions: List<AutoconsentExceptionEntity>)
+
+    @Transaction
+    open fun updateAll(exceptions: List<AutoconsentExceptionEntity>, disabledCmps: List<DisabledCmpsEntity>) {
+        deleteDisabledCmps()
+        deleteExceptions()
+        insertDisabledCmps(disabledCmps)
+        insertExceptions(exceptions)
+    }
+
+    @Query("select * from autoconsent_exceptions")
+    abstract fun getExceptions(): List<AutoconsentExceptionEntity>
+
+    @Query("select * from autoconsent_disabled_cmps")
+    abstract fun getDisabledCmps(): List<DisabledCmpsEntity>
+
+    @Query("delete from autoconsent_disabled_cmps")
+    abstract fun deleteDisabledCmps()
+
+    @Query("delete from autoconsent_exceptions")
+    abstract fun deleteExceptions()
+}

--- a/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentDatabase.kt
+++ b/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentDatabase.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.store
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    exportSchema = true,
+    version = 1,
+    entities = [
+        AutoconsentExceptionEntity::class,
+        DisabledCmpsEntity::class,
+    ]
+)
+abstract class AutoconsentDatabase : RoomDatabase() {
+    abstract fun autoconsentDao(): AutoconsentDao
+}

--- a/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentDatabaseModels.kt
+++ b/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentDatabaseModels.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.store
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "autoconsent_exceptions")
+data class AutoconsentExceptionEntity(
+    @PrimaryKey val domain: String,
+    val reason: String
+)
+
+@Entity(tableName = "autoconsent_disabled_cmps")
+data class DisabledCmpsEntity(
+    @PrimaryKey val name: String,
+)

--- a/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentFeatureToggleRepository.kt
+++ b/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentFeatureToggleRepository.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.store
+
+import android.content.Context
+
+interface AutoconsentFeatureToggleRepository : AutoconsentFeatureToggleStore {
+    companion object {
+        fun create(
+            context: Context,
+        ): AutoconsentFeatureToggleRepository {
+            val store = RealAutoconsentFeatureToggleStore(context)
+            return RealAutoconsentFeatureToggleRepository(store)
+        }
+    }
+}
+
+internal class RealAutoconsentFeatureToggleRepository constructor(
+    private val autoconsentFeatureToggleStore: AutoconsentFeatureToggleStore,
+) : AutoconsentFeatureToggleRepository, AutoconsentFeatureToggleStore by autoconsentFeatureToggleStore

--- a/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentFeatureToggleStore.kt
+++ b/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentFeatureToggleStore.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.store
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.autoconsent.api.AutoconsentFeatureName
+
+interface AutoconsentFeatureToggleStore {
+    fun deleteAll()
+
+    fun get(
+        featureName: AutoconsentFeatureName,
+        defaultValue: Boolean
+    ): Boolean
+
+    fun getMinSupportedVersion(featureName: AutoconsentFeatureName): Int
+
+    fun insert(toggle: AutoconsentFeatureToggles)
+}
+
+internal class RealAutoconsentFeatureToggleStore(private val context: Context) : AutoconsentFeatureToggleStore {
+    private val preferences: SharedPreferences
+        get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+
+    override fun deleteAll() {
+        preferences.edit().clear().apply()
+    }
+
+    override fun get(featureName: AutoconsentFeatureName, defaultValue: Boolean): Boolean {
+        return preferences.getBoolean(featureName.value, defaultValue)
+    }
+
+    override fun getMinSupportedVersion(featureName: AutoconsentFeatureName): Int {
+        return preferences.getInt("${featureName.value}$MIN_SUPPORTED_VERSION", 0)
+    }
+
+    override fun insert(toggle: AutoconsentFeatureToggles) {
+        preferences.edit {
+            putBoolean(toggle.featureName.value, toggle.enabled)
+            toggle.minSupportedVersion?.let {
+                putInt("${toggle.featureName.value}$MIN_SUPPORTED_VERSION", it)
+            }
+        }
+    }
+
+    companion object {
+        const val FILENAME = "com.duckduckgo.autoconsent.store.toggles"
+        const val MIN_SUPPORTED_VERSION = "MinSupportedVersion"
+    }
+}
+
+data class AutoconsentFeatureToggles(
+    val featureName: AutoconsentFeatureName,
+    val enabled: Boolean,
+    val minSupportedVersion: Int?
+)

--- a/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentRepository.kt
+++ b/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentRepository.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.store
+
+import com.duckduckgo.app.global.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
+
+interface AutoconsentRepository {
+    fun updateAll(exceptions: List<AutoconsentExceptionEntity>, disabledCmps: List<DisabledCmpsEntity>)
+    val exceptions: List<AutoconsentExceptionEntity>
+    val disabledCmps: List<DisabledCmpsEntity>
+}
+
+class RealAutoconsentRepository constructor(
+    val database: AutoconsentDatabase,
+    coroutineScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider
+) : AutoconsentRepository {
+
+    private val autoconsentDao: AutoconsentDao = database.autoconsentDao()
+
+    override val exceptions = CopyOnWriteArrayList<AutoconsentExceptionEntity>()
+    override val disabledCmps = CopyOnWriteArrayList<DisabledCmpsEntity>()
+
+    init {
+        coroutineScope.launch(dispatcherProvider.io()) {
+            loadToMemory()
+        }
+    }
+
+    override fun updateAll(exceptions: List<AutoconsentExceptionEntity>, disabledCmps: List<DisabledCmpsEntity>) {
+        autoconsentDao.updateAll(exceptions, disabledCmps)
+        loadToMemory()
+    }
+
+    private fun loadToMemory() {
+        exceptions.clear()
+        exceptions.addAll(autoconsentDao.getExceptions())
+
+        disabledCmps.clear()
+        disabledCmps.addAll(autoconsentDao.getDisabledCmps())
+    }
+}

--- a/autoconsent/autoconsent-store/src/test/java/com/duckduckgo/autoconsent/store/RealAutoconsentRepositoryTest.kt
+++ b/autoconsent/autoconsent-store/src/test/java/com/duckduckgo/autoconsent/store/RealAutoconsentRepositoryTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.store
+
+import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RealAutoconsentRepositoryTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val mockDatabase: AutoconsentDatabase = mock()
+    private val mockDao: AutoconsentDao = mock()
+
+    lateinit var repository: AutoconsentRepository
+
+    @Before
+    fun before() {
+        whenever(mockDatabase.autoconsentDao()).thenReturn(mockDao)
+
+        repository = RealAutoconsentRepository(mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
+    }
+
+    @Test
+    fun whenRepositoryIsCreatedThenExceptionsLoadedIntoMemory() {
+        givenDaoContainsExceptionsAndDisabledCmps()
+
+        repository = RealAutoconsentRepository(mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
+
+        assertEquals(exception, repository.exceptions.first())
+        assertEquals(disabledCmp, repository.disabledCmps.first())
+    }
+
+    @Test
+    fun whenUpdateAllThenUpdateAllCalled() = runTest {
+        repository = RealAutoconsentRepository(mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
+
+        repository.updateAll(listOf(), listOf())
+
+        verify(mockDao).updateAll(anyList(), anyList())
+    }
+
+    @Test
+    fun whenUpdateAllThenPreviousExceptionsAreCleared() = runTest {
+        givenDaoContainsExceptionsAndDisabledCmps()
+        repository = RealAutoconsentRepository(mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
+
+        assertEquals(1, repository.exceptions.size)
+        assertEquals(1, repository.disabledCmps.size)
+        reset(mockDao)
+
+        repository.updateAll(listOf(), listOf())
+
+        assertEquals(0, repository.exceptions.size)
+        assertEquals(0, repository.disabledCmps.size)
+    }
+
+    private fun givenDaoContainsExceptionsAndDisabledCmps() {
+        whenever(mockDao.getExceptions()).thenReturn(listOf(exception))
+        whenever(mockDao.getDisabledCmps()).thenReturn(listOf(disabledCmp))
+    }
+
+    companion object {
+        val exception = AutoconsentExceptionEntity("example.com", "reason")
+        val disabledCmp = DisabledCmpsEntity("disabledcmp")
+    }
+}

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UnprotectedTemporary.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UnprotectedTemporary.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.api
+
+/** Public interface for the Unprotected Temporary feature */
+interface UnprotectedTemporary {
+    /**
+     * This method takes a [url] and returns `true` or `false` depending if the [url] is in the
+     * unprotected temporary exceptions list
+     * @return a `true` if the given [url] if the url is in the unprotected temporary exceptions list and `false`
+     * otherwise.
+     */
+    fun isAnException(url: String): Boolean
+}

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/RealAmpLinks.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/RealAmpLinks.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.privacy.config.api.AmpLinkInfo
 import com.duckduckgo.privacy.config.api.AmpLinkType
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.amplinks.AmpLinksRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/autofill/RealAutofill.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/autofill/RealAutofill.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.impl.features.autofill
 import com.duckduckgo.app.global.UriString.Companion.sameOrSubdomain
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.api.Autofill
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.autofill.AutofillRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlocking.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlocking.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpc.kt
@@ -22,8 +22,8 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.impl.R
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/RealHttps.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/RealHttps.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.impl.features.https
 import com.duckduckgo.app.global.UriString.Companion.sameOrSubdomain
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.api.Https
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/RealTrackingParameters.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/RealTrackingParameters.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.TrackingParameters
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.trackingparameters.TrackingParametersRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporary.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporary.kt
@@ -18,14 +18,11 @@ package com.duckduckgo.privacy.config.impl.features.unprotectedtemporary
 
 import com.duckduckgo.app.global.UriString
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import dagger.SingleInstanceIn
-
-interface UnprotectedTemporary {
-    fun isAnException(url: String): Boolean
-}
 
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.privacy.config.impl.features.useragent
 
 import com.duckduckgo.app.global.UriString
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.api.UserAgent
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpFormatReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpFormatReferenceTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.privacy.config.api.AmpLinkException
 import com.duckduckgo.privacy.config.api.AmpLinkType
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.amplinks.AmpLinksRepository
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpKeywordReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpKeywordReferenceTest.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.privacy.config.api.AmpLinkException
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.amplinks.AmpLinksRepository
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/autofill/RealAutofillTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/autofill/RealAutofillTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.features.autofill
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.privacy.config.api.AutofillException
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.autofill.AutofillRepository
 import org.junit.Assert.*
 import org.junit.Before

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
@@ -20,7 +20,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.ContentBlockingException
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingRepository
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/gpc/RealGpcTest.kt
@@ -23,10 +23,10 @@ import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.GpcException
 import com.duckduckgo.privacy.config.api.GpcHeaderEnabledSite
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.impl.R
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER_VALUE
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/RealHttpsTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/RealHttpsTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.features.https
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.privacy.config.api.HttpsException
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParameterReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParameterReferenceTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.TrackingParameterException
 import com.duckduckgo.privacy.config.api.TrackingParameters
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.trackingparameters.TrackingParametersRepository
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgentTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgentTest.kt
@@ -17,8 +17,8 @@
 package com.duckduckgo.privacy.config.impl.features.useragent
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.api.UserAgentException
-import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
 import org.junit.Assert.*
 import org.junit.Before


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1125189844152671/1202811961217180

### Description
This PR only allows one CTA while browsing per page load. By CTA we mean a Dax Dialog what implements DaxDialogCta.

### Steps to test this PR

- [x] Install from the `feature/marcos/basic_messaging` branch 
- [x] Go to `cnn.com`
- [x] As soon as you see the onboarding cta click on the blue button (high five)
- [x] You will probably see the autoconsent cta right after that. If you didn't see it, you weren't quick enough. Repeat until it happens.
- [x] Install from this branch
- [x] Go to `cnn.com`
- [x] As soon as you see the onboarding cta click on the blue button (high five)
- [x] You should not see the autoconsent cta right after that.
- [x] Refresh the page and now you should see the autoconsent cta.
- [x] Try and repeat as many times as you want to see if you are quicker than my code 🥇 

Note: It is highly unlikely but if the autoconsent trigger happens before the onboarding one you might see the autoconsent dialog before the onboarding. If that happens, there are no issues because we are on a first come first serve basis.

