### PR TITLE
Site permissions change when turned off

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/sitepermissions/permissionsperwebsite/PermissionsPerWebsiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/sitepermissions/permissionsperwebsite/PermissionsPerWebsiteViewModel.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.location.data.LocationPermissionEntity
 import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.location.data.LocationPermissionsRepositoryAPI
-import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.sitepermissions.permissionsperwebsite.PermissionsPerWebsiteViewModel.Command.GoBackToSitePermissions
 import com.duckduckgo.app.sitepermissions.permissionsperwebsite.PermissionsPerWebsiteViewModel.Command.ShowPermissionSettingSelectionDialog
 import com.duckduckgo.app.sitepermissions.permissionsperwebsite.WebsitePermissionSettingType.ALLOW
@@ -43,8 +42,7 @@ import javax.inject.Inject
 @ContributesViewModel(ActivityScope::class)
 class PermissionsPerWebsiteViewModel @Inject constructor(
     private val sitePermissionsRepository: SitePermissionsRepository,
-    private val locationPermissionsRepository: LocationPermissionsRepositoryAPI,
-    private val settingsDataStore: SettingsDataStore
+    private val locationPermissionsRepository: LocationPermissionsRepositoryAPI
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -76,18 +74,9 @@ class PermissionsPerWebsiteViewModel @Inject constructor(
         sitePermissionsEntity: SitePermissionsEntity?,
         locationPermissionEntity: LocationPermissionEntity?
     ): List<WebsitePermissionSetting> {
-        val locationSetting = when (settingsDataStore.appLocationPermission) {
-            true -> WebsitePermissionSettingType.mapToWebsitePermissionSetting(locationPermissionEntity?.permission?.name)
-            false -> DENY
-        }
-        val cameraSetting = when (sitePermissionsRepository.askCameraEnabled) {
-            true -> WebsitePermissionSettingType.mapToWebsitePermissionSetting(sitePermissionsEntity?.askCameraSetting)
-            false -> DENY
-        }
-        val micSetting = when (sitePermissionsRepository.askMicEnabled) {
-            true -> WebsitePermissionSettingType.mapToWebsitePermissionSetting(sitePermissionsEntity?.askMicSetting)
-            false -> DENY
-        }
+        val locationSetting = WebsitePermissionSettingType.mapToWebsitePermissionSetting(locationPermissionEntity?.permission?.name)
+        val cameraSetting = WebsitePermissionSettingType.mapToWebsitePermissionSetting(sitePermissionsEntity?.askCameraSetting)
+        val micSetting = WebsitePermissionSettingType.mapToWebsitePermissionSetting(sitePermissionsEntity?.askMicSetting)
 
         return getSettingsList(locationSetting, cameraSetting, micSetting)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203336099175506/f

### Description
Remove logic to show site permissions settings for website denied if global toggle is off. We'll show actual values that user saved.
If child permission setting is Deny or Ask and global toggle is off, websites won't request site permissions.
If child permission was changes to Allow and global toggle is off, websites will grant permissions for that specific website.

### Steps to test this PR

- Install from this branch
- Go to mictest.cc and give access to microphone
- Go to Settings > Site Permissions and toggle off Microphone permission
- Open mictest.cc in a new tab or refresh current one
- [x] Check microphone permission is rejected
- Go to Settings > Site Permissions and tap on mictest.cc
- Change microphone setting to "Allow"
- Open mictest.cc in a new tab or refresh current one
- [x] Check microphone permission is granted

### No UI changes