### PR TITLE
Update content scope scripts to 3.1.0

### DIFF
--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -151,13 +151,16 @@ class RealContentScopeScripts @Inject constructor(
     }
 
     private fun getUserPreferencesJson(userPreferences: String): String {
+        val defaultParameters = "${getVersionNumberKeyValuePair()},${getPlatformKeyValuePair()}"
         if (userPreferences.isEmpty()) {
-            return "{${getVersionNumberKeyValuePair()}}"
+            return "{$defaultParameters}"
         }
-        return "{$userPreferences,${getVersionNumberKeyValuePair()}}"
+        return "{$userPreferences,$defaultParameters}"
     }
 
     private fun getVersionNumberKeyValuePair() = "\"versionNumber\":${appBuildConfig.versionCode}"
+
+    private fun getPlatformKeyValuePair() = "\"platform\":{\"name\":\"android\"}"
 
     private fun getContentScopeJson(config: String, unprotectedTemporaryExceptions: List<UnprotectedTemporaryException>): String = (
         "{\"features\":{$config},\"unprotectedTemporary\":${getUnprotectedTemporaryJson(unprotectedTemporaryExceptions)}}"

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -88,7 +88,7 @@ class RealContentScopeScriptsTest {
                 "\"config1\":{\"state\":\"enabled\"}," +
                 "\"config2\":{\"state\":\"disabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}," +
-                " [\"foo.com\"], {\"versionNumber\":1234})",
+                " [\"foo.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})",
             js
         )
 
@@ -113,7 +113,7 @@ class RealContentScopeScriptsTest {
                 "\"config1\":{\"state\":\"enabled\"}," +
                 "\"config2\":{\"state\":\"disabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}," +
-                " [\"example.com\"], {\"globalPrivacyControlValue\":false,\"versionNumber\":1234})",
+                " [\"example.com\"], {\"globalPrivacyControlValue\":false,\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})",
             js
         )
 
@@ -139,7 +139,7 @@ class RealContentScopeScriptsTest {
                 "{\"features\":{" +
                 "\"config1\":{\"state\":\"enabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}," +
-                " [\"example.com\"], {\"globalPrivacyControlValue\":true,\"versionNumber\":1234})",
+                " [\"example.com\"], {\"globalPrivacyControlValue\":true,\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})",
             js
         )
 
@@ -164,7 +164,7 @@ class RealContentScopeScriptsTest {
                 "\"config1\":{\"state\":\"enabled\"}," +
                 "\"config2\":{\"state\":\"disabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"}]}," +
-                " [\"example.com\"], {\"versionNumber\":1234})",
+                " [\"example.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})",
             js
         )
 
