### PR TITLE
Catch throwble if ServiceWorkerControllerCompat init

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -187,7 +187,7 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
         if (WebViewFeature.isFeatureSupported(WebViewFeature.SERVICE_WORKER_BASIC_USAGE)) {
             try {
                 ServiceWorkerControllerCompat.getInstance().setServiceWorkerClient(serviceWorkerClientCompat)
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 Timber.w(e.localizedMessage)
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202828695381301/f

### Description
- Change try-catch for ServiceWorkerControllerCompat initialization to catch Throwable instead of Exception only.
- So far all Throwable thrown by ServiceWorkerControllerCompat are webview/chromium related which we don't have controll of. Instead of letting the app crash and become unusable, we just hide this specific type of crashes.
