### PR TITLE
Add flag to tell if user has ever been prompted to save a login

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/store/AutofillStore.kt
@@ -43,6 +43,12 @@ interface AutofillStore {
     var showOnboardingWhenOfferingToSaveLogin: Boolean
 
     /**
+     * Used to determine if a user has ever been prompted to save a login (note: prompted to save, not necessarily saved)
+     * Defaults to false, and will be set to true after the user has been shown a prompt to save a login
+     */
+    var hasEverBeenPromptedToSaveLogin: Boolean
+
+    /**
      * Whether to monitor autofill decline counts or not
      * Used to determine whether we should actively detect when a user new to autofill doesn't appear to want it enabled
      */

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
@@ -107,6 +107,7 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
         savedInstanceState: Bundle?
     ): View {
         pixelNameDialogEvent(Shown)?.let { pixel.fire(it) }
+        viewModel.userPromptedToSaveCredentials()
 
         val binding = ContentAutofillSaveNewCredentialsBinding.inflate(inflater, container, false)
         configureViews(binding, getCredentialsToSave())

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
@@ -18,15 +18,20 @@ package com.duckduckgo.autofill.ui.credential.saving
 
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.store.AutofillStore
 import com.duckduckgo.di.scopes.ActivityScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ContributesViewModel(ActivityScope::class)
-class AutofillSavingCredentialsViewModel @Inject constructor() : ViewModel() {
+class AutofillSavingCredentialsViewModel @Inject constructor(
+    private val dispatchers: DispatcherProvider
+) : ViewModel() {
 
     @Inject
     lateinit var autofillStore: AutofillStore
@@ -68,6 +73,12 @@ class AutofillSavingCredentialsViewModel @Inject constructor() : ViewModel() {
             R.string.saveLoginMissingUsernameDialogButtonSave
         } else {
             R.string.saveLoginDialogButtonSave
+        }
+    }
+
+    fun userPromptedToSaveCredentials() {
+        viewModelScope.launch(dispatchers.io()) {
+            autofillStore.hasEverBeenPromptedToSaveLogin = true
         }
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
@@ -16,18 +16,27 @@
 
 package com.duckduckgo.autofill.ui.credential.saving
 
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.store.AutofillStore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@ExperimentalCoroutinesApi
 class AutofillSavingCredentialsViewModelTest {
 
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
     private val mockStore: AutofillStore = mock()
-    private val testee = AutofillSavingCredentialsViewModel().also { it.autofillStore = mockStore }
+    private val testee = AutofillSavingCredentialsViewModel(coroutineTestRule.testDispatcherProvider).also { it.autofillStore = mockStore }
 
     @Test
     fun whenShowingOnboardingThenTitleResourceIsAlwaysOnboardingTitle() {
@@ -78,6 +87,12 @@ class AutofillSavingCredentialsViewModelTest {
         whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
         val expectedResource = R.string.saveLoginMissingUsernameDialogButtonSave
         assertEquals(expectedResource, testee.determineTextResources(usernameMissing()).ctaButton)
+    }
+
+    @Test
+    fun whenUserPromptedToSaveThenFlagSet() = runTest {
+        testee.userPromptedToSaveCredentials()
+        verify(mockStore).hasEverBeenPromptedToSaveLogin = true
     }
 
     private fun usernamePresent() = loginCredentialsWithUsername(username = "foo")

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
@@ -25,6 +25,7 @@ interface AutofillPrefsStore {
     var showOnboardingWhenOfferingToSaveLogin: Boolean
     var autofillDeclineCount: Int
     var monitorDeclineCounts: Boolean
+    var hasEverBeenPromptedToSaveLogin: Boolean
 }
 
 class RealAutofillPrefsStore constructor(
@@ -45,6 +46,10 @@ class RealAutofillPrefsStore constructor(
         get() = prefs.getBoolean(SHOW_SAVE_LOGIN_ONBOARDING, true)
         set(value) = prefs.edit { putBoolean(SHOW_SAVE_LOGIN_ONBOARDING, value) }
 
+    override var hasEverBeenPromptedToSaveLogin: Boolean
+        get() = prefs.getBoolean(HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN, false)
+        set(value) = prefs.edit { putBoolean(HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN, value) }
+
     override var autofillDeclineCount: Int
         get() = prefs.getInt(AUTOFILL_DECLINE_COUNT, 0)
         set(value) = prefs.edit { putInt(AUTOFILL_DECLINE_COUNT, value) }
@@ -57,6 +62,7 @@ class RealAutofillPrefsStore constructor(
         const val FILENAME = "com.duckduckgo.autofill.store.autofill_store"
         const val AUTOFILL_ENABLED = "autofill_enabled"
         const val SHOW_SAVE_LOGIN_ONBOARDING = "autofill_show_onboardind_saved_login"
+        const val HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN = "autofill_has_ever_been_prompted_to_save_login"
         const val AUTOFILL_DECLINE_COUNT = "autofill_decline_count"
         const val MONITOR_AUTOFILL_DECLINES = "monitor_autofill_declines"
     }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -58,6 +58,12 @@ class SecureStoreBackedAutofillStore(
             autofillPrefsStore.showOnboardingWhenOfferingToSaveLogin = value
         }
 
+    override var hasEverBeenPromptedToSaveLogin: Boolean
+        get() = autofillPrefsStore.hasEverBeenPromptedToSaveLogin
+        set(value) {
+            autofillPrefsStore.hasEverBeenPromptedToSaveLogin = value
+        }
+
     override var autofillDeclineCount: Int
         get() = autofillPrefsStore.autofillDeclineCount
         set(value) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203328858503342/f

### Description
If autofill defaults to `off` for now, we'd like to preserve optionality in being able to switch it on by default. This includes existing users who have never tried it.

This PR adds a flag indicating if the user has ever been prompted to save a login or not. It doesn't matter if they chose to save one or declined the prompt.

### Steps to test this PR

Add a temporary log message to help determine the state of the flag. e.g., override the fire button or add as a line inside of `AutofillStoredBackJavascriptInterface.getAutofillData` that will get called on each page load. Log the state of: `autofillStore.hasEverBeenPromptedToSaveLogin`

- [x] Ensure `autofillStore.hasEverBeenPromptedToSaveLogin` defaults to `false`
- [x] Attempt a login such that the save credentials dialog is shown
- [x] Query `autofillStore.hasEverBeenPromptedToSaveLogin` again; verify it's now `true`