### PR TITLE
Add explanatory text for autofill authentication

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/res/values-bg/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-bg/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Ако имате проблеми с някое приложение (например съдържанието не се зарежда), опитайте да деактивирате защитата за това приложение и <annotation type="report_issues_link">докладвайте проблема.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Скорошни приложения</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Показване на всички приложения</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Все още няма скорошни приложения</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Тук се показват приложенията с наскоро блокирани опити за проследяване</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Деактивиране и изтриване на данните?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-cs/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-cs/strings-vpn.xml
@@ -373,7 +373,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Pokud máš s nějakou aplikací problémy (například se vám nenačítá obsah), zkus pro ni vypnout ochranu a <annotation type="report_issues_link">odeslat zprávu.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Poslední aplikace</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Zobrazit všechny aplikace</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Zatím žádné poslední aplikace</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Tady se zobrazí aplikace s nedávno zablokovanými pokusy o sledování</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Vypnout a smazat data?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-da/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-da/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Hvis du har problemer med en app (f.eks. indhold, der ikke indlæses), kan du prøve at deaktivere beskyttelsen for den pågældende app og <annotation type="report_issues_link">indsende en rapport. </annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Seneste apps</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Vis alle apps</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Endnu ingen apps</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Apps med nyligt blokerede sporingsforsøg vises her</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Deaktiver og slet data?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-de/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-de/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Wenn du Probleme mit einer App hast (z. B. Inhalte, die nicht geladen werden), versuche, den Schutz für diese App zu deaktivieren und <annotation type="report_issues_link">reiche einen Bericht ein</annotation>.</string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Aktuelle Apps</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Alle Apps anzeigen</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Noch keine aktuellen Apps</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Apps mit kürzlich blockierten Tracking-Versuchen werden hier angezeigt</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Daten deaktivieren und löschen?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-el/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-el/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Εάν αντιμετωπίζετε προβλήματα με μια εφαρμογή (όπως για παράδειγμα μη φόρτωση περιεχομένου), προσπαθήστε να απενεργοποιήσετε την προστασία για την εν λόγω εφαρμογή και <annotation type="report_issues_link">υποβάλετε μια αναφορά.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Πρόσφατες εφαρμογές</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Εμφάνιση όλων των εφαρμογών</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Δεν υπάρχουν ακόμη πρόσφατες εφαρμογές</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Οι εφαρμογές με προσπάθειες παρακολούθησης που αποκλείστηκαν πρόσφατα θα εμφανίζονται εδώ</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Απενεργοποίηση και διαγραφή δεδομένων;</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-es/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-es/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Si tienes problemas con una aplicación (como que el contenido no se cargue), prueba a desactivar la protección para esa aplicación y <annotation type="report_issues_link">envía un informe.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Aplicaciones recientes</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Mostrar todas las aplicaciones</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Aún no hay aplicaciones recientes</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Las aplicaciones con intentos recientes de rastreo bloqueados aparecerán aquí</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">¿Desactivar y borrar datos?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-et/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-et/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Kui sul on mõne rakendusega probleeme (näiteks sisu ei laadi), proovi selle rakenduse kaitse välja lülitada ja <annotation type="report_issues_link">saada meile asjakohane teavitus.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Hiljuti kasutatud rakendused</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Kuva kõik rakendused</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Hiljuti kasutatud rakendusi veel ei ole</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Siin ilmuvad äsja blokeeritud jälgimiskatsetega rakendused</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Andmete keelamine ja kustutamine?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-fi/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-fi/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Jos sinulla on ongelmia sovelluksen kanssa (sisältö ei esimerkiksi lataudu), yritä poistaa kyseisen sovelluksen suojaus käytöstä ja <annotation type="report_issues_link">lähettää raportti.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Viimeaikaiset sovellukset</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Näytä kaikki sovellukset</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Ei vielä viimeaikaisia sovelluksia</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Täällä näkyvät sovellukset, joiden seurantayritykset on estetty hiljattain</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Poistetaanko tiedot käytöstä ja poistetaan?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-fr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-fr/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Si vous rencontrez des problèmes avec une application (comme l\'absence de chargement du contenu), essayez de désactiver la protection de cette application et <annotation type="report_issues_link">envoyez un rapport.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Applications récentes</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Afficher toutes les applications</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Aucune application récente pour le moment</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Les applications ayant récemment bloqué des tentatives de pistage apparaîtront ici</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Désactiver et supprimer les données ?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-hr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-hr/strings-vpn.xml
@@ -373,7 +373,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Ako imaš problema s aplikacijom (kao što je sadržaj koji se ne učitava), pokušaj onemogućiti zaštitu za tu aplikaciju i <annotation type="report_issues_link">pošalji izvještaj o tome.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Nedavne aplikacije</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Prikaži sve aplikacije</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Još nema nedavnih aplikacija</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Ovdje će se pojaviti aplikacije s nedavno blokiranim pokušajima praćenja</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Onemogućiti i izbrisati podatke?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-hu/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-hu/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Ha problémád van egy alkalmazással (például a tartalom nem töltődik be), próbáld meg kikapcsolni az adott alkalmazás védelmét, és <annotation type="report_issues_link">küldj jelentést.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Legutóbbi alkalmazások</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Összes alkalmazás megjelenítése</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Még nincsenek legutóbbi alkalmazások</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Itt jelennek meg a nemrég blokkolt nyomkövetéssel próbálkozó alkalmazások</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Letiltod és törlöd az adatokat?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-it/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-it/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Se riscontri problemi con un\'app (come il mancato caricamento dei contenuti), prova a disabilitare la protezione per quell\'app e <annotation type="report_issues_link">invia una segnalazione.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">App recenti</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Mostra tutte le app</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Ancora nessuna app recente</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Le app il cui tentativo di tracciamento è stato bloccato di recente appariranno qui</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Disattivare ed eliminare i dati?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-lt/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-lt/strings-vpn.xml
@@ -373,7 +373,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Jei kyla problemų su programa (pvz., neįkeliamas turinys), pabandykite išjungti tos programos apsaugą ir <annotation type="report_issues_link">pateikite ataskaitą.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Naujausios programos</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Rodyti visas programas</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Naujausių programų dar nėra</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Čia bus rodomos programėlės, kuriose neseniai buvo užblokuoti bandymai sekti.</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Išjungti ir ištrinti duomenis?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-lv/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-lv/strings-vpn.xml
@@ -365,7 +365,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Ja rodas problēmas ar lietotni (piemēram, netiek ielādēts saturs), pamēģini atspējot šīs lietotnes aizsardzību un <annotation type="report_issues_link">iesniedz ziņojumu.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Nesenās lietotnes</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Rādīt visas lietotnes</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Vēl nav nevienas nesenas lietotnes</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Šeit parādīsies lietotnes ar nesen bloķētiem izsekošanas mēģinājumiem</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Atspējot un dzēst datus?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-nb/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-nb/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Hvis du har problemer med en app (for eksempel innhold som ikke lastes), kan du prøve å deaktivere beskyttelsen for den appen og <annotation type="report_issues_link">sende inn en rapport.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Nylig brukte apper</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Vis alle apper</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Ingen nylig brukte apper ennå</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Apper med nylig blokkerte sporingsforsøk vises her</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Vil du deaktivere og slette data?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-nl/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-nl/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Als je problemen hebt met een app (zoals inhoud die niet laadt), probeer dan de beveiliging voor die app uit te schakelen en <annotation type="report_issues_link">een rapport in te dienen.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Recente apps</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Alle apps weergeven</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Nog geen recente apps</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Apps met recent geblokkeerde trackingpogingen worden hier weergegeven</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Uitschakelen en gegevens verwijderen?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-pl/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-pl/strings-vpn.xml
@@ -373,7 +373,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Jeśli masz problemy z jakąś aplikacją (np. nie ładuje się jej zawartość), spróbuj wyłączyć ochronę dla tej aplikacji i <annotation type="report_issues_link">prześlij zgłoszenie</annotation>.</string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Ostatnie aplikacje</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Pokaż wszystkie aplikacje</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Brak ostatnich aplikacji</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Tutaj pojawią się aplikacje, w których ostatnio zablokowano próby śledzenia.</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Czy chcesz wyłączyć i usunąć dane?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-pt/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-pt/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Se tiveres problemas com uma aplicação (por exemplo, conteúdo que não é carregado), experimenta desativar a proteção para essa aplicação e <annotation type="report_issues_link">enviar um relatório.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Aplicações recentes</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Mostrar todas as aplicações</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Ainda não existem aplicações recentes</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">As aplicações com tentativas de rastreamento bloqueadas recentemente aparecem aqui</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Desativar e Eliminar os Dados?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-ro/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-ro/strings-vpn.xml
@@ -365,7 +365,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Dacă ai probleme cu o aplicație (cum ar fi faptul că nu se încarcă conținutul), încearcă să dezactivezi protecția pentru aplicația respectivă și <annotation type="report_issues_link">transmite un raport.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Aplicații recente</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Afișează toate aplicațiile</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Încă nu există aplicații recente</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Aplicațiile cu încercări de urmărire blocate recent vor apărea aici</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Dezactivează și șterge datele?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-ru/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-ru/strings-vpn.xml
@@ -373,7 +373,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Если вы столкнулись со сбоями в приложении (например, не грузится содержимое), попробуйте отключить его защиту и <annotation type="report_issues_link">сообщите нам о проблеме</annotation>.</string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Недавние приложения</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Показать все приложения</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Недавних приложений пока нет</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Здесь будут отображаться приложения, недавно пытавшиеся отследить ваши действия</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Отключить и удалить данные?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-sk/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-sk/strings-vpn.xml
@@ -373,7 +373,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Ak máte problémy s aplikáciou (napríklad sa nenačítava obsah), skúste pre danú aplikáciu vypnúť ochranu a <annotation type="report_issues_link"> odošlite hlásenie. </annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Nedávne aplikácie</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Zobraziť všetky aplikácie</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Zatiaľ žiadne najnovšie aplikácie</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Tu sa zobrazia aplikácie s nedávno zablokovanými pokusmi o sledovanie</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Zakázať a odstrániť údaje?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-sl/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-sl/strings-vpn.xml
@@ -373,7 +373,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Če imate težave z aplikacijo (na primer vsebina, ki se ne naloži), poskusite onemogočiti zaščito za to aplikacijo in <annotation type="report_issues_link">predložiti poročilo.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Nedavne aplikacije</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Prikaži vse aplikacije</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Nedavnih aplikacij še ni</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Aplikacije z nedavno blokiranimi poskusi sledenja bodo prikazane tukaj</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Onemogočiti in izbrisati podatke?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-sv/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-sv/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Om du har problem med en app (t.ex. innehåll som inte läses in) kan du prova med att inaktivera skyddet för den appen och <annotation type="report_issues_link">skicka in en rapport.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Senaste appar</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Visa alla appar</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Inga senaste appar ännu</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Appar med nyligen blockerade spårningsförsök visas här</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Inaktivera och radera data?</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-tr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-tr/strings-vpn.xml
@@ -357,7 +357,7 @@
     <string name="atp_ManageRecentAppsProtectionReportIssues">Bir uygulamayla ilgili sorun yaşıyorsanız (içeriğin yüklenmemesi gibi), bu uygulama için korumayı devre dışı bırakmayı deneyin ve <annotation type="report_issues_link">bir rapor gönderin.</annotation></string>
     <string name="atp_ManageRecentAppsProtectionActivityTitle">Son Uygulamalar</string>
     <string name="atp_ManageRecentAppsProtectionShowAll">Tüm Uygulamaları Göster</string>
