### PR TITLE
Add ability to manually create logins from credential management screen.

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
@@ -43,7 +43,8 @@ import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewMode
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowLockedMode
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowUserPasswordCopied
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowUserUsernameCopied
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Editing
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.EditingExisting
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.EditingNewEntry
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementCredentialsMode
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementDisabledMode
 import com.duckduckgo.autofill.ui.credential.management.viewing.AutofillManagementListMode
@@ -145,7 +146,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
     private fun processCommand(command: AutofillSettingsViewModel.Command) {
         var processed = true
         when (command) {
-            is ShowCredentialMode -> showCredentialMode(command.credentials, command.isLaunchedDirectly)
+            is ShowCredentialMode -> showCredentialMode(command.isLaunchedDirectly)
             is ShowUserUsernameCopied -> showCopiedToClipboardSnackbar("Username")
             is ShowUserPasswordCopied -> showCopiedToClipboardSnackbar("Password")
             is ShowDisabledMode -> showDisabledMode()
@@ -178,17 +179,12 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun showCredentialMode(
-        credentials: LoginCredentials?,
-        isLaunchedDirectly: Boolean,
-    ) {
-        if (credentials != null) {
-            supportFragmentManager.commit {
-                setReorderingAllowed(true)
-                replace(R.id.fragment_container_view, AutofillManagementCredentialsMode.instance(), TAG_CREDENTIAL)
-                if (!isLaunchedDirectly) {
-                    addToBackStack(TAG_CREDENTIAL)
-                }
+    private fun showCredentialMode(isLaunchedDirectly: Boolean) {
+        supportFragmentManager.commit {
+            setReorderingAllowed(true)
+            replace(R.id.fragment_container_view, AutofillManagementCredentialsMode.instance(), TAG_CREDENTIAL)
+            if (!isLaunchedDirectly) {
+                addToBackStack(TAG_CREDENTIAL)
             }
         }
     }
@@ -250,7 +246,8 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
 
     override fun onBackPressed() {
         when (viewModel.viewState.value.credentialMode) {
-            is Editing -> viewModel.onCancelEditMode()
+            is EditingExisting -> viewModel.onCancelEditMode()
+            is EditingNewEntry -> viewModel.onCancelManualCreation()
             else -> super.onBackPressed()
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -96,14 +96,13 @@ class AutofillSettingsViewModel @Inject constructor(
 
     fun onViewCredentials(
         credentials: LoginCredentials,
-        isLaunchedDirectly: Boolean,
     ) {
-        addCommand(ShowCredentialMode(isLaunchedDirectly = isLaunchedDirectly))
+        addCommand(ShowCredentialMode)
         _viewState.value = viewState.value.copy(credentialMode = Viewing(credentialsViewed = credentials))
     }
 
     fun onCreateNewCredentials() {
-        addCommand(ShowCredentialMode(isLaunchedDirectly = false))
+        addCommand(ShowCredentialMode)
         _viewState.value = viewState.value.copy(credentialMode = EditingNewEntry())
         addCommand(ShowManualCredentialMode)
     }
@@ -122,7 +121,7 @@ class AutofillSettingsViewModel @Inject constructor(
     // if edit is opened but not from view mode, it means that we should show the credentials view and we need to set hasPopulatedFields to false
     // to force credential view to prefill the fields.
     fun onEditCredentials(credentials: LoginCredentials) {
-        addCommand(ShowCredentialMode(isLaunchedDirectly = false))
+        addCommand(ShowCredentialMode)
 
         _viewState.value = viewState.value.copy(
             credentialMode = EditingExisting(
@@ -171,7 +170,6 @@ class AutofillSettingsViewModel @Inject constructor(
 
     fun onExitCredentialMode() {
         addCommand(ExitCredentialMode)
-        _viewState.value = viewState.value.copy(credentialMode = ListMode)
     }
 
     fun allowSaveInEditMode(saveable: Boolean) {
@@ -392,7 +390,7 @@ class AutofillSettingsViewModel @Inject constructor(
          * [isLaunchedDirectly] if true it means that the credential view was launched directly and didn't have to go through the management screen.
          */
         object ShowListMode : Command()
-        data class ShowCredentialMode(val isLaunchedDirectly: Boolean) : Command()
+        object ShowCredentialMode : Command()
         object ShowDisabledMode : Command()
         object ShowLockedMode : Command()
         object LaunchDeviceAuth : Command()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -198,7 +198,7 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     fun lock() {
-        Timber.w("Locking autofill settings")
+        Timber.v("Locking autofill settings")
         trackCurrentModeBeforeLocking()
         addCommand(ShowLockedMode)
         _viewState.value = _viewState.value.copy(credentialMode = Locked)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -77,7 +77,7 @@ class AutofillSettingsViewModel @Inject constructor(
     private var initialStateAlreadyPresented: Boolean = false
 
     // after unlocking, we want to know which mode to return to
-    private var credentialModeBeforeLocking: CredentialMode = ListMode
+    private var credentialModeBeforeLocking: CredentialMode? = null
 
     fun onCopyUsername(username: String?) {
         username?.let { clipboardInteractor.copyToClipboard(it) }
@@ -90,15 +90,15 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     fun onShowListMode() {
-        addCommand(ShowListMode)
         _viewState.value = _viewState.value.copy(credentialMode = ListMode)
+        addCommand(ShowListMode)
     }
 
     fun onViewCredentials(
         credentials: LoginCredentials,
     ) {
-        addCommand(ShowCredentialMode)
         _viewState.value = viewState.value.copy(credentialMode = Viewing(credentialsViewed = credentials))
+        addCommand(ShowCredentialMode)
     }
 
     fun onCreateNewCredentials() {
@@ -203,7 +203,7 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     fun unlock() {
-        Timber.v("Unlocking autofill settings. Will return view state to ${credentialModeBeforeLocking.javaClass.canonicalName}")
+        Timber.v("Unlocking autofill settings")
         addCommand(ExitDisabledMode)
         addCommand(ExitLockedMode)
 
@@ -212,7 +212,10 @@ class AutofillSettingsViewModel @Inject constructor(
             addCommand(InitialiseViewAfterUnlock)
         }
 
-        _viewState.value = _viewState.value.copy(credentialMode = credentialModeBeforeLocking)
+        credentialModeBeforeLocking?.let { mode ->
+            Timber.v("Will return view state to ${mode.javaClass.name}")
+            _viewState.value = _viewState.value.copy(credentialMode = mode)
+        }
     }
 
     private fun trackCurrentModeBeforeLocking() {
@@ -345,7 +348,7 @@ class AutofillSettingsViewModel @Inject constructor(
     data class ViewState(
         val autofillEnabled: Boolean = true,
         val logins: List<LoginCredentials>? = null,
-        val credentialMode: CredentialMode = ListMode,
+        val credentialMode: CredentialMode? = null,
     )
 
     /**

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.autofill.ui.credential.management
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.domain.app.LoginCredentials
 import com.duckduckgo.autofill.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
@@ -35,9 +36,12 @@ import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewMode
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowLockedMode
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowUserPasswordCopied
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.ShowUserUsernameCopied
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Editing
-import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.NotInCredentialMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.EditingExisting
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.EditingNewEntry
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.ListMode
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Viewing
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialModeCommand.ShowEditCredentialMode
+import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialModeCommand.ShowManualCredentialMode
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import com.duckduckgo.di.scopes.ActivityScope
 import java.util.*
@@ -54,6 +58,7 @@ class AutofillSettingsViewModel @Inject constructor(
     private val clipboardInteractor: AutofillClipboardInteractor,
     private val deviceAuthenticator: DeviceAuthenticator,
     private val pixel: Pixel,
+    private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -61,6 +66,9 @@ class AutofillSettingsViewModel @Inject constructor(
 
     private val _commands = MutableStateFlow<List<Command>>(emptyList())
     val commands: StateFlow<List<Command>> = _commands
+
+    private val _commandsCredentialView = MutableStateFlow<List<CredentialModeCommand>>(emptyList())
+    val commandsCredentialView: StateFlow<List<CredentialModeCommand>> = _commandsCredentialView
 
     // after unlocking, we want to initialise the view once (next unlock, the view stack will already exist)
     private var initialStateAlreadyPresented: Boolean = false
@@ -79,43 +87,54 @@ class AutofillSettingsViewModel @Inject constructor(
         credentials: LoginCredentials,
         isLaunchedDirectly: Boolean,
     ) {
-        addCommand(ShowCredentialMode(credentials = credentials, isLaunchedDirectly = isLaunchedDirectly))
+        addCommand(ShowCredentialMode(isLaunchedDirectly = isLaunchedDirectly))
         _viewState.value = viewState.value.copy(credentialMode = Viewing(credentialsViewed = credentials))
     }
 
-    fun onEditCredentials(
-        credentials: LoginCredentials,
-        isFromViewMode: Boolean,
-    ) {
-        // if edit is opened but not from view mode, it means that we should show the credentials view and we need to set hasPopulatedFields to false
-        // to force credential view to prefill the fields.
-        if (!isFromViewMode) {
-            addCommand(
-                ShowCredentialMode(
-                    credentials = credentials,
-                    isLaunchedDirectly = false,
-                ),
-            )
-            _viewState.value = viewState.value.copy(
-                credentialMode = Editing(
-                    credentialsViewed = credentials,
-                    startedCredentialModeWithEdit = !isFromViewMode,
-                    hasPopulatedFields = false,
-                ),
-            )
-        } else {
-            _viewState.value = viewState.value.copy(
-                credentialMode = Editing(
-                    credentialsViewed = credentials,
-                    startedCredentialModeWithEdit = !isFromViewMode,
-                ),
-            )
+    fun onCreateNewCredentials() {
+        addCommand(ShowCredentialMode(isLaunchedDirectly = false))
+        _viewState.value = viewState.value.copy(credentialMode = EditingNewEntry())
+        addCommand(ShowManualCredentialMode)
+    }
+
+    fun onEditCurrentCredentials() {
+        val credentials = getCurrentCredentials() ?: return
+        _viewState.value = viewState.value.copy(
+            credentialMode = EditingExisting(
+                credentialsViewed = credentials,
+                startedCredentialModeWithEdit = false,
+            ),
+        )
+        addCommand(ShowEditCredentialMode(credentials))
+    }
+
+    // if edit is opened but not from view mode, it means that we should show the credentials view and we need to set hasPopulatedFields to false
+    // to force credential view to prefill the fields.
+    fun onEditCredentials(credentials: LoginCredentials) {
+        addCommand(ShowCredentialMode(isLaunchedDirectly = false))
+
+        _viewState.value = viewState.value.copy(
+            credentialMode = EditingExisting(
+                credentialsViewed = credentials,
+                startedCredentialModeWithEdit = true,
+                hasPopulatedFields = false,
+            ),
+        )
+
+        addCommand(ShowEditCredentialMode(credentials))
+    }
+
+    private fun getCurrentCredentials(): LoginCredentials? {
+        return when (val viewMode = _viewState.value.credentialMode) {
+            is Viewing -> viewMode.credentialsViewed
+            is EditingExisting -> viewMode.credentialsViewed
+            else -> null
         }
     }
 
     fun onCredentialEditModePopulated() {
         _viewState.value.credentialMode.let { credentialMode ->
-            if (credentialMode is Editing) {
+            if (credentialMode is EditingExisting) {
                 _viewState.value = _viewState.value.copy(credentialMode = credentialMode.copy(hasPopulatedFields = true))
             }
         }
@@ -126,7 +145,7 @@ class AutofillSettingsViewModel @Inject constructor(
             value.credentialMode.let {
                 // if credential mode started with edit, it means that we need to exit credential mode right away instead of going
                 // back to view mode.
-                if (it is Editing && !it.startedCredentialModeWithEdit) {
+                if (it is EditingExisting && !it.startedCredentialModeWithEdit) {
                     _viewState.value = value.copy(credentialMode = Viewing(credentialsViewed = it.credentialsViewed))
                 } else {
                     onExitCredentialMode()
@@ -135,16 +154,20 @@ class AutofillSettingsViewModel @Inject constructor(
         }
     }
 
+    fun onCancelManualCreation() {
+        onExitCredentialMode()
+    }
+
     fun onExitCredentialMode() {
         addCommand(ExitCredentialMode)
-        _viewState.value = viewState.value.copy(credentialMode = NotInCredentialMode)
+        _viewState.value = viewState.value.copy(credentialMode = ListMode)
     }
 
     fun allowSaveInEditMode(saveable: Boolean) {
-        _viewState.value.credentialMode.let { credentialMode ->
-            if (credentialMode is Editing) {
-                _viewState.value = _viewState.value.copy(credentialMode = credentialMode.copy(saveable = saveable))
-            }
+        when (val credentialMode = _viewState.value.credentialMode) {
+            is EditingExisting -> _viewState.value = _viewState.value.copy(credentialMode = credentialMode.copy(saveable = saveable))
+            is EditingNewEntry -> _viewState.value = _viewState.value.copy(credentialMode = credentialMode.copy(saveable = saveable))
+            else -> {}
         }
     }
 
@@ -193,6 +216,13 @@ class AutofillSettingsViewModel @Inject constructor(
         }
     }
 
+    private fun addCommand(command: CredentialModeCommand) {
+        commandsCredentialView.value.let { commands ->
+            val updatedList = commands + command
+            _commandsCredentialView.value = updatedList
+        }
+    }
+
     fun commandProcessed(command: Command) {
         commands.value.let { currentCommands ->
             val updatedList = currentCommands.filterNot { it.id == command.id }
@@ -200,8 +230,15 @@ class AutofillSettingsViewModel @Inject constructor(
         }
     }
 
+    fun commandProcessed(command: CredentialModeCommand) {
+        commandsCredentialView.value.let { currentCommands ->
+            val updatedList = currentCommands.filterNot { it.id == command.id }
+            _commandsCredentialView.value = updatedList
+        }
+    }
+
     fun observeCredentials() {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatchers.default()) {
             _viewState.value = _viewState.value.copy(autofillEnabled = autofillStore.autofillEnabled)
 
             autofillStore.getAllCredentials().collect { credentials ->
@@ -212,26 +249,58 @@ class AutofillSettingsViewModel @Inject constructor(
         }
     }
 
-    fun onDeleteCredentials(loginCredentials: LoginCredentials) {
-        val credentialsId = loginCredentials.id ?: return
+    fun onDeleteCurrentCredentials() {
+        val credentialsId = getCurrentCredentials()?.id ?: return
 
-        viewModelScope.launch {
+        viewModelScope.launch(dispatchers.default()) {
             autofillStore.deleteCredentials(credentialsId)
         }
     }
 
-    fun updateCredentials(updatedCredentials: LoginCredentials) {
-        _viewState.value.credentialMode.credentialsViewed?.let { originalCredentials ->
-            viewModelScope.launch {
-                autofillStore.updateCredentials(updatedCredentials.copy(id = originalCredentials.id))
-                autofillStore.getCredentialsWithId(originalCredentials.id!!)?.let { credentialsWithLastUpdatedTimeUpdated ->
-                    _viewState.value = viewState.value.copy(
-                        credentialMode = Viewing(
-                            credentialsViewed = credentialsWithLastUpdatedTimeUpdated,
-                        ),
-                    )
-                }
+    fun onDeleteCredentials(loginCredentials: LoginCredentials) {
+        val credentialsId = loginCredentials.id ?: return
+
+        viewModelScope.launch(dispatchers.default()) {
+            autofillStore.deleteCredentials(credentialsId)
+        }
+    }
+
+    fun saveOrUpdateCredentials(credentials: LoginCredentials) {
+        viewModelScope.launch(dispatchers.default()) {
+            val credentialMode = _viewState.value.credentialMode
+
+            if (credentialMode is EditingExisting) {
+                updateExistingCredential(credentialMode, credentials)
+            } else if (credentialMode is EditingNewEntry) {
+                saveNewCredential(credentials)
             }
+        }
+    }
+
+    private suspend fun updateExistingCredential(
+        credentialMode: EditingExisting,
+        updatedCredentials: LoginCredentials,
+    ) {
+        val existingCredentials = credentialMode.credentialsViewed
+        autofillStore.updateCredentials(updatedCredentials.copy(id = existingCredentials.id))?.let { updated ->
+            _viewState.value = viewState.value.copy(
+                credentialMode = Viewing(
+                    credentialsViewed = updated,
+                ),
+            )
+        }
+    }
+
+    private suspend fun saveNewCredential(updatedCredentials: LoginCredentials) {
+        autofillStore.saveCredentials(
+            rawUrl = updatedCredentials.domain ?: "",
+            credentials = updatedCredentials,
+        )?.let { savedCredentials ->
+            _viewState.value = viewState.value.copy(
+                credentialMode = Viewing(
+                    credentialsViewed = savedCredentials,
+                ),
+            )
         }
     }
 
@@ -252,19 +321,37 @@ class AutofillSettingsViewModel @Inject constructor(
     data class ViewState(
         val autofillEnabled: Boolean = true,
         val logins: List<LoginCredentials>? = null,
-        val credentialMode: CredentialMode = NotInCredentialMode,
+        val credentialMode: CredentialMode = ListMode,
     )
 
-    sealed class CredentialMode(open val credentialsViewed: LoginCredentials?) {
-        data class Viewing(override val credentialsViewed: LoginCredentials) : CredentialMode(credentialsViewed)
-        data class Editing(
-            override val credentialsViewed: LoginCredentials,
-            val saveable: Boolean = true,
-            val startedCredentialModeWithEdit: Boolean,
-            val hasPopulatedFields: Boolean = true,
-        ) : CredentialMode(credentialsViewed)
+    /**
+     * Supported credentials modes, each of which might have a different UI and different subtypes.
+     *
+     * ListMode: Shows the list of all credentials. The default mode, shown when the user is not viewing or editing a credential
+     * Viewing: viewing a single credential
+     * Editing: there are two subtypes of editing:
+     *     EditingNewEntry is used when the user is creating a new credential.
+     *     EditingExisting is used when the user is editing an existing credential.
+     */
+    sealed class CredentialMode {
+        object ListMode : CredentialMode()
 
-        object NotInCredentialMode : CredentialMode(null)
+        data class Viewing(val credentialsViewed: LoginCredentials) : CredentialMode()
+
+        abstract class Editing(
+            open val saveable: Boolean = false,
+        ) : CredentialMode()
+
+        data class EditingExisting(
+            val credentialsViewed: LoginCredentials,
+            val hasPopulatedFields: Boolean = true,
+            override val saveable: Boolean = true,
+            val startedCredentialModeWithEdit: Boolean,
+        ) : Editing(saveable)
+
+        data class EditingNewEntry(
+            override val saveable: Boolean = true,
+        ) : Editing(saveable)
     }
 
     sealed class Command(val id: String = UUID.randomUUID().toString()) {
@@ -275,11 +362,7 @@ class AutofillSettingsViewModel @Inject constructor(
          * [credentials] Credentials to be used to render the credential view
          * [isLaunchedDirectly] if true it means that the credential view was launched directly and didn't have to go through the management screen.
          */
-        data class ShowCredentialMode(
-            val credentials: LoginCredentials,
-            val isLaunchedDirectly: Boolean,
-        ) : Command()
-
+        data class ShowCredentialMode(val isLaunchedDirectly: Boolean) : Command()
         object ShowDisabledMode : Command()
         object ShowLockedMode : Command()
         object LaunchDeviceAuth : Command()
@@ -288,5 +371,10 @@ class AutofillSettingsViewModel @Inject constructor(
         object ExitLockedMode : Command()
         object InitialiseViewAfterUnlock : Command()
         object ExitDisabledMode : Command()
+    }
+
+    sealed class CredentialModeCommand(val id: String = UUID.randomUUID().toString()) {
+        data class ShowEditCredentialMode(val credentials: LoginCredentials) : CredentialModeCommand()
+        object ShowManualCredentialMode : CredentialModeCommand()
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -158,6 +158,11 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
         binding.removeSaveStateWatcher(saveStateWatcher)
     }
 
+    private fun initialiseTextWatchers() {
+        stopEditTextWatchers()
+        startEditTextWatchers()
+    }
+
     private fun initialiseToolbar() {
         activity?.findViewById<Toolbar>(com.duckduckgo.mobile.android.R.id.toolbar)?.apply {
             initialActionBarTitle = title.toString()
@@ -175,6 +180,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
     private fun initializeEditStateIfNecessary(mode: EditingExisting) {
         if (!mode.hasPopulatedFields) {
             populateFields(mode.credentialsViewed)
+            initialiseTextWatchers()
             viewModel.onCredentialEditModePopulated()
         }
     }
@@ -250,7 +256,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
             domainEditText.isEditable = true
             notesEditText.isEditable = true
         }
-        startEditTextWatchers()
+        initialiseTextWatchers()
     }
 
     private fun DaxTextInput.setText(text: String?) {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -279,6 +279,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
                     is Viewing -> {
                         populateFields(state.credentialMode.credentialsViewed)
                         showViewMode(state.credentialMode.credentialsViewed)
+                        invalidateMenu()
                     }
 
                     is EditingExisting -> {
@@ -287,7 +288,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
                     }
 
                     is EditingNewEntry -> {
-                        updateToolbarForEdit()
+                        updateToolbarForNewEntry()
                     }
 
                     else -> {
@@ -315,6 +316,15 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
         getActionBar()?.apply {
             setHomeAsUpIndicator(com.duckduckgo.mobile.android.R.drawable.ic_close)
             title = getString(R.string.credentialManagementEditTitle)
+            setDisplayUseLogoEnabled(false)
+        }
+        invalidateMenu()
+    }
+
+    private fun updateToolbarForNewEntry() {
+        getActionBar()?.apply {
+            setHomeAsUpIndicator(com.duckduckgo.mobile.android.R.drawable.ic_close)
+            title = getString(R.string.autofillManagementAddLogin)
             setDisplayUseLogoEnabled(false)
         }
         invalidateMenu()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -124,7 +124,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     private fun getCurrentUrlForSuggestions() = arguments?.getString(ARG_CURRENT_URL, null)
 
     private fun observeViewModel() {
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.viewState.collect { state ->
                     binding.enabledToggle.quietlySetIsChecked(state.autofillEnabled, globalAutofillToggleListener)
@@ -134,7 +134,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
                 }
             }
         }
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.commands.collect { commands ->
                     commands.forEach { processCommand(it) }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -17,8 +17,12 @@
 package com.duckduckgo.autofill.ui.credential.management.viewing
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.widget.CompoundButton
+import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -93,6 +97,28 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
         configureToggle()
         configureRecyclerView()
         observeViewModel()
+        configureToolbar()
+    }
+
+    private fun configureToolbar() {
+        activity?.addMenuProvider(
+            object : MenuProvider {
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) = menuInflater.inflate(R.menu.autofill_list_mode_menu, menu)
+
+                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                    return when (menuItem.itemId) {
+                        R.id.addLoginManually -> {
+                            viewModel.onCreateNewCredentials()
+                            true
+                        }
+
+                        else -> false
+                    }
+                }
+            },
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED,
+        )
     }
 
     private fun getCurrentUrlForSuggestions() = arguments?.getString(ARG_CURRENT_URL, null)
@@ -165,7 +191,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
             onCredentialSelected = this::onCredentialsSelected,
             onContextMenuItemClicked = {
                 when (it) {
-                    is Edit -> viewModel.onEditCredentials(it.credentials, false)
+                    is Edit -> viewModel.onEditCredentials(it.credentials)
                     is Delete -> viewModel.onDeleteCredentials(it.credentials)
                     is CopyUsername -> onCopyUsername(it.credentials)
                     is CopyPassword -> onCopyPassword(it.credentials)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -201,7 +201,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     }
 
     private fun onCredentialsSelected(credentials: LoginCredentials) {
-        viewModel.onViewCredentials(credentials, false)
+        viewModel.onViewCredentials(credentials)
     }
 
     private fun onCopyUsername(credentials: LoginCredentials) {

--- a/autofill/autofill-impl/src/main/res/drawable/ic_baseline_add_24.xml
+++ b/autofill/autofill-impl/src/main/res/drawable/ic_baseline_add_24.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
@@ -15,6 +14,12 @@
   ~ limitations under the License.
   -->
 
-<resources>
-    <string name="managementAddLogin">Add Login</string>
-</resources>
+<vector android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="?attr/toolbarIconColor"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+</vector>

--- a/autofill/autofill-impl/src/main/res/menu/autofill_list_mode_menu.xml
+++ b/autofill/autofill-impl/src/main/res/menu/autofill_list_mode_menu.xml
@@ -20,7 +20,7 @@
     <item
         android:id="@+id/addLoginManually"
         android:icon="@drawable/ic_baseline_add_24"
-        android:title="@string/managementAddLogin"
+        android:title="@string/autofillManagementAddLogin"
         app:showAsAction="always" />
 
 </menu>

--- a/autofill/autofill-impl/src/main/res/menu/autofill_list_mode_menu.xml
+++ b/autofill/autofill-impl/src/main/res/menu/autofill_list_mode_menu.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,13 @@
   ~ limitations under the License.
   -->
 
-<resources>
-    <string name="managementAddLogin">Add Login</string>
-</resources>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/addLoginManually"
+        android:icon="@drawable/ic_baseline_add_24"
+        android:title="@string/managementAddLogin"
+        app:showAsAction="always" />
+
+</menu>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -16,5 +16,5 @@
   -->
 
 <resources>
-    <string name="managementAddLogin">Add Login</string>
+    <string name="autofillManagementAddLogin">Add Login</string>
 </resources>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -313,12 +313,32 @@ class AutofillSettingsViewModelTest {
     fun whenOnExitCredentialModeThenExitCredentialMode() = runTest {
         testee.onExitCredentialMode()
 
+        testee.commands.test {
+            awaitItem().first().assertCommandType(ExitCredentialMode::class)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenLockingAndUnlockingPreviousViewStateRestoredIfWasListMode() = runTest {
+        testee.onShowListMode()
+        testee.lock()
+        testee.unlock()
+
         testee.viewState.test {
             assertEquals(CredentialMode.ListMode, this.awaitItem().credentialMode)
             cancelAndIgnoreRemainingEvents()
         }
-        testee.commands.test {
-            awaitItem().first().assertCommandType(ExitCredentialMode::class)
+    }
+
+    @Test
+    fun whenLockingAndUnlockingPreviousViewStateRestoredIfWasCredentialViewingMode() = runTest {
+        testee.onViewCredentials(someCredentials())
+        testee.lock()
+        testee.unlock()
+
+        testee.viewState.test {
+            assertTrue(this.awaitItem().credentialMode is CredentialMode.Viewing)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -107,9 +107,9 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
-    fun whenUserDeletesViewedCredentialsLaunchedDirectlyThen() = runTest {
+    fun whenUserDeletesViewedCredentialsLaunchedDirectlyThenCredentialsDeleted() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials, isLaunchedDirectly = true)
+        testee.onViewCredentials(credentials)
         testee.onDeleteCredentials(credentials)
         verify(mockStore).deleteCredentials(credentials.id!!)
     }
@@ -117,10 +117,10 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenOnViewCredentialsCalledFromListThenShowCredentialViewingMode() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials, false)
+        testee.onViewCredentials(credentials)
 
         testee.commands.test {
-            assertEquals(ShowCredentialMode(false), awaitItem().first())
+            assertEquals(ShowCredentialMode, awaitItem().first())
             cancelAndIgnoreRemainingEvents()
         }
         testee.viewState.test {
@@ -132,10 +132,10 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenOnViewCredentialsCalledFirstThenShowCredentialViewingMode() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials, true)
+        testee.onViewCredentials(credentials)
 
         testee.commands.test {
-            assertEquals(ShowCredentialMode(true), awaitItem().first())
+            assertEquals(ShowCredentialMode, awaitItem().first())
             cancelAndIgnoreRemainingEvents()
         }
         testee.viewState.test {
@@ -147,7 +147,7 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenOnEditCredentialsCalledThenShowCredentialEditingMode() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials, false)
+        testee.onViewCredentials(credentials)
         testee.onEditCurrentCredentials()
 
         testee.viewState.test {
@@ -181,7 +181,7 @@ class AutofillSettingsViewModelTest {
 
         testee.commands.test {
             assertEquals(
-                ShowCredentialMode(isLaunchedDirectly = false),
+                ShowCredentialMode,
                 this.awaitItem().first(),
             )
             cancelAndIgnoreRemainingEvents()
@@ -285,7 +285,7 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenOnExitEditModeThenUpdateCredentialModeStateToViewing() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials, false)
+        testee.onViewCredentials(credentials)
         testee.onEditCurrentCredentials()
 
         testee.onCancelEditMode()
@@ -305,11 +305,6 @@ class AutofillSettingsViewModelTest {
 
         testee.commands.test {
             awaitItem().last().assertCommandType(ExitCredentialMode::class)
-            cancelAndIgnoreRemainingEvents()
-        }
-
-        testee.viewState.test {
-            assertEquals(CredentialMode.ListMode, this.awaitItem().credentialMode)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -346,7 +341,7 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenAllowSaveInEditModeSetToFalseThenUpdateViewStateToEditingSaveableFalse() = runTest {
         val credentials = someCredentials()
-        testee.onViewCredentials(credentials, true)
+        testee.onViewCredentials(credentials)
         testee.onEditCurrentCredentials()
 
         testee.allowSaveInEditMode(false)

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -123,7 +123,11 @@ class SecureStoreBackedAutofillStore(
             domainTitle = credentials.domainTitle,
             lastUpdatedMillis = lastUpdatedTimeProvider.getInMillis(),
         )
-        val webSiteLoginCredentials = WebsiteLoginDetailsWithCredentials(loginDetails, password = credentials.password)
+        val webSiteLoginCredentials = WebsiteLoginDetailsWithCredentials(
+            details = loginDetails,
+            password = credentials.password,
+            notes = credentials.notes,
+        )
 
         return withContext(dispatcherProvider.io()) {
             secureStorage.addWebsiteLoginDetailsWithCredentials(webSiteLoginCredentials)?.toLoginCredentials().also {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203522700191989/f

### Description
Adds ability to manually create logins from the credential management screen.

### Steps to test this PR

#### From empty login state
- [x] Delete all existing logins
- [x] Visit credential management screen; verify not prompted to authenticate
- [x] Click the ➕ button in the action bar
- [x] Verify you see the "manual creation" screen, and that all fields are editable
- [x] Verify that the ✔️ button is **not** enabled before you've entered any data
- [x] Add some text to a field, verify the ✔️ appears. Remove the text and verify it disappears again.
- [x] Repeat the last step for each individual text field, verifying that the ✔️ only appears when some data has been entered.
- [x] Enter some details across the fields and tap the ✔️ button to save
- [x] Verify you then see the "view mode" for the newly added credential
- [x] Navigate back; verify that you are not prompted to auth, and that you can see the newly created cred in the list view

#### Navigating back mid-creation
- [x] Start manually adding a credential, adding some data to the fields
- [x] Instead of saving, hit the back button to navigate away
- [x] Verify login is discarded (no confirmation prompt)
- [x] Verify the back button returns to being a left arrow and not ✖️

#### Backgrounding the app mid-creation
- [x] Start manually adding a credential, adding some data to the fields
- [x] Instead of saving, hit the home button
- [x] Return to the app; verify you are prompted to auth. 
- [x] Verify that successful auth returns you to the screen you were editing with data intact. (auth failure kicks you out and discards your mid-creation login)
- [x] Verify the back button is an ✖️ and not a left arrow


#### Bugs that were identified; should now be fixed

##### Disabled mode overlays list view
- [x] Open list mode
- [x] Open credential
- [x] Enter edit mode
- [x] Background app
- [x] Remove device auth
- [x] Go back to app
- [x] Verify disabled mode is rendered correctly (e.g., not as an overlay on the list)


##### Navigating back mid-creation
- updated test case **Navigating back mid-creation** with a new check

##### Backgrounding the app mid-creation
- updated test case **Backgrounding the app mid-creation** with a new check

##### On edit text change watcher not working when directly jumped into edit mode

- [x] From management list screen, use overflow to choose to edit
- [x] Verify the save button (✔️) is hidden by default
- [x] Verify it appears when you edit any data, and disappears when you restore the text to what it was originally
- [x] Repeat the above, but from navigating from list -> credential -> edit mode and verify it still works as expected