### PR TITLE
Fire pixel when there are 2+ concurrent VPN starts

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -219,5 +219,7 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
     ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR("m_atp_ev_apptp_create_network_stack_error_c"),
     ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR_DAILY("m_atp_ev_apptp_create_network_stack_error_d"),
 
+    ATP_REPORT_CONCURRENT_VPN_START("m_atp_ev_apptp_concurrent_vpn_start_c"),
+
     ;
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -378,6 +378,8 @@ interface DeviceShieldPixels {
     fun didPressOnAppTpEnabledCtaButton()
 
     fun reportErrorCreatingVpnNetworkStack()
+
+    fun reportConcurrentVpnStart()
 }
 
 @ContributesBinding(AppScope::class)
@@ -825,6 +827,10 @@ class RealDeviceShieldPixels @Inject constructor(
     override fun reportErrorCreatingVpnNetworkStack() {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR_DAILY)
         firePixel(DeviceShieldPixelNames.ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR)
+    }
+
+    override fun reportConcurrentVpnStart() {
+        firePixel(DeviceShieldPixelNames.ATP_REPORT_CONCURRENT_VPN_START)
     }
 
     private fun firePixel(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -229,6 +229,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
             if (currStateStats?.state == ENABLING) {
                 // Sometimes onStartCommand gets called twice - this is a safety rail against that
                 logcat(LogPriority.WARN) { "VPN is already being started, abort" }
+                deviceShieldPixels.reportConcurrentVpnStart()
                 return@withContext
             }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203563826440241/f

### Description
In https://github.com/duckduckgo/Android/pull/2637 we added a mitigation for concurrent VPN starts. This PR fires a pixel whenever we detect this condition to get an idea of how frequently users were affected by this.

### Steps to test this PR
- [x] Clean install from this branch
- [x] Go through AppTP onboarding
- [x] Check logs for `m_atp_ev_apptp_concurrent_vpn_start_c` pixel firing when AppTP starts (onboarding triggers this condition)