### PR TITLE
Forbid usage of kotlin-android-extensions

### DIFF
--- a/ad-click/ad-click-impl/build.gradle
+++ b/ad-click/ad-click-impl/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'kotlin-android-extensions'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/autofill/autofill-api/build.gradle
+++ b/autofill/autofill-api/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
+    id 'kotlin-parcelize'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/domain/app/LoginCredentials.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/domain/app/LoginCredentials.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.autofill.domain.app
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Representation of login credentials used for autofilling into the browser.

--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'kotlin-android-extensions'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/autofill/autofill-store/build.gradle
+++ b/autofill/autofill-store/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,14 @@ allprojects {
 
 subprojects {
 
+    // Break build when using deprecated plugins
+    String[] allowDeprecatedModuleIn = ["app", "vpn-impl"]
+    project.plugins.withId('kotlin-android-extensions') {
+        if (!allowDeprecatedModuleIn.contains(project.name)) {
+            throw new GradleException("kotlin-android-extensions plugin is deprecated, DO NOT USE!")
+        }
+    }
+
     String[] allowAndroidTestsIn = ["app"]
     if (!allowAndroidTestsIn.contains(project.name)) {
         project.projectDir.eachFile(groovy.io.FileType.DIRECTORIES) { File parent ->

--- a/downloads/downloads-impl/build.gradle
+++ b/downloads/downloads-impl/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'kotlin-android-extensions'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/macos/macos-impl/build.gradle
+++ b/macos/macos-impl/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'kotlin-android-extensions'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/privacy-config/privacy-config-impl/build.gradle
+++ b/privacy-config/privacy-config-impl/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'kotlin-android-extensions'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202728801491359/f

### Description
Forbid the usage of `kotlin-android-extension` as it is deprecated.

We use(d) it for two things:
* `@Parcelize`
* synthetics

For some modules like `:app` and `:vpn-impl` I've added an exception
because we first need to migrate way from synthetics

### Steps to test this PR
Smoke tests for autofill
