### PR TITLE
Autofill defaults to off generally, but overridden to on for internal testers

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/di/AutofillModule.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/di/AutofillModule.kt
@@ -49,7 +49,7 @@ class AutofillModule {
             secureStorage,
             internalTestUserChecker,
             RealLastUpdatedTimeProvider(),
-            RealAutofillPrefsStore(context)
+            RealAutofillPrefsStore(context, internalTestUserChecker)
         )
     }
 }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.autofill.store
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.autofill.InternalTestUserChecker
 
 interface AutofillPrefsStore {
     var isEnabled: Boolean
@@ -28,7 +29,8 @@ interface AutofillPrefsStore {
 }
 
 class RealAutofillPrefsStore constructor(
-    private val applicationContext: Context
+    private val applicationContext: Context,
+    private val internalTestUserChecker: InternalTestUserChecker
 ) : AutofillPrefsStore {
 
     private val prefs: SharedPreferences by lazy {
@@ -36,7 +38,7 @@ class RealAutofillPrefsStore constructor(
     }
 
     override var isEnabled: Boolean
-        get() = prefs.getBoolean(AUTOFILL_ENABLED, true)
+        get() = prefs.getBoolean(AUTOFILL_ENABLED, autofillEnabledDefaultValue())
         set(value) = prefs.edit {
             putBoolean(AUTOFILL_ENABLED, value)
         }
@@ -52,6 +54,15 @@ class RealAutofillPrefsStore constructor(
     override var monitorDeclineCounts: Boolean
         get() = prefs.getBoolean(MONITOR_AUTOFILL_DECLINES, true)
         set(value) = prefs.edit { putBoolean(MONITOR_AUTOFILL_DECLINES, value) }
+
+    /**
+     * Internal builds should have autofill enabled by default
+     * It'll be disabled by default for public users, even after internal testing gate removed
+     * If we decide to make it enabled by default for all users, we can hardcode the value to true
+     */
+    private fun autofillEnabledDefaultValue(): Boolean {
+        return internalTestUserChecker.isInternalTestUser
+    }
 
     companion object {
         const val FILENAME = "com.duckduckgo.autofill.store.autofill_store"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203328858503338/f

### Description

Autofill is currently gated behind two mechanisms
- global on/off switch
- available to internal testing only

The current default of the switch is `enabled`; this PR changes that to be enabled if an internal tester, false otherwise. The internal testing gate still applies, so really there is no behaviour change, but it's preparation for when the internal tester gate is removed.
