### PR TITLE
ADS: Edit padding-end toggle in ListItems

### DIFF
--- a/common-ui/src/main/res/layout/view_one_line_list_item.xml
+++ b/common-ui/src/main/res/layout/view_one_line_list_item.xml
@@ -78,7 +78,7 @@
             android:id="@+id/trailingSwitch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/keyline_2"
+            android:layout_marginEnd="@dimen/keyline_4"
             android:padding="0dp"
             tools:ignore="SpeakableTextPresentCheck" />
 

--- a/common-ui/src/main/res/layout/view_two_line_item.xml
+++ b/common-ui/src/main/res/layout/view_two_line_item.xml
@@ -106,7 +106,7 @@
             android:id="@+id/trailingSwitch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/keyline_2" />
+            android:layout_marginEnd="@dimen/keyline_4" />
 
     </FrameLayout>
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202857801505092/1203433424223914/f

### Description
Increase padding-end for OneLineListItem and TwoLineListItem when showing switch

### Steps to test this PR

- Install from this branch
- Go to Settings > Design Preview
- [ ] Check List Items with toggle look as expected

### UI changes
| Before  | After |
| ------ | ----- |
![autoconsent_old_light](https://user-images.githubusercontent.com/20798495/203793730-c9d9883e-c2a8-48bd-8a9e-6c19288f2f92.jpg)|![padding-end_16dp](https://user-images.githubusercontent.com/20798495/203793656-dae94b23-c40c-4d3b-8dce-65f8f9a4f539.jpg)|
