### PR TITLE
Improve UX of dialogs in landscape

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.autofill.impl.databinding.ContentAutofillSaveNewCredential
 import com.duckduckgo.autofill.ui.credential.dialog.animateClosed
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.ui.view.gone
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
@@ -68,6 +69,7 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
     }
 
     private fun configureViews(binding: ContentAutofillSaveNewCredentialsBinding, credentials: LoginCredentials) {
+        (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
         configureSiteDetails(binding)
         configureTitles(binding, credentials)
         configureCloseButtons(binding)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/selecting/AutofillSelectCredentialsDialogFragment.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ContentAutofillSelectCredentialsTooltipBinding
 import com.duckduckgo.autofill.ui.credential.dialog.animateClosed
 import com.duckduckgo.di.scopes.FragmentScope
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
@@ -70,6 +71,7 @@ class AutofillSelectCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
     }
 
     private fun configureViews(binding: ContentAutofillSelectCredentialsTooltipBinding) {
+        (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
         configureSiteDetails(binding)
         configureRecyclerView(binding)
         configureCloseButton(binding)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ContentAutofillUpdateExistingCredentialsBinding
 import com.duckduckgo.autofill.ui.credential.dialog.animateClosed
 import com.duckduckgo.di.scopes.FragmentScope
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
@@ -67,6 +68,7 @@ class AutofillUpdatingExistingCredentialsDialogFragment : BottomSheetDialogFragm
     }
 
     private fun configureViews(binding: ContentAutofillUpdateExistingCredentialsBinding) {
+        (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
         val credentials = getCredentialsToSave()
         val originalUrl = getOriginalUrl()
 

--- a/autofill/autofill-impl/src/main/res/values/styles.xml
+++ b/autofill/autofill-impl/src/main/res/values/styles.xml
@@ -22,6 +22,7 @@
 
     <style name="AutofillBottomSheetStyle" parent="Widget.MaterialComponents.BottomSheet.Modal">
         <item name="backgroundTint">@android:color/transparent</item>
+        <item name="behavior_skipCollapsed">true</item>
     </style>
 
     <style name="AutofillDialogRootViewStyle">


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202820530980762/f

### Description
Improves the UX for the autofill dialogs when in landscape (or split screen) view, ensuring it defaults to the full state and doesn't shrink down to peek mode when dragging down.

### Steps to test this PR
- [x] Load a site with a saved credential when viewing in landscape mode. Verify dialog is fully expanded.
- [x] Flick the dialog down to dismiss; verify it fully disappears and doesn't linger in "peek" mode
- [x] Repeat above for the "save" and "update" dialogs
- [ ] Ideally, also test in split screen that the dialogs are usable
