### PR TITLE
Add L2 encryption for notes

### DIFF
--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -90,7 +90,6 @@ class SecureStoreBackedAutofillStore(
             domain = url,
             username = credentials.username,
             domainTitle = credentials.domainTitle,
-            notes = credentials.notes,
             lastUpdatedMillis = lastUpdatedTimeProvider.getInMillis()
         )
         val webSiteLoginCredentials = WebsiteLoginDetailsWithCredentials(loginDetails, password = credentials.password)
@@ -186,7 +185,7 @@ class SecureStoreBackedAutofillStore(
             username = details.username,
             password = password,
             domainTitle = details.domainTitle,
-            notes = details.notes,
+            notes = notes,
             lastUpdatedMillis = details.lastUpdatedMillis
         )
     }
@@ -198,10 +197,10 @@ class SecureStoreBackedAutofillStore(
                 username = username,
                 id = id,
                 domainTitle = domainTitle,
-                notes = notes,
                 lastUpdatedMillis = lastUpdatedMillis
             ),
-            password = password
+            password = password,
+            notes = notes
         )
     }
 }

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -253,7 +253,12 @@ class SecureStoreBackedAutofillStoreTest {
 
         assertEquals(
             LoginCredentials(
-                id = 1, domain = url, username = "username1", password = "password123", lastUpdatedMillis = DEFAULT_INITIAL_LAST_UPDATED
+                id = 1,
+                domain = url,
+                username = "username1",
+                password = "password123",
+                lastUpdatedMillis = DEFAULT_INITIAL_LAST_UPDATED,
+                notes = "notes"
             ),
             testee.getCredentialsWithId(1)
         )
@@ -331,10 +336,11 @@ class SecureStoreBackedAutofillStoreTest {
         domain: String,
         username: String,
         password: String,
-        lastUpdatedTimeMillis: Long = DEFAULT_INITIAL_LAST_UPDATED
+        lastUpdatedTimeMillis: Long = DEFAULT_INITIAL_LAST_UPDATED,
+        notes: String = "notes"
     ) {
         val details = WebsiteLoginDetails(domain = domain, username = username, id = id, lastUpdatedMillis = lastUpdatedTimeMillis)
-        val credentials = WebsiteLoginDetailsWithCredentials(details, password)
+        val credentials = WebsiteLoginDetailsWithCredentials(details, password, notes)
         secureStore.addWebsiteLoginDetailsWithCredentials(credentials)
     }
 

--- a/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorageModels.kt
+++ b/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorageModels.kt
@@ -17,14 +17,16 @@
 package com.duckduckgo.securestorage.api
 
 /**
- * Public data class that wraps all data related to a website login.
+ * Public data class that wraps all data related to a website login. All succeeding l2 and above attributes should be added here directly.
  *
  * [details] contains all l1 encrypted attributes
- * [password] plain text password. All succeeding l2 and above attributes should be added here directly.
+ * [password] plain text password.
+ * [notes] plain text notes associated to a login credential
  */
 data class WebsiteLoginDetailsWithCredentials(
     val details: WebsiteLoginDetails,
-    val password: String?
+    val password: String?,
+    val notes: String? = null,
 )
 
 /**
@@ -34,12 +36,13 @@ data class WebsiteLoginDetailsWithCredentials(
  * [domain] url/name associated to a website login.
  * [username] used to populate the username fields in a login
  * [id] database id associated to the website login
+ * [domainTitle] title associated to the login
+ * [lastUpdatedMillis] time in milliseconds when the credential was last updated
  */
 data class WebsiteLoginDetails(
     val domain: String?,
     val username: String?,
     val id: Long? = null,
     val domainTitle: String? = null,
-    val notes: String? = null,
     val lastUpdatedMillis: Long? = null
 )

--- a/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
+++ b/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
@@ -118,14 +118,16 @@ class RealSecureStorage @Inject constructor(
         }
 
     private fun WebsiteLoginDetailsWithCredentials.toDataEntity(): WebsiteLoginCredentialsEntity {
-        val encryptedData = encryptData(password)
+        val encryptedPassword = encryptData(password)
+        val encryptedNotes = encryptData(notes)
         return WebsiteLoginCredentialsEntity(
             id = details.id ?: 0,
             domain = details.domain,
             username = details.username,
-            password = encryptedData?.data,
-            iv = encryptedData?.iv,
-            notes = details.notes,
+            password = encryptedPassword?.data,
+            passwordIv = encryptedPassword?.iv,
+            notes = encryptedNotes?.data,
+            notesIv = encryptedNotes?.iv,
             domainTitle = details.domainTitle,
             lastUpdatedInMillis = details.lastUpdatedMillis
         )
@@ -134,7 +136,8 @@ class RealSecureStorage @Inject constructor(
     private fun WebsiteLoginCredentialsEntity.toCredentials(): WebsiteLoginDetailsWithCredentials =
         WebsiteLoginDetailsWithCredentials(
             details = toDetails(),
-            password = decryptData(password, iv)
+            password = decryptData(password, passwordIv),
+            notes = decryptData(notes, notesIv)
         )
 
     private fun WebsiteLoginCredentialsEntity.toDetails(): WebsiteLoginDetails =
@@ -143,7 +146,6 @@ class RealSecureStorage @Inject constructor(
             username = username,
             id = id,
             domainTitle = domainTitle,
-            notes = notes,
             lastUpdatedMillis = lastUpdatedInMillis
         )
 

--- a/secure-storage/secure-storage-impl/src/test/java/com/duckduckgo/securestorage/impl/RealSecureStorageTest.kt
+++ b/secure-storage/secure-storage-impl/src/test/java/com/duckduckgo/securestorage/impl/RealSecureStorageTest.kt
@@ -60,10 +60,10 @@ class RealSecureStorageTest {
             username = "user@test.com",
             id = 1,
             domainTitle = "test",
-            notes = "notes",
             lastUpdatedMillis = 1000L
         ),
-        password = expectedDecryptedData
+        password = expectedDecryptedData,
+        notes = expectedDecryptedData
     )
 
     private val testEntity = WebsiteLoginCredentialsEntity(
@@ -71,8 +71,9 @@ class RealSecureStorageTest {
         domain = "test.com",
         username = "user@test.com",
         password = expectedEncryptedData,
-        iv = expectedEncryptedIv,
-        notes = "notes",
+        passwordIv = expectedEncryptedIv,
+        notes = expectedEncryptedData,
+        notesIv = expectedEncryptedIv,
         domainTitle = "test",
         lastUpdatedInMillis = 1000L
     )

--- a/secure-storage/secure-storage-store/schemas/com.duckduckgo.securestorage.store.db.SecureStorageDatabase/3.json
+++ b/secure-storage/secure-storage-store/schemas/com.duckduckgo.securestorage.store.db.SecureStorageDatabase/3.json
@@ -1,0 +1,82 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "6d7867da68af318934933f9a3133ced0",
+    "entities": [
+      {
+        "tableName": "website_login_credentials",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `domain` TEXT, `username` TEXT, `password` TEXT, `passwordIv` TEXT, `notes` TEXT, `notesIv` TEXT, `domainTitle` TEXT, `lastUpdatedInMillis` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "passwordIv",
+            "columnName": "passwordIv",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesIv",
+            "columnName": "notesIv",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "domainTitle",
+            "columnName": "domainTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdatedInMillis",
+            "columnName": "lastUpdatedInMillis",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6d7867da68af318934933f9a3133ced0')"
+    ]
+  }
+}

--- a/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/db/SecureStorageDatabase.kt
+++ b/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/db/SecureStorageDatabase.kt
@@ -22,7 +22,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    version = 2,
+    version = 3,
     entities = [WebsiteLoginCredentialsEntity::class]
 )
 abstract class SecureStorageDatabase : RoomDatabase() {
@@ -37,4 +37,12 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
     }
 }
 
