### PR TITLE
Use the correct progress from webview

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -144,7 +144,7 @@ class BrowserChromeClientTest {
     @Test
     fun whenOnProgressChangedCalledThenListenerInstructedToUpdateProgress() {
         testee.onProgressChanged(webView, 10)
-        verify(mockWebViewClientListener).progressChanged(10)
+        verify(mockWebViewClientListener).progressChanged(20) // Value should come from the webView instance
     }
 
     @UiThreadTest
@@ -292,6 +292,10 @@ class BrowserChromeClientTest {
     private class TestWebView(context: Context) : WebView(context) {
         override fun getUrl(): String {
             return "https://example.com"
+        }
+
+        override fun getProgress(): Int {
+            return 20
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -87,10 +87,12 @@ class BrowserChromeClient @Inject constructor(
         newProgress: Int,
     ) {
         try {
-            Timber.d("onProgressChanged ${webView.url}, $newProgress")
+            // We want to use webView.progress rather than newProgress because the former gives you the overall progress of the new site
+            // and the latter gives you the progress of the current main request being loaded and one site could have several redirects.
+            Timber.d("onProgressChanged ${webView.url}, ${webView.progress}")
             val navigationList = webView.safeCopyBackForwardList() ?: return
-            webViewClientListener?.navigationStateChanged(WebViewNavigationState(navigationList, newProgress))
-            webViewClientListener?.progressChanged(newProgress)
+            webViewClientListener?.navigationStateChanged(WebViewNavigationState(navigationList, webView.progress))
+            webViewClientListener?.progressChanged(webView.progress)
             webViewClientListener?.onCertificateReceived(webView.certificate)
         } catch (e: Throwable) {
             appCoroutineScope.launch(coroutineDispatcher.default()) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203175666892156/f 

### Description
This PR changes the progress value to be used to calculate the value of the progress bar, etc. We were incorrectly using newProgress which would trigger several callbacks reaching 100%.

### Steps to test this PR

_Feature 1_
- [x] In The BrowserTabFragment add a timber log above the call to `createTrackersAnimation()`
- [x] Go to SERP, the log should be shown only once
- [x] Go to other websites and the log should only be shown once per website.
- [x] Doing this from develop should show the log several times per website.

