### PR TITLE
Add fingerprint protection random seed

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.espresso.privacy
+
+import android.webkit.WebView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.IdlingPolicies
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.browser.R
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+import androidx.test.espresso.web.model.Atoms.script
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.getText
+import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
+import androidx.test.espresso.web.webdriver.Locator.ID
+import com.duckduckgo.espresso.PrivacyTest
+import com.duckduckgo.espresso.WebViewIdlingResource
+import com.duckduckgo.espresso.waitForView
+import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert.assertEquals
+
+class FingerprintProtectionTest {
+
+    @get:Rule
+    var activityScenarioRule = activityScenarioRule<BrowserActivity>(
+        BrowserActivity.intent(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            queryExtra = "https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/"
+        )
+    )
+
+    @Test @PrivacyTest
+    fun whenProtectionsAreFingerprintProtected() {
+        val waitTime = 16000L
+        IdlingPolicies.setMasterPolicyTimeout(waitTime * 10, TimeUnit.MILLISECONDS)
+        IdlingPolicies.setIdlingResourceTimeout(waitTime * 10, TimeUnit.MILLISECONDS)
+
+        var webView: WebView? = null
+
+        onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
+
+        activityScenarioRule.scenario.onActivity {
+            webView = it.findViewById(R.id.browserWebView)
+        }
+
+        val idlingResourceForDisableProtections = WebViewIdlingResource(webView!!)
+        IdlingRegistry.getInstance().register(idlingResourceForDisableProtections)
+
+        onWebView()
+            .withElement(findElement(ID, "start"))
+            .check(webMatches(getText(), containsString("Start the test")))
+            .perform(webClick())
+
+        val idlingResourceForScript = WebViewIdlingResource(webView!!)
+        IdlingRegistry.getInstance().register(idlingResourceForScript)
+
+        val results = onWebView()
+            .perform(script(SCRIPT))
+            .get()
+
+        val testJson: TestJson? = getTestJson(results.toJSONString())
+        testJson?.value?.map {
+            if (compatibleIds.contains(it.id)) {
+                assertEquals(compatibleIds[it.id], it.value.toString())
+            }
+        }
+        IdlingRegistry.getInstance().unregister(idlingResourceForDisableProtections, idlingResourceForScript)
+    }
+
+    private fun getTestJson(jsonString: String): TestJson? {
+        val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
+        val jsonAdapter: JsonAdapter<TestJson> = moshi.adapter(TestJson::class.java)
+        return jsonAdapter.fromJson(jsonString)
+    }
+
+    companion object {
+        const val SCRIPT = "return results.results;"
+        val compatibleIds = mapOf(
+            Pair("navigator.deviceMemory", "4.0"),
+            Pair("navigator.hardwareConcurrency", "8.0"),
+            Pair("navigator.getBattery()", "{level=1.0, chargingTime=0.0, charging=true}"),
+            Pair("navigator.webkitTemporaryStorage.queryUsageAndQuota", "{quota=4.294967296E9, usage=0.0}"),
+            Pair("navigator.webkitPersistentStorage.queryUsageAndQuota", "{quota=4.294967296E9, usage=0.0}"),
+            Pair("screen.colorDepth", "24.0"),
+            Pair("screen.pixelDepth", "24.0"),
+            Pair("screen.availLeft", "0.0"),
+            Pair("screen.availTop", "0.0"),
+        )
+    }
+
+    data class TestJson(val status: Int, val value: List<FingerProtectionTest>)
+    data class FingerProtectionTest(val id: String, val value: Any)
+}

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -20,8 +20,7 @@ import android.webkit.WebView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
-import androidx.test.espresso.matcher.ViewMatchers.isRoot
-import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.model.Atoms.script
 import androidx.test.espresso.web.sugar.Web.onWebView
