### PR TITLE
AppTP: Bug - The button to see All Activity is hidden (but you can still click it)

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_activity.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_activity.xml
@@ -118,6 +118,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/keyline_4"
+                app:primaryText="@string/atp_ActivityCtaShowAll"
                 android:paddingStart="72dp"
                 android:visibility="gone"/>
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1203165097819219/f

### Description
Set the primary text on the cta_show_all view.

### Steps to test this PR

Check the issue:
- [x] Install from develop.
- [x] Enable AppTP.
- [x] Insert at lest 6 different trackers (or same tracker in different days) in the list in the `vpn_tracker` in `vpn.db` database.
- [x] Go to the `App Tracking Protection` screen to the `Recent Activity` section and scroll to the end of the tracker list.
- [x] See that there is no `View All Recent Activity` text, but there is space allocated there and can tap on it.

Check the fix:
- [x] Install from this branch.
- [x] Enable AppTP.
- [x] Insert at lest 6 different trackers (or same tracker in different days) in the list in the `vpn_tracker` in `vpn.db` database.
- [x] Go to the `App Tracking Protection` screen to the `Recent Activity` section and scroll to the end of the tracker list.
- [x] See the `View All Recent Activity` text, and check that you can tap on it.

### UI changes
| Before  | After |
| ------ | ----- |
|![before_fix](https://user-images.githubusercontent.com/7963079/195818372-74fe4261-ec7f-4e6d-be40-2c9b05f16a9b.png)|![after_fix](https://user-images.githubusercontent.com/7963079/195818383-e5987b3c-b101-4fd3-a216-84340a01e3c0.png)|

