### PR TITLE
Update autofill to 0.0.3_test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@duckduckgo/autoconsent": "github:duckduckgo/autoconsent#v3.0.0",
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.1.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#undefined",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1666183539"
       },
@@ -1117,7 +1117,7 @@
     },
     "@duckduckgo/autofill": {
       "version": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#48fa29dc6a01930e5fb79fa1f67a9a5d1eb788b9",
-      "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#5.1.0",
+      "from": "@duckduckgo/autofill@github:duckduckgo/duckduckgo-autofill#undefined",
       "requires": {
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#1.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#5.1.0",
+    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#undefined",
     "@duckduckgo/autoconsent": "github:duckduckgo/autoconsent#v3.0.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1666183539"


### PR DESCRIPTION
**Reviewer:** 
**Asana:** https://app.asana.com/0/1203250571581508/1203250571581508
**Autofill Release:** https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.3_test


## Description
Updates Autofill to version [0.0.3_test](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/0.0.3_test).

### Autofill 0.0.3_test release notes
New test release 0.0.3_test

- Here feature
- Feature **again**

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).