### PR TITLE
Protect games

### DIFF
--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSetting.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSetting.kt
@@ -26,6 +26,7 @@ enum class AppTpSetting(override val value: String, override val defaultValue: B
     AlwaysSetDNS("alwaysSetDNS"),
     CPUMonitoring("cpuMonitoring"),
     VpnNewNetworkingLayer("vpnNewNetworkingLayer", defaultValue = true),
+    ProtectGames("protectGames"),
 }
 
 interface SettingName {

--- a/app-tracking-protection/vpn-impl/build.gradle
+++ b/app-tracking-protection/vpn-impl/build.gradle
@@ -91,6 +91,7 @@ dependencies {
 
     implementation KotlinX.coroutines.core
 
+    testImplementation project(':vpn-store-test')
     testImplementation (KotlinX.coroutines.test) {
         // https://github.com/Kotlin/kotlinx.coroutines/issues/2023
         // conflicts with mockito due to direct inclusion of byte buddy

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/ProtectGamesSettingPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/ProtectGamesSettingPlugin.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.feature.*
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.Moshi
+import timber.log.Timber
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AppTpSettingPlugin::class
+)
+class ProtectGamesSettingPlugin @Inject constructor(
+    private val appTpFeatureConfig: AppTpFeatureConfig,
+) : AppTpSettingPlugin {
+    private val jsonAdapter = Moshi.Builder().build().adapter(JsonConfigModel::class.java)
+
+    override fun store(name: SettingName, jsonString: String): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = appTpSettingValueOf(name.value)
+        if (name == settingName) {
+            Timber.d("Received configuration: $jsonString")
+            runCatching {
+                jsonAdapter.fromJson(jsonString)?.state?.let { state ->
+                    appTpFeatureConfig.edit { setEnabled(settingName, state == "enabled") }
+                }
+            }.onFailure {
+                Timber.w(it, "Invalid JSON remote configuration for $settingName")
+            }
+            return true
+        }
+
+        return false
+    }
+
+    override val settingName: SettingName = AppTpSetting.ProtectGames
+
+    private data class JsonConfigModel(val state: String?)
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/apps/TrackingProtectionAppsRepositoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/apps/TrackingProtectionAppsRepositoryTest.kt
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.apps
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.trackers.FakeAppTrackerRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class TrackingProtectionAppsRepositoryTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val packageManager: PackageManager = mock()
+    private val appTrackerRepository = FakeAppTrackerRepository()
+    private val appTpFeatureConfig: AppTpFeatureConfig = mock()
+
+    private lateinit var trackingProtectionAppsRepository: TrackingProtectionAppsRepository
+
+    @Before
+    fun setup() {
+        whenever(appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)).thenReturn(false)
+        whenever(packageManager.getInstalledApplications(PackageManager.GET_META_DATA)).thenReturn(INSTALLED_APPS.asApplicationInfo())
+        whenever(packageManager.getApplicationLabel(any())).thenReturn("App Name")
+        appTrackerRepository.appExclusionList = EXCLUSION_LIST.toSet()
+        appTrackerRepository.manualExclusionList = MANUAL_EXCLUSION_LIST.toMutableMap()
+        appTrackerRepository.systemAppOverrides = SYSTEM_OVERRIDE_LIST.toSet()
+
+        trackingProtectionAppsRepository =
+            RealTrackingProtectionAppsRepository(
+                packageManager, appTrackerRepository, coroutineRule.testDispatcherProvider, appTpFeatureConfig
+            )
+    }
+
+    @Test
+    fun whenGetExclusionAppListThenReturnExclusionList() = runTest {
+        val exclusionList = trackingProtectionAppsRepository.getExclusionAppsList()
+
+        assertEquals(
+            listOf("com.example.app2", "com.example.app3", "com.example.app5", "com.example.game", "com.example.system", "com.duckduckgo.mobile"),
+            exclusionList
+        )
+    }
+
+    @Test
+    fun whenIsProtectionEnabledCalledOnDisabledAppThenReturnFalse() = runTest {
+        whenever(packageManager.getApplicationInfo("com.example.app2", 0))
+            .thenReturn(ApplicationInfo().apply { packageName = "com.example.app2" })
+
+        val isEnabled = trackingProtectionAppsRepository.isAppProtectionEnabled("com.example.app2")
+
+        assertFalse(isEnabled)
+    }
+
+    @Test
+    fun whenIsProtectionEnabledCalledOnEnabledAppThenReturnTrue() = runTest {
+        whenever(packageManager.getApplicationInfo("com.example.app1", 0))
+            .thenReturn(ApplicationInfo().apply { packageName = "com.example.app1" })
+
+        val isEnabled = trackingProtectionAppsRepository.isAppProtectionEnabled("com.example.app1")
+
+        assertTrue(isEnabled)
+    }
+
+    @Test
+    fun whenIsProtectionEnabledCalledOnGameThenReturnFalse() = runTest {
+        whenever(packageManager.getApplicationInfo("com.example.game", 0))
+            .thenReturn(
+                ApplicationInfo().apply {
+                    packageName = "com.example.game"
+                    category = ApplicationInfo.CATEGORY_GAME
+                }
+            )
+
+        val isEnabled = trackingProtectionAppsRepository.isAppProtectionEnabled("com.example.game")
+
+        assertFalse(isEnabled)
+    }
+
+    @Test
+    fun whenIsProtectionEnabledCalledOnDdgAppThenReturnFalse() = runTest {
+        whenever(packageManager.getApplicationInfo("com.duckduckgo.mobile", 0))
+            .thenReturn(ApplicationInfo().apply { packageName = "com.duckduckgo.mobile" })
+
+        val isEnabled = trackingProtectionAppsRepository.isAppProtectionEnabled("com.duckduckgo.mobile")
+
+        assertFalse(isEnabled)
+    }
+
+    @Test
+    fun whenIsProtectionEnabledCalledOnUnknownPackageThenReturnTrue() = runTest {
+        whenever(packageManager.getApplicationInfo("com.example.unknown", 0))
+            .thenReturn(ApplicationInfo().apply { packageName = "com.example.unknown" })
+
+        val isEnabled = trackingProtectionAppsRepository.isAppProtectionEnabled("com.example.unknown")
+
+        assertTrue(isEnabled)
+    }
+
+    @Test
+    fun whenManuallyEnabledAppThenRemoveFromExclusionList() = runTest {
+        trackingProtectionAppsRepository.manuallyEnabledApp("com.example.app2")
+
+        val exclusionList = trackingProtectionAppsRepository.getExclusionAppsList()
+
+        assertEquals(listOf("com.example.app3", "com.example.app5", "com.example.game", "com.example.system", "com.duckduckgo.mobile"), exclusionList)
+    }
+
+    @Test
+    fun whenManuallyExcludedAppsThenReturnExcludedApps() = runTest {
+        trackingProtectionAppsRepository.manuallyExcludedApps().test {
+            assertEquals(
+                listOf("com.example.app1" to true, "com.example.app2" to false, "com.example.app3" to false),
+                awaitItem()
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenManuallyExcludeAppThenAddToExclusionList() = runTest {
+        trackingProtectionAppsRepository.manuallyExcludeApp("com.example.app1")
+
+        val exclusionList = trackingProtectionAppsRepository.getExclusionAppsList()
+
+        assertEquals(
+            listOf(
+                "com.example.app1",
+                "com.example.app2",
+                "com.example.app3",
+                "com.example.app5",
+                "com.example.game",
+                "com.example.system",
+                "com.duckduckgo.mobile"
+            ),
+            exclusionList
+        )
+    }
+
+    @Test
+    fun whenRestoreDefaultProtectedListThenClearManualExclusionList() = runTest {
+        trackingProtectionAppsRepository.restoreDefaultProtectedList()
+
+        val exclusionList = trackingProtectionAppsRepository.getExclusionAppsList()
+
+        assertEquals(
+            listOf("com.example.app1", "com.example.app3", "com.example.app5", "com.example.game", "com.example.system", "com.duckduckgo.mobile"),
+            exclusionList
+        )
+    }
+
+    @Test
+    fun whenGetAppsAndProtectionInfoThenReturnAppsWithProtectionInfo() = runTest {
+        trackingProtectionAppsRepository.getAppsAndProtectionInfo().test {
+            assertEquals(
+                listOf(
+                    "com.example.app1" to false,
+                    "com.example.app2" to true,
+                    "com.example.app3" to true,
+                    "com.example.app4" to false,
+                    "com.example.app5" to true,
+                    "com.example.app6" to false,
+                    "com.example.game" to true,
+                    "com.example.system.overriden" to false,
+                ),
+                this.awaitItem().map { it.packageName to it.isExcluded }
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenProtectGamesFeatureEnabledThenRemoveGamesFromExclusionList() = runTest {
+        whenever(appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)).thenReturn(true)
+
+        val exclusionList = trackingProtectionAppsRepository.getExclusionAppsList()
+
+        assertEquals(listOf("com.example.app2", "com.example.app3", "com.example.app5", "com.example.system", "com.duckduckgo.mobile"), exclusionList)
+    }
+
+    @Test
+    fun whenProtectGamesFeatureEnabledThenShowGamesAsProtectedInProtectionInfo() = runTest {
+        whenever(appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)).thenReturn(true)
+
+        trackingProtectionAppsRepository.getAppsAndProtectionInfo().test {
+            assertEquals(
+                listOf(
+                    "com.example.app1" to false,
+                    "com.example.app2" to true,
+                    "com.example.app3" to true,
+                    "com.example.app4" to false,
+                    "com.example.app5" to true,
+                    "com.example.app6" to false,
+                    "com.example.game" to false,
+                    "com.example.system.overriden" to false,
+                ),
+                this.awaitItem().map { it.packageName to it.isExcluded }
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun List<String>.asApplicationInfo(): List<ApplicationInfo> {
+        return this.map {
+            ApplicationInfo()
+                .apply {
+                    packageName = it
+                    category = if (it == "com.example.game") ApplicationInfo.CATEGORY_GAME else ApplicationInfo.CATEGORY_UNDEFINED
+                    flags = if (it.startsWith("com.example.system")) ApplicationInfo.FLAG_SYSTEM else 0
+                }
+        }
+    }
+
+    companion object {
+        private val INSTALLED_APPS = listOf(
+            "com.example.app1",
+            "com.example.app2",
+            "com.example.app3",
+            "com.example.app4",
+            "com.example.app5",
+            "com.example.app6",
+            "com.example.game", // should be automatically be added to exclusion list
+            "com.example.system", // should be automatically be added to exclusion list
+            "com.example.system.overriden",
+            "com.duckduckgo.mobile", // should be automatically be added to exclusion list
+        )
+        private val EXCLUSION_LIST = listOf(
+            "com.example.app1",
+            "com.example.app3",
+            "com.example.app5",
+        )
+        private val MANUAL_EXCLUSION_LIST = mapOf(
+            "com.example.app1" to true,
+            "com.example.app2" to false,
+            "com.example.app3" to false,
+        )
+        private val SYSTEM_OVERRIDE_LIST = listOf(
+            "com.example.system.overriden",
+        )
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureConfigImplTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureConfigImplTest.kt
@@ -67,6 +67,7 @@ class AppTpFeatureConfigImplTest {
                 AppTpSetting.VpnDdgBrowserTraffic -> assertFalse(config.isEnabled(setting))
                 AppTpSetting.ConnectivityChecks -> assertFalse(config.isEnabled(setting))
                 AppTpSetting.VpnNewNetworkingLayer -> assertTrue(config.isEnabled(setting))
+                AppTpSetting.ProtectGames -> assertFalse(config.isEnabled(setting))
             }
         }
     }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSettingTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSettingTest.kt
@@ -35,6 +35,7 @@ class AppTpSettingTest {
                 AppTpSetting.VpnDdgBrowserTraffic -> assertFalse(setting.defaultValue)
                 AppTpSetting.ConnectivityChecks -> assertFalse(setting.defaultValue)
                 AppTpSetting.VpnNewNetworkingLayer -> assertTrue(setting.defaultValue)
+                AppTpSetting.ProtectGames -> assertFalse(setting.defaultValue)
                 else -> throw java.lang.IllegalStateException("Missing AppTpSetting default checks")
             }
         }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/FakeAppTpFeatureConfig.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/FakeAppTpFeatureConfig.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature
+
+class FakeAppTpFeatureConfig : AppTpFeatureConfig, AppTpFeatureConfig.Editor {
+    private val settings = mutableMapOf<String, Setting>()
+
+    override fun isEnabled(settingName: SettingName): Boolean {
+        return settings[settingName.value]?.isEnabled ?: settingName.defaultValue
+    }
+
+    override fun edit() = this
+
+    override fun setEnabled(settingName: SettingName, enabled: Boolean, isManualOverride: Boolean) {
+        settings[settingName.value] = Setting(settingName, enabled, isManualOverride)
+    }
+
+    private data class Setting(val name: SettingName, val isEnabled: Boolean, val isManualOverride: Boolean)
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/ProtectGamesSettingPluginTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/ProtectGamesSettingPluginTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.FakeAppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.SettingName
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ProtectGamesSettingPluginTest {
+
+    private val appTpFeatureConfig = FakeAppTpFeatureConfig()
+    private val jsonEnabled = """
+        {
+          "state": "enabled",
+          "settings": {}
+        }
+    """.trimIndent()
+    private val jsonDisabled = """
+        {
+          "state": "disabled",
+          "settings": {}
+        }
+    """.trimIndent()
+
+    private lateinit var featureConfig: ProtectGamesSettingPlugin
+
+    @Before
+    fun setup() {
+        featureConfig = ProtectGamesSettingPlugin(appTpFeatureConfig)
+    }
+
+    @Test
+    fun whenStoreWithEnabledSettingThenStoreAndReturnTrue() {
+        assertTrue(featureConfig.store(featureConfig.settingName, jsonEnabled))
+        assertTrue(appTpFeatureConfig.isProtectGamesEnabled())
+    }
+
+    @Test
+    fun whenStoreWithDisabledSettingThenStoreAndReturnFalse() {
+        assertTrue(featureConfig.store(featureConfig.settingName, jsonDisabled))
+        assertFalse(appTpFeatureConfig.isProtectGamesEnabled())
+    }
+
+    @Test
+    fun whenStoreWithWrongSettingEnabledThenSkipStoreAndReturnFalse() {
+        assertFalse(featureConfig.store(SettingName { "wrongSetting" }, jsonEnabled))
+        assertFalse(appTpFeatureConfig.isProtectGamesEnabled())
+    }
+
+    @Test
+    fun whenStoreWithWrongSettingDisabledThenSkipStoreAndReturnTrue() {
+        appTpFeatureConfig.setEnabled(featureConfig.settingName, true)
+
+        assertFalse(featureConfig.store(SettingName { "wrongSetting" }, jsonDisabled))
+        assertTrue(appTpFeatureConfig.isProtectGamesEnabled())
+    }
+
+    @Test
+    fun whenStoreWithEmptyJsonThenSkipStoreAndReturnTrue() {
+        appTpFeatureConfig.setEnabled(featureConfig.settingName, true)
+
+        assertTrue(featureConfig.store(featureConfig.settingName, "{}"))
+        assertTrue(appTpFeatureConfig.isProtectGamesEnabled())
+    }
+
+    @Test
+    fun whenStoreWithInvalidJsonThenSkipStoreAndReturnTrue() {
+        appTpFeatureConfig.setEnabled(featureConfig.settingName, true)
+
+        assertTrue(featureConfig.store(featureConfig.settingName, ""))
+        assertTrue(appTpFeatureConfig.isProtectGamesEnabled())
+    }
+
+    private fun AppTpFeatureConfig.isProtectGamesEnabled(): Boolean {
+        return isEnabled(featureConfig.settingName)
+    }
+}

--- a/app-tracking-protection/vpn-store-test/build.gradle
+++ b/app-tracking-protection/vpn-store-test/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+dependencies {
+    implementation project(':vpn-store')
+    implementation Kotlin.stdlib.jdk7
+    implementation KotlinX.coroutines.core
+}
+android {
+  namespace 'com.duckduckgo.mobile.android.vpn.store.test'
+}

--- a/app-tracking-protection/vpn-store-test/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/FakeAppTrackerRepository.kt
+++ b/app-tracking-protection/vpn-store-test/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/FakeAppTrackerRepository.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.trackers
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeAppTrackerRepository : AppTrackerRepository {
+    // list of app IDs
+    var appExclusionList: Set<String> = setOf()
+        set(value) {
+            field = value
+            exclusionListFlow.value = getAppExclusionList()
+        }
+    // list of app IDs
+    var systemAppOverrides: Set<String> = setOf()
+    // appID -> isProtected
+    var manualExclusionList: MutableMap<String, Boolean> = mutableMapOf()
+        set(value) {
+            field = value
+            manualExclusionListFlow.value = getManualAppExclusionList()
+        }
+    // tracker -> app IDs
+    var blocklist: MutableMap<String, Set<String>> = mutableMapOf()
+    private val exclusionListFlow = MutableStateFlow(listOf<AppTrackerExcludedPackage>())
+    private val manualExclusionListFlow = MutableStateFlow(listOf<AppTrackerManualExcludedApp>())
+
+    override fun findTracker(hostname: String, packageName: String): AppTrackerType {
+        return if (blocklist[hostname]?.contains(packageName) == true) {
+            hostname.asThirdPartyAppTrackerType()
+        } else {
+            AppTrackerType.NotTracker
+        }
+    }
+
+    override fun getAppExclusionList(): List<AppTrackerExcludedPackage> {
+        return appExclusionList.map { AppTrackerExcludedPackage(it) }
+    }
+
+    override fun getAppExclusionListFlow(): Flow<List<AppTrackerExcludedPackage>> {
+        return exclusionListFlow
+    }
+
+    override fun getManualAppExclusionList(): List<AppTrackerManualExcludedApp> {
+        return manualExclusionList.map { AppTrackerManualExcludedApp(it.key, it.value) }
+    }
+
+    override fun getManualAppExclusionListFlow(): Flow<List<AppTrackerManualExcludedApp>> {
+        return manualExclusionListFlow
+    }
+
+    override fun getSystemAppOverrideList(): List<AppTrackerSystemAppOverridePackage> {
+        return systemAppOverrides.map { AppTrackerSystemAppOverridePackage(it) }
+    }
+
+    override fun manuallyExcludedApp(packageName: String) {
+        manualExclusionList[packageName] = false
+    }
+
+    override fun manuallyEnabledApp(packageName: String) {
+        manualExclusionList[packageName] = true
+    }
+
+    override fun restoreDefaultProtectedList() {
+        manualExclusionList = mutableMapOf()
+    }
+
+    private fun String.asThirdPartyAppTrackerType(): AppTrackerType {
+        return AppTrackerType.ThirdParty(
+            AppTracker(
+                hostname = this,
+                trackerCompanyId = this.hashCode(),
+                isCdn = false,
+                owner = TrackerOwner(
+                    name = this,
+                    displayName = this,
+                ),
+                app = TrackerApp(1, 1.0)
+            )
+        )
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202942224713452/f

### Description
This protects games and has a remote config to enable/disable that
functionality.

The PR incidentally also fixes a but we had in the
`TrackingProtectionAppsRepository:isAppProtectionEnabled()` method that
was causing games to show always as protected when going to the app
details screen.
This bug probably didn't manifest very often given that games protection
are disabled by default.

### Steps to test this PR

_Test the bug fix_
- [x] install from develop
- [x] install Among us game
- [x] launch our app and enable AppTP
- [x] enable protection for among us and launch it
- [x] ensure trackers for Among us are blocked
- [x] Go to AppTP dev settings and "restore default protections"
- [x] open DDG app and go to "App Tracking Protection" and in recent activity click on Among us row
- expected: Among us toggle should be OFF in the screen that opens
- actual: Among us toggle is ON in the screen that opens
- [x] install this branch and verify the expected behavior actually happens

_Test game protection_
- [x] In `PrivacyConfigService` replace the endpoint by https://jsonblob.com/api/jsonBlob/963471835740258304
- [x] install from this branch
- [x] launch and enable AppTP
- [x] Go to App Tracking protection -> "Having problems with an app" -> "Show all apps" and verify games are not protected
- [x] go to `https://www.jsonblob.com/963471835740258304` and change the `protectGames` state to `enabled`. Also bump the `version` number at the beginning of the JSON file
- [x] force-close the app and re-open (remote config should be downloaded)
- [x] Go to App Tracking protection -> "Having problems with an app" -> "Show all apps" and verify games are protected
- [x] Open Among Us game and verify tracking attempts are blocked

