### PR TITLE
Bug: Fire animation fades in white in dark theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -356,6 +356,7 @@
         <activity
             android:name="com.duckduckgo.app.fire.FireActivity"
             android:exported="false"
+            android:theme="@style/Theme.DuckDuckGo.Dark"
             android:process="@string/fireProcessName" />
         <activity
             android:name="com.duckduckgo.app.icon.ui.ChangeIconActivity"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1203238561022217

### Description
Background
[✓ Theming](https://app.asana.com/0/1202552961248957/1203142079944553/f) possibly caused this regression in 5.141.x
See [Comment by Aitor on Theming](https://app.asana.com/0/0/1203142079944553/1203245774898368/f)
5.140.x doesn't have that bug

### Steps to test this PR

_Any theme in Production_
- [x] Open Browser Activity
- [x] Launch Fire Button
- [x] Verify light screen is visible
- [x] Verify Browser Activity opens again

_Any theme in [5.140](https://github.com/duckduckgo/Android/releases/tag/5.140.0)_
- [x] Open Browser Activity
- [x] Launch Fire Button
- [x] Verify dark screen is visible
- [x] Verify Browser Activity opens again

_Light Theme from this branch_
- [x] Open Browser Activity
- [x] Launch Fire Button
- [x] Verify dark screen is visible
- [x] Verify Browser Activity opens again

Dark Theme from this branch_
- [x] Open Browser Activity
- [x] Launch Fire Button
- [x] Verify dark screen is visible
- [x] Verify Browser Activity opens again

### UI changes
| Before  | After |
| ------ | ----- |
|https://user-images.githubusercontent.com/531613/204055704-13cc233f-1fd5-4e13-9f19-7be6b3b5c469.mp4|(https://user-images.githubusercontent.com/531613/204055702-1dd9d914-7f58-4716-a248-9bdd3b9ed4a0.mp4)|