### PR TITLE
Search credentials from credential management screen

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementActivity.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
+import androidx.core.view.isVisible
 import androidx.fragment.app.commit
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.Lifecycle
@@ -61,6 +62,11 @@ import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.UserCancelle
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.ui.view.SearchBar
+import com.duckduckgo.mobile.android.ui.view.gone
+import com.duckduckgo.mobile.android.ui.view.hideKeyboard
+import com.duckduckgo.mobile.android.ui.view.show
+import com.duckduckgo.mobile.android.ui.view.showKeyboard
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.google.android.material.snackbar.Snackbar
 import com.squareup.anvil.annotations.ContributesTo
@@ -73,7 +79,7 @@ import timber.log.Timber
 @InjectWith(ActivityScope::class)
 class AutofillManagementActivity : DuckDuckGoActivity() {
 
-    private val binding: ActivityAutofillSettingsBinding by viewBinding()
+    val binding: ActivityAutofillSettingsBinding by viewBinding()
     private val viewModel: AutofillSettingsViewModel by bindViewModel()
 
     @Inject
@@ -86,7 +92,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
         super.onCreate(savedInstanceState)
         window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         setContentView(binding.root)
-        setupToolbar(binding.includeToolbar.toolbar)
+        setupToolbar(binding.toolbar)
         observeViewModel()
     }
 
@@ -242,9 +248,27 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
 
     private fun resetToolbar() {
         setTitle(R.string.managementScreenTitle)
-        binding.includeToolbar.toolbar.menu.clear()
+        binding.toolbar.menu.clear()
+        hideSearchBar()
         supportActionBar?.setHomeAsUpIndicator(com.duckduckgo.mobile.android.R.drawable.ic_back_24)
     }
+
+    fun showSearchBar() {
+        with(binding) {
+            toolbar.gone()
+            searchBar.handle(SearchBar.Event.ShowSearchBar)
+            searchBar.showKeyboard()
+        }
+    }
+
+    fun hideSearchBar() {
+        with(binding) {
+            toolbar.show()
+            searchBar.handle(SearchBar.Event.DismissSearchBar)
+            searchBar.hideKeyboard()
+        }
+    }
+    private fun isSearchBarVisible(): Boolean = binding.searchBar.isVisible
 
     override fun onBackPressed() {
         when (viewModel.viewState.value.credentialMode) {
@@ -257,7 +281,15 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
                     viewModel.onShowListMode()
                 }
             }
-            is ListMode -> finish()
+
+            is ListMode -> {
+                if (isSearchBarVisible()) {
+                    hideSearchBar()
+                } else {
+                    finish()
+                }
+            }
+
             is Disabled -> finish()
             is Locked -> finish()
             else -> super.onBackPressed()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementRecyclerAdapter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/AutofillManagementRecyclerAdapter.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ItemRowAutofillCredentialsManagementScreenBinding
 import com.duckduckgo.autofill.impl.databinding.ItemRowAutofillCredentialsManagementScreenDividerBinding
 import com.duckduckgo.autofill.impl.databinding.ItemRowAutofillCredentialsManagementScreenHeaderBinding
+import com.duckduckgo.autofill.impl.databinding.ItemRowSearchNoResultsBinding
 import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ContextMenuAction.CopyPassword
 import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ContextMenuAction.CopyUsername
 import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ContextMenuAction.Delete
@@ -40,6 +41,7 @@ import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecycl
 import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem.CredentialListItem.SuggestedCredential
 import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem.Divider
 import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem.GroupHeading
+import com.duckduckgo.autofill.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem.NoMatchingSearchResults
 import com.duckduckgo.autofill.ui.credential.management.sorting.CredentialGrouper
 import com.duckduckgo.autofill.ui.credential.management.suggestion.SuggestionListBuilder
 import com.duckduckgo.mobile.android.ui.menu.PopupMenu
@@ -82,6 +84,11 @@ class AutofillManagementRecyclerAdapter(
                 DividerViewHolder(binding)
             }
 
