### PR TITLE
Add getter to VPN shared preferences

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
@@ -30,10 +30,12 @@ private const val IS_INITIALIZED = "IS_INITIALIZED"
 
 internal class VpnFeaturesRegistryImpl(
     private val vpnServiceWrapper: VpnServiceWrapper,
-    sharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: VpnSharedPreferencesProvider,
 ) : VpnFeaturesRegistry, SharedPreferences.OnSharedPreferenceChangeListener {
 
-    private val preferences = sharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME, multiprocess = true, migrate = false)
+    private val preferences: SharedPreferences
+        get() = sharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME, multiprocess = true, migrate = false)
+
     private val registryInitialValue = Pair("", false)
     private val _registry = MutableStateFlow(registryInitialValue)
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.mobile.android.vpn.cohort
 
+import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.VpnScope
@@ -50,12 +51,13 @@ interface CohortStore {
     boundType = VpnServiceCallbacks::class
 )
 class RealCohortStore @Inject constructor(
-    sharedPreferencesProvider: VpnSharedPreferencesProvider
+    private val sharedPreferencesProvider: VpnSharedPreferencesProvider
 ) : CohortStore, VpnServiceCallbacks {
 
     private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
-    private val preferences = sharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = true)
+    private val preferences: SharedPreferences
+        get() = sharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = true)
 
     override fun getCohortStoredLocalDate(): LocalDate? {
         return preferences.getString(KEY_COHORT_LOCAL_DATE, null)?.let {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.mobile.android.vpn.pixels
 
+import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
@@ -406,10 +407,11 @@ interface DeviceShieldPixels {
 @SingleInstanceIn(AppScope::class)
 class RealDeviceShieldPixels @Inject constructor(
     private val pixel: Pixel,
-    vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
 ) : DeviceShieldPixels {
 
-    private val preferences = vpnSharedPreferencesProvider.getSharedPreferences(DS_PIXELS_PREF_FILE, multiprocess = true, migrate = true)
+    private val preferences: SharedPreferences
+        get() = vpnSharedPreferencesProvider.getSharedPreferences(DS_PIXELS_PREF_FILE, multiprocess = true, migrate = true)
 
     override fun deviceShieldEnabledOnSearch() {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_ENABLE_UPON_SEARCH_DAILY)

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.mobile.android.vpn.ui.onboarding
 
+import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -45,12 +46,12 @@ interface VpnStore {
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class SharedPreferencesVpnStore @Inject constructor(
-    sharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: VpnSharedPreferencesProvider,
     private val dispatcherProvider: DispatcherProvider,
 ) : VpnStore {
-    private val preferences = sharedPreferencesProvider.getSharedPreferences(
-        DEVICE_SHIELD_ONBOARDING_STORE_PREFS, multiprocess = true, migrate = true
-    )
+
+    private val preferences: SharedPreferences
+        get() = sharedPreferencesProvider.getSharedPreferences(DEVICE_SHIELD_ONBOARDING_STORE_PREFS, multiprocess = true, migrate = true)
 
     override fun onboardingDidShow() {
         preferences.edit { putBoolean(KEY_DEVICE_SHIELD_ONBOARDING_LAUNCHED, true) }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202952441304133/f

### Description
Adds `SharedPreferences` references behind a `get()`, which can reduce the work done on main thread when first initialising app process, and is inline with how we do it elsewhere in the app.

### Steps to test this PR

- [x] Smoke test starting the app with and without appTP enabled; nothing should be functionally different