### PR TITLE
Add pixels when FB login fails due to unsupported WebView

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -99,6 +99,8 @@ import com.duckduckgo.app.location.data.LocationPermissionsRepository
 import com.duckduckgo.app.location.ui.SiteLocationPermissionDialog
 import com.duckduckgo.app.location.ui.SystemLocationPermissionDialog
 import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.pixels.AppPixelName.FACEBOOK_LOGIN_BREAKAGE_INVESTIGATION
+import com.duckduckgo.app.pixels.AppPixelName.FACEBOOK_LOGIN_ERROR_BREAKAGE_INVESTIGATION
 import com.duckduckgo.app.privacy.db.NetworkLeaderboardDao
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -1156,14 +1158,28 @@ class BrowserTabViewModel @Inject constructor(
         command.value = ShowWebContent
     }
 
+    private fun sendBrokenFBLoginPixels(previousUrl: String?, url: String) {
+        // User lands on failed FB login due to WebView incompatibility
+        if (previousUrl != url && url.contains("LOGIN_DISABLED_FROM_WEBVIEW")) {
+            pixel.fire(FACEBOOK_LOGIN_ERROR_BREAKAGE_INVESTIGATION)
+        }
+        if (previousUrl != url && url.contains("facebook.com/login.php")) {
+            pixel.fire(FACEBOOK_LOGIN_BREAKAGE_INVESTIGATION)
+        }
+    }
+
     private fun pageChanged(
         url: String,
         title: String?,
     ) {
         Timber.v("Page changed: $url")
+        val previousUrl = site?.url
+
         hasCtaBeenShownForCurrentPage.set(false)
         buildSiteFactory(url, title)
         setAdClickActiveTabData(url)
+
+        sendBrokenFBLoginPixels(previousUrl, url)
 
         val currentOmnibarViewState = currentOmnibarViewState()
         val omnibarText = omnibarTextForUrl(url)

--- a/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
@@ -64,6 +64,8 @@ class AtbAndAppVersionPixelRemovalInterceptor @Inject constructor() : Intercepto
             AppPixelName.EMAIL_USE_ADDRESS.pixelName,
             AppPixelName.EMAIL_COPIED_TO_CLIPBOARD.pixelName,
             "m_atp_unprotected_apps_bucket_",
+            AppPixelName.FACEBOOK_LOGIN_ERROR_BREAKAGE_INVESTIGATION.pixelName,
+            AppPixelName.FACEBOOK_LOGIN_BREAKAGE_INVESTIGATION.pixelName,
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -249,4 +249,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     REMOTE_MESSAGE_SECONDARY_ACTION_CLICKED("m_remote_message_secondary_action_clicked"),
 
     CREATE_BLOOM_FILTER_ERROR("m_create_bloom_filter_error"),
+
+    FACEBOOK_LOGIN_ERROR_BREAKAGE_INVESTIGATION("m_facebook_login_error_breakage_investigation"),
+    FACEBOOK_LOGIN_BREAKAGE_INVESTIGATION("m_facebook_login_breakage_investigation"),
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203467208458897/f 

### Description
This PR adds a pixel whenever a user lands on the unsupported error page on FB and also when londing on login.php. A while ago FB disabled WebView from their auth flow and we get breakage reports every now and then, the idea of this PR is to monitor for a couple of weeks when this error happens using login.php as denominator and then decide next steps.

### Steps to test this PR

_Feature 1_
- [x] Install the app and go to `instagram.com`
- [x] Click on Log In
- [x] Click on `Continue Using Facebook`
- [x] You should eventually see the FB page for WebView unsupported
- [x] Two pixels should have been sent `m_facebook_login_breakage_investigation` and `m_facebook_login_error_breakage_investigation`
- [x] Pixels should not have atb or appVersion
