### PR TITLE
AppTP: Android pixels needed (daily) - percentage of unprotected apps

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -227,7 +227,8 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
     ATP_REPORT_ALWAYS_ON_ENABLED_DAILY("m_atp_ev_always_on_enabled_d"),
     ATP_REPORT_ALWAYS_ON_LOCKDOWN_ENABLED_DAILY("m_atp_ev_always_on_lockdown_enabled_d"),
 
-    ATP_REPORT_UNPROTECTED_APPS_BUCKET("m_atp_unprotected_apps_bucket_%d"),
+    ATP_REPORT_UNPROTECTED_APPS_BUCKET("m_atp_unprotected_apps_bucket_%d_c"),
+    ATP_REPORT_UNPROTECTED_APPS_BUCKET_DAILY("m_atp_unprotected_apps_bucket_%d_d"),
 
     ;
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -892,6 +892,9 @@ class RealDeviceShieldPixels @Inject constructor(
     }
 
     override fun reportUnprotectedAppsBucket(bucketSize: Int) {
+        tryToFireDailyPixel(
+            String.format(Locale.US, DeviceShieldPixelNames.ATP_REPORT_UNPROTECTED_APPS_BUCKET_DAILY.pixelName, bucketSize)
+        )
         firePixel(String.format(Locale.US, DeviceShieldPixelNames.ATP_REPORT_UNPROTECTED_APPS_BUCKET.pixelName, bucketSize))
     }
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
@@ -324,6 +324,7 @@ class RealDeviceShieldPixelsTest {
         deviceShieldPixels.reportUnprotectedAppsBucket(bucketSize)
 
         verify(pixel).fire(DeviceShieldPixelNames.ATP_REPORT_UNPROTECTED_APPS_BUCKET.notificationVariant(bucketSize))
+        verify(pixel).fire(DeviceShieldPixelNames.ATP_REPORT_UNPROTECTED_APPS_BUCKET_DAILY.notificationVariant(bucketSize))
     }
 
     private fun DeviceShieldPixelNames.notificationVariant(variant: Int): String {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1203038225582363/f

### Description
Added daily pixel for the unprotected apps bucket.

### Steps to test this PR

- [x] Install from this branch.
- [x] Filter logcat by `m_atp_unprotected_apps_bucket_` or use Kibana and filter by `pixel:m.atp.unprotected.apps.bucket.*`
- [x] Enable AppTP.
- [x] Check in logcat / Kibana that the `m_atp_unprotected_apps_bucket_` pixels are sent with the correct bucket size depending on what's installed on your device. Make sure you see both "_c" and "_d" pixels. The "_c" one should be sent every time AppTP is started/restarted. The "_d" pixel should be sent once.
- [x] Check in logcat / Kibana that the `m_atp_unprotected_apps_bucket_` pixels (both "_c" and "_d") dont contain any `atb`, `atp_cohort`, `appVersion` params.


### NO UI changes
