### PR TITLE
Make test work when phone in different language

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/cookies/impl/features/firstparty/RealFirstPartyCookiesModifierTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/cookies/impl/features/firstparty/RealFirstPartyCookiesModifierTest.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.cookies.store.CookiesRepository
 import com.duckduckgo.cookies.store.FirstPartyCookiePolicyEntity
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
+import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.Dispatchers
@@ -255,7 +256,8 @@ class RealFirstPartyCookiesModifierTest {
         val time = Instant.now()
             .plus(expiryTimeInSeconds, ChronoUnit.SECONDS)
             .atOffset(ZoneOffset.UTC)
-            .format(DateTimeFormatter.ofPattern("EEE, d MMMM yyyy HH:mm:ss Z"))
+            .format(DateTimeFormatter.ofPattern("EEE, d MMMM yyyy HH:mm:ss Z").withLocale(Locale.US))
+
         cookieManager.setCookie(cookieName, "da=da;expires=$time")
         cookieManager.flush()
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203543139728360/f 

### Description
This PR fixes a cookie test that was failing when the language of the device/emulator wasn't English.

### Steps to test this PR

- [ ] Change the language of the device to something other than English, i.e. Spanish
- [ ] Run the `when1stPartyCookiesExistAndThresholdIsHigherThenNewExpiryDateMatchesMaxAge test`
- [ ] Test should pass
