### PR TITLE
Autofill decline counter: remove in-memory counter

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/declines/AutofillDisablingDeclineCounter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/declines/AutofillDisablingDeclineCounter.kt
@@ -47,13 +47,6 @@ class AutofillDisablingDeclineCounter @Inject constructor(
     @VisibleForTesting
     var currentSessionPreviousDeclinedDomain: String? = null
 
-    /**
-     * The count of domains for which we have recorded a decline in the current session, held in-memory only.
-     * Only incremented if decline is on a new domain.
-     */
-    @VisibleForTesting
-    var currentSessionDomainDeclineCount = 0
-
     init {
         appCoroutineScope.launch(dispatchers.io()) {
             isActive = determineIfDeclineCounterIsActive().also {
@@ -75,7 +68,6 @@ class AutofillDisablingDeclineCounter @Inject constructor(
 
     private fun recordDeclineForDomain(domain: String) {
         Timber.d("User declined to save credentials for a new domain; recording the decline")
-        currentSessionDomainDeclineCount++
         autofillStore.autofillDeclineCount++
         currentSessionPreviousDeclinedDomain = domain
     }
@@ -85,7 +77,6 @@ class AutofillDisablingDeclineCounter @Inject constructor(
     override suspend fun disableDeclineCounter() {
         isActive = false
         currentSessionPreviousDeclinedDomain = null
-        currentSessionDomainDeclineCount = 0
 
         withContext(dispatchers.io()) {
             autofillStore.monitorDeclineCounts = false
@@ -97,14 +88,11 @@ class AutofillDisablingDeclineCounter @Inject constructor(
 
         return withContext(dispatchers.io()) {
 
-            val shouldOffer = currentSessionDomainDeclineCount >= CURRENT_SESSION_DECLINE_COUNT_THRESHOLD &&
-                autofillStore.autofillDeclineCount >= GLOBAL_DECLINE_COUNT_THRESHOLD
+            val shouldOffer = autofillStore.autofillDeclineCount >= GLOBAL_DECLINE_COUNT_THRESHOLD
 
             Timber.v(
-                "User declined to save credentials %d times globally from all sessions, " +
-                    "across at least %d domains this current session. Should prompt to disable: %s",
+                "User declined to save credentials %d times globally from all sessions. Should prompt to disable: %s",
                 autofillStore.autofillDeclineCount,
-                currentSessionDomainDeclineCount,
                 shouldOffer
             )
 
@@ -120,6 +108,5 @@ class AutofillDisablingDeclineCounter @Inject constructor(
 
     companion object {
         private const val GLOBAL_DECLINE_COUNT_THRESHOLD = 3
-        private const val CURRENT_SESSION_DECLINE_COUNT_THRESHOLD = 2
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/saving/declines/AutofillDisablingDeclineCounterTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/saving/declines/AutofillDisablingDeclineCounterTest.kt
@@ -58,12 +58,6 @@ class AutofillDisablingDeclineCounterTest {
     }
 
     @Test
-    fun whenInitialisedThenNoPreviouslySessionDeclinedCount() = runTest {
-        initialiseDeclineCounter()
-        assertEquals(0, testee.currentSessionDomainDeclineCount)
-    }
-
-    @Test
     fun whenNotMonitoringDeclineCountsThenShouldNotRecordNewDeclines() = runTest {
         whenever(autofillStore.monitorDeclineCounts).thenReturn(false)
         initialiseDeclineCounter()
@@ -114,30 +108,18 @@ class AutofillDisablingDeclineCounterTest {
     }
 
     @Test
-    fun whenDeclineIncreasesTotalCountAboveThresholdButInMemoryCountIsBelowThenShouldNotOfferToDisable() = runTest {
-        initialiseDeclineCounter()
-        configureGlobalDeclineCountAtThreshold()
-        testee.currentSessionDomainDeclineCount = 0
-        testee.userDeclinedToSaveCredentials("example.com")
-        assertShouldNotPromptToDisableAutofill()
-    }
-
-    @Test
-    fun whenDeclineTotalCountBelowThresholdButInMemoryCountIsAtThresholdThenShouldNotOfferToDisable() = runTest {
+    fun whenDeclineTotalCountBelowThresholdThenShouldNotOfferToDisable() = runTest {
         initialiseDeclineCounter()
         whenever(autofillStore.autofillDeclineCount).thenReturn(0)
-        configureInMemoryCountAtThreshold()
         testee.userDeclinedToSaveCredentials("example.com")
         assertShouldNotPromptToDisableAutofill()
     }
 
     @Test
-    fun whenDeclineIncreasesTotalCountAtThresholdAndInMemoryCountAtThresholdThenShouldOfferToDisable() = runTest {
+    fun whenDeclineIncreasesTotalCountAtThresholdThenShouldOfferToDisable() = runTest {
         initialiseDeclineCounter()
         configureGlobalDeclineCountAtThreshold()
         testee.userDeclinedToSaveCredentials("a.com")
-        assertShouldNotPromptToDisableAutofill()
-        testee.userDeclinedToSaveCredentials("b.com")
         assertShouldPromptToDisableAutofill()
     }
 
@@ -146,7 +128,6 @@ class AutofillDisablingDeclineCounterTest {
         initialiseDeclineCounter()
         testee.isActive = false
         configureGlobalDeclineCountAtThreshold()
-        configureInMemoryCountAtThreshold()
         assertFalse(testee.shouldPromptToDisableAutofill())
     }
 
@@ -168,10 +149,6 @@ class AutofillDisablingDeclineCounterTest {
         whenever(autofillStore.autofillDeclineCount).thenReturn(3)
     }
 
-    private fun configureInMemoryCountAtThreshold() {
-        testee.currentSessionDomainDeclineCount = 2
-    }
-
     private fun assertDeclineNotRecorded() {
         verify(autofillStore, never()).autofillDeclineCount = any()
     }
@@ -184,6 +161,7 @@ class AutofillDisablingDeclineCounterTest {
         assertTrue(testee.shouldPromptToDisableAutofill())
     }
 
+    @Suppress("SameParameterValue")
     private fun assertDeclineRecorded(expectedNewValue: Int) {
         verify(autofillStore).autofillDeclineCount = eq(expectedNewValue)
     }
@@ -196,6 +174,7 @@ class AutofillDisablingDeclineCounterTest {
         )
     }
 
+    @Suppress("SameParameterValue")
     private fun configureAutofillState(enabled: Boolean = true, available: Boolean = true) {
         whenever(autofillStore.autofillEnabled).thenReturn(enabled)
         whenever(autofillStore.autofillAvailable).thenReturn(available)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203135243423252/f

### Description
Simplify the logic used to detect when a user doesn't want to use autofill. Removes the in-memory decline counter.

### Steps to test this PR

Logcat filter: `AutofillDisablingDeclineCounter`

- [x] Visit a site with a login (e.g., trello.com/login) and attempt a login
- [x] Decline the dialog offering to save credentials (count now equals 1)
- [x] Verify not yet shown dialog to disable autofill
- [x] Try another login attempt on the same site (count remains at 1)
- [x] Try a login on another site (e.g., bottom form on https://privacy-test-pages.glitch.me/autofill/form-submission.html) 
- [x] Decline the dialog offering to save credentials (count now equals 2)
- [x] Verify not yet shown dialog to disable autofill
- [x] Kill and re-launch the app
- [x] Try a login on any site, and decline to save credentials when prompted (count now equals 3)
- [x] Verify prompt to disable autofill is presented