### PR TITLE
Allow VpnNetworkStack to provide dns and addresses

### DIFF
--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/network/VpnNetworkStack.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/network/VpnNetworkStack.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.mobile.android.vpn.network
 
 import android.os.ParcelFileDescriptor
+import java.net.InetAddress
 
 interface VpnNetworkStack {
 
@@ -55,4 +56,21 @@ interface VpnNetworkStack {
      * @return the MTU size you wish the VPN service to set
      */
     fun mtu(): Int
+
+    /**
+     * @return the address you wish to add to the VPN service.
+     * They key contains the InetAddress of the address and value should be the mask width.
+     */
+    fun addresses(): Map<InetAddress, Int>
+
+    /**
+     * @return the additional dns servers you wish to add to the VPN service
+     */
+    fun dns(): Set<InetAddress>
+
+    /**
+     * @return the additional routes you wish to add to the VPN service.
+     * They key contains the InetAddress of the route and value should be the mask width.
+     */
+    fun routes(): Map<InetAddress, Int>
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/integration/NgVpnNetworkStack.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/integration/NgVpnNetworkStack.kt
@@ -36,6 +36,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import dagger.Lazy
 import dagger.SingleInstanceIn
 import timber.log.Timber
+import java.net.InetAddress
 import javax.inject.Inject
 
 private const val LRU_CACHE_SIZE = 2048
@@ -84,7 +85,6 @@ class NgVpnNetworkStack @Inject constructor(
                 vpnNetwork.destroy(jniContext)
                 jniContext = 0
             }
-
         }
         jniContext = vpnNetwork.create()
 
@@ -114,6 +114,15 @@ class NgVpnNetworkStack @Inject constructor(
     override fun mtu(): Int {
         return vpnNetwork.get().mtu()
     }
+
+    override fun addresses(): Map<InetAddress, Int> = mapOf(
+        InetAddress.getByName("10.0.0.2") to 32,
+        InetAddress.getByName("fd00:1:fd00:1:fd00:1:fd00:1") to 128, // Add IPv6 Unique Local Address
+    )
+
+    override fun dns(): Set<InetAddress> = emptySet()
+
+    override fun routes(): Map<InetAddress, Int> = emptyMap()
 
     override fun onExit(reason: String) {
         Timber.w("Native exit reason=$reason")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203276170799087/f

### Description
This PR Includes:
- Allowing VPNNetworkStack impls to  provide additional dns servers (also add it as a route)
- Allowing VPNNetworkStack impls to provide the addresses for the VPNService to use
- Making VPNRoutes accessible outside of vpn-impl 

### Steps to test this PR

_Feature 1_
- Smoke test that AppTP works as expected
