### PR TITLE
Crash build if Android tests exist out of the app module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,19 @@ allprojects {
 }
 
 subprojects {
+
+    String[] allowAndroidTestsIn = ["app"]
+    if (!allowAndroidTestsIn.contains(project.name)) {
+        project.projectDir.eachFile(groovy.io.FileType.DIRECTORIES) { File parent ->
+            if (parent.name == "src") {
+                parent.eachFile(groovy.io.FileType.DIRECTORIES) { child ->
+                    if (child.name == "androidTest") {
+                        throw new GradleException("Only the app module can have Android Tests. Perhaps you could use Robolectric?")
+                    }
+                }
+            }
+        }
+    }
     def projectPath = path
     configurations.all {
         if (name == "compileClasspath" || name.endsWith("CompileClasspath")) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202931331947206/f 

### Description
This PR crashes the build whenever it detect Android tests that are not in the app module.

### Steps to test this PR
- [x] In build.gradle remove `app` from the `allowAndroidTestsIn` array.
- [x] Try to build/sync
- [x] Should fail with an error because app contains Android tests

