### PR TITLE
Fix support for no leadingImageBackground on OneLineListItem and TwoLineListItem

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/OneLineListItem.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/OneLineListItem.kt
@@ -143,6 +143,9 @@ class OneLineListItem @JvmOverloads constructor(
 
     /** Sets the background image type */
     fun setLeadingIconBackgroundType(value: Int) {
+        if (value == 0) {
+            binding.leadingIconBackground.setBackgroundResource(android.R.color.transparent)
+        }
         if (value == 1) {
             binding.leadingIconBackground.setBackgroundResource(R.drawable.list_item_image_circular_background)
         }

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/TwoLineListItem.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/TwoLineListItem.kt
@@ -139,6 +139,9 @@ class TwoLineListItem @JvmOverloads constructor(
 
     /** Sets the background image type */
     fun setLeadingIconBackgroundType(value: Int) {
+        if (value == 0) {
+            binding.leadingIconBackground.setBackgroundResource(android.R.color.transparent)
+        }
         if (value == 1) {
             binding.leadingIconBackground.setBackgroundResource(R.drawable.list_item_image_circular_background)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203563042100874/f

### Description
This PR includes:
- ~~Setting default LeadingIconBackground to none for TwoLineListItem~~ (_Deferred to later_)
- Set background to Transparent when setLeadingIconBackgroundType is called for none/0 for TwoLineListItem and OneLineListItem

### Steps to test this PR
- Check Design Preview is as expected.