@@ -39,11 +38,11 @@ import com.duckduckgo.espresso.waitForView
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
+import java.util.concurrent.TimeUnit
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
-import java.util.concurrent.TimeUnit
 
 class FingerprintProtectionTest {
 

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -20,21 +20,19 @@ import android.webkit.WebView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
-import androidx.test.espresso.web.sugar.Web.onWebView
-import androidx.test.ext.junit.rules.activityScenarioRule
-import androidx.test.platform.app.InstrumentationRegistry
-import com.duckduckgo.app.browser.BrowserActivity
-import com.duckduckgo.app.browser.R
-import org.junit.Rule
-import org.junit.Test
-import java.util.concurrent.TimeUnit
 import androidx.test.espresso.web.model.Atoms.script
+import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.DriverAtoms.getText
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.Locator.ID
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.espresso.PrivacyTest
 import com.duckduckgo.espresso.WebViewIdlingResource
 import com.duckduckgo.espresso.waitForView
@@ -43,6 +41,9 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.TimeUnit
 
 class FingerprintProtectionTest {
 
@@ -50,8 +51,8 @@ class FingerprintProtectionTest {
     var activityScenarioRule = activityScenarioRule<BrowserActivity>(
         BrowserActivity.intent(
             InstrumentationRegistry.getInstrumentation().targetContext,
-            queryExtra = "https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/"
-        )
+            queryExtra = "https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/",
+        ),
     )
 
     @Test @PrivacyTest

--- a/content-scope-scripts/content-scope-scripts-impl/build.gradle
+++ b/content-scope-scripts/content-scope-scripts-impl/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(':app-store')
     implementation project(':privacy-config-api')
     implementation project(':app-build-config-api')
+    implementation project(':fingerprint-protection-api')
 
     anvil project(':anvil-compiler')
     implementation project(':anvil-annotations')

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.contentscopescripts.api.ContentScopeConfigPlugin
 import com.duckduckgo.contentscopescripts.api.ContentScopeScripts
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
 import com.squareup.anvil.annotations.ContributesBinding
@@ -40,6 +41,7 @@ class RealContentScopeScripts @Inject constructor(
     private val contentScopeJSReader: ContentScopeJSReader,
     private val appBuildConfig: AppBuildConfig,
     private val unprotectedTemporary: UnprotectedTemporary,
+    private val fingerprintProtectionManager: FingerprintProtectionManager
 ) : ContentScopeScripts {
 
     private var cachedContentScopeJson: String = getContentScopeJson("", emptyList())
@@ -151,7 +153,7 @@ class RealContentScopeScripts @Inject constructor(
     }
 
     private fun getUserPreferencesJson(userPreferences: String): String {
-        val defaultParameters = "${getVersionNumberKeyValuePair()},${getPlatformKeyValuePair()}"
+        val defaultParameters = "${getVersionNumberKeyValuePair()},${getPlatformKeyValuePair()},${getSessionKeyValuePair()}"
         if (userPreferences.isEmpty()) {
             return "{$defaultParameters}"
         }
@@ -161,6 +163,7 @@ class RealContentScopeScripts @Inject constructor(
     private fun getVersionNumberKeyValuePair() = "\"versionNumber\":${appBuildConfig.versionCode}"
 
     private fun getPlatformKeyValuePair() = "\"platform\":{\"name\":\"android\"}"
+    private fun getSessionKeyValuePair() = "\"sessionKey\":\"${fingerprintProtectionManager.getSeed()}\""
 
     private fun getContentScopeJson(config: String, unprotectedTemporaryExceptions: List<UnprotectedTemporaryException>): String = (
         "{\"features\":{$config},\"unprotectedTemporary\":${getUnprotectedTemporaryJson(unprotectedTemporaryExceptions)}}"

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -41,7 +41,7 @@ class RealContentScopeScripts @Inject constructor(
     private val contentScopeJSReader: ContentScopeJSReader,
     private val appBuildConfig: AppBuildConfig,
     private val unprotectedTemporary: UnprotectedTemporary,
-    private val fingerprintProtectionManager: FingerprintProtectionManager
+    private val fingerprintProtectionManager: FingerprintProtectionManager,
 ) : ContentScopeScripts {
 
     private var cachedContentScopeJson: String = getContentScopeJson("", emptyList())

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -54,7 +54,7 @@ class RealContentScopeScriptsTest {
             mockContentScopeJsReader,
             mockAppBuildConfig,
             mockUnprotectedTemporary,
-            mockFingerprintProtectionManager
+            mockFingerprintProtectionManager,
         )
         whenever(mockPlugin1.config()).thenReturn(config1)
         whenever(mockPlugin2.config()).thenReturn(config2)
@@ -99,7 +99,7 @@ class RealContentScopeScriptsTest {
                 "\"config2\":{\"state\":\"disabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}," +
                 " [\"foo.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"},\"sessionKey\":\"5678\"})",
-            js
+            js,
         )
 
         verify(mockUnprotectedTemporary, times(3)).unprotectedTemporaryExceptions
@@ -125,7 +125,7 @@ class RealContentScopeScriptsTest {
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}," +
                 " [\"example.com\"], {\"globalPrivacyControlValue\":false,\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}," +
                 "\"sessionKey\":\"5678\"})",
-            js
+            js,
         )
 
         verify(mockUnprotectedTemporary, times(3)).unprotectedTemporaryExceptions
@@ -152,7 +152,7 @@ class RealContentScopeScriptsTest {
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}," +
                 " [\"example.com\"], {\"globalPrivacyControlValue\":true,\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}," +
                 "\"sessionKey\":\"5678\"})",
-            js
+            js,
         )
 
         verify(mockUnprotectedTemporary, times(3)).unprotectedTemporaryExceptions
@@ -177,7 +177,7 @@ class RealContentScopeScriptsTest {
                 "\"config2\":{\"state\":\"disabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"}]}," +
                 " [\"example.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"},\"sessionKey\":\"5678\"})",
-            js
+            js,
         )
 
         verify(mockUnprotectedTemporary, times(4)).unprotectedTemporaryExceptions

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.userwhitelist.api.UserWhiteListRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.contentscopescripts.api.ContentScopeConfigPlugin
 import com.duckduckgo.contentscopescripts.api.ContentScopeScripts
