### PR TITLE
Move bitmap generation off of main thread

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -374,8 +374,8 @@ class BrowserModule {
     }
 
     @Provides
-    fun webViewPreviewGenerator(): WebViewPreviewGenerator {
-        return FileBasedWebViewPreviewGenerator()
+    fun webViewPreviewGenerator(dispatchers: DispatcherProvider): WebViewPreviewGenerator {
+        return FileBasedWebViewPreviewGenerator(dispatchers = dispatchers)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewGenerator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewGenerator.kt
@@ -19,44 +19,49 @@ package com.duckduckgo.app.browser.tabpreview
 import android.graphics.Bitmap
 import android.webkit.WebView
 import androidx.core.view.drawToBitmap
-import kotlinx.coroutines.Dispatchers
+import com.duckduckgo.app.global.DispatcherProvider
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
 interface WebViewPreviewGenerator {
     suspend fun generatePreview(webView: WebView): Bitmap
 }
 
-class FileBasedWebViewPreviewGenerator : WebViewPreviewGenerator {
+class FileBasedWebViewPreviewGenerator(private val dispatchers: DispatcherProvider) : WebViewPreviewGenerator {
 
     override suspend fun generatePreview(webView: WebView): Bitmap {
         val fullSizeBitmap = convertWebViewToBitmap(webView)
-        val scaledBitmap = scaleBitmap(fullSizeBitmap)
-        Timber.d("Full size bitmap: ${fullSizeBitmap.byteCount}, reduced size: ${scaledBitmap.byteCount}")
-        return scaledBitmap
+        return scaleBitmap(fullSizeBitmap)
     }
 
     private suspend fun convertWebViewToBitmap(webView: WebView): Bitmap {
-        return withContext(Dispatchers.Main) {
-            disableScrollbars(webView)
-            val bm = webView.drawToBitmap()
-            enableScrollbars(webView)
-            return@withContext bm
+        disableScrollbars(webView)
+        val bm = createBitmap(webView)
+        enableScrollbars(webView)
+        return bm
+    }
+
+    private suspend fun createBitmap(webView: WebView): Bitmap {
+        return withContext(dispatchers.default()) {
+            webView.drawToBitmap()
         }
     }
 
-    private fun enableScrollbars(webView: WebView) {
-        webView.isVerticalScrollBarEnabled = true
-        webView.isHorizontalScrollBarEnabled = true
+    private suspend fun enableScrollbars(webView: WebView) {
+        withContext(dispatchers.main()) {
+            webView.isVerticalScrollBarEnabled = true
+            webView.isHorizontalScrollBarEnabled = true
+        }
     }
 
-    private fun disableScrollbars(webView: WebView) {
-        webView.isVerticalScrollBarEnabled = false
-        webView.isHorizontalScrollBarEnabled = false
+    private suspend fun disableScrollbars(webView: WebView) {
+        withContext(dispatchers.main()) {
+            webView.isVerticalScrollBarEnabled = false
+            webView.isHorizontalScrollBarEnabled = false
+        }
     }
 
     private suspend fun scaleBitmap(bitmap: Bitmap): Bitmap {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.default()) {
             return@withContext Bitmap.createScaledBitmap(
                 bitmap,
                 (bitmap.width * COMPRESSION_RATIO).toInt(),

--- a/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewGenerator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewGenerator.kt
@@ -29,15 +29,11 @@ interface WebViewPreviewGenerator {
 class FileBasedWebViewPreviewGenerator(private val dispatchers: DispatcherProvider) : WebViewPreviewGenerator {
 
     override suspend fun generatePreview(webView: WebView): Bitmap {
-        val fullSizeBitmap = convertWebViewToBitmap(webView)
-        return scaleBitmap(fullSizeBitmap)
-    }
-
-    private suspend fun convertWebViewToBitmap(webView: WebView): Bitmap {
         disableScrollbars(webView)
-        val bm = createBitmap(webView)
+        val fullSizeBitmap = createBitmap(webView)
+        val scaledBitmap = scaleBitmap(fullSizeBitmap)
         enableScrollbars(webView)
-        return bm
+        return scaledBitmap
     }
 
     private suspend fun createBitmap(webView: WebView): Bitmap {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1202973737705663/f

### Description
Moves the work to generate a `Bitmap` from the `WebView` off of the main thread. We do this work to generate `WebView` image previews for the tab switcher but it can be too heavy to do on the main thread and is showing up as ANRs. 

From testing, it is safe to generate the `Bitmap` off of the main thread.

### Steps to test this PR

_WebView image preview generator_
- [x] Visit a webpage, then switch to the tab switcher view
- [x] Verify the WebView preview image is generated for the tab
- [x] Return to the browser and scroll page or visit a new one
- [x] Visit tab switcher and verify tab preview updates
- [x] Open a second tab, and smoke test webview preview generation works as expected