+            ITEM_VIEW_TYPE_NO_MATCHING_SEARCH_RESULTS -> {
+                val binding = ItemRowSearchNoResultsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                NoMatchingSearchResultsViewHolder(binding)
+            }
+
             else -> throw IllegalArgumentException("Unknown view type")
         }
     }
@@ -94,7 +101,17 @@ class AutofillManagementRecyclerAdapter(
             is SuggestedCredentialsViewHolder -> onBindViewHolderSuggestedCredential(position, viewHolder)
             is CredentialsViewHolder -> onBindViewHolderCredential(position, viewHolder)
             is HeadingViewHolder -> onBindViewHolderHeading(position, viewHolder)
+            is NoMatchingSearchResultsViewHolder -> onBindViewHolderNoMatchingSearchResults(position, viewHolder)
         }
+    }
+
+    private fun onBindViewHolderNoMatchingSearchResults(
+        position: Int,
+        viewHolder: NoMatchingSearchResultsViewHolder,
+    ) {
+        val item = listItems[position] as NoMatchingSearchResults
+        val formattedNoResultsText = viewHolder.itemView.context.getString(R.string.autofillManagementNoSearchResults, item.query)
+        viewHolder.binding.noMatchingLoginsHint.text = formattedNoResultsText
     }
 
     private fun onBindViewHolderCredential(
@@ -147,6 +164,7 @@ class AutofillManagementRecyclerAdapter(
             is Credential -> ITEM_VIEW_TYPE_CREDENTIAL
             is SuggestedCredential -> ITEM_VIEW_TYPE_SUGGESTED_CREDENTIAL
             is Divider -> ITEM_VIEW_TYPE_DIVIDER
+            is NoMatchingSearchResults -> ITEM_VIEW_TYPE_NO_MATCHING_SEARCH_RESULTS
         }
     }
 
@@ -199,6 +217,12 @@ class AutofillManagementRecyclerAdapter(
         notifyDataSetChanged()
     }
 
