### PR TITLE
Re-structure VPN tracker db table

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ManageAppsProtectionViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ManageAppsProtectionViewModel.kt
@@ -92,7 +92,7 @@ class ManageAppsProtectionViewModel @Inject constructor(
         trackerData: List<BucketizedVpnTracker>
     ): List<TrackingApp> {
         val sourceData = mutableListOf<TrackingApp>()
-        val perSessionData = trackerData.groupBy { it.bucket }
+        val perSessionData = trackerData.groupBy { it.trackerCompanySignal.tracker.bucket }
 
         perSessionData.values.forEach { sessionTrackers ->
             coroutineContext.ensureActive()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/report/PrivacyReportViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/report/PrivacyReportViewModel.kt
@@ -53,11 +53,11 @@ class PrivacyReportViewModel @Inject constructor(
             if (trackers.isEmpty()) {
                 PrivacyReportView.TrackersBlocked("", 0, 0)
             } else {
-                val perApp = trackers.groupBy { it.trackingApp }.toList().sortedByDescending { it.second.size }
+                val perApp = trackers.groupBy { it.trackingApp }.toList().sortedByDescending { it.second.sumOf { t -> t.count } }
                 val otherAppsSize = (perApp.size - 1).coerceAtLeast(0)
                 val latestApp = perApp.first().first.appDisplayName
 
-                PrivacyReportView.TrackersBlocked(latestApp, otherAppsSize, trackers.size)
+                PrivacyReportView.TrackersBlocked(latestApp, otherAppsSize, trackers.sumOf { it.count })
             }
 
         }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
@@ -111,7 +111,7 @@ constructor(
                 CompanyTrackingDetails(
                     companyName = trackerCompanyName,
                     companyDisplayName = trackerCompanyDisplayName,
-                    trackingAttempts = data.value.size,
+                    trackingAttempts = data.value.sumOf { it.tracker.count },
                     timestamp = timestamp,
                     trackingSignals = trackingSignals
                 )
@@ -119,7 +119,7 @@ constructor(
         }
 
         return viewStateFlow.value.copy(
-            totalTrackingAttempts = trackerData.size,
+            totalTrackingAttempts = sourceData.sumOf { it.trackingAttempts },
             lastTrackerBlockedAgo = lastTrackerBlockedAgo,
             trackingCompanies = sourceData,
             protectionEnabled = excludedAppsRepository.isAppProtectionEnabled(packageName)

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModel.kt
@@ -80,7 +80,7 @@ class DeviceShieldActivityFeedViewModel @Inject constructor(
         showHeadings: Boolean
     ): List<TrackerFeedItem> {
         val sourceData = mutableListOf<TrackerFeedItem>()
-        val perSessionData = trackerData.groupBy { it.bucket }
+        val perSessionData = trackerData.groupBy { it.trackerCompanySignal.tracker.bucket }
 
         perSessionData.values.forEach { sessionTrackers ->
             coroutineContext.ensureActive()
@@ -110,7 +110,7 @@ class DeviceShieldActivityFeedViewModel @Inject constructor(
                             companyPrevalence = trackerCompanyPrevalence
                         )
                     )
-                    totalTrackerCount += trackerBucket.value.size
+                    totalTrackerCount += trackerBucket.value.sumOf { it.trackerCompanySignal.tracker.count }
                 }
 
                 if (firstInBucket && showHeadings) {
@@ -120,8 +120,8 @@ class DeviceShieldActivityFeedViewModel @Inject constructor(
 
                 sourceData.add(
                     TrackerFeedItem.TrackerFeedData(
-                        id = item.bucket.hashCode() + item.trackerCompanySignal.tracker.trackingApp.packageId.hashCode(),
-                        bucket = item.bucket,
+                        id = item.trackerCompanySignal.tracker.bucket.hashCode() + item.trackerCompanySignal.tracker.trackingApp.packageId.hashCode(),
+                        bucket = item.trackerCompanySignal.tracker.bucket,
                         trackingApp = TrackingApp(
                             item.trackerCompanySignal.tracker.trackingApp.packageId,
                             item.trackerCompanySignal.tracker.trackingApp.appDisplayName

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -312,12 +312,10 @@ class DeviceShieldTrackerActivity :
         AlwaysOnAlertDialogFragment.newAlwaysOnLockdownDialog(
             object : AlwaysOnAlertDialogFragment.Listener {
                 override fun onGoToSettingsClicked() {
-                    Timber.d("aitor: onGoToSettingsClicked")
                     viewModel.onViewEvent(ViewEvent.PromoteAlwaysOnOpenSettings)
                 }
 
                 override fun onCanceled() {
-                    Timber.d("aitor: onCanceled")
                     viewModel.onViewEvent(ViewEvent.PromoteAlwaysOnCancelled)
                 }
             }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepositoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepositoryTest.kt
@@ -85,7 +85,7 @@ class AppTrackerBlockingStatsRepositoryTest {
         trackerFound(trackerDomain)
         val vpnTrackers = repository.getVpnTrackers({ dateOfPreviousMidnightAsString() }).firstOrNull()
         assertTrackerFound(vpnTrackers, trackerDomain)
-        assertEquals(2, vpnTrackers!!.size)
+        assertEquals(2, vpnTrackers!!.sumOf { it.count })
     }
 
     @Test

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldDailyNotificationFactoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldDailyNotificationFactoryTest.kt
@@ -78,7 +78,11 @@ class DeviceShieldDailyNotificationFactoryTest {
     fun createsTotalTrackersNotificationWhenTrackersFoundInTwoApps() = runBlocking {
         val trackerDomain = "example.com"
         trackerFound(trackerDomain, appContainingTracker = trackingApp1())
-        trackerFound(trackerDomain, appContainingTracker = trackingApp2())
+        trackerFound(
+            trackerDomain,
+            appContainingTracker = trackingApp2(),
+            timestamp = DatabaseDateFormatter.bucketByHour(LocalDateTime.now().plusHours(1))
+        )
 
         val notification = factory.dailyNotificationFactory.createDailyDeviceShieldNotification(0)
 
@@ -165,7 +169,11 @@ class DeviceShieldDailyNotificationFactoryTest {
     fun createsLastCompanyAttemptNotificationWhenTrackersFoundInTwoApps() = runBlocking {
         val trackerDomain = "example.com"
         trackerFound(trackerDomain, appContainingTracker = trackingApp1())
-        trackerFound(trackerDomain, appContainingTracker = trackingApp2())
+        trackerFound(
+            trackerDomain,
+            appContainingTracker = trackingApp2(),
+            timestamp = DatabaseDateFormatter.bucketByHour(LocalDateTime.now().plusHours(1))
+        )
 
         val notification = factory.dailyNotificationFactory.createDailyDeviceShieldNotification(3)
 
@@ -177,16 +185,16 @@ class DeviceShieldDailyNotificationFactoryTest {
     fun createsLastCompanyAttemptNotificationWhenTrackersFoundInThreeApps() = runBlocking {
         val trackerDomain = "example.com"
         trackerFound(trackerDomain, appContainingTracker = trackingApp1())
-        trackerFound(trackerDomain, trackerCompanyId = 1, company = "Google", appContainingTracker = trackingApp1())
+        trackerFound("google.com", trackerCompanyId = 1, company = "Google", appContainingTracker = trackingApp1())
         trackerFound(
-            trackerDomain,
+            "google.com",
             trackerCompanyId = 1,
             company = "Google",
             appContainingTracker = trackingApp2(),
             timestamp = DatabaseDateFormatter.bucketByHour(LocalDateTime.now().plusHours(3))
         )
         trackerFound(
-            trackerDomain,
+            "google.com",
             trackerCompanyId = 1,
             company = "Google",
             appContainingTracker = trackingApp3(),

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldWeeklyNotificationFactoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldWeeklyNotificationFactoryTest.kt
@@ -77,7 +77,11 @@ class DeviceShieldWeeklyNotificationFactoryTest {
     fun createsWeeklyReportNotificationWhenTrackersFoundInTwoApps() = runBlocking {
         val trackerDomain = "example.com"
         trackerFound(trackerDomain, appContainingTracker = trackingApp1())
-        trackerFound(trackerDomain, appContainingTracker = trackingApp2())
+        trackerFound(
+            trackerDomain,
+            appContainingTracker = trackingApp2(),
+            timestamp = DatabaseDateFormatter.bucketByHour(LocalDateTime.now().plusHours(1))
+        )
 
         val notification = factory.weeklyNotificationFactory.createWeeklyDeviceShieldNotification(0)
         notification.assertTitleEquals("App Tracking Protection blocked 2 tracking attempts in app2 and 1 other app (past week).")
@@ -89,7 +93,11 @@ class DeviceShieldWeeklyNotificationFactoryTest {
         val trackerDomain = "example.com"
         trackerFound(trackerDomain, appContainingTracker = trackingApp1())
         trackerFound(trackerDomain, appContainingTracker = trackingApp2())
-        trackerFound(trackerDomain, appContainingTracker = trackingApp3())
+        trackerFound(
+            trackerDomain,
+            appContainingTracker = trackingApp3(),
+            timestamp = DatabaseDateFormatter.bucketByHour(LocalDateTime.now().plusHours(1))
+        )
 
         val notification = factory.weeklyNotificationFactory.createWeeklyDeviceShieldNotification(0)
         notification.assertTitleEquals("App Tracking Protection blocked 3 tracking attempts in app3 and 2 other apps (past week).")
@@ -104,7 +112,11 @@ class DeviceShieldWeeklyNotificationFactoryTest {
         trackerFound(trackerDomain, appContainingTracker = trackingApp2())
         trackerFound(trackerDomain, appContainingTracker = trackingApp3())
         trackerFound(trackerDomain, appContainingTracker = trackingApp3())
-        trackerFound(trackerDomain, appContainingTracker = trackingApp3())
+        trackerFound(
+            trackerDomain,
+            appContainingTracker = trackingApp3(),
+            timestamp = DatabaseDateFormatter.bucketByHour(LocalDateTime.now().plusHours(1))
+        )
 
         val notification = factory.weeklyNotificationFactory.createWeeklyDeviceShieldNotification(0)
         notification.assertTitleEquals("App Tracking Protection blocked 6 tracking attempts in app3 and 2 other apps (past week).")
@@ -131,13 +143,13 @@ class DeviceShieldWeeklyNotificationFactoryTest {
     fun createsWeeklyTopTrackerCompanyNotificationWhenTrackersFoundInTwoApps() = runBlocking {
         val trackerDomain = "example.com"
 
-        trackerFound(trackerDomain, company = "Google", appContainingTracker = trackingApp1())
-        trackerFound(trackerDomain, company = "Google", appContainingTracker = trackingApp1())
-        trackerFound(trackerDomain, company = "Facebook", appContainingTracker = trackingApp2())
-        trackerFound(trackerDomain, company = "Google", appContainingTracker = trackingApp2())
-        trackerFound(trackerDomain, company = "Google", appContainingTracker = trackingApp2())
+        trackerFound("google.com", company = "Google", appContainingTracker = trackingApp1())
+        trackerFound("google.com", company = "Google", appContainingTracker = trackingApp1())
+        trackerFound("facebook.com", company = "Facebook", appContainingTracker = trackingApp2())
+        trackerFound("google.com", company = "Google", appContainingTracker = trackingApp2())
+        trackerFound("google.com", company = "Google", appContainingTracker = trackingApp2())
         trackerFound(
-            trackerDomain, company = "Google", appContainingTracker = trackingApp2(),
+            "google.com", company = "Google", appContainingTracker = trackingApp2(),
             timestamp = DatabaseDateFormatter.bucketByHour(
                 LocalDateTime.now().plusHours(2)
             )

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModelTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModelTest.kt
@@ -88,9 +88,9 @@ class DeviceShieldActivityFeedViewModelTest {
 
     @Test
     fun whenGetMostRecentTrackersIsNotEmptyThenStartWithSkeletonThenEmit() = runBlocking {
-        db.vpnTrackerDao().insert(dummyTrackers[2])
-        db.vpnTrackerDao().insert(dummyTrackers[1])
         db.vpnTrackerDao().insert(dummyTrackers[0])
+        db.vpnTrackerDao().insert(dummyTrackers[1])
+        db.vpnTrackerDao().insert(dummyTrackers[2])
         db.vpnAppTrackerBlockingDao().insertTrackerEntities(dummySignals)
 
         viewModel.getMostRecentTrackers(timeWindow, false).test {

--- a/app-tracking-protection/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.VpnDatabase/28.json
+++ b/app-tracking-protection/vpn-store/schemas/com.duckduckgo.mobile.android.vpn.store.VpnDatabase/28.json
@@ -1,0 +1,654 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 28,
+    "identityHash": "ead21760aad5c9e3d436ce19800400dd",
+    "entities": [
+      {
+        "tableName": "vpn_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `uuid` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_tracker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackerCompanyId` INTEGER NOT NULL, `domain` TEXT NOT NULL, `company` TEXT NOT NULL, `companyDisplayName` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `bucket` TEXT NOT NULL, `count` INTEGER NOT NULL, `packageId` TEXT NOT NULL, `appDisplayName` TEXT NOT NULL, PRIMARY KEY(`bucket`, `domain`, `packageId`))",
+        "fields": [
+          {
+            "fieldPath": "trackerCompanyId",
+            "columnName": "trackerCompanyId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "company",
+            "columnName": "company",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "companyDisplayName",
+            "columnName": "companyDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bucket",
+            "columnName": "bucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackingApp.packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackingApp.appDisplayName",
+            "columnName": "appDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "bucket",
+            "domain",
+            "packageId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_vpn_tracker_bucket",
+            "unique": false,
+            "columnNames": [
+              "bucket"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_vpn_tracker_bucket` ON `${TABLE_NAME}` (`bucket`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_running_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `timeRunningMillis` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeRunningMillis",
+            "columnName": "timeRunningMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_service_state_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` TEXT NOT NULL, `state` TEXT NOT NULL, `stopReason` TEXT NOT NULL, `alwaysOnEnabled` INTEGER NOT NULL, `alwaysOnLockedDown` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopReason",
+            "columnName": "stopReason",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alwaysOnState.alwaysOnEnabled",
+            "columnName": "alwaysOnEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alwaysOnState.alwaysOnLockedDown",
+            "columnName": "alwaysOnLockedDown",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_heartbeat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`type`))",
+        "fields": [
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "type"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_phoenix",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `reason` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `formattedTimestamp` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formattedTimestamp",
+            "columnName": "formattedTimestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_notification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `timesRun` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timesRun",
+            "columnName": "timesRun",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_blocking_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hostname` TEXT NOT NULL, `trackerCompanyId` INTEGER NOT NULL, `isCdn` INTEGER NOT NULL, `name` TEXT NOT NULL, `displayName` TEXT NOT NULL, `score` INTEGER NOT NULL, `prevalence` REAL NOT NULL, PRIMARY KEY(`hostname`))",
+        "fields": [
+          {
+            "fieldPath": "hostname",
+            "columnName": "hostname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackerCompanyId",
+            "columnName": "trackerCompanyId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCdn",
+            "columnName": "isCdn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner.name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner.displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "app.score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "app.prevalence",
+            "columnName": "prevalence",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "hostname"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_blocking_list_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exclusion_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageId` TEXT NOT NULL, PRIMARY KEY(`packageId`))",
+        "fields": [
+          {
+            "fieldPath": "packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exclusion_list_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exception_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rule` TEXT NOT NULL, `packageNames` TEXT NOT NULL, PRIMARY KEY(`rule`))",
+        "fields": [
+          {
+            "fieldPath": "rule",
+            "columnName": "rule",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageNames",
+            "columnName": "packageNames",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "rule"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_exception_rules_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_blocking_app_packages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `entityName` TEXT NOT NULL, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityName",
+            "columnName": "entityName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageName"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_manual_exclusion_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageId` TEXT NOT NULL, `isProtected` INTEGER NOT NULL, PRIMARY KEY(`packageId`))",
+        "fields": [
+          {
+            "fieldPath": "packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isProtected",
+            "columnName": "isProtected",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_system_app_override_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageId` TEXT NOT NULL, PRIMARY KEY(`packageId`))",
+        "fields": [
+          {
+            "fieldPath": "packageId",
+            "columnName": "packageId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "packageId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_system_app_override_list_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `eTag` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_app_tracker_entities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackerCompanyId` INTEGER NOT NULL, `entityName` TEXT NOT NULL, `score` INTEGER NOT NULL, `signals` TEXT NOT NULL, PRIMARY KEY(`trackerCompanyId`))",
+        "fields": [
+          {
+            "fieldPath": "trackerCompanyId",
+            "columnName": "trackerCompanyId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityName",
+            "columnName": "entityName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "signals",
+            "columnName": "signals",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "trackerCompanyId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_feature_remover",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `isFeatureRemoved` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFeatureRemoved",
+            "columnName": "isFeatureRemoved",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "vpn_address_lookup",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `domain` TEXT NOT NULL, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "address"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ead21760aad5c9e3d436ce19800400dd')"
+    ]
+  }
+}

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnTrackerDao.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnTrackerDao.kt
@@ -25,16 +25,31 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface VpnTrackerDao {
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun insert(tracker: VpnTracker)
+    @Transaction
+    fun insert(tracker: VpnTracker) {
+        getTrackerFor(tracker.bucket, tracker.domain, tracker.trackingApp.packageId)?.let {
+            incrementCount(tracker.bucket, tracker.timestamp, tracker.domain, tracker.trackingApp.packageId)
+        } ?: internalInsertTracker(tracker.copy(count = 1))
+    }
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun insert(tracker: List<VpnTracker>)
+    fun internalInsertTracker(tracker: VpnTracker)
+
+    @Transaction
+    fun insert(tracker: List<VpnTracker>) {
+        tracker.forEach { insert(it) }
+    }
+
+    @Query("UPDATE vpn_tracker SET count = count + 1, timestamp = :timestamp WHERE bucket = :bucket AND domain = :domain AND packageId = :packageId")
+    fun incrementCount(bucket: String, timestamp: String, domain: String, packageId: String)
+
+    @Query("SELECT * FROM vpn_tracker WHERE bucket = :bucket AND domain = :domain AND packageId = :packageId LIMIT 1")
+    fun getTrackerFor(bucket: String, domain: String, packageId: String): VpnTracker?
 
     @Query("DELETE FROM vpn_tracker")
     fun deleteAllTrackers()
 
-    @Query("SELECT * FROM vpn_tracker ORDER BY trackerId DESC LIMIT 1")
+    @Query("SELECT * FROM vpn_tracker ORDER BY timestamp DESC LIMIT 1")
     fun getLatestTracker(): Flow<VpnTracker?>
 
     @Query(
@@ -58,7 +73,7 @@ interface VpnTrackerDao {
     @Query("DELETE FROM vpn_tracker WHERE timestamp < :startTime")
     fun deleteOldDataUntil(startTime: String)
 
-    @Query("SELECT COUNT(*) FROM vpn_tracker WHERE timestamp >= :startTime AND timestamp < :endTime")
+    @Query("SELECT sum(count) FROM vpn_tracker WHERE timestamp >= :startTime AND timestamp < :endTime")
     fun getTrackersCountBetween(
         startTime: String,
         endTime: String
@@ -71,7 +86,7 @@ interface VpnTrackerDao {
     ): Flow<Int>
 
     @Query(
-        "SELECT strftime('%Y-%m-%d', timestamp) bucket, * FROM vpn_tracker " +
+        "SELECT * FROM vpn_tracker " +
             "WHERE timestamp >= :startTime order by timestamp DESC limit $MAX_NUMBER_OF_TRACKERS_IN_QUERY_RESULTS"
     )
     fun getPagedTrackersSince(startTime: String): Flow<List<BucketizedVpnTracker>>

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/VpnDatabaseModels.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/VpnDatabaseModels.kt
@@ -25,20 +25,21 @@ import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerEntity
 
 @Entity(
     tableName = "vpn_tracker",
-    indices = [Index(value = ["timestamp"])]
+    indices = [Index(value = ["bucket"])],
+    primaryKeys = ["bucket", "domain", "packageId"]
 )
 data class VpnTracker(
-    @PrimaryKey(autoGenerate = true) val trackerId: Int = 0,
     val trackerCompanyId: Int,
     val domain: String,
     val company: String,
     val companyDisplayName: String,
     @Embedded val trackingApp: TrackingApp,
-    val timestamp: String = DatabaseDateFormatter.timestamp()
+    val timestamp: String = DatabaseDateFormatter.timestamp(),
+    val bucket: String = DatabaseDateFormatter.timestamp().split("T").first(),
+    val count: Int = 1,
 )
 
 data class BucketizedVpnTracker(
-    val bucket: String,
     @Embedded val trackerCompanySignal: VpnTrackerCompanySignal
 )
 

--- a/app/src/internal/java/com/duckduckgo/app/flipper/plugins/TrackerProtectionFlipperPlugin.kt
+++ b/app/src/internal/java/com/duckduckgo/app/flipper/plugins/TrackerProtectionFlipperPlugin.kt
@@ -67,7 +67,6 @@ class TrackerProtectionFlipperPlugin @Inject constructor(
                 tracker?.let {
                     Timber.v("$id: sending $tracker")
                     FlipperObject.Builder()
-                        .put("id", tracker.trackerId)
                         .put("timestamp", tracker.timestamp)
                         .put("domain", tracker.domain)
                         .put("company", tracker.companyDisplayName)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203195823975934/f

### Description
Change the `vpn_tracker` schema so that we don't need one entry per tracking attempt.


This should:
* improve DB access performance
* fix some bugs when we have more than 10,000 tracking attempts

### Steps to test this PR
_Test DB migration_
- [x] install from develop
- [x] enable AppTP
- [x] open several apps that track
- [x] (alternatively you can follow the instructions down below to create tracking attempts)
- [x] In the `vpn_tracker` db table in `vpn.db`, modify the day part of the `timestamp` in some of the tracking attempts (eg. 1,2,3,4 days ago) so that the DB is more representative
- [x] (alternative/in addition you can change the termux script to go from `1..1000` to create more than 10,000 tracking attempts)
- [x] update from this branch
- [x] launch app and enable AppTP
- [x] ensure app doesn't crash (migration is done correctly)
- [x] open AppTP activity screen and ensure all counters are correct, ie. past 7 days general counter, recent activity counters
- [x] open AppTP "view all recent activity" and ensure all counters are correct–for this you may need to have tracking attempts from more than 5 apps and/or different days
- [x] open some apps that generate new tracking attempts or do so with Termux
- [x] verify AppTP accounts tracking attempts correctly


_How to create tracking attempts_
* install Termux
* execute the script below
```bash
for i in {1..10}
do
  curl -v https://api2.branch.io &
  sleep 0.5
done
```
