### PR TITLE
Restrict autofill edit fields to be singular lines (except notes)

### DIFF
--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_edit_mode.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_edit_mode.xml
@@ -31,6 +31,7 @@
             android:id="@+id/domainTitleEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:type="single_line"
             android:layout_marginBottom="@dimen/keyline_5"
             android:hint="@string/credentialManagementEditLoginTitleHint"
             android:visibility="gone"
@@ -43,6 +44,7 @@
             android:layout_height="wrap_content"
             android:hint="@string/credentialManagementEditUsernameHint"
             app:editable="false"
+            app:type="single_line"
             app:endIcon="@drawable/ic_copy"
             app:endIconContentDescription="@string/credentialManagementEditButtonCopyUsername" />
 
@@ -63,6 +65,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/keyline_5"
             android:hint="@string/credentialManagementEditWebsiteHint"
+            app:type="single_line"
             app:editable="false" />
 
         <com.duckduckgo.mobile.android.ui.view.OutLinedTextInputView
@@ -70,6 +73,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/keyline_5"
+            app:type="multi_line"
             android:hint="@string/credentialManagementEditNotesHint"
             app:editable="false" />
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201131549756850/f

### Description
Restricts the autofill edit screen's fields to be single lines only (apart from notes)

### Steps to test this PR

- [x] Save a login, then visit the manage autofill logins screen
- [x] Choose to edit the saved login
- [x] Verify that notes can have multiple lines
- [x] Verify that all other fields are restricted to a single line only
- [x] Edit some fields and save. Verify it is saved correctly.

