### PR TITLE
Support themed icons

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_black.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_black.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_black_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_black_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_black_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_black_round.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_black_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_black_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_blue.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_blue.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_blue_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_blue_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_blue_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_blue_round.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_blue_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_blue_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_gold.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_gold.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_gold_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_gold_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_gold_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_gold_round.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_gold_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_gold_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_green.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_green.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_green_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_green_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_green_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_green_round.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_green_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_green_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_purple.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_purple.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_purple_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_purple_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_purple_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_purple_round.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_purple_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_purple_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_red.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_red.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_red_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_red_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_red_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_red_round.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_red_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_red_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_silhouette.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_silhouette.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_silhouette_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_silhouette_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_silhouette_round.xml
@@ -18,4 +18,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_silhouette_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_silhouette_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203156990301208/f

### Description
This PR adds support for the new "Themed icons" feature in Android 13.

### Steps to test this PR

- [ ] Install from `develop` on an Android 13 (API 33) device/emulator
- [ ] Long press on the device's home screen and go to "Wallpaper and style"
- [ ] Enable "Themed icons"
- [ ] Verify that the icon does not change
- [ ] Install from this branch (`feature/josh/themed-icon-support`)
- [ ] Verify that the icon is themed
- [ ] Change the "App icon" in "Settings"
- [ ] Verify that the icon remains themed
- [ ] Long press on the device's home screen and go to "Wallpaper and style"
- [ ] Disable "Themed icons"
- [ ] Verify that the icon is no longer themed

### UI changes
| Before  | After |
| ------ | ----- |
![before](https://user-images.githubusercontent.com/3471025/195725404-409f504d-ef64-4de7-ad19-675159451052.png)|![after](https://user-images.githubusercontent.com/3471025/195725455-5d2e93d8-36bd-4886-9325-620e422d0dc2.png)
