### PR TITLE
Android crash: Exception kotlin.UninitializedPropertyAccessException: lateinit property listener has not been initialized

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -575,7 +575,7 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
         get() = (flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
 
     private fun showAppEnjoymentPrompt(prompt: DialogFragment) {
-        (supportFragmentManager.findFragmentByTag(APP_ENJOYMENT_DIALOG_TAG) as? DialogFragment)?.dismiss()
+        (supportFragmentManager.findFragmentByTag(APP_ENJOYMENT_DIALOG_TAG) as? DialogFragment)?.dismissNow()
         prompt.show(supportFragmentManager, APP_ENJOYMENT_DIALOG_TAG)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203023500295199/f

### Description
Updated to use dismissNow() instead of dismiss() for App Enjoyment dialog.

### Steps to test this PR

See the crash:
- [x] Enable Don't keep activities. This can be reproduced without this, however it involves more steps and it's not 100% reproducible.
- [ ] Checkout the **develop** branch. Comment out the below lines in order to make sure the App Enjoyment dialog is displayed once when opening the app.
https://github.com/duckduckgo/Android/blob/develop/app/src/main/java/com/duckduckgo/app/global/rating/ShowInitialPromptDecider.kt#L33-L36
https://github.com/duckduckgo/Android/blob/develop/app/src/main/java/com/duckduckgo/app/global/rating/PromptTypeDecider.kt#L45-L47
https://github.com/duckduckgo/Android/blob/develop/app/src/main/java/com/duckduckgo/app/global/rating/PromptTypeDecider.kt#L54-L57
- [x] Fresh install the app after making the above code changes.
- [x] Open the app, tap on "Let's Do It!", dismiss the default browser prompt.
- [x] Notice the App Enjoyment dialog, don't touch it.
- [x] Put the app in background / foreground at least 3 times.
- [x] Tap on "IT NEEDS WORK"
- [x] Tap on "NO THANKS"
- [x] Do this until there are no dialogs (the dialog appears multiple times).
- [x] See the app crashing.

Test the fix:
- [x] Enable Don't keep activities. This can be reproduced without this, however it involves more steps and it's not 100% reproducible.
- [x] Checkout **this** branch. Comment out the below lines in order to make sure the App Enjoyment dialog is displayed once when opening the app.
https://github.com/duckduckgo/Android/blob/develop/app/src/main/java/com/duckduckgo/app/global/rating/ShowInitialPromptDecider.kt#L33-L36
https://github.com/duckduckgo/Android/blob/develop/app/src/main/java/com/duckduckgo/app/global/rating/PromptTypeDecider.kt#L45-L47
https://github.com/duckduckgo/Android/blob/develop/app/src/main/java/com/duckduckgo/app/global/rating/PromptTypeDecider.kt#L54-L57
- [x] Fresh install the app after making the above code changes.
- [x] Open the app, tap on "Let's Do It!", dismiss the default browser prompt.
- [x] Notice the App Enjoyment dialog, don't touch it.
- [x] Put the app in background / foreground at least 3 times.
- [x] Tap on "IT NEEDS WORK"
- [x] Tap on "NO THANKS"
- [x] Do this until there are no dialogs (the dialog appears twice). 
- [x] See the app is NOT crashing.

### NO UI changes