### PR TITLE
Prevent autofill cred picker showing after certain user-interactions

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4267,10 +4267,65 @@ class BrowserTabViewModelTest {
         }
     }
 
+    @Test
+    fun whenNotEditingUrlBarAndNotCancelledThenCanAutomaticallyShowAutofillPrompt() {
+        configureOmnibarNotEditing()
+        assertTrue(testee.canAutofillSelectCredentialsDialogCanAutomaticallyShow())
+    }
+
+    @Test
+    fun whenEditingUrlBarAndNotCancelledThenCannotAutomaticallyShowAutofillPrompt() {
+        configureOmnibarEditing()
+        assertFalse(testee.canAutofillSelectCredentialsDialogCanAutomaticallyShow())
+    }
+
+    @Test
+    fun whenNotEditingUrlBarAndCancelledThenCannotAutomaticallyShowAutofillPrompt() {
+        configureOmnibarNotEditing()
+        testee.cancelPendingAutofillRequestToChooseCredentials()
+        assertFalse(testee.canAutofillSelectCredentialsDialogCanAutomaticallyShow())
+    }
+
+    @Test
+    fun whenEditingUrlBarAndCancelledThenCannotAutomaticallyShowAutofillPrompt() {
+        configureOmnibarEditing()
+        testee.cancelPendingAutofillRequestToChooseCredentials()
+        assertFalse(testee.canAutofillSelectCredentialsDialogCanAutomaticallyShow())
+    }
+
+    @Test
+    fun whenNavigationStateChangesSameSiteThenShowAutofillPromptFlagIsReset() {
+        testee.cancelPendingAutofillRequestToChooseCredentials()
+        updateUrl("example.com", "example.com", true)
+        assertTrue(testee.canAutofillSelectCredentialsDialogCanAutomaticallyShow())
+    }
+
+    @Test
+    fun whenNavigationStateChangesDifferentSiteThenShowAutofillPromptFlagIsReset() {
+        testee.cancelPendingAutofillRequestToChooseCredentials()
+        updateUrl("example.com", "foo.com", true)
+        assertTrue(testee.canAutofillSelectCredentialsDialogCanAutomaticallyShow())
+    }
+
+    @Test
+    fun whenPageRefreshesThenShowAutofillPromptFlagIsReset() {
+        testee.cancelPendingAutofillRequestToChooseCredentials()
+        testee.onWebViewRefreshed()
+        assertTrue(testee.canAutofillSelectCredentialsDialogCanAutomaticallyShow())
+    }
+
     private fun assertShowHistoryCommandSent(expectedStackSize: Int) {
         assertCommandIssued<ShowBackNavigationHistory> {
             assertEquals(expectedStackSize, history.size)
         }
+    }
+
+    private fun configureOmnibarEditing() {
+        testee.onOmnibarInputStateChanged(hasFocus = true, query = "", hasQueryChanged = false)
+    }
+
+    private fun configureOmnibarNotEditing() {
+        testee.onOmnibarInputStateChanged(hasFocus = false, query = "", hasQueryChanged = false)
     }
 
     private fun buildNavigationHistoryStack(stackSize: Int) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -480,6 +480,13 @@ class BrowserTabViewModel @Inject constructor(
     private var refreshOnViewVisible = MutableStateFlow(true)
     private var ctaChangedTicker = MutableStateFlow("")
 
+    /*
+      Used to prevent autofill credential picker from automatically showing
+      Useful if user has done something that would result in a strange UX to then show the picker
+      This only prevents against automatically showing; if the user taps on an autofill field directly, the dialog can still show
+     */
+    private var canAutofillSelectCredentialsDialogCanAutomaticallyShow = true
+
     val url: String?
         get() = site?.url
 
@@ -1111,6 +1118,8 @@ class BrowserTabViewModel @Inject constructor(
         webNavigationState = newWebNavigationState
 
         if (!currentBrowserViewState().browserShowing) return
+
+        canAutofillSelectCredentialsDialogCanAutomaticallyShow = true
 
         browserViewState.value = currentBrowserViewState().copy(
             canGoBack = newWebNavigationState.canGoBack || !skipHome,
@@ -2697,6 +2706,7 @@ class BrowserTabViewModel @Inject constructor(
 
     fun onWebViewRefreshed() {
         accessibilityViewState.value = currentAccessibilityViewState().copy(refreshWebView = false)
+        canAutofillSelectCredentialsDialogCanAutomaticallyShow = true
     }
 
     override fun handleCloakedAmpLink(initialUrl: String) {
@@ -2772,6 +2782,14 @@ class BrowserTabViewModel @Inject constructor(
     @VisibleForTesting
     fun updateWebNavigation(webNavigationState: WebNavigationState) {
         this.webNavigationState = webNavigationState
+    }
+
+    fun cancelPendingAutofillRequestToChooseCredentials() {
+        canAutofillSelectCredentialsDialogCanAutomaticallyShow = false
+    }
+
+    fun canAutofillSelectCredentialsDialogCanAutomaticallyShow(): Boolean {
+        return canAutofillSelectCredentialsDialogCanAutomaticallyShow && !currentOmnibarViewState().isEditing
     }
 
     companion object {

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/BrowserAutofill.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/BrowserAutofill.kt
@@ -52,6 +52,11 @@ interface BrowserAutofill {
      */
     fun injectCredentials(credentials: LoginCredentials?)
 
+    /**
+     * Cancels any ongoing autofill operations which would show the user the prompt to choose credentials
+     * This would only normally be needed if a user-interaction happened such that showing autofill prompt would be undesirable.
+     */
+    fun cancelPendingAutofillRequestToChooseCredentials()
 }
 
 /**

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/InlineBrowserAutofill.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/InlineBrowserAutofill.kt
@@ -50,4 +50,8 @@ class InlineBrowserAutofill @Inject constructor(
             autofillInterface.injectCredentials(credentials)
         }
     }
+
+    override fun cancelPendingAutofillRequestToChooseCredentials() {
+        autofillInterface.cancelRetrievingStoredLogins()
+    }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/InlineBrowserAutofillTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/InlineBrowserAutofillTest.kt
@@ -117,6 +117,10 @@ class InlineBrowserAutofillTest {
             lastAction = NoCredentialsInjected
         }
 
+        override fun cancelRetrievingStoredLogins() {
+
+        }
+
         override var callback: Callback? = null
         override var webView: WebView? = null
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203130404520146/f

### Description
It is possible now for a strange UX if the user clicks the URL bar just before the autofill prompt pops up offering to autofill.

This PR fixes that interaction:
- When the user interacts with the URL bar, we should disable the autofill prompt from automatically appearing until the user navigates page or refreshes. 
- Any manual autofill prompts, triggered by the user interacting with the form fields directly, should still result in the autofill prompt showing.


### Steps to test this PR

Useful logcat filter: `AutoPrompt is disabled, not showing dialog`

#### Automatic prompt disabled upon URL bar interaction; manual prompt still works
- [x] Save login details for a site that will automatically promp to autofill saved logins (e.g., trello.com/login)
- [x] Logout / refresh, and verify the automatic prompt shows as expected
- [x] Refresh again, but this time **immediately** click on the URL bar when the page is loading (if timing of this is tricky, you can add a synthetic delay to `AutofillStoredBackJavascriptInterface.getAutofillData` of a few hundred millis)
- [x] Verify that autofill prompt does not show
- [x] Manually tap on username field; verify the autofill prompt shows

#### Works again on refresh 
- [x] Repeat steps above, such that you have a saved login and you have cancelled a site from showing autofill by tapping on the URL bar when it is loading (or after it is loaded, no matter)
- [x] Refresh the page; verify the autofill prompt is automatically shown

#### Works again after a page navigation
- [x] Repeat steps above, such that you have a saved login and you have cancelled a site from showing autofill by tapping on the URL bar when it is loading (or after it is loaded, no matter)
- [x] Navigate to a different page with a saved login (or go to another site and come back)
- [x] Verify the autofill prompt is automatically shown

