### PR TITLE
Add fireproofed sites and serp sites to the exclusion list for first party cookies expiry

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
@@ -22,6 +22,7 @@ import android.os.Build
 import androidx.core.net.toUri
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.FileUtilities
+import com.duckduckgo.app.fire.FireproofRepository
 import com.duckduckgo.app.fire.WebViewDatabaseLocator
 import com.duckduckgo.app.global.DefaultDispatcherProvider
 import com.duckduckgo.app.global.exception.RootExceptionFinder
@@ -76,6 +77,7 @@ class FirstPartyCookiesReferenceTest(private val testCase: TestCase) {
     private val cookiesRepository = mock<CookiesRepository>()
     private val unprotectedTemporary = mock<UnprotectedTemporary>()
     private val userAllowListRepository = mock<UserAllowListRepository>()
+    private val fireproofRepository = mock<FireproofRepository>()
     private val webViewDatabaseLocator = WebViewDatabaseLocator(context)
     private lateinit var cookieModifier: FirstPartyCookiesModifier
 
@@ -107,6 +109,7 @@ class FirstPartyCookiesReferenceTest(private val testCase: TestCase) {
             userAllowListRepository,
             webViewDatabaseLocator,
             ExceptionPixel(mockPixel, RootExceptionFinder()),
+            fireproofRepository,
             DefaultDispatcherProvider(),
         )
         val host = testCase.siteURL.toUri().host
@@ -221,6 +224,7 @@ class FirstPartyCookiesReferenceTest(private val testCase: TestCase) {
         whenever(cookiesRepository.exceptions).thenReturn(CopyOnWriteArrayList(cookieExceptions))
         whenever(cookiesRepository.firstPartyCookiePolicy).thenReturn(policy)
         whenever(unprotectedTemporary.unprotectedTemporaryExceptions).thenReturn(unprotectedTemporaryExceptions)
+        whenever(fireproofRepository.fireproofWebsites()).thenReturn(emptyList())
     }
 
     data class TestCase(

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/WebViewCookieManager.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/WebViewCookieManager.kt
@@ -89,6 +89,6 @@ class WebViewCookieManager @Inject constructor(
     }
 
     companion object {
-        private val DDG_COOKIE_DOMAINS = listOf(AppUrl.Url.COOKIES, AppUrl.Url.SURVEY_COOKIES)
+        val DDG_COOKIE_DOMAINS = listOf(AppUrl.Url.COOKIES, AppUrl.Url.SURVEY_COOKIES)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203562061689358/f 

### Description
This PR adds fireproofed sites and SERP sites to the exclusion list before changing their expiry date in their 1st party cookies

### Steps to test this PR

- [ ] In `FirstPartyCookiesModifier` line 98, change the value of maxAge to 1 `maxAge = 1`
- [ ] Go to SERP and change the theme
- [ ] Close the app and wait a few seconds seconds before opening the app again
- [ ] Go to SERP, theme should still be the one you set.
- [ ] Doing the same in develop should reset the theme.

