### PR TITLE
AppTP - Improve Recent Apps empty state

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/ManageRecentAppsProtectionActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/ManageRecentAppsProtectionActivity.kt
@@ -144,6 +144,8 @@ class ManageRecentAppsProtectionActivity :
             adapter.update(viewState.excludedApps)
             binding.manageRecentAppsRecycler.show()
         }
+        binding.manageRecentAppsShowAll.show()
+        binding.manageRecentAppsDivider.show()
         shimmerLayout.gone()
     }
 

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_manage_recent_apps_protection.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_manage_recent_apps_protection.xml
@@ -91,21 +91,31 @@
 
             <TextView
                 android:id="@+id/manageRecentAppsEmptyView"
-                android:textAppearance="@style/TextAppearance.DuckDuckGo.Body2"
+                style="@style/DeviceShield.PrivacyReport.TrackerEntry"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="?secondaryTextColor"
-                android:textAlignment="center"
-                android:paddingTop="40dp"
-                android:paddingBottom="40dp"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:drawablePadding="@dimen/keyline_4"
+                android:gravity="center_vertical"
+                android:padding="@dimen/keyline_4"
                 android:visibility="gone"
-                android:text="@string/atp_ManageRecentAppsProtectionEmpty" />
+                android:text="@string/atp_ManageRecentAppsProtectionEmpty"
+                app:drawableStartCompat="@drawable/ic_green_key"/>
+
+            <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
+                android:id="@+id/manageRecentAppsDivider"
+                android:layout_marginStart="72dp"
+                app:defaultPadding="false"
+                android:visibility="gone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
 
             <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
                 android:id="@+id/manageRecentAppsShowAll"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingStart="56dp"
+                android:visibility="gone"
                 app:primaryText="@string/atp_ManageRecentAppsProtectionShowAll"/>
 
         </LinearLayout>

--- a/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
@@ -360,7 +360,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">If you’re having problems with an app (such as content not loading), try disabling protection for that app and <annotation type="report_issues_link">submit a report.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Recent Apps</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Show All Apps</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">No recent apps yet</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Apps with recently blocked tracking attempts will appear here</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Disable and Delete Data?</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1203291839292809

### Description
This PR updates the UI in Recent Apps, improving the empty state

### Steps to test this PR

_Recent Apps
- [x] Fresh Install, enable AppTP
- [x] Quickly disable it so no trackers are blocked
- [x] Open Recent Apps screen
- [x] Check UI what's expected

### UI changes
| Before  | After |
| ------ | ----- |
|![Recent Apps (2)](https://user-images.githubusercontent.com/531613/199947988-0d6f57be-fd5b-40c8-8d4e-e52a814ef442.jpg)|![Screenshot_20221104_105955](https://user-images.githubusercontent.com/531613/199947757-7ac9b65c-0bf2-4632-9f8e-ff782c80d4a9.png)|