### PR TITLE
Add rule to detect hardcoded coroutine dispatchers

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DataRemovalAdClickWorker.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DataRemovalAdClickWorker.kt
@@ -28,9 +28,9 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
@@ -43,8 +43,11 @@ class DataRemovalAdClickWorker(context: Context, workerParameters: WorkerParamet
     @Inject
     lateinit var adClickManager: AdClickManager
 
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
+
     override suspend fun doWork(): Result {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io()) {
             adClickManager.clearAllExpiredAsync()
 
             return@withContext Result.success()

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorker.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorker.kt
@@ -27,9 +27,9 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
@@ -42,8 +42,11 @@ class AdClickDailyReportingWorker(context: Context, workerParameters: WorkerPara
     @Inject
     lateinit var adClickPixels: AdClickPixels
 
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
+
     override suspend fun doWork(): Result {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io()) {
             adClickPixels.fireCountPixel(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION)
             return@withContext Result.success()
         }

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/DataRemovalAdClickWorkerTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/DataRemovalAdClickWorkerTest.kt
@@ -50,6 +50,7 @@ class DataRemovalAdClickWorkerTest {
         runTest {
             val worker = TestListenableWorkerBuilder<DataRemovalAdClickWorker>(context = context).build()
             worker.adClickManager = mockAdClickManager
+            worker.dispatchers = coroutineRule.testDispatcherProvider
 
             val result = worker.doWork()
 

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorkerTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorkerTest.kt
@@ -49,6 +49,7 @@ internal class AdClickDailyReportingWorkerTest {
         runTest {
             val worker = TestListenableWorkerBuilder<AdClickDailyReportingWorker>(context = context).build()
             worker.adClickPixels = mockAdClickPixels
+            worker.dispatchers = coroutineRule.testDispatcherProvider
 
             val result = worker.doWork()
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerExclusionListUpdateWorker.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerExclusionListUpdateWorker.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
@@ -29,7 +30,6 @@ import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExclusionListMetadata
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerSystemAppOverrideListMetadata
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
@@ -44,10 +44,13 @@ class AppTrackerExclusionListUpdateWorker(
     lateinit var appTrackerListDownloader: AppTrackerListDownloader
     @Inject
     lateinit var vpnDatabase: VpnDatabase
-    @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
+    @Inject
+    lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     override suspend fun doWork(): Result {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io()) {
             val exclusionListResult = updateExclusionList()
             val sysAppOverridesListResult = updateSystemAppOverrides()
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListUpdateWorker.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListUpdateWorker.kt
@@ -27,6 +27,7 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExceptionRuleMetadata
@@ -34,7 +35,6 @@ import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerMetadata
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -45,9 +45,11 @@ class AppTrackerListUpdateWorker(context: Context, workerParameters: WorkerParam
     lateinit var appTrackerListDownloader: AppTrackerListDownloader
     @Inject
     lateinit var vpnDatabase: VpnDatabase
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     override suspend fun doWork(): Result {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io()) {
             val updateBlocklistResult = updateTrackerBlocklist()
             val updateRulesResult = updateTrackerExceptionRules()
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
@@ -24,13 +24,13 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.di.VpnCoroutineScope
 import com.duckduckgo.mobile.android.vpn.ui.notification.*
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -73,7 +73,8 @@ class DeviceShieldNotificationsDebugReceiverRegister @Inject constructor(
     private val weeklyNotificationPressedHandler: WeeklyNotificationPressedHandler,
     private val dailyNotificationPressedHandler: DailyNotificationPressedHandler,
     private val deviceShieldAlertNotificationBuilder: DeviceShieldAlertNotificationBuilder,
-    @VpnCoroutineScope private val vpnCoroutineScope: CoroutineScope
+    @VpnCoroutineScope private val vpnCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider
 ) : DefaultLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
@@ -88,7 +89,7 @@ class DeviceShieldNotificationsDebugReceiverRegister @Inject constructor(
             val weekly = kotlin.runCatching { intent.getStringExtra("weekly")?.toInt() }.getOrNull()
             val daily = kotlin.runCatching { intent.getStringExtra("daily")?.toInt() }.getOrNull()
 
-            vpnCoroutineScope.launch(Dispatchers.IO) {
+            vpnCoroutineScope.launch(dispatchers.io()) {
                 val notification = if (weekly != null) {
                     Timber.v("Debug - Sending weekly notification $weekly")
                     weeklyNotificationPressedHandler.notificationVariant = weekly

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
@@ -20,6 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
@@ -31,7 +32,6 @@ import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.threeten.bp.LocalDateTime
@@ -55,6 +55,7 @@ class SendTrackerDebugReceiver @Inject constructor(
     private val context: Context,
     private val appBuildConfig: AppBuildConfig,
     private val vpnDatabase: VpnDatabase,
+    private val dispatchers: DispatcherProvider
 ) : BroadcastReceiver(), VpnServiceCallbacks {
 
     private fun register() {
@@ -73,7 +74,7 @@ class SendTrackerDebugReceiver @Inject constructor(
     }
 
     fun handleIntent(intent: Intent) {
-        GlobalScope.launch(Dispatchers.IO) {
+        GlobalScope.launch(dispatchers.io()) {
             val times = intent.getStringExtra("times")?.toInt() ?: 1
             val hoursAgo = intent.getStringExtra("hago")?.toLong() ?: 0L
             Timber.i("Inserting %d trackers into the DB", times)

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/DeviceShieldTileService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/DeviceShieldTileService.kt
@@ -26,6 +26,7 @@ import android.service.quicksettings.TileService
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.QuickSettingsScope
@@ -53,9 +54,10 @@ class DeviceShieldTileService : TileService() {
     @Inject lateinit var deviceShieldPixels: DeviceShieldPixels
     @Inject lateinit var repository: AtpWaitlistStateRepository
     @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
+    @Inject lateinit var dispatchers: DispatcherProvider
 
     private var deviceShieldStatePollingJob = ConflatedJob()
-    private val serviceScope = CoroutineScope(Dispatchers.IO)
+    private val serviceScope = CoroutineScope(dispatchers.io())
 
     override fun onCreate() {
         super.onCreate()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -54,6 +54,8 @@ import timber.log.Timber
 import java.net.Inet4Address
 import java.net.InetAddress
 import javax.inject.Inject
+
+@Suppress("NoHardcodedCoroutineDispatcher")
 @InjectWith(VpnScope::class)
 class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnReminderReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnReminderReceiver.kt
@@ -63,6 +63,7 @@ class VpnReminderReceiver : BroadcastReceiver() {
     }
 }
 
+@Suppress("NoHardcodedCoroutineDispatcher")
 fun goAsync(
     pendingResult: BroadcastReceiver.PendingResult?,
     coroutineScope: CoroutineScope = GlobalScope,

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepository.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepository.kt
@@ -17,13 +17,13 @@
 package com.duckduckgo.mobile.android.vpn.stats
 
 import androidx.annotation.WorkerThread
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.mobile.android.vpn.dao.VpnPhoenixEntity
 import com.duckduckgo.mobile.android.vpn.model.*
 import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import org.threeten.bp.LocalDateTime
 import java.util.concurrent.TimeUnit
@@ -85,7 +85,8 @@ interface AppTrackerBlockingStatsRepository {
 
 @ContributesBinding(AppScope::class)
 class RealAppTrackerBlockingStatsRepository @Inject constructor(
-    val vpnDatabase: VpnDatabase
+    val vpnDatabase: VpnDatabase,
+    private val dispatchers: DispatcherProvider
 ) : AppTrackerBlockingStatsRepository {
 
     private val trackerDao = vpnDatabase.vpnTrackerDao()
@@ -100,7 +101,7 @@ class RealAppTrackerBlockingStatsRepository @Inject constructor(
             .conflate()
             .distinctUntilChanged()
             .map { it.filter { tracker -> tracker.timestamp >= startTime() } }
-            .flowOn(Dispatchers.Default)
+            .flowOn(dispatchers.default())
     }
 
     @WorkerThread
@@ -140,7 +141,7 @@ class RealAppTrackerBlockingStatsRepository @Inject constructor(
             .transform { runningTimes ->
                 emit(runningTimes.sumOf { it.timeRunningMillis })
             }
-            .flowOn(Dispatchers.Default)
+            .flowOn(dispatchers.default())
     }
 
     @WorkerThread

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyDetailsAdapter.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyDetailsAdapter.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.*
 
+@Suppress("NoHardcodedCoroutineDispatcher")
 class AppTPCompanyDetailsAdapter : RecyclerView.Adapter<AppTPCompanyDetailsAdapter.CompanyDetailsViewHolder>() {
 
     private val items = mutableListOf<AppTPCompanyTrackersViewModel.CompanyTrackingDetails>()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
@@ -28,7 +28,6 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackingSignal
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
@@ -65,7 +64,7 @@ constructor(
             statsRepository
                 .getTrackersForAppFromDate(date, packageName)
                 .map { aggregateDataPerApp(it, packageName) }
-                .flowOn(Dispatchers.Default)
+                .flowOn(dispatchers.default())
                 .collectLatest { state ->
                     viewStateFlow.emit(state)
                 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModel.kt
@@ -38,7 +38,7 @@ import kotlin.coroutines.coroutineContext
 @ContributesViewModel(FragmentScope::class)
 class DeviceShieldActivityFeedViewModel @Inject constructor(
     private val statsRepository: AppTrackerBlockingStatsRepository,
-    private val dispatcherProvider: DispatcherProvider,
+    private val dispatchers: DispatcherProvider,
     private val timeDiffFormatter: TimeDiffFormatter
 ) : ViewModel() {
 
@@ -62,11 +62,11 @@ class DeviceShieldActivityFeedViewModel @Inject constructor(
     suspend fun getMostRecentTrackers(
         timeWindow: TimeWindow,
         showHeadings: Boolean
-    ): Flow<List<TrackerFeedItem>> = withContext(dispatcherProvider.io()) {
+    ): Flow<List<TrackerFeedItem>> = withContext(dispatchers.io()) {
         return@withContext statsRepository.getMostRecentVpnTrackers { timeWindow.asString() }
             .combine(tickerChannel.asStateFlow()) { trackers, _ -> trackers }
             .map { aggregateDataPerApp(it, showHeadings) }
-            .flowOn(Dispatchers.Default)
+            .flowOn(dispatchers.default())
             .map { it.ifEmpty { listOf(TrackerFeedItem.TrackerEmptyFeed) } }
             .onStart {
                 startTickerRefresher()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/TrackerFeedAdapter.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/TrackerFeedAdapter.kt
@@ -29,6 +29,7 @@ import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.extensions.safeGetApplicationIcon
 import com.duckduckgo.mobile.android.ui.TextDrawable
 import com.duckduckgo.mobile.android.ui.recyclerviewext.StickyHeaders
@@ -38,13 +39,13 @@ import com.duckduckgo.mobile.android.vpn.R
 import com.duckduckgo.app.global.formatters.time.TimeDiffFormatter
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerFeedItem
 import com.facebook.shimmer.ShimmerFrameLayout
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.threeten.bp.LocalDateTime
 import javax.inject.Inject
 
 class TrackerFeedAdapter @Inject constructor(
     private val timeDiffFormatter: TimeDiffFormatter,
+    private val dispatchers: DispatcherProvider
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>(), StickyHeaders {
 
     private val trackerFeedItems = mutableListOf<TrackerFeedItem>()
@@ -99,7 +100,7 @@ class TrackerFeedAdapter @Inject constructor(
         onAppClick = onAppClickListener
         val newData = data
         val oldData = trackerFeedItems
-        val diffResult = withContext(Dispatchers.IO) {
+        val diffResult = withContext(dispatchers.io()) {
             DiffCallback(oldData, newData).run { DiffUtil.calculateDiff(this) }
         }
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepositoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepositoryTest.kt
@@ -61,7 +61,7 @@ class AppTrackerBlockingStatsRepositoryTest {
         vpnRunningStatsDao = db.vpnRunningStatsDao()
         vpnTrackerDao = db.vpnTrackerDao()
         vpnPhoenixDao = db.vpnPhoenixDao()
-        repository = RealAppTrackerBlockingStatsRepository(db)
+        repository = RealAppTrackerBlockingStatsRepository(db, coroutineRule.testDispatcherProvider)
     }
 
     @After

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/PrivacyReportViewModelTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/PrivacyReportViewModelTest.kt
@@ -81,7 +81,7 @@ class PrivacyReportViewModelTest {
     fun before() {
         prepareDb()
 
-        repository = RealAppTrackerBlockingStatsRepository(db)
+        repository = RealAppTrackerBlockingStatsRepository(db, coroutineRule.testDispatcherProvider)
 
         context.getSharedPreferences(PREFS_FILENAME, Context.MODE_PRIVATE).edit { clear() }
         vpnPreferences = RealVpnPreferences(context)

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldDailyNotificationFactoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldDailyNotificationFactoryTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.mobile.android.vpn.ui.notification
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.mobile.android.vpn.dao.VpnTrackerDao
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
@@ -28,16 +29,22 @@ import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsReposi
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldNotificationFactory.DeviceShieldNotification
 import com.jakewharton.threetenabp.AndroidThreeTen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.threeten.bp.LocalDateTime
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class DeviceShieldDailyNotificationFactoryTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private lateinit var db: VpnDatabase
     private lateinit var vpnTrackerDao: VpnTrackerDao
@@ -52,7 +59,7 @@ class DeviceShieldDailyNotificationFactoryTest {
             .allowMainThreadQueries()
             .build()
         vpnTrackerDao = db.vpnTrackerDao()
-        appTrackerBlockingStatsRepository = RealAppTrackerBlockingStatsRepository(db)
+        appTrackerBlockingStatsRepository = RealAppTrackerBlockingStatsRepository(db, coroutineTestRule.testDispatcherProvider)
 
         factory =
             DeviceShieldNotificationFactory(InstrumentationRegistry.getInstrumentation().targetContext.resources, appTrackerBlockingStatsRepository)

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldNotificationFactoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldNotificationFactoryTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.mobile.android.vpn.ui.notification
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.mobile.android.vpn.dao.VpnTrackerDao
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
@@ -28,14 +29,20 @@ import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsReposi
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldNotificationFactory.DeviceShieldNotification
 import com.jakewharton.threetenabp.AndroidThreeTen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class DeviceShieldNotificationFactoryTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private lateinit var db: VpnDatabase
     private lateinit var vpnTrackerDao: VpnTrackerDao
@@ -50,7 +57,7 @@ class DeviceShieldNotificationFactoryTest {
             .allowMainThreadQueries()
             .build()
         vpnTrackerDao = db.vpnTrackerDao()
-        appTrackerBlockingStatsRepository = RealAppTrackerBlockingStatsRepository(db)
+        appTrackerBlockingStatsRepository = RealAppTrackerBlockingStatsRepository(db, coroutineTestRule.testDispatcherProvider)
 
         factory =
             DeviceShieldNotificationFactory(InstrumentationRegistry.getInstrumentation().targetContext.resources, appTrackerBlockingStatsRepository)

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldWeeklyNotificationFactoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldWeeklyNotificationFactoryTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.mobile.android.vpn.ui.notification
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.mobile.android.vpn.dao.VpnTrackerDao
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
@@ -28,16 +29,22 @@ import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsReposi
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldNotificationFactory.DeviceShieldNotification
 import com.jakewharton.threetenabp.AndroidThreeTen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.threeten.bp.LocalDateTime
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class DeviceShieldWeeklyNotificationFactoryTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private lateinit var db: VpnDatabase
     private lateinit var vpnTrackerDao: VpnTrackerDao
@@ -52,7 +59,7 @@ class DeviceShieldWeeklyNotificationFactoryTest {
             .allowMainThreadQueries()
             .build()
         vpnTrackerDao = db.vpnTrackerDao()
-        appTrackerBlockingStatsRepository = RealAppTrackerBlockingStatsRepository(db)
+        appTrackerBlockingStatsRepository = RealAppTrackerBlockingStatsRepository(db, coroutineTestRule.testDispatcherProvider)
 
         factory =
             DeviceShieldNotificationFactory(InstrumentationRegistry.getInstrumentation().targetContext.resources, appTrackerBlockingStatsRepository)

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModelTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModelTest.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.TimeUnit.DAYS
@@ -46,6 +47,9 @@ import kotlin.time.ExperimentalTime
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class DeviceShieldActivityFeedViewModelTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private lateinit var db: VpnDatabase
     private lateinit var viewModel: DeviceShieldActivityFeedViewModel
@@ -58,9 +62,9 @@ class DeviceShieldActivityFeedViewModelTest {
             .build()
 
         viewModel = DeviceShieldActivityFeedViewModel(
-            RealAppTrackerBlockingStatsRepository(db),
-            CoroutineTestRule().testDispatcherProvider,
-            RealTimeDiffFormatter(InstrumentationRegistry.getInstrumentation().targetContext)
+            RealAppTrackerBlockingStatsRepository(db, coroutineTestRule.testDispatcherProvider),
+            coroutineTestRule.testDispatcherProvider,
+            RealTimeDiffFormatter(InstrumentationRegistry.getInstrumentation().targetContext),
         )
     }
 

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugActivity.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugActivity.kt
@@ -25,6 +25,7 @@ import android.view.View
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.di.scopes.ActivityScope
@@ -32,7 +33,6 @@ import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExceptionRule
 import com.duckduckgo.vpn.internal.databinding.ActivityExceptionRulesDebugBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.isActive
@@ -49,6 +49,9 @@ class ExceptionRulesDebugActivity : DuckDuckGoActivity(), RuleTrackerView.RuleTr
 
     @Inject
     lateinit var exclusionRulesRepository: ExclusionRulesRepository
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     private val binding: ActivityExceptionRulesDebugBinding by viewBinding()
 
@@ -69,7 +72,7 @@ class ExceptionRulesDebugActivity : DuckDuckGoActivity(), RuleTrackerView.RuleTr
                 rules to getAppTrackers()
             }
             .onStart { startRefreshTicker() }
-            .flowOn(Dispatchers.IO)
+            .flowOn(dispatchers.io())
             .onEach {
                 val (rules, appTrackers) = it
 
@@ -97,7 +100,7 @@ class ExceptionRulesDebugActivity : DuckDuckGoActivity(), RuleTrackerView.RuleTr
                 binding.progress.isVisible = false
 
             }
-            .flowOn(Dispatchers.Main)
+            .flowOn(dispatchers.main())
             .launchIn(lifecycleScope)
     }
 
@@ -151,7 +154,7 @@ class ExceptionRulesDebugActivity : DuckDuckGoActivity(), RuleTrackerView.RuleTr
         view: View,
         enabled: Boolean
     ) {
-        lifecycleScope.launch(Dispatchers.IO) {
+        lifecycleScope.launch(dispatchers.io()) {
             val tag = (view.tag as String?).orEmpty()
             val (appPackageName, domain) = tag.split("_")
             Timber.v("$appPackageName / $domain enabled: $enabled")

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
@@ -20,13 +20,13 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExceptionRule
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -76,6 +76,7 @@ class ExceptionRulesDebugReceiver(
 class ExceptionRulesDebugReceiverRegister @Inject constructor(
     private val context: Context,
     private val exclusionRulesRepository: ExclusionRulesRepository,
+    private val dispatchers: DispatcherProvider
 ) : VpnServiceCallbacks {
 
     private val exceptionRulesSavedState = mutableListOf<AppTrackerExceptionRule>()
@@ -92,7 +93,7 @@ class ExceptionRulesDebugReceiverRegister @Inject constructor(
             Timber.i("Excluding %s for app %s", domain, appId)
 
             if (appId != null && domain != null) {
-                coroutineScope.launch(Dispatchers.IO) {
+                coroutineScope.launch(dispatchers.io()) {
                     exclusionRulesRepository.upsertRule(appId, domain)
                 }
             }
@@ -105,7 +106,7 @@ class ExceptionRulesDebugReceiverRegister @Inject constructor(
     ) {
         Timber.i("Debug receiver ExceptionRulesDebugReceiver restoring exception rules")
 
-        coroutineScope.launch(Dispatchers.IO) {
+        coroutineScope.launch(dispatchers.io()) {
             exclusionRulesRepository.deleteAllTrackerRules()
             exclusionRulesRepository.insertTrackerRules(exceptionRulesSavedState).also {
                 exceptionRulesSavedState.clear()
@@ -114,7 +115,7 @@ class ExceptionRulesDebugReceiverRegister @Inject constructor(
     }
 
     private fun saveExceptionRulesState(coroutineScope: CoroutineScope) {
-        coroutineScope.launch(Dispatchers.IO) {
+        coroutineScope.launch(dispatchers.io()) {
             exceptionRulesSavedState.clear()
             exceptionRulesSavedState.addAll(exclusionRulesRepository.getAllTrackerRules())
         }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/tabpreview/FileBasedWebViewPreviewPersisterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/tabpreview/FileBasedWebViewPreviewPersisterTest.kt
@@ -19,6 +19,7 @@
 package com.duckduckgo.app.browser.tabpreview
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.file.FileDeleter
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -29,11 +30,15 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import java.io.File
 
 @ExperimentalCoroutinesApi
 class FileBasedWebViewPreviewPersisterTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private lateinit var testee: FileBasedWebViewPreviewPersister
     private val mockFileDeleter: FileDeleter = mock()
@@ -42,7 +47,7 @@ class FileBasedWebViewPreviewPersisterTest {
 
     @Before
     fun setup() {
-        testee = FileBasedWebViewPreviewPersister(context, mockFileDeleter)
+        testee = FileBasedWebViewPreviewPersister(context, mockFileDeleter, coroutineTestRule.testDispatcherProvider)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
@@ -418,7 +417,8 @@ class TabDataRepositoryTest {
             SiteFactory(privacyPractices, entityLookup),
             webViewPreviewPersister,
             faviconManager,
-            TestScope()
+            coroutinesTestRule.testScope,
+            coroutinesTestRule.testDispatcherProvider
         )
     }
 

--- a/app/src/internal/java/com/duckduckgo/app/flipper/plugins/TrackerProtectionFlipperPlugin.kt
+++ b/app/src/internal/java/com/duckduckgo/app/flipper/plugins/TrackerProtectionFlipperPlugin.kt
@@ -36,7 +36,7 @@ import kotlin.random.Random
 @ContributesMultibinding(AppScope::class)
 class TrackerProtectionFlipperPlugin @Inject constructor(
     vpnDatabase: VpnDatabase,
-    private val dispatcherProvider: DispatcherProvider,
+    private val dispatchers: DispatcherProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) : FlipperPlugin {
 
@@ -76,7 +76,7 @@ class TrackerProtectionFlipperPlugin @Inject constructor(
                         .also { enqueueRow(it) }
                 }
             }
-            .flowOn(Dispatchers.IO)
+            .flowOn(dispatchers.io())
             .launchIn(appCoroutineScope)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -178,6 +178,7 @@ import com.duckduckgo.app.browser.menu.BrowserPopupMenu
 import com.duckduckgo.app.browser.print.PrintInjector
 import com.duckduckgo.app.browser.remotemessage.asMessage
 import com.duckduckgo.app.cta.ui.DaxDialogCta.DaxAutoconsentCta
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.DuckDuckGoFragment
 import com.duckduckgo.app.global.FragmentViewModelFactory
 import com.duckduckgo.app.global.view.launchDefaultAppActivity
@@ -224,7 +225,10 @@ class BrowserTabFragment :
     private val supervisorJob = SupervisorJob()
 
     override val coroutineContext: CoroutineContext
-        get() = supervisorJob + Dispatchers.Main
+        get() = supervisorJob + dispatchers.main()
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     @Inject
     lateinit var webViewClient: BrowserWebViewClient
@@ -1550,7 +1554,7 @@ class BrowserTabFragment :
         // send pixel before submitting the query and changing the autocomplete state to empty; otherwise will send the wrong params
         appCoroutineScope.launch {
             viewModel.fireAutocompletePixel(suggestion)
-            withContext(Dispatchers.Main) {
+            withContext(dispatchers.main()) {
                 val origin = when (suggestion) {
                     is AutoCompleteBookmarkSuggestion -> FromAutocomplete(isNav = true)
                     is AutoCompleteSearchSuggestion -> FromAutocomplete(isNav = suggestion.isUrl)
@@ -1698,7 +1702,7 @@ class BrowserTabFragment :
         delay: Long = 200
     ) {
         delay(delay)
-        withContext(Dispatchers.Main) {
+        withContext(dispatchers.main()) {
             browserLayout.makeSnackbarWithNoBottomInset(messageResourceId, Snackbar.LENGTH_LONG)
                 .setAction(R.string.autofillSnackbarAction) {
                     context?.let { startActivity(autofillSettingsActivityLauncher.intent(it, loginCredentials)) }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -41,7 +41,6 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -63,7 +62,7 @@ class BrowserViewModel @Inject constructor(
     CoroutineScope {
 
     override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Main
+        get() = dispatchers.main()
 
     data class ViewState(
         val hideWebContent: Boolean = true

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -313,8 +313,8 @@ class BrowserWebViewClient(
     ): WebResourceResponse? {
         return runBlocking {
             try {
-                val documentUrl = withContext(Dispatchers.Main) { webView.url }
-                withContext(Dispatchers.Main) {
+                val documentUrl = withContext(dispatcherProvider.main()) { webView.url }
+                withContext(dispatcherProvider.main()) {
                     loginDetector.onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, request))
                 }
                 Timber.v("Intercepting resource ${request.url} type:${request.method} on page $documentUrl")

--- a/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
@@ -21,8 +21,9 @@ import android.webkit.WebView
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.cookies.db.AuthCookieAllowedDomainEntity
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsRepository
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -37,7 +38,8 @@ interface ThirdPartyCookieManager {
 
 class AppThirdPartyCookieManager(
     private val cookieManagerProvider: CookieManagerProvider,
-    private val authCookiesAllowedDomainsRepository: AuthCookiesAllowedDomainsRepository
+    private val authCookiesAllowedDomainsRepository: AuthCookiesAllowedDomainsRepository,
+    private val dispatchers: DispatcherProvider = DefaultDispatcherProvider()
 ) : ThirdPartyCookieManager {
 
     override suspend fun processUriForThirdPartyCookies(
@@ -61,7 +63,7 @@ class AppThirdPartyCookieManager(
     ) {
         val host = uri.host ?: return
         val domain = authCookiesAllowedDomainsRepository.getDomain(host)
-        withContext(Dispatchers.Main) {
+        withContext(dispatchers.main()) {
             if (domain != null && hasUserIdCookie()) {
                 Timber.d("Cookies enabled for $uri")
                 cookieManagerProvider.get().setAcceptThirdPartyCookies(webView, true)

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -312,9 +312,10 @@ class BrowserModule {
     @Provides
     fun webViewPreviewPersister(
         context: Context,
-        fileDeleter: FileDeleter
+        fileDeleter: FileDeleter,
+        dispatchers: DispatcherProvider
     ): WebViewPreviewPersister {
-        return FileBasedWebViewPreviewPersister(context, fileDeleter)
+        return FileBasedWebViewPreviewPersister(context, fileDeleter, dispatchers)
     }
 
     @SingleInstanceIn(AppScope::class)

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.browser.rating.db.AppEnjoymentDao
 import com.duckduckgo.app.browser.rating.db.AppEnjoymentDatabaseRepository
 import com.duckduckgo.app.browser.rating.db.AppEnjoymentRepository
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.rating.*
 import com.duckduckgo.app.playstore.PlayStoreAndroidUtils
@@ -72,15 +73,15 @@ class RatingModule {
         searchCountDao: SearchCountDao,
         @Named(INITIAL_PROMPT_DECIDER_NAME) initialPromptDecider: ShowPromptDecider,
         @Named(SECONDARY_PROMPT_DECIDER_NAME) secondaryPromptDecider: ShowPromptDecider,
-        context: Context,
-        appBuildConfig: AppBuildConfig
+        appBuildConfig: AppBuildConfig,
+        dispatchers: DispatcherProvider
     ): PromptTypeDecider {
         return InitialPromptTypeDecider(
             playStoreUtils,
             searchCountDao,
             initialPromptDecider,
             secondaryPromptDecider,
-            context,
+            dispatchers,
             appBuildConfig
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewPersister.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewPersister.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.app.browser.tabpreview
 
 import android.content.Context
 import android.graphics.Bitmap
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.file.FileDeleter
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
@@ -46,7 +46,8 @@ interface WebViewPreviewPersister {
 
 class FileBasedWebViewPreviewPersister(
     val context: Context,
-    private val fileDeleter: FileDeleter
+    private val fileDeleter: FileDeleter,
+    private val dispatchers: DispatcherProvider
 ) : WebViewPreviewPersister {
 
     override suspend fun deleteAll() {
@@ -57,7 +58,7 @@ class FileBasedWebViewPreviewPersister(
         bitmap: Bitmap,
         tabId: String
     ): String {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io()) {
 
             val previewFile = prepareDestinationFile(tabId)
             writeBytesToFile(previewFile, bitmap)

--- a/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
@@ -77,7 +77,7 @@ class UrlExtractingWebViewClient(
         request: WebResourceRequest
     ): WebResourceResponse? {
         return runBlocking {
-            val documentUrl = withContext(Dispatchers.Main) { webView.url }
+            val documentUrl = withContext(dispatcherProvider.main()) { webView.url }
             Timber.v(
                 "Intercepting resource ${request.url} type:${request.method} on page $documentUrl"
             )

--- a/app/src/main/java/com/duckduckgo/app/di/FileModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/FileModule.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.di
 
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.file.AndroidFileDeleter
 import com.duckduckgo.app.global.file.FileDeleter
 import dagger.Module
@@ -25,7 +26,7 @@ import dagger.Provides
 object FileModule {
 
     @Provides
-    fun providesFileDeleter(): FileDeleter {
-        return AndroidFileDeleter()
+    fun providesFileDeleter(dispatchers: DispatcherProvider): FileDeleter {
+        return AndroidFileDeleter(dispatchers)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearingWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearingWorker.kt
@@ -22,12 +22,12 @@ import androidx.work.CoroutineWorker
 import androidx.work.ListenableWorker.Result.success
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.di.scopes.AppScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
@@ -40,8 +40,12 @@ class DataClearingWorker(
 
     @Inject
     lateinit var settingsDataStore: SettingsDataStore
+
     @Inject
     lateinit var clearDataAction: ClearDataAction
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     @WorkerThread
     override suspend fun doWork(): Result {
@@ -83,7 +87,7 @@ class DataClearingWorker(
 
     private suspend fun clearEverything() {
         Timber.i("App is in background, so just outright killing the process")
-        withContext(Dispatchers.Main) {
+        withContext(dispatchers.main()) {
             clearDataAction.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = false)
             clearDataAction.setAppUsedSinceLastClearFlag(false)
 

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -63,6 +63,9 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
     @Inject
     lateinit var injectorFactoryMap: DaggerMap<Class<*>, AndroidInjector.Factory<*, *>>
 
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
+
     private val applicationCoroutineScope = CoroutineScope(SupervisorJob())
 
     open lateinit var daggerAppComponent: AppComponent
@@ -178,7 +181,7 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
     private fun initializeDateLibrary() {
         AndroidThreeTen.init(this)
         // Query the ZoneRulesProvider so that it is loaded on a background coroutine
-        GlobalScope.launch(Dispatchers.IO) {
+        GlobalScope.launch(dispatchers.io()) {
             ZoneRulesProvider.getAvailableZoneIds()
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionModule.kt
@@ -36,9 +36,10 @@ class UncaughtExceptionModule {
     fun uncaughtWebViewExceptionRepository(
         uncaughtExceptionDao: UncaughtExceptionDao,
         rootExceptionFinder: RootExceptionFinder,
-        deviceInfo: DeviceInfo
+        deviceInfo: DeviceInfo,
+        dispatchers: DispatcherProvider,
     ): UncaughtExceptionRepository {
-        return UncaughtExceptionRepositoryDb(uncaughtExceptionDao, rootExceptionFinder, deviceInfo)
+        return UncaughtExceptionRepositoryDb(uncaughtExceptionDao, rootExceptionFinder, deviceInfo, dispatchers)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/global/file/FileDeleter.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/file/FileDeleter.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.app.global.file
 
-import kotlinx.coroutines.Dispatchers
+import com.duckduckgo.app.global.DispatcherProvider
 import kotlinx.coroutines.withContext
 import java.io.File
 
@@ -47,12 +47,12 @@ interface FileDeleter {
     )
 }
 
-class AndroidFileDeleter : FileDeleter {
+class AndroidFileDeleter(private val dispatchers: DispatcherProvider) : FileDeleter {
     override suspend fun deleteContents(
         parentDirectory: File,
         excludedFiles: List<String>
     ) {
-        withContext(Dispatchers.IO) {
+        withContext(dispatchers.io()) {
             val files = parentDirectory.listFiles() ?: return@withContext
             val filesToDelete = files.filterNot { excludedFiles.contains(it.name) }
             filesToDelete.forEach { it.deleteRecursively() }
@@ -60,7 +60,7 @@ class AndroidFileDeleter : FileDeleter {
     }
 
     override suspend fun deleteDirectory(directoryToDelete: File) {
-        withContext(Dispatchers.IO) {
+        withContext(dispatchers.io()) {
             directoryToDelete.deleteRecursively()
         }
     }
@@ -69,7 +69,7 @@ class AndroidFileDeleter : FileDeleter {
         parentDirectory: File,
         files: List<String>
     ) {
-        withContext(Dispatchers.IO) {
+        withContext(dispatchers.io()) {
             val allFiles = parentDirectory.listFiles() ?: return@withContext
             val filesToDelete = allFiles.filter { files.contains(it.name) }
             filesToDelete.forEach { it.deleteRecursively() }

--- a/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserver.kt
@@ -19,19 +19,21 @@ package com.duckduckgo.app.global.rating
 import androidx.annotation.UiThread
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class AppEnjoymentAppCreationObserver(
     private val appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
     private val promptTypeDecider: PromptTypeDecider,
-    private val appCoroutineScope: CoroutineScope
+    private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider = DefaultDispatcherProvider()
 ) : DefaultLifecycleObserver {
 
     @UiThread
     override fun onStart(owner: LifecycleOwner) {
-        appCoroutineScope.launch(Dispatchers.Main) {
+        appCoroutineScope.launch(dispatchers.main()) {
             appEnjoymentPromptEmitter.promptType.value = promptTypeDecider.determineInitialPromptType()
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/global/rating/PromptTypeDecider.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/PromptTypeDecider.kt
@@ -16,13 +16,12 @@
 
 package com.duckduckgo.app.global.rating
 
-import android.content.Context
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions.ShowEnjoymentPrompt
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions.ShowNothing
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -35,12 +34,12 @@ class InitialPromptTypeDecider(
     private val searchCountDao: SearchCountDao,
     private val initialPromptDecider: ShowPromptDecider,
     private val secondaryPromptDecider: ShowPromptDecider,
-    private val context: Context,
+    private val dispatchers: DispatcherProvider,
     private val appBuildConfig: AppBuildConfig
 ) : PromptTypeDecider {
 
     override suspend fun determineInitialPromptType(): AppEnjoymentPromptOptions {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io()) {
 
             if (!isPlayStoreInstalled()) return@withContext ShowNothing
             if (!wasInstalledThroughPlayStore()) return@withContext ShowNothing

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -36,7 +36,6 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -86,7 +85,7 @@ class ClearPersonalDataAction(
         appInForeground: Boolean,
         shouldFireDataClearPixel: Boolean
     ) {
-        withContext(Dispatchers.IO) {
+        withContext(dispatchers.io()) {
             clearDataPixel.onDataCleared()
             val fireproofDomains = fireproofWebsiteRepository.fireproofWebsitesSync().map { it.domain }
             cookieManager.flush()
@@ -96,7 +95,7 @@ class ClearPersonalDataAction(
             clearTabsAsync(appInForeground)
         }
 
-        withContext(Dispatchers.Main) {
+        withContext(dispatchers.main()) {
             clearDataAsync(shouldFireDataClearPixel)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/privacy/store/TermsOfServiceRawStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/store/TermsOfServiceRawStore.kt
@@ -18,12 +18,12 @@ package com.duckduckgo.app.privacy.store
 
 import android.content.Context
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.privacy.model.TermsOfService
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
@@ -36,14 +36,15 @@ import dagger.SingleInstanceIn
 @SingleInstanceIn(AppScope::class)
 class TermsOfServiceRawStore @Inject constructor(
     private val moshi: Moshi,
-    private val context: Context
+    private val context: Context,
+    private val dispatchers: DispatcherProvider
 ) : TermsOfServiceStore {
 
     private var data: List<TermsOfService> = ArrayList()
     private var initialized: Boolean = false
 
     override suspend fun loadData() {
-        withContext(Dispatchers.IO) {
+        withContext(dispatchers.io()) {
             val json = context.resources.openRawResource(R.raw.tosdr).bufferedReader().use { it.readText() }
             val type = Types.newParameterizedType(List::class.java, TermsOfService::class.java)
             val adapter: JsonAdapter<List<TermsOfService>> = moshi.adapter(type)

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -18,10 +18,10 @@ package com.duckduckgo.app.tabs.db
 
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -29,7 +29,8 @@ import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
 class TabsDbSanitizer @Inject constructor(
-    private val tabRepository: TabRepository
+    private val tabRepository: TabRepository,
+    private val dispatchers: DispatcherProvider
 ) : DefaultLifecycleObserver {
 
     override fun onStart(owner: LifecycleOwner) {
@@ -38,7 +39,7 @@ class TabsDbSanitizer @Inject constructor(
         }
     }
 
-    private suspend fun purgeTabsDatabaseAsync() = withContext(Dispatchers.IO) {
+    private suspend fun purgeTabsDatabaseAsync() = withContext(dispatchers.io()) {
         tabRepository.purgeDeletableTabs()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.distinctUntilChanged
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.tabs.db.TabsDao
@@ -31,7 +32,6 @@ import dagger.SingleInstanceIn
 import io.reactivex.Scheduler
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -49,7 +49,8 @@ class TabDataRepository @Inject constructor(
     private val siteFactory: SiteFactory,
     private val webViewPreviewPersister: WebViewPreviewPersister,
     private val faviconManager: FaviconManager,
-    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider
 ) : TabRepository {
 
     override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs().distinctUntilChanged()
@@ -232,7 +233,7 @@ class TabDataRepository @Inject constructor(
         }
     }
 
-    override suspend fun purgeDeletableTabs() = withContext(Dispatchers.IO) {
+    override suspend fun purgeDeletableTabs() = withContext(dispatchers.io()) {
         appCoroutineScope.launch {
             tabsDao.purgeDeletableTabsAndUpdateSelection()
         }.join()

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.downloads.DownloadsActivity
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.view.ClearDataAction
@@ -48,7 +49,6 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -58,7 +58,10 @@ import kotlin.coroutines.CoroutineContext
 class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, CoroutineScope {
 
     override val coroutineContext: CoroutineContext
-        get() = SupervisorJob() + Dispatchers.Main
+        get() = SupervisorJob() + dispatchers.main()
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     @Inject
     lateinit var settingsDataStore: SettingsDataStore

--- a/app/src/test/java/com/duckduckgo/app/global/rating/InitialPromptTypeDeciderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/rating/InitialPromptTypeDeciderTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.global.rating
 
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.usage.search.SearchCountDao
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -26,11 +27,15 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
 @Suppress("RemoveExplicitTypeArguments")
 class InitialPromptTypeDeciderTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private lateinit var testee: InitialPromptTypeDecider
 
@@ -48,8 +53,8 @@ class InitialPromptTypeDeciderTest {
             searchCountDao = mockSearchCountDao,
             initialPromptDecider = mockInitialPromptDecider,
             secondaryPromptDecider = mockSecondaryPromptDecider,
-            context = mock(),
-            appBuildConfig = mockAppBuildConfig
+            appBuildConfig = mockAppBuildConfig,
+            dispatchers = coroutineTestRule.testDispatcherProvider
         )
 
         whenever(mockPlayStoreUtils.isPlayStoreInstalled()).thenReturn(true)

--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -75,7 +75,7 @@ android {
     anvil {
         generateDaggerFactories = true // default is false
     }
-    lintOptions {
+    lint {
         baseline file("lint-baseline.xml")
     }
     testOptions {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/configuration/InlineBrowserAutofillConfigurator.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/configuration/InlineBrowserAutofillConfigurator.kt
@@ -18,11 +18,12 @@ package com.duckduckgo.autofill.configuration
 import android.webkit.WebView
 import com.duckduckgo.app.autofill.JavascriptInjector
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.autofill.BrowserAutofill.Configurator
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -32,6 +33,7 @@ class InlineBrowserAutofillConfigurator @Inject constructor(
     private val autofillRuntimeConfigProvider: AutofillRuntimeConfigProvider,
     private val javascriptInjector: JavascriptInjector,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider = DefaultDispatcherProvider()
 ) : Configurator {
     override fun configureAutofillForCurrentPage(
         webView: WebView,
@@ -41,7 +43,7 @@ class InlineBrowserAutofillConfigurator @Inject constructor(
             val rawJs = javascriptInjector.getFunctionsJS()
             val formatted = autofillRuntimeConfigProvider.getRuntimeConfiguration(rawJs, url)
 
-            withContext(Dispatchers.Main) {
+            withContext(dispatchers.main()) {
                 webView.evaluateJavascript("javascript:$formatted", null)
             }
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/jsbridge/AutofillMessagePoster.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/jsbridge/AutofillMessagePoster.kt
@@ -22,9 +22,9 @@ import androidx.core.net.toUri
 import androidx.webkit.WebMessageCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
@@ -34,13 +34,15 @@ interface AutofillMessagePoster {
 }
 
 @ContributesBinding(FragmentScope::class)
-class AutofillWebViewMessagePoster @Inject constructor() : AutofillMessagePoster {
+class AutofillWebViewMessagePoster @Inject constructor(
+    private val dispatchers: DispatcherProvider
+) : AutofillMessagePoster {
 
     @SuppressLint("RequiresFeature")
     override suspend fun postMessage(webView: WebView?, message: String) {
 
         webView?.let { wv ->
-            withContext(Dispatchers.Main) {
+            withContext(dispatchers.main()) {
                 if (!WebViewFeature.isFeatureSupported(WebViewFeature.POST_WEB_MESSAGE)) {
                     Timber.e("Unable to post web message")
                     return@withContext

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/jsbridge/request/AutofillRequestParser.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/jsbridge/request/AutofillRequestParser.kt
@@ -16,10 +16,11 @@
 
 package com.duckduckgo.autofill.jsbridge.request
 
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Moshi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -29,19 +30,22 @@ interface AutofillRequestParser {
 }
 
 @ContributesBinding(FragmentScope::class)
-class AutofillJsonRequestParser @Inject constructor(val moshi: Moshi) : AutofillRequestParser {
+class AutofillJsonRequestParser @Inject constructor(
+    val moshi: Moshi,
+    private val dispatchers: DispatcherProvider = DefaultDispatcherProvider()
+) : AutofillRequestParser {
 
     private val autofillDataRequestParser by lazy { moshi.adapter(AutofillDataRequest::class.java) }
     private val autofillStoreFormDataRequestParser by lazy { moshi.adapter(AutofillStoreFormDataRequest::class.java) }
 
     override suspend fun parseAutofillDataRequest(request: String): AutofillDataRequest {
-        return withContext(Dispatchers.Default) {
+        return withContext(dispatchers.default()) {
             autofillDataRequestParser.fromJson(request) ?: throw IllegalArgumentException("Failed to parse autofill request")
         }
     }
 
     override suspend fun parseStoreFormDataRequest(request: String): AutofillStoreFormDataRequest {
-        return withContext(Dispatchers.Default) {
+        return withContext(dispatchers.default()) {
             autofillStoreFormDataRequestParser.fromJson(request) ?: throw IllegalArgumentException("Failed to parse autofill request")
         }
     }

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/TypeAnimationTextView.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/TypeAnimationTextView.kt
@@ -26,6 +26,7 @@ import java.text.BreakIterator
 import java.text.StringCharacterIterator
 import kotlin.coroutines.CoroutineContext
 
+@Suppress("NoHardcodedCoroutineDispatcher")
 class TypeAnimationTextView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/common/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepository.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/exception/UncaughtExceptionRepository.kt
@@ -17,8 +17,9 @@
 package com.duckduckgo.app.global.exception
 
 import androidx.annotation.VisibleForTesting
+import com.duckduckgo.app.global.DefaultDispatcherProvider
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.device.DeviceInfo
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -35,7 +36,8 @@ interface UncaughtExceptionRepository {
 class UncaughtExceptionRepositoryDb(
     private val uncaughtExceptionDao: UncaughtExceptionDao,
     private val rootExceptionFinder: RootExceptionFinder,
-    private val deviceInfo: DeviceInfo
+    private val deviceInfo: DeviceInfo,
+    private val dispatchers: DispatcherProvider = DefaultDispatcherProvider()
 ) : UncaughtExceptionRepository {
 
     private var lastSeenException: Throwable? = null
@@ -44,7 +46,7 @@ class UncaughtExceptionRepositoryDb(
         e: Throwable?,
         exceptionSource: UncaughtExceptionSource
     ) {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io()) {
             if (e == lastSeenException) {
                 return@withContext
             }
@@ -89,13 +91,13 @@ class UncaughtExceptionRepositoryDb(
     }
 
     override suspend fun getExceptions(): List<UncaughtExceptionEntity> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io()) {
             uncaughtExceptionDao.all()
         }
     }
 
     override suspend fun deleteException(id: Long) {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io()) {
             uncaughtExceptionDao.delete(id)
         }
     }

--- a/lint-rules/src/main/java/com/duckduckgo/lint/NoHardcodedCoroutineDispatcherDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/NoHardcodedCoroutineDispatcherDetector.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiElement
+import org.jetbrains.uast.UReferenceExpression
+import org.jetbrains.uast.getContainingUClass
+import java.util.*
+
+class NoHardcodedCoroutineDispatcherDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableReferenceNames(): List<String> = listOf("Dispatchers")
+
+    override fun visitReference(
+        context: JavaContext,
+        reference: UReferenceExpression,
+        referenced: PsiElement
+    ) {
+        val classUnderInspection = reference.getContainingUClass()?.qualifiedName
+        if (EXCLUDED_SOURCE_FILES.contains(classUnderInspection)) return
+
+        val referencedPackage = context.evaluator.getPackage(referenced)?.qualifiedName
+        val referencedClassName = reference.resolvedName
+
+        when ("${referencedPackage}.${referencedClassName}") {
+            "kotlinx.coroutines.Dispatchers" -> {
+                context.report(NO_HARCODED_COROUTINE_DISPATCHER, reference, context.getLocation(reference), ERROR_DESCRIPTION)
+            }
+        }
+    }
+
+    companion object {
+        const val ERROR_ID = "NoHardcodedCoroutineDispatcher"
+        const val ERROR_DESCRIPTION = "Hardcoded coroutine dispatcher"
+
+        private val EXCLUDED_SOURCE_FILES = listOf(
+            "com.duckduckgo.app.global.DispatcherProvider",
+            "com.duckduckgo.app.CoroutineTestRule"
+        )
+
+        val NO_HARCODED_COROUTINE_DISPATCHER = Issue.create(
+            ERROR_ID,
+            ERROR_DESCRIPTION,
+            "Inject com.duckduckgo.app.global.DispatcherProvider instead.",
+            Category.CORRECTNESS, 10, ERROR,
+            Implementation(NoHardcodedCoroutineDispatcherDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES))
+        )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -21,6 +21,7 @@ import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import com.duckduckgo.lint.NoFragmentDetector.Companion.NO_FRAGMENT_ISSUE
+import com.duckduckgo.lint.NoHardcodedCoroutineDispatcherDetector.Companion.NO_HARCODED_COROUTINE_DISPATCHER
 import com.duckduckgo.lint.NoLifecycleObserverDetector.Companion.NO_LIFECYCLE_OBSERVER_ISSUE
 import com.duckduckgo.lint.NoSingletonDetector.Companion.NO_SINGLETON_ISSUE
 import com.duckduckgo.lint.NoSystemLoadLibraryDetector.Companion.NO_SYSTEM_LOAD_LIBRARY
@@ -40,6 +41,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_LIFECYCLE_OBSERVER_ISSUE,
             NO_FRAGMENT_ISSUE,
             NO_SYSTEM_LOAD_LIBRARY,
+            NO_HARCODED_COROUTINE_DISPATCHER,
 
             // Android Design System
             DEPRECATED_BUTTON_IN_XML,

--- a/lint-rules/src/test/java/com/duckduckgo/lint/NoHardcodedCoroutineDispatchersTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/NoHardcodedCoroutineDispatchersTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.duckduckgo.lint.NoHardcodedCoroutineDispatcherDetector.Companion.ERROR_DESCRIPTION
+import com.duckduckgo.lint.NoHardcodedCoroutineDispatcherDetector.Companion.ERROR_ID
+import com.duckduckgo.lint.NoHardcodedCoroutineDispatcherDetector.Companion.NO_HARCODED_COROUTINE_DISPATCHER
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class NoHardcodedCoroutineDispatchersTest {
+
+    @Test
+    fun whenUsedInsideWithContextThenDetectedAsAViolation() {
+        val callSite = """
+              package com.duckduckgo.lint
+
+                import kotlinx.coroutines.Dispatchers
+
+                class Duck {
+                    fun quack() {
+                        withContext(Dispatchers.IO) { }                 
+                    }
+                }
+            """
+
+        assertLintError(listOf(kotlin(callSite).indented(), kotlin(classDefinitions).indented()))
+    }
+
+    @Test
+    fun whenDispatchersIoThenDetectedAsAViolation() {
+        val callSite = """
+              package com.duckduckgo.lint
+
+                import kotlinx.coroutines.Dispatchers
+
+                class Duck {
+                    fun quack() {
+                        Dispatchers.IO  
+                    }
+                }
+            """
+
+        assertLintError(listOf(kt(callSite), kt(classDefinitions)))
+    }
+
+    @Test
+    fun whenDispatchersMainThenDetectedAsAViolation() {
+        val callSite = """
+              package com.duckduckgo.lint
+
+                import kotlinx.coroutines.Dispatchers
+
+                class Duck {
+                    fun quack() {
+                        Dispatchers.Main  
+                    }
+                }
+            """
+
+        assertLintError(listOf(kt(callSite), kt(classDefinitions)))
+    }
+
+    @Test
+    fun whenDispatchersDefaultThenDetectedAsAViolation() {
+        val callSite = """
+              package com.duckduckgo.lint
+
+                import kotlinx.coroutines.Dispatchers
+
+                class Duck {
+                    fun quack() {
+                        Dispatchers.Default  
+                    }
+                }
+            """
+
+        assertLintError(listOf(kt(callSite), kt(classDefinitions)))
+    }
+
+
+    @Test
+    fun whenDispatchersUnconfinedThenDetectedAsAViolation() {
+        val callSite = """
+              package com.duckduckgo.lint
+
+                import kotlinx.coroutines.Dispatchers
+
+                class Duck {
+                    fun quack() {
+                        Dispatchers.Unconfined  
+                    }
+                }
+            """
+
+        assertLintError(listOf(kt(callSite), kt(classDefinitions)))
+    }
+
+
+    @Test
+    fun whenRecommendedDispatcherProviderUsedThenNotDetectedAsAViolation() {
+        val callSite = """
+              package com.duckduckgo.lint
+
+                import kotlinx.coroutines.Dispatchers
+
+                class Duck(private val dispatcherProvider: DispatcherProvider) {
+                    fun quack() {
+                        withContext(dispatcherProvider.io()) { }                 
+                    }
+                }
+            """
+
+        assertNotLintError(listOf(kt(callSite), kt(classDefinitions)))
+    }
+
+
+    private val classDefinitions = """
+            package kotlinx.coroutines
+
+            object Dispatchers {
+
+                @JvmStatic
+                val IO: CoroutineScope = object: CoroutineScope(){}
+                val Main: CoroutineScope = object: CoroutineScope(){}
+                val Default: CoroutineScope = object: CoroutineScope(){}
+                val Unconfined: CoroutineScope = object: CoroutineScope(){}
+                val Test: CoroutineScope = object: CoroutineScope(){}
+            }
+
+           class CoroutineScope       
+
+        """
+
+    private fun assertLintError(files: List<TestFile>) {
+        lint()
+            .files(*files.toTypedArray())
+            .issues(NO_HARCODED_COROUTINE_DISPATCHER)
+            .testModes(TestMode.DEFAULT)
+            .run()
+            .expectContains(expectedError)
+    }
+
+    private fun assertNotLintError(files: List<TestFile>) {
+        lint()
+            .files(*files.toTypedArray())
+            .issues(NO_HARCODED_COROUTINE_DISPATCHER)
+            .testModes(TestMode.DEFAULT)
+            .run()
+            .expectClean()
+    }
+
+    companion object {
+        private const val expectedError = "Error: $ERROR_DESCRIPTION [$ERROR_ID]"
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202882025878544/f

### Description
Introduces a new lint rule for detecting hardcoded coroutine dispatchers. 

Stacked PR https://github.com/duckduckgo/Android/pull/2454 fixes or suppresses the violations. The checks in _this_ PR will fail until that other one is merged.

### Steps to test this PR

- [x] Add a deliberate violation in main app module to test. e.g., in `DuckDuckGoApplication.onMainProcessCreate`, add `Dispatchers.Main`
- [x] Run lint and ensure it errors. `./gradlew lint`
- [x] Add a deliberate violation in another module
- [x] Run lint and ensure it errors. `./gradlew lint`
