### PR TITLE
Translations for Site Permission when Ask is disabled

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -109,7 +109,7 @@
     <string name="tabClosedUndo">Отмяна</string>
     <string name="downloadsMenuItemTitle">Изтеглени файлове</string>
 
-   <!-- Fire -->
+    <!-- Fire -->
     <string name="fireMenu">Изчистване на данни</string>
     <string name="fireClearAll">Изчистване на всички раздели и данни</string>
     <string name="fireCancel">Отмени</string>
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Микрофон</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Управление на сайтове</string>
     <string name="sitePermissionsSettingsEmptyText">Все още няма сайтове</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Разрешенията са премахнати за всички сайтове</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Разрешения за \"%1$s\" </string>
     <string name="permissionsPerWebsiteAskSetting">Питане</string>
     <string name="permissionsPerWebsiteDenySetting">Отказвам</string>
     <string name="permissionsPerWebsiteAllowSetting">Разрешавам</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">Опцията „Питай“ е деактивирана за всички сайтове</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s разрешение за %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -109,7 +109,7 @@
     <string name="tabClosedUndo">Vrátit</string>
     <string name="downloadsMenuItemTitle">Stahování</string>
 
-   <!-- Fire -->
+    <!-- Fire -->
     <string name="fireMenu">Vymazat data</string>
     <string name="fireClearAll">Vymazat všechny karty a data</string>
     <string name="fireCancel">Zrušit</string>
@@ -671,10 +671,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Správa webů</string>
     <string name="sitePermissionsSettingsEmptyText">Zatím žádné weby</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Oprávnění odebrána všem webům</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Oprávnění „%1$s“ </string>
     <string name="permissionsPerWebsiteAskSetting">Zeptat se</string>
     <string name="permissionsPerWebsiteDenySetting">Odmítnout</string>
     <string name="permissionsPerWebsiteAllowSetting">Povolit</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">Možnost „Zeptat se“ je u všech webů vypnutá</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s – povolení pro web %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Administrer websteder</string>
     <string name="sitePermissionsSettingsEmptyText">Ingen websteder endnu</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Tilladelser fjernet for alle websteder</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Tilladelser til \"%1$s\" </string>
     <string name="permissionsPerWebsiteAskSetting">Spørg</string>
     <string name="permissionsPerWebsiteDenySetting">Afvis</string>
     <string name="permissionsPerWebsiteAllowSetting">Tillad</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">\"Spørg\" er deaktiveret for alle websteder</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s tilladelse til %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -109,7 +109,7 @@
     <string name="tabClosedUndo">Rückgängig machen</string>
     <string name="downloadsMenuItemTitle">Downloads</string>
 
-   <!-- Fire -->
+    <!-- Fire -->
     <string name="fireMenu">Daten löschen</string>
     <string name="fireClearAll">Alle Tabs schließen und Daten löschen</string>
     <string name="fireCancel">Abbrechen</string>
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Websites verwalten</string>
     <string name="sitePermissionsSettingsEmptyText">Noch keine Websites</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Berechtigungen für alle Websites entfernt</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Berechtigungen für „%1$s“ </string>
     <string name="permissionsPerWebsiteAskSetting">Fragen</string>
     <string name="permissionsPerWebsiteDenySetting">Ablehnen</string>
     <string name="permissionsPerWebsiteAllowSetting">Zulassen</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">„Fragen“ für alle Seiten deaktiviert</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s-Berechtigung für %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Μικρόφωνο</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Διαχείριση ιστότοπων</string>
     <string name="sitePermissionsSettingsEmptyText">Δεν υπάρχουν ακόμη ιστότοποι</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Τα δικαιώματα καταργήθηκαν για όλους τους ιστότοπους</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Δικαιώματα για «%1$s» </string>
     <string name="permissionsPerWebsiteAskSetting">Αιτηθείτε</string>
     <string name="permissionsPerWebsiteDenySetting">Απόρριψη</string>
     <string name="permissionsPerWebsiteAllowSetting">Αποδοχή</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">Η επιλογή «Να γίνεται ερώτηση» είναι απενεργοποιημένη για όλους τους ιστότοπους</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s άδεια για %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Micrófono</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Administrar sitios</string>
     <string name="sitePermissionsSettingsEmptyText">Aún no hay sitios</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Permisos eliminados para todos los sitios</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Permisos para \"%1$s\" </string>
     <string name="permissionsPerWebsiteAskSetting">Solicitar</string>
     <string name="permissionsPerWebsiteDenySetting">Rechazar</string>
     <string name="permissionsPerWebsiteAllowSetting">Permitir</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">\"Preguntar\" desactivado para todos los sitios</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s permiso para %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -109,7 +109,7 @@
     <string name="tabClosedUndo">Võta tagasi</string>
     <string name="downloadsMenuItemTitle">Allalaadimised</string>
 
