### PR TITLE
Fix theming for auto night mode

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
@@ -16,12 +16,11 @@
 
 package com.duckduckgo.mobile.android.ui
 
-import android.app.UiModeManager
-import android.app.UiModeManager.MODE_NIGHT_YES
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.res.Configuration
 import android.graphics.drawable.Drawable
 import android.view.ContextThemeWrapper
 import androidx.appcompat.app.AppCompatActivity
@@ -44,14 +43,7 @@ object Theming {
         theme: DuckDuckGoTheme
     ): Drawable? {
         val themeId = when (theme) {
-            DuckDuckGoTheme.SYSTEM_DEFAULT -> {
-                val uiManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
-                when (uiManager.nightMode) {
-                    MODE_NIGHT_YES -> R.style.Theme_DuckDuckGo_Dark
-                    else -> R.style.Theme_DuckDuckGo_Light
-                }
-            }
-
+            DuckDuckGoTheme.SYSTEM_DEFAULT -> context.getSystemDefaultTheme()
             DuckDuckGoTheme.DARK -> R.style.Theme_DuckDuckGo_Dark
             else -> R.style.Theme_DuckDuckGo_Light
         }
@@ -72,17 +64,20 @@ fun AppCompatActivity.applyTheme(theme: DuckDuckGoTheme): BroadcastReceiver? {
 
 fun AppCompatActivity.getThemeId(theme: DuckDuckGoTheme): Int {
     return when (theme) {
-        DuckDuckGoTheme.SYSTEM_DEFAULT -> {
-            val uiManager = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
-            when (uiManager.nightMode) {
-                MODE_NIGHT_YES -> R.style.Theme_DuckDuckGo_Dark
-                else -> R.style.Theme_DuckDuckGo_Light
-            }
-        }
-
+        DuckDuckGoTheme.SYSTEM_DEFAULT -> getSystemDefaultTheme()
         DuckDuckGoTheme.DARK -> R.style.Theme_DuckDuckGo_Dark
         else -> R.style.Theme_DuckDuckGo_Light
     }
+}
+
+private fun Context.getSystemDefaultTheme(): Int {
+    return  if (isInNightMode()) R.style.Theme_DuckDuckGo_Dark
+    else R.style.Theme_DuckDuckGo_Light
+}
+
+private fun Context.isInNightMode(): Boolean {
+    val mode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+    return mode == Configuration.UI_MODE_NIGHT_YES
 }
 
 // Move this to LiveData/Flow and use appDelegate for night/day theming


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: 
https://github.com/duckduckgo/Android/issues/1729

### Description
`UiModeManager` provides only static information about night mode (yes/no/auto/custom), needs to get dynamic info about mode from `Configuration`. This fix shows how to get system night mode correctly.

