### PR TITLE
Add e2e release tests to CI nightlies

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -62,9 +62,19 @@ jobs:
           workspace: .maestro/ad_click_detection_flows
 
       - name: Privacy Tests
+        if: always()
         uses: mobile-dev-inc/action-maestro-cloud@v1.1.1
         with:
           api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
           name: ${{ github.sha }}
           app-file: apk/release.apk
           workspace: .maestro/privacy_tests
+
+      - name: Release Tests
+        if: always()
+        uses: mobile-dev-inc/action-maestro-cloud@v1.1.1
+        with:
+          api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
+          name: ${{ github.sha }}
+          app-file: apk/release.apk
+          workspace: .maestro/release_tests

--- a/.maestro/release_tests/1_-_bookmarks.yaml
+++ b/.maestro/release_tests/1_-_bookmarks.yaml
@@ -1,0 +1,46 @@
+appId: com.duckduckgo.mobile.android
+---
+- launchApp:
+      clearState: true
+      stopApp: true
+- assertVisible:
+    text: ".*Not to worry! Searching and browsing privately.*"
+- tapOn: "let's do it!"
+- tapOn: "cancel"
+- assertVisible:
+    text: ".*I'll also upgrade the security of your connection if possible.*"
+- tapOn:
+    text: "search or type URL"
+- inputText: "https://privacy-test-pages.glitch.me"
+- tapOn:
+    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+    text: ".*keep browsing.*"
+- tapOn:
+    text: "got it"
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+    text: "add bookmark"
+- tapOn:
+    text: "add bookmark"
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+    text: "bookmarks"
+- tapOn:
+    text: "bookmarks"
+- assertVisible:
+    text: "No favorites added yet"
+- assertVisible:
+    text: "Privacy Test Pages - Home"
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/trailingIcon"
+- assertVisible:
+    text: "Delete"
+- tapOn:
+    text: "delete"
+- assertNotVisible:
+    text: "Privacy Test Pages - Home"
+- assertVisible:
+    text: "No bookmarks added yet"

--- a/.maestro/release_tests/2_-_browsing.yaml
+++ b/.maestro/release_tests/2_-_browsing.yaml
@@ -1,0 +1,22 @@
+appId: com.duckduckgo.mobile.android
+---
+- launchApp:
+      clearState: true
+      stopApp: true
+- assertVisible:
+    text: ".*Not to worry! Searching and browsing privately.*"
+- tapOn: "let's do it!"
+- tapOn: "cancel"
+- assertVisible:
+    text: ".*I'll also upgrade the security of your connection if possible.*"
+- tapOn:
+    text: "search or type URL"
+- inputText: "https://privacy-test-pages.glitch.me"
+- tapOn:
+    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+    text: ".*keep browsing.*"
+- tapOn:
+    text: "got it"
+- assertVisible:
+    text: ".*Privacy Test Pages.*"

--- a/.maestro/release_tests/3_-_favorites.yaml
+++ b/.maestro/release_tests/3_-_favorites.yaml
@@ -1,0 +1,69 @@
+appId: com.duckduckgo.mobile.android
+---
+- launchApp:
+    clearState: true
+    stopApp: true
+- assertVisible:
+    text: ".*Not to worry! Searching and browsing privately.*"
+- tapOn: "let's do it!"
+- tapOn: "cancel"
+- assertVisible:
+    text: ".*I'll also upgrade the security of your connection if possible.*"
+- tapOn:
+    text: "search or type URL"
+- inputText: "https://privacy-test-pages.glitch.me"
+- tapOn:
+    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+    text: ".*keep browsing.*"
+- tapOn:
+    text: "got it"
+# Add favorite from menu button
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+      text: "add favorite"
+- tapOn:
+    text: "add favorite"
+# Remove favorite from menu button
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+      text: "remove favorite"
+- tapOn:
+      text: "remove favorite"
+# Re-add favorite from menu button
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+      text: "add favorite"
+- tapOn:
+      text: "add favorite"
+# Check favorites from bookmarks screen
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+    text: "bookmarks"
+- tapOn:
+    text: "bookmarks"
+- assertVisible:
+    text: "No bookmarks added yet"
+- assertVisible:
+    text: "Privacy Test Pages - Home"
+# Remove favorite from bookmarks screen
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/trailingIcon"
+- assertVisible:
+    text: "Delete"
+- tapOn:
+    text: "delete"
+- assertVisible: "Deleted Privacy Test Pages - Home"
+- assertNotVisible:
+    text: "Privacy Test Pages - Home"
+- assertVisible:
+    text: "No favorites added yet"
+# Undo remove favorite from bookmarks screen
+- assertVisible: "Undo"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/snackbar_action"
+- assertVisible: "Privacy Test Pages - Home"

