### PR TITLE
Improve always on promotion [4/4]–Lockdown notification

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
@@ -125,7 +125,7 @@ class VpnServiceStateLogger @Inject constructor(
         times: Int = Int.MAX_VALUE,
         initialDelay: Long = 500, // 0.5 second
         maxDelay: Long = 300_000, // 5 minutes
-        factor: Double = 1.1,
+        factor: Double = 1.05, // 5% increase
         block: suspend () -> Unit
     ) {
         var currentDelay = initialDelay

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/alwayson/AlwaysOnAlertDialogFragment.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/alwayson/AlwaysOnAlertDialogFragment.kt
@@ -32,15 +32,21 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
-import java.lang.ref.WeakReference
+import timber.log.Timber
 import javax.inject.Inject
+
+private enum class FragmentType {
+    ALWAYS_ON,
+    ALWAYS_ON_LOCKDOWN,
+}
 
 @InjectWith(FragmentScope::class)
 class AlwaysOnAlertDialogFragment private constructor() : BottomSheetDialogFragment() {
 
     @Inject lateinit var appBuildConfig: AppBuildConfig
     @Inject lateinit var appTheme: AppTheme
-    private var listener: WeakReference<Listener> = WeakReference(null)
+    private lateinit var listener: Listener
+    private lateinit var fragmentType: FragmentType
 
     override fun getTheme(): Int = R.style.AlwaysOnBottomSheetDialogTheme
 
@@ -62,10 +68,21 @@ class AlwaysOnAlertDialogFragment private constructor() : BottomSheetDialogFragm
 
         fun configureCloseButtons(binding: ContentVpnAlwaysOnAlertBinding) {
             binding.closeButton.setOnClickListener { animatedClosed() }
-            binding.notNowButton.setOnClickListener { animatedClosed() }
+            binding.notNowButton.setOnClickListener {
+                animatedClosed()
+                if (this::listener.isInitialized) {
+                    listener.onCanceled()
+                } else {
+                    Timber.e("Listener not initialized")
+                }
+            }
             binding.goToSettingsButton.setOnClickListener {
                 animatedClosed()
-                listener.get()?.onGoToSettingsClicked()
+                if (this::listener.isInitialized) {
+                    listener.onGoToSettingsClicked()
+                } else {
+                    Timber.e("Listener not initialized")
+                }
             }
         }
 
@@ -84,7 +101,13 @@ class AlwaysOnAlertDialogFragment private constructor() : BottomSheetDialogFragm
         }
 
         fun bindViewElements() {
-            binding.alwaysOnModalDescription.text = HtmlCompat.fromHtml(getString(R.string.atp_AlwaysOnModalBody), 0)
+            if (fragmentType == FragmentType.ALWAYS_ON) {
+                binding.alwaysOnModalHeading.text = HtmlCompat.fromHtml(getString(R.string.atp_AlwaysOnModalHeading), 0)
+                binding.alwaysOnModalDescription.text = HtmlCompat.fromHtml(getString(R.string.atp_AlwaysOnModalBody), 0)
+            } else {
+                binding.alwaysOnModalHeading.text = HtmlCompat.fromHtml(getString(R.string.atp_AlwaysOnLockdownModalHeading), 0)
+                binding.alwaysOnModalDescription.text = HtmlCompat.fromHtml(getString(R.string.atp_AlwaysOnLockdownModalBody), 0)
+            }
         }
 
         configureBehavior()
@@ -93,17 +116,27 @@ class AlwaysOnAlertDialogFragment private constructor() : BottomSheetDialogFragm
         bindViewElements()
     }
 
