### PR TITLE
Consume netguard as a dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "submodules/privacy-grade"]
 	path = submodules/privacy-grade
 	url = https://github.com/duckduckgo/privacy-grade
-[submodule "vpn-network/vpn-network-impl/src/main/cpp/netguard"]
-	path = vpn-network/vpn-network-impl/src/main/cpp/netguard
-	url = https://github.com/duckduckgo/netguard.git

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
 buildscript {
 
     ext {
@@ -39,6 +40,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
     configurations.all {
         resolutionStrategy.force 'org.objenesis:objenesis:2.6'

--- a/vpn-network/vpn-network-impl/build.gradle
+++ b/vpn-network/vpn-network-impl/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     implementation Kotlin.stdlib.jdk7
     implementation "com.squareup.logcat:logcat:_"
+    implementation "com.github.duckduckgo:netguard:1.0.0"
 
     implementation Google.dagger
     implementation AndroidX.core.ktx
@@ -49,12 +50,6 @@ dependencies {
 }
 
 android {
-    externalNativeBuild {
-
-        cmake {
-            path "CMakeLists.txt"
-        }
-    }
     anvil {
         generateDaggerFactories = true // default is false
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203208709178851/f

### Description
Remove netguard submodule and consume it as a library dependency

### Steps to test this PR
- [x] pull this branch and ensure the `vpn-network/vpn-network-impl/src/main/cpp` is deleted
- [x] clean build from this branch
- [x] verify it builds
- [x] install app and smoke test AppTP

