### PR TITLE
Feature/ana/add additional pixels

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManager.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManager.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_M
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_MISMATCH
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_NONE
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_SERP_ONLY
+import com.duckduckgo.adclick.impl.pixels.AdClickPixels
 import com.duckduckgo.app.global.UriString
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
@@ -41,6 +42,7 @@ class DuckDuckGoAdClickManager @Inject constructor(
     private val adClickData: AdClickData,
     private val adClickAttribution: AdClickAttribution,
     private val pixel: Pixel,
+    private val adClickPixels: AdClickPixels
 ) : AdClickManager {
 
     private val publicSuffixDatabase = PublicSuffixDatabase()
@@ -195,6 +197,7 @@ class DuckDuckGoAdClickManager @Inject constructor(
                         adClickActivePixelFired = false
                     )
                 )
+                adClickPixels.updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
             }
         } else {
             // propagate exemption with timeout since it's a different host
@@ -207,6 +210,7 @@ class DuckDuckGoAdClickManager @Inject constructor(
                     adClickActivePixelFired = false
                 )
             )
+            adClickPixels.updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
         }
     }
 
@@ -220,9 +224,11 @@ class DuckDuckGoAdClickManager @Inject constructor(
                 )
             )
             fireAdClickDetectedPixel(savedAdDomain, urlAdDomain)
+            adClickPixels.updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
         }
     }
 
