### PR TITLE
Parse and user default action field in blocklist

### DIFF
--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTracker.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTracker.kt
@@ -28,7 +28,8 @@ data class AppTracker(
     val trackerCompanyId: Int,
     @Embedded val owner: TrackerOwner,
     @Embedded val app: TrackerApp,
-    val isCdn: Boolean,
+    @Deprecated("This field is no longer used. Stays to avoid db migration, SQLite doesn't allow rename columns")
+    val isCdn: Boolean = false,
 )
 
 @Entity(tableName = "vpn_app_tracker_blocking_list_metadata")
@@ -105,8 +106,8 @@ data class JsonAppBlockingList(
 class JsonAppTracker(
     val owner: TrackerOwner,
     val app: TrackerApp,
-    @field:Json(name = "CDN")
-    val isCdn: Boolean,
+    @field:Json(name = "default")
+    val defaultAction: String? = null,
 )
 
 class JsonTrackingSignal(

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParser.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParser.kt
@@ -34,20 +34,19 @@ class AppTrackerJsonParser {
             return AppTrackerBlocklist(version, appTrackers, appPackages, entities)
         }
 
-        fun parseBlocklistVersion(parsed: JsonAppBlockingList?) = parsed?.version.orEmpty()
+        private fun parseBlocklistVersion(parsed: JsonAppBlockingList?) = parsed?.version.orEmpty()
 
         fun parseAppTrackers(parsed: JsonAppBlockingList?) =
             parsed
                 ?.trackers
                 .orEmpty()
-                .filter { !it.value.isCdn }
+                .filter { it.value.defaultAction == "block" }
                 .mapValues {
                     AppTracker(
                         hostname = it.key,
                         trackerCompanyId = it.value.owner.name.hashCode(),
                         owner = it.value.owner,
                         app = it.value.app,
-                        isCdn = it.value.isCdn,
                     )
                 }
                 .map { it.value }

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
@@ -31,7 +31,7 @@ class AppTrackerJsonParserTest {
         val blocklist = AppTrackerJsonParser.parseAppTrackerJson(moshi, json)
 
         Assert.assertEquals("1639624032609", blocklist.version)
-        Assert.assertEquals(255, blocklist.trackers.count())
+        Assert.assertEquals(257, blocklist.trackers.count())
         Assert.assertEquals(376, blocklist.packages.count())
         Assert.assertEquals(127, blocklist.entities.count())
     }

--- a/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
+++ b/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
@@ -3240,6 +3240,42 @@
       },
       "default": "block",
       "CDN": false
+    },
+    "com.fake.cdn.ignore": {
+      "owner": {
+        "name": "CDN",
+        "displayName": "CDN"
+      },
+      "app": {
+        "score": 86,
+        "prevalence": 0.067
+      },
+      "default": "ignore",
+      "CDN": true
+    },
+    "com.fake.tracker.block": {
+      "owner": {
+        "name": "CDN",
+        "displayName": "CDN"
+      },
+      "app": {
+        "score": 86,
+        "prevalence": 0.067
+      },
+      "default": "block",
+      "CDN": false
+    },
+    "com.fake.cdn.block": {
+      "owner": {
+        "name": "CDN",
+        "displayName": "CDN"
+      },
+      "app": {
+        "score": 86,
+        "prevalence": 0.067
+      },
+      "default": "block",
+      "CDN": true
     }
   },
   "packageNames": {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203285431672073/f

### Description
Parse and use the `default` field in the AppTP blocklist.

### Steps to test this PR
_Test Fresh Install_
- [x] fresh install from this branch
- [x] verify tracker blocker list is downloaded correctly (you can inspect the DB directly)
- [x] smoke tests on AppTP to verify tracking blocking functionality

_Test App Update_
- [x] fresh install from develop
- [x] enable AppTP
- [x] update from this branch
- [x] force an update of the exclusion list (you can modify the eTag `vpn_app_tracker_blocking_list_metadata` db table)
- [x] verify logcat `Updating the app tracker blocklist...` appears
- [x] smoke test AppTP
