### PR TITLE
Avoid starting VPN twice

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -223,7 +223,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
 
     private suspend fun startVpn() = withContext(Dispatchers.IO) {
         logcat { "VPN log: Starting VPN" }
-        
+
         synchronized(startVpnLock) {
             val currStateStats = vpnServiceStateStatsDao.getLastStateStats()
             if (currStateStats?.state == ENABLING) {
@@ -235,7 +235,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
             // We need to rethink how to log this state. This will likely change.
             vpnServiceStateStatsDao.insert(VpnServiceStateStats(state = ENABLING))
         }
-        
+
         vpnNetworkStack.onPrepareVpn().getOrNull().also {
             if (it != null) {
                 createTunnelInterface(it)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203529428649444/f

### Description
#### Background
Users report that AppTP causes all protected apps to lose connectivity. Reproducing this issue in-house revealed that sometimes two TUN interfaces are created. Upon further inspection, we found the root cause to be the system calling `onStartCommand` twice (even though we call `startForegroundService` once).

#### Fix
The fix here is to detect when we are already in the middle of creating a VPN and not start creating another one.

### Steps to test this PR
- [x] Install from this branch
- [x] Smoke tests for AppTP
- [x] Attempt to repro the bug: 
  1. Open an app and then force close it
  2. Disable protection for it
  3. Re-enable protection
  4. Rinse and repeat ~10 times
- [x] Check logs for TUN errors - none should appear
- [x] Check logs for the "VPN is already being started, abort" message - it should appear, meaning that we reached a condition where `onStartCommand` was called twice and the fix is working
