### PR TITLE
Align autofill pixels with iOS

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/pixel/AutofillPixelNames.kt
@@ -23,6 +23,10 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_SAVE_LOGIN_PROMPT_DISMISSED("m_autofill_logins_save_login_inline_dismissed"),
     AUTOFILL_SAVE_LOGIN_PROMPT_SAVED("m_autofill_logins_save_login_inline_confirmed"),
 
+    AUTOFILL_SAVE_PASSWORD_PROMPT_SHOWN("m_autofill_logins_save_password_inline_displayed"),
+    AUTOFILL_SAVE_PASSWORD_PROMPT_DISMISSED("m_autofill_logins_save_password_inline_dismissed"),
+    AUTOFILL_SAVE_PASSWORD_PROMPT_SAVED("m_autofill_logins_save_password_inline_confirmed"),
+
     AUTOFILL_UPDATE_LOGIN_PROMPT_SHOWN("m_autofill_logins_update_password_inline_displayed"),
     AUTOFILL_UPDATE_LOGIN_PROMPT_DISMISSED("m_autofill_logins_update_password_inline_dismissed"),
     AUTOFILL_UPDATE_LOGIN_PROMPT_SAVED("m_autofill_logins_update_password_inline_confirmed"),
@@ -35,15 +39,10 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_SELECT_LOGIN_AUTOPROMPT_DISMISSED("m_autofill_logins_autoprompt_dismissed"),
     AUTOFILL_SELECT_LOGIN_AUTOPROMPT_SELECTED("m_autofill_logins_fill_login_inline_autoprompt_confirmed"),
 