-val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2)
+val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("UPDATE `website_login_credentials` SET `notes` = null")
+        database.execSQL("ALTER TABLE `website_login_credentials` ADD COLUMN `notesIv` TEXT")
+        database.execSQL("ALTER TABLE `website_login_credentials` RENAME COLUMN `iv` to `passwordIv`")
+    }
+}
+
+val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2, MIGRATION_2_3)

--- a/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/db/WebsiteLoginCredentialsEntity.kt
+++ b/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/db/WebsiteLoginCredentialsEntity.kt
@@ -25,8 +25,9 @@ data class WebsiteLoginCredentialsEntity(
     val domain: String?,
     val username: String?,
     val password: String?,
-    val iv: String?,
+    val passwordIv: String?,
     val notes: String?,
+    val notesIv: String?,
     val domainTitle: String?,
     val lastUpdatedInMillis: Long?
 )

--- a/secure-storage/secure-storage-store/src/test/java/com/duckduckgo/securestorage/store/RealSecureStorageRepositoryTest.kt
+++ b/secure-storage/secure-storage-store/src/test/java/com/duckduckgo/securestorage/store/RealSecureStorageRepositoryTest.kt
@@ -40,8 +40,9 @@ class RealSecureStorageRepositoryTest {
         domain = "test.com",
         username = "test",
         password = "pass123",
-        iv = "iv",
+        passwordIv = "iv",
         notes = "my notes",
+        notesIv = "notesIv",
         domainTitle = "test",
         lastUpdatedInMillis = 0L
     )


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202945231028273/f

### Description
This PR includes:
- Adding L2 encryption on notes. Store iv for notes in the db as well. We can't reuse the same iv and key for when encrypting.
- Since autofill is still in internal beta, we just drop all notes saved atm instead of migrating it.

### Steps to test this PR

_Migration works as expected_
- [ ] Install a build before this change.
- [ ] Add a few credentials.
- [ ] Edit the saved credentials and add some notes.
- [ ] Install a build from this change.
- [ ] Verify that no crash occurs.
- [ ] Verify that all notes were removed.

_Adding notes works as expected_
- [ ] Add new notes to saved credentials
- [ ] Veriify that they are saved when you revisit the credential page.
