### PR TITLE
AppTP: Select breakage category in Dark theme

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_report_breakage_category_single_choice.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_report_breakage_category_single_choice.xml
@@ -41,7 +41,7 @@
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/textInputLayout"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                style="@style/FeedbackInputBoxStyle"
                 android:layout_width="match_parent"
                 android:layout_height="60dp"
                 android:layout_marginStart="25dp"
@@ -49,8 +49,6 @@
                 android:layout_marginEnd="25dp"
                 android:hint="@string/atp_ReportBreakageCategoriesHint"
                 android:textColorHint="?attr/normalTextColor"
-                app:endIconDrawable="@drawable/ic_report_breakage_down_arrow_24dp"
-                app:endIconMode="custom"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/include_toolbar">
@@ -66,7 +64,7 @@
                     android:inputType="none"
                     android:labelFor="@id/categoriesSelection"
                     android:maxLines="1"
-                    android:paddingEnd="32dp"
+                    android:drawableEnd="@drawable/ic_report_breakage_down_arrow_24dp"
                     android:textColor="?attr/normalTextColor"
                     android:textIsSelectable="false"
                     tools:ignore="RtlSymmetry" />


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1202802090030480/f

### Description
Fixed style in report breakage screen.

### Steps to test this PR

1/ Test in Dark mode
- [x] Install from this branch.
- [x] Enable `Dark` theme on the app.
- [x] Enable AppTP.
- [x] On `App Tracking Protection` screen tap on `Having problems with an app?`.
- [x] On `Recent Apps` screen tap on `Show All Apps`.
- [x] On `All Apps` screen tap on the overflow menu and select `Report an Issue With an App`.
- [x] On `Report an Issue` screen select any app from the list and tap on `SUBMIT`.
- [x] On `Report an Issue` screen check the style for `What's happening` box looks as expected (you can see the outline and the down arrow).

2/ Test in Light mode
- [x] Install from this branch.
- [x] Enable `Light` theme on the app.
- [x] Enable AppTP.
- [x] On `App Tracking Protection` screen tap on `Having problems with an app?`.
- [x] On `Recent Apps` screen tap on `Show All Apps`.
- [x] On `All Apps` screen tap on the overflow menu and select `Report an Issue With an App`.
- [x] On `Report an Issue` screen select any app from the list and tap on `SUBMIT`.
- [x] On `Report an Issue` screen check the style for `What's happening` box looks as expected (you can see the outline and the down arrow).

### UI changes
| Before (Dark)  | After (Dark) |
| ------ | ----- |
![dark_before](https://user-images.githubusercontent.com/7963079/191478490-f070e94e-983c-48f2-a273-230d6d5946ee.png)|![dark](https://user-images.githubusercontent.com/7963079/191478538-ff7938f4-f481-4aa0-b83a-904ef50f4100.png)|

| After (Light - unchanged)  | After (Dark - as above) |
| ------ | ----- |
![light](https://user-images.githubusercontent.com/7963079/191478702-debbec67-17c7-4f09-8bb2-6734134bd1b7.png)|![dark](https://user-images.githubusercontent.com/7963079/191478726-61a5e816-ecf5-4934-9a69-c8a00546b4a8.png)|