-   <!-- Fire -->
+    <!-- Fire -->
     <string name="fireMenu">Kustuta andmed</string>
     <string name="fireClearAll">Kustuta kõik vahekaardid ja andmed</string>
     <string name="fireCancel">Tühista</string>
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Saitide haldamine</string>
     <string name="sitePermissionsSettingsEmptyText">Saite pole veel</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Kõikide saitide load on eemaldatud</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Saidi „%1$s“ load </string>
     <string name="permissionsPerWebsiteAskSetting">Küsi</string>
     <string name="permissionsPerWebsiteDenySetting">Keela</string>
     <string name="permissionsPerWebsiteAllowSetting">Luba</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">„Küsi“ on kõigil saitidel keelatud</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Luba %1$s saidile %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofoni</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Hallitse sivustoja</string>
     <string name="sitePermissionsSettingsEmptyText">Ei vielä yhtään sivustoa</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Käyttöoikeudet poistettu kaikilta sivustoilta</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Oikeudet: %1$s </string>
     <string name="permissionsPerWebsiteAskSetting">Kysy</string>
     <string name="permissionsPerWebsiteDenySetting">Estä</string>
     <string name="permissionsPerWebsiteAllowSetting">Salli</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">Kysy-toiminto poistettu käytöstä kaikilta sivustoilta</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s: käyttöoikeus – lupa %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Micro</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Gérer les sites</string>
     <string name="sitePermissionsSettingsEmptyText">Pas encore de sites</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Autorisations supprimées pour tous les sites</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Autorisations pour « %1$s » </string>
     <string name="permissionsPerWebsiteAskSetting">Demander</string>
     <string name="permissionsPerWebsiteDenySetting">Refuser</string>
     <string name="permissionsPerWebsiteAllowSetting">Autoriser</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">« Demander » désactivé pour tous les sites</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Autorisation de %1$s pour %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -671,10 +671,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Upravljanje web-lokacijama</string>
     <string name="sitePermissionsSettingsEmptyText">Još nema ni jedne web-lokacije</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Uklonjena su dopuštenja za sve web lokacije</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Dopuštenja za „%1$s“ </string>
     <string name="permissionsPerWebsiteAskSetting">Zatraži</string>
     <string name="permissionsPerWebsiteDenySetting">Odbij</string>
     <string name="permissionsPerWebsiteAllowSetting">Dopusti</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">Opcija \"Pitaj\" onemogućena je za sve web lokacije</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s dopuštenje za %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Webhelyek kezelése</string>
     <string name="sitePermissionsSettingsEmptyText">Még nincsenek oldalak</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Minden webhely engedélye eltávolítva</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Engedélyek a következőhöz: „%1$s” </string>
     <string name="permissionsPerWebsiteAskSetting">Rákérdezés</string>
     <string name="permissionsPerWebsiteDenySetting">Megtagadás</string>
     <string name="permissionsPerWebsiteAllowSetting">Engedélyezés</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">A „Rákérdezés” minden webhelyen letiltva</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s engedély a(z) %2$s számára</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Microfono</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Gestisci siti</string>
     <string name="sitePermissionsSettingsEmptyText">Non esistono ancora siti</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Autorizzazioni rimosse per tutti i siti</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Autorizzazioni per \"%1$s\" </string>
     <string name="permissionsPerWebsiteAskSetting">Chiedi</string>
     <string name="permissionsPerWebsiteDenySetting">Rifiuta</string>
     <string name="permissionsPerWebsiteAllowSetting">Consenti</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">\"Chiedi\" disattivato per tutti i siti</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Autorizzazione %1$s per %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -671,10 +671,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofonas</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Tvarkyti svetaines</string>
     <string name="sitePermissionsSettingsEmptyText">Svetainių dar nėra</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Pašalinti visų svetainių leidimai</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Leidimai „%1$s“ </string>
     <string name="permissionsPerWebsiteAskSetting">Klausti</string>
     <string name="permissionsPerWebsiteDenySetting">Atsisakyti</string>
     <string name="permissionsPerWebsiteAllowSetting">Leisti</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">„Klausti“ išjungta visose svetainėse</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s leidimas %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -667,10 +667,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofons</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Pārvaldīt vietnes</string>
     <string name="sitePermissionsSettingsEmptyText">Vēl nav nevienas vietnes</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Atļaujas ir noņemtas visām vietnēm</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Atļaujas vietnei \"%1$s\" </string>
     <string name="permissionsPerWebsiteAskSetting">Jautāt</string>
     <string name="permissionsPerWebsiteDenySetting">Liegt</string>
     <string name="permissionsPerWebsiteAllowSetting">Atļaut</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">“Jautāt” ir atspējots visām vietnēm</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s – atļauja vietnei %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Administrer nettsteder</string>
     <string name="sitePermissionsSettingsEmptyText">Ingen nettsteder ennå</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Tillatelser fjernet for alle nettsteder</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Tillatelser for «%1$s» </string>
     <string name="permissionsPerWebsiteAskSetting">Spør</string>
     <string name="permissionsPerWebsiteDenySetting">Avvis</string>
     <string name="permissionsPerWebsiteAllowSetting">Tillat</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">«Spør» er deaktivert for alle nettsteder</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$stillatelse for %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Microfoon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Sites beheren</string>
     <string name="sitePermissionsSettingsEmptyText">Nog geen sites</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Toestemmingen verwijderd voor alle sites</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Toestemmingen voor \'%1$s\' </string>
     <string name="permissionsPerWebsiteAskSetting">Vragen</string>
     <string name="permissionsPerWebsiteDenySetting">Weigeren</string>
     <string name="permissionsPerWebsiteAllowSetting">Toestaan</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">\"Vragen\" uitgeschakeld voor alle sites</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Toestemming voor %1$s voor %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -671,10 +671,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Zarządzaj witrynami</string>
     <string name="sitePermissionsSettingsEmptyText">Nie masz jeszcze witryn</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Usunięto uprawnienia wszystkich witryn</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Uprawnienia dla: „%1$s” </string>
     <string name="permissionsPerWebsiteAskSetting">Poproś</string>
     <string name="permissionsPerWebsiteDenySetting">Odmów</string>
     <string name="permissionsPerWebsiteAllowSetting">Zezwól</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">Wyłączono opcję „Pytaj” dla wszystkich witryn</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Pozwolenie dla witryny %2$s na dostęp do urządzenia: %1$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Microfone</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Gerir sites</string>
     <string name="sitePermissionsSettingsEmptyText">Ainda não há sites</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">As permissões foram removidas para todos os sites</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Permissões para \"%1$s\" </string>
     <string name="permissionsPerWebsiteAskSetting">Perguntar</string>
     <string name="permissionsPerWebsiteDenySetting">Recusar</string>
     <string name="permissionsPerWebsiteAllowSetting">Permitir</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">A funcionalidade \"Perguntar\" foi desativada para todos os sites</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Permissão para %2$s utilizar %1$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -667,10 +667,12 @@
     <string name="sitePermissionsSettingsMicrophone">Microfon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Gestionează site-urile</string>
     <string name="sitePermissionsSettingsEmptyText">Niciun site încă</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Permisiuni eliminate pentru toate site-urile</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Permisiuni pentru „%1$s” </string>
     <string name="permissionsPerWebsiteAskSetting">Cere</string>
     <string name="permissionsPerWebsiteDenySetting">Refuză</string>
     <string name="permissionsPerWebsiteAllowSetting">Permite</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">„Întreabă” este dezactivat pentru toate site-urile</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Permisiune %1$s pentru %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -109,7 +109,7 @@
     <string name="tabClosedUndo">Отменить</string>
     <string name="downloadsMenuItemTitle">Загрузки</string>
 
