### PR TITLE
ADS: Fix primaryTextTruncated attribute in TwoLineListItem

### DIFF
--- a/app/src/main/res/layout/content_settings_appearance.xml
+++ b/app/src/main/res/layout/content_settings_appearance.xml
@@ -36,6 +36,7 @@
         android:id="@+id/selectedThemeSetting"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:primaryTextTruncated="false"
         app:secondaryText="@string/settingsSystemTheme"
         app:primaryText="@string/settingsTheme" />
 
@@ -69,6 +70,7 @@
         android:id="@+id/selectedFireAnimationSetting"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:primaryTextTruncated="false"
         app:secondaryText="@string/settingsHeroFireAnimation"
         app:primaryText="@string/settingsFireAnimation" />
 

--- a/app/src/main/res/layout/content_settings_customize.xml
+++ b/app/src/main/res/layout/content_settings_customize.xml
@@ -48,6 +48,7 @@
         android:id="@+id/appLinksSetting"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:primaryTextTruncated="false"
         app:primaryText="@string/settingsTitleAppLinks" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/content_settings_other.xml
+++ b/app/src/main/res/layout/content_settings_other.xml
@@ -45,6 +45,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/settingsOtherTitle"
         app:showBetaPill="true"
+        app:primaryTextTruncated="false"
         app:secondaryText="@string/macos_settings_description"
         app:primaryText="@string/macos_settings_title" />
 
@@ -56,6 +57,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/macOsSetting"
         app:showBetaPill="true"
+        app:primaryTextTruncated="false"
         app:secondaryText="@string/settingsEmailProtectionSubtitle"
         app:primaryText="@string/settingsEmailProtectionTitle" />
 
@@ -67,6 +69,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/emailSetting"
         app:showBetaPill="true"
+        app:primaryTextTruncated="false"
         app:secondaryText="@string/atp_SettingsDeviceShieldDisabled"
         app:primaryText="@string/atp_SettingsTitle" />
 

--- a/app/src/main/res/layout/content_settings_privacy.xml
+++ b/app/src/main/res/layout/content_settings_privacy.xml
@@ -36,6 +36,7 @@
         android:id="@+id/globalPrivacyControlSetting"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:primaryTextTruncated="false"
         app:primaryText="@string/globalPrivacyControlSetting"
         tools:secondaryText="test test test" />
 
@@ -43,6 +44,7 @@
         android:id="@+id/autoconsentSetting"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:primaryTextTruncated="false"
         app:primaryText="@string/autoconsentSetting" />
 
     <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
@@ -61,6 +63,7 @@
         android:id="@+id/automaticallyClearWhatSetting"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:primaryTextTruncated="false"
         app:primaryText="@string/settingsAutomaticallyClearWhat"
         tools:secondaryText="test test test" />
 

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/TwoLineListItem.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/TwoLineListItem.kt
@@ -35,7 +35,6 @@ import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import com.duckduckgo.mobile.android.ui.view.setEnabledOpacity
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
-import kotlin.Int.Companion
 
 class TwoLineListItem @JvmOverloads constructor(
     context: Context,

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/TwoLineListItem.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/TwoLineListItem.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.mobile.android.ui.view.quietlySetIsChecked
 import com.duckduckgo.mobile.android.ui.view.setEnabledOpacity
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import kotlin.Int.Companion
 
 class TwoLineListItem @JvmOverloads constructor(
     context: Context,
@@ -59,10 +60,12 @@ class TwoLineListItem @JvmOverloads constructor(
                 binding.primaryText.setTextColor(getColorStateList(R.styleable.TwoLineListItem_primaryTextColorOverlay))
             }
 
-            val truncated = getBoolean(R.styleable.TwoLineListItem_primaryTextTruncated, false)
+            val truncated = getBoolean(R.styleable.TwoLineListItem_primaryTextTruncated, true)
             if (truncated) {
                 binding.primaryText.maxLines = 1
                 binding.primaryText.ellipsize = TruncateAt.END
+            } else {
+                binding.primaryText.maxLines = Int.MAX_VALUE
             }
 
             if (hasValue(R.styleable.TwoLineListItem_secondaryTextColorOverlay)) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203491129613227/f

### Description

- Change primaryTextTruncated default value to match specs. 
- Now sections like Bookmarks and Downloads will look as they used to
- Set primaryTextTruncated to false for settings items

### Steps to test this PR

- Install from this branch
- [ ] Check Bookmark's titles are truncated
- [ ] Check Downloads file names are truncated
- [ ] Check Settings items doesn't collapse

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20221205_190117_DuckDuckGo](https://user-images.githubusercontent.com/20798495/205732672-f5fe78c5-e99c-4816-9baa-b4c0d18a928f.jpg)|![Screenshot_20221205_192941_DuckDuckGo](https://user-images.githubusercontent.com/20798495/205732678-48fe5d65-e64c-4887-8d8e-67e71ce0baab.jpg)|
