### PR TITLE
Favorites widget stopped working on 5.134.0.4-nightly

### DIFF
--- a/app/src/main/java/com/duckduckgo/widget/SearchAndFavoritesWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchAndFavoritesWidget.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.RemoteViews
@@ -31,6 +32,7 @@ import com.duckduckgo.app.browser.BrowserActivity.Companion.FAVORITES_ONBOARDING
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.systemsearch.SystemSearchActivity
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.widget.FavoritesWidgetService.Companion.THEME_EXTRAS
 import timber.log.Timber
 import javax.inject.Inject
@@ -62,6 +64,9 @@ class SearchAndFavoritesWidget : AppWidgetProvider() {
 
     @Inject
     lateinit var voiceSearchWidgetConfigurator: VoiceSearchWidgetConfigurator
+
+    @Inject
+    lateinit var appBuildConfig: AppBuildConfig
 
     private var layoutId: Int = R.layout.search_favorites_widget_daynight_auto
 
@@ -215,7 +220,8 @@ class SearchAndFavoritesWidget : AppWidgetProvider() {
         widgetTheme: WidgetTheme
     ) {
         val favoriteItemClickIntent = Intent(context, BrowserActivity::class.java)
-        val favoriteClickPendingIntent = PendingIntent.getActivity(context, 0, favoriteItemClickIntent, PendingIntent.FLAG_IMMUTABLE)
+        val pendingIntentFlags = if (appBuildConfig.sdkInt >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+        val favoriteClickPendingIntent = PendingIntent.getActivity(context, 0, favoriteItemClickIntent, pendingIntentFlags)
 
         val extras = Bundle()
         extras.putInt(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202864079845783/f

### Description
Updated `SearchAndFavoritesWidget` to use the mutable flag for pending intent on sdk 31 (Android 12) and above.

### Steps to test this PR

Perform the below tests on Android 6, 11, 12, 13:

- [x] fresh install from this branch
- [x] add the search and favorites widget
- [x] create a favorite
- [x] navigate to a different site
- [x] click on the favorite from the widget
- [x] check the app is opened and the favorite url is loaded

### NO UI changes
