### PR TITLE
Use relinker to load native libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,65 +150,67 @@ fladle {
 }
 
 dependencies {
-    implementation project(path: ':autofill-api')
-    implementation project(path: ':autofill-impl')
-    implementation project(path: ':autofill-store')
+    implementation project(':library-loader-api')
 
-    anvil project(path: ':anvil-compiler')
-    implementation project(path: ':anvil-annotations')
+    implementation project(':autofill-api')
+    implementation project(':autofill-impl')
+    implementation project(':autofill-store')
 
-    implementation project(path: ':app-build-config-api')
-    implementation project(path: ':browser-api')
-    implementation project(path: ':statistics')
-    implementation project(path: ':common')
-    implementation project(path: ':app-store')
-    implementation project(path: ':common-ui')
-    implementation project(path: ':di')
-    implementation project(path: ':vpn-impl')
-    implementation project(path: ':vpn-api')
-    implementation project(path: ':vpn-store')
-    internalImplementation project(path: ':vpn-internal')
+    anvil project(':anvil-compiler')
+    implementation project(':anvil-annotations')
 
-    implementation project(path: ':feature-toggles-api')
-    implementation project(path: ':feature-toggles-impl')
-    implementation project(path: ':privacy-config-api')
-    implementation project(path: ':privacy-config-impl')
-    implementation project(path: ':privacy-config-store')
-    implementation project(path: ':anrs-api')
-    implementation project(path: ':anrs-store')
-    implementation project(path: ':anrs-impl')
-    implementation project(path: ':macos-api')
-    implementation project(path: ':macos-impl')
-    implementation project(path: ':macos-store')
+    implementation project(':app-build-config-api')
+    implementation project(':browser-api')
+    implementation project(':statistics')
+    implementation project(':common')
+    implementation project(':app-store')
+    implementation project(':common-ui')
+    implementation project(':di')
+    implementation project(':vpn-impl')
+    implementation project(':vpn-api')
+    implementation project(':vpn-store')
+    internalImplementation project(':vpn-internal')
 
-    implementation project(path: ':remote-messaging-api')
-    implementation project(path: ':remote-messaging-impl')
-    implementation project(path: ':remote-messaging-store')
+    implementation project(':feature-toggles-api')
+    implementation project(':feature-toggles-impl')
+    implementation project(':privacy-config-api')
+    implementation project(':privacy-config-impl')
+    implementation project(':privacy-config-store')
+    implementation project(':anrs-api')
+    implementation project(':anrs-store')
+    implementation project(':anrs-impl')
+    implementation project(':macos-api')
+    implementation project(':macos-impl')
+    implementation project(':macos-store')
 
-    implementation project(path: ':voice-search-api')
-    implementation project(path: ':voice-search-impl')
-    implementation project(path: ':voice-search-store')
+    implementation project(':remote-messaging-api')
+    implementation project(':remote-messaging-impl')
+    implementation project(':remote-messaging-store')
 
-    implementation project(path: ':downloads-api')
-    implementation project(path: ':downloads-impl')
-    implementation project(path: ':downloads-store')
+    implementation project(':voice-search-api')
+    implementation project(':voice-search-impl')
+    implementation project(':voice-search-store')
 
-    internalImplementation project(path: ':traces-api')
-    internalImplementation project(path: ':traces-impl')
+    implementation project(':downloads-api')
+    implementation project(':downloads-impl')
+    implementation project(':downloads-store')
 
-    implementation project(path: ':bandwidth-impl')
-    implementation project(path: ':bandwidth-store')
+    internalImplementation project(':traces-api')
+    internalImplementation project(':traces-impl')
 
-    implementation project(path: ':secure-storage-api')
-    implementation project(path: ':secure-storage-impl')
-    implementation project(path: ':secure-storage-store')
+    implementation project(':bandwidth-impl')
+    implementation project(':bandwidth-store')
 
-    implementation project(path: ':device-auth-api')
-    implementation project(path: ':device-auth-impl')
+    implementation project(':secure-storage-api')
+    implementation project(':secure-storage-impl')
+    implementation project(':secure-storage-store')
 
-    implementation project(path: ':ad-click-api')
-    implementation project(path: ':ad-click-impl')
-    implementation project(path: ':ad-click-store')
+    implementation project(':device-auth-api')
+    implementation project(':device-auth-impl')
+
+    implementation project(':ad-click-api')
+    implementation project(':ad-click-impl')
+    implementation project(':ad-click-store')
 
     // Deprecated. TODO: Stop using this artifact.
     implementation "androidx.legacy:legacy-support-v4:_"
@@ -331,8 +333,8 @@ dependencies {
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
 
-    androidTestImplementation project(path: ':common-test')
-    testImplementation project(path: ':common-test')
+    androidTestImplementation project(':common-test')
+    testImplementation project(':common-test')
     lintChecks project(":lint-rules")
 }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/BloomFilterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/BloomFilterTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.httpsupgrade
 
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -23,16 +24,17 @@ import org.junit.Test
 class BloomFilterTest {
 
     private lateinit var testee: BloomFilter
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
 
     @Test
     fun whenBloomFilterEmptyThenContainsIsFalse() {
-        testee = BloomFilter(FILTER_ELEMENT_COUNT, TARGET_ERROR_RATE)
+        testee = BloomFilter(context, BloomFilter.Config.ProbabilityConfig(FILTER_ELEMENT_COUNT, TARGET_ERROR_RATE))
         assertFalse(testee.contains("abc"))
     }
 
     @Test
     fun whenBloomFilterContainsElementThenContainsIsTrue() {
-        testee = BloomFilter(FILTER_ELEMENT_COUNT, TARGET_ERROR_RATE)
+        testee = BloomFilter(context, BloomFilter.Config.ProbabilityConfig(FILTER_ELEMENT_COUNT, TARGET_ERROR_RATE))
         testee.add("abc")
         assertTrue(testee.contains("abc"))
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/httpsupgrade/HttpsUpgraderTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.httpsupgrade
 
 import android.net.Uri
+import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.httpsupgrade.store.HttpsFalsePositivesDao
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.feature.toggles.api.FeatureToggle
@@ -33,13 +34,15 @@ class HttpsUpgraderTest {
 
     lateinit var testee: HttpsUpgrader
 
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+
     private var mockHttpsBloomFilterFactory: HttpsBloomFilterFactory = mock()
     private var mockBloomFalsePositiveListDao: HttpsFalsePositivesDao = mock()
     private var mockUserAllowlistDao: UserWhitelistDao = mock()
 
     private var mockFeatureToggle: FeatureToggle = mock()
     private var mockHttps: Https = mock()
-    private var bloomFilter = BloomFilter(100, 0.01)
+    private var bloomFilter = BloomFilter(context, BloomFilter.Config.ProbabilityConfig(100, 0.01))
 
     @Before
     fun before() {

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/HttpsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/HttpsReferenceTest.kt
@@ -201,7 +201,8 @@ class HttpsReferenceTest(private val testCase: TestCase) {
             binaryDataStore,
             embeddedDataPersister,
             httpsDataPersister,
-            mockPixel
+            mockPixel,
+            InstrumentationRegistry.getInstrumentation().targetContext,
         )
     }
 

--- a/app/src/androidTestPlay/java/com/duckduckgo/app/integration/HttpsEmbeddedDataIntegrationTest.kt
+++ b/app/src/androidTestPlay/java/com/duckduckgo/app/integration/HttpsEmbeddedDataIntegrationTest.kt
@@ -74,7 +74,8 @@ class HttpsEmbeddedDataIntegrationTest {
 
         val embeddedDataPersister = PlayHttpsEmbeddedDataPersister(persister, binaryDataStore, httpsBloomSpecDao, context, moshi)
 
-        val factory = HttpsBloomFilterFactoryImpl(httpsBloomSpecDao, binaryDataStore, embeddedDataPersister, persister, mockPixel)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val factory = HttpsBloomFilterFactoryImpl(httpsBloomSpecDao, binaryDataStore, embeddedDataPersister, persister, mockPixel, context)
         httpsUpgrader = HttpsUpgraderImpl(factory, httpsFalsePositivesDao, mockUserAllowlistDao, mockFeatureToggle, mockHttps)
         httpsUpgrader.reloadData()
     }

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsBloomFilterFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsBloomFilterFactory.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.httpsupgrade
 
+import android.content.Context
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.global.store.BinaryDataStore
 import com.duckduckgo.app.httpsupgrade.model.HttpsBloomFilterSpec.Companion.HTTPS_BINARY_FILE
@@ -40,6 +41,7 @@ class HttpsBloomFilterFactoryImpl @Inject constructor(
     private val httpsEmbeddedDataPersister: HttpsEmbeddedDataPersister,
     private val httpsDataPersister: HttpsDataPersister,
     private val pixel: Pixel,
+    private val context: Context,
 ) : HttpsBloomFilterFactory {
 
     @WorkerThread
@@ -60,7 +62,7 @@ class HttpsBloomFilterFactoryImpl @Inject constructor(
         val initialTimestamp = System.currentTimeMillis()
         Timber.d("Found https data at $dataPath, building filter")
         val bloomFilter = try {
-            BloomFilter(dataPath, specification.bitCount, specification.totalEntries)
+            BloomFilter(context, BloomFilter.Config.PathConfig(path = dataPath, bits = specification.bitCount, maxItems = specification.totalEntries))
         } catch (t: Throwable) {
             Timber.e(t, "Error creating the bloom filter")
             pixel.fire(AppPixelName.CREATE_BLOOM_FILTER_ERROR)

--- a/library-loader/library-loader-api/build.gradle
+++ b/library-loader/library-loader-api/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+dependencies {
+
+    implementation "com.getkeepsafe.relinker:relinker:_"
+    implementation Kotlin.stdlib.jdk7
+}
+
+android {
+    namespace 'com.duckduckgo.library.loader'
+}
+

--- a/library-loader/library-loader-api/src/main/java/com/duckduckgo/library/loader/LibraryLoader.kt
+++ b/library-loader/library-loader-api/src/main/java/com/duckduckgo/library/loader/LibraryLoader.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.library.loader
+
+import android.content.Context
+import com.getkeepsafe.relinker.ReLinker
+
+class LibraryLoader {
+    companion object {
+        fun loadLibrary(context: Context, name: String) {
+            ReLinker.loadLibrary(context, name)
+        }
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/DuckDuckGoIssueRegistry.kt
@@ -23,6 +23,7 @@ import com.android.tools.lint.detector.api.Issue
 import com.duckduckgo.lint.NoFragmentDetector.Companion.NO_FRAGMENT_ISSUE
 import com.duckduckgo.lint.NoLifecycleObserverDetector.Companion.NO_LIFECYCLE_OBSERVER_ISSUE
 import com.duckduckgo.lint.NoSingletonDetector.Companion.NO_SINGLETON_ISSUE
+import com.duckduckgo.lint.NoSystemLoadLibraryDetector.Companion.NO_SYSTEM_LOAD_LIBRARY
 
 @Suppress("UnstableApiUsage")
 class DuckDuckGoIssueRegistry : IssueRegistry() {
@@ -31,6 +32,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_SINGLETON_ISSUE,
             NO_LIFECYCLE_OBSERVER_ISSUE,
             NO_FRAGMENT_ISSUE,
+            NO_SYSTEM_LOAD_LIBRARY,
         )
 
     override val api: Int

--- a/lint-rules/src/main/java/com/duckduckgo/lint/NoSystemLoadLibraryDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/NoSystemLoadLibraryDetector.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.tryResolveNamed
+import java.util.*
+
+@Suppress("UnstableApiUsage")
+class NoSystemLoadLibraryDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = NoInternalImportHandler(context)
+
+    internal class NoInternalImportHandler(private val context: JavaContext) : UElementHandler() {
+        override fun visitCallExpression(node: UCallExpression) {
+            if (node.methodName == "loadLibrary" && node.receiver?.tryResolveNamed()?.name == "System") {
+                context.report(NO_SYSTEM_LOAD_LIBRARY, node, context.getNameLocation(node), "System.loadLibrary() should not be used.")
+            }
+        }
+    }
+
+    companion object {
+        val NO_SYSTEM_LOAD_LIBRARY = Issue.create("NoSystemLoadLibrary",
+            "Do not use System.loadLibrary().",
+            """
+                System.loadLibrary() should not be used.
+                Use LibraryLoader.loadLibrary() instead.
+            """.trimIndent(),
+            Category.CORRECTNESS, 10, ERROR,
+            Implementation(NoSystemLoadLibraryDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES))
+        )
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/NoSystemLoadLibraryDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/NoSystemLoadLibraryDetectorTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class NoSystemLoadLibraryDetectorTest {
+    @Test
+    fun whenSystemDotLibraryFoundThenFailWithError() {
+        lint()
+            .files(kt("""
+              package com.duckduckgo.lint
+    
+                class Duck {
+                    fun quack() {
+                        System.loadLibrary()
+                    }
+                }
+            """).indented())
+            .issues(NoSystemLoadLibraryDetector.NO_SYSTEM_LOAD_LIBRARY)
+            .run()
+            .expect("""
+               src/com/duckduckgo/lint/Duck.kt:5: Error: System.loadLibrary() should not be used. [NoSystemLoadLibrary]
+                         System.loadLibrary()
+                                ~~~~~~~~~~~
+               1 errors, 0 warnings
+            """.trimMargin())
+    }
+
+    @Test
+    fun whenSystemDotLibraryNotFoundThenFailWithError() {
+        lint()
+            .files(kt("""
+              package com.duckduckgo.lint
+    
+                fun loadLibrary() {}
+
+                class Duck {
+                    fun quack() {
+                        loadLibrary()
+                    }
+                }
+            """).indented())
+            .allowCompilationErrors()
+            .issues(NoSystemLoadLibraryDetector.NO_SYSTEM_LOAD_LIBRARY)
+            .run()
+            .expectClean()
+    }
+}

--- a/versions.properties
+++ b/versions.properties
@@ -57,6 +57,8 @@ version.com.android.installreferrer..installreferrer=2.2
 
 version.com.frybits.harmony..harmony=1.1.11
 
+version.com.getkeepsafe.relinker..relinker=1.4.5
+
 version.com.github.bumptech.glide..compiler=4.13.2
 
 version.com.github.bumptech.glide..glide=4.13.2


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202242362471737/f

### Description
Use `ReLinker` (as also suggested by Google in [here](https://developer.android.com/training/articles/perf-jni#native-libraries)) to avoid issues when linking native libraryes. Like the ones we see with the bloom filter.

ReLinker internaly uses `System.loadLibrary()` but falls back to do their own thing when that fails. So it should not worsen the situation.

### Steps to test this PR

_Test libary loading_
- [x] install from current branch
- [x] filter logcat by `HttpsBloomFilterFactoryImpl`
- [x] launch the app
- [x] verify `Found https data at /data/user/0/com.duckduckgo.mobile.android.debug/files/HTTPS_BINARY_FILE, building filter` and `Loading took...` logs appear
- [x] verify the error logcat message `Error creating the bloom filter` does not appear

