### PR TITLE
Fix scroll issue for edit mode autofill credential

### DIFF
--- a/autofill/autofill-impl/src/main/AndroidManifest.xml
+++ b/autofill/autofill-impl/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <activity
             android:name="com.duckduckgo.autofill.ui.credential.management.AutofillManagementActivity"
             android:configChanges="orientation|screenSize"
+            android:windowSoftInputMode="stateVisible|adjustResize"
             android:exported="false" />
     </application>
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202882686065977/f

### Description
- Adjust autofill activity main window when soft input is visible

### Steps to test this PR

_Edit mode is scrollable_
- [x] Make text for device the biggest
- [x] Go to Autofill Credential Edit mode
- [x] Verify that notes is initially not visible
- [x] Verify that you can scroll the page to see notes.
