### PR TITLE
Fix crash caused by unitialised dispatcher provider

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/DeviceShieldTileService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/DeviceShieldTileService.kt
@@ -26,7 +26,6 @@ import android.service.quicksettings.TileService
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import com.duckduckgo.anvil.annotations.InjectWith
-import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.QuickSettingsScope
@@ -41,6 +40,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.*
 import timber.log.Timber
 
+@Suppress("NoHardcodedCoroutineDispatcher")
 @RequiresApi(Build.VERSION_CODES.N)
 // We don't use the DeviceShieldTileService::class as binding key because TileService (Android) class does not
 // exist in all APIs, and so using it DeviceShieldTileService::class as key would compile but immediately crash
@@ -54,10 +54,9 @@ class DeviceShieldTileService : TileService() {
     @Inject lateinit var deviceShieldPixels: DeviceShieldPixels
     @Inject lateinit var repository: AtpWaitlistStateRepository
     @Inject lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
-    @Inject lateinit var dispatchers: DispatcherProvider
 
     private var deviceShieldStatePollingJob = ConflatedJob()
-    private val serviceScope = CoroutineScope(dispatchers.io())
+    private val serviceScope = CoroutineScope(Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203277450694429/f

### Description
Reverts changes made to `DeviceShieldTileService` so that it doesn't use an injected coroutine dispatcher (easiest fix for a niche / hard to test area of code)

### Steps to test this PR

- [x] enable appTP
- [x] swipe down on the system notification shade, and edit quick tiles such that the appTP one is selected
- [x] test it doesn't crash when interacting with it
