### PR TITLE
Catch app link SecurityException

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1184,7 +1184,14 @@ class BrowserTabFragment :
     private fun openAppLink(appLink: SpecialUrlDetector.UrlType.AppLink) {
         if (appLink.appIntent != null) {
             appLink.appIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            startActivity(appLink.appIntent)
+            try {
+                startActivity(appLink.appIntent)
+            } catch (e: SecurityException) {
+                e.message?.let { message ->
+                    pixel.fire(AppPixelName.APP_LINKS_SECURITY_EXCEPTION, mapOf(Pixel.PixelParameter.APP_LINKS_SECURITY_EXCEPTION to message))
+                }
+                showToast(R.string.unableToOpenLink)
+            }
         } else if (appLink.excludedComponents != null && appBuildConfig.sdkInt >= Build.VERSION_CODES.N) {
             val title = getString(R.string.appLinkIntentChooserTitle)
             val chooserIntent = getChooserIntent(appLink.uriString, title, appLink.excludedComponents)

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -158,6 +158,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
 
     APP_LINKS_SNACKBAR_SHOWN("m_app_links_snackbar_shown"),
     APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED("m_app_links_snackbar_open_action_pressed"),
+    APP_LINKS_SECURITY_EXCEPTION("m_app_links_security_exception"),
 
     FEEDBACK_POSITIVE_SUBMISSION("mfbs_%s_submit"),
     FEEDBACK_NEGATIVE_SUBMISSION("mfbs_%s_%s_%s"),

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -74,6 +74,7 @@ interface Pixel {
         const val LAST_USED_DAY = "duck_address_last_used"
         const val WEBVIEW_VERSION = "webview_version"
         const val OS_VERSION = "os_version"
+        const val APP_LINKS_SECURITY_EXCEPTION = "app_links_security_exception"
     }
 
     object PixelValues {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1203064213689934/f

### Description
1. Catches `SecurityException` when trying to start certain app links and shows the "unableToOpenLink" toast.
2. Sends a pixel containing the exception message for debugging purposes.

### Steps to test this PR
Code review.
