### PR TITLE
Android: Remove support for non-ad_domain parameters

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/AdClickAttributionFeature.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/AdClickAttributionFeature.kt
@@ -34,8 +34,6 @@ data class AdClickAttributionSettings(
 
 data class AdClickAttributionLinkFormat(
     val url: String,
-    val parameterName: String?,
-    val parameterValue: String?,
     val adDomainParameterName: String?
 )
 

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/AdClickAttributionPlugin.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/AdClickAttributionPlugin.kt
@@ -55,8 +55,6 @@ class AdClickAttributionPlugin @Inject constructor(
                 linkFormats.add(
                     AdClickAttributionLinkFormatEntity(
                         url = it.url,
-                        parameterName = it.parameterName.orEmpty(),
-                        parameterValue = it.parameterValue.orEmpty(),
                         adDomainParameterName = it.adDomainParameterName.orEmpty()
                     )
                 )

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/RealAdClickAttribution.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/RealAdClickAttribution.kt
@@ -108,17 +108,11 @@ class RealAdClickAttribution @Inject constructor(
         }
 
         val uri = Uri.parse(url)
-        if (linkFormat.parameterName.isEmpty() && linkFormat.parameterValue.isEmpty() && linkFormat.adDomainParameterName.isEmpty()) {
+        if (linkFormat.adDomainParameterName.isEmpty()) {
             return Pair(true, null)
         }
         if (linkFormat.adDomainParameterName.isNotEmpty() && uri.queryParameterNames.contains(linkFormat.adDomainParameterName)) {
             return Pair(true, uri.getQueryParameter(linkFormat.adDomainParameterName))
-        }
-        if (linkFormat.parameterName.isNotEmpty() && linkFormat.parameterValue.isNotEmpty()) {
-            return Pair(uri.getQueryParameter(linkFormat.parameterName) == linkFormat.parameterValue, null)
-        }
-        if (linkFormat.parameterName.isNotEmpty()) {
-            return Pair(uri.queryParameterNames.contains(linkFormat.parameterName), null)
         }
 
         return noMatch

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/di/AdClickModule.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/di/AdClickModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.adclick.store.AdClickAttributionRepository
 import com.duckduckgo.adclick.store.AdClickDatabase
+import com.duckduckgo.adclick.store.AdClickDatabase.Companion.ALL_MIGRATIONS
 import com.duckduckgo.adclick.store.AdClickFeatureToggleRepository
 import com.duckduckgo.adclick.store.RealAdClickAttributionRepository
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -39,6 +40,7 @@ class AdClickModule {
     @SingleInstanceIn(AppScope::class)
     fun provideAdClickDatabase(context: Context): AdClickDatabase {
         return Room.databaseBuilder(context, AdClickDatabase::class.java, "adclick.db")
+            .addMigrations(*ALL_MIGRATIONS)
             .enableMultiInstanceInvalidation()
             .fallbackToDestructiveMigration()
             .build()

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/AdClickAttributionPluginTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/AdClickAttributionPluginTest.kt
@@ -100,12 +100,9 @@ class AdClickAttributionPluginTest {
         val linkFormatEntity = linkFormatCaptor.firstValue
         assertEquals(6, linkFormatEntity.size)
         assertEquals("duckduckgo.com/y.js", linkFormatEntity[0].url)
-        assertEquals("u3", linkFormatEntity[0].parameterName)
-        assertTrue(linkFormatEntity[0].parameterValue.isEmpty())
+        assertEquals("ad_domain", linkFormatEntity[0].adDomainParameterName)
         assertEquals("links.duckduckgo.com/m.js", linkFormatEntity[3].url)
-        assertEquals("dsl", linkFormatEntity[3].parameterName)
-        assertEquals("1", linkFormatEntity[3].parameterValue)
-
+        assertEquals("ad_domain", linkFormatEntity[3].adDomainParameterName)
         val allowlistEntity = allowlistCaptor.firstValue
         assertEquals(3, allowlistEntity.size)
         assertEquals("bing.com", allowlistEntity[0].blocklistEntry)

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/RealAdClickAttributionTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/RealAdClickAttributionTest.kt
@@ -158,8 +158,6 @@ class RealAdClickAttributionTest {
             listOf(
                 AdClickAttributionLinkFormatEntity(
                     url = "https://example.com",
-                    parameterName = "",
-                    parameterValue = "",
                     adDomainParameterName = ""
                 )
             )
@@ -182,8 +180,6 @@ class RealAdClickAttributionTest {
             listOf(
                 AdClickAttributionLinkFormatEntity(
                     url = "https://example.com",
-                    parameterName = "",
-                    parameterValue = "",
                     adDomainParameterName = ""
                 )
             )
@@ -206,8 +202,6 @@ class RealAdClickAttributionTest {
             listOf(
                 AdClickAttributionLinkFormatEntity(
                     url = "https://example.com",
-                    parameterName = "",
-                    parameterValue = "",
                     adDomainParameterName = "ad_domain"
                 )
             )
@@ -224,102 +218,6 @@ class RealAdClickAttributionTest {
     }
 
     @Test
-    fun whenFeatureEnabledAndUrlMatchesLinkFormatAndParamNameThenIsAdClickReturnsTrue() {
-        givenFeatureEnabled()
-        givenDetectionsEnabled(domainEnabled = true, heuristicEnabled = true)
-        whenever(mockAdClickAttributionRepository.linkFormats).thenReturn(
-            listOf(
-                AdClickAttributionLinkFormatEntity(
-                    url = "https://example.com",
-                    parameterName = "a",
-                    parameterValue = "",
-                    adDomainParameterName = ""
-                )
-            )
-        )
-        testee = RealAdClickAttribution(
-            mockAdClickAttributionRepository,
-            mockFeatureToggle
-        )
-
-        val result = testee.isAdClick("https://example.com?a=100")
-
-        assertTrue(result.first)
-    }
-
-    @Test
-    fun whenFeatureEnabledAndUrlMatchesLinkFormatAndParamNameAndParamValueThenIsAdClickReturnsTrue() {
-        givenFeatureEnabled()
-        givenDetectionsEnabled(domainEnabled = true, heuristicEnabled = true)
-        whenever(mockAdClickAttributionRepository.linkFormats).thenReturn(
-            listOf(
-                AdClickAttributionLinkFormatEntity(
-                    url = "https://example.com",
-                    parameterName = "a",
-                    parameterValue = "100",
-                    adDomainParameterName = ""
-                )
-            )
-        )
-        testee = RealAdClickAttribution(
-            mockAdClickAttributionRepository,
-            mockFeatureToggle
-        )
-
-        val result = testee.isAdClick("https://example.com?a=100")
-
-        assertTrue(result.first)
-    }
-
-    @Test
-    fun whenFeatureEnabledAndUrlMatchesLinkFormatAndDoesntMatchParamNameThenIsAdClickReturnsFalse() {
-        givenFeatureEnabled()
-        givenDetectionsEnabled(domainEnabled = true, heuristicEnabled = true)
-        whenever(mockAdClickAttributionRepository.linkFormats).thenReturn(
-            listOf(
-                AdClickAttributionLinkFormatEntity(
-                    url = "https://example.com",
-                    parameterName = "b",
-                    parameterValue = "100",
-                    adDomainParameterName = ""
-                )
-            )
-        )
-        testee = RealAdClickAttribution(
-            mockAdClickAttributionRepository,
-            mockFeatureToggle
-        )
-
-        val result = testee.isAdClick("https://example.com?a=100")
-
-        assertFalse(result.first)
-    }
-
-    @Test
-    fun whenFeatureEnabledAndUrlMatchesLinkFormatAndParamNameAndDoesntMatchParmaValueThenIsAdClickReturnsFalse() {
-        givenFeatureEnabled()
-        givenDetectionsEnabled(domainEnabled = true, heuristicEnabled = true)
-        whenever(mockAdClickAttributionRepository.linkFormats).thenReturn(
-            listOf(
-                AdClickAttributionLinkFormatEntity(
-                    url = "https://example.com",
-                    parameterName = "a",
-                    parameterValue = "0",
-                    adDomainParameterName = ""
-                )
-            )
-        )
-        testee = RealAdClickAttribution(
-            mockAdClickAttributionRepository,
-            mockFeatureToggle
-        )
-
-        val result = testee.isAdClick("https://example.com?a=100")
-
-        assertFalse(result.first)
-    }
-
-    @Test
     fun whenFeatureEnabledAndOnlyDomainDetectionEnabledAndUrlMatchesLinkFormatThenAdClickReturnsTrue() {
         givenFeatureEnabled()
         givenDetectionsEnabled(domainEnabled = true, heuristicEnabled = false)
@@ -327,8 +225,6 @@ class RealAdClickAttributionTest {
             listOf(
                 AdClickAttributionLinkFormatEntity(
                     url = "https://example.com",
-                    parameterName = "",
-                    parameterValue = "",
                     adDomainParameterName = ""
                 )
             )
@@ -351,8 +247,6 @@ class RealAdClickAttributionTest {
             listOf(
                 AdClickAttributionLinkFormatEntity(
                     url = "https://example.com",
-                    parameterName = "",
-                    parameterValue = "",
                     adDomainParameterName = ""
                 )
             )

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/referencetests/AdClickAttributionLinkFormatsReferenceTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/referencetests/AdClickAttributionLinkFormatsReferenceTest.kt
@@ -91,8 +91,6 @@ class AdClickAttributionLinkFormatsReferenceTest(private val testCase: TestCase)
                 list.map {
                     AdClickAttributionLinkFormatEntity(
                         url = it.url,
-                        parameterName = it.parameterName.orEmpty(),
-                        parameterValue = it.parameterValue.orEmpty(),
                         adDomainParameterName = it.adDomainParameterName.orEmpty()
                     )
                 }

--- a/ad-click/ad-click-impl/src/test/resources/json/ad_click_attribution.json
+++ b/ad-click/ad-click-impl/src/test/resources/json/ad_click_attribution.json
@@ -5,40 +5,31 @@
     "linkFormats": [
       {
         "url": "duckduckgo.com/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "SERP Ads"
       },
       {
         "url": "www.search-company.site/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "www.search-company.example/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "links.duckduckgo.com/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Shopping Ads"
       },
       {
         "url": "www.search-company.site/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "www.search-company.example/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       }

--- a/ad-click/ad-click-impl/src/test/resources/json/ad_click_attribution_disabled.json
+++ b/ad-click/ad-click-impl/src/test/resources/json/ad_click_attribution_disabled.json
@@ -5,40 +5,31 @@
     "linkFormats": [
       {
         "url": "duckduckgo.com/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "SERP Ads"
       },
       {
         "url": "www.search-company.site/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "www.search-company.example/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "links.duckduckgo.com/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Shopping Ads"
       },
       {
         "url": "www.search-company.site/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "www.search-company.example/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       }

--- a/ad-click/ad-click-impl/src/test/resources/json/ad_click_attribution_min_supported_version.json
+++ b/ad-click/ad-click-impl/src/test/resources/json/ad_click_attribution_min_supported_version.json
@@ -6,40 +6,31 @@
     "linkFormats": [
       {
         "url": "duckduckgo.com/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "SERP Ads"
       },
       {
         "url": "www.search-company.site/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "www.search-company.example/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "links.duckduckgo.com/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Shopping Ads"
       },
       {
         "url": "www.search-company.site/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "www.search-company.example/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       }

--- a/ad-click/ad-click-impl/src/test/resources/reference_tests/adclickattribution/ad_click_attribution_matching_tests.json
+++ b/ad-click/ad-click-impl/src/test/resources/reference_tests/adclickattribution/ad_click_attribution_matching_tests.json
@@ -4,17 +4,22 @@
     "desc": "These tests use the ad_click_attribution_reference.json file.",
     "tests": [
       {
-        "name": "A URL is matching the first rule - url and param name in first position.",
-        "url": "https://duckduckgo.com/y.js?u3=1",
+        "name": "A URL is matching the first rule - url and empty adDomainParameterName name (no other params).",
+        "url": "https://duckduckgo.com/y.js?ad_domain=",
         "isAdClick": true
       },
       {
-        "name": "A URL is matching the first rule - url and param name.",
-        "url": "https://duckduckgo.com/y.js?ad_provider=bing&u3=1&other_param=true",
+        "name": "A URL is matching the first rule - url and empty adDomainParameterName name (other params are there).",
+        "url": "https://duckduckgo.com/y.js?ad_provider=bing&ad_domain=&other_param=true",
         "isAdClick": true
       },
       {
-        "name": "A URL is matching the first rule - url and ad domain param when no param name.",
+        "name": "A URL is matching the first rule - url and non empty adDomainParameterName name (no other params).",
+        "url": "https://duckduckgo.com/y.js?ad_domain=nike.com",
+        "isAdClick": true
+      },
+      {
+        "name": "A URL is matching the first rule - url and non empty adDomainParameterName name (other params are there).",
         "url": "https://duckduckgo.com/y.js?ad_provider=bing&ad_domain=nike.com&other_param=true",
         "isAdClick": true
       },
@@ -29,37 +34,37 @@
         "isAdClick": false
       },
       {
-        "name": "A URL is matching the second rule - url and param name in first position.",
-        "url": "https://www.search-company.site/y.js?u3=1",
+        "name": "A URL is matching the second rule - url and adDomainParameterName name (no other params).",
+        "url": "https://www.search-company.site/y.js?ad_domain=nike.com",
         "isAdClick": true
       },
       {
-        "name": "A URL is matching the second rule - url and param name.",
-        "url": "https://www.search-company.site/y.js?ad_provider=bing&u3=1&other_param=true",
+        "name": "A URL is matching the second rule - url and adDomainParameterName name (other params are there).",
+        "url": "https://www.search-company.site/y.js?ad_provider=bing&ad_domain=nike.com1&other_param=true",
         "isAdClick": true
       },
       {
-        "name": "A URL is matching the third rule - url and param name in first position.",
-        "url": "https://www.search-company.example/y.js?u3=1",
+        "name": "A URL is matching the third rule - url and adDomainParameterName name (no other params).",
+        "url": "https://www.search-company.example/y.js?ad_domain=nike.com",
         "isAdClick": true
       },
       {
-        "name": "A URL is matching the third rule - url and param name.",
-        "url": "https://www.search-company.example/y.js?ad_provider=bing&u3=1&other_param=true",
+        "name": "A URL is matching the third rule - url and adDomainParameterName name (other params are there).",
+        "url": "https://www.search-company.example/y.js?ad_provider=bing&ad_domain=nike.com&other_param=true",
         "isAdClick": true
       },
       {
-        "name": "A URL is matching the fourth rule - url and param name in first position.",
-        "url": "https://links.duckduckgo.com/m.js?dsl=1",
+        "name": "A URL is matching the fourth rule - url and adDomainParameterName name (no other params).",
+        "url": "https://links.duckduckgo.com/m.js?ad_domain=nike.com",
         "isAdClick": true
       },
       {
-        "name": "A URL is matching the fourth rule - url and param name.",
-        "url": "https://links.duckduckgo.com/m.js?ad_provider=bing&dsl=1&other_param=true",
+        "name": "A URL is matching the fourth rule - url and adDomainParameterName name (other params are there).",
+        "url": "https://links.duckduckgo.com/m.js?ad_provider=bing&ad_domain=nike.com&other_param=true",
         "isAdClick": true
       },
       {
-        "name": "A URL is not matching any rules - url and param name are matching, but the param value is not the expected one.",
+        "name": "A URL is not matching any rules - url and param name are matching, but the adDomainParameterName is not there.",
         "url": "https://links.duckduckgo.com/m.js?ad_provider=bing&dsl=2&other_param=true",
         "isAdClick": false
       },

--- a/ad-click/ad-click-impl/src/test/resources/reference_tests/adclickattribution/ad_click_attribution_reference.json
+++ b/ad-click/ad-click-impl/src/test/resources/reference_tests/adclickattribution/ad_click_attribution_reference.json
@@ -5,40 +5,31 @@
     "linkFormats": [
       {
         "url": "duckduckgo.com/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "SERP Ads"
       },
       {
         "url": "www.search-company.site/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "www.search-company.example/y.js",
-        "parameterName": "u3",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "links.duckduckgo.com/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Shopping Ads"
       },
       {
         "url": "www.search-company.site/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       },
       {
         "url": "www.search-company.example/m.js",
-        "parameterName": "dsl",
-        "parameterValue": "1",
         "adDomainParameterName": "ad_domain",
         "desc": "Test Domain"
       }

--- a/ad-click/ad-click-store/src/main/java/com/duckduckgo/adclick/store/AdClickDatabase.kt
+++ b/ad-click/ad-click-store/src/main/java/com/duckduckgo/adclick/store/AdClickDatabase.kt
@@ -18,10 +18,12 @@ package com.duckduckgo.adclick.store
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     exportSchema = true,
-    version = 1,
+    version = 2,
     entities = [
         AdClickAttributionLinkFormatEntity::class,
         AdClickAttributionAllowlistEntity::class,
@@ -31,4 +33,19 @@ import androidx.room.RoomDatabase
 )
 abstract class AdClickDatabase : RoomDatabase() {
     abstract fun adClickDao(): AdClickDao
+
+    companion object {
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // Drop column is not supported by SQLite, so the data must be moved manually.
+                with(database) {
+                    execSQL("CREATE TABLE `link_formats_bk` (`url` TEXT NOT NULL, `adDomainParameterName` TEXT NOT NULL, PRIMARY KEY(`url`))")
+                    execSQL("INSERT INTO `link_formats_bk` SELECT `url`, `adDomainParameterName` FROM `link_formats`")
+                    execSQL("DROP TABLE `link_formats`")
+                    execSQL("ALTER TABLE `link_formats_bk` RENAME to `link_formats`")
+                }
+            }
+        }
+        val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2)
+    }
 }

--- a/ad-click/ad-click-store/src/main/java/com/duckduckgo/adclick/store/AdClickEntities.kt
+++ b/ad-click/ad-click-store/src/main/java/com/duckduckgo/adclick/store/AdClickEntities.kt
@@ -22,8 +22,6 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "link_formats")
 data class AdClickAttributionLinkFormatEntity(
     @PrimaryKey val url: String,
-    val parameterName: String,
-    val parameterValue: String,
     val adDomainParameterName: String
 )
 

--- a/ad-click/ad-click-store/src/test/java/com/duckduckgo/adclick/store/RealAdClickAttributionRepositoryTest.kt
+++ b/ad-click/ad-click-store/src/test/java/com/duckduckgo/adclick/store/RealAdClickAttributionRepositoryTest.kt
@@ -112,8 +112,6 @@ class RealAdClickAttributionRepositoryTest {
     companion object {
         val linkFormatEntity = AdClickAttributionLinkFormatEntity(
             url = "good.first-party.site/y.js",
-            parameterName = "a",
-            parameterValue = "1",
             adDomainParameterName = ""
         )
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1202815075182083/f

### Description
Removed the usage of parameterName and parameterValue from link_formats.

### Steps to test this PR

1/ Test update (important for DB migrations)

- [x] install from develop
- [x] open the app
- [x] inspect the `adclick.db` database and notice the `link_formats` table is populated and contains the columns `parameterName` and `parameterValue`
- [x] update from this branch
- [x] inspect the `adclick.db` database and notice the `link_formats` table is populated and does NOT contain anymore the columns `parameterName` and `parameterValue`
- [x] do a quick test for ads:
         - Go to: https://www.search-company.site/
          Click "[Ad 5]"
          ✅ Loaded:
          [https://convert.ad-company.site/convert.js](https://convert.ad-site.example/convert.js)
          ❌ Blocked:
         [https://track.ad-company.site/track.js](https://track.ad-site.example/track.js)


2/ Test fresh install
- [x] install from this branch
- [x] inspect the `adclick.db` database and notice the `link_formats` table is populated and does NOT contain the columns `parameterName` and `parameterValue`
- [x] do a quick test for ads:
         - Go to: https://www.search-company.site/
          Click "[Ad 5]"
          ✅ Loaded:
          [https://convert.ad-company.site/convert.js](https://convert.ad-site.example/convert.js)
          ❌ Blocked:
         [https://track.ad-company.site/track.js](https://track.ad-site.example/track.js)


### NO UI changes
