### PR TITLE
VPN start trampoline

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
+++ b/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
@@ -105,6 +105,11 @@
             android:exported="false"/>
 
         <service
+            android:name=".service.state.VpnTrampolineService"
+            android:exported="false"
+            android:process=":vpn"/>
+
+        <service
             android:name=".service.TrackerBlockingVpnService"
             android:exported="false"
             android:permission="android.permission.BIND_VPN_SERVICE"

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.mobile.android.vpn.network.util.isLocal
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.prefs.VpnPreferences
 import com.duckduckgo.mobile.android.vpn.service.state.VpnStateMonitorService
+import com.duckduckgo.mobile.android.vpn.service.state.VpnTrampolineService
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldEnabledNotificationBuilder
 import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldNotificationFactory
@@ -492,6 +493,26 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
         }
 
         internal fun startService(context: Context) {
+            startTrampolineService(context.applicationContext)
+        }
+
+        private fun startTrampolineService(context: Context) {
+            val applicationContext = context.applicationContext
+
+            if (isServiceRunning(applicationContext)) return
+
+            runCatching {
+                Intent(applicationContext, VpnTrampolineService::class.java).also { i ->
+                    applicationContext.startService(i)
+                }
+            }.onFailure {
+                // fallback for when both browser and vpn processes are not up, as we can't start a non-foreground service in the background
+                Timber.w(it, "VPN log: Failed to start trampoline service")
+                startVpnService(applicationContext)
+            }
+        }
+
+        internal fun startVpnService(context: Context) {
             val applicationContext = context.applicationContext
 
             if (isServiceRunning(applicationContext)) return
@@ -528,7 +549,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
                 }
 
                 Timber.v("VPN log: re-starting service")
-                startService(applicationContext)
+                startTrampolineService(applicationContext)
             }
         }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/VpnTrampolineService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/VpnTrampolineService.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service.state
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
+import timber.log.Timber
+
+/**
+ * This is a trampoline service that is used to start the VPN service.
+ * The reason why we go through this is because we want to make sure the :vpn process is already created when we call
+ * startForegroundService() method. That should reduce the time between startForegroundService() and startForeground()
+ */
+internal class VpnTrampolineService : Service() {
+
+    override fun onCreate() {
+        Timber.d("onCreate")
+        super.onCreate()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Timber.d("onStartCommand")
+        return super.onStartCommand(intent, flags, startId).also {
+            TrackerBlockingVpnService.startVpnService(this)
+            stopSelf()
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        Timber.d("Bound to VPN")
+        return null
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        Timber.d("Unbound from VPN")
+        return super.onUnbind(intent)
+    }
+
+    override fun onDestroy() {
+        Timber.d("onDestroy")
+        super.onDestroy()
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1202332814862288/f

### Description
Comprehensive discussion in the [Asana
task](https://app.asana.com/0/1202279501986195/1202332814862288/f).

TL;DR
* VpnService runs in its own process
* But it is started from the main browser process
* majority of the time is spent on Android creating the `:vpn` process
* which increases the likehood of exceptions because the time between startForegroundService() and startForeground() exceeds the Android predefine threshold
* this PR uses a trapoline service whenever possible so that the process
  creation time doesn't account

### Steps to test this PR
Sanity checks on AppTP enable/disable, ie:
- [x] enable/disable from the UI
- [x] enable/disable when device reboots should work
- [ ] force close app when AppTP is enable and re-open should enable
  AppTP normally
