### PR TITLE
Fix disk io on main thread, BrowserTabViewModel.initializeViewStates

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/accessibility/data/AccessibilityDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/accessibility/data/AccessibilityDataStore.kt
@@ -40,7 +40,13 @@ class AccessibilitySettingsSharedPreferences(
     private val appCoroutineScope: CoroutineScope
 ) : AccessibilitySettingsDataStore {
 
-    private val accessibilityStateFlow = MutableStateFlow(AccessibilitySettings(overrideSystemFontSize, fontSize, forceZoom))
+    private val accessibilityStateFlow = MutableStateFlow(
+        AccessibilitySettings(
+            overrideSystemFontSize = false,
+            fontSize = FONT_SIZE_DEFAULT,
+            forceZoom = false
+        )
+    )
 
     private val preferences: SharedPreferences
         get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2166,8 +2166,6 @@ class BrowserTabViewModel @Inject constructor(
             val addToHomeSupported = addToHomeCapabilityDetector.isAddToHomeSupported()
             val showAutofill = autofillStore.autofillAvailable
             val showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch()
-            val fontSize = accessibilitySettingsDataStore.fontSize
-            val forceZoom = accessibilitySettingsDataStore.forceZoom
 
             withContext(dispatchers.main()) {
                 browserViewState.value = currentBrowserViewState().copy(
@@ -2176,11 +2174,6 @@ class BrowserTabViewModel @Inject constructor(
                 )
                 omnibarViewState.value = currentOmnibarViewState().copy(
                     showVoiceSearch = showVoiceSearch
-                )
-                accessibilityViewState.value = currentAccessibilityViewState().copy(
-                    fontSize = fontSize,
-                    forceZoom = forceZoom,
-                    refreshWebView = false
                 )
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202908047221081/f

### Description
The current implementation of `BrowserTabViewModel.initializeViewStates` can be very slow, as it involves reading persisted data (on the main thread) to populate the view states. This can be pretty taxing on the main thread (measured at blocking UI thread for over 300ms on one device). Most view states don't require providing dynamic init values, leaving only a few offenders:

- autofill
- voice search capabilities
- add to home capabilities
- accessibility preferences

This PR makes the logic to initialise the `BrowserTabViewModel` view states happen in two parts:
- a default init which is instant as it does no disk IO
- async init to update view states which require fetching data from disk

In practice both parts should initialise so quickly that the user doesn't notice any difference, but we apply sensible defaults to the view states in case fetching the data is noticeably delayed.

### Steps to test this PR

#### Accessibility 
- [ ] Visit settings->accessibility, and change the font size to largest and to allow force zooming
- [ ] visit twitter.com (text size should be large and force zooming supported)
- [ ] Relaunch the app (so that `BrowserTabViewModel` re initialised and twitter page reloaded)
- [ ] Verify font size still large, and force zooming still supported

#### Autofill
ℹ️ Autofill being available or not can be tested by using different types (enabled on `internal`; disabled on `play`) or by hacking `val showAutofill = autofillStore.autofillAvailable` to return a hardcoded value

- [ ] Test with autofill enabled; verify autofill is in the overflow menu
- [ ] Test with autofill disabled; verify autofill is not in the overflow menu


#### Add to home
ℹ️ Can adjust whether add to home supported or not by manually changing `AddToHomeSystemCapabilityDetector.isAddToHomeSupported()`

- [ ] Test with add to home returning true; verify add to home is an option in the overflow menu
- [ ] Test with add to home returning false; verify add to home is not an option in the overflow menu

#### Voice search 
ℹ️ Can adjust whether voice search should be shown by hardcoding response to `RealVoiceSearchAvailability.shouldShowVoiceSearch()`

- [ ] Test with should show voice search returning false; verify voice search button isn't shown in url bar
- [ ] Test with should show voice search returning true; verify voice search button is shown in url bar


#### Testing an unexpectedly large delay in the second init
- [ ] Hardcode a delay in the init function. e.g., inside `initializeViewStatesFromPersistedData` add `delay(5_000)`
- [ ] Launch the app and verify there is a sensible UI while waiting for the synthetic delay period to pass