+    @SuppressLint("NotifyDataSetChanged")
+    fun showNoMatchingSearchResults(query: String) {
+        listItems = listOf(NoMatchingSearchResults(query))
+        notifyDataSetChanged()
+    }
+
     override fun getItemCount(): Int = listItems.size
 
     sealed class ContextMenuAction {
@@ -216,17 +240,20 @@ class AutofillManagementRecyclerAdapter(
 
         data class GroupHeading(val label: String) : ListItem
         object Divider : ListItem
+        data class NoMatchingSearchResults(val query: String) : ListItem
     }
 
     open class CredentialsViewHolder(open val binding: ItemRowAutofillCredentialsManagementScreenBinding) : RecyclerView.ViewHolder(binding.root)
     class SuggestedCredentialsViewHolder(override val binding: ItemRowAutofillCredentialsManagementScreenBinding) : CredentialsViewHolder(binding)
     class HeadingViewHolder(val binding: ItemRowAutofillCredentialsManagementScreenHeaderBinding) : RecyclerView.ViewHolder(binding.root)
     class DividerViewHolder(val binding: ItemRowAutofillCredentialsManagementScreenDividerBinding) : RecyclerView.ViewHolder(binding.root)
+    class NoMatchingSearchResultsViewHolder(val binding: ItemRowSearchNoResultsBinding) : RecyclerView.ViewHolder(binding.root)
 
     companion object {
         private const val ITEM_VIEW_TYPE_HEADER = 0
         private const val ITEM_VIEW_TYPE_CREDENTIAL = 1
         private const val ITEM_VIEW_TYPE_SUGGESTED_CREDENTIAL = 2
         private const val ITEM_VIEW_TYPE_DIVIDER = 3
+        private const val ITEM_VIEW_TYPE_NO_MATCHING_SEARCH_RESULTS = 4
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/searching/CredentialListFilter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/searching/CredentialListFilter.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management.searching
+
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface CredentialListFilter {
+    suspend fun filter(
+        originalList: List<LoginCredentials>,
+        query: String,
+    ): List<LoginCredentials>
+}
+
+@ContributesBinding(AppScope::class)
+class ManagementScreenCredentialListFilter @Inject constructor(private val autofillCredentialMatcher: AutofillCredentialMatcher) :
+    CredentialListFilter {
+
+    override suspend fun filter(
+        originalList: List<LoginCredentials>,
+        query: String,
+    ): List<LoginCredentials> {
+        if (query.isBlank()) return originalList
+
+        return originalList.filter {
+            autofillCredentialMatcher.matches(it, query)
+        }
+    }
+}
+
+interface AutofillCredentialMatcher {
+    fun matches(
+        credential: LoginCredentials,
+        query: String,
+    ): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class ManagementScreenAutofillCredentialMatcher @Inject constructor() : AutofillCredentialMatcher {
+    override fun matches(
+        credential: LoginCredentials,
+        query: String,
+    ): Boolean {
+        if (query.isBlank()) return true
+        var matches = false
+
+        if (credential.username?.contains(query, true) == true) {
+            matches = true
+        } else if (credential.domainTitle?.contains(query, true) == true) {
+            matches = true
+        } else if (credential.notes?.contains(query, true) == true) {
+            matches = true
+        } else if (credential.domain?.contains(query, true) == true) {
+            matches = true
+        }
+
+        return matches
+    }
+}

--- a/autofill/autofill-impl/src/main/res/drawable/ic_baseline_search_24.xml
+++ b/autofill/autofill-impl/src/main/res/drawable/ic_baseline_search_24.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<!--
   ~ Copyright (c) 2022 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +14,13 @@
   ~ limitations under the License.
   -->
 
-<resources>
-    <string name="autofillManagementAddLogin">Add Login</string>
-    <string name="autofillManagementSearchLogins">Search</string>
-    <string name="autofillManagementSearchClearDescription">Clear search input</string>
-    <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for 'kittens'">No results for \'%1$s\'</string>
-</resources>
+<vector android:height="24dp"
+    android:tint="#000000"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="?attr/toolbarIconColor"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
+</vector>

--- a/autofill/autofill-impl/src/main/res/layout/activity_autofill_settings.xml
+++ b/autofill/autofill-impl/src/main/res/layout/activity_autofill_settings.xml
@@ -14,17 +14,45 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     tools:context="com.duckduckgo.autofill.ui.credential.management.AutofillManagementActivity">
 
-    <include
-        android:id="@+id/includeToolbar"
-        layout="@layout/include_default_toolbar" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?toolbarBgColor"
+        android:theme="@style/Widget.DuckDuckGo.ToolbarTheme">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/toolbarBgColor"
+                android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+                app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu" />
+
+            <com.duckduckgo.mobile.android.ui.view.SearchBarView
+                android:id="@+id/search_bar"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="@dimen/keyline_2"
+                android:visibility="gone"
+                app:searchHint="@string/autofillManagementSearchLogins"
+                app:clearActionContentDescription="@string/autofillManagementSearchClearDescription"/>
+        </FrameLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container_view"

--- a/autofill/autofill-impl/src/main/res/layout/item_row_search_no_results.xml
+++ b/autofill/autofill-impl/src/main/res/layout/item_row_search_no_results.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2022 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.google.android.material.textview.MaterialTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/noMatchingLoginsHint"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fontFamily="sans-serif"
+    android:gravity="center"
+    android:lineSpacingExtra="4sp"
+    android:paddingStart="16dp"
+    android:paddingTop="24dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="24dp"
+    android:textColor="?attr/normalTextColor"
+    android:textSize="16sp"
+    android:textStyle="normal"
+    tools:text="Lorem ipsum dolor sit amet" />

--- a/autofill/autofill-impl/src/main/res/menu/autofill_list_mode_menu.xml
+++ b/autofill/autofill-impl/src/main/res/menu/autofill_list_mode_menu.xml
@@ -18,6 +18,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/searchLogins"
+        android:icon="@drawable/ic_baseline_search_24"
+        android:title="@string/autofillManagementSearchLogins"
+        android:visible="false"
+        app:showAsAction="always" />
+
+    <item
         android:id="@+id/addLoginManually"
         android:icon="@drawable/ic_baseline_add_24"
         android:title="@string/autofillManagementAddLogin"

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewMode
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.Command.*
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode
 import com.duckduckgo.autofill.ui.credential.management.AutofillSettingsViewModel.CredentialMode.EditingExisting
+import com.duckduckgo.autofill.ui.credential.management.searching.CredentialListFilter
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -51,12 +52,14 @@ class AutofillSettingsViewModelTest {
     private val clipboardInteractor: AutofillClipboardInteractor = mock()
     private val pixel: Pixel = mock()
     private val deviceAuthenticator: DeviceAuthenticator = mock()
+    private val credentialListFilter: CredentialListFilter = mock()
     private val testee = AutofillSettingsViewModel(
         autofillStore = mockStore,
         clipboardInteractor = clipboardInteractor,
         deviceAuthenticator = deviceAuthenticator,
         pixel = pixel,
         dispatchers = coroutineTestRule.testDispatcherProvider,
+        credentialListFilter = credentialListFilter,
     )
 
     @Test

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/searching/ManagementScreenAutofillCredentialMatcherTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/searching/ManagementScreenAutofillCredentialMatcherTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management.searching
+
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ManagementScreenAutofillCredentialMatcherTest {
+
+    private val testee = ManagementScreenAutofillCredentialMatcher()
+
+    @Test
+    fun whenEmptyQueryThenMatchesCredential() = runTest {
+        assertTrue(testee.matches(creds(), ""))
+    }
+
+    @Test
+    fun whenQueryMatchesUsernameThenMatchesCredential() {
+        val creds = creds(username = "username")
+        assertTrue(testee.matches(creds, "username"))
+        assertTrue(EXPECT_PREFIXES, testee.matches(creds, "user"))
+        assertTrue(EXPECT_IN_THE_MIDDLE, testee.matches(creds, "erna"))
+        assertTrue(EXPECT_SUFFIXES, testee.matches(creds, "name"))
+        assertTrue(EXPECT_CASE_INSENSITIVE, testee.matches(creds, "USERNAME"))
+    }
+
+    @Test
+    fun whenQueryMatchesPasswordThenNotAMatch() {
+        val creds = creds(password = "password")
+        assertFalse(testee.matches(creds, "password"))
+    }
+
+    @Test
+    fun whenQueryMatchesTitleThenMatchesCredential() {
+        val creds = creds(title = "title")
+        assertTrue(testee.matches(creds, "title"))
+        assertTrue(EXPECT_PREFIXES, testee.matches(creds, "ti"))
+        assertTrue(EXPECT_IN_THE_MIDDLE, testee.matches(creds, "itl"))
+        assertTrue(EXPECT_SUFFIXES, testee.matches(creds, "le"))
+        assertTrue(EXPECT_CASE_INSENSITIVE, testee.matches(creds, "TITLE"))
+    }
+
+    @Test
+    fun whenQueryMatchesNotesThenMatchesCredential() {
+        val creds = creds(notes = "notes")
+        assertTrue(testee.matches(creds, "notes"))
+        assertTrue(EXPECT_PREFIXES, testee.matches(creds, "no"))
+        assertTrue(EXPECT_IN_THE_MIDDLE, testee.matches(creds, "ote"))
+        assertTrue(EXPECT_SUFFIXES, testee.matches(creds, "es"))
+        assertTrue(EXPECT_CASE_INSENSITIVE, testee.matches(creds, "NOTES"))
+    }
+
+    @Test
+    fun whenQueryMatchesDomainThenMatchesCredential() {
+        val creds = creds(domain = "example.com")
+        assertTrue(testee.matches(creds, "example.com"))
+        assertTrue(EXPECT_PREFIXES, testee.matches(creds, "exa"))
+        assertTrue(EXPECT_IN_THE_MIDDLE, testee.matches(creds, "ample.c"))
+        assertTrue(EXPECT_SUFFIXES, testee.matches(creds, ".com"))
+        assertTrue(EXPECT_CASE_INSENSITIVE, testee.matches(creds, "EXAMPLE.com"))
+    }
+
+    @Test
+    fun whenQueryMatchesMultipleFieldsThenMatchesCredential() {
+        val creds = creds(domain = "example.com", username = "example", title = "example", notes = "example")
+        assertTrue(testee.matches(creds, "example"))
+    }
+
+    private fun creds(
+        id: Long = 0,
+        username: String? = null,
+        password: String? = null,
+        domain: String? = null,
+        title: String? = null,
+        notes: String? = null,
+    ): LoginCredentials {
+        return LoginCredentials(
+            id = id,
+            domain = domain,
+            username = username,
+            password = password,
+            domainTitle = title,
+            notes = notes,
+        )
+    }
+
+    private companion object {
+        private const val EXPECT_PREFIXES = "Should partially match prefixes"
+        private const val EXPECT_IN_THE_MIDDLE = "Should partially match in the middle"
+        private const val EXPECT_SUFFIXES = "Should partially match suffixes"
+        private const val EXPECT_CASE_INSENSITIVE = "Should case insensitive match"
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/searching/ManagementScreenCredentialListFilterTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/ui/credential/management/searching/ManagementScreenCredentialListFilterTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.ui.credential.management.searching
+
+import com.duckduckgo.autofill.domain.app.LoginCredentials
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+@ExperimentalCoroutinesApi
+class ManagementScreenCredentialListFilterTest {
+
+    private val matcher: AutofillCredentialMatcher = mock()
+    private val testee = ManagementScreenCredentialListFilter(matcher)
+
+    @Test
+    fun whenEmptyListAndEmptyQueryThenEmptyListReturned() = runTest {
+        assertTrue(testee.filter(emptyList(), "").isEmpty())
+    }
+
+    @Test
+    fun whenNonEmptyListAndEmptyQueryThenUnfilteredListReturned() = runTest {
+        val originalList = listOf(
+            creds(),
+            creds(),
+        )
+        val results = testee.filter(originalList, "")
+        assertEquals(2, results.size)
+    }
+
+    @Test
+    fun whenEmptyListWithAQueryThenEmptyListReturned() = runTest {
+        assertTrue(testee.filter(emptyList(), "foo").isEmpty())
+    }
+
+    private fun creds(id: Long = 0): LoginCredentials {
+        return LoginCredentials(id = id, domain = "example.com", username = "u", password = "p")
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203563399643944/f

### Description
Adds ability to search for saved credentials from the credential management screen. Fields searched for a match are:
- title
- domain
- username
- notes

Note, password field isn't checked for a match.

### Steps to test this PR

_With credentials already saved_
- [x] Verify the search button **is** visible 🔍
- [x] Click it; verify you see the expanded input view
- [x] Hit the ⬅️ button; verify you are returned to the normal list view
- [x] Hit the 🔍 button again and type in some characters that don't anything saved; verify you see the "no results" message which includes the search term
- [x] Tap the ✖️ button; verify it clears the search and all credentials are shown again
- [x] Type some text which does match some entries; verify they are visible and any others are hidden
- [x] Tap on a matching entry and return; verify the search bar state has returned to normal (ie, not expanded or focussed)

_With no credentials saved_
- [x] Remove all saved credentials
- [x] Verify the search button **is not** visible
- [x] Tap the ➕ button and manually add an entry, and return to list view
- [x] Verify the search button **is now** visible

### UI changes

**No credentials saved - no search button**
<img src="https://user-images.githubusercontent.com/1336281/209105464-c13b2a61-c178-452b-8f1e-716a3d9cf918.png" width=50% />  
<hr/>

**Credentials saved - search button is visible**
<img src="https://user-images.githubusercontent.com/1336281/209105610-1cbc23e3-c5bb-4bb1-96fc-5ed15d9d15cf.png" width=50% />
<hr/>

**Mid-search: results found**
<img src="https://user-images.githubusercontent.com/1336281/209105613-8d7e584f-8d52-4ef1-a3dc-b158a1783b26.png" width=50% />
<hr/>

**Mid-search: no results found**
<img src="https://user-images.githubusercontent.com/1336281/209105625-f7fec13c-9a3a-4424-92ac-f0938b3ab3e4.png" width=50% />








