### PR TITLE
Avoid crash when onPrepareVpn fails

### DIFF
--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSetting.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSetting.kt
@@ -27,6 +27,7 @@ enum class AppTpSetting(override val value: String, override val defaultValue: B
     ProtectGames("protectGames"),
     OpenBeta("openBeta"),
     CheckBlockingFunction("checkBlockingFunction"),
+    StartVpnErrorHandling("startVpnErrorHandling", defaultValue = true),
 }
 
 interface SettingName {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/StartVpnErrorHandlingSettingPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/StartVpnErrorHandlingSettingPlugin.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSettingPlugin
+import com.duckduckgo.mobile.android.vpn.feature.SettingName
+import com.duckduckgo.mobile.android.vpn.feature.edit
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.Moshi
+import javax.inject.Inject
+import timber.log.Timber
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AppTpSettingPlugin::class,
+)
+class StartVpnErrorHandlingSettingPlugin @Inject constructor(
+    private val appTpFeatureConfig: AppTpFeatureConfig,
+) : AppTpSettingPlugin {
+    private val jsonAdapter = Moshi.Builder().build().adapter(JsonConfigModel::class.java)
+
+    override fun store(name: SettingName, jsonString: String): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = appTpSettingValueOf(name.value)
+        if (name == settingName) {
+            Timber.d("Received configuration: $jsonString")
+            runCatching {
+                jsonAdapter.fromJson(jsonString)?.state?.let { state ->
+                    appTpFeatureConfig.edit { setEnabled(settingName, state == "enabled") }
+                }
+            }.onFailure {
+                Timber.w(it, "Invalid JSON remote configuration for $settingName")
+            }
+            return true
+        }
+
+        return false
+    }
+
+    override val settingName: SettingName = AppTpSetting.StartVpnErrorHandling
+
+    private data class JsonConfigModel(val state: String?)
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureConfigImplTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureConfigImplTest.kt
@@ -68,6 +68,7 @@ class AppTpFeatureConfigImplTest {
                 AppTpSetting.ProtectGames -> assertFalse(config.isEnabled(setting))
                 AppTpSetting.OpenBeta -> assertFalse(config.isEnabled(setting))
                 AppTpSetting.CheckBlockingFunction -> assertFalse(config.isEnabled(setting))
+                AppTpSetting.StartVpnErrorHandling -> assertTrue(config.isEnabled(setting))
             }
         }
     }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSettingTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSettingTest.kt
@@ -36,6 +36,7 @@ class AppTpSettingTest {
                 AppTpSetting.ProtectGames -> assertFalse(setting.defaultValue)
                 AppTpSetting.OpenBeta -> assertFalse(setting.defaultValue)
                 AppTpSetting.CheckBlockingFunction -> assertFalse(setting.defaultValue)
+                AppTpSetting.StartVpnErrorHandling -> assertTrue(setting.defaultValue)
                 else -> throw java.lang.IllegalStateException("Missing AppTpSetting default checks")
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203455535355535/f

### Description
This PR includes:
- Not throwing an exception when issues occur on onPrepareVpn and onStartVpn. Instead, we do graceful handling and stop the VPN service instead.
- Introduced a kill switch for the new error handling.
- Don't call stop on ServiceCallbacks if start hasn't been called.

### Steps to test this PR
Smoke test appTP

