### PR TITLE
Nightly builds should also run KtLint

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  spotless:
-    name: Spotless
+  code_formatting:
+    name: Code Formatting
     runs-on: ubuntu-latest
 
     steps:
@@ -26,10 +26,10 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-      - name: Spotless
+      - name: Run Code Formatting Checks
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: spotless
+          arguments: code_format_checks
 
   unit_tests:
     name: Unit tests


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1203404929443459

### Description
In [✓ Android: Trigger KtLint via Kotlinter instead of Spotless](https://app.asana.com/0/1174433894299346/1203115816821758) we changed the tool use to check the code formatting in Kotlin
We made the appropriate changes in CI for PR, but didn't change for Nightly builds. 
https://github.com/duckduckgo/Android/actions/runs/3501659127/jobs/5865491231#step:4:106