+import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
 import junit.framework.TestCase.assertEquals
@@ -41,12 +42,20 @@ class RealContentScopeScriptsTest {
     private val mockPlugin2: ContentScopeConfigPlugin = mock()
     private val mockAppBuildConfig: AppBuildConfig = mock()
     private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
+    private val mockFingerprintProtectionManager: FingerprintProtectionManager = mock()
 
     lateinit var testee: ContentScopeScripts
 
     @Before
     fun setup() {
-        testee = RealContentScopeScripts(mockPluginPoint, mockAllowList, mockContentScopeJsReader, mockAppBuildConfig, mockUnprotectedTemporary)
+        testee = RealContentScopeScripts(
+            mockPluginPoint,
+            mockAllowList,
+            mockContentScopeJsReader,
+            mockAppBuildConfig,
+            mockUnprotectedTemporary,
+            mockFingerprintProtectionManager
+        )
         whenever(mockPlugin1.config()).thenReturn(config1)
         whenever(mockPlugin2.config()).thenReturn(config2)
         whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1, mockPlugin2))
@@ -55,6 +64,7 @@ class RealContentScopeScriptsTest {
         whenever(mockAppBuildConfig.versionCode).thenReturn(versionCode)
         whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions)
             .thenReturn(listOf(unprotectedTemporaryException, unprotectedTemporaryException2))
+        whenever(mockFingerprintProtectionManager.getSeed()).thenReturn(sessionKey)
     }
 
     @Test
@@ -88,8 +98,8 @@ class RealContentScopeScriptsTest {
                 "\"config1\":{\"state\":\"enabled\"}," +
                 "\"config2\":{\"state\":\"disabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}," +
-                " [\"foo.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})",
-            js,
+                " [\"foo.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"},\"sessionKey\":\"5678\"})",
+            js
         )
 
         verify(mockUnprotectedTemporary, times(3)).unprotectedTemporaryExceptions
@@ -113,8 +123,9 @@ class RealContentScopeScriptsTest {
                 "\"config1\":{\"state\":\"enabled\"}," +
                 "\"config2\":{\"state\":\"disabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}," +
-                " [\"example.com\"], {\"globalPrivacyControlValue\":false,\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})",
-            js,
+                " [\"example.com\"], {\"globalPrivacyControlValue\":false,\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}," +
+                "\"sessionKey\":\"5678\"})",
+            js
         )
 
         verify(mockUnprotectedTemporary, times(3)).unprotectedTemporaryExceptions
@@ -139,8 +150,9 @@ class RealContentScopeScriptsTest {
                 "{\"features\":{" +
                 "\"config1\":{\"state\":\"enabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}," +
-                " [\"example.com\"], {\"globalPrivacyControlValue\":true,\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})",
-            js,
+                " [\"example.com\"], {\"globalPrivacyControlValue\":true,\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}," +
+                "\"sessionKey\":\"5678\"})",
+            js
         )
 
         verify(mockUnprotectedTemporary, times(3)).unprotectedTemporaryExceptions
@@ -164,8 +176,8 @@ class RealContentScopeScriptsTest {
                 "\"config1\":{\"state\":\"enabled\"}," +
                 "\"config2\":{\"state\":\"disabled\"}}," +
                 "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"}]}," +
-                " [\"example.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})",
-            js,
+                " [\"example.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"},\"sessionKey\":\"5678\"})",
+            js
         )
 
         verify(mockUnprotectedTemporary, times(4)).unprotectedTemporaryExceptions