@@ -184,7 +184,7 @@ class RealContentScopeScriptsTest {
             "\"config1\":{\"state\":\"enabled\"}," +
             "\"config2\":{\"state\":\"disabled\"}}," +
             "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}, " +
-            "[\"example.com\"], {\"versionNumber\":1234})"
+            "[\"example.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})"
         const val versionCode = 1234
         val unprotectedTemporaryException = UnprotectedTemporaryException(domain = "example.com", reason = "reason")
         val unprotectedTemporaryException2 = UnprotectedTemporaryException(domain = "foo.com", reason = "reason2")

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -669,23 +669,35 @@
 
   /* global cloneInto, exportFunction, false */
 
-  function getTopLevelURL () {
+  /**
+   * Best guess effort of the tabs hostname; where possible always prefer the args.site.domain
+   * @returns {string|null} inferred tab hostname
+   */
+  function getTabHostname () {
+      let framingOrigin = null;
       try {
-          // FROM: https://stackoverflow.com/a/7739035/73479
-          // FIX: Better capturing of top level URL so that trackers in embedded documents are not considered first party
-          if (window.location !== window.parent.location) {
-              return new URL(window.location.href !== 'about:blank' ? document.referrer : window.parent.location.href)
-          } else {
-              return new URL(window.location.href)
-          }
-      } catch (error) {
-          return new URL(location.href)
+          framingOrigin = globalThis.top.location.href;
+      } catch {
+          framingOrigin = globalThis.document.referrer;
       }
+
+      // Not supported in Firefox
+      if ('ancestorOrigins' in globalThis.location && globalThis.location.ancestorOrigins.length) {
+          // ancestorOrigins is reverse order, with the last item being the top frame
+          framingOrigin = globalThis.location.ancestorOrigins.item(globalThis.location.ancestorOrigins.length - 1);
+      }
+
+      try {
+          framingOrigin = new URL(framingOrigin).hostname;
+      } catch {
+          framingOrigin = null;
+      }
+      return framingOrigin
   }
 
-  function isUnprotectedDomain (topLevelUrl, featureList) {
+  function isUnprotectedDomain (topLevelHostname, featureList) {
       let unprotectedDomain = false;
-      const domainParts = topLevelUrl && topLevelUrl.host ? topLevelUrl.host.split('.') : [];
+      const domainParts = topLevelHostname.split('.');
 
       // walk up the domain to see if it's unprotected
       while (domainParts.length > 1 && !unprotectedDomain) {
@@ -699,18 +711,24 @@
       return unprotectedDomain
   }
 
+  /**
+   * @param {{ features: Record<string, { state: string; settings: any; exceptions: string[] }>; unprotectedTemporary: string; }} data
+   * @param {string[]} userList
+   * @param {Record<string, unknown>} preferences
+   * @param {string[]} platformSpecificFeatures
+   */
   function processConfig (data, userList, preferences, platformSpecificFeatures = []) {
-      const topLevelUrl = getTopLevelURL();
-      const allowlisted = userList.filter(domain => domain === topLevelUrl.host).length > 0;
+      const topLevelHostname = getTabHostname();
+      const allowlisted = userList.filter(domain => domain === topLevelHostname).length > 0;
       const remoteFeatureNames = Object.keys(data.features);
       const platformSpecificFeaturesNotInRemoteConfig = platformSpecificFeatures.filter((featureName) => !remoteFeatureNames.includes(featureName));
       const enabledFeatures = remoteFeatureNames.filter((featureName) => {
           const feature = data.features[featureName];
-          return feature.state === 'enabled' && !isUnprotectedDomain(topLevelUrl, feature.exceptions)
+          return feature.state === 'enabled' && !isUnprotectedDomain(topLevelHostname, feature.exceptions)
       }).concat(platformSpecificFeaturesNotInRemoteConfig); // only disable platform specific features if it's explicitly disabled in remote config
-      const isBroken = isUnprotectedDomain(topLevelUrl, data.unprotectedTemporary);
+      const isBroken = isUnprotectedDomain(topLevelHostname, data.unprotectedTemporary);
       preferences.site = {
-          domain: topLevelUrl.hostname,
+          domain: topLevelHostname,
           isBroken,
           allowlisted,
           enabledFeatures
@@ -729,6 +747,10 @@
       });
 
       return preferences
+  }
+
+  function isGloballyDisabled (args) {
+      return args.site.allowlisted || args.site.isBroken
   }
 
   var contentScopeFeatures = (function (exports) {
@@ -1449,8 +1471,7 @@
       if ('ancestorOrigins' in globalThis.location) {
           return globalThis.location.ancestorOrigins.length > 0
       }
-      // @ts-ignore types do overlap whilst in DOM context
-      return globalThis.top !== globalThis
+      return globalThis.top !== globalThis.window
   }
 
   /**
@@ -1461,14 +1482,14 @@
       if (!isBeingFramed()) {
           return false
       }
-      return !matchHostname(globalThis.location.hostname, getTabOrigin())
+      return !matchHostname(globalThis.location.hostname, getTabHostname())
   }
 
   /**
-   * Best guess effort of the tabs origin
-   * @returns {string|null} inferred tab origin
+   * Best guess effort of the tabs hostname; where possible always prefer the args.site.domain
+   * @returns {string|null} inferred tab hostname
    */
-  function getTabOrigin () {
+  function getTabHostname () {
       let framingOrigin = null;
       try {
           framingOrigin = globalThis.top.location.href;
@@ -1793,6 +1814,7 @@
   function __variableDynamicImportRuntime0__(path) {
      switch (path) {
        case './features/cookie.js': return Promise.resolve().then(function () { return cookie; });
+       case './features/element-hiding.js': return Promise.resolve().then(function () { return elementHiding; });
        case './features/fingerprinting-audio.js': return Promise.resolve().then(function () { return fingerprintingAudio; });
        case './features/fingerprinting-battery.js': return Promise.resolve().then(function () { return fingerprintingBattery; });
        case './features/fingerprinting-canvas.js': return Promise.resolve().then(function () { return fingerprintingCanvas; });
@@ -1825,7 +1847,7 @@
   const updates = [];
   const features = [];
 
-  async function load$1 () {
+  async function load$1 (args) {
       if (!shouldRun()) {
           return
       }
@@ -1842,14 +1864,15 @@
           'referrer',
           'fingerprintingScreenSize',
           'fingerprintingTemporaryStorage',
-          'navigatorInterface'
+          'navigatorInterface',
+          'elementHiding'
       ];
 
       for (const featureName of featureNames) {
           const filename = featureName.replace(/([a-zA-Z])(?=[A-Z0-9])/g, '$1-').toLowerCase();
           const feature = __variableDynamicImportRuntime0__(`./features/${filename}.js`).then(({ init, load, update }) => {
               if (load) {
-                  load();
+                  load(args);
               }
               return { featureName, init, update }
           });
@@ -1857,7 +1880,7 @@
       }
   }
 
-  async function init$d (args) {
+  async function init$e (args) {
       initArgs = args;
       if (!shouldRun()) {
           return
@@ -2049,12 +2072,12 @@
   ];
 
   let protectionExempted = true;
-  const tabOrigin = getTabOrigin();
+  const tabHostname = getTabHostname();
   let tabExempted = true;
 
-  if (tabOrigin != null) {
+  if (tabHostname != null) {
       tabExempted = exceptions.some((exception) => {
-          return matchHostname(tabOrigin, exception.domain)
+          return matchHostname(tabHostname, exception.domain)
       });
   }
   const frameExempted = excludedCookieDomains.some((exception) => {
@@ -2114,6 +2137,10 @@
   }
 
   function load (args) {
+      // Feature is only relevant to the extension, we should skip for other platforms for now as the config testing is broken.
+      if (args.platform.name !== 'extension') {
+          return
+      }
       trackerHosts.clear();
 
       // The cookie policy is injected into every frame immediately so that no cookie will
@@ -2209,7 +2236,7 @@
       });
   }
 
-  function init$c (args) {
+  function init$d (args) {
       args.cookie.debug = args.debug;
       cookiePolicy = args.cookie;
 
@@ -2233,8 +2260,143 @@
   var cookie = /*#__PURE__*/Object.freeze({
     __proto__: null,
     load: load,
-    init: init$c,
+    init: init$d,
     update: update
+  });
+
+  let adLabelStrings = [];
+
+  function collapseDomNode (element, type) {
+      if (!element) {
+          return
+      }
+
+      switch (type) {
+      case 'hide':
+          if (!element.hidden) {
+              hideNode(element);
+          }
+          break
+      case 'hide-empty':
+          if (!element.hidden && isDomNodeEmpty(element)) {
+              hideNode(element);
+          }
+          break
+      case 'closest-empty':
+          // if element already hidden, continue onto parent element
+          if (element.hidden) {
+              collapseDomNode(element.parentNode, type);
+              break
+          }
+
+          if (isDomNodeEmpty(element)) {
+              hideNode(element);
+              collapseDomNode(element.parentNode, type);
+          }
+          break
+      default:
+          console.log(`Unsupported rule: ${type}`);
+      }
+  }
+
+  function hideNode (element) {
+      element.style.setProperty('display', 'none', 'important');
+      element.hidden = true;
+  }
+
+  function isDomNodeEmpty (node) {
+      const visibleText = node.innerText.trim().toLocaleLowerCase();
+      const mediaContent = node.querySelector('video,canvas');
+      const frameElements = [...node.querySelectorAll('iframe')];
+      // about:blank iframes don't count as content, return true if:
+      // - node doesn't contain any iframes
+      // - node contains iframes, all of which are hidden or have src='about:blank'
+      const noFramesWithContent = frameElements.every((frame) => {
+          return (frame.hidden || frame.src === 'about:blank')
+      });
+      if ((visibleText === '' || adLabelStrings.includes(visibleText)) &&
+          noFramesWithContent && mediaContent === null) {
+          return true
+      }
+      return false
+  }
+
+  function hideMatchingDomNodes (rules) {
+      const document = globalThis.document;
+
+      function hideMatchingNodesInner () {
+          rules.forEach((rule) => {
+              const matchingElementArray = [...document.querySelectorAll(rule.selector)];
+              matchingElementArray.forEach((element) => {
+                  collapseDomNode(element, rule.type);
+              });
+          });
+      }
+      // wait 300ms before hiding ad containers so ads have a chance to load
+      setTimeout(hideMatchingNodesInner, 300);
+
+      // handle any ad containers that weren't added to the page within 300ms of page load
+      setTimeout(hideMatchingNodesInner, 1000);
+  }
+
+  function init$c (args) {
+      if (isBeingFramed()) {
+          return
+      }
+
+      const featureName = 'elementHiding';
+      const domain = args.site.domain;
+      const domainRules = getFeatureSetting(featureName, args, 'domains');
+      const globalRules = getFeatureSetting(featureName, args, 'rules');
+      adLabelStrings = getFeatureSetting(featureName, args, 'adLabelStrings');
+
+      // collect all matching rules for domain
+      const activeDomainRules = domainRules.filter((rule) => {
+          return matchHostname(domain, rule.domain)
+      }).flatMap((item) => item.rules);
+
+      const overrideRules = activeDomainRules.filter((rule) => {
+          return rule.type === 'override'
+      });
+
+      let activeRules = activeDomainRules.concat(globalRules);
+
+      // remove overrides and rules that match overrides from array of rules to be applied to page
+      overrideRules.forEach((override) => {
+          activeRules = activeRules.filter((rule) => {
+              return rule.selector !== override.selector
+          });
+      });
+
+      // now have the final list of rules to apply, so we apply them when document is loaded
+      if (document.readyState === 'loading') {
+          window.addEventListener('DOMContentLoaded', (event) => {
+              hideMatchingDomNodes(activeRules);
+          });
+      } else {
+          hideMatchingDomNodes(activeRules);
+      }
+      // single page applications don't have a DOMContentLoaded event on navigations, so
+      // we use proxy/reflect on history.pushState and history.replaceState to call hideMatchingDomNodes
+      // on page navigations, and listen for popstate events that indicate a back/forward navigation
+      const methods = ['pushState', 'replaceState'];
+      for (const methodName of methods) {
+          const historyMethodProxy = new DDGProxy(featureName, History.prototype, methodName, {
+              apply (target, thisArg, args) {
+                  hideMatchingDomNodes(activeRules);
+                  return DDGReflect.apply(target, thisArg, args)
+              }
+          });
+          historyMethodProxy.overload();
+      }
+      window.addEventListener('popstate', (event) => {
+          hideMatchingDomNodes(activeRules);
+      });
+  }
+
+  var elementHiding = /*#__PURE__*/Object.freeze({
+    __proto__: null,
+    init: init$c
   });
 
   function init$b (args) {
@@ -3614,9 +3776,11 @@
               'drawArrays'
           ];
           const glContexts = [
-              WebGL2RenderingContext,
               WebGLRenderingContext
           ];
+          if ('WebGL2RenderingContext' in globalThis) {
+              glContexts.push(WebGL2RenderingContext);
+          }
           for (const context of glContexts) {
               for (const methodName of unsafeGlMethods) {
                   // Some methods are browser specific
@@ -4010,6 +4174,9 @@
    * Fixes incorrect sizing value for outerHeight and outerWidth
    */
   function windowSizingFix () {
+      if (window.outerHeight !== 0 && window.outerWidth !== 0) {
+          return
+      }
       window.outerHeight = window.innerHeight;
       window.outerWidth = window.innerWidth;
   }
@@ -4019,6 +4186,9 @@
    */
   function navigatorCredentialsFix () {
       try {
+          if ('credentials' in navigator && 'get' in navigator.credentials) {
+              return
+          }
           const value = {
               get () {
                   return Promise.reject(new Error())
@@ -4034,9 +4204,25 @@
       }
   }
 
+  function safariObjectFix () {
+      try {
+          if (window.safari) {
+              return
+          }
+          defineProperty(window, 'safari', {
+              value: {},
+              configurable: true,
+              enumerable: true
+          });
+      } catch {
+          // Ignore exceptions that could be caused by conflicting with other extensions
+      }
+  }
+
   function init$1 () {
       windowSizingFix();
       navigatorCredentialsFix();
+      safariObjectFix();
   }
 
   var webCompat = /*#__PURE__*/Object.freeze({
@@ -4426,7 +4612,7 @@
     init: init
   });
 
-  exports.init = init$d;
+  exports.init = init$e;
   exports.load = load$1;
   exports.update = update$1;
 
@@ -4439,11 +4625,13 @@
 
   function init () {
       const processedConfig = processConfig($CONTENT_SCOPE$, $USER_UNPROTECTED_DOMAINS$, $USER_PREFERENCES$);
-      if (processedConfig.site.allowlisted) {
+      if (isGloballyDisabled(processedConfig)) {
           return
       }
 
-      contentScopeFeatures.load();
+      contentScopeFeatures.load({
+          platform: processedConfig.platform
+      });
 
       contentScopeFeatures.init(processedConfig);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "github:duckduckgo/autoconsent#v3.0.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.6.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1.0.0"
       },
       "devDependencies": {
@@ -70,7 +70,7 @@
       }
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#503be35342f1e31e5b85bd0fb053fde208e7135c",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#db764ac851a9a2c6dd68bfb7cc1048ef064e546d",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -132,9 +132,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz",
-      "integrity": "sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
@@ -257,9 +257,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.8.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.4.tgz",
-      "integrity": "sha512-WdlVphvfR/GJCLEMbNA8lJ0lhFNBj4SW3O+O5/cEGw9oYrv0al9zTwuQsq+myDUXgNx2jgBynoVgZ2MMJ6pbow==",
+      "version": "18.8.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
+      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -1124,8 +1124,8 @@
       }
     },
     "@duckduckgo/content-scope-scripts": {
-      "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#503be35342f1e31e5b85bd0fb053fde208e7135c",
-      "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#2.6.0",
+      "version": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#db764ac851a9a2c6dd68bfb7cc1048ef064e546d",
+      "from": "@duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#3.1.0",
       "requires": {
         "seedrandom": "^3.0.5",
         "sjcl": "^1.0.8"
@@ -1175,9 +1175,9 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz",
-      "integrity": "sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
@@ -1276,9 +1276,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.8.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.4.tgz",
-      "integrity": "sha512-WdlVphvfR/GJCLEMbNA8lJ0lhFNBj4SW3O+O5/cEGw9oYrv0al9zTwuQsq+myDUXgNx2jgBynoVgZ2MMJ6pbow==",
+      "version": "18.8.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
+      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
       "dev": true
     },
     "@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.1.0",
     "@duckduckgo/autoconsent": "github:duckduckgo/autoconsent#v3.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#2.6.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1.0.0"
   }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203156990301220/f

### Description
This PR updates to latest version of content scope scripts ([3.1.0](https://github.com/duckduckgo/content-scope-scripts/releases/tag/3.1.0))

### Steps to test this PR

_Privacy Test Pages_
- [x] Go http://privacy-test-pages.glitch.me/privacy-protections/gpc/
- [x] Click "Start test"
- [x] Verify that "top frame header" is 1 and "top frame JS API" is true
- [x] Go to "Settings"
- [x] Disable "Global Privacy Control (GPC)"
- [x] Reload the page
- [x] Click "Start test"
- [x] Verify that all of the tests are "..."

_Global Privacy Control_
- [x] Go to globalprivacycontrol.org
- [x] Verify that the banner with "GPC signal detected" is shown.
- [x] Test against the reference server.
- [x] Verify that client-side detection is activated.
- [x] Go to Settings.
- [x] Disable GPC.
- [x] Reload the page.
- [x] Verify that client-side detection is de-activated.
- [x] Go back.
- [x] Verify that the banner with "GPC signal not detected" is shown.
