### PR TITLE
Report remote configs in breakage report

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/RemoteConfigCollector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/RemoteConfigCollector.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.bugreport
+
+import com.duckduckgo.di.scopes.VpnScope
+import com.duckduckgo.mobile.android.vpn.feature.JSONObjectAdapter
+import com.duckduckgo.mobile.android.vpn.remote_config.VpnConfigToggle
+import com.duckduckgo.mobile.android.vpn.remote_config.VpnRemoteConfigDatabase
+import com.duckduckgo.mobile.android.vpn.state.VpnStateCollectorPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import org.json.JSONObject
+import javax.inject.Inject
+
+@ContributesMultibinding(VpnScope::class)
+class RemoteConfigCollector @Inject constructor(
+    vpnRemoteConfigDatabase: VpnRemoteConfigDatabase,
+) : VpnStateCollectorPlugin {
+
+    private val togglesDao = vpnRemoteConfigDatabase.vpnConfigTogglesDao()
+    val adapter: JsonAdapter<List<Toggle>> = Moshi
+        .Builder()
+        .add(JSONObjectAdapter())
+        .build()
+        .adapter(Types.newParameterizedType(List::class.java, Toggle::class.java))
+
+    override val collectorName: String
+        get() = "remoteConfigInfo"
+
+    override suspend fun collectVpnRelatedState(appPackageId: String?): JSONObject {
+        return JSONObject().apply {
+            togglesDao.getConfigToggles().map { it.toToggle() }.forEach { toggle ->
+                put(toggle.name, toggle.value)
+            }
+        }
+    }
+
+    data class Toggle(val name: String, val value: Boolean)
+    private fun VpnConfigToggle.toToggle() = Toggle(name, enabled)
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/bugreport/RemoteConfigCollectorTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/bugreport/RemoteConfigCollectorTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.bugreport
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.mobile.android.vpn.remote_config.VpnConfigToggle
+import com.duckduckgo.mobile.android.vpn.remote_config.VpnConfigTogglesDao
+import com.duckduckgo.mobile.android.vpn.remote_config.VpnRemoteConfigDatabase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class RemoteConfigCollectorTest {
+
+    private val vpnRemoteConfigDatabase: VpnRemoteConfigDatabase = mock()
+
+    private lateinit var vpnConfigTogglesDao: VpnConfigTogglesDao
+    private lateinit var remoteConfigCollector: RemoteConfigCollector
+
+    @Before
+    fun setup() {
+        vpnConfigTogglesDao = FakeVpnConfigTogglesDao()
+        whenever(vpnRemoteConfigDatabase.vpnConfigTogglesDao()).thenReturn(vpnConfigTogglesDao)
+        remoteConfigCollector = RemoteConfigCollector(vpnRemoteConfigDatabase)
+    }
+
+    @Test
+    fun whenCollectAndNoTogglesThenEmptyMap() = runTest {
+        val result = remoteConfigCollector.collectVpnRelatedState(null)
+        assertEquals("{}", result.toString())
+    }
+
+    @Test
+    fun whenCollectAndOneToggleThenReturnToggle() = runTest {
+        vpnConfigTogglesDao.insert(VpnConfigToggle("test", true))
+        val result = remoteConfigCollector.collectVpnRelatedState(null)
+        assertEquals("{\"test\":true}", result.toString())
+    }
+
+    @Test
+    fun whenCollectAndMultipleToggleThenReturnToggles() = runTest {
+        vpnConfigTogglesDao.insert(VpnConfigToggle("foo", true))
+        vpnConfigTogglesDao.insert(VpnConfigToggle("bar", false))
+        val result = remoteConfigCollector.collectVpnRelatedState(null)
+        assertEquals(
+            "{\"foo\":true,\"bar\":false}",
+            result.toString()
+        )
+    }
+
+    class FakeVpnConfigTogglesDao : VpnConfigTogglesDao {
+        private val toggles = mutableListOf<VpnConfigToggle>()
+
+        override suspend fun insert(vpnConfigToggle: VpnConfigToggle) {
+            toggles.add(vpnConfigToggle)
+        }
+
+        override fun getConfigToggles(): List<VpnConfigToggle> {
+            return toggles
+        }
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandlerTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/health/AppBadHealthStateHandlerTest.kt
@@ -68,7 +68,7 @@ class AppBadHealthStateHandlerTest {
     fun setup() {
         MockitoAnnotations.openMocks(this)
 
-        AndroidThreeTen.init(context)
+        AndroidThreeTen.init(InstrumentationRegistry.getInstrumentation().targetContext)
 
         db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppHealthDatabase::class.java)
             .allowMainThreadQueries()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203162345927883/f

### Description
Send the remote configs in the breakage reports for better debugging

### Steps to test this PR

_Test breakage report_
- [ ] install/update from this branch
- [ ] filter logcat by `m_atp_breakage_report`
- [ ] report AppTP breakage for any app
- [ ] copy the value for `breakageMetadata` (it's base64)
- [ ] ensure the unencoded json contains the `remoteConfigInfo` object with a map of config/value pairs (you can use https://onlinestringtools.com/convert-base64-to-string to unencode the base64)
