### PR TITLE
Filters LiveTabs duplicated events

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.tabs.model
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.distinctUntilChanged
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -51,7 +52,7 @@ class TabDataRepository @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) : TabRepository {
 
-    override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs()
+    override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs().distinctUntilChanged()
 
     override val flowTabs: Flow<List<TabEntity>> = tabsDao.flowTabs()
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202925412789676/f

### Description
Filters duplicate liveTabs events triggered by updates on Tabs database that don't change any actual data.

### Steps to test this PR

_Test_
- [ ] Just run a smoke test of closing/opening tabs, navigate, etc. and see if notice any issue

_Advanced Test (optional)_
- [ ] Go to BrowserActivity, line 336
- [ ] Add to the following observer a Log
```
        viewModel.tabs.observe(this) {
<ADD YOUR LOG HERE>
            clearStaleTabs(it)
            launch { viewModel.onTabsUpdated(it) }
        }
```
- [ ] smoke test and notice the events are only received when actual data has changed. (testing this on develop will trigger multiple events)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
