### PR TITLE
Fix count used for search bar's clear button

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/SearchBar.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/SearchBar.kt
@@ -65,8 +65,8 @@ class SearchBarView @JvmOverloads constructor(
         binding.upAction.setOnClickListener {
             actionHandler(SearchBar.Action.PerformUpAction)
         }
-        binding.omnibarTextInput.doOnTextChanged { text, _, _, count ->
-            binding.clearTextButton.visibility = if (count == 0) GONE else VISIBLE
+        binding.omnibarTextInput.doOnTextChanged { text, _, _, _ ->
+            binding.clearTextButton.visibility = if (text.isNullOrEmpty()) GONE else VISIBLE
             actionHandler(SearchBar.Action.PerformSearch(text.toString()))
         }
         binding.clearTextButton.setOnClickListener {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203570146222881/f

### Description
Fixes the way the `SearchBar` decides to show its clear button (✖️) or not.

### Steps to test this PR
- [x] Visit `BookmarksActivity` and add some folders/bookmarks if you don't have any
- [x] Tap on the search loupe 🔍
- [x] Type "hello"; verify the ✖️ button is visible
- [x] Delete a single character, leaving text in the box; verify the ✖️ button is still visible
- [x] Test that tapping on ✖️clears the text