### PR TITLE
persist global permission settings

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
@@ -45,9 +45,6 @@ class SitePermissionsManagerImpl @Inject constructor(
             .toTypedArray()
 
     override suspend fun clearAllButFireproof(fireproofDomains: List<String>) {
-        sitePermissionsRepository.askCameraEnabled = true
-        sitePermissionsRepository.askMicEnabled = true
-
         sitePermissionsRepository.sitePermissionsForAllWebsites().forEach { permission ->
             if (!fireproofDomains.contains(permission.domain)) {
                 sitePermissionsRepository.deletePermissionsForSite(permission.domain)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/715106103902962/1203249594027451/f 

### Description
Do not remove global permission settings when clearing data

### Steps to test this PR

_Test_
- [ ] fresh install
- [ ] disable all permission in site permission settings
- [ ] clear data with fire button
- [ ] ensure permission global settings are persisted

_Test 2_
- [ ] fresh install
- [ ] go to http://webcamtest.com
- [ ] grand permissions
- [ ] fireproof the site
- [ ] go to permission settings
- [ ] disable ask for camera permission
- [ ] click on webcamtest.com site and choose "Allow" for camera permission
- [ ] clear data with fire button
- [ ] go to http://webcamtest.com
- [ ] ensure camera permission is automatically allowed
- [ ] ensure permission global settings are persisted


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