@@ -184,8 +196,9 @@ class RealContentScopeScriptsTest {
             "\"config1\":{\"state\":\"enabled\"}," +
             "\"config2\":{\"state\":\"disabled\"}}," +
             "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"},{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]}, " +
-            "[\"example.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"}})"
+            "[\"example.com\"], {\"versionNumber\":1234,\"platform\":{\"name\":\"android\"},\"sessionKey\":\"5678\"})"
         const val versionCode = 1234
+        const val sessionKey = "5678"
         val unprotectedTemporaryException = UnprotectedTemporaryException(domain = "example.com", reason = "reason")
         val unprotectedTemporaryException2 = UnprotectedTemporaryException(domain = "foo.com", reason = "reason2")
     }

--- a/fingerprint-protection/fingerprint-protection-api/src/main/java/com/duckduckgo/fingerprintprotection/api/FingerprintProtectionManager.kt
+++ b/fingerprint-protection/fingerprint-protection-api/src/main/java/com/duckduckgo/fingerprintprotection/api/FingerprintProtectionManager.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fingerprintprotection.api
+
+/** Public interface for the Fingerprint Protection feature */
+interface FingerprintProtectionManager {
+
+    /**
+     * Gets the current random seed.
+     */
+    fun getSeed(): String
+}

--- a/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedManager.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedManager.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
 class FingerprintProtectionSeedManager @Inject constructor(
-    private val fingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository
+    private val fingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository,
 ) : FingerprintProtectionManager {
 
     override fun getSeed(): String {

--- a/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedManager.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedManager.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fingerprintprotection.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
+import com.duckduckgo.fingerprintprotection.store.seed.FingerprintProtectionSeedRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class FingerprintProtectionSeedManager @Inject constructor(
+    private val fingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository
+) : FingerprintProtectionManager {
+
+    override fun getSeed(): String {
+        return fingerprintProtectionSeedRepository.fingerprintProtectionSeedEntity.seed
+    }
+}

--- a/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedWorker.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedWorker.kt
@@ -32,15 +32,15 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.fingerprintprotection.store.seed.FingerprintProtectionSeedRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
-import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.DAYS
 import javax.inject.Inject
+import kotlinx.coroutines.withContext
 
 @ContributesWorker(AppScope::class)
 class FingerprintProtectionSeedWorker(
     context: Context,
-    workerParameters: WorkerParameters
+    workerParameters: WorkerParameters,
 ) : CoroutineWorker(context, workerParameters) {
 
     @Inject
@@ -59,12 +59,12 @@ class FingerprintProtectionSeedWorker(
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class
+    boundType = LifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class FingerprintProtectionSeedWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
-    private val fingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository
+    private val fingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository,
 ) : DefaultLifecycleObserver {
 
     private val workerRequest = PeriodicWorkRequestBuilder<FingerprintProtectionSeedWorker>(1, DAYS)

--- a/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedWorker.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedWorker.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fingerprintprotection.impl
+
+import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.work.BackoffPolicy
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.fingerprintprotection.store.seed.FingerprintProtectionSeedRepository
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.DAYS
+import javax.inject.Inject
+
+@ContributesWorker(AppScope::class)
+class FingerprintProtectionSeedWorker(
+    context: Context,
+    workerParameters: WorkerParameters
+) : CoroutineWorker(context, workerParameters) {
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject
+    lateinit var fingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository
+
+    override suspend fun doWork(): Result {
+        return withContext(dispatcherProvider.io()) {
+            fingerprintProtectionSeedRepository.storeNewSeed()
+            return@withContext Result.success()
+        }
+    }
+}
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = LifecycleObserver::class
+)
+@SingleInstanceIn(AppScope::class)
+class FingerprintProtectionSeedWorkerScheduler @Inject constructor(
+    private val workManager: WorkManager,
+    private val fingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository
+) : DefaultLifecycleObserver {
+
+    private val workerRequest = PeriodicWorkRequestBuilder<FingerprintProtectionSeedWorker>(1, DAYS)
+        .addTag(FINGERPRINT_PROTECTION_SEED_WORKER_TAG)
+        .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+        .build()
+
+    override fun onStop(owner: LifecycleOwner) {
+        fingerprintProtectionSeedRepository.storeNewSeed()
+        workManager.enqueueUniquePeriodicWork(FINGERPRINT_PROTECTION_SEED_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, workerRequest)
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        workManager.enqueueUniquePeriodicWork(FINGERPRINT_PROTECTION_SEED_WORKER_TAG, ExistingPeriodicWorkPolicy.KEEP, workerRequest)
+    }
+
+    companion object {
+        private const val FINGERPRINT_PROTECTION_SEED_WORKER_TAG = "FINGERPRINT_PROTECTION_SEED_WORKER_TAG"
+    }
+}

--- a/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/di/FingerprintProtectionModule.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/di/FingerprintProtectionModule.kt
@@ -33,6 +33,8 @@ import com.duckduckgo.fingerprintprotection.store.features.fingerprintingscreens
 import com.duckduckgo.fingerprintprotection.store.features.fingerprintingscreensize.RealFingerprintingScreenSizeRepository
 import com.duckduckgo.fingerprintprotection.store.features.fingerprintingtemporarystorage.FingerprintingTemporaryStorageRepository
 import com.duckduckgo.fingerprintprotection.store.features.fingerprintingtemporarystorage.RealFingerprintingTemporaryStorageRepository
+import com.duckduckgo.fingerprintprotection.store.seed.FingerprintProtectionSeedRepository
+import com.duckduckgo.fingerprintprotection.store.seed.RealFingerprintProtectionSeedRepository
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
@@ -100,5 +102,15 @@ object FingerprintProtectionModule {
         dispatcherProvider: DispatcherProvider,
     ): FingerprintingTemporaryStorageRepository {
         return RealFingerprintingTemporaryStorageRepository(database, coroutineScope, dispatcherProvider)
+    }
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideFingerprintProtectionSeedRepository(
+        database: FingerprintProtectionDatabase,
+        @AppCoroutineScope coroutineScope: CoroutineScope,
+        dispatcherProvider: DispatcherProvider
+    ): FingerprintProtectionSeedRepository {
+        return RealFingerprintProtectionSeedRepository(database, coroutineScope, dispatcherProvider)
     }
 }

--- a/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/di/FingerprintProtectionModule.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/di/FingerprintProtectionModule.kt
@@ -109,7 +109,7 @@ object FingerprintProtectionModule {
     fun provideFingerprintProtectionSeedRepository(
         database: FingerprintProtectionDatabase,
         @AppCoroutineScope coroutineScope: CoroutineScope,
-        dispatcherProvider: DispatcherProvider
+        dispatcherProvider: DispatcherProvider,
     ): FingerprintProtectionSeedRepository {
         return RealFingerprintProtectionSeedRepository(database, coroutineScope, dispatcherProvider)
     }

--- a/fingerprint-protection/fingerprint-protection-impl/src/test/java/com/duckduckgo/fingerprintprotection/FingerprintProtectionSeedWorkerSchedulerTest.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/test/java/com/duckduckgo/fingerprintprotection/FingerprintProtectionSeedWorkerSchedulerTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fingerprintprotection
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.work.ExistingPeriodicWorkPolicy.KEEP
+import androidx.work.ExistingPeriodicWorkPolicy.REPLACE
+import androidx.work.WorkManager
+import com.duckduckgo.fingerprintprotection.impl.FingerprintProtectionSeedWorkerScheduler
+import com.duckduckgo.fingerprintprotection.store.seed.FingerprintProtectionSeedRepository
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class FingerprintProtectionSeedWorkerSchedulerTest {
+
+    private val fingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository = mock()
+    private val mockWorkManager: WorkManager = mock()
+    private val mockOwner: LifecycleOwner = mock()
+
+    lateinit var fingerprintProtectionSeedWorkerScheduler: FingerprintProtectionSeedWorkerScheduler
+
+    @Before
+    fun before() {
+        fingerprintProtectionSeedWorkerScheduler = FingerprintProtectionSeedWorkerScheduler(mockWorkManager, fingerprintProtectionSeedRepository)
+    }
+
+    @Test
+    fun whenOnStopThenStoreNewSeedAndEnqueueWorkWithReplacePolicy() {
+        fingerprintProtectionSeedWorkerScheduler.onStop(mockOwner)
+
+        verify(mockWorkManager).enqueueUniquePeriodicWork(any(), eq(REPLACE), any())
+        verify(fingerprintProtectionSeedRepository).storeNewSeed()
+    }
+
+    @Test
+    fun whenOnStartThenEnqueueWorkWithKeepPolicy() {
+        fingerprintProtectionSeedWorkerScheduler.onStart(mockOwner)
+
+        verify(mockWorkManager).enqueueUniquePeriodicWork(any(), eq(KEEP), any())
+    }
+}

--- a/fingerprint-protection/fingerprint-protection-impl/src/test/java/com/duckduckgo/fingerprintprotection/FingerprintProtectionSeedWorkerTest.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/test/java/com/duckduckgo/fingerprintprotection/FingerprintProtectionSeedWorkerTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fingerprintprotection
+
+import android.content.Context
+import androidx.work.ListenableWorker.Result
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.fingerprintprotection.impl.FingerprintProtectionSeedWorker
+import com.duckduckgo.fingerprintprotection.store.seed.FingerprintProtectionSeedRepository
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class FingerprintProtectionSeedWorkerTest {
+    @get:Rule var coroutineRule = CoroutineTestRule()
+
+    private val mockFingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository = mock()
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = mock()
+    }
+
+    @Test
+    fun whenDoWorkThenReturnSuccess() = runTest {
+        val worker = TestListenableWorkerBuilder<FingerprintProtectionSeedWorker>(context = context).build()
+
+        worker.fingerprintProtectionSeedRepository = mockFingerprintProtectionSeedRepository
+        worker.dispatcherProvider = coroutineRule.testDispatcherProvider
+
+        val result = worker.doWork()
+        assertThat(result, `is`(Result.success()))
+        verify(mockFingerprintProtectionSeedRepository).storeNewSeed()
+    }
+}

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/FingerprintProtectionDatabase.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/FingerprintProtectionDatabase.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.fingerprintprotection.store.features.fingerprintingcanvas.
 import com.duckduckgo.fingerprintprotection.store.features.fingerprintinghardware.FingerprintingHardwareDao
 import com.duckduckgo.fingerprintprotection.store.features.fingerprintingscreensize.FingerprintingScreenSizeDao
 import com.duckduckgo.fingerprintprotection.store.features.fingerprintingtemporarystorage.FingerprintingTemporaryStorageDao
+import com.duckduckgo.fingerprintprotection.store.seed.FingerprintProtectionSeedDao
 
 @Database(
     exportSchema = true,
@@ -34,6 +35,7 @@ import com.duckduckgo.fingerprintprotection.store.features.fingerprintingtempora
         FingerprintingHardwareEntity::class,
         FingerprintingScreenSizeEntity::class,
         FingerprintingTemporaryStorageEntity::class,
+        FingerprintProtectionSeedEntity::class,
     ],
 )
 abstract class FingerprintProtectionDatabase : RoomDatabase() {
@@ -42,6 +44,7 @@ abstract class FingerprintProtectionDatabase : RoomDatabase() {
     abstract fun fingerprintingHardwareDao(): FingerprintingHardwareDao
     abstract fun fingerprintingScreenSizeDao(): FingerprintingScreenSizeDao
     abstract fun fingerprintingTemporaryStorageDao(): FingerprintingTemporaryStorageDao
+    abstract fun fingerprintProtectionSeedDao(): FingerprintProtectionSeedDao
 }
 
 val ALL_MIGRATIONS = emptyArray<Migration>()

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/FingerprintProtectionEntities.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/FingerprintProtectionEntities.kt
@@ -47,3 +47,9 @@ data class FingerprintingTemporaryStorageEntity(
     @PrimaryKey val id: Int = 1,
     val json: String,
 )
+
+@Entity(tableName = "fingerprint_protection_seed")
+data class FingerprintProtectionSeedEntity(
+    @PrimaryKey val id: Int = 1,
+    val seed: String,
+)

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/seed/FingerprintProtectionSeedDao.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/seed/FingerprintProtectionSeedDao.kt
@@ -31,7 +31,7 @@ abstract class FingerprintProtectionSeedDao {
 
     @Transaction
     open fun updateAll(
-        fingerprintProtectionSeed: FingerprintProtectionSeedEntity
+        fingerprintProtectionSeed: FingerprintProtectionSeedEntity,
     ) {
         delete()
         insert(fingerprintProtectionSeed)

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/seed/FingerprintProtectionSeedDao.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/seed/FingerprintProtectionSeedDao.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fingerprintprotection.store.seed
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.fingerprintprotection.store.FingerprintProtectionSeedEntity
+
+@Dao
+abstract class FingerprintProtectionSeedDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insert(fingerprintProtectionSeed: FingerprintProtectionSeedEntity)
+
+    @Transaction
+    open fun updateAll(
+        fingerprintProtectionSeed: FingerprintProtectionSeedEntity
+    ) {
+        delete()
+        insert(fingerprintProtectionSeed)
+    }
+
+    @Query("select * from fingerprint_protection_seed")
+    abstract fun get(): FingerprintProtectionSeedEntity?
+
+    @Query("delete from fingerprint_protection_seed")
+    abstract fun delete()
+}

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/seed/FingerprintProtectionSeedRepository.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/seed/FingerprintProtectionSeedRepository.kt
@@ -19,9 +19,9 @@ package com.duckduckgo.fingerprintprotection.store.seed
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.fingerprintprotection.store.FingerprintProtectionDatabase
 import com.duckduckgo.fingerprintprotection.store.FingerprintProtectionSeedEntity
+import java.util.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import java.util.*
 
 interface FingerprintProtectionSeedRepository {
     var fingerprintProtectionSeedEntity: FingerprintProtectionSeedEntity
@@ -31,7 +31,7 @@ interface FingerprintProtectionSeedRepository {
 class RealFingerprintProtectionSeedRepository constructor(
     val database: FingerprintProtectionDatabase,
     val coroutineScope: CoroutineScope,
-    val dispatcherProvider: DispatcherProvider
+    val dispatcherProvider: DispatcherProvider,
 ) : FingerprintProtectionSeedRepository {
 
     private val fingerprintProtectionSeedDao: FingerprintProtectionSeedDao = database.fingerprintProtectionSeedDao()

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/seed/FingerprintProtectionSeedRepository.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/seed/FingerprintProtectionSeedRepository.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fingerprintprotection.store.seed
+
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.fingerprintprotection.store.FingerprintProtectionDatabase
+import com.duckduckgo.fingerprintprotection.store.FingerprintProtectionSeedEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.util.*
+
+interface FingerprintProtectionSeedRepository {
+    var fingerprintProtectionSeedEntity: FingerprintProtectionSeedEntity
+    fun storeNewSeed()
+}
+
+class RealFingerprintProtectionSeedRepository constructor(
+    val database: FingerprintProtectionDatabase,
+    val coroutineScope: CoroutineScope,
+    val dispatcherProvider: DispatcherProvider
+) : FingerprintProtectionSeedRepository {
+
+    private val fingerprintProtectionSeedDao: FingerprintProtectionSeedDao = database.fingerprintProtectionSeedDao()
+    override var fingerprintProtectionSeedEntity = FingerprintProtectionSeedEntity(seed = getRandomSeed())
+
+    init {
+        storeNewSeed()
+    }
+
+    override fun storeNewSeed() {
+        coroutineScope.launch(dispatcherProvider.io()) {
+            updateAll(FingerprintProtectionSeedEntity(seed = getRandomSeed()))
+        }
+    }
+
+    private fun updateAll(fingerprintProtectionSeedEntity: FingerprintProtectionSeedEntity) {
+        fingerprintProtectionSeedDao.updateAll(fingerprintProtectionSeedEntity)
+        loadToMemory()
+    }
+
+    private fun loadToMemory() {
+        fingerprintProtectionSeedEntity =
+            fingerprintProtectionSeedDao.get() ?: FingerprintProtectionSeedEntity(seed = getRandomSeed())
+    }
+
+    private fun getRandomSeed(): String {
+        return UUID.randomUUID().toString()
+    }
+}

--- a/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/seed/RealFingerprintProtectionSeedRepositoryTest.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/seed/RealFingerprintProtectionSeedRepositoryTest.kt
@@ -57,7 +57,7 @@ class RealFingerprintProtectionSeedRepositoryTest {
                 RealFingerprintProtectionSeedRepository(
                     mockDatabase,
                     TestScope(),
-                    coroutineRule.testDispatcherProvider
+                    coroutineRule.testDispatcherProvider,
                 )
             assertEquals("1234", testee.fingerprintProtectionSeedEntity.seed)
 
@@ -66,7 +66,7 @@ class RealFingerprintProtectionSeedRepositoryTest {
                 RealFingerprintProtectionSeedRepository(
                     mockDatabase,
                     TestScope(),
-                    coroutineRule.testDispatcherProvider
+                    coroutineRule.testDispatcherProvider,
                 )
             assertEquals("5678", testee.fingerprintProtectionSeedEntity.seed)
 
@@ -93,7 +93,7 @@ class RealFingerprintProtectionSeedRepositoryTest {
                 RealFingerprintProtectionSeedRepository(
                     mockDatabase,
                     TestScope(),
-                    coroutineRule.testDispatcherProvider
+                    coroutineRule.testDispatcherProvider,
                 )
             testee.storeNewSeed()
 

--- a/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/seed/RealFingerprintProtectionSeedRepositoryTest.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/seed/RealFingerprintProtectionSeedRepositoryTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fingerprintprotection.store.seed
+
+import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.fingerprintprotection.store.FingerprintProtectionDatabase
+import com.duckduckgo.fingerprintprotection.store.FingerprintProtectionSeedEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class RealFingerprintProtectionSeedRepositoryTest {
+    @get:Rule var coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: RealFingerprintProtectionSeedRepository
+
+    private val mockDatabase: FingerprintProtectionDatabase = mock()
+    private val mockFingerprintProtectionSeedDao: FingerprintProtectionSeedDao = mock()
+
+    @Before
+    fun before() {
+        whenever(mockFingerprintProtectionSeedDao.get()).thenReturn(null)
+        whenever(mockDatabase.fingerprintProtectionSeedDao()).thenReturn(mockFingerprintProtectionSeedDao)
+    }
+
+    @Test
+    fun whenInitializedThenStoreNewSeedAndLoadToMemory() =
+        runTest {
+            whenever(mockFingerprintProtectionSeedDao.get()).thenReturn(FingerprintProtectionSeedEntity(seed = "1234"))
+            testee =
+                RealFingerprintProtectionSeedRepository(
+                    mockDatabase,
+                    TestScope(),
+                    coroutineRule.testDispatcherProvider
+                )
+            assertEquals("1234", testee.fingerprintProtectionSeedEntity.seed)
+
+            whenever(mockFingerprintProtectionSeedDao.get()).thenReturn(FingerprintProtectionSeedEntity(seed = "5678"))
+            testee =
+                RealFingerprintProtectionSeedRepository(
+                    mockDatabase,
+                    TestScope(),
+                    coroutineRule.testDispatcherProvider
+                )
+            assertEquals("5678", testee.fingerprintProtectionSeedEntity.seed)
+
+            verify(mockFingerprintProtectionSeedDao, times(2)).get()
+
+            val captor = argumentCaptor<FingerprintProtectionSeedEntity>()
+            val captor2 = argumentCaptor<FingerprintProtectionSeedEntity>()
+
+            mockFingerprintProtectionSeedDao.inOrder {
+                verify().updateAll(captor.capture())
+                verify().updateAll(captor2.capture())
+            }
+            val seed = captor.firstValue.seed
+            val seed2 = captor2.firstValue.seed
+
+            assertNotEquals(seed, seed2)
+        }
+
+    @Test
+    fun whenStoreNewSeedThenStoreNewSeedAndLoadToMemory() =
+        runTest {
+            whenever(mockFingerprintProtectionSeedDao.get()).thenReturn(FingerprintProtectionSeedEntity(seed = "1234"))
+            testee =
+                RealFingerprintProtectionSeedRepository(
+                    mockDatabase,
+                    TestScope(),
+                    coroutineRule.testDispatcherProvider
+                )
+            testee.storeNewSeed()
+
+            verify(mockFingerprintProtectionSeedDao, times(2)).get()
+
+            val captor = argumentCaptor<FingerprintProtectionSeedEntity>()
+            val captor2 = argumentCaptor<FingerprintProtectionSeedEntity>()
+
+            mockFingerprintProtectionSeedDao.inOrder {
+                verify().updateAll(captor.capture())
+                verify().updateAll(captor2.capture())
+            }
+            val seed = captor.firstValue.seed
+            val seed2 = captor2.firstValue.seed
+
+            assertNotEquals(seed, seed2)
+        }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203278063438410/f

### Description
This PR adds a random seed that is used in the fingerprint protection feature.
- The seed is supplied to the content scope config as the `sessionKey` variable.
- The seed is refreshed when the app is stopped (Or the repo is re-instantiated) or every 24 hours.

### Steps to test this PR

_Privacy Protection Tests_
- [x] Uninstall any previous debug build of the app and install from this branch (To ensure that the privacy config is downloaded)
- [x] Navigate to https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/
- [x] Start the test

_In the results, verify that the following values are returned:_
- [x] navigator.deviceMemory - 4
- [x] navigator.hardwareConcurrency - 8
- [x] navigator.getBattery() - charging: true, chargingTime: 0, level: 1 
- [x] navigator.webkitTemporaryStorage.queryUsageAndQuota - usage: 0, quota: 4294967296
- [x] navigator.webkitPersistentStorage.queryUsageAndQuota - usage: 0, quota: 4294967296
- [x] screen.colorDepth - 24
- [x] screen.pixelDepth - 24
- [x] screen.availLeft - 0
- [x] screen.availTop - 0

_Cover Your Tracks_
- [x] Navigate to https://coveryourtracks.eff.org
- [x] Test your browser

_In the results, verify that the following values are returned:_
- [x] Hash of Canvas Fingerprint - randomized by first party domain
- [x] Hash of WebGL Fingerprint - randomized by first party domain
