### PR TITLE
Fixed/Patch🐛 JMESPath for Ruby uses unsafe JSON.load when safe JSON.parse is preferable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    jmespath (1.4.0)
+    jmespath (1.6.1)
     json (2.5.1)
     jwt (2.2.3)
     memoist (0.16.2)


### PR DESCRIPTION
## Description Vulnerabilities 👍 
jmespath.rb (aka JMESPath for Ruby) before 1.6.1 uses JSON.load in a situation where JSON.parse is preferable.

**CVE-2022-32511**
`9.8 / 10`
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`

@imhunterand is creating a security update to fix [1 help alert](https://github.com/duckduckgo/Android/) on jmespath in [Gemfile.lock](https://github.com/duckduckgo/Android/blob/-/Gemfile.lock).