-    AUTOFILL_AUTHENTICATION_TO_AUTOFILL_SHOWN("m_autofill_authentication_to_autofill_shown"),
-    AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_SUCCESSFUL("m_autofill_authentication_to_autofill_success"),
-    AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_FAILURE("m_autofill_authentication_to_autofill_failure"),
-    AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_CANCELLED("m_autofill_authentication_to_autofill_cancelled"),
-
-    AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_SHOWN("m_autofill_authentication_to_creds_management_shown"),
-    AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_SUCCESSFUL("m_autofill_authentication_to_creds_management_success"),
-    AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_FAILURE("m_autofill_authentication_to_creds_management_failure"),
-    AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_CANCELLED("m_autofill_authentication_to_creds_management_cancelled"),
+    AUTOFILL_AUTHENTICATION_TO_AUTOFILL_SHOWN("m_autofill_logins_fill_login_inline_authentication_device-displayed"),
+    AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_SUCCESSFUL("m_autofill_logins_fill_login_inline_authentication_device-auth_authenticated"),
+    AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_FAILURE("m_autofill_logins_fill_login_inline_authentication_device-auth_failed"),
+    AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_CANCELLED("m_autofill_logins_fill_login_inline_authentication_device-auth_cancelled"),
 
     AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SHOWN("m_autofill_logins_save_disable-prompt_shown"),
     AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_KEEP_USING("m_autofill_logins_save_disable-prompt_autofill-kept"),

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
@@ -29,13 +29,20 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ActivityAutofillSettingsBinding
-import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_CANCELLED
-import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_FAILURE
-import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_SHOWN
-import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_SUCCESSFUL
 import com.duckduckgo.autofill.ui.AutofillSettingsActivityLauncher
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.*
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.*
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ExitCredentialMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ExitDisabledMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ExitListMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ExitLockedMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.LaunchDeviceAuth
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowCredentialMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowDisabledMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowLockedMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowUserPasswordCopied
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowUserUsernameCopied
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Editing
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.NotInCredentialMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Viewing
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementCredentialsMode
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementDisabledMode
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementListMode
@@ -101,7 +108,6 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
         if (deviceAuthenticator.hasValidDeviceAuthentication()) {
             viewModel.lock()
 
-            pixel.fire(AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_SHOWN)
             deviceAuthenticator.authenticate(AUTOFILL, this) {
                 when (it) {
                     Success -> onAuthenticationSuccessful()
@@ -116,17 +122,14 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
     }
 
     private fun onAuthenticationSuccessful() {
-        pixel.fire(AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_SUCCESSFUL)
         viewModel.unlock()
     }
 
     private fun onAuthenticationCancelled() {
-        pixel.fire(AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_CANCELLED)
         finish()
     }
 
     private fun onAuthenticationError() {
-        pixel.fire(AUTOFILL_AUTHENTICATION_TO_CREDENTIAL_MANAGEMENT_FAILURE)
         finish()
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingPixelEventNamesTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingPixelEventNamesTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.saving
+
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_SAVE_LOGIN_PROMPT_DISMISSED
+import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_SAVE_LOGIN_PROMPT_SAVED
+import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_SAVE_LOGIN_PROMPT_SHOWN
+import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_SAVE_PASSWORD_PROMPT_DISMISSED
+import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_SAVE_PASSWORD_PROMPT_SAVED
+import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_SAVE_PASSWORD_PROMPT_SHOWN
+import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment.AutofillSavingPixelEventNames.Companion.pixelNameDialogAccepted
+import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment.AutofillSavingPixelEventNames.Companion.pixelNameDialogDismissed
+import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment.AutofillSavingPixelEventNames.Companion.pixelNameDialogShown
+import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment.AutofillSavingPixelEventNames.Companion.saveType
+import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment.CredentialSaveType.PasswordOnly
+import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment.CredentialSaveType.UsernameAndPassword
+import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment.CredentialSaveType.UsernameOnly
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AutofillSavingPixelEventNamesTest {
+
+    @Test
+    fun whenSavingAcceptedWithUsernameAndPasswordThenCorrectPixelUsed() {
+        assertEquals(pixelNameDialogAccepted(UsernameAndPassword), AUTOFILL_SAVE_LOGIN_PROMPT_SAVED)
+    }
+
+    @Test
+    fun whenSavingAcceptedWithPasswordOnlyThenCorrectPixelUsed() {
+        assertEquals(pixelNameDialogAccepted(PasswordOnly), AUTOFILL_SAVE_PASSWORD_PROMPT_SAVED)
+    }
+
+    @Test
+    fun whenDialogShownWithUsernameAndPasswordThenCorrectPixelUsed() {
+        assertEquals(pixelNameDialogShown(UsernameAndPassword), AUTOFILL_SAVE_LOGIN_PROMPT_SHOWN)
+    }
+
+    @Test
+    fun whenDialogShownWithPasswordOnlyThenCorrectPixelUsed() {
+        assertEquals(pixelNameDialogShown(PasswordOnly), AUTOFILL_SAVE_PASSWORD_PROMPT_SHOWN)
+    }
+
+    @Test
+    fun whenDialogDismissedWithUsernameAndPasswordThenCorrectPixelUsed() {
+        assertEquals(pixelNameDialogDismissed(UsernameAndPassword), AUTOFILL_SAVE_LOGIN_PROMPT_DISMISSED)
+    }
+
+    @Test
+    fun whenDialogDismissedWithPasswordOnlyThenCorrectPixelUsed() {
+        assertEquals(pixelNameDialogDismissed(PasswordOnly), AUTOFILL_SAVE_PASSWORD_PROMPT_DISMISSED)
+    }
+
+    @Test
+    fun whenUsernameAndPasswordProvidedThenSaveTypeIsUsernameAndPassword() {
+        val loginCredentials = loginCredentials(username = "username", password = "password")
+        assertEquals(loginCredentials.saveType(), UsernameAndPassword)
+    }
+
+    @Test
+    fun whenUsernameOnlyProvidedThenSaveTypeIsUsernameOnly() {
+        val loginCredentials = loginCredentials(username = "username", password = null)
+        assertEquals(loginCredentials.saveType(), UsernameOnly)
+    }
+
+    @Test
+    fun whenPassworldOnlyProvidedThenSaveTypeIsUsernameOnly() {
+        val loginCredentials = loginCredentials(username = null, password = "password")
+        assertEquals(loginCredentials.saveType(), PasswordOnly)
+    }
+
+    private fun loginCredentials(username: String? = null, password: String? = null): LoginCredentials {
+        return LoginCredentials(id = 0, domain = "example.com", username = username, password = password)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203201174202056/f

### Description
When saving credentials, we want separate pixels for each of the following scenarios:
- User is saving just a password
- User is saving both a username + password
- (saving only username is yet not supported)

### Steps to test this PR

#### Testing username plus password

Ensure testing on a site where both username and password are correctly picked up (e.g., trello.com/login)

- [ ] trigger a login, and accept the the offer to save credentials. verify pixels as expected for showing and accepting
    - `AUTOFILL_SAVE_LOGIN_PROMPT_SHOWN`
    - `AUTOFILL_SAVE_LOGIN_PROMPT_SAVED`
- [ ] trigger a login, and decline the offer. verify pixels as expected for showing and dismissing 
    - `AUTOFILL_SAVE_LOGIN_PROMPT_SHOWN`
    - `AUTOFILL_SAVE_LOGIN_PROMPT_DISMISSED`


#### Testing just a password

Easiest way to test is to hardcode the credentials parsed in `AutofillStoredBackJavascriptInterface.storeFormData` to only contain a password + `null` username.

- [x] trigger a login, and accept the offer to save password. verify pixels as expected for showing and accepting
    - `AUTOFILL_SAVE_PASSWORD_PROMPT_SHOWN`
    - `AUTOFILL_SAVE_PASSWORD_PROMPT_SAVED`
- [x] trigger a login, and decline the offer. verify pixels as expected for showing and dismissing 
    - `AUTOFILL_SAVE_PASSWORD_PROMPT_SHOWN`
    - `AUTOFILL_SAVE_PASSWORD_PROMPT_DISMISSED`


