### PR TITLE
Avoid reconfiguring VPN when game is installed

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/NewAppBroadcastReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/NewAppBroadcastReceiver.kt
@@ -27,6 +27,8 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.service.goAsync
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
@@ -49,6 +51,7 @@ class NewAppBroadcastReceiver @Inject constructor(
     private val appTrackerRepository: AppTrackerRepository,
     private val dispatcherProvider: DispatcherProvider,
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
+    private val appTpFeatureConfig: AppTpFeatureConfig,
 ) : BroadcastReceiver(), VpnServiceCallbacks {
 
     @MainThread
@@ -91,7 +94,7 @@ class NewAppBroadcastReceiver @Inject constructor(
     }
 
     private fun isGame(packageName: String): Boolean {
-        return appCategoryDetector.getAppCategory(packageName) is AppCategory.Game
+        return appCategoryDetector.getAppCategory(packageName) is AppCategory.Game && !appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)
     }
 
     @WorkerThread

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnAppTrackerListInfoCollector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnAppTrackerListInfoCollector.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.mobile.android.vpn.bugreport
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.apps.AppCategory
 import com.duckduckgo.mobile.android.vpn.apps.AppCategoryDetector
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
 import com.duckduckgo.mobile.android.vpn.state.VpnStateCollectorPlugin
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerRepository
@@ -31,6 +33,7 @@ class VpnAppTrackerListInfoCollector @Inject constructor(
     private val vpnDatabase: VpnDatabase,
     private val appTrackerRepository: AppTrackerRepository,
     private val appCategoryDetector: AppCategoryDetector,
+    private val appTpFeatureConfig: AppTpFeatureConfig,
 ) : VpnStateCollectorPlugin {
 
     override val collectorName: String
@@ -49,8 +52,11 @@ class VpnAppTrackerListInfoCollector @Inject constructor(
     }
 
     private fun isUnprotectedByDefault(appPackageId: String): Boolean {
-        return appCategoryDetector.getAppCategory(appPackageId) is AppCategory.Game ||
-            appTrackerRepository.getAppExclusionList().any { it.packageId == appPackageId }
+        return isGame(appPackageId) || appTrackerRepository.getAppExclusionList().any { it.packageId == appPackageId }
+    }
+
+    private fun isGame(packageName: String): Boolean {
+        return appCategoryDetector.getAppCategory(packageName) is AppCategory.Game && !appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)
     }
 
     private fun isProtectionOverriden(appPackageId: String): Boolean {

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnAppTrackerListInfoCollectorTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnAppTrackerListInfoCollectorTest.kt
@@ -20,6 +20,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.mobile.android.vpn.apps.AppCategory
 import com.duckduckgo.mobile.android.vpn.apps.AppCategoryDetector
 import com.duckduckgo.mobile.android.vpn.dao.VpnAppTrackerBlockingDao
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -40,6 +42,7 @@ class VpnAppTrackerListInfoCollectorTest {
 
     private val appTrackerRepository = mock<AppTrackerRepository>()
     private val appCategoryDetector = mock<AppCategoryDetector>()
+    private val appTpFeatureConfig = mock<AppTpFeatureConfig>()
 
     private lateinit var collector: VpnAppTrackerListInfoCollector
 
@@ -48,7 +51,7 @@ class VpnAppTrackerListInfoCollectorTest {
         whenever(vpnDatabase.vpnAppTrackerBlockingDao()).thenReturn(vpnAppTrackerBlockingDao)
         whenever(appTrackerRepository.getManualAppExclusionList()).thenReturn(listOf())
 
-        collector = VpnAppTrackerListInfoCollector(vpnDatabase, appTrackerRepository, appCategoryDetector)
+        collector = VpnAppTrackerListInfoCollector(vpnDatabase, appTrackerRepository, appCategoryDetector, appTpFeatureConfig)
     }
 
     @Test
@@ -104,11 +107,42 @@ class VpnAppTrackerListInfoCollectorTest {
 
     @Test
     fun whenCollectStateAndAppGameAndInExclusionListThenReturnUnprotectedByDefaultTrue() = runTest {
+        whenever(appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)).thenReturn(false)
         whenever(appCategoryDetector.getAppCategory(PACKAGE_ID)).thenReturn(AppCategory.Game)
         whenever(appTrackerRepository.getAppExclusionList()).thenReturn(listOf(AppTrackerExcludedPackage(PACKAGE_ID)))
         val jsonObject = collector.collectVpnRelatedState(PACKAGE_ID)
 
         assertEquals("true", jsonObject.get("reportedAppUnprotectedByDefault"))
+    }
+
+    @Test
+    fun whenCollectStateAndAppRemoteGameProtectionEnabledAndInExclusionListThenReturnUnprotectedByDefaultTrue() = runTest {
+        whenever(appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)).thenReturn(true)
+        whenever(appCategoryDetector.getAppCategory(PACKAGE_ID)).thenReturn(AppCategory.Game)
+        whenever(appTrackerRepository.getAppExclusionList()).thenReturn(listOf(AppTrackerExcludedPackage(PACKAGE_ID)))
+        val jsonObject = collector.collectVpnRelatedState(PACKAGE_ID)
+
+        assertEquals("true", jsonObject.get("reportedAppUnprotectedByDefault"))
+    }
+
+    @Test
+    fun whenCollectStateAndAppGameAndNotInExclusionListThenReturnUnprotectedByDefaultTrue() = runTest {
+        whenever(appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)).thenReturn(false)
+        whenever(appCategoryDetector.getAppCategory(PACKAGE_ID)).thenReturn(AppCategory.Game)
+        whenever(appTrackerRepository.getAppExclusionList()).thenReturn(listOf())
+        val jsonObject = collector.collectVpnRelatedState(PACKAGE_ID)
+
+        assertEquals("true", jsonObject.get("reportedAppUnprotectedByDefault"))
+    }
+
+    @Test
+    fun whenCollectStateAndAppRemoteGameProtectionEnabledAndNotInExclusionListThenReturnUnprotectedByDefaultFalse() = runTest {
+        whenever(appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)).thenReturn(true)
+        whenever(appCategoryDetector.getAppCategory(PACKAGE_ID)).thenReturn(AppCategory.Game)
+        whenever(appTrackerRepository.getAppExclusionList()).thenReturn(listOf())
+        val jsonObject = collector.collectVpnRelatedState(PACKAGE_ID)
+
+        assertEquals("false", jsonObject.get("reportedAppUnprotectedByDefault"))
     }
 
     @Test