-   <!-- Fire -->
+    <!-- Fire -->
     <string name="fireMenu">Сбросить данные</string>
     <string name="fireClearAll">Закрыть вкладки и удалить данные</string>
     <string name="fireCancel">Отменить</string>
@@ -671,10 +671,12 @@
     <string name="sitePermissionsSettingsMicrophone">Микрофон</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Управление сайтами</string>
     <string name="sitePermissionsSettingsEmptyText">Пока нет сайтов</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Разрешения удалены для всех сайтов</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Разрешения для «%1$s» </string>
     <string name="permissionsPerWebsiteAskSetting">Запрашивать</string>
     <string name="permissionsPerWebsiteDenySetting">Отказать</string>
     <string name="permissionsPerWebsiteAllowSetting">Разрешить</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">«Запросить» отключено для всех сайтов</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Разрешение на доступ %2$s к %1$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -671,10 +671,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofón</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Správa lokalít</string>
     <string name="sitePermissionsSettingsEmptyText">Zatiaľ žiadne lokality</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Povolenia boli odstránené pre všetky lokality</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Povolenia pre „%1$s” </string>
     <string name="permissionsPerWebsiteAskSetting">Opýtať sa</string>
     <string name="permissionsPerWebsiteDenySetting">Odmietnuť</string>
     <string name="permissionsPerWebsiteAllowSetting">Povoliť</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">Možnosť „Spýtať sa“ je pre všetky lokality vypnutá</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s povolenie pre %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -671,10 +671,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Upravljanje spletnih mest</string>
     <string name="sitePermissionsSettingsEmptyText">Spletnih mest še ni</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Dovoljenja so odstranjena za vsa spletna mesta</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Dovoljenja za »%1$s« </string>
     <string name="permissionsPerWebsiteAskSetting">Vprašaj</string>
     <string name="permissionsPerWebsiteDenySetting">Zavrni</string>
     <string name="permissionsPerWebsiteAllowSetting">Dovoli</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">Poziv »Vprašaj« je onemogočen za vsa spletna mesta</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s dovoljenje za %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Hantera webbplatser</string>
     <string name="sitePermissionsSettingsEmptyText">Inga webbplatser ännu</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Behörigheter har tagits bort för alla webbplatser</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Behörigheter för %1$s </string>
     <string name="permissionsPerWebsiteAskSetting">Fråga</string>
     <string name="permissionsPerWebsiteDenySetting">Neka</string>
     <string name="permissionsPerWebsiteAllowSetting">Tillåt</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">”Fråga” inaktiverat för alla webbplatser</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s-behörighet för %2$s</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -663,10 +663,12 @@
     <string name="sitePermissionsSettingsMicrophone">Mikrofon</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Siteleri Yönet</string>
     <string name="sitePermissionsSettingsEmptyText">Henüz site yok</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Tüm Siteler İçin İzinler Kaldırıldı</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">\"%1$s\" için izinler </string>
     <string name="permissionsPerWebsiteAskSetting">Sor</string>
     <string name="permissionsPerWebsiteDenySetting">Reddet</string>
     <string name="permissionsPerWebsiteAllowSetting">İzin ver</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">Tüm siteler için \"Sor\" devre dışı bırakıldı</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%2$s için %1$s izni</string>
 
     <!-- Autofill -->

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -16,10 +16,6 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- Site Permissions Settings -->
-    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Permissions Removed for All Sites</string>
-    <string name="permissionsPerWebsiteAskDisabledSetting">\"Ask\" disabled for all sites</string>
-
     <!-- Autofill -->
     <string name="autofillSnackbarAction">View</string>
     <string name="autofillLoginSavedSnackbarMessage">Login saved</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -664,10 +664,12 @@
     <string name="sitePermissionsSettingsMicrophone">Microphone</string>
     <string name="sitePermissionsSettingsAllowedSitesTitle">Manage Sites</string>
     <string name="sitePermissionsSettingsEmptyText">No sites yet</string>
