### PR TITLE
Fix broken site reports

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteData.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteData.kt
@@ -36,7 +36,7 @@ data class BrokenSiteData(
         fun fromSite(site: Site?): BrokenSiteData {
             val events = site?.trackingEvents
             val blockedTrackers = events?.filter { it.status == TrackerStatus.BLOCKED }
-                ?.map { Uri.parse(it.trackerUrl).host }
+                ?.map { Uri.parse(it.trackerUrl).baseHost.orEmpty() }
                 .orEmpty().distinct().joinToString(",")
             val upgradedHttps = site?.upgradedHttps ?: false
             val surrogates = site?.surrogates?.map { Uri.parse(it.name).baseHost }.orEmpty().distinct().joinToString(",")

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -67,10 +67,10 @@ class BrokenSiteSubmitter(
                 WEBVIEW_VERSION_KEY to brokenSite.webViewVersion,
                 SITE_TYPE_KEY to brokenSite.siteType,
                 GPC to isGpcEnabled,
-                URL_PARAMETERS_REMOVED to brokenSite.urlParametersRemoved.toString(),
-                CONSENT_MANAGED to brokenSite.consentManaged.toString(),
-                CONSENT_OPT_OUT_FAILED to brokenSite.consentOptOutFailed.toString(),
-                CONSENT_SELF_TEST_FAILED to brokenSite.consentSelfTestFailed.toString(),
+                URL_PARAMETERS_REMOVED to brokenSite.urlParametersRemoved.toBinaryString(),
+                CONSENT_MANAGED to brokenSite.consentManaged.toBinaryString(),
+                CONSENT_OPT_OUT_FAILED to brokenSite.consentOptOutFailed.toBinaryString(),
+                CONSENT_SELF_TEST_FAILED to brokenSite.consentSelfTestFailed.toBinaryString(),
             )
             val encodedParams = mapOf(
                 BLOCKED_TRACKERS_KEY to brokenSite.blockedTrackers,
@@ -109,3 +109,5 @@ class BrokenSiteSubmitter(
         private const val CONSENT_SELF_TEST_FAILED = "consentSelftestFailed"
     }
 }
+
+fun Boolean.toBinaryString(): String = if (this) "1" else "0"

--- a/app/src/test/java/com/duckduckgo/app/brokensite/BrokenSiteDataTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/BrokenSiteDataTest.kt
@@ -105,7 +105,7 @@ class BrokenSiteDataTest {
         )
         site.trackerDetected(event)
         site.trackerDetected(anotherEvent)
-        assertEquals("www.tracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
+        assertEquals("tracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
     }
 
     @Test
@@ -131,7 +131,23 @@ class BrokenSiteDataTest {
         )
         site.trackerDetected(event)
         site.trackerDetected(anotherEvent)
-        assertEquals("www.tracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
+        assertEquals("tracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
+    }
+
+    @Test
+    fun whenSiteHasBlockedCnamedTrackersThenBlockedTrackersExist() {
+        val site = buildSite(SITE_URL)
+        val event = TrackingEvent(
+            documentUrl = "http://www.example.com",
+            trackerUrl = ".tracker.com/tracker.js",
+            categories = emptyList(),
+            entity = null,
+            surrogateId = null,
+            status = TrackerStatus.BLOCKED,
+            type = TrackerType.OTHER
+        )
+        site.trackerDetected(event)
+        assertEquals(".tracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -126,10 +126,10 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             surrogates = testCase.surrogates.joinToString(","),
             webViewVersion = "webViewVersion",
             siteType = BrokenSiteViewModel.DESKTOP_SITE,
-            urlParametersRemoved = testCase.urlParameterRemoved,
-            consentManaged = testCase.consentManaged,
-            consentOptOutFailed = testCase.consentOptOutFailed,
-            consentSelfTestFailed = testCase.consentSelfTestFailed,
+            urlParametersRemoved = testCase.urlParametersRemoved.toBoolean(),
+            consentManaged = testCase.consentManaged.toBoolean(),
+            consentOptOutFailed = testCase.consentOptOutFailed.toBoolean(),
+            consentSelfTestFailed = testCase.consentSelfTestFailed.toBoolean(),
         )
 
         testee.submitBrokenSiteFeedback(brokenSite)
@@ -173,10 +173,10 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
         val expectReportURLPrefix: String,
         val expectReportURLParams: List<UrlParam>,
         val exceptPlatforms: List<String>,
-        val urlParameterRemoved: Boolean,
-        val consentManaged: Boolean,
-        val consentOptOutFailed: Boolean,
-        val consentSelfTestFailed: Boolean,
+        val urlParametersRemoved: String,
+        val consentManaged: String,
+        val consentOptOutFailed: String,
+        val consentSelfTestFailed: String,
     )
 
     data class UrlParam(

--- a/app/src/test/resources/reference_tests/brokensites/tests.json
+++ b/app/src/test/resources/reference_tests/brokensites/tests.json
@@ -20,9 +20,10 @@
           {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
           {"name": "surrogates", "value": "surrogate.domain.test"}
         ],
-        "consentManaged": false,
-        "consentOptoutFailed": false,
-        "consentSelftestFailed": false,
+        "urlParametersRemoved": "0",
+        "consentManaged": "0",
+        "consentOptoutFailed": "0",
+        "consentSelftestFailed": "0",
         "exceptPlatforms": []
       },
       {
@@ -43,9 +44,10 @@
           {"name": "blockedTrackers", "value": ""},
           {"name": "surrogates", "value": ""}
         ],
-        "consentManaged": false,
-        "consentOptoutFailed": false,
-        "consentSelftestFailed": false,
+        "urlParametersRemoved": "0",
+        "consentManaged": "0",
+        "consentOptoutFailed": "0",
+        "consentSelftestFailed": "0",
         "exceptPlatforms": []
       },
       {
@@ -74,9 +76,10 @@
           {"name": "os", "value": "12"},
           {"name": "gpc", "value": "true"}
         ],
-        "consentManaged": false,
-        "consentOptoutFailed": false,
-        "consentSelftestFailed": false,
+        "urlParametersRemoved": "0",
+        "consentManaged": "0",
+        "consentOptoutFailed": "0",
+        "consentSelftestFailed": "0",
         "exceptPlatforms": [
           "web-extension",
           "safari-extension"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203001266625718/f 

### Description
This PR fixes the broken sites report to send 1 or 0 instead of true false for a few parameters. It also fixes trackers sent as null when they are CNAME'd.

### Steps to test this PR

_Feature 1_
- [x] Install from this branch
- [x] Go to onlyfans.com
- [x] Filter by pixel send in the logcat
- [x] Submit a broken site report
- [x] The pixel should not contain null in the blockedTrackers parameter and only have the domain of the tracker with no path
- [x] Pixel shoult have urlParametersRemoved, consentManaged, consentOptoutFailed and consentSelftestFailed as 0 (or 1) instead of true/false

