### PR TITLE
Fix disk io on main thread, data clearing

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/AutomaticDataClearer.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/AutomaticDataClearer.kt
@@ -39,7 +39,6 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -74,7 +73,7 @@ class AutomaticDataClearer @Inject constructor(
     private val clearJob: Job = Job()
 
     override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Main + clearJob
+        get() = dispatchers.main() + clearJob
 
     override val dataClearerState: MutableLiveData<ApplicationClearDataState> = MutableLiveData<ApplicationClearDataState>().also {
         it.postValue(INITIALIZING)
@@ -170,7 +169,7 @@ class AutomaticDataClearer @Inject constructor(
                 .setInitialDelay(durationMillis, TimeUnit.MILLISECONDS)
                 .addTag(DataClearingWorker.WORK_REQUEST_TAG)
                 .build()
-            it.enqueue(workRequest)
+            // it.enqueue(workRequest)
             Timber.i(
                 "Work request scheduled, ${durationMillis}ms from now, " +
                     "to clear data if the user hasn't returned to the app. job id: ${workRequest.id}"

--- a/app/src/main/java/com/duckduckgo/app/fire/AutomaticDataClearer.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/AutomaticDataClearer.kt
@@ -21,12 +21,14 @@ import android.os.SystemClock
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.postDelayed
-import androidx.lifecycle.*
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.duckduckgo.app.global.ApplicationClearDataState
 import com.duckduckgo.app.global.ApplicationClearDataState.FINISHED
 import com.duckduckgo.app.global.ApplicationClearDataState.INITIALIZING
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.clear.ClearWhenOption
@@ -36,7 +38,11 @@ import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -61,7 +67,8 @@ class AutomaticDataClearer @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val clearDataAction: ClearDataAction,
     private val dataClearerTimeKeeper: BackgroundTimeKeeper,
-    private val dataClearerForegroundAppRestartPixel: DataClearerForegroundAppRestartPixel
+    private val dataClearerForegroundAppRestartPixel: DataClearerForegroundAppRestartPixel,
+    private val dispatchers: DispatcherProvider
 ) : DataClearer, BrowserLifecycleObserver, CoroutineScope {
 
     private val clearJob: Job = Job()
@@ -82,57 +89,71 @@ class AutomaticDataClearer @Inject constructor(
         }
     }
 
-    @UiThread
     @VisibleForTesting
     suspend fun onAppForegroundedAsync() {
-        dataClearerState.value = INITIALIZING
+        postDataClearerState(INITIALIZING)
 
         Timber.i("onAppForegrounded; is from fresh app launch? $isFreshAppLaunch")
 
         workManager.cancelAllWorkByTag(DataClearingWorker.WORK_REQUEST_TAG)
 
-        val appUsedSinceLastClear = settingsDataStore.appUsedSinceLastClear
-        settingsDataStore.appUsedSinceLastClear = true
+        withContext(dispatchers.io()) {
 
-        val appIconChanged = settingsDataStore.appIconChanged
-        settingsDataStore.appIconChanged = false
+            val appUsedSinceLastClear = settingsDataStore.appUsedSinceLastClear
+            settingsDataStore.appUsedSinceLastClear = true
 
-        val clearWhat = settingsDataStore.automaticallyClearWhatOption
-        val clearWhen = settingsDataStore.automaticallyClearWhenOption
-        Timber.i("Currently configured to automatically clear $clearWhat / $clearWhen")
+            val appIconChanged = settingsDataStore.appIconChanged
+            settingsDataStore.appIconChanged = false
 
-        if (clearWhat == ClearWhatOption.CLEAR_NONE) {
-            Timber.i("No data will be cleared as it's configured to clear nothing automatically")
-            dataClearerState.value = FINISHED
-        } else {
-            if (shouldClearData(clearWhen, appUsedSinceLastClear, appIconChanged)) {
-                Timber.i("Decided data should be cleared")
-                clearDataWhenAppInForeground(clearWhat)
+            val clearWhat = settingsDataStore.automaticallyClearWhatOption
+            val clearWhen = settingsDataStore.automaticallyClearWhenOption
+            Timber.i("Currently configured to automatically clear $clearWhat / $clearWhen")
+
+            if (clearWhat == ClearWhatOption.CLEAR_NONE) {
+                Timber.i("No data will be cleared as it's configured to clear nothing automatically")
+                postDataClearerState(FINISHED)
             } else {
-                Timber.i("Decided not to clear data at this time")
-                dataClearerState.value = FINISHED
+                if (shouldClearData(clearWhen, appUsedSinceLastClear, appIconChanged)) {
+                    Timber.i("Decided data should be cleared")
+                    withContext(dispatchers.main()) {
+                        clearDataWhenAppInForeground(clearWhat)
+                    }
+                } else {
+                    Timber.i("Decided not to clear data at this time")
+                    postDataClearerState(FINISHED)
+                }
             }
-        }
 
-        isFreshAppLaunch = false
-        settingsDataStore.clearAppBackgroundTimestamp()
+            isFreshAppLaunch = false
+            settingsDataStore.clearAppBackgroundTimestamp()
+        }
+    }
+
+    private suspend fun postDataClearerState(state: ApplicationClearDataState) {
+        withContext(dispatchers.main()) {
+            dataClearerState.value = state
+        }
     }
 
     override fun onClose() {
-        val timeNow = SystemClock.elapsedRealtime()
-        Timber.i("Recording when app backgrounded ($timeNow)")
+        launch {
+            val timeNow = SystemClock.elapsedRealtime()
+            Timber.i("Recording when app backgrounded ($timeNow)")
 
-        dataClearerState.value = INITIALIZING
+            postDataClearerState(INITIALIZING)
 
-        settingsDataStore.appBackgroundedTimestamp = timeNow
+            withContext(dispatchers.io()) {
+                settingsDataStore.appBackgroundedTimestamp = timeNow
 
-        val clearWhenOption = settingsDataStore.automaticallyClearWhenOption
-        val clearWhatOption = settingsDataStore.automaticallyClearWhatOption
+                val clearWhenOption = settingsDataStore.automaticallyClearWhenOption
+                val clearWhatOption = settingsDataStore.automaticallyClearWhatOption
 
-        if (clearWhatOption == ClearWhatOption.CLEAR_NONE || clearWhenOption == ClearWhenOption.APP_EXIT_ONLY) {
-            Timber.d("No background timer required for current configuration: $clearWhatOption / $clearWhenOption")
-        } else {
-            scheduleBackgroundTimerToTriggerClear(clearWhenOption.durationMilliseconds())
+                if (clearWhatOption == ClearWhatOption.CLEAR_NONE || clearWhenOption == ClearWhenOption.APP_EXIT_ONLY) {
+                    Timber.d("No background timer required for current configuration: $clearWhatOption / $clearWhenOption")
+                } else {
+                    scheduleBackgroundTimerToTriggerClear(clearWhenOption.durationMilliseconds())
+                }
+            }
         }
     }
 
@@ -160,42 +181,45 @@ class AutomaticDataClearer @Inject constructor(
     @UiThread
     @Suppress("NON_EXHAUSTIVE_WHEN")
     private suspend fun clearDataWhenAppInForeground(clearWhat: ClearWhatOption) {
-        Timber.i("Clearing data when app is in the foreground: $clearWhat")
+        withContext(dispatchers.main()) {
 
-        when (clearWhat) {
-            ClearWhatOption.CLEAR_TABS_ONLY -> {
+            Timber.i("Clearing data when app is in the foreground: $clearWhat")
 
-                withContext(Dispatchers.IO) {
+            when (clearWhat) {
+                ClearWhatOption.CLEAR_TABS_ONLY -> {
+
                     clearDataAction.clearTabsAsync(true)
-                }
 
-                withContext(Dispatchers.Main) {
                     Timber.i("Notifying listener that clearing has finished")
-                    dataClearerState.value = FINISHED
+                    postDataClearerState(FINISHED)
                 }
-            }
 
-            ClearWhatOption.CLEAR_TABS_AND_DATA -> {
-                val processNeedsRestarted = !isFreshAppLaunch
-                Timber.i("App is in foreground; restart needed? $processNeedsRestarted")
+                ClearWhatOption.CLEAR_TABS_AND_DATA -> {
+                    val processNeedsRestarted = !isFreshAppLaunch
+                    Timber.i("App is in foreground; restart needed? $processNeedsRestarted")
 
-                clearDataAction.clearTabsAndAllDataAsync(appInForeground = true, shouldFireDataClearPixel = false)
+                    clearDataAction.clearTabsAndAllDataAsync(appInForeground = true, shouldFireDataClearPixel = false)
 
-                Timber.i("All data now cleared, will restart process? $processNeedsRestarted")
-                if (processNeedsRestarted) {
-                    clearDataAction.setAppUsedSinceLastClearFlag(false)
-                    dataClearerForegroundAppRestartPixel.incrementCount()
-                    // need a moment to draw background color (reduces flickering UX)
-                    Handler().postDelayed(100) {
-                        Timber.i("Will now restart process")
-                        clearDataAction.killAndRestartProcess(notifyDataCleared = true)
+                    Timber.i("All data now cleared, will restart process? $processNeedsRestarted")
+                    if (processNeedsRestarted) {
+                        withContext(dispatchers.io()) {
+                            clearDataAction.setAppUsedSinceLastClearFlag(false)
+                            dataClearerForegroundAppRestartPixel.incrementCount()
+                        }
+
+                        // need a moment to draw background color (reduces flickering UX)
+                        Handler().postDelayed(100) {
+                            Timber.i("Will now restart process")
+                            clearDataAction.killAndRestartProcess(notifyDataCleared = true)
+                        }
+                    } else {
+                        Timber.i("Will not restart process")
+                        postDataClearerState(FINISHED)
                     }
-                } else {
-                    Timber.i("Will not restart process")
-                    dataClearerState.value = FINISHED
                 }
+
+                else -> {}
             }
-            else -> {}
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -28,6 +28,8 @@ import com.duckduckgo.app.fire.AppCacheClearer
 import com.duckduckgo.app.fire.DuckDuckGoCookieManager
 import com.duckduckgo.app.fire.FireActivity
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.location.GeoLocationPermissions
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -45,7 +47,7 @@ interface ClearDataAction {
         shouldFireDataClearPixel: Boolean
     ): Unit?
 
-    fun setAppUsedSinceLastClearFlag(appUsedSinceLastClear: Boolean)
+    suspend fun setAppUsedSinceLastClearFlag(appUsedSinceLastClear: Boolean)
     fun killProcess()
     fun killAndRestartProcess(notifyDataCleared: Boolean)
 }
@@ -60,7 +62,8 @@ class ClearPersonalDataAction(
     private val appCacheClearer: AppCacheClearer,
     private val geoLocationPermissions: GeoLocationPermissions,
     private val thirdPartyCookieManager: ThirdPartyCookieManager,
-    private val adClickManager: AdClickManager
+    private val adClickManager: AdClickManager,
+    private val dispatchers: DispatcherProvider = DefaultDispatcherProvider()
 ) : ClearDataAction {
 
     override fun killAndRestartProcess(notifyDataCleared: Boolean) {
@@ -93,12 +96,14 @@ class ClearPersonalDataAction(
 
     @WorkerThread
     override suspend fun clearTabsAsync(appInForeground: Boolean) {
-        Timber.i("Clearing tabs")
-        dataManager.clearWebViewSessions()
-        tabRepository.deleteAll()
-        adClickManager.clearAll()
-        setAppUsedSinceLastClearFlag(appInForeground)
-        Timber.d("Finished clearing tabs")
+        withContext(dispatchers.io()) {
+            Timber.i("Clearing tabs")
+            dataManager.clearWebViewSessions()
+            tabRepository.deleteAll()
+            adClickManager.clearAll()
+            setAppUsedSinceLastClearFlag(appInForeground)
+            Timber.d("Finished clearing tabs")
+        }
     }
 
     @UiThread
@@ -123,8 +128,10 @@ class ClearPersonalDataAction(
         return WebStorage.getInstance()
     }
 
-    override fun setAppUsedSinceLastClearFlag(appUsedSinceLastClear: Boolean) {
-        settingsDataStore.appUsedSinceLastClear = appUsedSinceLastClear
-        Timber.d("Set appUsedSinceClear flag to $appUsedSinceLastClear")
+    override suspend fun setAppUsedSinceLastClearFlag(appUsedSinceLastClear: Boolean) {
+        withContext(dispatchers.io()) {
+            settingsDataStore.appUsedSinceLastClear = appUsedSinceLastClear
+            Timber.d("Set appUsedSinceClear flag to $appUsedSinceLastClear")
+        }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202899711152150/f

### Description

### Steps to test this PR

- Enable StrictMode (see [here](https://app.asana.com/0/0/1202897877101652/f))
- Add Logcat filter (regex):
- `SettingsSharedPreferences.setAppUsedSinceLastClear|SettingsSharedPreferences.setAppBackgroundedTimestamp`
- Run the app, and do the following to reproduce StrictMode warning in develop:
    - Go through onboarding
    - Go to settings, and configure it to automatically clear tabs only, after 5s
    - Open a webpage, then hit the home button to background the app
    - Wait for >=6 seconds
    - Return to the app, and you'll see the StrictMode warning about disk IO writing

Verify no behaviour changes to automatic data clearing and fire button: 

#### Tabs
- [ ] Change automatic clear settings to only clear Tabs, clearing data after 5s
- [ ] Open a site
- [ ] Hit the device home button, and immediately re-open; verify tabs not closed
- [ ] Hit the device home button, and wait 5+ seconds
- [ ] Return to the app and verify tabs all closed
- [ ] Disable WM from executing (see below), and repeat the above steps

#### Tabs and data
- [ ] Change automatic clear settings to clear Tabs and Data, clearing data after 5s
- [ ] Open a site and set a cookie (e.g., accept the cookie banner on cnn.com)
- [ ] Hit the device home button, and immediately re-open; verify tabs not closed
- [ ] Hit the device home button, and wait 5+ seconds
- [ ] Return to the app and verify tabs all closed
- [ ] Re-open the same site, and verify cookies were cleared (e.g., re-prompted for cookie banner)
- [ ] Disable WM from executing, and repeat the above steps

#### Fire button
- [ ] Open a site and set a cookie (e.g., accept the cookie banner on cnn.com)
- [ ] Hit the fire button to clear data
- [ ] Re-open the same site, and verify cookies were cleared (e.g., re-prompted for cookie banner)



**Disabling WM**
There is a scenario whereby the WM task to clear the data in the background would not have run, and we have to handle the data clearing when the user returns to the app. To test this scenario, we need to hack the code not to actually schedule the WM task.
Comment out the contents of AutomaticDataClearer.scheduleBackgroundTimerToTriggerClear()