### PR TITLE
Ignore 0 values to progress bar

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -156,6 +156,16 @@ class BrowserChromeClientTest {
 
     @UiThreadTest
     @Test
+    fun whenOnProgressChangedCalledAndValueIsZeroThenNothingCalled() {
+        val mockWebView: WebView = mock()
+        whenever(mockWebView.progress).thenReturn(0)
+        testee.onProgressChanged(mockWebView, 10)
+        verify(mockWebViewClientListener, never()).navigationStateChanged(any())
+        verify(mockWebViewClientListener, never()).progressChanged(any())
+    }
+
+    @UiThreadTest
+    @Test
     fun whenOnProgressChangedThrowsExceptionThenRecordException() = runTest {
         val exception = RuntimeException()
         whenever(mockWebViewClientListener.progressChanged(anyInt())).thenThrow(exception)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -90,6 +90,7 @@ class BrowserChromeClient @Inject constructor(
             // We want to use webView.progress rather than newProgress because the former gives you the overall progress of the new site
             // and the latter gives you the progress of the current main request being loaded and one site could have several redirects.
             Timber.d("onProgressChanged ${webView.url}, ${webView.progress}")
+            if (webView.progress == 0) return
             val navigationList = webView.safeCopyBackForwardList() ?: return
             webViewClientListener?.navigationStateChanged(WebViewNavigationState(navigationList, webView.progress))
             webViewClientListener?.progressChanged(webView.progress)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203515134776652/f 

### Description
This PR ignores zero values from on progress changed callback to avoid double loads.

### Steps to test this PR

_Feature_
- [x] Go to SERP
- [x] Progress bar should go to 100% only once

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
