### PR TITLE
Add autoconsent flags to broken sites

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4203,6 +4203,15 @@ class BrowserTabViewModelTest {
         verify(mockAutofillStore).updateCredentials(url, credentials)
     }
 
+    @Test
+    fun whenOnAutoconsentResultReceivedThenSiteUpdated() {
+        updateUrl("http://www.example.com/", "http://twitter.com/explore", true)
+        testee.onAutoconsentResultReceived(consentManaged = true, optOutFailed = true, selfTestFailed = true)
+        assertTrue(testee.siteLiveData.value?.consentManaged!!)
+        assertTrue(testee.siteLiveData.value?.consentOptOutFailed!!)
+        assertTrue(testee.siteLiveData.value?.consentSelfTestFailed!!)
+    }
+
     private fun assertShowHistoryCommandSent(expectedStackSize: Int) {
         assertCommandIssued<ShowBackNavigationHistory> {
             assertEquals(expectedStackSize, history.size)

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
@@ -62,7 +62,19 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         val upgradedHttps = intent.getBooleanExtra(UPGRADED_TO_HTTPS_EXTRA, false)
         val surrogates = intent.getStringExtra(SURROGATES_EXTRA).orEmpty()
         val urlParametersRemoved = intent.getBooleanExtra(URL_PARAMETERS_REMOVED_EXTRA, false)
-        viewModel.setInitialBrokenSite(url, blockedTrackers, surrogates, upgradedHttps, urlParametersRemoved)
+        val consentManaged = intent.getBooleanExtra(CONSENT_MANAGED_EXTRA, false)
+        val consentOptOutFailed = intent.getBooleanExtra(CONSENT_OPT_OUT_FAILED_EXTRA, false)
+        val consentSelfTestFailed = intent.getBooleanExtra(CONSENT_SELF_TEST_FAILED_EXTRA, false)
+        viewModel.setInitialBrokenSite(
+            url = url,
+            blockedTrackers = blockedTrackers,
+            surrogates = surrogates,
+            upgradedHttps = upgradedHttps,
+            urlParametersRemoved = urlParametersRemoved,
+            consentManaged = consentManaged,
+            consentOptOutFailed = consentOptOutFailed,
+            consentSelfTestFailed = consentSelfTestFailed,
+        )
     }
 
     private fun configureListeners() {
@@ -126,6 +138,9 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         private const val UPGRADED_TO_HTTPS_EXTRA = "UPGRADED_TO_HTTPS_EXTRA"
         private const val SURROGATES_EXTRA = "SURROGATES_EXTRA"
         private const val URL_PARAMETERS_REMOVED_EXTRA = "URL_PARAMETERS_REMOVED_EXTRA"
+        private const val CONSENT_MANAGED_EXTRA = "CONSENT_MANAGED_EXTRA"
+        private const val CONSENT_OPT_OUT_FAILED_EXTRA = "CONSENT_OPT_OUT_FAILED_EXTRA"
+        private const val CONSENT_SELF_TEST_FAILED_EXTRA = "CONSENT_SELF_TEST_FAILED_EXTRA"
 
         fun intent(
             context: Context,
@@ -137,6 +152,9 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
             intent.putExtra(SURROGATES_EXTRA, data.surrogates)
             intent.putExtra(UPGRADED_TO_HTTPS_EXTRA, data.upgradedToHttps)
             intent.putExtra(URL_PARAMETERS_REMOVED_EXTRA, data.urlParametersRemoved)
+            intent.putExtra(CONSENT_MANAGED_EXTRA, data.consentManaged)
+            intent.putExtra(CONSENT_OPT_OUT_FAILED_EXTRA, data.consentOptOutFailed)
+            intent.putExtra(CONSENT_SELF_TEST_FAILED_EXTRA, data.consentSelfTestFailed)
             return intent
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteData.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteData.kt
@@ -26,7 +26,10 @@ data class BrokenSiteData(
     val blockedTrackers: String,
     val surrogates: String,
     val upgradedToHttps: Boolean,
-    val urlParametersRemoved: Boolean
+    val urlParametersRemoved: Boolean,
+    val consentManaged: Boolean,
+    val consentOptOutFailed: Boolean,
+    val consentSelfTestFailed: Boolean,
 ) {
 
     companion object {
@@ -39,7 +42,19 @@ data class BrokenSiteData(
             val surrogates = site?.surrogates?.map { Uri.parse(it.name).baseHost }.orEmpty().distinct().joinToString(",")
             val url = site?.url.orEmpty()
             val urlParametersRemoved = site?.urlParametersRemoved ?: false
-            return BrokenSiteData(url, blockedTrackers, surrogates, upgradedHttps, urlParametersRemoved)
+            val consentManaged = site?.consentManaged ?: false
+            val consentOptOutFailed = site?.consentOptOutFailed ?: false
+            val consentSelfTestFailed = site?.consentSelfTestFailed ?: false
+            return BrokenSiteData(
+                url = url,
+                blockedTrackers = blockedTrackers,
+                surrogates = surrogates,
+                upgradedToHttps = upgradedHttps,
+                urlParametersRemoved = urlParametersRemoved,
+                consentManaged = consentManaged,
+                consentOptOutFailed = consentOptOutFailed,
+                consentSelfTestFailed = consentSelfTestFailed,
+            )
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -70,6 +70,9 @@ class BrokenSiteViewModel @Inject constructor(
     private var upgradedHttps: Boolean = false
     private val viewValue: ViewState get() = viewState.value!!
     private var urlParametersRemoved: Boolean = false
+    private var consentManaged: Boolean = false
+    private var consentOptOutFailed: Boolean = false
+    private var consentSelfTestFailed: Boolean = false
 
     init {
         viewState.value = ViewState()
@@ -80,13 +83,19 @@ class BrokenSiteViewModel @Inject constructor(
         blockedTrackers: String,
         surrogates: String,
         upgradedHttps: Boolean,
-        urlParametersRemoved: Boolean
+        urlParametersRemoved: Boolean,
+        consentManaged: Boolean,
+        consentOptOutFailed: Boolean,
+        consentSelfTestFailed: Boolean,
     ) {
         this.url = url
         this.blockedTrackers = blockedTrackers
         this.upgradedHttps = upgradedHttps
         this.surrogates = surrogates
         this.urlParametersRemoved = urlParametersRemoved
+        this.consentManaged = consentManaged
+        this.consentOptOutFailed = consentOptOutFailed
+        this.consentSelfTestFailed = consentSelfTestFailed
     }
 
     fun onCategoryIndexChanged(newIndex: Int) {
@@ -139,14 +148,16 @@ class BrokenSiteViewModel @Inject constructor(
             surrogates = surrogates,
             webViewVersion = webViewVersion,
             siteType = if (Uri.parse(url).isMobileSite) MOBILE_SITE else DESKTOP_SITE,
-            urlParametersRemoved = urlParametersRemoved
+            urlParametersRemoved = urlParametersRemoved,
+            consentManaged = consentManaged,
+            consentOptOutFailed = consentOptOutFailed,
+            consentSelfTestFailed = consentSelfTestFailed,
         )
     }
 
     private fun canSubmit(): Boolean = categories.elementAtOrNull(indexSelected) != null
 
     companion object {
-        const val WEBVIEW_UNKNOWN_VERSION = "unknown"
         const val MOBILE_SITE = "mobile"
         const val DESKTOP_SITE = "desktop"
     }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -67,7 +67,10 @@ class BrokenSiteSubmitter(
                 WEBVIEW_VERSION_KEY to brokenSite.webViewVersion,
                 SITE_TYPE_KEY to brokenSite.siteType,
                 GPC to isGpcEnabled,
-                URL_PARAMETERS_REMOVED to brokenSite.urlParametersRemoved.toString()
+                URL_PARAMETERS_REMOVED to brokenSite.urlParametersRemoved.toString(),
+                CONSENT_MANAGED to brokenSite.consentManaged.toString(),
+                CONSENT_OPT_OUT_FAILED to brokenSite.consentOptOutFailed.toString(),
+                CONSENT_SELF_TEST_FAILED to brokenSite.consentSelfTestFailed.toString(),
             )
             val encodedParams = mapOf(
                 BLOCKED_TRACKERS_KEY to brokenSite.blockedTrackers,
@@ -101,5 +104,8 @@ class BrokenSiteSubmitter(
         private const val SITE_TYPE_KEY = "siteType"
         private const val GPC = "gpc"
         private const val URL_PARAMETERS_REMOVED = "urlParametersRemoved"
+        private const val CONSENT_MANAGED = "consentManaged"
+        private const val CONSENT_OPT_OUT_FAILED = "consentOptoutFailed"
+        private const val CONSENT_SELF_TEST_FAILED = "consentSelftestFailed"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/model/BrokenSite.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/model/BrokenSite.kt
@@ -27,7 +27,10 @@ data class BrokenSite(
     val surrogates: String,
     val webViewVersion: String,
     val siteType: String,
-    val urlParametersRemoved: Boolean
+    val urlParametersRemoved: Boolean,
+    val consentManaged: Boolean,
+    val consentOptOutFailed: Boolean,
+    val consentSelfTestFailed: Boolean,
 )
 
 sealed class BrokenSiteCategory(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -451,8 +451,8 @@ class BrowserTabFragment :
             }
         }
 
-        override fun onResultReceived(consentManaged: Boolean, optOutFailed: Boolean, selfTestFailed: Boolean?) {
-            TODO("Not yet implemented")
+        override fun onResultReceived(consentManaged: Boolean, optOutFailed: Boolean, selfTestFailed: Boolean) {
+            viewModel.onAutoconsentResultReceived(consentManaged, optOutFailed, selfTestFailed)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1636,6 +1636,12 @@ class BrowserTabViewModel @Inject constructor(
         onSiteChanged()
     }
 
+    fun onAutoconsentResultReceived(consentManaged: Boolean, optOutFailed: Boolean, selfTestFailed: Boolean) {
+        site?.consentManaged = consentManaged
+        site?.consentOptOutFailed = optOutFailed
+        site?.consentSelfTestFailed = selfTestFailed
+    }
+
     private fun onSiteChanged() {
         httpsUpgraded = false
         viewModelScope.launch {

--- a/app/src/main/java/com/duckduckgo/app/global/model/Site.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/model/Site.kt
@@ -69,6 +69,9 @@ interface Site {
     )
 
     var urlParametersRemoved: Boolean
+    var consentManaged: Boolean
+    var consentOptOutFailed: Boolean
+    var consentSelfTestFailed: Boolean
 }
 
 fun Site.orderedTrackingEntities(): List<Entity> = trackingEvents

--- a/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
@@ -141,6 +141,12 @@ class SiteMonitor(
 
     override var urlParametersRemoved: Boolean = false
 
+    override var consentManaged: Boolean = false
+
+    override var consentOptOutFailed: Boolean = false
+
+    override var consentSelfTestFailed: Boolean = false
+
     private fun privacyGrade(scores: Grade.Scores): PrivacyGrade {
         return when (scores) {
             Grade.Scores.ScoresUnavailable -> PrivacyGrade.UNKNOWN

--- a/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
@@ -124,7 +124,16 @@ class BrokenSiteViewModelTest {
 
     @Test
     fun whenCanSubmitBrokenSiteAndUrlNotNullAndSubmitPressedThenReportAndPixelSubmitted() {
-        testee.setInitialBrokenSite(url, "", "", upgradedHttps = false, urlParametersRemoved = false)
+        testee.setInitialBrokenSite(
+            url = url,
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+        )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion")
 
@@ -136,7 +145,10 @@ class BrokenSiteViewModelTest {
             surrogates = "",
             webViewVersion = "webViewVersion",
             siteType = BrokenSiteViewModel.DESKTOP_SITE,
-            urlParametersRemoved = false
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
@@ -147,7 +159,16 @@ class BrokenSiteViewModelTest {
     @Test
     fun whenCanSubmitBrokenSiteAndUrlIsEmptyAndSubmitPressedThenDoNotSubmit() {
         val nullUrl = ""
-        testee.setInitialBrokenSite(nullUrl, "", "", upgradedHttps = false, urlParametersRemoved = false)
+        testee.setInitialBrokenSite(
+            url = nullUrl,
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+        )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion")
 
@@ -159,7 +180,10 @@ class BrokenSiteViewModelTest {
             surrogates = "",
             webViewVersion = "webViewVersion",
             siteType = BrokenSiteViewModel.DESKTOP_SITE,
-            urlParametersRemoved = false
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
         )
 
         verify(mockPixel, never()).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to nullUrl))
@@ -171,7 +195,16 @@ class BrokenSiteViewModelTest {
     fun whenCanSubmitBrokenSiteAndLastAmpLinkIsNullAndSubmitPressedThenReportUrlAndPixelSubmitted() {
         whenever(mockAmpLinks.lastAmpLinkInfo).thenReturn(null)
 
-        testee.setInitialBrokenSite(url, "", "", upgradedHttps = false, urlParametersRemoved = false)
+        testee.setInitialBrokenSite(
+            url = url,
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+        )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion")
 
@@ -183,7 +216,10 @@ class BrokenSiteViewModelTest {
             surrogates = "",
             webViewVersion = "webViewVersion",
             siteType = BrokenSiteViewModel.DESKTOP_SITE,
-            urlParametersRemoved = false
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
@@ -195,7 +231,16 @@ class BrokenSiteViewModelTest {
     fun whenCanSubmitBrokenSiteAndUrlHasAssociatedAmpLinkAndSubmitPressedThenAmpLinkReportedAndPixelSubmitted() {
         whenever(mockAmpLinks.lastAmpLinkInfo).thenReturn(AmpLinkInfo(trackingUrl, url))
 
-        testee.setInitialBrokenSite(url, "", "", upgradedHttps = false, urlParametersRemoved = false)
+        testee.setInitialBrokenSite(
+            url = url,
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+        )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion")
 
@@ -207,7 +252,10 @@ class BrokenSiteViewModelTest {
             surrogates = "",
             webViewVersion = "webViewVersion",
             siteType = BrokenSiteViewModel.DESKTOP_SITE,
-            urlParametersRemoved = false
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to trackingUrl))
@@ -217,7 +265,16 @@ class BrokenSiteViewModelTest {
 
     @Test
     fun whenUrlIsDesktopThenSendDesktopParameter() {
-        testee.setInitialBrokenSite(url, "", "", upgradedHttps = false, urlParametersRemoved = false)
+        testee.setInitialBrokenSite(
+            url = url,
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+        )
         selectAndAcceptCategory()
 
         val brokenSiteExpected = testee.getBrokenSite(url, "")
@@ -227,7 +284,16 @@ class BrokenSiteViewModelTest {
     @Test
     fun whenUrlIsMobileThenSendMobileParameter() {
         val url = "http://m.example.com"
-        testee.setInitialBrokenSite(url, "", "", upgradedHttps = false, urlParametersRemoved = false)
+        testee.setInitialBrokenSite(
+            url = url,
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+        )
         selectAndAcceptCategory()
 
         val brokenSiteExpected = testee.getBrokenSite(url, "")
@@ -238,7 +304,16 @@ class BrokenSiteViewModelTest {
     fun whenGetBrokenSiteThenReturnCorrectCategory() {
         val url = "http://m.example.com"
         val categoryIndex = 0
-        testee.setInitialBrokenSite(url, "", "", upgradedHttps = false, urlParametersRemoved = false)
+        testee.setInitialBrokenSite(
+            url = url,
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+        )
         selectAndAcceptCategory(categoryIndex)
 
         val categoryExpected = testee.categories[categoryIndex].key
@@ -248,7 +323,16 @@ class BrokenSiteViewModelTest {
 
     @Test
     fun whenCancelSelectionThenAssignOldIndexValue() {
-        testee.setInitialBrokenSite("", "", "", upgradedHttps = false, urlParametersRemoved = false)
+        testee.setInitialBrokenSite(
+            url = "",
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+        )
         selectAndAcceptCategory(0)
         testee.onCategoryIndexChanged(1)
         testee.onCategorySelectionCancelled()
@@ -258,7 +342,16 @@ class BrokenSiteViewModelTest {
 
     @Test
     fun whenCancelSelectionAndNoPreviousValueThenAssignMinusOne() {
-        testee.setInitialBrokenSite("", "", "", upgradedHttps = false, urlParametersRemoved = false)
+        testee.setInitialBrokenSite(
+            url = "",
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+        )
         testee.onCategoryIndexChanged(1)
         testee.onCategorySelectionCancelled()
 

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -126,7 +126,10 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             surrogates = testCase.surrogates.joinToString(","),
             webViewVersion = "webViewVersion",
             siteType = BrokenSiteViewModel.DESKTOP_SITE,
-            urlParametersRemoved = testCase.urlParameterRemoved
+            urlParametersRemoved = testCase.urlParameterRemoved,
+            consentManaged = testCase.consentManaged,
+            consentOptOutFailed = testCase.consentOptOutFailed,
+            consentSelfTestFailed = testCase.consentSelfTestFailed,
         )
 
         testee.submitBrokenSiteFeedback(brokenSite)
@@ -170,7 +173,10 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
         val expectReportURLPrefix: String,
         val expectReportURLParams: List<UrlParam>,
         val exceptPlatforms: List<String>,
-        val urlParameterRemoved: Boolean
+        val urlParameterRemoved: Boolean,
+        val consentManaged: Boolean,
+        val consentOptOutFailed: Boolean,
+        val consentSelfTestFailed: Boolean,
     )
 
     data class UrlParam(

--- a/app/src/test/resources/reference_tests/brokensites/tests.json
+++ b/app/src/test/resources/reference_tests/brokensites/tests.json
@@ -20,6 +20,9 @@
           {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
           {"name": "surrogates", "value": "surrogate.domain.test"}
         ],
+        "consentManaged": false,
+        "consentOptoutFailed": false,
+        "consentSelftestFailed": false,
         "exceptPlatforms": []
       },
       {
@@ -40,6 +43,9 @@
           {"name": "blockedTrackers", "value": ""},
           {"name": "surrogates", "value": ""}
         ],
+        "consentManaged": false,
+        "consentOptoutFailed": false,
+        "consentSelftestFailed": false,
         "exceptPlatforms": []
       },
       {
@@ -68,6 +74,9 @@
           {"name": "os", "value": "12"},
           {"name": "gpc", "value": "true"}
         ],
+        "consentManaged": false,
+        "consentOptoutFailed": false,
+        "consentSelftestFailed": false,
         "exceptPlatforms": [
           "web-extension",
           "safari-extension"

--- a/autoconsent/autoconsent-api/src/main/java/com/duckduckgo/autoconsent/api/Autoconsent.kt
+++ b/autoconsent/autoconsent-api/src/main/java/com/duckduckgo/autoconsent/api/Autoconsent.kt
@@ -74,7 +74,7 @@ interface AutoconsentCallback {
     /**
      * This method is called whenever autoconsent has a result to be sent
      */
-    fun onResultReceived(consentManaged: Boolean, optOutFailed: Boolean, selfTestFailed: Boolean?)
+    fun onResultReceived(consentManaged: Boolean, optOutFailed: Boolean, selfTestFailed: Boolean)
 }
 
 /** List of [AutoconsentFeatureName] that belong to the Autoconsent feature */

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPlugin.kt
@@ -67,6 +67,9 @@ class InitMessageHandlerPlugin @Inject constructor(
                         return@launch
                     }
 
+                    // Reset site
+                    autoconsentCallback.onResultReceived(consentManaged = false, optOutFailed = false, selfTestFailed = false)
+
                     val disabledCmps = repository.disabledCmps.map { it.name }
                     val autoAction = getAutoAction()
                     val enablePreHide = settingsRepository.userSetting

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPlugin.kt
@@ -51,7 +51,7 @@ class OptOutAndAutoconsentDoneMessageHandlerPlugin @Inject constructor() : Messa
             val message: OptOutResultMessage = parseOptOutMessage(jsonString) ?: return
 
             if (!message.result) {
-                autoconsentCallback.onResultReceived(consentManaged = true, optOutFailed = true, selfTestFailed = null)
+                autoconsentCallback.onResultReceived(consentManaged = true, optOutFailed = true, selfTestFailed = false)
             } else if (message.scheduleSelfTest) {
                 selfTest = true
             }
@@ -64,11 +64,10 @@ class OptOutAndAutoconsentDoneMessageHandlerPlugin @Inject constructor() : Messa
     private fun processAutoconsentDone(jsonString: String, webView: WebView, autoconsentCallback: AutoconsentCallback) {
         try {
             val message: AutoconsentDoneMessage = parseAutoconsentDoneMessage(jsonString) ?: return
-            val host: String = message.url.toUri().host ?: return
+            message.url.toUri().host ?: return
 
-            if (true) { // ToDo Store the host and check it doesn't exist
-                autoconsentCallback.onPopUpHandled()
-            }
+            autoconsentCallback.onPopUpHandled()
+            autoconsentCallback.onResultReceived(consentManaged = true, optOutFailed = false, selfTestFailed = false)
 
             if (selfTest) {
                 webView.evaluateJavascript("javascript:${ReplyHandler.constructReply("""{ "type": "selfTest" }""")}", null)

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPluginTest.kt
@@ -35,6 +35,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.Shadows.shadowOf
 
@@ -136,6 +137,16 @@ class InitMessageHandlerPluginTest {
         assertTrue(initResp.config.enabled)
         assertEquals(20, initResp.config.detectRetries)
         assertEquals("initResp", initResp.type)
+    }
+
+    @Test
+    fun whenProcessMessageThenOnResultReceivedCalled() {
+        settingsRepository.userSetting = true
+        settingsRepository.firstPopupHandled = true
+
+        initHandlerPlugin.process(initHandlerPlugin.supportedTypes.first(), message(), webView, mockCallback)
+
+        verify(mockCallback).onResultReceived(consentManaged = false, optOutFailed = false, selfTestFailed = false)
     }
 
     private fun message(): String {

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPluginTest.kt
@@ -60,7 +60,7 @@ class OptOutAndAutoconsentDoneMessageHandlerPluginTest {
     fun whenProcessOptOutIfResultIsFailsThenSendResultWithFailure() {
         handler.process(getOptOut(), optOutMessage(result = false, selfTest = false), webView, mockCallback)
 
-        verify(mockCallback).onResultReceived(consentManaged = true, optOutFailed = true, selfTestFailed = null)
+        verify(mockCallback).onResultReceived(consentManaged = true, optOutFailed = true, selfTestFailed = false)
     }
 
     @Test


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202833726990280/f 

### Description
This PR adds autoconsent flags to broken sites report

### Steps to test this PR

- [x] In the logcat filter by `Pixel sent`
- [x] Install from this branch 
- [x] Go to mailchimp.com, dismiss the Dax onboarding dialog
- [x] Refresh the page and click on manage cookie pop ups
- [x] After the animation has finished, go to the menu and report broken site
- [x] The pixel should contain 3 new flags with `autoconsentManaged` to true and the other autoconsent flags to false.
