### PR TITLE
Autofill: Add grace period where device auth not required

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/FragmentUtils.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/FragmentUtils.kt
@@ -16,30 +16,13 @@
 
 package com.duckduckgo.autofill.ui.credential.management
 
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
-import com.duckduckgo.autofill.impl.R
 
-fun FragmentManager.forceExitFragment(tag: String) {
+fun FragmentManager.removeFragment(tag: String) {
     commit {
         findFragmentByTag(tag)?.let {
             this.remove(it)
-            popBackStackImmediate()
-        }
-    }
-}
-
-fun FragmentManager.showFragment(
-    fragment: Fragment,
-    tag: String,
-    shouldAddToBackStack: Boolean,
-) {
-    if (findFragmentByTag(tag) == null) {
-        commit {
-            setReorderingAllowed(true)
-            replace(R.id.fragment_container_view, fragment, tag)
-            if (shouldAddToBackStack) addToBackStack(tag)
         }
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -188,18 +188,8 @@ class AutofillSettingsViewModelTest {
         testee.unlock()
 
         testee.commands.test {
-            assertEquals(
-                listOf(
-                    ExitDisabledMode,
-                    ExitLockedMode,
-                ),
-                this.expectMostRecentItem().toList(),
-            )
-            cancelAndIgnoreRemainingEvents()
-        }
-
-        testee.viewState.test {
-            assertFalse(this.awaitItem().isLocked)
+            val commands = this.awaitItem()
+            assertTrue(commands.contains(ExitLockedMode))
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -218,11 +208,6 @@ class AutofillSettingsViewModelTest {
                 ),
                 this.expectMostRecentItem().toList(),
             )
-            cancelAndIgnoreRemainingEvents()
-        }
-
-        testee.viewState.test {
-            assertTrue(this.awaitItem().isLocked)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -293,11 +278,6 @@ class AutofillSettingsViewModelTest {
         testee.onEditCredentials(someCredentials(), true)
         testee.disabled()
 
-        testee.viewState.test {
-            val finalResult = this.expectMostRecentItem()
-            assertTrue(finalResult.isLocked)
-            cancelAndIgnoreRemainingEvents()
-        }
         testee.commands.test {
             assertEquals(
                 listOf(
@@ -334,11 +314,6 @@ class AutofillSettingsViewModelTest {
     fun whenLaunchDeviceAuthThenUpdateStateToIsAuthenticatingAndEmitLaunchDeviceCommand() = runTest {
         testee.launchDeviceAuth()
 
-        testee.viewState.test {
-            val finalResult = this.expectMostRecentItem()
-            assertTrue(finalResult.isAuthenticating)
-            cancelAndIgnoreRemainingEvents()
-        }
         testee.commands.test {
             awaitItem().first().assertCommandType(LaunchDeviceAuth::class)
             cancelAndIgnoreRemainingEvents()
@@ -346,29 +321,8 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
-    fun whenLaunchDeviceAuthTwiceThenEmitLaunchDeviceCommandOnceOnly() = runTest {
-        testee.launchDeviceAuth()
-        testee.launchDeviceAuth()
-
-        testee.commands.test {
-            assertEquals(
-                listOf(LaunchDeviceAuth),
-                this.expectMostRecentItem().toList(),
-            )
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun whenLaunchedDeviceAuthHasEndedAndLaunchedAgainThenEmitLaunchDeviceCommandtwice() = runTest {
         testee.launchDeviceAuth()
-        testee.onAuthenticationEnded()
-
-        testee.viewState.test {
-            val finalResult = this.expectMostRecentItem()
-            assertFalse(finalResult.isAuthenticating)
-            cancelAndIgnoreRemainingEvents()
-        }
 
         testee.launchDeviceAuth()
 
@@ -377,18 +331,6 @@ class AutofillSettingsViewModelTest {
                 listOf(LaunchDeviceAuth, LaunchDeviceAuth),
                 this.expectMostRecentItem().toList(),
             )
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenAuthWasLaunchAndThenDeviceAuthDisabledThenEmitViewStateWithIsAuthenticatingFalse() = runTest {
-        testee.launchDeviceAuth()
-        testee.disabled()
-
-        testee.viewState.test {
-            val finalResult = this.expectMostRecentItem()
-            assertFalse(finalResult.isAuthenticating)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/device-auth/device-auth-api/src/main/java/com/duckduckgo/deviceauth/api/AutofillAuthorizationGracePeriod.kt
+++ b/device-auth/device-auth-api/src/main/java/com/duckduckgo/deviceauth/api/AutofillAuthorizationGracePeriod.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.deviceauth.api
+
+/**
+ * A grace period for autofill authorization.
+ * This is used to allow autofill authorization to be skipped for a short period of time after a successful authorization.
+ */
+interface AutofillAuthorizationGracePeriod {
+
+    /**
+     * Can be used to determine if device auth is required. If not required, it can be bypassed.
+     * @return true if authorization is required, false otherwise
+     */
+    fun isAuthRequired(): Boolean
+
+    /**
+     * Records the timestamp of a successful device authorization
+     */
+    fun recordSuccessfulAuthorization()
+
+    /**
+     * Invalidates the grace period, so that the next call to [isAuthRequired] will return true
+     */
+    fun invalidate()
+}

--- a/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AuthLauncher.kt
+++ b/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AuthLauncher.kt
@@ -25,6 +25,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.deviceauth.api.AutofillAuthorizationGracePeriod
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Error
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Success
@@ -52,6 +53,7 @@ interface AuthLauncher {
 class RealAuthLauncher @Inject constructor(
     private val context: Context,
     private val appBuildConfig: AppBuildConfig,
+    private val autofillAuthorizationGracePeriod: AutofillAuthorizationGracePeriod,
 ) : AuthLauncher {
     private val biometricPromptInfoBuilder by lazy {
         BiometricPrompt.PromptInfo.Builder()
@@ -106,6 +108,7 @@ class RealAuthLauncher @Inject constructor(
         override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
             super.onAuthenticationSucceeded(result)
             Timber.d("onAuthenticationSucceeded ${result.authenticationType}")
+            autofillAuthorizationGracePeriod.recordSuccessfulAuthorization()
             onResult(Success)
         }
 

--- a/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AutofillGracePeriodLifecycleObserver.kt
+++ b/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AutofillGracePeriodLifecycleObserver.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.deviceauth.impl
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.deviceauth.api.AutofillAuthorizationGracePeriod
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import timber.log.Timber
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = LifecycleObserver::class,
+)
+@SingleInstanceIn(AppScope::class)
+class AutofillGracePeriodLifecycleObserver @Inject constructor(
+    private val gracePeriod: AutofillAuthorizationGracePeriod,
+) : DefaultLifecycleObserver {
+
+    override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
+        Timber.d("App in background, invalidating autofill grace period")
+        gracePeriod.invalidate()
+    }
+}

--- a/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AutofillTimeBasedAuthorizationGracePeriod.kt
+++ b/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/AutofillTimeBasedAuthorizationGracePeriod.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.deviceauth.impl
+
+import com.duckduckgo.deviceauth.api.AutofillAuthorizationGracePeriod
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import timber.log.Timber
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class AutofillTimeBasedAuthorizationGracePeriod @Inject constructor(
+    private val timeProvider: TimeProvider,
+) : AutofillAuthorizationGracePeriod {
+
+    private var lastSuccessfulAuthTime: Long? = null
+
+    override fun recordSuccessfulAuthorization() {
+        lastSuccessfulAuthTime = timeProvider.currentTimeMillis()
+        Timber.v("Recording timestamp of successful auth")
+    }
+
+    override fun isAuthRequired(): Boolean {
+        lastSuccessfulAuthTime?.let { lastAuthTime ->
+            val timeSinceLastAuth = timeProvider.currentTimeMillis() - lastAuthTime
+            Timber.v("Last authentication was $timeSinceLastAuth ms ago")
+            if (timeSinceLastAuth <= AUTH_GRACE_PERIOD_MS) {
+                Timber.v("Within grace period; auth not required")
+                return false
+            }
+        }
+        Timber.v("No last auth time recorded or outside grace period; auth required")
+
+        return true
+    }
+
+    override fun invalidate() {
+        lastSuccessfulAuthTime = null
+    }
+
+    companion object {
+        private const val AUTH_GRACE_PERIOD_MS = 15_000
+    }
+}
+
+interface TimeProvider {
+    fun currentTimeMillis(): Long
+}
+
+@ContributesBinding(AppScope::class)
+class SystemCurrentTimeProvider @Inject constructor() : TimeProvider {
+    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+}

--- a/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticator.kt
+++ b/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticator.kt
@@ -20,6 +20,7 @@ import android.os.Build
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.deviceauth.api.AutofillAuthorizationGracePeriod
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features
@@ -32,6 +33,7 @@ class RealDeviceAuthenticator @Inject constructor(
     private val deviceAuthChecker: SupportedDeviceAuthChecker,
     private val appBuildConfig: AppBuildConfig,
     private val authLauncher: AuthLauncher,
+    private val autofillAuthGracePeriod: AutofillAuthorizationGracePeriod,
 ) : DeviceAuthenticator {
 
     override fun hasValidDeviceAuthentication(): Boolean {
@@ -49,7 +51,11 @@ class RealDeviceAuthenticator @Inject constructor(
         fragment: Fragment,
         onResult: (AuthResult) -> Unit,
     ) {
-        authLauncher.launch(getAuthText(featureToAuth), fragment, onResult)
+        if (autofillAuthGracePeriod.isAuthRequired()) {
+            authLauncher.launch(getAuthText(featureToAuth), fragment, onResult)
+        } else {
+            onResult(AuthResult.Success)
+        }
     }
 
     override fun authenticate(
@@ -57,7 +63,11 @@ class RealDeviceAuthenticator @Inject constructor(
         fragmentActivity: FragmentActivity,
         onResult: (AuthResult) -> Unit,
     ) {
-        authLauncher.launch(getAuthText(featureToAuth), fragmentActivity, onResult)
+        if (autofillAuthGracePeriod.isAuthRequired()) {
+            authLauncher.launch(getAuthText(featureToAuth), fragmentActivity, onResult)
+        } else {
+            onResult(AuthResult.Success)
+        }
     }
 
     private fun getAuthText(

--- a/device-auth/device-auth-impl/src/test/java/com/duckduckgo/deviceauth/impl/AutofillTimeBasedAuthorizationGracePeriodTest.kt
+++ b/device-auth/device-auth-impl/src/test/java/com/duckduckgo/deviceauth/impl/AutofillTimeBasedAuthorizationGracePeriodTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.deviceauth.impl
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AutofillTimeBasedAuthorizationGracePeriodTest {
+
+    private val timeProvider: TimeProvider = mock()
+    private val testee = AutofillTimeBasedAuthorizationGracePeriod(timeProvider)
+
+    @Test
+    fun whenNoInteractionsThenAuthRequired() {
+        assertTrue(testee.isAuthRequired())
+    }
+
+    @Test
+    fun whenLastSuccessfulAuthWasBeforeGracePeriodThenAuthRequired() {
+        recordAuthorizationInDistantPast()
+        timeProvider.reset()
+        assertTrue(testee.isAuthRequired())
+    }
+
+    @Test
+    fun whenLastSuccessfulAuthWasWithinGracePeriodThenAuthNotRequired() {
+        recordAuthorizationWithinGracePeriod()
+        timeProvider.reset()
+        assertFalse(testee.isAuthRequired())
+    }
+
+    @Test
+    fun whenLastSuccessfulAuthWasWithinGracePeriodButInvalidatedThenAuthRequired() {
+        recordAuthorizationWithinGracePeriod()
+        timeProvider.reset()
+        testee.invalidate()
+        assertTrue(testee.isAuthRequired())
+    }
+
+    private fun recordAuthorizationInDistantPast() {
+        whenever(timeProvider.currentTimeMillis()).thenReturn(0)
+        testee.recordSuccessfulAuthorization()
+    }
+
+    private fun recordAuthorizationWithinGracePeriod() {
+        whenever(timeProvider.currentTimeMillis()).thenReturn(System.currentTimeMillis())
+        testee.recordSuccessfulAuthorization()
+    }
+
+    private fun TimeProvider.reset() = whenever(this.currentTimeMillis()).thenReturn(System.currentTimeMillis())
+}

--- a/device-auth/device-auth-impl/src/test/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticatorTest.kt
+++ b/device-auth/device-auth-impl/src/test/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticatorTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.deviceauth.impl
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.deviceauth.api.AutofillAuthorizationGracePeriod
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL
 import org.junit.Before
 import org.junit.Test
@@ -26,7 +27,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -43,6 +44,15 @@ class RealDeviceAuthenticatorTest {
     @Mock
     private lateinit var authLauncher: AuthLauncher
 
+    @Mock
+    private lateinit var autofillAuthorizationGracePeriod: AutofillAuthorizationGracePeriod
+
+    @Mock
+    private lateinit var fragment: Fragment
+
+    @Mock
+    private lateinit var fragmentActivity: FragmentActivity
+
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
@@ -50,7 +60,9 @@ class RealDeviceAuthenticatorTest {
             deviceAuthChecker,
             appBuildConfig,
             authLauncher,
+            autofillAuthorizationGracePeriod,
         )
+        whenever(autofillAuthorizationGracePeriod.isAuthRequired()).thenReturn(true)
     }
 
     @Test
@@ -82,8 +94,6 @@ class RealDeviceAuthenticatorTest {
 
     @Test
     fun whenAuthenticateIsCalledWithFragmentThenLaunchAuthLauncher() {
-        val fragment: Fragment = mock()
-
         testee.authenticate(AUTOFILL, fragment) {}
 
         verify(authLauncher).launch(eq(R.string.autofill_auth_text), eq(fragment), any())
@@ -91,10 +101,20 @@ class RealDeviceAuthenticatorTest {
 
     @Test
     fun whenAuthenticateIsCalledWithActivityThenLaunchAuthLauncher() {
-        val fragment: FragmentActivity = mock()
-
         testee.authenticate(AUTOFILL, fragment) {}
 
         verify(authLauncher).launch(eq(R.string.autofill_auth_text), eq(fragment), any())
+    }
+
+    @Test
+    fun whenAuthGracePeriodActiveThenNoDeviceAuthLaunched() {
+        whenever(autofillAuthorizationGracePeriod.isAuthRequired()).thenReturn(false)
+        testee.authenticate(AUTOFILL, fragmentActivity) {}
+        verifyAuthNotLaunched()
+    }
+
+    private fun verifyAuthNotLaunched() {
+        verify(authLauncher, never()).launch(any(), any<Fragment>(), any())
+        verify(authLauncher, never()).launch(any(), any<FragmentActivity>(), any())
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203472964310393/f

### Description
There are cases where the user has to authenticate twice in quick succession to access autofill data. In these situations we can reduce friction by not requiring authentication again with a short time period, assuming they haven't backgrounded the app.

The ability to skip auth happens only if:

- last successful auth happened within last 15 seconds
- app has not been backgrounded
- app has not been killed


### Steps to test this PR

#### Autofilling
- [x] Save a login for trello.com/login
- [x] Reload the page (it should show a page where password field is hidden until username filled in, if not, trello's A/B testing is likely messing with you)
- [x] When prompted, choose to fill the username. Verify auth required (and do it)
- [x] Within 15 seconds, choose to fill the password. Verify no 2nd auth is required.

- [x] Reload the page + wait 16 seconds
- [x] When prompted, choose to fill the username. Verify auth required (and do it)
- [x] Wait 16 seconds, choose to fill the password. Verify auth required (and do it)

#### Credential Management screen, from overflow or device settings
There's been a fair bit of refactoring in here, around fragments and view state, so thorough testing appreciated 🙏

- [x] Ensure >15s since last auth
- [x] Access credential management screen; verify auth required and hit back to cancel. Verify management screen exited.
- [x] Access again; verify auth required and this time do it. Verify you can see management screen correctly.
- [x] Hit back and verify back out. Then quickly (<15s) return. Verify you are not required to auth.
- [x] Access the details for a login. Verify functionality still generally works to edit, copy usernames etc...
- [x] Ensure back navigation works as you'd expect
- [x] Delete a credential from the list view; verify you remain in the list view
- [x] Delete a credential from the credential details view; verify you automatically navigate back to list view

#### Credential Management screen, accessing a credential directly from snackbar

- [x] Create a new login, and tap on the snackbar to view the credential directly (do this once when it's been over 15s since last auth and verify auth required, and repeat again quickly and verify auth not required)
- [x] Edit the login and verify that saves ok. 
- [x] Go back; verify you do not see the list view and instead return straight to the web view
- [x] Create a new login; and tap on the snackbar to view the credential directly
- [x] Delete the login; verify you do not see the list view and instead return straight to the web view