### PR TITLE
Fix crash on VpnPermissionRequesterActivity

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/DeviceShieldTileService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/DeviceShieldTileService.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.mobile.android.vpn.service
 import android.content.Intent
 import android.net.VpnService
 import android.os.Build
+import android.os.Bundle
 import android.service.quicksettings.Tile.STATE_ACTIVE
 import android.service.quicksettings.Tile.STATE_INACTIVE
 import android.service.quicksettings.TileService
@@ -150,6 +151,11 @@ class DeviceShieldTileService : TileService() {
 @InjectWith(ActivityScope::class)
 class VpnPermissionRequesterActivity : AppCompatActivity() {
     @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        AndroidInjection.inject(this)
+    }
 
     override fun onStart() {
         super.onStart()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202994567277582/f

### Description
Fixes a crash with an uninitialized property in VpnPermissionRequesterActivity

### Steps to test this PR
1. Fresh install of the app
1. Swipe down on the system status bar (possibly twice depending on OEM) to reveal quick tiles
1. If App Tracking Protection not visible, choose to edit the tiles and make it visible
1. Click on the tile
1. Choose to grant VPN permissions  ← crash happens here
1. Crash happens because vpnFeaturesRegistry is uninitialized