--- a/.maestro/release_tests/4_-_tabs.yaml
+++ b/.maestro/release_tests/4_-_tabs.yaml
@@ -1,0 +1,53 @@
+appId: com.duckduckgo.mobile.android
+---
+- launchApp:
+      clearState: true
+      stopApp: true
+- assertVisible:
+      text: ".*Not to worry! Searching and browsing privately.*"
+- tapOn: "let's do it!"
+- tapOn: "cancel"
+- assertVisible:
+      text: ".*I'll also upgrade the security of your connection if possible.*"
+- tapOn:
+    text: "search or type URL"
+- inputText: "https://privacy-test-pages.glitch.me"
+- tapOn:
+    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+    text: ".*keep browsing.*"
+- tapOn:
+    text: "got it"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/tabCount"
+- assertVisible:
+    text: "Privacy Test Pages - Home"
+- tapOn: "New Tab"
+- assertVisible:
+    text: "Search or type URL"
+- inputText: "https://www.search-company.site"
+- tapOn:
+    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+    text: "Search engine"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/tabCount"
+- assertVisible:
+    text: "Ad Click Flow"
+- assertVisible:
+    text: "Privacy Test Pages - Home"
+- tapOn:
+    text: "Privacy Test Pages - Home"
+- assertNotVisible:
+    text: "Ad Click Flow"
+- assertVisible:
+    text: "Privacy Test Pages - Home"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/tabCount"
+- assertVisible:
+    text: "Ad Click Flow"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/close"
+    rightOf: "Ad Click Flow"
+- assertNotVisible:
+    text: "Ad Click Flow"

--- a/.maestro/release_tests/5_-_app_tp_onboarding.yaml
+++ b/.maestro/release_tests/5_-_app_tp_onboarding.yaml
@@ -1,0 +1,55 @@
+appId: com.duckduckgo.mobile.android
+---
+- launchApp:
+      clearState: true
+      stopApp: true
+- assertVisible:
+    text: ".*Not to worry! Searching and browsing privately.*"
+- tapOn: "let's do it!"
+- tapOn: "cancel"
+- assertVisible:
+    text: ".*I'll also upgrade the security of your connection if possible.*"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- tapOn:
+    text: "Settings"
+    index: 0
+- scroll
+- scroll
+- assertVisible: "Block app trackers on your device"
+- tapOn: "App Tracking Protection"
+- assertVisible: "One easy step for better app privacy!"
+- assertVisible: "Continue"
+- tapOn: "Continue"
+- assertVisible: "How does it work?"
+- assertVisible: "Continue"
+- tapOn: "Continue"
+- assertVisible: "Who sees your data?"
+- assertVisible:
+    text: "Enable App Tracking Protection"
+    index: 1
+- tapOn:
+    text: "Enable App Tracking Protection"
+    index: 1
+- assertVisible: "Connection request"
+- tapOn: "OK"
+- assertVisible:
+      text: "Good news! App Tracking Protection is now enabled.*"
+- assertVisible: "Got it!"
+- tapOn: "Got it!"
+- assertVisible: "This feature is in beta. Having issues with an app? Help us improve"
+- assertVisible: "Blocked tracking attempts will appear here"
+- assertVisible:
+    id: "com.duckduckgo.mobile.android:id/activity_apps"
+    index: 0
+- assertVisible:
+    id: "com.duckduckgo.mobile.android:id/activity_apps"
+    index: 1
+- scroll
+- assertVisible: "ABOUT"
+- assertVisible: "What are app trackers?"
+- assertVisible: "App Tracking Protection FAQ"
+- assertVisible: "MANAGE"
+- assertVisible: "Having issues with an app?"
+- assertVisible: "View Apps"
+- assertVisible: "Disable and Delete Data"

