### PR TITLE
Reset listeners when BookmarksActivity is recreated

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -355,6 +355,21 @@ class BookmarksActivity : DuckDuckGoActivity() {
         dialog.listener = viewModel
     }
 
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+        super.onRestoreInstanceState(savedInstanceState)
+        with(supportFragmentManager) {
+            findFragmentByTag(EDIT_BOOKMARK_FRAGMENT_TAG)?.let { dialog ->
+                (dialog as EditSavedSiteDialogFragment).listener = viewModel
+            }
+            findFragmentByTag(ADD_BOOKMARK_FOLDER_FRAGMENT_TAG)?.let { dialog ->
+                (dialog as AddBookmarkFolderDialogFragment).listener = viewModel
+            }
+            findFragmentByTag(EDIT_BOOKMARK_FOLDER_FRAGMENT_TAG)?.let { dialog ->
+                (dialog as EditBookmarkFolderDialogFragment).listener = viewModel
+            }
+        }
+    }
+
     override fun onDestroy() {
         deleteDialog?.dismiss()
         super.onDestroy()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -532,6 +532,10 @@ class BrowserTabFragment :
                 }
             }
         })
+
+        childFragmentManager.findFragmentByTag(ADD_SAVED_SITE_FRAGMENT_TAG)?.let { dialog ->
+            (dialog as EditSavedSiteDialogFragment).listener = viewModel
+        }
     }
 
     private fun getDaxDialogFromActivity(): Fragment? = activity?.supportFragmentManager?.findFragmentByTag(DAX_DIALOG_DIALOG_TAG)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202885885052668/f

### Description
This PR resets the listeners (Add folder, edit folder and edit bookmark) when BookmarksActivity has been destroyed in the background and recreated.

### Steps to test this PR

- [x] Activate "Don't keep activities" in the device's developer settings.

_Editing from Bookmarks screen_
- [x] Visit a site and "Add Bookmark" from the overflow menu.
- [x] Click on "Bookmarks" in the overflow menu and add a folder.
- [x] Edit the bookmark and move it into the folder.
- [x] Verify that the bookmark has been moved.
- [x] Edit the folder and on the folder hierarchy screen, add a new folder.
- [x] Go back and verify that folder has been created.
- [x] Edit the folder and move it into the first folder.
- [x] Verify that the folder has been moved.

_Editing from BrowserTabFragment_
- [x] Visit a site and "Add Bookmark" from the overflow menu.
- [x] Click on "Bookmarks" in the overflow menu and add a folder.
- [x] Go back.
- [x] Click "Edit Bookmark" in the overflow menu.
- [x] Move the bookmark to the folder.
- [x] Verify that the bookmark was moved.


