### PR TITLE
Crash: DuckDuckGoAdClickManager.toTldPlusOne

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManager.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManager.kt
@@ -128,7 +128,7 @@ class DuckDuckGoAdClickManager @Inject constructor(
     private fun toTldPlusOne(url: String): String? {
         val urlAdDomain = UriString.host(url)
         if (urlAdDomain.isNullOrEmpty()) return urlAdDomain
-        return publicSuffixDatabase.getEffectiveTldPlusOne(urlAdDomain)
+        return kotlin.runCatching { publicSuffixDatabase.getEffectiveTldPlusOne(urlAdDomain) }.getOrNull()
     }
 
     private fun adClicked(detectedAdDomain: String?) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202820659663269/f

### Description
Return null instead of crashing when the `toTldPlusOne` (`PublicSuffixDatabase.getEffectiveTldPlusOne`) encounters an exception.

### Steps to test this PR

- we couldn't replicate

### NO UI changes
