### PR TITLE
Fix WidgetInstructions Activity crash

### DIFF
--- a/common-ui/src/main/res/values/themes.xml
+++ b/common-ui/src/main/res/values/themes.xml
@@ -297,7 +297,7 @@
         <item name="android:statusBarColor">@color/atp_onboardingHeaderBg</item>
     </style>
 
-    <style name="ModalCardTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="ModalCardTheme" parent="AppTheme.BaseLight">
         <item name="colorPrimary">@color/darkThemePrimary</item>
         <item name="colorPrimaryDark">@color/darkThemePrimaryDark</item>
         <item name="colorAccent">@color/cornflowerBlue</item>
@@ -306,6 +306,7 @@
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowAnimationStyle">@android:style/Animation</item>
+        <item name="android:windowTranslucentStatus">true</item>
         <item name="toolbarIconColor">@color/white</item>
     </style>
 


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1157893581871903/1203056086367606

### Description
Previous Theme updates forgot to update this screen. Making it crash when opened...

### Steps to test this PR

_From develop_
- [x] Fresh install
- [x] Search for something and hide dax tips
- [x] Open New Tab until you're prompted to try the Search Widget
- [x] Tap on Show me how
- [x] App crashes

_From this branch_
- [x] Fresh install
- [x] Search for something and hide dax tips
- [x] Open New Tab until you're prompted to try the Search Widget
- [x] Tap on Show me how
- [x] Instructions screen should appear
