### PR TITLE
Fix Settings missalignment

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -22,14 +22,10 @@
 
     <include
         android:id="@+id/includeToolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         layout="@layout/include_default_toolbar" />
 
     <include
         android:id="@+id/includeSettings"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         layout="@layout/content_settings" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1202552961248957/1203071545508078

### Description
Merging [✓ Android Component: Section Header](https://app.asana.com/0/1202552961248957/1203032895896306) messed with the Settings screen, hiding the Default Browser item. This fixes it.

### Steps to test this PR
Smoke test
