### PR TITLE
fix: domain can be null for some URIs

### DIFF
--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -110,7 +110,7 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
 
     data class SiteViewState(
         val url: String,
-        val domain: String,
+        val domain: String?,
         val upgradedHttps: Boolean,
         val parentEntity: EntityViewState?,
         val secCertificateViewModels: List<CertificateViewState?> = emptyList(),
@@ -191,12 +191,14 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
         Timber.i("PrivacyDashboard: onPrivacyProtectionsClicked $enabled")
 
         viewModelScope.launch(dispatcher.io()) {
-            if (enabled) {
-                userWhitelistDao.delete(currentViewState().siteViewState.domain)
-                pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_REMOVE)
-            } else {
-                userWhitelistDao.insert(currentViewState().siteViewState.domain)
-                pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_ADD)
+            currentViewState().siteViewState.domain?.let { domain ->
+                if (enabled) {
+                    userWhitelistDao.delete(domain)
+                    pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_REMOVE)
+                } else {
+                    userWhitelistDao.insert(domain)
+                    pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_ADD)
+                }
             }
             delay(CLOSE_DASHBOARD_ON_INTERACTION_DELAY)
             withContext(dispatcher.main()) {

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/SiteViewStateMapper.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/SiteViewStateMapper.kt
@@ -46,7 +46,7 @@ class AppSiteViewStateMapper @Inject constructor(
 
         return SiteViewState(
             url = site.url,
-            domain = site.domain!!,
+            domain = site.domain,
             upgradedHttps = site.upgradedHttps,
             parentEntity = entityViewState,
             secCertificateViewModels = site.certificate?.let { listOf(it.map()) } ?: emptyList(),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203517684270584/f 

### Description
Fixes null pointer exception when getting domain from an URI.

Note:
I wasn't able to test a URI that can return null as host, but it seems possible according to crash reports.
We already have a safe check when enable/disable protections from the overflow menu, so taking same approach here.


### Steps to test this PR

_Feature 1_
- [x] Hardcode `null` inside `AppSiteViewStateMapper` when mapping site domain (`domain = site.domain`)
- [x] install the app
- [x] Visit a random site
- [x] Accessing the privacy dashboard doesn't crash
- [x] interacting with the protections toggle does add an empty site to exceptions

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