--- a/.maestro/release_tests/6_-_fire-during-onboarding.yaml
+++ b/.maestro/release_tests/6_-_fire-during-onboarding.yaml
@@ -1,0 +1,30 @@
+appId: com.duckduckgo.mobile.android
+---
+- launchApp:
+    clearState: true
+    stopApp: true
+- assertVisible:
+    text: ".*Not to worry! Searching and browsing privately.*"
+- tapOn: "let's do it!"
+- tapOn: "cancel"
+- assertVisible:
+    text: ".*I'll also upgrade the security of your connection if possible.*"
+- tapOn:
+    text: "search or type URL"
+- inputText: "https://privacy-test-pages.glitch.me"
+- tapOn:
+    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+    text: ".*keep browsing.*"
+- tapOn:
+    text: "got it"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/fireIconImageView"
+- assertVisible: "Personal data can build up in your browser.*"
+- tapOn: "Cancel"
+- assertNotVisible: "Personal data can build up in your browser.*"
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/fireIconImageView"
+- assertNotVisible: "Personal data can build up in your browser.*"
+- tapOn: "Clear All Tabs And Data"
+- assertVisible: "You've got this!.*"

--- a/.maestro/shared/onboarding.yaml
+++ b/.maestro/shared/onboarding.yaml
@@ -1,0 +1,8 @@
+appId: com.duckduckgo.mobile.android.debug
+---
+- assertVisible:
+    text: ".*Not to worry! Searching and browsing privately.*"
+- tapOn: "let's do it!"
+- tapOn: "cancel"
+- assertVisible:
+    text: ".*I'll also upgrade the security of your connection if possible.*"

--- a/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesNonCachingServiceApi.kt
+++ b/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesNonCachingServiceApi.kt
@@ -19,12 +19,12 @@ package com.duckduckgo.anvil.annotations
 import kotlin.reflect.KClass
 
 /**
- * Anvil annotation to generate plugin points
+ * Anvil annotation to generate a non-caching Retrofit service interface implementation.
  *
  * Usage:
  * ```kotlin
- * @ContributesPluginPoint(SomeDaggerScope::class)
- * interface MyPlugin {
+ * @ContributesNonCachingServiceApi(SomeDaggerScope::class)
+ * interface MyServiceApi {
  *
  * }
  * ```
@@ -41,7 +41,7 @@ annotation class ContributesNonCachingServiceApi(
      *
      * usage:
      * ```kotlin
-     * @ContributesServiceApi(
+     * @ContributesNonCachingServiceApi(
      *   scope = AppScope::class,
      * )
      * interface MyRetrofitServiceApi {...}

--- a/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesServiceApi.kt
+++ b/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesServiceApi.kt
@@ -19,12 +19,12 @@ package com.duckduckgo.anvil.annotations
 import kotlin.reflect.KClass
 
 /**
- * Anvil annotation to generate plugin points
+ * Anvil annotation to generate a Retrofit service interface implementation.
  *
  * Usage:
  * ```kotlin
- * @ContributesPluginPoint(SomeDaggerScope::class)
- * interface MyPlugin {
+ * @ContributesServiceApi(SomeDaggerScope::class)
+ * interface MyServiceApi {
  *
  * }
  * ```


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203568230967986/f

### Description
Add release e2e tests that will run on nightly CI.

Incidentally fixing some unrelated javadocs.

### Steps to test this PR
With maestro installed, `cd .maestro/release_tests` and run the following script

```bash
for i in *.yaml; do
  maestro test "$i"
done
```

All should pass

Also, tests on movile.dev (https://github.com/duckduckgo/Android/actions/runs/3726837954) have passed
