### PR TITLE
Support updating username when matching password provided

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -124,6 +124,7 @@ import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.trackerdetection.model.TrackerType
 import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
+import com.duckduckgo.autofill.CredentialUpdateExistingCredentialsDialog.CredentialUpdateType
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.downloads.api.DownloadStateListener
@@ -4205,9 +4206,9 @@ class BrowserTabViewModelTest {
             username = "tester",
             password = "test123"
         )
-        testee.updateCredentials(url, credentials)
+        testee.updateCredentials(url, credentials, CredentialUpdateType.Password)
 
-        verify(mockAutofillStore).updateCredentials(url, credentials)
+        verify(mockAutofillStore).updateCredentials(url, credentials, CredentialUpdateType.Password)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -487,7 +487,8 @@ class BrowserTabFragment :
 
             when (existingCredentialMatchDetector.determine(currentUrl, username, password)) {
                 ExactMatch -> Timber.w("Credentials already exist for %s", currentUrl)
-                UsernameMatch -> showAutofillDialogUpdateCredentials(currentUrl, credentials)
+                UsernameMatch -> showAutofillDialogUpdatePassword(currentUrl, credentials)
+                UsernameMissing -> showAutofillDialogUpdateUsername(currentUrl, credentials)
                 NoMatch -> showAutofillDialogSaveCredentials(currentUrl, credentials)
                 UrlOnlyMatch -> showAutofillDialogSaveCredentials(currentUrl, credentials)
             }
@@ -1684,11 +1685,19 @@ class BrowserTabFragment :
         showDialogHidingPrevious(dialog, CredentialSavePickerDialog.TAG)
     }
 
