### PR TITLE
Fix setting activity rtl bug

### DIFF
--- a/app/src/main/res/layout/content_settings_appearance.xml
+++ b/app/src/main/res/layout/content_settings_appearance.xml
@@ -61,7 +61,7 @@
             android:layout_marginEnd="16dp"
             android:importantForAccessibility="no"
             app:layout_constraintBottom_toBottomOf="@+id/changeAppIconLabel"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="@+id/changeAppIconLabel"
             tools:srcCompat="@drawable/ic_app_icon_red_round" />
 

--- a/common-ui/src/main/res/values/styles.xml
+++ b/common-ui/src/main/res/values/styles.xml
@@ -127,6 +127,8 @@
         <item name="android:textStyle">normal</item>
         <item name="android:selectable">false</item>
         <item name="android:gravity">start</item>
+        <item name="android:layoutDirection">ltr</item>
+
     </style>
 
     <style name="SectionDivider">


### PR DESCRIPTION
### Description
Content setting activity in RTL devices is not good, you can change locale for preview in activity design tab and see how is it in RTL devices

https://stackoverflow.com/a/50079390/6046829

If duckduckgo want I can fix other RTL bugs in browser.

### Steps to test this PR

_Feature 1_
- [ Fixed RTL bug in setting activity ]
- [ ]

### UI changes


|  Before | 

![Screenshot_۲۰۲۲-۰۹-۲۳-۱۹-۴۱-۳۸-۱۹۰_com duckduckgo mobile android](https://user-images.githubusercontent.com/16717834/192576771-4e0a4c97-0869-46d2-bf7b-fad6c9650fc1.jpg)




|After | -------------------------------------------------------------
 


![Screenshot_۲۰۲۲-۰۹-۲۵-۲۲-۵۳-۳۹-۶۵۹_com duckduckgo mobile android debug](https://user-images.githubusercontent.com/16717834/192162114-307c6360-371d-4572-b2ac-af00fd5dd6d0.jpg)
 |
!(Upload before screenshot)|(Upload after screenshot)|
