### PR TITLE
Fix setting state back to DISABLED when vpn fails to start

### DIFF
--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnServiceCallbacks.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnServiceCallbacks.kt
@@ -20,6 +20,10 @@ import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import kotlinx.coroutines.CoroutineScope
 
 interface VpnServiceCallbacks {
+    fun onVpnStarting(coroutineScope: CoroutineScope) {}
+
+    fun onVpnStartFailed(coroutineScope: CoroutineScope) {}
+
     fun onVpnStarted(coroutineScope: CoroutineScope)
 
     fun onVpnStopped(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.mobile.android.vpn.dao.VpnServiceStateStatsDao
 import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
 import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
 import com.duckduckgo.mobile.android.vpn.integration.VpnNetworkStackProvider
+import com.duckduckgo.mobile.android.vpn.model.VpnServiceState.ENABLED
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceState.ENABLING
 import com.duckduckgo.mobile.android.vpn.network.VpnNetworkStack.VpnTunnelConfig
 import com.duckduckgo.mobile.android.vpn.network.util.asRoute
@@ -225,7 +226,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
 
         synchronized(startVpnLock) {
             val currStateStats = vpnServiceStateStatsDao.getLastStateStats()
-            if (currStateStats?.state == ENABLING) {
+            if (currStateStats?.state == ENABLING || currStateStats?.state == ENABLED) {
                 // Sometimes onStartCommand gets called twice - this is a safety rail against that
                 logcat(LogPriority.WARN) { "VPN is already being started, abort" }
                 return@withContext

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -38,7 +38,6 @@ import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
 import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
 import com.duckduckgo.mobile.android.vpn.integration.VpnNetworkStackProvider
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceState.ENABLING
-import com.duckduckgo.mobile.android.vpn.model.VpnServiceStateStats
 import com.duckduckgo.mobile.android.vpn.network.VpnNetworkStack.VpnTunnelConfig
 import com.duckduckgo.mobile.android.vpn.network.util.asRoute
 import com.duckduckgo.mobile.android.vpn.network.util.getActiveNetwork
@@ -232,8 +231,10 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
                 return@withContext
             }
 
-            // We need to rethink how to log this state. This will likely change.
-            vpnServiceStateStatsDao.insert(VpnServiceStateStats(state = ENABLING))
+            vpnServiceCallbacksPluginPoint.getPlugins().forEach {
+                logcat { "VPN log: onVpnStarting ${it.javaClass} callback" }
+                it.onVpnStarting(this)
+            }
         }
 
         vpnNetworkStack.onPrepareVpn().getOrNull().also {
@@ -274,7 +275,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
         }
 
         vpnServiceCallbacksPluginPoint.getPlugins().forEach {
-            logcat { "VPN log: starting ${it.javaClass} callback" }
+            logcat { "VPN log: onVpnStarted ${it.javaClass} callback" }
             it.onVpnStarted(this)
         }
 
@@ -451,7 +452,10 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
         }
     }
 
-    private suspend fun stopVpn(reason: VpnStopReason, shouldStopCallbacks: Boolean = true) = withContext(Dispatchers.IO) {
+    private suspend fun stopVpn(
+        reason: VpnStopReason,
+        hasVpnAlreadyStarted: Boolean = true,
+    ) = withContext(Dispatchers.IO) {
         logcat { "VPN log: Stopping VPN. $reason" }
 
         vpnNetworkStack.onStopVpn()
@@ -461,10 +465,16 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
 
         sendStopPixels(reason)
 
-        if (shouldStopCallbacks) {
+        // If VPN has been started, then onVpnStopped must be called. Else, an error might have occurred before start so we call onVpnStartFailed
+        if (hasVpnAlreadyStarted) {
             vpnServiceCallbacksPluginPoint.getPlugins().forEach {
                 logcat { "VPN log: stopping ${it.javaClass} callback" }
                 it.onVpnStopped(this, reason)
+            }
+        } else {
+            vpnServiceCallbacksPluginPoint.getPlugins().forEach {
+                logcat { "VPN log: onVpnStartFailed ${it.javaClass} callback" }
+                it.onVpnStartFailed(this)
             }
         }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/stats/VpnServiceStateLogger.kt
@@ -61,10 +61,8 @@ class VpnServiceStateLogger @Inject constructor(
     private val job = ConflatedJob()
 
     override fun onVpnStarting(coroutineScope: CoroutineScope) {
-        job += coroutineScope.launch(dispatcher) {
-            logcat { "VpnServiceStateLogger, new state ENABLING" }
-            vpnDatabase.vpnServiceStateDao().insert(VpnServiceStateStats(state = VpnServiceState.ENABLING))
-        }
+        logcat { "VpnServiceStateLogger, new state ENABLING" }
+        vpnDatabase.vpnServiceStateDao().insert(VpnServiceStateStats(state = VpnServiceState.ENABLING))
     }
 
     override fun onVpnStartFailed(coroutineScope: CoroutineScope) {

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -74,6 +74,7 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
 
     override fun onMainProcessCreate() {
         configureLogging()
+        AndroidLogcatLogger.installOnDebuggableApp(this, minPriority = LogPriority.VERBOSE)
         Timber.d("onMainProcessCreate $currentProcessName")
 
         configureDependencyInjection()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203586092184943/f

### Description
This PR includes resetting the VPN state to DISABLED when any error occurs before the VPN successfully starts.

### Steps to test this PR

Smoke test AppTP

_Attempt repro 2 tun interface bug_
- [x] Open an app and then force close it
- [x] Disable protection for it
- [x] Re-enable protection
- [x] Rinse and repeat ~10 times
- [x] See "VPN is already being started, abort" in the logs