+    <string name="sitePermissionsRemoveAllWebsitesSnackbarText">Permissions Removed for All Sites</string>
     <string name="permissionPerWebsiteText" instruction="Placeholder is the name of a website">Permissions for \"%1$s\" </string>
     <string name="permissionsPerWebsiteAskSetting">Ask</string>
     <string name="permissionsPerWebsiteDenySetting">Deny</string>
     <string name="permissionsPerWebsiteAllowSetting">Allow</string>
+    <string name="permissionsPerWebsiteAskDisabledSetting">\"Ask\" disabled for all sites</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s permission for %2$s</string>
 
     <!-- Autofill -->

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-bg/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-bg/strings-dashboard.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-cs/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-cs/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-da/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-da/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-de/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-de/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-el/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-el/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-es/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-es/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-et/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-et/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-fi/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-fi/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-fr/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-fr/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-hr/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-hr/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-hu/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-hu/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-it/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-it/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-lt/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-lt/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-lv/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-lv/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-nb/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-nb/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-nl/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-nl/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-pl/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-pl/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-pt/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-pt/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-ro/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-ro/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-ru/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-ru/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-sk/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-sk/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-sl/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-sl/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-sv/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-sv/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-tr/strings-dashboard.xml
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/res/values-tr/strings-dashboard.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203428655709483/f

### Description
Translations for `sitePermissionsRemoveAllWebsitesSnackbarText` and `permissionsPerWebsiteAskDisabledSetting` keys

### Steps to test this PR

- Install from this branch
- Change device language
- Go to Settings > Site Permissions
- Toggle off any of the permissions
- Tap on a website you granted permissions before
- [x] Check "Ask" disabled for all sites is translated

### No UI changes
