### PR TITLE
Fix bug where exceptions were matching full hostname instead of SLD

### DIFF
--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnAppTrackerBlockingDao.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnAppTrackerBlockingDao.kt
@@ -109,7 +109,7 @@ interface VpnAppTrackerBlockingDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertTrackerExceptionRules(trackerExceptionRules: List<AppTrackerExceptionRule>)
 
-    @Query("SELECT * from vpn_app_tracker_exception_rules WHERE rule = :domain LIMIT 1")
+    @Query("SELECT * from vpn_app_tracker_exception_rules WHERE :domain LIKE '%' || rule LIMIT 1")
     fun getRuleByTrackerDomain(domain: String): AppTrackerExceptionRule?
 
     @Query("SELECT * from vpn_app_tracker_exception_rules")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1203278838524404/f

### Description
Our exceptions are based on SLDs, but we were matching on FQDNs. Fix to match exceptions the same way we match domains in the blocklist.

### Steps to test this PR
- [x] Install from this branch
- [x] Smoke tests on AppTP
- [x] Use AppTP dev settings to add some App/Tracker exception rules and verify they work as intended