### PR TITLE
Fix trackers onboarding pixel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -504,5 +504,5 @@ fun DaxCta.addCtaToHistory(newCta: String): String {
 
 fun DaxCta.canSendShownPixel(): Boolean {
     val param = onboardingStore.onboardingDialogJourney?.split("-").orEmpty().toMutableList()
-    return !(param.isNotEmpty() && param.any { it.contains(ctaPixelParam) })
+    return !(param.isNotEmpty() && param.any { it.split(":").firstOrNull().orEmpty() == ctaPixelParam })
 }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaTest.kt
@@ -217,6 +217,13 @@ class CtaTest {
     }
 
     @Test
+    fun whenCanSendPixelAndCtaNotPartOfHistoryButIsASubstringThenReturnTrue() {
+        whenever(mockOnboardingStore.onboardingDialogJourney).thenReturn("s:0-te:0")
+        val testee = DaxBubbleCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore)
+        assertTrue(testee.canSendShownPixel())
+    }
+
+    @Test
     fun whenCanSendPixelAndCtaIsPartOfHistoryThenReturnFalse() {
         whenever(mockOnboardingStore.onboardingDialogJourney).thenReturn("i:0-e:0-s:0")
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203148286727678/f

### Description
This PR fixes a bug when onboarding pixels were not sent in some cases.

### Steps to test this PR
Filter the logcat by "Pixel sent"
- [ ] Install the app
- [ ] Go to `wikipedia.org`
- [ ] You should see `Pixel sent: m_odc_s with params: {cta=i:0-nt:0} {}`
- [ ] Go to `cnn.com` 
- [ ] You should see `Pixel sent: m_odc_s with params: {cta=i:0-nt:0-t:0} {}`
- [ ] Doing the above in develop won't send any pixels after going to `cnn.com`
