### PR TITLE
Fix infinite authentication loop on older Android

### DIFF
--- a/autofill/autofill-impl/src/main/AndroidManifest.xml
+++ b/autofill/autofill-impl/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <application>
         <activity
             android:name="com.duckduckgo.autofill.ui.credential.management.AutofillManagementActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="false" />
     </application>
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
@@ -96,6 +96,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
                 } else {
                     finish()
                 }
+                viewModel.onAuthenticationEnded()
             }
         } else {
             viewModel.disabled()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -127,7 +127,10 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     fun launchDeviceAuth() {
-        addCommand(LaunchDeviceAuth)
+        if (!viewState.value.isAuthenticating) {
+            _viewState.value = viewState.value.copy(isAuthenticating = true)
+            addCommand(LaunchDeviceAuth)
+        }
     }
 
     fun lock() {
@@ -144,7 +147,7 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     fun disabled() {
-        _viewState.value = viewState.value.copy(isLocked = true)
+        _viewState.value = viewState.value.copy(isLocked = true, isAuthenticating = false)
         // Remove backstack modes if they are present
         addCommand(ExitListMode)
         addCommand(ExitCredentialMode)
@@ -212,10 +215,15 @@ class AutofillSettingsViewModel @Inject constructor(
         _viewState.value = viewState.value.copy(autofillEnabled = false)
     }
 
+    fun onAuthenticationEnded() {
+        _viewState.value = viewState.value.copy(isAuthenticating = false)
+    }
+
     data class ViewState(
         val autofillEnabled: Boolean = true,
         val logins: List<LoginCredentials> = emptyList(),
         val credentialMode: CredentialMode = NotInCredentialMode,
+        val isAuthenticating: Boolean = false,
         val isLocked: Boolean = false
     )
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: 
https://app.asana.com/0/488551667048375/1202821446406981/f
https://app.asana.com/0/488551667048375/1202828695381297/f

### Description
This PR includes:
- Ensuring that only one device auth flow is launched until it is completed. The issue is originally caused by the auth flow in older android device that launches a new activity. Once the auth is completed, the auth activity is closed and triggers the management screen's `onStart` where we call `launchDeviceAuth`. To fix this, we add a check before launching auth that there is no already ongoing auth. An auth flow is considered `ended` once we have received the result in the AutofillManagementActivity.
- Don't reauth when orientation changes. Used https://developer.android.com/guide/topics/manifest/activity-element#config android:configChanges to prevent the activity from being restarted. We needed to add ScreenSize since orientation alone for some reason doesn't work.

### Steps to test this PR

_Check Autofill management works_
- [x] Launch autofill on an older android device (API 23) with device auth enrolled
- [x] Open autofill management screen
- [x] Complete device auth
- [x] Verify that list view is shown
- [x] Exit Autofill management screen and open it again.
- [x] Cancel device auth
- [x] Confirm that you are returned to browser/settings page.

_Check Autofill management works on newer device_
- [ ] Launch autofill on a newer android device (Android 12) with device auth enrolled
- [ ] Repeat steps above and ensure that everything works as expected.

_Orientation change doesm't reauth_
- [x] Launch autofill management and complete device auth
- [x] Change orientation and confirm that device auth is not triggered
- [x] Confirm that backgrounding app and locking screen launches device auth still.
