### PR TITLE
Fix trailing icon removed from Fireproof and WhiteList web list items

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsiteAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsiteAdapter.kt
@@ -201,8 +201,9 @@ sealed class FireproofWebSiteViewHolder(itemView: View) : RecyclerView.ViewHolde
                 entity.website()
             )
 
-            listItem.setPrimaryText(entity.website())
             loadFavicon(entity.domain, listItem.leadingIcon())
+            listItem.setPrimaryText(entity.website())
+            listItem.showTrailingIcon()
             listItem.setTrailingIconClickListener { anchor ->
                 showOverFlowMenu(anchor, entity)
             }

--- a/app/src/main/java/com/duckduckgo/app/privacy/ui/WebsitesAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/ui/WebsitesAdapter.kt
@@ -169,8 +169,9 @@ sealed class WebsiteViewHolder(itemView: View) : RecyclerView.ViewHolder(itemVie
                 entity.domain
             )
 
-            listItem.setPrimaryText(entity.domain)
             loadFavicon(entity.domain, listItem.leadingIcon())
+            listItem.setPrimaryText(entity.domain)
+            listItem.showTrailingIcon()
             listItem.setTrailingIconClickListener { anchor ->
                 showOverFlowMenu(anchor, entity)
             }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203386039977800/f

### Description
Show trailing icon back in Fireproof websites list and Unprotected sites

### Steps to test this PR

_Fireproof sites_
- Install from this branch
- Go to Settings > Fireproof Sites
- [ ] Check websites list items has trailing icon

_Unprotected sites_
- Install from this branch
- Go to Settings > Unprotected Sites
- [ ] Check websites list items has trailing icon

### UI changes
| Fireproof Sites screen  | Unprotected Sites screen |
| ------ | ----- |
![Screenshot_20221117-120952_DuckDuckGo](https://user-images.githubusercontent.com/20798495/202443222-b8e03640-26a2-433c-bf45-0f0115609604.jpg)|![Screenshot_20221117-120944_DuckDuckGo](https://user-images.githubusercontent.com/20798495/202443238-0519f0fb-a4fb-4b10-ac90-3918a7e0f63d.jpg)|