-    private fun showAutofillDialogUpdateCredentials(currentUrl: String, credentials: LoginCredentials) {
+    private fun showAutofillDialogUpdatePassword(currentUrl: String, credentials: LoginCredentials) {
         val url = webView?.url ?: return
         if (url != currentUrl) return
 
-        val dialog = credentialAutofillDialogFactory.autofillSavingUpdateCredentialsDialog(url, credentials, tabId)
+        val dialog = credentialAutofillDialogFactory.autofillSavingUpdatePasswordDialog(url, credentials, tabId)
+        showDialogHidingPrevious(dialog, CredentialUpdateExistingCredentialsDialog.TAG)
+    }
+
+    private fun showAutofillDialogUpdateUsername(currentUrl: String, credentials: LoginCredentials) {
+        val url = webView?.url ?: return
+        if (url != currentUrl) return
+
+        val dialog = credentialAutofillDialogFactory.autofillSavingUpdateUsernameDialog(url, credentials, tabId)
         showDialogHidingPrevious(dialog, CredentialUpdateExistingCredentialsDialog.TAG)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -114,6 +114,7 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.usage.search.SearchCountDao
+import com.duckduckgo.autofill.CredentialUpdateExistingCredentialsDialog.CredentialUpdateType
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.di.scopes.FragmentScope
@@ -2745,9 +2746,13 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    override suspend fun updateCredentials(url: String, credentials: LoginCredentials): LoginCredentials? {
+    override suspend fun updateCredentials(
+        url: String,
+        credentials: LoginCredentials,
+        updateType: CredentialUpdateType
+    ): LoginCredentials? {
         return withContext(appCoroutineScope.coroutineContext) {
-            autofillStore.updateCredentials(url, credentials)
+            autofillStore.updateCredentials(url, credentials, updateType)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandler.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.CredentialAutofillPickerDialog
 import com.duckduckgo.autofill.CredentialSavePickerDialog
 import com.duckduckgo.autofill.CredentialUpdateExistingCredentialsDialog
+import com.duckduckgo.autofill.CredentialUpdateExistingCredentialsDialog.CredentialUpdateType
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.pixel.AutofillPixelNames
 import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_CANCELLED
@@ -152,7 +153,9 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(
     ): LoginCredentials? {
         val selectedCredentials = result.getParcelable<LoginCredentials>(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIALS) ?: return null
         val originalUrl = result.getString(CredentialUpdateExistingCredentialsDialog.KEY_URL) ?: return null
-        return credentialSaver.updateCredentials(originalUrl, selectedCredentials)
+        val updateType =
+            result.getParcelable<CredentialUpdateType>(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIAL_UPDATE_TYPE) ?: return null
+        return credentialSaver.updateCredentials(originalUrl, selectedCredentials, updateType)
     }
 
     private suspend fun refreshCurrentWebPageToDisableAutofill(viewModel: BrowserTabViewModel) {
@@ -178,7 +181,8 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(
 
         suspend fun updateCredentials(
             url: String,
-            credentials: LoginCredentials
+            credentials: LoginCredentials,
+            updateType: CredentialUpdateType
         ): LoginCredentials?
     }
 }

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/AutofillCredentialDialogs.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/AutofillCredentialDialogs.kt
@@ -16,9 +16,11 @@
 
 package com.duckduckgo.autofill
 
+import android.os.Parcelable
 import androidx.fragment.app.DialogFragment
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.domain.app.LoginTriggerType
+import kotlinx.parcelize.Parcelize
 
 /**
  * Dialog which can be shown when user is required to select which saved credential to autofill
@@ -59,6 +61,16 @@ interface CredentialSavePickerDialog {
  */
 interface CredentialUpdateExistingCredentialsDialog {
 
+    @Parcelize
+    sealed interface CredentialUpdateType : Parcelable {
+
+        @Parcelize
+        object Username : CredentialUpdateType
+
+        @Parcelize
+        object Password : CredentialUpdateType
+    }
+
     companion object {
         fun resultKey(tabId: String) = "$tabId/CredentialUpdateExistingCredentialsResult"
 
@@ -66,6 +78,7 @@ interface CredentialUpdateExistingCredentialsDialog {
         const val KEY_URL = "url"
         const val KEY_CREDENTIALS = "credentials"
         const val KEY_TAB_ID = "tabId"
+        const val KEY_CREDENTIAL_UPDATE_TYPE = "updateType"
     }
 }
 
@@ -87,7 +100,13 @@ interface CredentialAutofillDialogFactory {
         tabId: String
     ): DialogFragment
 
-    fun autofillSavingUpdateCredentialsDialog(
+    fun autofillSavingUpdatePasswordDialog(
+        url: String,
+        credentials: LoginCredentials,
+        tabId: String
+    ): DialogFragment
+
+    fun autofillSavingUpdateUsernameDialog(
         url: String,
         credentials: LoginCredentials,
         tabId: String

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.store
 
+import com.duckduckgo.autofill.CredentialUpdateExistingCredentialsDialog.CredentialUpdateType
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import kotlinx.coroutines.flow.Flow
 
@@ -77,9 +78,10 @@ interface AutofillStore {
      * Updates the credentials saved for the given URL
      * @param rawUrl Can be a full, unmodified URL taken from the URL bar (containing subdomains, query params etc...)
      * @param credentials The credentials to be updated. The ID can be null.
+     * @param updateType The type of update to perform, whether updating the username or password.
      * @return The saved credential if it saved successfully, otherwise null
      */
-    suspend fun updateCredentials(rawUrl: String, credentials: LoginCredentials): LoginCredentials?
+    suspend fun updateCredentials(rawUrl: String, credentials: LoginCredentials, updateType: CredentialUpdateType): LoginCredentials?
 
     /**
      * Returns the full list of stored login credentials
@@ -113,6 +115,7 @@ interface AutofillStore {
         object ExactMatch : ContainsCredentialsResult
         object UsernameMatch : ContainsCredentialsResult
         object UrlOnlyMatch : ContainsCredentialsResult
+        object UsernameMissing : ContainsCredentialsResult
         object NoMatch : ContainsCredentialsResult
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/CredentialAutofillDialogAndroidFactory.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/CredentialAutofillDialogAndroidFactory.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.ui
 
 import androidx.fragment.app.DialogFragment
 import com.duckduckgo.autofill.CredentialAutofillDialogFactory
+import com.duckduckgo.autofill.CredentialUpdateExistingCredentialsDialog.CredentialUpdateType
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.ui.credential.saving.AutofillSavingCredentialsDialogFragment
@@ -47,11 +48,19 @@ class CredentialAutofillDialogAndroidFactory @Inject constructor() : CredentialA
         return AutofillSavingCredentialsDialogFragment.instance(url, credentials, tabId)
     }
 
-    override fun autofillSavingUpdateCredentialsDialog(
+    override fun autofillSavingUpdatePasswordDialog(
         url: String,
         credentials: LoginCredentials,
         tabId: String
     ): DialogFragment {
-        return AutofillUpdatingExistingCredentialsDialogFragment.instance(url, credentials, tabId)
+        return AutofillUpdatingExistingCredentialsDialogFragment.instance(url, credentials, tabId, CredentialUpdateType.Password)
+    }
+
+    override fun autofillSavingUpdateUsernameDialog(
+        url: String,
+        credentials: LoginCredentials,
+        tabId: String
+    ): DialogFragment {
+        return AutofillUpdatingExistingCredentialsDialogFragment.instance(url, credentials, tabId, CredentialUpdateType.Username)
     }
 }

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
@@ -59,7 +59,7 @@
         app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer" />
 
     <TextView
-        android:id="@+id/passwordOutline"
+        android:id="@+id/updatedFieldPreview"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
@@ -69,20 +69,20 @@
         android:textAlignment="center"
         android:textColor="?attr/normalTextColor"
         android:textSize="14sp"
-        app:layout_constraintEnd_toEndOf="@id/updatePasswordButton"
-        app:layout_constraintStart_toStartOf="@id/updatePasswordButton"
+        app:layout_constraintEnd_toEndOf="@id/updateCredentialsButton"
+        app:layout_constraintStart_toStartOf="@id/updateCredentialsButton"
         app:layout_constraintTop_toBottomOf="@id/dialogTitle"
         tools:text="•••••••" />
 
     <com.duckduckgo.mobile.android.ui.view.button.ButtonPrimaryLowercase
-        android:id="@+id/updatePasswordButton"
+        android:id="@+id/updateCredentialsButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
         android:text="@string/updateLoginDialogButtonUpdatePassword"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/passwordOutline"
+        app:layout_constraintTop_toBottomOf="@id/updatedFieldPreview"
         app:layout_constraintWidth_percent="0.8" />
 
     <com.duckduckgo.mobile.android.ui.view.button.ButtonSecondaryLarge
@@ -91,8 +91,8 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         android:text="@string/updateLoginDialogButtonNotNow"
-        app:layout_constraintEnd_toEndOf="@id/updatePasswordButton"
-        app:layout_constraintStart_toStartOf="@id/updatePasswordButton"
-        app:layout_constraintTop_toBottomOf="@id/updatePasswordButton" />
+        app:layout_constraintEnd_toEndOf="@id/updateCredentialsButton"
+        app:layout_constraintStart_toStartOf="@id/updateCredentialsButton"
+        app:layout_constraintTop_toBottomOf="@id/updateCredentialsButton" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2022 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="updateLoginDialogTitleUpdateUsername">Update Username?</string>
+    <string name="updateLoginDialogButtonUpdateUsername">Update Username</string>
+</resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203058117400612/f

### Description
Detects when a saved login is missing a username, and offers to save the username when logging in again (when a matching password is included)

### Steps to test this PR

#### Updating usernames for same site
- [x] Save 3 logins for the same site, **using the same password for each** (different usernames)
- [x] Edit one of the logins: remove the username
- [x] Save a few other logins for the same site using different usernames and passwords
- [x] Refresh the login page and refuse any offers to autofill
- [x] Login using a unique username with the same password from step 1
- [x] Verify it offers you to update your username, but choose not to
- [x] Login using a unique username with the same password from step 1
- [x] This time, accept its offer to update your username
- [x] Visit autofill logins in settings and verify the username was updated for only the entry which matched this password but was missing the username

#### No updating usernames for a different site
- [x] Clear all autofill entries
- [x] Add a saved login for a site and remove its username manually
- [x] Visit another site and attempt a login using the same password from above
- [x] Verify you are not offered to update the username

#### Updating password
- [x] Clear all autofill entries
- [x] Add a saved login for a site
- [x] Revisit login page and attempt a login using the same username as before. 
- [x] Verify you are prompted to update password. Say not now, and verify the password wasn't updated
- [x] Revisit login page and attempt a login using the same username as before. 
- [x] Verify you are prompted to update password. Agree, and verify the password was updated correctly

<img src=https://user-images.githubusercontent.com/1336281/196967856-78f08094-ea84-475b-bab4-33b68c32e579.png width=50%>

<img src=https://user-images.githubusercontent.com/1336281/196969423-9a8a89c1-1d70-4a24-918d-798209a4e988.png width=50%>


