### PR TITLE
Ensure fragment result listeners respond to correct tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -138,8 +138,6 @@ import kotlinx.android.synthetic.main.include_omnibar_toolbar.view.*
 import kotlinx.android.synthetic.main.include_quick_access_items.*
 import kotlinx.android.synthetic.main.popup_window_browser_menu.view.*
 import com.duckduckgo.autofill.*
-import com.duckduckgo.autofill.CredentialAutofillPickerDialog.Companion.RESULT_KEY_CREDENTIAL_PICKER
-import com.duckduckgo.autofill.CredentialSavePickerDialog.Companion.RESULT_KEY_CREDENTIAL_RESULT_SAVE
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResultListener
 import kotlinx.coroutines.*
@@ -188,7 +186,6 @@ import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.BrowserAutofill
 import com.duckduckgo.autofill.Callback
-import com.duckduckgo.autofill.CredentialUpdateExistingCredentialsDialog.Companion.RESULT_KEY_CREDENTIAL_RESULT_UPDATE
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.*
@@ -1576,11 +1573,12 @@ class BrowserTabFragment :
     private fun configureWebViewForAutofill(it: DuckDuckGoWebView) {
         browserAutofill.addJsInterface(it, autofillCallback)
 
-        setFragmentResultListener(RESULT_KEY_CREDENTIAL_PICKER) { _, result ->
+        setFragmentResultListener(CredentialAutofillPickerDialog.resultKey(tabId)) { _, result ->
             autofillCredentialsSelectionResultHandler.processAutofillCredentialSelectionResult(result, this, viewModel)
         }
 
-        setFragmentResultListener(RESULT_KEY_CREDENTIAL_RESULT_SAVE) { _, result ->
+        setFragmentResultListener(CredentialSavePickerDialog.resultKey(tabId)) { _, result ->
+            Timber.i("Received result for saving credentials. $tabId handling it")
             launch {
                 autofillCredentialsSelectionResultHandler.processSaveCredentialsResult(result, viewModel)?.let {
                     showAuthenticationSavedOrUpdatedSnackbar(it, R.string.autofillLoginSavedSnackbarMessage)
@@ -1588,7 +1586,7 @@ class BrowserTabFragment :
             }
         }
 
-        setFragmentResultListener(RESULT_KEY_CREDENTIAL_RESULT_UPDATE) { _, result ->
+        setFragmentResultListener(CredentialUpdateExistingCredentialsDialog.resultKey(tabId)) { _, result ->
             launch {
                 autofillCredentialsSelectionResultHandler.processUpdateCredentialsResult(result, viewModel)?.let {
                     showAuthenticationSavedOrUpdatedSnackbar(it, R.string.autofillLoginUpdatedSnackbarMessage)
@@ -1610,7 +1608,7 @@ class BrowserTabFragment :
     private fun showAutofillDialogChooseCredentials(credentials: List<LoginCredentials>, triggerType: LoginTriggerType) {
         Timber.v("onCredentialsAvailable. %d creds to choose from", credentials.size)
         val url = webView?.url ?: return
-        val dialog = credentialAutofillDialogFactory.autofillSelectCredentialsDialog(url, credentials, triggerType)
+        val dialog = credentialAutofillDialogFactory.autofillSelectCredentialsDialog(url, credentials, triggerType, tabId)
         showDialogHidingPrevious(dialog, CredentialAutofillPickerDialog.TAG)
     }
 
@@ -1618,7 +1616,7 @@ class BrowserTabFragment :
         val url = webView?.url ?: return
         if (url != currentUrl) return
 
-        val dialog = credentialAutofillDialogFactory.autofillSavingCredentialsDialog(url, credentials)
+        val dialog = credentialAutofillDialogFactory.autofillSavingCredentialsDialog(url, credentials, tabId)
         showDialogHidingPrevious(dialog, CredentialSavePickerDialog.TAG)
     }
 
@@ -1626,7 +1624,7 @@ class BrowserTabFragment :
         val url = webView?.url ?: return
         if (url != currentUrl) return
 
-        val dialog = credentialAutofillDialogFactory.autofillSavingUpdateCredentialsDialog(url, credentials)
+        val dialog = credentialAutofillDialogFactory.autofillSavingUpdateCredentialsDialog(url, credentials, tabId)
         showDialogHidingPrevious(dialog, CredentialUpdateExistingCredentialsDialog.TAG)
     }
 

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/AutofillCredentialDialogs.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/AutofillCredentialDialogs.kt
@@ -26,12 +26,15 @@ import com.duckduckgo.autofill.domain.app.LoginTriggerType
 interface CredentialAutofillPickerDialog {
 
     companion object {
+
+        fun resultKey(tabId: String) = "$tabId/CredentialAutofillPickerDialogResult"
+
         const val TAG = "CredentialAutofillPickerDialog"
-        const val RESULT_KEY_CREDENTIAL_PICKER = "CredentialAutofillPickerDialogResult"
         const val KEY_CANCELLED = "cancelled"
         const val KEY_URL = "url"
         const val KEY_CREDENTIALS = "credentials"
         const val KEY_TRIGGER_TYPE = "triggerType"
+        const val KEY_TAB_ID = "tabId"
     }
 }
 
@@ -41,10 +44,12 @@ interface CredentialAutofillPickerDialog {
 interface CredentialSavePickerDialog {
 
     companion object {
+        fun resultKey(tabId: String) = "$tabId/CredentialSavePickerDialogResultSave"
+
         const val TAG = "CredentialSavePickerDialog"
-        const val RESULT_KEY_CREDENTIAL_RESULT_SAVE = "CredentialSavePickerDialogResultSave"
         const val KEY_URL = "url"
         const val KEY_CREDENTIALS = "credentials"
+        const val KEY_TAB_ID = "tabId"
     }
 }
 
@@ -54,10 +59,12 @@ interface CredentialSavePickerDialog {
 interface CredentialUpdateExistingCredentialsDialog {
 
     companion object {
+        fun resultKey(tabId: String) = "$tabId/CredentialUpdateExistingCredentialsResult"
+
         const val TAG = "CredentialUpdateExistingCredentialsDialog"
         const val KEY_URL = "url"
         const val KEY_CREDENTIALS = "credentials"
-        const val RESULT_KEY_CREDENTIAL_RESULT_UPDATE = "CredentialUpdateExistingCredentialsResult"
+        const val KEY_TAB_ID = "tabId"
     }
 }
 
@@ -66,10 +73,23 @@ interface CredentialUpdateExistingCredentialsDialog {
  */
 interface CredentialAutofillDialogFactory {
 
-    fun autofillSelectCredentialsDialog(url: String, credentials: List<LoginCredentials>, triggerType: LoginTriggerType): DialogFragment
+    fun autofillSelectCredentialsDialog(
+        url: String,
+        credentials: List<LoginCredentials>,
+        triggerType: LoginTriggerType,
+        tabId: String
+    ): DialogFragment
 
-    fun autofillSavingCredentialsDialog(url: String, credentials: LoginCredentials): DialogFragment
+    fun autofillSavingCredentialsDialog(
+        url: String,
+        credentials: LoginCredentials,
+        tabId: String
+    ): DialogFragment
 
-    fun autofillSavingUpdateCredentialsDialog(url: String, credentials: LoginCredentials): DialogFragment
+    fun autofillSavingUpdateCredentialsDialog(
+        url: String,
+        credentials: LoginCredentials,
+        tabId: String
+    ): DialogFragment
 
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/CredentialAutofillDialogAndroidFactory.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/CredentialAutofillDialogAndroidFactory.kt
@@ -21,8 +21,8 @@ import com.duckduckgo.autofill.CredentialAutofillDialogFactory
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment
-import com.duckduckgo.autofill.ui.credential.updating.AutofillUpdatingExistingCredentialsDialogFragment
 import com.duckduckgo.autofill.ui.credential.selecting.AutofillSelectCredentialsDialogFragment
+import com.duckduckgo.autofill.ui.credential.updating.AutofillUpdatingExistingCredentialsDialogFragment
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -30,15 +30,28 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 class CredentialAutofillDialogAndroidFactory @Inject constructor() : CredentialAutofillDialogFactory {
 
-    override fun autofillSelectCredentialsDialog(url: String, credentials: List<LoginCredentials>, triggerType: LoginTriggerType): DialogFragment {
-        return AutofillSelectCredentialsDialogFragment.instance(url, credentials, triggerType)
+    override fun autofillSelectCredentialsDialog(
+        url: String,
+        credentials: List<LoginCredentials>,
+        triggerType: LoginTriggerType,
+        tabId: String
+    ): DialogFragment {
+        return AutofillSelectCredentialsDialogFragment.instance(url, credentials, triggerType, tabId)
     }
 
-    override fun autofillSavingCredentialsDialog(url: String, credentials: LoginCredentials): DialogFragment {
-        return AutofillSavingCredentialsDialogFragment.instance(url, credentials)
+    override fun autofillSavingCredentialsDialog(
+        url: String,
+        credentials: LoginCredentials,
+        tabId: String
+    ): DialogFragment {
+        return AutofillSavingCredentialsDialogFragment.instance(url, credentials, tabId)
     }
 
-    override fun autofillSavingUpdateCredentialsDialog(url: String, credentials: LoginCredentials): DialogFragment {
-        return AutofillUpdatingExistingCredentialsDialogFragment.instance(url, credentials)
+    override fun autofillSavingUpdateCredentialsDialog(
+        url: String,
+        credentials: LoginCredentials,
+        tabId: String
+    ): DialogFragment {
+        return AutofillUpdatingExistingCredentialsDialogFragment.instance(url, credentials, tabId)
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
@@ -80,7 +80,7 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
                 it.putString(CredentialSavePickerDialog.KEY_URL, getOriginalUrl())
                 it.putParcelable(CredentialSavePickerDialog.KEY_CREDENTIALS, getCredentialsToSave())
             }
-            parentFragment?.setFragmentResult(CredentialSavePickerDialog.RESULT_KEY_CREDENTIAL_RESULT_SAVE, result)
+            parentFragment?.setFragmentResult(CredentialSavePickerDialog.resultKey(getTabId()), result)
             (dialog as BottomSheetDialog).animateClosed()
         }
     }
@@ -113,20 +113,21 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
     }
 
     private fun getCredentialsToSave() = arguments?.getParcelable<LoginCredentials>(CredentialSavePickerDialog.KEY_CREDENTIALS)!!
-
+    private fun getTabId() = arguments?.getString(CredentialSavePickerDialog.KEY_TAB_ID)!!
     private fun getOriginalUrl() = arguments?.getString(CredentialSavePickerDialog.KEY_URL)!!
 
     private fun showOnboarding() = viewModel.showOnboarding()
 
     companion object {
 
-        fun instance(url: String, credentials: LoginCredentials): AutofillSavingCredentialsDialogFragment {
+        fun instance(url: String, credentials: LoginCredentials, tabId: String): AutofillSavingCredentialsDialogFragment {
 
             val fragment = AutofillSavingCredentialsDialogFragment()
             fragment.arguments =
                 Bundle().also {
                     it.putString(CredentialSavePickerDialog.KEY_URL, url)
                     it.putParcelable(CredentialSavePickerDialog.KEY_CREDENTIALS, credentials)
+                    it.putString(CredentialSavePickerDialog.KEY_TAB_ID, tabId)
                 }
             return fragment
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.global.extractDomain
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.CredentialAutofillPickerDialog
+import com.duckduckgo.autofill.CredentialSavePickerDialog
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.domain.app.LoginTriggerType.AUTOPROMPT
@@ -59,7 +60,11 @@ class AutofillSelectCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
         super.onAttach(context)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
         val binding = ContentAutofillSelectCredentialsTooltipBinding.inflate(inflater, container, false)
         configureViews(binding)
         return binding.root
@@ -104,7 +109,7 @@ class AutofillSelectCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
                 it.putString(CredentialAutofillPickerDialog.KEY_URL, getOriginalUrl())
                 it.putParcelable(CredentialAutofillPickerDialog.KEY_CREDENTIALS, selectedCredentials)
             }
-            parentFragment?.setFragmentResult(CredentialAutofillPickerDialog.RESULT_KEY_CREDENTIAL_PICKER, result)
+            parentFragment?.setFragmentResult(CredentialAutofillPickerDialog.resultKey(getTabId()), result)
             dismiss()
         }
     }
@@ -120,16 +125,22 @@ class AutofillSelectCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
             else -> {}
         }
 
-        parentFragment?.setFragmentResult(CredentialAutofillPickerDialog.RESULT_KEY_CREDENTIAL_PICKER, result)
+        parentFragment?.setFragmentResult(CredentialAutofillPickerDialog.resultKey(getTabId()), result)
     }
 
     private fun getAvailableCredentials() = arguments?.getParcelableArrayList<LoginCredentials>(CredentialAutofillPickerDialog.KEY_CREDENTIALS)!!
     private fun getOriginalUrl() = arguments?.getString(CredentialAutofillPickerDialog.KEY_URL)!!
     private fun getTriggerType() = arguments?.getSerializable(CredentialAutofillPickerDialog.KEY_TRIGGER_TYPE) as LoginTriggerType
+    private fun getTabId() = arguments?.getString(CredentialAutofillPickerDialog.KEY_TAB_ID)!!
 
     companion object {
 
-        fun instance(url: String, credentials: List<LoginCredentials>, triggerType: LoginTriggerType): AutofillSelectCredentialsDialogFragment {
+        fun instance(
+            url: String,
+            credentials: List<LoginCredentials>,
+            triggerType: LoginTriggerType,
+            tabId: String
+        ): AutofillSelectCredentialsDialogFragment {
 
             val cr = ArrayList<LoginCredentials>(credentials)
 
@@ -139,6 +150,7 @@ class AutofillSelectCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
                     it.putString(CredentialAutofillPickerDialog.KEY_URL, url)
                     it.putParcelableArrayList(CredentialAutofillPickerDialog.KEY_CREDENTIALS, cr)
                     it.putSerializable(CredentialAutofillPickerDialog.KEY_TRIGGER_TYPE, triggerType)
+                    it.putString(CredentialSavePickerDialog.KEY_TAB_ID, tabId)
                 }
             return fragment
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.global.extractDomain
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.CredentialAutofillPickerDialog
-import com.duckduckgo.autofill.CredentialSavePickerDialog
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.domain.app.LoginTriggerType.AUTOPROMPT
@@ -150,7 +149,7 @@ class AutofillSelectCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
                     it.putString(CredentialAutofillPickerDialog.KEY_URL, url)
                     it.putParcelableArrayList(CredentialAutofillPickerDialog.KEY_CREDENTIALS, cr)
                     it.putSerializable(CredentialAutofillPickerDialog.KEY_TRIGGER_TYPE, triggerType)
-                    it.putString(CredentialSavePickerDialog.KEY_TAB_ID, tabId)
+                    it.putString(CredentialAutofillPickerDialog.KEY_TAB_ID, tabId)
                 }
             return fragment
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
@@ -79,7 +79,7 @@ class AutofillUpdatingExistingCredentialsDialogFragment : BottomSheetDialogFragm
                 it.putString(CredentialUpdateExistingCredentialsDialog.KEY_URL, originalUrl)
                 it.putParcelable(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIALS, credentials)
             }
-            parentFragment?.setFragmentResult(CredentialUpdateExistingCredentialsDialog.RESULT_KEY_CREDENTIAL_RESULT_UPDATE, result)
+            parentFragment?.setFragmentResult(CredentialUpdateExistingCredentialsDialog.resultKey(getTabId()), result)
             (dialog as BottomSheetDialog).animateClosed()
         }
     }
@@ -109,18 +109,19 @@ class AutofillUpdatingExistingCredentialsDialogFragment : BottomSheetDialogFragm
     }
 
     private fun getCredentialsToSave() = arguments?.getParcelable<LoginCredentials>(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIALS)!!
-
+    private fun getTabId() = arguments?.getString(CredentialUpdateExistingCredentialsDialog.KEY_TAB_ID)!!
     private fun getOriginalUrl() = arguments?.getString(CredentialUpdateExistingCredentialsDialog.KEY_URL)!!
 
     companion object {
 
-        fun instance(url: String, credentials: LoginCredentials): AutofillUpdatingExistingCredentialsDialogFragment {
+        fun instance(url: String, credentials: LoginCredentials, tabId: String): AutofillUpdatingExistingCredentialsDialogFragment {
 
             val fragment = AutofillUpdatingExistingCredentialsDialogFragment()
             fragment.arguments =
                 Bundle().also {
                     it.putString(CredentialUpdateExistingCredentialsDialog.KEY_URL, url)
                     it.putParcelable(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIALS, credentials)
+                    it.putString(CredentialUpdateExistingCredentialsDialog.KEY_TAB_ID, tabId)
                 }
             return fragment
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202829664561720/f
Task/Issue URL: [Bug: Unable to save credentials](https://app.asana.com/0/1202820940582292/1202820940582292/f)
Task/Issue URL: [Flaky behavior of snackbar after saving](https://app.asana.com/0/0/1202821157855651/f)

### Description
Ensures that the fragment result listeners are not overwritten by another tab, which would mean the results get delivered to the most newly-created tab, which isn't always the current tab.

### Steps to test this PR
Repeat the steps listed in [Flaky behavior of snackbar after saving](https://app.asana.com/0/0/1202821157855651/f) and [Bug: Unable to save credentials](https://app.asana.com/0/1202820940582292/1202820940582292/f) and make sure the problems no longer appear
