### PR TITLE
Handle uninstalled apps in AppTP

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
@@ -281,6 +281,7 @@
     <string name="atp_CompanyDetailsTrackingLearnMore">Apps may include trackers from other companies for things like analytics and marketing. If we didn\'t block them, these trackers could create even more detailed digital profiles on you. <annotation type="learn_more_link">Learn more.</annotation></string>
     <string name="atp_CompanyDetailsTrackingShowLess">Show Less</string>
     <string name="atp_CompanyDetailsAppInfoPanel">Protection is currently disabled for this app. If App Tracking Protection caused a problem, please <annotation type="report_issues_link">report the issue</annotation></string>
+    <string name="atp_CompanyDetailsNotAvailableForUninstalledApps" instruction="Toast shown when users tap on item that corresponds to an already uninstalled application">Tracker details not available for uninstalled apps</string>
 
     <!--  App Tracking Company Signals -->
     <string name="atp_TrackingSignalAAID">Android Advertising ID</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202937064608957/f

### Description
Show a toast when users click to see app tracking details for an app that is no longer installed

### Steps to test this PR

_Test uninstalled app_
- [ ] install from this branch
- [ ] launch app and enable AppTP
- [ ] open app that tracks, eg. speedtest
- [ ] ensure tracking attempts are blocked
- [ ] uninstall app that tracks
- [ ] go to App tracking protection screen and click on speedtest item
- [ ] Ensure toast is shown 
