### PR TITLE
Show key icon on compatible WebView fields

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/AutofillJavascriptInterface.kt
@@ -52,7 +52,10 @@ interface AutofillJavascriptInterface {
     @JavascriptInterface
     fun getAutofillData(requestString: String)
 
-    suspend fun getRuntimeConfiguration(rawJs: String, url: String?): String
+    suspend fun getRuntimeConfiguration(
+        rawJs: String,
+        url: String?
+    ): String
 
     fun injectCredentials(credentials: LoginCredentials)
     fun injectNoCredentials()
@@ -147,7 +150,10 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
 
         val contentScope = autofillResponseWriter.generateContentScope()
         val userUnprotectedDomains = autofillResponseWriter.generateUserUnprotectedDomains()
-        val userPreferences = autofillResponseWriter.generateUserPreferences(autofillCredentials = determineIfAutofillEnabled())
+        val userPreferences = autofillResponseWriter.generateUserPreferences(
+            autofillCredentials = determineIfAutofillEnabled(),
+            showInlineKeyIcon = true
+        )
         val availableInputTypes = generateAvailableInputTypes(url)
 
         return rawJs
@@ -234,7 +240,10 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
         )
     }
 
-    private fun JavascriptCredentials.asLoginCredentials(url: String, title: String?): LoginCredentials {
+    private fun JavascriptCredentials.asLoginCredentials(
+        url: String,
+        title: String?
+    ): LoginCredentials {
         return LoginCredentials(
             id = null,
             domain = url,

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/jsbridge/response/AutofillResponseWriter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/jsbridge/response/AutofillResponseWriter.kt
@@ -28,7 +28,7 @@ interface AutofillResponseWriter {
     fun generateResponseGetAvailableInputTypes(credentialsAvailable: Boolean, emailAvailable: Boolean): String
     fun generateContentScope(): String
     fun generateUserUnprotectedDomains(): String
-    fun generateUserPreferences(autofillCredentials: Boolean, showInlineKeyIcon: Boolean = false): String
+    fun generateUserPreferences(autofillCredentials: Boolean, showInlineKeyIcon: Boolean): String
 }
 
 @ContributesBinding(AppScope::class)

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoredBackJavascriptInterfaceTest.kt
@@ -242,7 +242,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
 
         testee.getRuntimeConfiguration("", url)
 
-        verify(autofillResponseWriter).generateUserPreferences(false)
+        verifyAutofillCredentialsReturnedAs(false)
     }
 
     @Test
@@ -255,7 +255,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
 
         testee.getRuntimeConfiguration("", url)
 
-        verify(autofillResponseWriter).generateUserPreferences(false)
+        verifyAutofillCredentialsReturnedAs(false)
     }
 
     @Test
@@ -268,7 +268,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
 
         testee.getRuntimeConfiguration("", url)
 
-        verify(autofillResponseWriter).generateUserPreferences(false)
+        verifyAutofillCredentialsReturnedAs(false)
     }
 
     @Test
@@ -278,10 +278,17 @@ class AutofillStoredBackJavascriptInterfaceTest {
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
         whenever(autofillStore.autofillEnabled).thenReturn(true)
         whenever(autofillStore.autofillAvailable).thenReturn(true)
-
         testee.getRuntimeConfiguration("", url)
 
-        verify(autofillResponseWriter).generateUserPreferences(true)
+        verifyAutofillCredentialsReturnedAs(true)
+    }
+
+    @Test
+    fun whenCanAutofillThenConfigSpecifiesShowingKeyIcon() = runTest {
+        val url = "example.com"
+        configureAutofillAvailableForSite(url)
+        testee.getRuntimeConfiguration("", url)
+        verifyKeyIconRequestedToShow()
     }
 
     @Test
@@ -439,6 +446,21 @@ class AutofillStoredBackJavascriptInterfaceTest {
         configureRequestParserToReturn(username = " ", password = " ")
         testee.storeFormData("")
         assertNull(testCallback.credentialsToSave)
+    }
+
+    private fun verifyAutofillCredentialsReturnedAs(expectedValue: Boolean) {
+        verify(autofillResponseWriter).generateUserPreferences(autofillCredentials = eq(expectedValue), showInlineKeyIcon = any())
+    }
+
+    private fun verifyKeyIconRequestedToShow() {
+        verify(autofillResponseWriter).generateUserPreferences(showInlineKeyIcon = any(), autofillCredentials = eq(true))
+    }
+
+    private suspend fun configureAutofillAvailableForSite(url: String) {
+        whenever(autofillStore.getCredentials(url)).thenReturn(emptyList())
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
+        whenever(autofillStore.autofillEnabled).thenReturn(true)
+        whenever(autofillStore.autofillAvailable).thenReturn(true)
     }
 
     private suspend fun configureRequestParserToReturn(username: String?, password: String?) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202856772457648/f

### Description
Shows the inline key icon in the WebView fields which can be autofilled.

### Steps to test this PR

- [x] Visit a login page with a saved credential
- [x] Verify the fields in the login show a `key` icon
- [x] Click on the fields and dismiss the autofill dialog. Verify that clicking on the key brings back the autofill dialog.