### PR TITLE
Respect manual exclusion list first before SystemAppOverrideList

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/TrackingProtectionAppsRepository.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/TrackingProtectionAppsRepository.kt
@@ -19,9 +19,7 @@ package com.duckduckgo.mobile.android.vpn.apps
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExcludedPackage
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerManualExcludedApp
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerRepository
@@ -60,8 +58,6 @@ interface TrackingProtectionAppsRepository {
 class RealTrackingProtectionAppsRepository @Inject constructor(
     private val packageManager: PackageManager,
     private val appTrackerRepository: AppTrackerRepository,
-    private val appBuildConfig: AppBuildConfig,
-    private val appTpFeatureConfig: AppTpFeatureConfig,
     private val dispatcherProvider: DispatcherProvider
 ) : TrackingProtectionAppsRepository {
 
@@ -199,13 +195,13 @@ class RealTrackingProtectionAppsRepository @Inject constructor(
         val appExclusionList = appTrackerRepository.getAppExclusionList()
         val manualAppExclusionList = appTrackerRepository.getManualAppExclusionList()
 
-        if (appTrackerRepository.getSystemAppOverrideList().map { it.packageId }.contains(packageName)) {
-            return true
-        }
-
         val userExcludedApp = manualAppExclusionList.find { it.packageId == packageName }
         if (userExcludedApp != null) {
             return userExcludedApp.isProtected
+        }
+
+        if (appTrackerRepository.getSystemAppOverrideList().map { it.packageId }.contains(packageName)) {
+            return true
         }
 
         return !appExclusionList.any { it.packageId == packageName }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202844197903911/f

### Description
- Prior to this PR, In `RealTrackingProtectionAppsRepository.isAppProtectionEnabled` we always check the SystemAppOverrideList first to determine if App Protection is Enabled. However, if the user has manually changed the protection for the App, it should be respected first.

### Steps to test this PR

_System overrides are respected_
- [x] Ensure that Chrome app and Youtube app is installed.
- [x] Verify that both are disabled by default in the App TP All Apps page.
- [x] Verify that no trackers are blocked from both and they don't appear in recent activity even after using them.

_Manual overrides respected and persisted_
- [x] Enable AppTP manually both for Chrome app and Youtube app.
- [x] Use the apps and verify that they show in the Recent Activity section.
- [x] Click to Having problems with an app?
- [x] Disable AppTP for chrome and youtube
- [x] Click on the recent activities entries for both apps and confirm that they are disabled there too.
- [x] Use the apps again and verify that for both apps the recent activity is NOT updated (time of last update not changed to just now or anything recent).