@@ -122,11 +156,22 @@ class VpnAppTrackerListInfoCollectorTest {
 
     @Test
     fun whenCollectStateAndAppGameThenReturnUnprotectedByDefaultTrue() = runTest {
+        whenever(appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)).thenReturn(false)
         whenever(appCategoryDetector.getAppCategory(PACKAGE_ID)).thenReturn(AppCategory.Game)
         whenever(appTrackerRepository.getAppExclusionList()).thenReturn(listOf())
         val jsonObject = collector.collectVpnRelatedState(PACKAGE_ID)
 
         assertEquals("true", jsonObject.get("reportedAppUnprotectedByDefault"))
+    }
+
+    @Test
+    fun whenCollectStateAndRemoteGameProtectionEnabledThenReturnUnprotectedByDefaultFalse() = runTest {
+        whenever(appTpFeatureConfig.isEnabled(AppTpSetting.ProtectGames)).thenReturn(true)
+        whenever(appCategoryDetector.getAppCategory(PACKAGE_ID)).thenReturn(AppCategory.Game)
+        whenever(appTrackerRepository.getAppExclusionList()).thenReturn(listOf())
+        val jsonObject = collector.collectVpnRelatedState(PACKAGE_ID)
+
+        assertEquals("false", jsonObject.get("reportedAppUnprotectedByDefault"))
     }
 
     @Test


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203238561022240/f

### Description
Avoid re-starting AppTP when games are installed, see [asana task](https://app.asana.com/0/488551667048375/1203238561022240/f) for more details

### Steps to test this PR

_Test install games_
- [ ] install from this branch
- [ ] enable AppTP
- [ ] install a game, eg. candy crash
- [ ] verify VPN is not restarted

