### PR TITLE
Lazy init for new networking stack

### DIFF
--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/network/VpnNetworkStack.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/network/VpnNetworkStack.kt
@@ -40,23 +40,31 @@ interface VpnNetworkStack {
 
     /**
      * Called before the networking layer is enabled
+     *
+     * @return `true` if the networking layer is successfully created, `false` otherwise
      */
-    fun onCreateVpn()
+    fun onCreateVpn(): Result<Unit>
 
     /**
      * Called before the VPN is started
+     *
+     * @return `true` if the VPN is successfully started, `false` otherwise
      */
-    fun onStartVpn(tunfd: ParcelFileDescriptor)
+    fun onStartVpn(tunfd: ParcelFileDescriptor): Result<Unit>
 
     /**
      * Called before the VPN is stopped
+     *
+     * @return `true` if the VPN is successfully stopped, `false` otherwise
      */
-    fun onStopVpn()
+    fun onStopVpn(): Result<Unit>
 
     /**
      * Clean when the networking layer is destroyed. You can use this method to clean up resources
+     *
+     * @return `true` if the networking layer is successfully destroyed, `false` otherwise
      */
-    fun onDestroyVpn()
+    fun onDestroyVpn(): Result<Unit>
 
     /**
      * @return the MTU size you wish the VPN service to set

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/integration/LegacyVpnNetworkStack.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/integration/LegacyVpnNetworkStack.kt
@@ -66,12 +66,14 @@ class LegacyVpnNetworkStack @Inject constructor(
         return appTpFeatureConfig.isEnabled(AppTpSetting.NetworkSwitchHandling)
     }
 
-    override fun onCreateVpn() {
+    override fun onCreateVpn(): Result<Unit> {
         udpPacketProcessor = udpPacketProcessorFactory.build()
         tcpPacketProcessor = tcpPacketProcessorFactory.build(coroutineScope)
+
+        return Result.success(Unit)
     }
 
-    override fun onStartVpn(tunfd: ParcelFileDescriptor) {
+    override fun onStartVpn(tunfd: ParcelFileDescriptor): Result<Unit> {
         queues.clearAll()
 
         executorService?.shutdownNow()
@@ -84,17 +86,22 @@ class LegacyVpnNetworkStack @Inject constructor(
         executorService = Executors.newFixedThreadPool(processors.size).also { executorService ->
             processors.forEach { executorService.submit(it) }
         }
+
+        return Result.success(Unit)
     }
 
-    override fun onStopVpn() {
+    override fun onStopVpn(): Result<Unit> {
         queues.clearAll()
         executorService?.shutdownNow()
         udpPacketProcessor.stop()
         tcpPacketProcessor.stop()
+
+        return Result.success(Unit)
     }
 
-    override fun onDestroyVpn() {
+    override fun onDestroyVpn(): Result<Unit> {
         // noop
+        return Result.success(Unit)
     }
 
     override fun mtu(): Int = 16_384

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -132,7 +132,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
         AndroidInjection.inject(this)
 
         vpnNetworkStack = vpnNetworkStackPluginPoint.getPlugins().first { it.isEnabled() }.apply {
-            onCreateVpn()
+            onCreateVpn().getOrThrow()
         }
 
         Timber.d("VPN log onCreate")
@@ -198,7 +198,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
             Timber.v("NetworkSwitchHandling disabled...skip setting underlying network")
         }
 
-        vpnNetworkStack.onStartVpn(tunInterface!!)
+        vpnNetworkStack.onStartVpn(tunInterface!!).getOrThrow()
 
         vpnServiceCallbacksPluginPoint.getPlugins().forEach {
             Timber.v("VPN log: starting ${it.javaClass} callback")

--- a/vpn-network/vpn-network-impl/src/main/java/com/duckduckgo/vpn/network/impl/RealVpnNetwork.kt
+++ b/vpn-network/vpn-network-impl/src/main/java/com/duckduckgo/vpn/network/impl/RealVpnNetwork.kt
@@ -229,6 +229,7 @@ class RealVpnNetwork @Inject constructor(
 
     init {
         try {
+            Timber.v("Loading native VPN networking library")
             LibraryLoader.loadLibrary(context, "netguard")
         } catch (ignored: Throwable) {
             Timber.e(ignored, "Error loading netguard library")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203002043003671/f

### Description
Avoid loading the native (new) networking library when using the legacy
one.

### Steps to test this PR

_Test lazy loading_
- [x] install from this branch
- [x] filter logcat by `Loading native VPN networking library`
- [x] launch the app and enable AppTP
- [x] IF "VPN new networking layer" appears and it's enabled in Settings -> AppTP dev settings -> CONFIG section the logcat should appear, otherwise it should not
- [x] clear data for the app and re-launch
- [x] (repeat clear data and re-launch until Settings -> AppTP dev settings does not have the "VPN new networking layer" option
- [x] launch the app and enable AppTP
- [x] the logcat should NOT appear

