### PR TITLE
Fix/david/bookmark search crash

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -68,6 +68,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
     lateinit var bookmarksAdapter: BookmarksAdapter
     lateinit var favoritesAdapter: FavoritesAdapter
     lateinit var bookmarkFoldersAdapter: BookmarkFoldersAdapter
+    lateinit var searchListener: BookmarksEntityQueryListener
 
     private var deleteDialog: AlertDialog? = null
     private var searchMenuItem: MenuItem? = null
@@ -265,7 +266,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
     }
 
     private fun initializeSearchBar() {
-        val listener = BookmarksEntityQueryListener(viewModel, bookmarksAdapter, bookmarkFoldersAdapter)
+        searchListener = BookmarksEntityQueryListener(viewModel, bookmarksAdapter, bookmarkFoldersAdapter)
         searchMenuItem?.setOnMenuItemClickListener {
             showSearchBar()
             return@setOnMenuItemClickListener true
@@ -274,7 +275,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
         searchBar.onAction {
             when (it) {
                 is SearchBar.Action.PerformUpAction -> hideSearchBar()
-                is SearchBar.Action.PerformSearch -> listener.onQueryTextChange(it.searchText)
+                is SearchBar.Action.PerformSearch -> searchListener.onQueryTextChange(it.searchText)
             }
         }
     }
@@ -374,6 +375,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
 
     override fun onDestroy() {
         deleteDialog?.dismiss()
+        searchListener.cancelSearch()
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksAdapter.kt
@@ -71,7 +71,8 @@ class BookmarksAdapter(
 
     fun setItems(
         bookmarkItems: List<BookmarkItem>,
-        showEmptyHint: Boolean
+        showEmptyHint: Boolean,
+        filteringMode: Boolean = false
     ) {
         val generatedList = generateNewList(bookmarkItems, showEmptyHint)
         val diffCallback = DiffCallback(old = this.bookmarkItems, new = generatedList)
@@ -79,7 +80,7 @@ class BookmarksAdapter(
         this.bookmarkItems.clear().also { this.bookmarkItems.addAll(generatedList) }
         diffResult.dispatchUpdatesTo(this)
 
-        if (bookmarkItems.isEmpty()) {
+        if (filteringMode || bookmarkItems.isEmpty()) {
             return
         }
 

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/bookmarkfolders/BookmarkFoldersAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/bookmarkfolders/BookmarkFoldersAdapter.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.mobile.android.ui.menu.PopupMenu
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ViewBookmarkFolderEntryBinding
 import com.duckduckgo.app.browser.databinding.ViewSavedSiteSectionTitleBinding
+import timber.log.Timber
 
 class BookmarkFoldersAdapter(
     private val layoutInflater: LayoutInflater,
@@ -53,6 +54,7 @@ class BookmarkFoldersAdapter(
         }
 
     private fun generateNewList(value: List<BookmarkFoldersItemTypes>): List<BookmarkFoldersItemTypes> {
+        Timber.d("Bookmarks: generateNewList")
         return if (parentId == 0L) {
             listOf(Header) + value
         } else {
@@ -78,15 +80,13 @@ class BookmarkFoldersAdapter(
         }
     }
 
-    override fun getItemCount(): Int = bookmarkFolderItems.size
-
     override fun onBindViewHolder(
         holder: BookmarkFolderScreenViewHolders,
         position: Int
     ) {
         when (holder) {
             is BookmarkFolderScreenViewHolders.BookmarkFoldersViewHolder -> {
-                holder.update((bookmarkFolderItems[position] as BookmarkFolderItem).bookmarkFolder)
+                holder.update((currentList[position] as BookmarkFolderItem).bookmarkFolder)
             }
             is BookmarkFolderScreenViewHolders.SectionTitle -> {
                 holder.bind()
@@ -95,7 +95,8 @@ class BookmarkFoldersAdapter(
     }
 
     override fun getItemViewType(position: Int): Int {
-        return when (bookmarkFolderItems[position]) {
+        Timber.d("Bookmarks: getItemViewType $bookmarkFolderItems")
+        return when (currentList[position]) {
             is Header -> BOOKMARK_FOLDERS_SECTION_TITLE_TYPE
             else -> BOOKMARK_FOLDER_TYPE
         }

--- a/common-ui/src/main/res/layout/view_message_cta.xml
+++ b/common-ui/src/main/res/layout/view_message_cta.xml
@@ -88,7 +88,7 @@
         app:layout_goneMarginStart="0dp"
         tools:text="button" />
 
-    <com.duckduckgo.mobile.android.ui.view.button.ButtonSecondarySmall
+    <com.duckduckgo.mobile.android.ui.view.button.ButtonGhostSmall
         android:id="@+id/secondaryActionButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/common-ui/src/main/res/values/strings.xml
+++ b/common-ui/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="snackbar_label_title">Snackbar</string>
     <string name="text_dialog_title">Title</string>
     <string name="text_dialog_message">You can put as much text in here as you like. This dialog scales automagically.</string>
-    <string name="text_dialog_positive">Positive</string>
+    <string name="text_dialog_positive">Keep using</string>
     <string name="text_dialog_negative">Negative</string>
     <string name="text_dialog_option">Option</string>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1203032947589836

### Description
This PR fixes a crash when searching in Bookmarks.
The ListAdapter should use the internal list of items, as opposed to use the one we maintain externally.

### Steps to test this PR

_From current develop / production_
- Add a bookmark folder
- Add a bookmark to that folder
- Start filtering the list
- App will crash

_From this branch_
- Add a bookmark folder
- Add a bookmark to that folder
- Start filtering the list
- App will not crash