+    // TODO: [ANA] move these 2 to AdClickPixels
     private fun fireAdClickDetectedPixel(savedAdDomain: String?, urlAdDomain: String) {
         val params = mutableMapOf<String, String>()
         when {

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorker.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorker.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adclick.impl.pixels
+
+import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.work.BackoffPolicy
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+@ContributesWorker(AppScope::class)
+class AdClickDailyReportingWorker(context: Context, workerParameters: WorkerParameters) :
+    CoroutineWorker(context, workerParameters) {
+
+    @Inject
+    lateinit var adClickPixels: AdClickPixels
+
+    override suspend fun doWork(): Result {
+        return withContext(Dispatchers.IO) {
+            adClickPixels.fireCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+            return@withContext Result.success()
+        }
+    }
+}
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = LifecycleObserver::class
+)
+class AdClickDailyReportingWorkerScheduler @Inject constructor(
+    private val workManager: WorkManager
+) : DefaultLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        Timber.v("Scheduling ad click daily reporting worker")
+        val workerRequest = PeriodicWorkRequestBuilder<AdClickDailyReportingWorker>(24, TimeUnit.HOURS)
+            .addTag(DAILY_REPORTING_AD_CLICK_WORKER_TAG)
+            .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+            .build()
+        workManager.enqueueUniquePeriodicWork(DAILY_REPORTING_AD_CLICK_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, workerRequest)
+    }
+
+    companion object {
+        private const val DAILY_REPORTING_AD_CLICK_WORKER_TAG = "DAILY_REPORTING_AD_CLICK_WORKER_TAG"
+    }
+}

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixelName.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixelName.kt
@@ -20,7 +20,8 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 
 enum class AdClickPixelName(override val pixelName: String) : Pixel.PixelName {
     AD_CLICK_DETECTED("m_ad_click_detected"),
-    AD_CLICK_ACTIVE("m_ad_click_active")
+    AD_CLICK_ACTIVE("m_ad_click_active"),
+    AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION("m_pageloads_with_ad_attribution")
 }
 
 object AdClickPixelValues {
@@ -35,4 +36,5 @@ object AdClickPixelParameters {
     const val AD_CLICK_DOMAIN_DETECTION = "domainDetection"
     const val AD_CLICK_HEURISTIC_DETECTION = "heuristicDetection"
     const val AD_CLICK_DOMAIN_DETECTION_ENABLED = "domainDetectionEnabled"
+    const val AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION_COUNT = "count"
 }

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixels.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixels.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 interface AdClickPixels {
+    fun fireAdClickDetectedPixel(savedAdDomain: String?, urlAdDomain: String, heuristicEnabled: Boolean, domainEnabled: Boolean)
     fun updateCountPixel(adClickPixelName: AdClickPixelName)
     fun fireCountPixel(adClickPixelName: AdClickPixelName)
 }
@@ -40,6 +41,25 @@ class RealAdClickPixels @Inject constructor(
 
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+
+    override fun fireAdClickDetectedPixel(savedAdDomain: String?, urlAdDomain: String, heuristicEnabled: Boolean, domainEnabled: Boolean) {
+        val params = mutableMapOf<String, String>()
+        when {
+            !savedAdDomain.isNullOrEmpty() && savedAdDomain == urlAdDomain ->
+                params[AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION] = AdClickPixelValues.AD_CLICK_DETECTED_MATCHED
+            !savedAdDomain.isNullOrEmpty() && urlAdDomain.isNotEmpty() && savedAdDomain != urlAdDomain ->
+                params[AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION] = AdClickPixelValues.AD_CLICK_DETECTED_MISMATCH
+            !savedAdDomain.isNullOrEmpty() ->
+                params[AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION] = AdClickPixelValues.AD_CLICK_DETECTED_SERP_ONLY
+            savedAdDomain.isNullOrEmpty() && urlAdDomain.isNotEmpty() ->
+                params[AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION] = AdClickPixelValues.AD_CLICK_DETECTED_HEURISTIC_ONLY
+            else ->
+                params[AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION] = AdClickPixelValues.AD_CLICK_DETECTED_NONE
+        }
+        params[AdClickPixelParameters.AD_CLICK_HEURISTIC_DETECTION] = heuristicEnabled.toString()
+        params[AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION_ENABLED] = domainEnabled.toString()
+        pixel.fire(AdClickPixelName.AD_CLICK_DETECTED, params)
+    }
 
     override fun updateCountPixel(adClickPixelName: AdClickPixelName) {
         val count = preferences.getInt(adClickPixelName.appendCountSuffix(), 0)

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixels.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixels.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.adclick.impl.pixels
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.adclick.impl.Exemption
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelParameters.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION_COUNT
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
@@ -28,6 +29,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 interface AdClickPixels {
+    fun fireAdClickActivePixel(exemption: Exemption?): Boolean
     fun fireAdClickDetectedPixel(savedAdDomain: String?, urlAdDomain: String, heuristicEnabled: Boolean, domainEnabled: Boolean)
     fun updateCountPixel(adClickPixelName: AdClickPixelName)
     fun fireCountPixel(adClickPixelName: AdClickPixelName)
@@ -41,6 +43,14 @@ class RealAdClickPixels @Inject constructor(
 
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+
+    override fun fireAdClickActivePixel(exemption: Exemption?): Boolean {
+        if (exemption == null || exemption.adClickActivePixelFired) return false
+
+        pixel.fire(AdClickPixelName.AD_CLICK_ACTIVE)
+
+        return true
+    }
 
     override fun fireAdClickDetectedPixel(savedAdDomain: String?, urlAdDomain: String, heuristicEnabled: Boolean, domainEnabled: Boolean) {
         val params = mutableMapOf<String, String>()

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixels.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixels.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adclick.impl.pixels
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.adclick.impl.pixels.AdClickPixelParameters.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION_COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import org.threeten.bp.Instant
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+interface AdClickPixels {
+    fun updateCountPixel(adClickPixelName: AdClickPixelName)
+    fun fireCountPixel(adClickPixelName: AdClickPixelName)
+}
+
+@ContributesBinding(AppScope::class)
+class RealAdClickPixels @Inject constructor(
+    private val pixel: Pixel,
+    private val context: Context
+) : AdClickPixels {
+
+    private val preferences: SharedPreferences
+        get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+
+    override fun updateCountPixel(adClickPixelName: AdClickPixelName) {
+        val count = preferences.getInt(adClickPixelName.appendCountSuffix(), 0)
+        preferences.edit { putInt(adClickPixelName.appendCountSuffix(), count + 1) }
+    }
+
+    override fun fireCountPixel(adClickPixelName: AdClickPixelName) {
+        val now = Instant.now().toEpochMilli()
+
+        val count = preferences.getInt(adClickPixelName.appendCountSuffix(), 0)
+        if (count == 0) {
+            return
+        }
+
+        val timestamp = preferences.getLong(adClickPixelName.appendTimestampSuffix(), 0L)
+        if (timestamp == 0L || now >= timestamp) {
+            pixel.fire(adClickPixelName, mapOf(AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION_COUNT to count.toString()))
+                .also {
+                    preferences.edit {
+                        putLong(adClickPixelName.appendTimestampSuffix(), now.plus(TimeUnit.HOURS.toMillis(WINDOW_INTERVAL_HOURS)))
+                        putInt(adClickPixelName.appendCountSuffix(), 0)
+                    }
+                }
+        }
+    }
+
+    private fun AdClickPixelName.appendTimestampSuffix(): String {
+        return "${this.pixelName}_timestamp"
+    }
+
+    private fun AdClickPixelName.appendCountSuffix(): String {
+        return "${this.pixelName}_count"
+    }
+
+    companion object {
+        private const val FILENAME = "com.duckduckgo.adclick.impl.pixels"
+        private const val WINDOW_INTERVAL_HOURS = 24L
+    }
+}

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManagerTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManagerTest.kt
@@ -18,17 +18,7 @@ package com.duckduckgo.adclick.impl
 
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelName
-import com.duckduckgo.adclick.impl.pixels.AdClickPixelName.AD_CLICK_DETECTED
-import com.duckduckgo.adclick.impl.pixels.AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION
-import com.duckduckgo.adclick.impl.pixels.AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION_ENABLED
-import com.duckduckgo.adclick.impl.pixels.AdClickPixelParameters.AD_CLICK_HEURISTIC_DETECTION
-import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_HEURISTIC_ONLY
-import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_MATCHED
-import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_MISMATCH
-import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_NONE
-import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_SERP_ONLY
 import com.duckduckgo.adclick.impl.pixels.AdClickPixels
-import com.duckduckgo.app.statistics.pixels.Pixel
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -50,13 +40,12 @@ class DuckDuckGoAdClickManagerTest {
 
     private val mockAdClickData: AdClickData = mock()
     private val mockAdClickAttribution: AdClickAttribution = mock()
-    private val mockPixel: Pixel = mock()
     private val mockAdClickPixels: AdClickPixels = mock()
     private lateinit var testee: AdClickManager
 
     @Before
     fun before() {
-        testee = DuckDuckGoAdClickManager(mockAdClickData, mockAdClickAttribution, mockPixel, mockAdClickPixels)
+        testee = DuckDuckGoAdClickManager(mockAdClickData, mockAdClickAttribution, mockAdClickPixels)
     }
 
     @Test
@@ -217,13 +206,11 @@ class DuckDuckGoAdClickManagerTest {
 
         testee.detectAdDomain(url = "https://landing_page.com/")
 
-        verify(mockPixel).fire(
-            AD_CLICK_DETECTED,
-            mapOf(
-                AD_CLICK_DOMAIN_DETECTION to AD_CLICK_DETECTED_MATCHED,
-                AD_CLICK_HEURISTIC_DETECTION to "false",
-                AD_CLICK_DOMAIN_DETECTION_ENABLED to "false"
-            )
+        verify(mockAdClickPixels).fireAdClickDetectedPixel(
+            savedAdDomain = "landing_page.com",
+            urlAdDomain = "landing_page.com",
+            heuristicEnabled = false,
+            domainEnabled = false
         )
     }
 
@@ -233,13 +220,11 @@ class DuckDuckGoAdClickManagerTest {
 
         testee.detectAdDomain(url = "https://other_landing_page.com/")
 
-        verify(mockPixel).fire(
-            AD_CLICK_DETECTED,
-            mapOf(
-                AD_CLICK_DOMAIN_DETECTION to AD_CLICK_DETECTED_MISMATCH,
-                AD_CLICK_HEURISTIC_DETECTION to "false",
-                AD_CLICK_DOMAIN_DETECTION_ENABLED to "false"
-            )
+        verify(mockAdClickPixels).fireAdClickDetectedPixel(
+            savedAdDomain = "landing_page.com",
+            urlAdDomain = "other_landing_page.com",
+            heuristicEnabled = false,
+            domainEnabled = false
         )
     }
 
@@ -249,13 +234,11 @@ class DuckDuckGoAdClickManagerTest {
 
         testee.detectAdDomain(url = "https://")
 
-        verify(mockPixel).fire(
-            AD_CLICK_DETECTED,
-            mapOf(
-                AD_CLICK_DOMAIN_DETECTION to AD_CLICK_DETECTED_SERP_ONLY,
-                AD_CLICK_HEURISTIC_DETECTION to "false",
-                AD_CLICK_DOMAIN_DETECTION_ENABLED to "false"
-            )
+        verify(mockAdClickPixels).fireAdClickDetectedPixel(
+            savedAdDomain = "landing_page",
+            urlAdDomain = "",
+            heuristicEnabled = false,
+            domainEnabled = false
         )
     }
 
@@ -265,13 +248,11 @@ class DuckDuckGoAdClickManagerTest {
 
         testee.detectAdDomain(url = "https://landing_page.com/")
 
-        verify(mockPixel).fire(
-            AD_CLICK_DETECTED,
-            mapOf(
-                AD_CLICK_DOMAIN_DETECTION to AD_CLICK_DETECTED_HEURISTIC_ONLY,
-                AD_CLICK_HEURISTIC_DETECTION to "false",
-                AD_CLICK_DOMAIN_DETECTION_ENABLED to "false"
-            )
+        verify(mockAdClickPixels).fireAdClickDetectedPixel(
+            savedAdDomain = "",
+            urlAdDomain = "landing_page.com",
+            heuristicEnabled = false,
+            domainEnabled = false
         )
     }
 
@@ -281,13 +262,11 @@ class DuckDuckGoAdClickManagerTest {
 
         testee.detectAdDomain(url = "https://")
 
-        verify(mockPixel).fire(
-            AD_CLICK_DETECTED,
-            mapOf(
-                AD_CLICK_DOMAIN_DETECTION to AD_CLICK_DETECTED_NONE,
-                AD_CLICK_HEURISTIC_DETECTION to "false",
-                AD_CLICK_DOMAIN_DETECTION_ENABLED to "false"
-            )
+        verify(mockAdClickPixels).fireAdClickDetectedPixel(
+            savedAdDomain = "",
+            urlAdDomain = "",
+            heuristicEnabled = false,
+            domainEnabled = false
         )
     }
 
@@ -298,13 +277,11 @@ class DuckDuckGoAdClickManagerTest {
 
         testee.detectAdDomain(url = "https://")
 
-        verify(mockPixel).fire(
-            AD_CLICK_DETECTED,
-            mapOf(
-                AD_CLICK_DOMAIN_DETECTION to AD_CLICK_DETECTED_NONE,
-                AD_CLICK_HEURISTIC_DETECTION to "true",
-                AD_CLICK_DOMAIN_DETECTION_ENABLED to "false"
-            )
+        verify(mockAdClickPixels).fireAdClickDetectedPixel(
+            savedAdDomain = "",
+            urlAdDomain = "",
+            heuristicEnabled = true,
+            domainEnabled = false
         )
     }
 
@@ -315,13 +292,11 @@ class DuckDuckGoAdClickManagerTest {
 
         testee.detectAdDomain(url = "https://")
 
-        verify(mockPixel).fire(
-            AD_CLICK_DETECTED,
-            mapOf(
-                AD_CLICK_DOMAIN_DETECTION to AD_CLICK_DETECTED_NONE,
-                AD_CLICK_HEURISTIC_DETECTION to "false",
-                AD_CLICK_DOMAIN_DETECTION_ENABLED to "true"
-            )
+        verify(mockAdClickPixels).fireAdClickDetectedPixel(
+            savedAdDomain = "",
+            urlAdDomain = "",
+            heuristicEnabled = false,
+            domainEnabled = true
         )
     }
 
@@ -354,7 +329,7 @@ class DuckDuckGoAdClickManagerTest {
         val url = "https://tracker.com"
 
         val result = testee.isExemption(documentUrl = documentUrl, url = url)
-        verify(mockPixel, never()).fire(AdClickPixelName.AD_CLICK_ACTIVE)
+        verify(mockAdClickPixels, never()).fireAdClickActivePixel(any())
         assertFalse(result)
     }
 
@@ -370,7 +345,7 @@ class DuckDuckGoAdClickManagerTest {
         val result = testee.isExemption(documentUrl = documentUrl, url = url)
 
         verify(mockAdClickData).removeExemption()
-        verify(mockPixel, never()).fire(AdClickPixelName.AD_CLICK_ACTIVE)
+        verify(mockAdClickPixels, never()).fireAdClickActivePixel(any())
         assertFalse(result)
     }
 
@@ -387,7 +362,7 @@ class DuckDuckGoAdClickManagerTest {
         val result = testee.isExemption(documentUrl = documentUrl, url = url)
 
         verify(mockAdClickData, never()).removeExemption()
-        verify(mockPixel, never()).fire(AdClickPixelName.AD_CLICK_ACTIVE)
+        verify(mockAdClickPixels, never()).fireAdClickActivePixel(any())
         assertFalse(result)
     }
 
@@ -404,7 +379,7 @@ class DuckDuckGoAdClickManagerTest {
         val result = testee.isExemption(documentUrl = documentUrl, url = url)
 
         verify(mockAdClickData, never()).removeExemption()
-        verify(mockPixel).fire(AdClickPixelName.AD_CLICK_ACTIVE)
+        verify(mockAdClickPixels).fireAdClickActivePixel(any())
         assertTrue(result)
     }
 

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManagerTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManagerTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_M
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_MISMATCH
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_NONE
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelValues.AD_CLICK_DETECTED_SERP_ONLY
+import com.duckduckgo.adclick.impl.pixels.AdClickPixels
 import com.duckduckgo.app.statistics.pixels.Pixel
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -50,11 +51,12 @@ class DuckDuckGoAdClickManagerTest {
     private val mockAdClickData: AdClickData = mock()
     private val mockAdClickAttribution: AdClickAttribution = mock()
     private val mockPixel: Pixel = mock()
+    private val mockAdClickPixels: AdClickPixels = mock()
     private lateinit var testee: AdClickManager
 
     @Before
     fun before() {
-        testee = DuckDuckGoAdClickManager(mockAdClickData, mockAdClickAttribution, mockPixel)
+        testee = DuckDuckGoAdClickManager(mockAdClickData, mockAdClickAttribution, mockPixel, mockAdClickPixels)
     }
 
     @Test
@@ -165,6 +167,7 @@ class DuckDuckGoAdClickManagerTest {
 
         verify(mockAdClickData).setActiveTab(tabId)
         verify(mockAdClickData).addExemption(tabId = any(), exemption = any())
+        verify(mockAdClickPixels).updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
     }
 
     @Test
@@ -180,6 +183,7 @@ class DuckDuckGoAdClickManagerTest {
 
         verify(mockAdClickData).setActiveTab(tabId)
         verify(mockAdClickData, never()).addExemption(tabId = any(), exemption = any())
+        verify(mockAdClickPixels, never()).updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
     }
 
     @Test

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorkerTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorkerTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adclick.impl.pixels
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.duckduckgo.app.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@ExperimentalCoroutinesApi
+internal class AdClickDailyReportingWorkerTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val mockAdClickPixels: AdClickPixels = mock()
+
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = mock()
+    }
+
+    @Test
+    fun whenDoWorkThenCallFireCountPixelWithCorrectParamNameAndReturnSuccess() =
+        runTest {
+            val worker = TestListenableWorkerBuilder<AdClickDailyReportingWorker>(context = context).build()
+            worker.adClickPixels = mockAdClickPixels
+
+            val result = worker.doWork()
+
+            verify(mockAdClickPixels).fireCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+            Assert.assertEquals(result, ListenableWorker.Result.success())
+        }
+}

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adclick.impl.pixels
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.app.global.api.InMemorySharedPreferences
+import com.duckduckgo.app.statistics.pixels.Pixel
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.threeten.bp.Instant
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class RealAdClickPixelsTest {
+
+    private lateinit var testee: AdClickPixels
+    private lateinit var prefs: SharedPreferences
+
+    private val mockPixel: Pixel = mock()
+    private val mockContext: Context = mock()
+
+    @Before
+    fun setup() {
+        prefs = InMemorySharedPreferences()
+        whenever(mockContext.getSharedPreferences("com.duckduckgo.adclick.impl.pixels", 0)).thenReturn(prefs)
+        testee = RealAdClickPixels(mockPixel, mockContext)
+    }
+
+    @Test
+    fun whenUpdateCountPixelCalledThenSharedPrefUpdated() {
+        val key = "${AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION.pixelName}_count"
+        assertEquals(0, prefs.getInt(key, 0))
+
+        testee.updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+        testee.updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+
+        assertEquals(2, prefs.getInt(key, 0))
+    }
+
+    @Test
+    fun whenFireCountPixelCalledForZeroCountThenPixelNotSent() {
+        val key = "${AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION.pixelName}_count"
+        assertEquals(0, prefs.getInt(key, 0))
+
+        testee.fireCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+
+        verify(mockPixel, never()).fire(
+            pixel = eq(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION),
+            parameters = any(),
+            encodedParameters = any()
+        )
+    }
+
+    @Test
+    fun whenFireCountPixelCalledForNonZeroCountAndCurrentTimeNotSetThenPixelSent() {
+        val key = "${AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION.pixelName}_count"
+        testee.updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+        assertEquals(1, prefs.getInt(key, 0))
+
+        testee.fireCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+
+        verify(mockPixel).fire(
+            pixel = eq(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION),
+            parameters = eq(mapOf(AdClickPixelParameters.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION_COUNT to "1")),
+            encodedParameters = any()
+        )
+    }
+
+    @Test
+    fun whenFireCountPixelCalledForNonZeroCountAndCurrentTimeBeforeTimestampThenPixelNotSent() {
+        val key = "${AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION.pixelName}_count"
+        val timestampKey = "${AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION.pixelName}_timestamp"
+        val now = Instant.now().toEpochMilli()
+        testee.updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+        assertEquals(1, prefs.getInt(key, 0))
+        prefs.edit { putLong(timestampKey, now.plus(TimeUnit.HOURS.toMillis(1))) }
+
+        testee.fireCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+
+        verify(mockPixel, never()).fire(
+            pixel = eq(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION),
+            parameters = any(),
+            encodedParameters = any()
+        )
+    }
+
+    @Test
+    fun whenFireCountPixelCalledForNonZeroCountAndCurrentTimeAfterTimestampThenPixelSent() {
+        val key = "${AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION.pixelName}_count"
+        val timestampKey = "${AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION.pixelName}_timestamp"
+        val now = Instant.now().toEpochMilli()
+        testee.updateCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+        assertEquals(1, prefs.getInt(key, 0))
+        prefs.edit { putLong(timestampKey, now.minus(TimeUnit.HOURS.toMillis(1))) }
+
+        testee.fireCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
+
+        verify(mockPixel).fire(
+            pixel = eq(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION),
+            parameters = eq(mapOf(AdClickPixelParameters.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION_COUNT to "1")),
+            encodedParameters = any()
+        )
+    }
+}

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
@@ -53,6 +53,141 @@ class RealAdClickPixelsTest {
         testee = RealAdClickPixels(mockPixel, mockContext)
     }
 
+    // TODO: [ANA] add tests for fireAdClickActivePixel
+
+    @Test
+    fun whenFireAdClickDetectedPixelCalledWithSavedAdDomainSameAsUrlAdDomainThenPixelSentWithMatchedParam() {
+        val savedAdDomain = "ad_domain"
+        val urlAdDomain = "ad_domain"
+        val heuristicEnabled = true
+        val domainEnabled = true
+
+        testee.fireAdClickDetectedPixel(savedAdDomain, urlAdDomain, heuristicEnabled, domainEnabled)
+
+        verify(mockPixel).fire(
+            AdClickPixelName.AD_CLICK_DETECTED,
+            mapOf(
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION to AdClickPixelValues.AD_CLICK_DETECTED_MATCHED,
+                AdClickPixelParameters.AD_CLICK_HEURISTIC_DETECTION to "true",
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION_ENABLED to "true"
+            )
+        )
+    }
+
+    @Test
+    fun whenFireAdClickDetectedPixelCalledWithSavedAdDomainDifferentThanUrlAdDomainThenPixelSentWithMismatchParam() {
+        val savedAdDomain = "ad_domain"
+        val urlAdDomain = "other_domain"
+        val heuristicEnabled = true
+        val domainEnabled = true
+
+        testee.fireAdClickDetectedPixel(savedAdDomain, urlAdDomain, heuristicEnabled, domainEnabled)
+
+        verify(mockPixel).fire(
+            AdClickPixelName.AD_CLICK_DETECTED,
+            mapOf(
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION to AdClickPixelValues.AD_CLICK_DETECTED_MISMATCH,
+                AdClickPixelParameters.AD_CLICK_HEURISTIC_DETECTION to "true",
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION_ENABLED to "true"
+            )
+        )
+    }
+
+    @Test
+    fun whenFireAdClickDetectedPixelCalledWithSavedAdDomainAndNoUrlAdDomainThenPixelSentWithSerpOnlyParam() {
+        val savedAdDomain = "ad_domain"
+        val urlAdDomain = ""
+        val heuristicEnabled = true
+        val domainEnabled = true
+
+        testee.fireAdClickDetectedPixel(savedAdDomain, urlAdDomain, heuristicEnabled, domainEnabled)
+
+        verify(mockPixel).fire(
+            AdClickPixelName.AD_CLICK_DETECTED,
+            mapOf(
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION to AdClickPixelValues.AD_CLICK_DETECTED_SERP_ONLY,
+                AdClickPixelParameters.AD_CLICK_HEURISTIC_DETECTION to "true",
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION_ENABLED to "true"
+            )
+        )
+    }
+
+    @Test
+    fun whenFireAdClickDetectedPixelCalledWithNoSavedAdDomainAndUrlAdDomainThenPixelSentWithHeuristicOnlyParam() {
+        val savedAdDomain = ""
+        val urlAdDomain = "ad_domain"
+        val heuristicEnabled = true
+        val domainEnabled = true
+
+        testee.fireAdClickDetectedPixel(savedAdDomain, urlAdDomain, heuristicEnabled, domainEnabled)
+
+        verify(mockPixel).fire(
+            AdClickPixelName.AD_CLICK_DETECTED,
+            mapOf(
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION to AdClickPixelValues.AD_CLICK_DETECTED_HEURISTIC_ONLY,
+                AdClickPixelParameters.AD_CLICK_HEURISTIC_DETECTION to "true",
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION_ENABLED to "true"
+            )
+        )
+    }
+
+    @Test
+    fun whenFireAdClickDetectedPixelCalledWithNoSavedAdDomainAndNoUrlAdDomainThenPixelSentWithNoneParam() {
+        val savedAdDomain = ""
+        val urlAdDomain = ""
+        val heuristicEnabled = true
+        val domainEnabled = true
+
+        testee.fireAdClickDetectedPixel(savedAdDomain, urlAdDomain, heuristicEnabled, domainEnabled)
+
+        verify(mockPixel).fire(
+            AdClickPixelName.AD_CLICK_DETECTED,
+            mapOf(
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION to AdClickPixelValues.AD_CLICK_DETECTED_NONE,
+                AdClickPixelParameters.AD_CLICK_HEURISTIC_DETECTION to "true",
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION_ENABLED to "true"
+            )
+        )
+    }
+
+    @Test
+    fun whenFireAdClickDetectedPixelCalledWithDisabledHeuristicDetectionThenPixelSentWithCorrectParam() {
+        val savedAdDomain = ""
+        val urlAdDomain = ""
+        val heuristicEnabled = false
+        val domainEnabled = true
+
+        testee.fireAdClickDetectedPixel(savedAdDomain, urlAdDomain, heuristicEnabled, domainEnabled)
+
+        verify(mockPixel).fire(
+            AdClickPixelName.AD_CLICK_DETECTED,
+            mapOf(
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION to AdClickPixelValues.AD_CLICK_DETECTED_NONE,
+                AdClickPixelParameters.AD_CLICK_HEURISTIC_DETECTION to "false",
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION_ENABLED to "true"
+            )
+        )
+    }
+
+    @Test
+    fun whenFireAdClickDetectedPixelCalledWithDisabledDomainDetectionThenPixelSentWithCorrectParam() {
+        val savedAdDomain = ""
+        val urlAdDomain = ""
+        val heuristicEnabled = true
+        val domainEnabled = false
+
+        testee.fireAdClickDetectedPixel(savedAdDomain, urlAdDomain, heuristicEnabled, domainEnabled)
+
+        verify(mockPixel).fire(
+            AdClickPixelName.AD_CLICK_DETECTED,
+            mapOf(
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION to AdClickPixelValues.AD_CLICK_DETECTED_NONE,
+                AdClickPixelParameters.AD_CLICK_HEURISTIC_DETECTION to "true",
+                AdClickPixelParameters.AD_CLICK_DOMAIN_DETECTION_ENABLED to "false"
+            )
+        )
+    }
+
     @Test
     fun whenUpdateCountPixelCalledThenSharedPrefUpdated() {
         val key = "${AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION.pixelName}_count"

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
@@ -19,9 +19,12 @@ package com.duckduckgo.adclick.impl.pixels
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.adclick.impl.Exemption
 import com.duckduckgo.app.global.api.InMemorySharedPreferences
 import com.duckduckgo.app.statistics.pixels.Pixel
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -53,7 +56,43 @@ class RealAdClickPixelsTest {
         testee = RealAdClickPixels(mockPixel, mockContext)
     }
 
-    // TODO: [ANA] add tests for fireAdClickActivePixel
+    @Test
+    fun whenFireAdClickActivePixelCalledWithNullExemptionThenReturnFalse() {
+        val exemption = null
+
+        val result = testee.fireAdClickActivePixel(exemption)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenFireAdClickActivePixelCalledWithNonNullExemptionAndPixelAlreadyFiredThenReturnFalse() {
+        val exemption = Exemption(
+            hostTldPlusOne = "ad_domain",
+            navigationExemptionDeadline = 0L,
+            exemptionDeadline = 0L,
+            adClickActivePixelFired = true
+        )
+
+        val result = testee.fireAdClickActivePixel(exemption)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenFireAdClickActivePixelCalledWithNonNullExemptionAndPixelNotAlreadyFiredThenFirePixelAndReturnTrue() {
+        val exemption = Exemption(
+            hostTldPlusOne = "ad_domain",
+            navigationExemptionDeadline = 0L,
+            exemptionDeadline = 0L,
+            adClickActivePixelFired = false
+        )
+
+        val result = testee.fireAdClickActivePixel(exemption)
+
+        verify(mockPixel).fire(AdClickPixelName.AD_CLICK_ACTIVE)
+        assertTrue(result)
+    }
 
     @Test
     fun whenFireAdClickDetectedPixelCalledWithSavedAdDomainSameAsUrlAdDomainThenPixelSentWithMatchedParam() {

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptor.kt
@@ -35,10 +35,16 @@ class PixelAdClickAttributionRemovalInterceptor @Inject constructor() : Intercep
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request().newBuilder()
         val pixel = chain.request().url.pathSegments.last()
+        val pixelName = getPixelName(pixel)
 
-        val url = if (PIXELS_SET.contains(getPixelName(pixel))) {
+        val url = if (PIXELS_SET_NO_ATB.contains(pixelName)) {
             chain.request().url.newBuilder()
                 .removeAllQueryParameters(AppUrl.ParamKey.ATB)
+                .build()
+        } else if (PIXELS_SET_NO_ATB_AND_VERSION.contains(pixelName)) {
+            chain.request().url.newBuilder()
+                .removeAllQueryParameters(AppUrl.ParamKey.ATB)
+                .removeAllQueryParameters(APP_VERSION_PARAM)
                 .build()
         } else {
             chain.request().url
@@ -56,11 +62,17 @@ class PixelAdClickAttributionRemovalInterceptor @Inject constructor() : Intercep
 
     companion object {
         private const val PIXEL_PLATFORM_SUFFIX = "_android"
+        private const val APP_VERSION_PARAM = "appVersion"
 
         @VisibleForTesting
-        internal val PIXELS_SET = setOf(
+        internal val PIXELS_SET_NO_ATB = setOf(
             AdClickPixelName.AD_CLICK_DETECTED.pixelName,
             AdClickPixelName.AD_CLICK_ACTIVE.pixelName,
+        )
+
+        @VisibleForTesting
+        internal val PIXELS_SET_NO_ATB_AND_VERSION = setOf(
+            AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION.pixelName,
         )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptorTest.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.global.api
 
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelName
-import com.duckduckgo.app.global.api.PixelAdClickAttributionRemovalInterceptor.Companion.PIXELS_SET
+import com.duckduckgo.app.global.api.PixelAdClickAttributionRemovalInterceptor.Companion.PIXELS_SET_NO_ATB
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -34,7 +34,7 @@ class PixelAdClickAttributionRemovalInterceptorTest {
     fun whenSendPixelTheRemoveAtbInfoFromDefinedPixels() {
         AdClickPixelName.values().map { it.pixelName }.forEach { pixelName ->
             val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
-            val removalExpected = PIXELS_SET.contains(pixelName)
+            val removalExpected = PIXELS_SET_NO_ATB.contains(pixelName)
 
             val interceptedUrl = interceptor.intercept(FakeChain(pixelUrl)).request.url
 

--- a/app/src/test/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/api/PixelAdClickAttributionRemovalInterceptorTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.global.api
 
 import com.duckduckgo.adclick.impl.pixels.AdClickPixelName
 import com.duckduckgo.app.global.api.PixelAdClickAttributionRemovalInterceptor.Companion.PIXELS_SET_NO_ATB
+import com.duckduckgo.app.global.api.PixelAdClickAttributionRemovalInterceptor.Companion.PIXELS_SET_NO_ATB_AND_VERSION
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -34,11 +35,23 @@ class PixelAdClickAttributionRemovalInterceptorTest {
     fun whenSendPixelTheRemoveAtbInfoFromDefinedPixels() {
         AdClickPixelName.values().map { it.pixelName }.forEach { pixelName ->
             val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
-            val removalExpected = PIXELS_SET_NO_ATB.contains(pixelName)
+            val removalExpected = PIXELS_SET_NO_ATB.contains(pixelName) || PIXELS_SET_NO_ATB_AND_VERSION.contains(pixelName)
 
             val interceptedUrl = interceptor.intercept(FakeChain(pixelUrl)).request.url
 
             assertEquals(removalExpected, interceptedUrl.queryParameter("atb") == null)
+        }
+    }
+
+    @Test
+    fun whenSendPixelTheRemoveAppVersionInfoFromDefinedPixels() {
+        AdClickPixelName.values().map { it.pixelName }.forEach { pixelName ->
+            val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
+            val removalExpected = PIXELS_SET_NO_ATB_AND_VERSION.contains(pixelName)
+
+            val interceptedUrl = interceptor.intercept(FakeChain(pixelUrl)).request.url
+
+            assertEquals(removalExpected, interceptedUrl.queryParameter("appVersion") == null)
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202838955162255/f

### Description
Added new pixel. Small refactoring to move the code sending ad click pixels to a separate class.

### Steps to test this PR

- [x] get the code from this branch and change the window from 24h to 2min as below:
- [x] **in AdClickDailyReportingWorker** replace 
val workerRequest = PeriodicWorkRequestBuilder<AdClickDailyReportingWorker>(24, TimeUnit.HOURS)
with
val workerRequest = PeriodicWorkRequestBuilder<AdClickDailyReportingWorker>(2, TimeUnit.MINUTES)
- [x] **in RealAdClickPixels** replace 
putLong(adClickPixelName.appendTimestampSuffix(), now.plus(TimeUnit.HOURS.toMillis(WINDOW_INTERVAL_HOURS)))
with 
putLong(adClickPixelName.appendTimestampSuffix(), now.plus(TimeUnit.MINUTES.toMillis(2L)))
- [x] install on a device / emulator
- [x] open the app and navigate to https://www.search-company.site/
- [x] click on Ad1
- [x] open another tab and navigate to https://www.search-company.site/
- [x] click on Ad1
- [x] close the app
- [x] wait 2 min
- [x] open the app and check in logcat that the `m_pageloads_with_ad_attribution pixel` was sent with `count=2`. Also check that no `atb` or `appVersion` params were sent for this pixel.
- [x] open another tab and navigate to https://www.search-company.site/
- [x] click on Ad1
- [x] close the app
- [x] wait 2 min
- [x] open the app and check in logcat that the `m_pageloads_with_ad_attribution` pixel was sent with `count=1`. Also check that no `atb` or `appVersion` params were sent for this pixel.

### NO UI changes
