### PR TITLE
add a custom shape drawable for the DaxDialog Card

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/AppComponentsPagerAdapter.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/AppComponentsPagerAdapter.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.themepreview.ui.component.ComponentOtherFragment
 import com.duckduckgo.mobile.android.themepreview.ui.component.buttons.ComponentButtonsFragment
 import com.duckduckgo.mobile.android.themepreview.ui.component.buttons.ComponentInteractiveElementsFragment
+import com.duckduckgo.mobile.android.themepreview.ui.component.cards.ComponentCardsFragment
 import com.duckduckgo.mobile.android.themepreview.ui.component.listitems.ComponentListItemsElementsFragment
 import com.duckduckgo.mobile.android.themepreview.ui.component.navigation.ComponentMessagingFragment
 import com.duckduckgo.mobile.android.themepreview.ui.component.textinput.ComponentTextInputFragment
@@ -44,6 +45,7 @@ class AppComponentsPagerAdapter(
         BUTTONS(R.string.tab_title_buttons),
         TEXT_INPUT(R.string.tab_title_text_input),
         DIALOGS(R.string.tab_title_dialogs),
+        CARDS(R.string.tab_title_cards),
         INTERACTIVE_ELEMENTS(R.string.tab_title_component_interactive),
         MESSAGING(R.string.tab_title_component_messaging),
         LIST_ITEMS(R.string.tab_title_component_list_items),
@@ -67,6 +69,7 @@ class AppComponentsPagerAdapter(
             MainFragments.BUTTONS -> ComponentButtonsFragment()
             MainFragments.TEXT_INPUT -> ComponentTextInputFragment()
             MainFragments.DIALOGS -> DialogsFragment()
+            MainFragments.CARDS -> ComponentCardsFragment()
             MainFragments.INTERACTIVE_ELEMENTS -> ComponentInteractiveElementsFragment()
             MainFragments.MESSAGING -> ComponentMessagingFragment()
             MainFragments.LIST_ITEMS -> ComponentListItemsElementsFragment()

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/ComponentViewHolder.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/ComponentViewHolder.kt
@@ -27,6 +27,9 @@ import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
 import com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
 import com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.shape.ShapeAppearanceModel
+import com.google.android.material.shape.TriangleEdgeTreatment
 import com.google.android.material.snackbar.Snackbar
 
 sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
@@ -199,6 +202,23 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
 
     class DividerComponentViewHolder(parent: ViewGroup) : ComponentViewHolder(inflate(parent, R.layout.component_section_divider))
 
+    class CardComponentViewHolder(parent: ViewGroup) : ComponentViewHolder(inflate(parent, R.layout.component_card)) {
+        override fun bind(component: Component) {
+            view.findViewById<MaterialCardView>(R.id.ticketViewCard).apply {
+                val cornerSize = resources.getDimension(R.dimen.smallShapeCornerRadius)
+                val edgeTreatment = TriangleEdgeTreatment(cornerSize, true)
+                shapeAppearanceModel = ShapeAppearanceModel.Builder()
+                    .setLeftEdge(edgeTreatment)
+                    .setRightEdge(edgeTreatment)
+                    .setAllCornerSizes(cornerSize)
+                    .build()
+                elevation = 8f
+
+                setOnClickListener { Snackbar.make(this, component.name, Snackbar.LENGTH_SHORT).show() }
+            }
+        }
+    }
+
     companion object {
         fun create(
             parent: ViewGroup,
@@ -218,6 +238,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.SINGLE_LINE_LIST_ITEM -> OneLineListItemComponentViewHolder(parent)
                 Component.TWO_LINE_LIST_ITEM -> TwoLineItemComponentViewHolder(parent)
                 Component.SECTION_DIVIDER -> DividerComponentViewHolder(parent)
+                Component.CARD -> CardComponentViewHolder(parent)
                 else -> {
                     TODO()
                 }

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/cards/ComponentCardsFragment.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/cards/ComponentCardsFragment.kt
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.mobile.android.themepreview.ui.component.buttons
+package com.duckduckgo.mobile.android.themepreview.ui.component.cards
 
 import com.duckduckgo.mobile.android.themepreview.ui.component.Component
 import com.duckduckgo.mobile.android.themepreview.ui.component.ComponentFragment
 
-class ComponentInteractiveElementsFragment : ComponentFragment() {
+class ComponentCardsFragment : ComponentFragment() {
     override fun getComponents(): List<Component> {
-        return listOf(
-            Component.SWITCH,
-            Component.RADIO_BUTTON,
-            Component.CHECKBOX,
-            Component.SEARCH_BAR,
-        )
+        return listOf(Component.CARD)
     }
 }

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/shape/DaxBubbleCardView.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/shape/DaxBubbleCardView.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.view.shape
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.util.AttributeSet
+import com.duckduckgo.mobile.android.R
+import com.duckduckgo.mobile.android.ui.view.getColorFromAttr
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.shape.MaterialShapeDrawable
+import com.google.android.material.shape.ShapeAppearanceModel
+
+class DaxBubbleCardView
+@JvmOverloads
+constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.cardViewStyle,
+) : MaterialCardView(context, attrs, defStyleAttr) {
+
+    init {
+        val cornderRadius = resources.getDimension(R.dimen.mediumShapeCornerRadius)
+        val cornerSize = resources.getDimension(R.dimen.daxBubbleDialogEdge)
+        val distanceFromEdge = resources.getDimension(R.dimen.daxBubbleDialogDistanceFromEdge)
+        val edgeTreatment = DaxBubbleEdgeTreatment(cornerSize, distanceFromEdge)
+
+        background = MaterialShapeDrawable(
+            ShapeAppearanceModel.builder()
+                .setAllCornerSizes(cornderRadius)
+                .setTopEdge(edgeTreatment)
+                .build(),
+        ).apply {
+            fillColor = ColorStateList.valueOf(context.getColorFromAttr(R.attr.daxColorSurface))
+        }
+    }
+}

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/shape/Shapes.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/shape/Shapes.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.view.shape
+
+import com.google.android.material.shape.CornerFamily
+import com.google.android.material.shape.EdgeTreatment
+import com.google.android.material.shape.MaterialShapeDrawable
+import com.google.android.material.shape.ShapeAppearanceModel
+import com.google.android.material.shape.ShapePath
+
+class DaxBubbleEdgeTreatment
+/**
+ * Instantiates a triangle treatment of the given size, which faces inward or outward relative to
+ * the shape.
+ *
+ * @param size the length in pixels that the triangle extends into or out of the shape. The length
+ * of the side of the triangle coincident with the rest of the edge is 2 * size.
+ * @param inside true if the triangle should be "cut out" of the shape (i.e. inward-facing); false
+ * if the triangle should extend out of the shape.
+ */(
+    private val size: Float,
+    private val distanceFromEdge: Float,
+) : EdgeTreatment() {
+    override fun getEdgePath(
+        length: Float,
+        center: Float,
+        interpolation: Float,
+        shapePath: ShapePath,
+    ) {
+        shapePath.lineTo(distanceFromEdge - size * interpolation, 0f)
+        shapePath.lineTo(distanceFromEdge, -size * interpolation)
+        shapePath.lineTo(distanceFromEdge + size * interpolation, 0f)
+        shapePath.lineTo(length, 0f)
+    }
+}
+
+class TicketEdgeTreatment(
+    private val size: Float,
+) : EdgeTreatment() {
+    override fun getEdgePath(
+        length: Float,
+        center: Float,
+        interpolation: Float,
+        shapePath: ShapePath,
+    ) {
+        val circleRadius = size * interpolation
+        shapePath.lineTo(center - circleRadius, 0f)
+        shapePath.addArc(
+            center - circleRadius,
+            -circleRadius,
+            center + circleRadius,
+            circleRadius,
+            180f,
+            -180f,
+        )
+        shapePath.lineTo(length, 0f)
+    }
+}
+
+val ticketShapePathModel = ShapeAppearanceModel
+    .Builder()
+    .setAllCorners(CornerFamily.ROUNDED, 36f)
+    .setLeftEdge(TicketEdgeTreatment(36f))
+    .setRightEdge(TicketEdgeTreatment(36f))
+    .build()
+
+class TicketDrawable : MaterialShapeDrawable(ticketShapePathModel)

--- a/common-ui/src/main/res/layout/component_card.xml
+++ b/common-ui/src/main/res/layout/component_card.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+~ Copyright (C) 2019 The Android Open Source Project
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/keyline_5"
+    android:paddingBottom="@dimen/keyline_5"
+    android:clipChildren="false"
+    android:orientation="vertical">
+
+    <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
+        android:id="@+id/daxBubbleLabel"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        app:primaryText="Dax Dialog Card"/>
+
+    <com.duckduckgo.mobile.android.ui.view.shape.DaxBubbleCardView
+        android:id="@+id/daxBubbleCardView"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_margin="@dimen/keyline_4"/>
+
+    <com.duckduckgo.mobile.android.ui.view.shape.DaxBubbleCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/keyline_4">
+
+        <LinearLayout
+            android:id="@+id/cardContainer"
+            android:paddingStart="16dp"
+            android:paddingTop="26dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="20dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+                android:id="@+id/hiddenText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/onboardingDaxText"/>
+
+            <com.duckduckgo.mobile.android.ui.view.button.DaxButtonPrimary
+                android:id="@+id/dax_button_primary_disabled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                app:buttonSize="large"
+                android:text="Primary"/>
+
+        </LinearLayout>
+
+    </com.duckduckgo.mobile.android.ui.view.shape.DaxBubbleCardView>
+
+
+    <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
+        android:id="@+id/label"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        app:primaryText="Default Card"/>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/defaultCard"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_margin="@dimen/keyline_4"/>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/ticketViewCard"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_margin="@dimen/keyline_4"/>
+
+</LinearLayout>

--- a/common-ui/src/main/res/layout/view_dax_dialog.xml
+++ b/common-ui/src/main/res/layout/view_dax_dialog.xml
@@ -38,8 +38,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/dimmed"
-            app:layout_constraintTop_toTopOf="@id/hideText"/>
-
+            app:layout_constraintTop_toTopOf="@id/hideText" tools:layout_editor_absoluteX="0dp"/>
         <TextView
             android:id="@+id/hideText"
             android:layout_width="wrap_content"

--- a/common-ui/src/main/res/values/design-system-attrs.xml
+++ b/common-ui/src/main/res/values/design-system-attrs.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright (c) 2018 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+
+    <attr name="cardViewStyle" format="reference"/>
+
+</resources>

--- a/common-ui/src/main/res/values/design-system-dimensions.xml
+++ b/common-ui/src/main/res/values/design-system-dimensions.xml
@@ -86,4 +86,8 @@
 
     <!-- InfoPanel -->
     <dimen name="infoPanelIconSize">16dp</dimen>
+
+    <!-- Card -->
+    <dimen name="daxBubbleDialogDistanceFromEdge">40dp</dimen>
+    <dimen name="daxBubbleDialogEdge">9dp</dimen>
 </resources>

--- a/common-ui/src/main/res/values/design-system-theming.xml
+++ b/common-ui/src/main/res/values/design-system-theming.xml
@@ -80,6 +80,7 @@
         <item name="materialButtonStyle">@style/Widget.DuckDuckGo.DaxButton.TextButton.Primary</item>
         <item name="materialButtonOutlinedStyle">@style/Widget.DuckDuckGo.DaxButton.Secondary</item>
         <item name="borderlessButtonStyle">@style/Widget.DuckDuckGo.DaxButton.Ghost</item>
+        <item name="materialCardViewStyle">@style/Widget.DuckDuckGo.CardView</item>
 
         <!-- Design System Components -->
         <item name="daxButtonPrimary">@style/Widget.DuckDuckGo.DaxButton.TextButton.Primary</item>
@@ -97,8 +98,11 @@
         <item name="primaryButtonRoundedStyle">@style/Widget.DuckDuckGo.Button.Rounded</item>
         <item name="secondaryButtonRoundedStyle">@style/Widget.DuckDuckGo.Button.Secondary.Rounded</item>
         <item name="primaryButtonLowercaseStyle">@style/Widget.DuckDuckGo.Button.Primary.Lowercase</item>
+
         <item name="oneLineListItemStyle">@style/Widget.DuckDuckGo.OneLineListItem</item>
         <item name="twoLineListItemStyle">@style/Widget.DuckDuckGo.TwoLineListItem</item>
+
+        <item name="cardViewStyle">@style/Widget.DuckDuckGo.CardView</item>
     </style>
 
     <style name="Theme.DuckDuckGo" parent="Base.Theme.DuckDuckGo">

--- a/common-ui/src/main/res/values/donottranslate.xml
+++ b/common-ui/src/main/res/values/donottranslate.xml
@@ -22,6 +22,7 @@
     <string name="tab_title_buttons" translatable="false">Buttons</string>
     <string name="tab_title_text_input" translatable="false">Text Input</string>
     <string name="tab_title_dialogs" translatable="false">Dialogs</string>
+    <string name="tab_title_cards" translatable="false">Cards</string>
     <string name="tab_title_component_interactive" translatable="false">Interactive</string>
     <string name="tab_title_component_messaging" translatable="false">Messaging</string>
     <string name="tab_title_component_list_items" translatable="false">List items</string>

--- a/common-ui/src/main/res/values/widgets.xml
+++ b/common-ui/src/main/res/values/widgets.xml
@@ -396,4 +396,11 @@
         <item name="android:layout_height">match_parent</item>
         <item name="android:background">?attr/sectionDividerColor</item>
     </style>
+
+    <!-- Cards -->
+    <style name="Widget.DuckDuckGo.CardView" parent="Widget.MaterialComponents.CardView">
+        <item name="cardBackgroundColor">?attr/daxColorSurface</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.DuckDuckGo.MediumComponent</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202857801505092/1203425281067996

### Description
The top triangle in the DaxDialog doesn't respect elevation. The outline around it is not consistent with the rest of the Card.

### UI changes

| Before  | After |
| ------ | ----- |
![Screenshot_20221122_174516](https://user-images.githubusercontent.com/531613/203578300-1a80b73e-cb28-441c-831c-cb9a1307319f.png)|![Screenshot_20221123_140401](https://user-images.githubusercontent.com/531613/203578315-8778a408-8158-40f3-ae88-d1bc3039937a.png)|