-    <string name="atp_ManageRecentAppsProtectionEmpty">Son uygulama yok</string>
+    <string name="atp_ManageRecentAppsProtectionEmpty">Yakın zamanda izleme girişimleri engellenen uygulamalar burada gösterilir</string>
 
     <!--  App Tracking Protection Remove Feature Dialog -->
     <string name="atp_RemoveFeatureDialogTitle">Veriler Devre Dışı Bırakılsın ve Silinsin mi?</string>

--- a/device-auth/device-auth-impl/src/main/res/values-bg/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-bg/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Отключете, за да използвате запазени данни за вход</string>
-    <string name="biometric_prompt_title">Потвърдете, че това сте вие</string>
+    <string name="autofill_auth_text">Отключете устройството, за да използвате запазените данни за вход.</string>
+    <string name="biometric_prompt_title">Автоматичното попълване е заключено</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-cs/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-cs/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Jestli chceš použít uložená přihlášení, zařízení odemkni</string>
-    <string name="biometric_prompt_title">Ověř, že jsi to ty</string>
+    <string name="autofill_auth_text">Jestli chceš používat svá uložená jména a hesla, zařízení odemkni.</string>
+    <string name="biometric_prompt_title">Automatické vyplňování je zamčené</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-da/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-da/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Lås op for at bruge gemte logins</string>
-    <string name="biometric_prompt_title">Bekræft, at det er dig</string>
+    <string name="autofill_auth_text">Lås enheden op for at bruge dine gemte logins.</string>
+    <string name="biometric_prompt_title">Automatisk udfyldning låst</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-de/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-de/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Freischaltung zur Verwendung gespeicherter Logins</string>
-    <string name="biometric_prompt_title">Bestätige, dass du es bist</string>
+    <string name="autofill_auth_text">Schalte das Gerät frei, um deine gespeicherten Logins zu verwenden.</string>
+    <string name="biometric_prompt_title">Automatisches Ausfüllen gesperrt</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-el/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-el/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Ξεκλειδώστε για να χρησιμοποιήσετε τα Αποθηκευμένα στοιχεία σύνδεσης</string>
-    <string name="biometric_prompt_title">Επαληθεύστε ότι είστε εσείς</string>
+    <string name="autofill_auth_text">Ξεκλειδώστε τη συσκευή για να χρησιμοποιήσετε τα αποθηκευμένα στοιχεία σύνδεσής σας.</string>
+    <string name="biometric_prompt_title">Η αυτόματη συμπλήρωση είναι κλειδωμένη</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-es/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-es/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Desbloquear para usar inicios de sesión guardados</string>
-    <string name="biometric_prompt_title">Confirma que eres tú</string>
+    <string name="autofill_auth_text">Desbloquea el dispositivo para usar tus inicios de sesión guardados.</string>
+    <string name="biometric_prompt_title">Función de autocompletar bloqueada</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-et/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-et/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Ava salvestatud sisselogimiste kasutamiseks</string>
-    <string name="biometric_prompt_title">Kinnita, et see oled sina</string>
+    <string name="autofill_auth_text">Salvestatud sisselogimisandmete kasutamiseks ava seade.</string>
+    <string name="biometric_prompt_title">Automaatsisestus on lukustatud</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-fi/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-fi/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Avaa lukitus käyttääksesi tallennettuja kirjautumisia</string>
-    <string name="biometric_prompt_title">Varmista, että se olet sinä</string>
+    <string name="autofill_auth_text">Avaa laite, jotta voit käyttää tallennettuja kirjautumistietoja.</string>
+    <string name="biometric_prompt_title">Automaattinen täyttö lukittu</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-fr/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-fr/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Déverrouiller pour utiliser les identifiants enregistrés</string>
-    <string name="biometric_prompt_title">Vérifiez que c\'est bien vous</string>
+    <string name="autofill_auth_text">Déverrouillez l\'appareil pour utiliser vos identifiants enregistrés.</string>
+    <string name="biometric_prompt_title">Saisie automatique verrouillée</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-hr/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-hr/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Otključaj za korištenje spremljenih prijava</string>
-    <string name="biometric_prompt_title">Potvrdi da si to ti</string>
+    <string name="autofill_auth_text">Otključaj uređaj za korištenje spremljenih prijava.</string>
+    <string name="biometric_prompt_title">Automatsko popunjavanje zaključano</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-hu/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-hu/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Zárolás feloldása a mentett bejelentkezések használatához</string>
-    <string name="biometric_prompt_title">Személyazonosságod igazolása</string>
+    <string name="autofill_auth_text">A mentett bejelentkezések használatához oldd fel az eszköz zárolását.</string>
+    <string name="biometric_prompt_title">Automatikus kitöltés zárolva</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-it/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-it/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Sblocca per utilizzare gli accessi salvati</string>
-    <string name="biometric_prompt_title">Verifica la tua identità</string>
+    <string name="autofill_auth_text">Sblocca il dispositivo per utilizzare gli accessi salvati.</string>
+    <string name="biometric_prompt_title">Compilazione automatica bloccata</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-lt/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-lt/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Atrakinkite norėdami naudoti išsaugotus prisijungimus</string>
-    <string name="biometric_prompt_title">Patvirtinkite, kad tai jūs</string>
+    <string name="autofill_auth_text">Atrakinkite įrenginį, kad galėtumėte naudoti išsaugotus prisijungimus.</string>
+    <string name="biometric_prompt_title">Automatinis užpildymas užrakintas</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-lv/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-lv/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Atbloķē, lai izmantotu saglabātos pieteikšanās datus</string>
-    <string name="biometric_prompt_title">Apstiprini, ka tas esi tu</string>
+    <string name="autofill_auth_text">Atbloķē ierīci, lai izmantotu saglabātos pieteikšanās datus.</string>
+    <string name="biometric_prompt_title">Automātiskā aizpildīšana bloķēta</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-nb/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-nb/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Lås opp for å bruke lagrede pålogginger</string>
-    <string name="biometric_prompt_title">Bekreft at det er deg</string>
+    <string name="autofill_auth_text">Lås opp enheten for å bruke lagrede pålogginger.</string>
+    <string name="biometric_prompt_title">Autofyll er låst</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-nl/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-nl/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Ontgrendelen om opgeslagen aanmeldgegevens te gebruiken</string>
-    <string name="biometric_prompt_title">Toon aan dat jij het bent</string>
+    <string name="autofill_auth_text">Ontgrendel apparaat om je opgeslagen aanmeldgegevens te gebruiken.</string>
+    <string name="biometric_prompt_title">Automatisch invullen vergrendeld</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-pl/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-pl/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Odblokuj, aby korzystać z zapisanych danych logowania</string>
-    <string name="biometric_prompt_title">Potwierdź tożsamość</string>
+    <string name="autofill_auth_text">Odblokuj urządzenie, aby użyć zapisanych loginów.</string>
+    <string name="biometric_prompt_title">Automatyczne wypełnianie zablokowane</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-pt/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-pt/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Desbloqueia para usar inícios de sessão guardados</string>
-    <string name="biometric_prompt_title">Valida a tua identidade</string>
+    <string name="autofill_auth_text">Desbloqueia o dispositivo para utilizares os teus inícios de sessão guardados.</string>
+    <string name="biometric_prompt_title">Preenchimento automático bloqueado</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-ro/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-ro/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Deblochează pentru a utiliza Datele de conectare salvate</string>
-    <string name="biometric_prompt_title">Verifică dacă ești tu</string>
+    <string name="autofill_auth_text">Deblochează dispozitivul pentru a utiliza datele de conectare salvate.</string>
+    <string name="biometric_prompt_title">Completare automată blocată</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-ru/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-ru/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Разблокируйте, чтобы использовать сохраненные логины</string>
-    <string name="biometric_prompt_title">Подтвердите свою личность</string>
+    <string name="autofill_auth_text">Чтобы использовать сохраненные учетные данные, разблокируйте устройство.</string>
+    <string name="biometric_prompt_title">Автозаполнение заблокировано</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-sk/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-sk/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Odomknúť pre použitie Uložených prihlásení</string>
-    <string name="biometric_prompt_title">Overiť, že ste to vy</string>
+    <string name="autofill_auth_text">Na použite uložených prihlásení odomknite zariadenie.</string>
+    <string name="biometric_prompt_title">Automatické dopĺňanie je uzamknuté</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-sl/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-sl/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Odklenite za uporabo shranjenih prijav</string>
-    <string name="biometric_prompt_title">Potrdite, da ste to vi</string>
+    <string name="autofill_auth_text">Odklenite napravo, če želite uporabiti shranjene podatke za prijavo.</string>
+    <string name="biometric_prompt_title">Samodejno izpolnjevanje je zaklenjeno</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-sv/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-sv/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Lås upp för att använda sparade inloggningar</string>
-    <string name="biometric_prompt_title">Verifiera att det är du</string>
+    <string name="autofill_auth_text">Lås upp enheten för att använda dina sparade inloggningar.</string>
+    <string name="biometric_prompt_title">Automatisk ifyllning låst</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-tr/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-tr/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Kayıtlı Giriş Bilgilerini kullanmak için kilidi açın</string>
-    <string name="biometric_prompt_title">Siz olduğunuzu doğrulayın</string>
+    <string name="autofill_auth_text">Kayıtlı girişlerinizi kullanmak için cihazın kilidini açın.</string>
+    <string name="biometric_prompt_title">Otomatik Doldurma Kilitli</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values/strings-device-auth.xml
@@ -17,6 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Unlock to use Saved Logins</string>
-    <string name="biometric_prompt_title">Verify it\'s you</string>
+    <string name="autofill_auth_text">Unlock device to use your saved logins.</string>
+    <string name="biometric_prompt_title">Autofill Locked</string>
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203115636198556/f

### Description
Changes the text used when autofill authentication screen is showing.

### Steps to test this PR

- [ ] Visit credential management screen (to force an auth prompt)
- [ ] Verify the title and subtitle is correct
- [ ] Repeat across a few different auth types (e.g., fingerprint, PIN, swipe, password)