### PR TITLE
Fix button style for Remote Messaging

### DIFF
--- a/common-ui/src/main/res/layout/view_message_cta.xml
+++ b/common-ui/src/main/res/layout/view_message_cta.xml
@@ -88,7 +88,7 @@
         app:layout_goneMarginStart="0dp"
         tools:text="button" />
 
-    <com.duckduckgo.mobile.android.ui.view.button.ButtonSecondarySmall
+    <com.duckduckgo.mobile.android.ui.view.button.ButtonGhostSmall
         android:id="@+id/secondaryActionButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1203021475583761

### Description
In [✓ Android Component: Button](https://app.asana.com/0/1174433894299346/1202861107912487) we standarised the button component across the app. When updating the layout for Remote Messaging I used the wrong style (see screenshot)

Objective
Fix the style, moving from Secondary to Ghost