### PR TITLE
Fix AppTP enable state during onboarding

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
@@ -51,7 +51,7 @@ internal class VpnFeaturesRegistryImpl(
             // we use random UUID to force change listener to be called
             putString(feature.featureName, UUID.randomUUID().toString())
         }
-        vpnServiceWrapper.restartVpnService()
+        vpnServiceWrapper.restartVpnService(forceRestart = true)
     }
 
     @Synchronized
@@ -64,7 +64,7 @@ internal class VpnFeaturesRegistryImpl(
 
         logcat { "unregisterFeature: $feature" }
         if (registeredFeatures().isNotEmpty()) {
-            vpnServiceWrapper.restartVpnService()
+            vpnServiceWrapper.restartVpnService(forceRestart = true)
         } else {
             vpnServiceWrapper.stopService()
         }
@@ -75,7 +75,7 @@ internal class VpnFeaturesRegistryImpl(
     }
 
     override suspend fun refreshFeature(feature: VpnFeature) {
-        vpnServiceWrapper.restartVpnService()
+        vpnServiceWrapper.restartVpnService(forceRestart = false)
     }
 
     override fun registryChanges(): Flow<Pair<String, Boolean>> {
@@ -107,8 +107,8 @@ internal class VpnFeaturesRegistryImpl(
  * The class is marked as open to be able to mock it in tests.
  */
 internal open class VpnServiceWrapper(private val context: Context) {
-    open fun restartVpnService() {
-        TrackerBlockingVpnService.restartVpnService(context, forceRestart = true)
+    open fun restartVpnService(forceRestart: Boolean) {
+        TrackerBlockingVpnService.restartVpnService(context, forceRestart = forceRestart)
     }
 
     open fun stopService() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -242,6 +242,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
             } else {
                 logcat(LogPriority.ERROR) { "Failed to obtain config needed to establish the TUN interface" }
                 stopVpn(VpnStopReason.ERROR, false)
+                return@withContext
             }
         }
 
@@ -437,16 +438,6 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
         }
 
         return dns.toSet()
-    }
-
-    private fun Builder.safelyAddAllowedApps(apps: List<String>) {
-        for (app in apps) {
-            try {
-                addAllowedApplication(app)
-            } catch (e: PackageManager.NameNotFoundException) {
-                logcat(LogPriority.WARN) { "Package name not found: $app" }
-            }
-        }
     }
 
     private fun Builder.safelyAddDisallowedApps(apps: List<String>) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203553001428526/f

### Description
Fix bug that caused AppTP not to get enabled after onboarding

### Steps to test this PR

_Test bug fix_
- [x] filter logs by "VPN log"
- [x] fresh install from this branch
- [x] launch app
- [x] verify no logs appear
- [x] (clear log filter)
- [x] Enable AppTP from settings going through onboarding
- [x] verify AppTP is enabled and stays enabled after onboarding is completed
- [x] smoke tests AppTP, ie. blocking, enable/disable, protect/unprotec apps


_Test app update_
- [x] install from develop
- [x] enable AppTP
(you may experience the bug we're fixing here, so ensure you enable it)
- [x] update app from this branch
- [x] launch app
- [x] verify AppTP is remains enabled
- [x] smoke tests AppTP, ie. blocking, enable/disable, protect/unprotec apps
