### PR TITLE
Fix disk io on main thread, FaviconManager

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManager.kt
@@ -93,17 +93,19 @@ class DuckDuckGoFaviconManager constructor(
     ): Bitmap? {
         val domain = url.extractDomain() ?: return null
 
-        var cachedFavicon: File? = null
-        if (tabId != null) {
-            cachedFavicon = faviconPersister.faviconFile(FAVICON_TEMP_DIR, tabId, domain)
-        }
-        if (cachedFavicon == null) {
-            cachedFavicon = faviconPersister.faviconFile(FAVICON_PERSISTED_DIR, NO_SUBFOLDER, domain)
-        }
+        return withContext(dispatcherProvider.io()) {
+            var cachedFavicon: File? = null
+            if (tabId != null) {
+                cachedFavicon = faviconPersister.faviconFile(FAVICON_TEMP_DIR, tabId, domain)
+            }
+            if (cachedFavicon == null) {
+                cachedFavicon = faviconPersister.faviconFile(FAVICON_PERSISTED_DIR, NO_SUBFOLDER, domain)
+            }
 
-        return if (cachedFavicon != null) {
-            faviconDownloader.getFaviconFromDisk(cachedFavicon)
-        } else null
+            return@withContext if (cachedFavicon != null) {
+                faviconDownloader.getFaviconFromDisk(cachedFavicon)
+            } else null
+        }
     }
 
     override suspend fun loadFromDiskWithParams(
@@ -115,17 +117,19 @@ class DuckDuckGoFaviconManager constructor(
     ): Bitmap? {
         val domain = url.extractDomain() ?: return null
 
-        var cachedFavicon: File? = null
-        if (tabId != null) {
-            cachedFavicon = faviconPersister.faviconFile(FAVICON_TEMP_DIR, tabId, domain)
-        }
-        if (cachedFavicon == null) {
-            cachedFavicon = faviconPersister.faviconFile(FAVICON_PERSISTED_DIR, NO_SUBFOLDER, domain)
-        }
+        return withContext(dispatcherProvider.io()) {
+            var cachedFavicon: File? = null
+            if (tabId != null) {
+                cachedFavicon = faviconPersister.faviconFile(FAVICON_TEMP_DIR, tabId, domain)
+            }
+            if (cachedFavicon == null) {
+                cachedFavicon = faviconPersister.faviconFile(FAVICON_PERSISTED_DIR, NO_SUBFOLDER, domain)
+            }
 
-        return if (cachedFavicon != null) {
-            faviconDownloader.getFaviconFromDisk(cachedFavicon, cornerRadius, width, height)
-        } else null
+            return@withContext if (cachedFavicon != null) {
+                faviconDownloader.getFaviconFromDisk(cachedFavicon, cornerRadius, width, height)
+            } else null
+        }
     }
 
     override suspend fun loadToViewFromLocalOrFallback(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202897565527408/f

### Description

### Steps to test this PR

1. Enable StrictMode (see [here](https://app.asana.com/0/0/1202897877101652/f))
1. Add Logcat filter: DuckDuckGoFaviconManager.loadToViewFromLocalOrFallback
1. Run app, and do the following to reproduce StrictMode warning:
    1. Visit a site (e.g., [cnn.com](https://cnn.com/))
    1. Open tab switcher

- [ ] You will see a StrictMode warning on develop; verify the warning is gone on this branch
- [ ] Verify the favicon works correctly in TabSwitcher view
- [ ] Add a bookmark, and verify the favicon works correctly in Bookmarks view