### PR TITLE
Improve autofill subdomain/url handling

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/ui/urlmatcher/AutofillUrlMatcher.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/ui/urlmatcher/AutofillUrlMatcher.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.urlmatcher
+
+interface AutofillUrlMatcher {
+    fun extractUrlPartsForAutofill(originalUrl: String): ExtractedUrlParts
+    fun matchingForAutofill(visitedSite: ExtractedUrlParts, savedSite: ExtractedUrlParts): Boolean
+
+    data class ExtractedUrlParts(val eTldPlus1: String?, val subdomain: String?)
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/di/AutofillModule.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/di/AutofillModule.kt
@@ -24,6 +24,8 @@ import com.duckduckgo.autofill.store.RealAutofillPrefsStore
 import com.duckduckgo.autofill.store.RealInternalTestUserStore
 import com.duckduckgo.autofill.store.RealLastUpdatedTimeProvider
 import com.duckduckgo.autofill.store.SecureStoreBackedAutofillStore
+import com.duckduckgo.autofill.store.urlmatcher.AutofillDomainNameUrlMatcher
+import com.duckduckgo.autofill.ui.urlmatcher.AutofillUrlMatcher
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.securestorage.api.SecureStorage
 import com.squareup.anvil.annotations.ContributesTo
@@ -44,12 +46,17 @@ class AutofillModule {
         secureStorage: SecureStorage,
         context: Context,
         internalTestUserChecker: InternalTestUserChecker,
+        autofillUrlMatcher: AutofillUrlMatcher,
     ): AutofillStore {
         return SecureStoreBackedAutofillStore(
-            secureStorage,
-            internalTestUserChecker,
-            RealLastUpdatedTimeProvider(),
-            RealAutofillPrefsStore(context, internalTestUserChecker),
+            secureStorage = secureStorage,
+            internalTestUserChecker = internalTestUserChecker,
+            lastUpdatedTimeProvider = RealLastUpdatedTimeProvider(),
+            autofillPrefsStore = RealAutofillPrefsStore(context, internalTestUserChecker),
+            autofillUrlMatcher = autofillUrlMatcher,
         )
     }
+
+    @Provides
+    fun provideAutofillUrlMatcher(): AutofillUrlMatcher = AutofillDomainNameUrlMatcher()
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/suggestion/SuggestionMatcher.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/suggestion/SuggestionMatcher.kt
@@ -16,20 +16,24 @@
 
 package com.duckduckgo.autofill.ui.credential.management.suggestion
 
-import com.duckduckgo.app.global.extractSchemeAndDomain
 import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.autofill.ui.urlmatcher.AutofillUrlMatcher
 import javax.inject.Inject
 
-class SuggestionMatcher @Inject constructor() {
+class SuggestionMatcher @Inject constructor(private val autofillUrlMatcher: AutofillUrlMatcher) {
 
     fun getSuggestions(
         currentUrl: String?,
         credentials: List<LoginCredentials>,
     ): List<LoginCredentials> {
         if (currentUrl == null) return emptyList()
+        val currentSite = autofillUrlMatcher.extractUrlPartsForAutofill(currentUrl)
+        if (currentSite.eTldPlus1 == null) return emptyList()
 
         return credentials.filter {
-            it.domain?.extractSchemeAndDomain() == currentUrl.extractSchemeAndDomain()
+            val storedDomain = it.domain ?: return@filter false
+            val savedSite = autofillUrlMatcher.extractUrlPartsForAutofill(storedDomain)
+            return@filter autofillUrlMatcher.matchingForAutofill(currentSite, savedSite)
         }
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/suggestion/SuggestionMatcherTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/suggestion/SuggestionMatcherTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.autofill.ui.credential.management.suggestion
 
 import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.autofill.store.urlmatcher.AutofillDomainNameUrlMatcher
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,7 +26,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class SuggestionMatcherTest {
 
-    private val testee = SuggestionMatcher()
+    private val testee = SuggestionMatcher(AutofillDomainNameUrlMatcher())
 
     @Test
     fun whenUrlIsNullThenNoSuggestions() {
@@ -67,6 +68,13 @@ class SuggestionMatcherTest {
         )
         val suggestions = testee.getSuggestions("https://duckduckgo.com", creds)
         assertEquals(2, suggestions.size)
+    }
+
+    @Test
+    fun whenSubdomainIncludedInSavedSiteAndVisitingRootSiteThenSuggestionOffered() {
+        val creds = listOf(creds("https://duckduckgo.com"))
+        val suggestions = testee.getSuggestions("https://test.duckduckgo.com", creds)
+        assertEquals(1, suggestions.size)
     }
 
     private fun creds(domain: String): LoginCredentials {

--- a/autofill/autofill-store/build.gradle
+++ b/autofill/autofill-store/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation KotlinX.coroutines.core
     implementation Google.android.material
     implementation project(path: ':secure-storage-api')
+    implementation Square.okHttp3.okHttp
 
     implementation Google.dagger
     implementation JakeWharton.timber

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcher.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcher.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.store.urlmatcher
+
+import com.duckduckgo.app.global.extractDomain
+import com.duckduckgo.autofill.ui.urlmatcher.AutofillUrlMatcher
+import javax.inject.Inject
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import timber.log.Timber
+
+class AutofillDomainNameUrlMatcher @Inject constructor() : AutofillUrlMatcher {
+
+    override fun extractUrlPartsForAutofill(originalUrl: String): AutofillUrlMatcher.ExtractedUrlParts {
+        val normalizedUrl = originalUrl.normalizeScheme()
+        return try {
+            val eTldPlus1 = normalizedUrl.toHttpUrl().topPrivateDomain()
+            val domain = originalUrl.extractDomain()
+            val subdomain = determineSubdomain(domain, eTldPlus1)
+            AutofillUrlMatcher.ExtractedUrlParts(eTldPlus1, subdomain)
+        } catch (e: IllegalArgumentException) {
+            Timber.w("Unable to parse e-tld+1 from $originalUrl")
+            AutofillUrlMatcher.ExtractedUrlParts(null, null)
+        }
+    }
+
+    private fun determineSubdomain(
+        domain: String?,
+        eTldPlus1: String?,
+    ): String? {
+        if (eTldPlus1 == null) return null
+
+        val subdomain = domain?.replace(eTldPlus1 ?: "", "", ignoreCase = true)?.removeSuffix(".")
+        if (subdomain?.isBlank() == true) return null
+
+        return subdomain
+    }
+
+    override fun matchingForAutofill(
+        visitedSite: AutofillUrlMatcher.ExtractedUrlParts,
+        savedSite: AutofillUrlMatcher.ExtractedUrlParts,
+    ): Boolean {
+        // e-tld+1 must match
+        if (!identicalEffectiveTldPlusOne(visitedSite, savedSite)) return false
+
+        // any of these rules can match
+        return identicalSubdomains(visitedSite, savedSite) ||
+            specialHandlingForWwwSubdomainOnSavedSite(visitedSite, savedSite) ||
+            savedSiteHasNoSubdomain(savedSite)
+    }
+
+    private fun identicalEffectiveTldPlusOne(
+        visitedSite: AutofillUrlMatcher.ExtractedUrlParts,
+        savedSite: AutofillUrlMatcher.ExtractedUrlParts,
+    ): Boolean {
+        return visitedSite.eTldPlus1.equals(savedSite.eTldPlus1, ignoreCase = true)
+    }
+
+    private fun identicalSubdomains(
+        visitedSite: AutofillUrlMatcher.ExtractedUrlParts,
+        savedSite: AutofillUrlMatcher.ExtractedUrlParts,
+    ): Boolean {
+        return visitedSite.subdomain.equals(savedSite.subdomain, ignoreCase = true)
+    }
+
+    private fun specialHandlingForWwwSubdomainOnSavedSite(
+        visitedSite: AutofillUrlMatcher.ExtractedUrlParts,
+        savedSite: AutofillUrlMatcher.ExtractedUrlParts,
+    ): Boolean {
+        return (visitedSite.subdomain == null && savedSite.subdomain.equals(WWW, ignoreCase = true))
+    }
+
+    private fun savedSiteHasNoSubdomain(savedSite: AutofillUrlMatcher.ExtractedUrlParts): Boolean {
+        return savedSite.subdomain == null
+    }
+
+    private fun String.normalizeScheme(): String {
+        if (!startsWith("https://") && !startsWith("http://")) {
+            return "https://$this"
+        }
+        return this
+    }
+
+    companion object {
+        private const val WWW = "www"
+    }
+}

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -27,6 +27,8 @@ import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.NoM
 import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.UrlOnlyMatch
 import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.UsernameMatch
 import com.duckduckgo.autofill.store.AutofillStore.ContainsCredentialsResult.UsernameMissing
+import com.duckduckgo.autofill.store.urlmatcher.AutofillDomainNameUrlMatcher
+import com.duckduckgo.autofill.ui.urlmatcher.AutofillUrlMatcher
 import com.duckduckgo.securestorage.api.SecureStorage
 import com.duckduckgo.securestorage.api.WebsiteLoginDetails
 import com.duckduckgo.securestorage.api.WebsiteLoginDetailsWithCredentials
@@ -64,6 +66,8 @@ class SecureStoreBackedAutofillStoreTest {
     private lateinit var testee: SecureStoreBackedAutofillStore
     private lateinit var internalTestUserChecker: FakeInternalTestUserChecker
     private lateinit var secureStore: FakeSecureStore
+
+    private val autofillUrlMatcher: AutofillUrlMatcher = AutofillDomainNameUrlMatcher()
 
     @Before
     fun setUp() {
@@ -349,6 +353,75 @@ class SecureStoreBackedAutofillStoreTest {
         assertNull(testee.getCredentialsWithId(1))
     }
 
+    @Test
+    fun whenExactUrlMatchesThenCredentialsReturned() = runTest {
+        setupTesteeWithAutofillAvailable()
+        val savedUrl = "https://example.com"
+        val visitedSite = "https://example.com"
+        storeCredentials(1, savedUrl, "username1", "password123")
+
+        val results = testee.getCredentials(visitedSite)
+        assertEquals(1, results.size)
+        assertEquals(1L, results[0].id)
+    }
+
+    @Test
+    fun whenExactSubdomainMatchesThenCredentialsReturned() = runTest {
+        setupTesteeWithAutofillAvailable()
+        val savedUrl = "https://subdomain.example.com"
+        val visitedSite = "https://subdomain.example.com"
+        storeCredentials(1, savedUrl, "username1", "password123")
+
+        val results = testee.getCredentials(visitedSite)
+        assertEquals(1, results.size)
+        assertEquals(1L, results[0].id)
+    }
+
+    @Test
+    fun whenExactWwwSubdomainMatchesThenCredentialsReturned() = runTest {
+        setupTesteeWithAutofillAvailable()
+        val savedUrl = "https://www.example.com"
+        val visitedSite = "https://www.example.com"
+        storeCredentials(1, savedUrl, "username1", "password123")
+
+        val results = testee.getCredentials(visitedSite)
+        assertEquals(1, results.size)
+        assertEquals(1L, results[0].id)
+    }
+
+    @Test
+    fun whenSavedCredentialHasSubdomainAndVisitedPageDoesNotThenCredentialNotMatched() = runTest {
+        setupTesteeWithAutofillAvailable()
+        val savedUrl = "https://test.example.com"
+        val visitedSite = "https://example.com"
+        storeCredentials(1, savedUrl, "username1", "password123")
+
+        val results = testee.getCredentials(visitedSite)
+        assertEquals(0, results.size)
+    }
+
+    @Test
+    fun whenSavedCredentialHasNoSubdomainAndVisitedPageDoesThenCredentialNotMatched() = runTest {
+        setupTesteeWithAutofillAvailable()
+        val savedUrl = "https://example.com"
+        val visitedSite = "https://test.example.com"
+        storeCredentials(1, savedUrl, "username1", "password123")
+
+        val results = testee.getCredentials(visitedSite)
+        assertEquals(1, results.size)
+    }
+
+    @Test
+    fun whenSavedCredentialHasDifferentSubdomainToVisitedPageSubdomainThenCredentialNotMatched() = runTest {
+        setupTesteeWithAutofillAvailable()
+        val savedUrl = "https://test.example.com"
+        val visitedSite = "https://different.example.com"
+        storeCredentials(1, savedUrl, "username1", "password123")
+
+        val results = testee.getCredentials(visitedSite)
+        assertEquals(0, results.size)
+    }
+
     private fun List<LoginCredentials>.assertHasNoLoginCredentials(
         url: String,
         username: String,
@@ -376,7 +449,13 @@ class SecureStoreBackedAutofillStoreTest {
     private fun setupTesteeWithAutofillAvailable() {
         internalTestUserChecker = FakeInternalTestUserChecker(true)
         secureStore = FakeSecureStore(true)
-        testee = SecureStoreBackedAutofillStore(secureStore, internalTestUserChecker, lastUpdatedTimeProvider, autofillPrefsStore)
+        testee = SecureStoreBackedAutofillStore(
+            secureStorage = secureStore,
+            internalTestUserChecker = internalTestUserChecker,
+            lastUpdatedTimeProvider = lastUpdatedTimeProvider,
+            autofillPrefsStore = autofillPrefsStore,
+            autofillUrlMatcher = autofillUrlMatcher,
+        )
     }
 
     private fun setupTestee(
@@ -386,11 +465,12 @@ class SecureStoreBackedAutofillStoreTest {
         internalTestUserChecker = FakeInternalTestUserChecker(isInternalUser)
         secureStore = FakeSecureStore(canAccessSecureStorage)
         testee = SecureStoreBackedAutofillStore(
-            secureStore,
-            internalTestUserChecker,
-            lastUpdatedTimeProvider,
-            autofillPrefsStore,
+            secureStorage = secureStore,
+            internalTestUserChecker = internalTestUserChecker,
+            lastUpdatedTimeProvider = lastUpdatedTimeProvider,
+            autofillPrefsStore = autofillPrefsStore,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+            autofillUrlMatcher = autofillUrlMatcher,
         )
     }
 
@@ -442,7 +522,7 @@ class SecureStoreBackedAutofillStoreTest {
             return flow {
                 emit(
                     credentials.filter {
-                        it.details.domain == domain
+                        it.details.domain?.contains(domain) == true
                     }.map {
                         it.details
                     },
@@ -464,7 +544,7 @@ class SecureStoreBackedAutofillStoreTest {
             return flow {
                 emit(
                     credentials.filter {
-                        it.details.domain == domain
+                        it.details.domain?.contains(domain) == true
                     },
                 )
             }

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcherTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcherTest.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.store.urlmatcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AutofillDomainNameUrlMatcherTest {
+
+    private val testee = AutofillDomainNameUrlMatcher()
+
+    @Test
+    fun whenBasicDomainThenSameReturnedForEtldPlus1() {
+        val inputUrl = "duckduckgo.com"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals(inputUrl, result.eTldPlus1)
+    }
+
+    @Test
+    fun whenUrlIsInvalidMissingTldThenEtldPlusOneIsNull() {
+        val inputUrl = "duckduckgo"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertNull(result.eTldPlus1)
+    }
+
+    @Test
+    fun whenUrlIsInvalidMissingTldThenSubdomainIsNull() {
+        val inputUrl = "duckduckgo"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertNull(result.subdomain)
+    }
+
+    @Test
+    fun whenContainsHttpSchemeThenEtldPlus1Returned() {
+        val inputUrl = "http://duckduckgo.com"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals("duckduckgo.com", result.eTldPlus1)
+    }
+
+    @Test
+    fun whenContainsHttpsSchemeThenEtldPlus1Returned() {
+        val inputUrl = "https://duckduckgo.com"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals("duckduckgo.com", result.eTldPlus1)
+    }
+
+    @Test
+    fun whenContainsWwwSubdomainThenEtldPlus1Returned() {
+        val inputUrl = "www.duckduckgo.com"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals("duckduckgo.com", result.eTldPlus1)
+    }
+
+    @Test
+    fun whenContainsAnotherSubdomainThenEtldPlus1Returned() {
+        val inputUrl = "foo.duckduckgo.com"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals("duckduckgo.com", result.eTldPlus1)
+    }
+
+    @Test
+    fun whenTwoPartTldWithNoSubdomainThenEtldPlus1Returned() {
+        val inputUrl = "duckduckgo.co.uk"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals("duckduckgo.co.uk", result.eTldPlus1)
+    }
+
+    @Test
+    fun whenTwoPartTldWithSubdomainThenEtldPlus1Returned() {
+        val inputUrl = "www.duckduckgo.co.uk"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals("duckduckgo.co.uk", result.eTldPlus1)
+    }
+
+    @Test
+    fun whenSubdomainIsWwwThenCorrectlyIdentifiedAsSubdomain() {
+        val inputUrl = "www.duckduckgo.co.uk"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals("www", result.subdomain)
+    }
+
+    @Test
+    fun whenSubdomainIsPresentButNotWwwThenCorrectlyIdentifiedAsSubdomain() {
+        val inputUrl = "test.duckduckgo.co.uk"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals("test", result.subdomain)
+    }
+
+    @Test
+    fun whenSubdomainHasTwoLevelsThenCorrectlyIdentifiedAsSubdomain() {
+        val inputUrl = "foo.bar.duckduckgo.co.uk"
+        val result = testee.extractUrlPartsForAutofill(inputUrl)
+        assertEquals("foo.bar", result.subdomain)
+    }
+
+    @Test
+    fun whenUrlsAreIdenticalThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("https://example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("https://example.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenUrlsAreIdenticalExceptForUppercaseVisitedSiteThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("https://example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("https://EXAMPLE.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenUrlsAreIdenticalExceptForUppercaseSavedSiteThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("https://EXAMPLE.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("https://example.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenBothUrlsContainSameSubdomainThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("test.example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("test.example.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenBothUrlsContainWwwSubdomainThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("www.example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("www.example.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteContainsSubdomainAndVisitedSiteDoesNotThenNoMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("foo.example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("example.com")
+        assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteDoesNotContainSubdomainAndVisitedSiteDoesThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("foo.example.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenUrlsHaveDifferentSubdomainsThenNoMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("bar.example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("foo.example.com")
+        assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteContainsWwwSubdomainAndVisitedSiteDoesNotThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("www.example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("example.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteContainsUppercaseWwwSubdomainAndVisitedSiteDoesNotThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("WWW.example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("example.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteDoesNotContainSubdomainAndVisitedSiteDoesContainWwwSubdomainThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("www.example.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteDoesNotContainSubdomainAndVisitedSiteDoesContainUppercaseWwwSubdomainThenMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("WWW.example.com")
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteContainNestedSubdomainsAndVisitedSiteContainsMatchingRootSubdomainThenNotMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("a.b.example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("b.example.com")
+        assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteContainSubdomainAndVisitedSiteContainsNestedSubdomainsThenNotMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("b.example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("a.b.example.com")
+        assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteHasNoSubdomainAndVisitedMaliciousSitePartiallyContainSavedSiteThenNoMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("example.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("example.com.malicious.com")
+        assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedMaliciousSitePartiallyContainsVisitedSiteThenNoMatchingForAutofill() {
+        val savedSite = testee.extractUrlPartsForAutofill("example.com.malicious.com")
+        val visitedSite = testee.extractUrlPartsForAutofill("example.com")
+        assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+}

--- a/secure-storage/secure-storage-store/build.gradle
+++ b/secure-storage/secure-storage-store/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     kapt AndroidX.room.compiler
 
     testImplementation Testing.junit4
+    testImplementation project(path: ':common-test')
+    testImplementation Testing.robolectric
+    testImplementation AndroidX.archCore.testing
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation (KotlinX.coroutines.test) {
         // https://github.com/Kotlin/kotlinx.coroutines/issues/2023

--- a/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/db/WebsiteLoginCredentialsDao.kt
+++ b/secure-storage/secure-storage-store/src/main/java/com/duckduckgo/securestorage/store/db/WebsiteLoginCredentialsDao.kt
@@ -36,7 +36,7 @@ interface WebsiteLoginCredentialsDao {
     @Query("select * from website_login_credentials")
     fun websiteLoginCredentials(): Flow<List<WebsiteLoginCredentialsEntity>>
 
-    @Query("select * from website_login_credentials where domain = :domain")
+    @Query("select * from website_login_credentials where domain like '%' || :domain || '%'")
     fun websiteLoginCredentialsByDomain(domain: String): Flow<List<WebsiteLoginCredentialsEntity>>
 
     @Query("select * from website_login_credentials where id = :id")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203418026431060/f

### Description
Updates the autofill URL matching logic to the linked task. Summarizing:

- better use of e-tld+1 for comparisons
- better handling of subdomains

To achieve this fully, we now filter for matching credentials in two steps:

- at the DB level first using etld+1 
- in Kotlin, where we further filter the results based on subdomains

### Steps to test this PR

Each of the scenarios listed in the spreadsheet should be tested: [Autofill domain matching rules](https://app.asana.com/0/1203115518054842/1203386153863287/f)

- For each row, make sure you have a saved credential in the form listed. Then visit the site detailed for it and validate if autofill is offered, and whether that matches the expected state (✅ meaning we should autofill, ❌ meaning we should not)