### PR TITLE
CT7–Crash after restoring default protection

### DIFF
--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/state/VpnStateMonitor.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/state/VpnStateMonitor.kt
@@ -54,6 +54,7 @@ interface VpnStateMonitor {
         SELF_STOP,
         ERROR,
         REVOKED,
-        UNKNOWN
+        UNKNOWN,
+        RESTART
     }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionExclusionListActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionExclusionListActivity.kt
@@ -264,7 +264,6 @@ class TrackingProtectionExclusionListActivity :
 
     override fun onDefaultProtectionRestored() {
         viewModel.restoreProtectedApps()
-        restartVpn()
         Snackbar.make(shimmerLayout, getString(R.string.atp_ExcludeAppsRestoreDefaultSnackbar), Snackbar.LENGTH_LONG)
             .show()
     }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/heartbeat/VpnServiceHeartbeat.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/heartbeat/VpnServiceHeartbeat.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason.ERROR
+import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason.RESTART
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason.REVOKED
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason.SELF_STOP
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason.UNKNOWN
@@ -74,6 +75,7 @@ class VpnServiceHeartbeat @Inject constructor(
         Timber.v("onVpnStopped called")
         when (vpnStopReason) {
             ERROR -> Timber.v("HB monitor: sudden vpn stopped $vpnStopReason")
+            RESTART -> Timber.v("HB monitor: restarting vpn $vpnStopReason")
             SELF_STOP, REVOKED, UNKNOWN -> {
                 Timber.v("HB monitor: self stopped or revoked: $vpnStopReason")
                 coroutineScope.launch { storeHeartbeat(VpnServiceHeartbeatMonitor.DATA_HEART_BEAT_TYPE_STOPPED) }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/RealVpnStateMonitor.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/RealVpnStateMonitor.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.mobile.android.vpn.model.VpnServiceState.DISABLED
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceState.ENABLED
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceStateStats
 import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason.ERROR
+import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason.RESTART
 import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason.REVOKED
 import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason.SELF_STOP
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
@@ -79,6 +80,7 @@ class RealVpnStateMonitor @Inject constructor(
 
     private fun mapState(lastState: VpnServiceStateStats?): VpnState {
         val stoppingReason = when (lastState?.stopReason) {
+            RESTART -> VpnStopReason.RESTART
             SELF_STOP -> VpnStopReason.SELF_STOP
             REVOKED -> VpnStopReason.REVOKED
             ERROR -> VpnStopReason.ERROR

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.mobile.android.vpn.model.VpnServiceState
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceStateStats
 import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason
 import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason.ERROR
+import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason.RESTART
 import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason.REVOKED
 import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason.SELF_STOP
 import com.duckduckgo.mobile.android.vpn.model.VpnStoppingReason.UNKNOWN
@@ -114,6 +115,7 @@ class VpnServiceStateLogger @Inject constructor(
 
     private fun mapStopReason(vpnStopReason: VpnStopReason): VpnStoppingReason {
         return when (vpnStopReason) {
+            VpnStopReason.RESTART -> RESTART
             VpnStopReason.SELF_STOP -> SELF_STOP
             VpnStopReason.REVOKED -> REVOKED
             VpnStopReason.ERROR -> ERROR

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldReminderNotificationScheduler.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldReminderNotificationScheduler.kt
@@ -67,6 +67,7 @@ class DeviceShieldReminderNotificationScheduler @Inject constructor(
         vpnStopReason: VpnStopReason
     ) {
         when (vpnStopReason) {
+            VpnStopReason.RESTART -> {} // no-op
             VpnStopReason.SELF_STOP -> onVPNManuallyStopped()
             VpnStopReason.REVOKED -> onVPNRevoked()
             else -> onVPNUndesiredStop()

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/VpnDatabaseModels.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/VpnDatabaseModels.kt
@@ -59,7 +59,8 @@ enum class VpnStoppingReason {
     SELF_STOP,
     ERROR,
     REVOKED,
-    UNKNOWN
+    UNKNOWN,
+    RESTART
 }
 
 data class AlwaysOnState(val alwaysOnEnabled: Boolean, val alwaysOnLockedDown: Boolean) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203286669056489/f

### Description
Updated the way we restart the vpn service in an attempt to reduce the `android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException` exceptions.

### Steps to test this PR

**Note**: it's very difficult to reproduce the crash by using the app. See more details in [Asana ](https://app.asana.com/0/0/1203286669056489/f)

- [x] Fresh install from this branch.
- [x] Enable AppTP from Settings.
- [x] Go to `All Apps` screen (`App Tracking Protection` screen -> tap on `Please Report an issue` -> `Recent Apps` screen -> tap on `Show All Apps`) and disable a large number of apps,  then tap on the overflow menu and choose `Restore Default Protected Apps`.
- [x] You should see how the vpn service restarts (look at the key icon in the status bar).
- [x] The app should not crash.

### NO UI changes
