### PR TITLE
Carry over property annotations when generating worker plugins

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesWorkerCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesWorkerCodeGenerator.kt
@@ -82,6 +82,22 @@ class ContributesWorkerCodeGenerator : CodeGenerator {
                 PropertySpec
                     .builder(it.name, ClassName("javax.inject", "Provider").parameterizedBy(it.type().asTypeName()))
                     .addModifiers(KModifier.PRIVATE)
+                    .apply {
+                        // carry over the property annotations
+                        it.annotations.filter { ann -> ann.fqName != Inject::class.fqName }.forEach { annotation ->
+                            addAnnotation(
+                                AnnotationSpec.builder(annotation.fqName.asClassName(module))
+                                    .apply {
+                                        annotation.arguments.forEach { argument ->
+                                            argument.name?.let { name -> addMember("%N = %S", name, argument.value()) }
+                                                ?: addMember("%S", argument.value())
+
+                                        }
+                                    }
+                                    .build()
+                            )
+                        }
+                    }
                     .build()
             }.toTypedArray()
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203056086367700/f

### Description
Honor property annotations when using the `@ContributesWorker` annotation. Example:
```kotlin
@ContributesWorker(AppScope::class)
class FooWorker(context: Context, workerParameters: WorkerParameters) :
 CoroutineWorker(context, workerParameters) {

 @Inject
 @Named("foo")
 lateinit var foo: Foo
}
```

### Steps to test this PR
Should build