-    fun interface Listener {
+    interface Listener {
         /**
          * Called when the user clicks on the "Go to settings" button.
          */
         fun onGoToSettingsClicked()
+
+        /** Called when the user clicks on the "Not now" button. */
+        fun onCanceled()
     }
 
     companion object {
-        fun newInstance(listener: Listener? = null): AlwaysOnAlertDialogFragment {
+        fun newAlwaysOnDialog(listener: Listener): AlwaysOnAlertDialogFragment {
             return AlwaysOnAlertDialogFragment().apply {
-                this.listener = WeakReference(listener)
+                this.listener = listener
+                this.fragmentType = FragmentType.ALWAYS_ON
+            }
+        }
+        fun newAlwaysOnLockdownDialog(listener: Listener): AlwaysOnAlertDialogFragment {
+            return AlwaysOnAlertDialogFragment().apply {
+                this.listener = listener
+                this.fragmentType = FragmentType.ALWAYS_ON_LOCKDOWN
             }
         }
     }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/alwayson/AlwaysOnLockDownDetector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/alwayson/AlwaysOnLockDownDetector.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.ui.alwayson
+
+import android.content.Context
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.ResultReceiver
+import android.text.SpannableStringBuilder
+import androidx.core.app.NotificationManagerCompat
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.utils.ConflatedJob
+import com.duckduckgo.di.scopes.VpnScope
+import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.dao.VpnServiceStateStatsDao
+import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
+import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
+import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldAlertNotificationBuilder
+import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldNotificationFactory
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+import kotlin.random.Random
+
+@ContributesMultibinding(
+    scope = VpnScope::class,
+    boundType = VpnServiceCallbacks::class
+)
+@SingleInstanceIn(VpnScope::class)
+class AlwaysOnLockDownDetector @Inject constructor(
+    private val vpnServiceStateStatsDao: VpnServiceStateStatsDao,
+    private val dispatcherProvider: DispatcherProvider,
+    private val deviceShieldAlertNotificationBuilder: DeviceShieldAlertNotificationBuilder,
+    private val context: Context,
+    private val notificationManagerCompat: NotificationManagerCompat,
+) : VpnServiceCallbacks {
+
+    private val job = ConflatedJob()
+    private val resources = context.resources
+    private val notificationId = Random.nextInt()
+
+    override fun onVpnStarted(coroutineScope: CoroutineScope) {
+        job += coroutineScope.launch(dispatcherProvider.io()) {
+            vpnServiceStateStatsDao.getStateStats()
+                .mapNotNull { it?.alwaysOnState?.alwaysOnLockedDown }
+                .distinctUntilChanged()
+                .cancellable()
+                .collect { alwaysOnLockedDown ->
+                    if (alwaysOnLockedDown) {
+                        showNotification()
+                    } else {
+                        removeNotification()
+                    }
+                }
+        }
+    }
+
+    override fun onVpnStopped(coroutineScope: CoroutineScope, vpnStopReason: VpnStateMonitor.VpnStopReason) {
+        job.cancel()
+        removeNotification()
+    }
+
+    private fun showNotification() {
+        val title = SpannableStringBuilder(resources.getString(R.string.atp_AlwaysOnLockDownNotificationTitle))
+        val notification = DeviceShieldNotificationFactory.DeviceShieldNotification(title = title)
+        deviceShieldAlertNotificationBuilder.buildAlwaysOnLockdownNotification(
+            context,
+            notification,
+            NotificationPressedHandler(),
+        ).also {
+            notificationManagerCompat.notify(notificationId, it)
+        }
+    }
+
+    private fun removeNotification() {
+        notificationManagerCompat.cancel(notificationId)
+    }
+
+    private class NotificationPressedHandler constructor() : ResultReceiver(Handler(Looper.getMainLooper())) {
+        override fun onReceiveResult(
+            resultCode: Int,
+            resultData: Bundle?
+        ) {
+            Timber.v("Lockdown notification pressed")
+        }
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldAlertNotificationBuilder.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldAlertNotificationBuilder.kt
@@ -63,7 +63,13 @@ interface DeviceShieldAlertNotificationBuilder {
     fun buildStatusNotification(
         context: Context,
         deviceShieldNotification: DeviceShieldNotificationFactory.DeviceShieldNotification,
-        onNotificationPressedCallback: ResultReceiver
+        onNotificationPressedCallback: ResultReceiver,
+    ): Notification
+
+    fun buildAlwaysOnLockdownNotification(
+        context: Context,
+        deviceShieldNotification: DeviceShieldNotificationFactory.DeviceShieldNotification,
+        onNotificationPressedCallback: ResultReceiver,
     ): Notification
 }
 
@@ -169,7 +175,7 @@ class AndroidDeviceShieldAlertNotificationBuilder constructor(
     override fun buildStatusNotification(
         context: Context,
         deviceShieldNotification: DeviceShieldNotificationFactory.DeviceShieldNotification,
-        onNotificationPressedCallback: ResultReceiver
+        onNotificationPressedCallback: ResultReceiver,
     ): Notification {
         registerAlertChannel(context)
 
@@ -179,7 +185,23 @@ class AndroidDeviceShieldAlertNotificationBuilder constructor(
         notificationLayout.setImageViewResource(R.id.deviceShieldNotificationStatusIcon, notificationImage)
         notificationLayout.setTextViewText(R.id.deviceShieldNotificationText, deviceShieldNotification.title)
 
-        return buildNotification(context, notificationLayout, onNotificationPressedCallback)
+        return buildNotification(context, notificationLayout, onNotificationPressedCallback, addReportIssueAction = true)
+    }
+
+    override fun buildAlwaysOnLockdownNotification(
+        context: Context,
+        deviceShieldNotification: DeviceShieldNotificationFactory.DeviceShieldNotification,
+        onNotificationPressedCallback: ResultReceiver,
+    ): Notification {
+        registerAlertChannel(context)
+
+        val notificationLayout = RemoteViews(context.packageName, R.layout.notification_device_shield_report)
+
+        val notificationImage = getNotificationImage(deviceShieldNotification)
+        notificationLayout.setImageViewResource(R.id.deviceShieldNotificationStatusIcon, notificationImage)
+        notificationLayout.setTextViewText(R.id.deviceShieldNotificationText, deviceShieldNotification.title)
+
+        return buildNotification(context, notificationLayout, onNotificationPressedCallback, addReportIssueAction = false)
     }
 
     private fun getNotificationImage(deviceShieldNotification: DeviceShieldNotificationFactory.DeviceShieldNotification): Int {
@@ -201,7 +223,8 @@ class AndroidDeviceShieldAlertNotificationBuilder constructor(
     private fun buildNotification(
         context: Context,
         content: RemoteViews,
-        resultReceiver: ResultReceiver? = null
+        resultReceiver: ResultReceiver? = null,
+        addReportIssueAction: Boolean
     ): Notification {
         registerAlertChannel(context)
 
@@ -220,7 +243,11 @@ class AndroidDeviceShieldAlertNotificationBuilder constructor(
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setCategory(NotificationCompat.CATEGORY_STATUS)
-            .addAction(NotificationActionReportIssue.reportIssueNotificationAction(context))
+            .apply {
+                if (addReportIssueAction) {
+                    addAction(NotificationActionReportIssue.reportIssueNotificationAction(context))
+                }
+            }
             .build()
     }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
@@ -37,6 +37,8 @@ interface VpnStore {
     fun didShowOnboarding(): Boolean
     suspend fun isAlwaysOnEnabled(): Boolean
     suspend fun vpnLastDisabledByAndroid(): Boolean
+    suspend fun increaseAlwaysOnPromotionDialogCancelCount()
+    suspend fun alwaysOnPromotionDialogCancelCount(): Int
 }
 
 @ContributesBinding(AppScope::class)
@@ -87,9 +89,19 @@ class SharedPreferencesVpnStore @Inject constructor(
         return vpnUnexpectedlyDisabled() || vpnKilledBySystem()
     }
 
+    override suspend fun increaseAlwaysOnPromotionDialogCancelCount() {
+        val count = preferences.getInt(KEY_ALWAYS_ON_PROMOTION_DIALOG_CANCEL_COUNT, 0)
+        preferences.edit(commit = true) { putInt(KEY_ALWAYS_ON_PROMOTION_DIALOG_CANCEL_COUNT, count + 1) }
+    }
+
+    override suspend fun alwaysOnPromotionDialogCancelCount(): Int {
+        return preferences.getInt(KEY_ALWAYS_ON_PROMOTION_DIALOG_CANCEL_COUNT, 0)
+    }
+
     companion object {
         private const val DEVICE_SHIELD_ONBOARDING_STORE_PREFS = "com.duckduckgo.android.atp.onboarding.store"
 
         private const val KEY_DEVICE_SHIELD_ONBOARDING_LAUNCHED = "KEY_DEVICE_SHIELD_ONBOARDING_LAUNCHED"
+        private const val KEY_ALWAYS_ON_PROMOTION_DIALOG_CANCEL_COUNT = "KEY_ALWAYS_ON_PROMOTION_DIALOG_CANCEL_COUNT"
     }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -61,9 +61,8 @@ import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTracker
 import com.google.android.material.snackbar.Snackbar
 import dummy.ui.VpnControllerActivity
 import dummy.ui.VpnDiagnosticsActivity
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
@@ -178,6 +177,7 @@ class DeviceShieldTrackerActivity :
             .commitNow()
     }
 
+    @OptIn(FlowPreview::class)
     private fun observeViewModel() {
         lifecycleScope.launch {
             viewModel.getBlockedTrackersCount()
@@ -189,6 +189,18 @@ class DeviceShieldTrackerActivity :
                 }
                 .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
                 .collect { renderViewState(it) }
+        }
+
+        lifecycleScope.launch {
+            // This is a one-shot check as soon as the screen is shown
+            viewModel.getRunningState()
+                .map { it.alwaysOnState }
+                .debounce(500) // give a bit of time so that pop doesn't just suddenly pops up
+                .take(1)
+                .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+                .collect {
+                    viewModel.onViewEvent(ViewEvent.AlwaysOnInitialState(it))
+                }
         }
 
         viewModel.commands()
@@ -229,6 +241,7 @@ class DeviceShieldTrackerActivity :
             is DeviceShieldTrackerActivityViewModel.Command.ShowVpnConflictDialog -> launchVPNConflictDialog(false)
             is DeviceShieldTrackerActivityViewModel.Command.ShowVpnAlwaysOnConflictDialog -> launchVPNConflictDialog(true)
             is DeviceShieldTrackerActivityViewModel.Command.ShowAlwaysOnPromotionDialog -> launchAlwaysOnPromotionDialog()
+            is DeviceShieldTrackerActivityViewModel.Command.ShowAlwaysOnLockdownWarningDialog -> launchAlwaysOnLockdownEnabledDialog()
             is DeviceShieldTrackerActivityViewModel.Command.VPNPermissionNotGranted -> quietlyToggleAppTpSwitch(false)
             is DeviceShieldTrackerActivityViewModel.Command.ShowRemoveFeatureConfirmationDialog -> launchRemoveFeatureConfirmationDialog()
             is DeviceShieldTrackerActivityViewModel.Command.CloseScreen -> finish()
@@ -275,11 +288,39 @@ class DeviceShieldTrackerActivity :
     }
 
     private fun launchAlwaysOnPromotionDialog() {
-        val dialog = AlwaysOnAlertDialogFragment.newInstance { viewModel.onViewEvent(ViewEvent.PromoteAlwaysOnOpenSettings) }
-        dialog.show(
-            supportFragmentManager,
-            TAG_APPTP_PROMOTE_ALWAYS_ON_DIALOG
-        )
+        val dialog = supportFragmentManager.findFragmentByTag(TAG_APPTP_PROMOTE_ALWAYS_ON_DIALOG) as? AlwaysOnAlertDialogFragment
+        dialog?.dismiss()
+
+        AlwaysOnAlertDialogFragment.newAlwaysOnDialog(
+            object : AlwaysOnAlertDialogFragment.Listener {
+                override fun onGoToSettingsClicked() {
+                    viewModel.onViewEvent(ViewEvent.PromoteAlwaysOnOpenSettings)
+                }
+
+                override fun onCanceled() {
+                    viewModel.onViewEvent(ViewEvent.PromoteAlwaysOnCancelled)
+                }
+            }
+        ).show(supportFragmentManager, TAG_APPTP_PROMOTE_ALWAYS_ON_DIALOG)
+    }
+
+    private fun launchAlwaysOnLockdownEnabledDialog() {
+        val dialog = supportFragmentManager.findFragmentByTag(TAG_APPTP_PROMOTE_ALWAYS_ON_DIALOG) as? AlwaysOnAlertDialogFragment
+        dialog?.dismiss()
+
+        AlwaysOnAlertDialogFragment.newAlwaysOnLockdownDialog(
+            object : AlwaysOnAlertDialogFragment.Listener {
+                override fun onGoToSettingsClicked() {
+                    Timber.d("aitor: onGoToSettingsClicked")
+                    viewModel.onViewEvent(ViewEvent.PromoteAlwaysOnOpenSettings)
+                }
+
+                override fun onCanceled() {
+                    Timber.d("aitor: onCanceled")
+                    viewModel.onViewEvent(ViewEvent.PromoteAlwaysOnCancelled)
+                }
+            }
+        ).show(supportFragmentManager, TAG_APPTP_PROMOTE_ALWAYS_ON_DIALOG)
     }
 
     override fun onOpenAppProtection() {

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/content_vpn_always_on_alert.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/content_vpn_always_on_alert.xml
@@ -54,6 +54,7 @@
     >
 
         <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+            android:id="@+id/alwaysOnModalHeading"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="24dp"

--- a/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
@@ -229,8 +229,11 @@
     <string name="atp_ActivityRemoveFeature">Disable and Delete Data</string>
 
     <string name="atp_AlwaysOnModalBody"><![CDATA[Go to your device’s VPN Settings for DuckDuckGo and enable <b>Always-on</b> VPN to prevent Android disabling protection.\n\nMake sure to leave the other setting OFF.]]></string>
+    <string name="atp_AlwaysOnLockdownModalBody"><![CDATA[To avoid app issues, go to your device\'s <b>VPN Settings for DuckDuckGo</b> and disable <b>Block connections without VPN</b>]]></string>
     <string name="atp_AlwaysOnModalHeading">Set to Always-on</string>
+    <string name="atp_AlwaysOnLockdownModalHeading">Change your VPN settings</string>
     <string name="atp_AlwaysOnLockDownEnabled"><b>Action required.</b> To avoid app issues, you need to change your Android settings. <annotation type="open_settings_link">Change settings</annotation></string>
+    <string name="atp_AlwaysOnLockDownNotificationTitle">Action required! An Android setting needs to be changed for App Tracking Protection.</string>
 
     <!--  App Tracking Protection FAQ -->
     <string name="atp_FAQActivityTitle">FAQ</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

https://app.asana.com/0/0/1203149173362393

### Description
This stacked PR implements the notification triggered when detecting always-on lockdown mode. As per [figma](https://www.figma.com/file/yJqzxIICeXw6F8co5uffnX/AppTP-%3A-Re-think-Always-on-Promotion?node-id=1202%3A56156)


The logic is the following:
* When we detect the user sets the lockdown mode we'll trigger a notification so that user can take action
* Tapping on notification takes the user to AppTP activity screen
* AppTP activity screen will show the bottom sheet dialog
* If rather than tapping on the notification, the user opens the app and goes to AppTP activity screen, bottom sheet dialog should also be shown
* If the user selects "Not now" in the bottom sheet dialog 3 times, we won't show the sheet anymore

Main things that changed:
* `incrementalPeriodicChecks` for lockdown configuration, factor went from 1.1 to 1.05
* Added `onCanceled` listener function to the `AlwaysOnAlertDialogFragment` listener so that we can notify caller when user presses "not now"
* Added `AlwaysOnLockDownDetector` that subscribes to changes in the VPN state and triggers the notification

### Steps to test this PR

_Test notification_
- [ ] install from this branch and enable AppTP
- [ ] enable always-on and lockdown model from Android settings
- [ ] verify the notification pops with "Action required!" warning
- [ ] tap on the notification
- [ ] verify bottom sheet notification pops
- [ ] tap on go to settings
- [ ] verify user is taken to settings and disable lockdown
- [ ] go back to AppTP activity screen
- [ ] verify bottom sheet is gone, and info panel is blue showing "The feature is in beta..." message

_Test AppTP activity screen_
- [ ] enable AppTP
- [ ] go to android settings and enable lockdown
- [ ] back to AppTP activity screen
- [ ] verify bottom sheet notification pops
- [ ] dismiss notification
- [ ] verify info panel is yellow and shows "Action required..." message
- [ ] go to settings and disable lockdown
- [ ] back to AppTP activity screen
- [ ] verify info panel is blue showing "The feature is in beta..." message and bottom sheet doesn't show


_Test Not now_
- [ ] enable AppTP
- [ ] go to android settings and enable lockdown
- [ ] back to AppTP activity screen
- [ ] tap on "not now" in the bottom sheet
- [ ] home app and back to AppTP activity screen
- [ ] back to AppTP activity screen
- [ ] tap on "not now" in the bottom sheet
- [ ] home app and back to AppTP activity screen
- [ ] back to AppTP activity screen
- [ ] tap on "not now" in the bottom sheet
- [ ] home app and back to AppTP activity screen
- [ ] back to AppTP activity screen
- [ ] verify bottom sheet doesn't appear

