### PR TITLE
Migrate to MainProcessLifecycleObserver

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DataRemovalAdClickWorker.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DataRemovalAdClickWorker.kt
@@ -17,8 +17,6 @@
 package com.duckduckgo.adclick.impl
 
 import android.content.Context
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
@@ -29,6 +27,7 @@ import androidx.work.WorkerParameters
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.util.concurrent.TimeUnit
@@ -57,11 +56,11 @@ class DataRemovalAdClickWorker(context: Context, workerParameters: WorkerParamet
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class DataRemovalAdClickWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorker.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickDailyReportingWorker.kt
@@ -17,8 +17,6 @@
 package com.duckduckgo.adclick.impl.pixels
 
 import android.content.Context
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
@@ -28,6 +26,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.util.concurrent.TimeUnit
@@ -55,11 +54,11 @@ class AdClickDailyReportingWorker(context: Context, workerParameters: WorkerPara
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class AdClickDailyReportingWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListUpdateWorker.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListUpdateWorker.kt
@@ -17,8 +17,6 @@
 package com.duckduckgo.mobile.android.vpn.blocklist
 
 import android.content.Context
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
@@ -28,6 +26,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerMetadata
@@ -102,11 +101,11 @@ class AppTrackerListUpdateWorker(context: Context, workerParameters: WorkerParam
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class AppTrackerListUpdateWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         logcat { "Scheduling tracker blocklist update worker" }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
@@ -21,10 +21,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import androidx.core.app.NotificationManagerCompat
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.ui.notification.*
@@ -63,7 +62,7 @@ class DeviceShieldNotificationsDebugReceiver(
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class DeviceShieldNotificationsDebugReceiverRegister @Inject constructor(
     private val context: Context,
@@ -75,7 +74,7 @@ class DeviceShieldNotificationsDebugReceiverRegister @Inject constructor(
     private val deviceShieldAlertNotificationBuilder: DeviceShieldAlertNotificationBuilder,
     @VpnCoroutineScope private val vpnCoroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         if (!appBuildConfig.isDebug) {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/heartbeat/VpnServiceHeartbeatMonitor.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/heartbeat/VpnServiceHeartbeatMonitor.kt
@@ -19,13 +19,12 @@ package com.duckduckgo.mobile.android.vpn.heartbeat
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.ReceiverScope
 import com.duckduckgo.mobile.android.vpn.dao.HeartBeatEntity
@@ -52,7 +51,7 @@ import logcat.logcat
 class VpnServiceHeartbeatMonitorModule {
     @Provides
     @IntoSet
-    fun provideVpnServiceHeartbeatMonitor(workManager: WorkManager): LifecycleObserver {
+    fun provideVpnServiceHeartbeatMonitor(workManager: WorkManager): MainProcessLifecycleObserver {
         return VpnServiceHeartbeatMonitor(workManager)
     }
 
@@ -62,7 +61,7 @@ class VpnServiceHeartbeatMonitorModule {
 
 class VpnServiceHeartbeatMonitor(
     private val workManager: WorkManager,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         startHeartbeatMonitor(workManager)

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/logging/AndroidLogcatLoggerRegistrar.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/logging/AndroidLogcatLoggerRegistrar.kt
@@ -14,29 +14,30 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.deviceauth.impl
+package com.duckduckgo.mobile.android.vpn.logging
 
-import androidx.lifecycle.LifecycleOwner
-import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
-import com.duckduckgo.deviceauth.api.AutofillAuthorizationGracePeriod
+import com.duckduckgo.app.lifecycle.VpnProcessLifecycleObserver
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
-import dagger.SingleInstanceIn
 import javax.inject.Inject
-import timber.log.Timber
+import logcat.AndroidLogcatLogger
+import logcat.LogPriority
+import logcat.LogcatLogger
+import logcat.logcat
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = MainProcessLifecycleObserver::class,
+    boundType = VpnProcessLifecycleObserver::class,
 )
-@SingleInstanceIn(AppScope::class)
-class AutofillGracePeriodLifecycleObserver @Inject constructor(
-    private val gracePeriod: AutofillAuthorizationGracePeriod,
-) : MainProcessLifecycleObserver {
+class AndroidLogcatLoggerRegistrar @Inject constructor(
+    private val appBuildConfig: AppBuildConfig,
+) : VpnProcessLifecycleObserver {
 
-    override fun onStop(owner: LifecycleOwner) {
-        super.onStop(owner)
-        Timber.d("App in background, invalidating autofill grace period")
-        gracePeriod.invalidate()
+    override fun onVpnProcessCreated() {
+        if (appBuildConfig.isDebug) {
+            LogcatLogger.install(AndroidLogcatLogger(LogPriority.DEBUG))
+            logcat { "Registering LogcatLogger" }
+        }
     }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/logging/AndroidLogcatLoggerRegistrar.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/logging/AndroidLogcatLoggerRegistrar.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.mobile.android.vpn.logging
 
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.lifecycle.VpnProcessLifecycleObserver
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
@@ -30,9 +32,17 @@ import logcat.logcat
     scope = AppScope::class,
     boundType = VpnProcessLifecycleObserver::class,
 )
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
 class AndroidLogcatLoggerRegistrar @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
-) : VpnProcessLifecycleObserver {
+) : VpnProcessLifecycleObserver, MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        onVpnProcessCreated()
+    }
 
     override fun onVpnProcessCreated() {
         if (appBuildConfig.isDebug) {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldStatusReporting.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldStatusReporting.kt
@@ -17,13 +17,10 @@
 package com.duckduckgo.mobile.android.vpn.pixels
 
 import android.content.Context
-import androidx.lifecycle.Lifecycle.Event
-import androidx.lifecycle.Lifecycle.Event.ON_CREATE
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
@@ -42,7 +39,7 @@ import logcat.logcat
 object DeviceShieldStatusReportingModule {
     @Provides
     @IntoSet
-    fun provideDeviceShieldStatusReporting(workManager: WorkManager): LifecycleObserver {
+    fun provideDeviceShieldStatusReporting(workManager: WorkManager): MainProcessLifecycleObserver {
         return DeviceShieldStatusReporting(workManager)
     }
 
@@ -54,12 +51,10 @@ object DeviceShieldStatusReportingModule {
 
 class DeviceShieldStatusReporting(
     private val workManager: WorkManager,
-) : LifecycleEventObserver {
+) : MainProcessLifecycleObserver {
 
-    override fun onStateChanged(source: LifecycleOwner, event: Event) {
-        if (event == ON_CREATE) {
-            scheduleDeviceShieldStatusReporting()
-        }
+    override fun onCreate(owner: LifecycleOwner) {
+        scheduleDeviceShieldStatusReporting()
     }
 
     private fun scheduleDeviceShieldStatusReporting() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldNotificationScheduler.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldNotificationScheduler.kt
@@ -18,12 +18,11 @@ package com.duckduckgo.mobile.android.vpn.ui.notification
 
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.dao.VpnNotification
 import com.duckduckgo.mobile.android.vpn.dao.VpnNotificationsDao
@@ -51,7 +50,7 @@ object DeviceShieldNotificationSchedulerModule {
         workManager: WorkManager,
         vpnDatabase: VpnDatabase,
         dispatchers: DispatcherProvider,
-    ): LifecycleObserver {
+    ): MainProcessLifecycleObserver {
         return DeviceShieldNotificationScheduler(coroutineScope, workManager, vpnDatabase, dispatchers)
     }
 
@@ -64,7 +63,7 @@ class DeviceShieldNotificationScheduler(
     private val workManager: WorkManager,
     private val vpnDatabase: VpnDatabase,
     private val dispatchers: DispatcherProvider,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         scheduleDailyNotification()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -273,7 +273,6 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxjava:_"
     implementation "io.reactivex.rxjava2:rxandroid:_"
     implementation JakeWharton.timber
-    implementation "com.squareup.logcat:logcat:_"
 
     // ThreeTenABP
     implementation "com.jakewharton.threetenabp:threetenabp:_"

--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
@@ -17,9 +17,9 @@
 package com.duckduckgo.app.di
 
 import android.content.Context
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.global.device.ContextDeviceInfo
 import com.duckduckgo.app.global.device.DeviceInfo
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.AtbInitializer
 import com.duckduckgo.app.statistics.AtbInitializerListener
 import com.duckduckgo.app.statistics.api.PixelSender
@@ -109,7 +109,7 @@ class StubStatisticsModule {
         statisticsDataStore: StatisticsDataStore,
         statisticsUpdater: StatisticsUpdater,
         listeners: DaggerSet<AtbInitializerListener>,
-    ): LifecycleObserver {
+    ): MainProcessLifecycleObserver {
         return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners)
     }
 

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/privacy/TrackerDataDevReceiver.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/privacy/TrackerDataDevReceiver.kt
@@ -22,9 +22,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.widget.Toast
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.trackerdetection.api.TrackerDataDownloader
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
@@ -57,13 +56,13 @@ class TrackerDataDevReceiver(
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class TrackerDataDevReceiverRegister @Inject constructor(
     private val context: Context,
     private val trackderDataDownloader: TrackerDataDownloader,
     private val appBuildConfig: AppBuildConfig,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     @SuppressLint("CheckResult")
     override fun onCreate(owner: LifecycleOwner) {

--- a/app/src/internal/java/com/duckduckgo/app/flipper/FlipperInitializer.kt
+++ b/app/src/internal/java/com/duckduckgo/app/flipper/FlipperInitializer.kt
@@ -17,10 +17,9 @@
 package com.duckduckgo.app.flipper
 
 import android.content.Context
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.core.FlipperPlugin
@@ -32,12 +31,12 @@ import timber.log.Timber
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class FlipperInitializer @Inject constructor(
     private val context: Context,
     private val flipperPluginPoint: PluginPoint<FlipperPlugin>,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         Timber.v("Flipper: setup flipper")

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
@@ -16,9 +16,9 @@
 
 package com.duckduckgo.app.browser.defaultbrowsing
 
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
@@ -27,7 +27,7 @@ class DefaultBrowserObserver(
     private val defaultBrowserDetector: DefaultBrowserDetector,
     private val appInstallStore: AppInstallStore,
     private val pixel: Pixel,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onResume(owner: LifecycleOwner) {
         val isDefaultBrowser = defaultBrowserDetector.isDefaultBrowser()

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.browser.di
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.pm.PackageManager
-import androidx.lifecycle.LifecycleObserver
 import androidx.work.WorkManager
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.accessibility.AccessibilityManager
@@ -61,6 +60,7 @@ import com.duckduckgo.app.global.file.FileDeleter
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.httpsupgrade.HttpsUpgrader
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.referral.AppReferrerDataStore
@@ -208,7 +208,7 @@ class BrowserModule {
         defaultBrowserDetector: DefaultBrowserDetector,
         appInstallStore: AppInstallStore,
         pixel: Pixel,
-    ): LifecycleObserver {
+    ): MainProcessLifecycleObserver {
         return DefaultBrowserObserver(defaultBrowserDetector, appInstallStore, pixel)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/httpauth/WebViewHttpAuthStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/httpauth/WebViewHttpAuthStore.kt
@@ -19,14 +19,13 @@ package com.duckduckgo.app.browser.httpauth
 import android.webkit.WebView
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.browser.WebViewDatabaseProvider
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.fire.DatabaseCleaner
 import com.duckduckgo.app.fire.DatabaseLocator
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -70,7 +69,7 @@ interface WebViewHttpAuthStore {
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @ContributesBinding(
     scope = AppScope::class,
@@ -84,7 +83,7 @@ class RealWebViewHttpAuthStore @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val appBuildConfig: AppBuildConfig,
-) : WebViewHttpAuthStore, DefaultLifecycleObserver {
+) : WebViewHttpAuthStore, MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         // API 28 seems to use WAL for the http_auth db and changing the journal mode does not seem

--- a/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.browser.rating.di
 
 import android.content.Context
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.browser.rating.db.AppEnjoymentDao
 import com.duckduckgo.app.browser.rating.db.AppEnjoymentDatabaseRepository
 import com.duckduckgo.app.browser.rating.db.AppEnjoymentRepository
@@ -25,6 +24,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.rating.*
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.playstore.PlayStoreAndroidUtils
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.usage.app.AppDaysUsedRepository
@@ -48,7 +48,7 @@ class RatingModule {
         appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
         promptTypeDecider: PromptTypeDecider,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
-    ): LifecycleObserver {
+    ): MainProcessLifecycleObserver {
         return AppEnjoymentAppCreationObserver(appEnjoymentPromptEmitter, promptTypeDecider, appCoroutineScope)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.di
 
 import android.content.Context
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.WebDataManager
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
@@ -33,6 +32,7 @@ import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.file.FileDeleter
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.global.view.ClearPersonalDataAction
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.location.GeoLocationPermissions
 import com.duckduckgo.app.location.GeoLocationPermissionsManager
 import com.duckduckgo.app.location.data.LocationPermissionsDao
@@ -107,7 +107,7 @@ object PrivacyModule {
     @IntoSet
     fun dataClearerForegroundAppRestartPixelObserver(
         dataClearerForegroundAppRestartPixel: DataClearerForegroundAppRestartPixel,
-    ): LifecycleObserver = dataClearerForegroundAppRestartPixel
+    ): MainProcessLifecycleObserver = dataClearerForegroundAppRestartPixel
 
     @Provides
     @SingleInstanceIn(AppScope::class)

--- a/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
@@ -17,11 +17,11 @@
 package com.duckduckgo.app.di
 
 import android.content.Context
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.device.ContextDeviceInfo
 import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.app.global.exception.UncaughtExceptionRepository
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.AtbInitializer
 import com.duckduckgo.app.statistics.AtbInitializerListener
 import com.duckduckgo.app.statistics.api.*
@@ -60,7 +60,7 @@ object StatisticsModule {
         statisticsDataStore: StatisticsDataStore,
         statisticsUpdater: StatisticsUpdater,
         listeners: DaggerSet<AtbInitializerListener>,
-    ): LifecycleObserver {
+    ): MainProcessLifecycleObserver {
         return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
@@ -16,13 +16,13 @@
 
 package com.duckduckgo.app.di
 
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStoreSharedPreferences
 import com.duckduckgo.app.global.events.db.AppUserEventsStore
 import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.install.AppInstallSharedPreferences
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.onboarding.store.AppUserStageStore
 import com.duckduckgo.app.onboarding.store.OnboardingSharedPreferences
 import com.duckduckgo.app.onboarding.store.OnboardingStore
@@ -63,7 +63,7 @@ abstract class StoreModule {
 
     @Binds
     @IntoSet
-    abstract fun bindAppInstallStoreObserver(appInstallStore: AppInstallStore): LifecycleObserver
+    abstract fun bindAppInstallStoreObserver(appInstallStore: AppInstallStore): MainProcessLifecycleObserver
 
     @Binds
     abstract fun bindDataClearingStore(store: UnsentForgetAllPixelStoreSharedPreferences): UnsentForgetAllPixelStore
@@ -79,11 +79,11 @@ abstract class StoreModule {
 
     @Binds
     @IntoSet
-    abstract fun bindTabsDbSanitizerObserver(tabsDbSanitizer: TabsDbSanitizer): LifecycleObserver
+    abstract fun bindTabsDbSanitizerObserver(tabsDbSanitizer: TabsDbSanitizer): MainProcessLifecycleObserver
 
     @Binds
     @IntoSet
-    abstract fun bindFavoritesObserver(favoritesObserver: FavoritesObserver): LifecycleObserver
+    abstract fun bindFavoritesObserver(favoritesObserver: FavoritesObserver): MainProcessLifecycleObserver
 
     @Binds
     abstract fun bindWidgetPreferences(store: AppWidgetThemePreferences): WidgetPreferences

--- a/app/src/main/java/com/duckduckgo/app/di/SystemComponentsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/SystemComponentsModule.kt
@@ -18,13 +18,13 @@ package com.duckduckgo.app.di
 
 import android.content.Context
 import android.content.pm.PackageManager
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.fire.FireAnimationLoader
 import com.duckduckgo.app.fire.LottieFireAnimationLoader
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.shortcut.AppShortcutCreator
 import com.duckduckgo.app.icon.api.AppIconModifier
 import com.duckduckgo.app.icon.api.IconModifier
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.systemsearch.DeviceAppListProvider
 import com.duckduckgo.app.systemsearch.DeviceAppLookup
@@ -79,5 +79,5 @@ object SystemComponentsModule {
 abstract class SystemComponentsModuleBindings {
     @Binds
     @IntoSet
-    abstract fun animatorLoaderObserver(fireAnimationLoader: FireAnimationLoader): LifecycleObserver
+    abstract fun animatorLoaderObserver(fireAnimationLoader: FireAnimationLoader): MainProcessLifecycleObserver
 }

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
@@ -22,9 +22,9 @@ import android.content.SharedPreferences
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.intentText
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchActivity
@@ -43,7 +43,7 @@ import timber.log.Timber
 class DataClearerForegroundAppRestartPixel @Inject constructor(
     private val context: Context,
     private val pixel: Pixel,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
     private var detectedUserIntent: Boolean = false
 
     private val pendingAppForegroundRestart: Int

--- a/app/src/main/java/com/duckduckgo/app/fire/LottieFireAnimationLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/LottieFireAnimationLoader.kt
@@ -18,15 +18,15 @@ package com.duckduckgo.app.fire
 
 import android.content.Context
 import androidx.annotation.UiThread
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.airbnb.lottie.LottieCompositionFactory
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-interface FireAnimationLoader : DefaultLifecycleObserver {
+interface FireAnimationLoader : MainProcessLifecycleObserver {
     fun preloadSelectedAnimation()
 }
 

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -16,13 +16,14 @@
 
 package com.duckduckgo.app.global
 
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.duckduckgo.app.browser.BuildConfig
 import com.duckduckgo.app.di.AppComponent
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.DaggerAppComponent
 import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.lifecycle.VpnProcessLifecycleObserver
 import com.duckduckgo.app.referral.AppInstallationReferrerStateListener
 import com.duckduckgo.di.DaggerMap
 import com.duckduckgo.mobile.android.vpn.service.VpnUncaughtExceptionHandler
@@ -34,8 +35,6 @@ import io.reactivex.plugins.RxJavaPlugins
 import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.*
-import logcat.AndroidLogcatLogger
-import logcat.LogPriority
 import org.threeten.bp.zone.ZoneRulesProvider
 import timber.log.Timber
 
@@ -53,7 +52,10 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
     lateinit var referralStateListener: AppInstallationReferrerStateListener
 
     @Inject
-    lateinit var lifecycleObserverPluginPoint: PluginPoint<LifecycleObserver>
+    lateinit var primaryLifecycleObserverPluginPoint: PluginPoint<MainProcessLifecycleObserver>
+
+    @Inject
+    lateinit var vpnLifecycleObserverPluginPoint: PluginPoint<VpnProcessLifecycleObserver>
 
     @Inject
     lateinit var activityLifecycleCallbacks: PluginPoint<com.duckduckgo.app.global.ActivityLifecycleCallbacks>
@@ -74,7 +76,6 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
 
     override fun onMainProcessCreate() {
         configureLogging()
-        AndroidLogcatLogger.installOnDebuggableApp(this, minPriority = LogPriority.VERBOSE)
         Timber.d("onMainProcessCreate $currentProcessName")
 
         configureDependencyInjection()
@@ -84,7 +85,7 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
 
         // Deprecated, we need to move all these into AppLifecycleEventObserver
         ProcessLifecycleOwner.get().lifecycle.apply {
-            lifecycleObserverPluginPoint.getPlugins().forEach {
+            primaryLifecycleObserverPluginPoint.getPlugins().forEach {
                 Timber.d("Registering application lifecycle observer: ${it.javaClass.canonicalName}")
                 addObserver(it)
             }
@@ -96,13 +97,24 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
     }
 
     override fun onSecondaryProcessCreate(shortProcessName: String) {
-        AndroidLogcatLogger.installOnDebuggableApp(this, minPriority = LogPriority.VERBOSE)
+        configureLogging()
         Timber.d("onSecondaryProcessCreate $shortProcessName")
+
         runInSecondaryProcessNamed(VPN_PROCESS_NAME) {
             Timber.d("Init for secondary process $shortProcessName")
             configureDependencyInjection()
             configureUncaughtExceptionHandlerVpn()
             initializeDateLibrary()
+
+            // ProcessLifecycleOwner doesn't know about secondary processes, so the callbacks are our own callbacks and limited to onCreate which
+            // is good enough.
+            // See https://developer.android.com/reference/android/arch/lifecycle/ProcessLifecycleOwner#get
+            ProcessLifecycleOwner.get().lifecycle.apply {
+                vpnLifecycleObserverPluginPoint.getPlugins().forEach {
+                    Timber.d("Registering secondary process lifecycle observer: ${it.javaClass.canonicalName}")
+                    it.onVpnProcessCreated()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -97,9 +97,6 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
     }
 
     override fun onSecondaryProcessCreate(shortProcessName: String) {
-        configureLogging()
-        Timber.d("onSecondaryProcessCreate $shortProcessName")
-
         runInSecondaryProcessNamed(VPN_PROCESS_NAME) {
             Timber.d("Init for secondary process $shortProcessName")
             configureDependencyInjection()
@@ -111,7 +108,6 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
             // See https://developer.android.com/reference/android/arch/lifecycle/ProcessLifecycleOwner#get
             ProcessLifecycleOwner.get().lifecycle.apply {
                 vpnLifecycleObserverPluginPoint.getPlugins().forEach {
-                    Timber.d("Registering secondary process lifecycle observer: ${it.javaClass.canonicalName}")
                     it.onVpnProcessCreated()
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
@@ -21,13 +21,13 @@ import android.content.SharedPreferences
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import timber.log.Timber
 
-interface AppInstallStore : DefaultLifecycleObserver {
+interface AppInstallStore : MainProcessLifecycleObserver {
     var installTimestamp: Long
 
     var widgetInstalled: Boolean

--- a/app/src/main/java/com/duckduckgo/app/global/migrations/MigrationLifecycleObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/migrations/MigrationLifecycleObserver.kt
@@ -16,11 +16,10 @@
 
 package com.duckduckgo.app.global.migrations
 
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.global.plugins.migrations.MigrationPlugin
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -28,13 +27,13 @@ import javax.inject.Inject
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class MigrationLifecycleObserver @Inject constructor(
     private val migrationPluginPoint: PluginPoint<MigrationPlugin>,
     private val migrationStore: MigrationStore,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         val currentVersion = migrationStore.version

--- a/app/src/main/java/com/duckduckgo/app/global/plugin/PrimaryProcessLifecycleObserverPluginPoint.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/plugin/PrimaryProcessLifecycleObserverPluginPoint.kt
@@ -16,13 +16,13 @@
 
 package com.duckduckgo.app.global.plugin
 
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 
 @ContributesPluginPoint(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @Suppress("unused")
-interface LifecycleObserverPluginPoint
+interface PrimaryProcessLifecycleObserverPluginPoint

--- a/app/src/main/java/com/duckduckgo/app/global/plugin/VpnProcessLifecycleObserverPluginPoint.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/plugin/VpnProcessLifecycleObserverPluginPoint.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.plugin
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.app.lifecycle.VpnProcessLifecycleObserver
+import com.duckduckgo.di.scopes.AppScope
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = VpnProcessLifecycleObserver::class,
+)
+@Suppress("unused")
+interface VpnProcessLifecycleObserverPluginPoint

--- a/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserver.kt
@@ -17,10 +17,10 @@
 package com.duckduckgo.app.global.rating
 
 import androidx.annotation.UiThread
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.DefaultDispatcherProvider
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -29,7 +29,7 @@ class AppEnjoymentAppCreationObserver(
     private val promptTypeDecider: PromptTypeDecider,
     private val appCoroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     @UiThread
     override fun onStart(owner: LifecycleOwner) {

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -26,12 +26,11 @@ import androidx.annotation.RequiresApi
 import androidx.annotation.UiThread
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.graphics.drawable.IconCompat
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.bookmarks.ui.BookmarksActivity
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
@@ -47,7 +46,7 @@ import timber.log.Timber
 class AppShortcutCreatorModule {
     @Provides
     @IntoSet
-    fun provideAppShortcutCreatorObserver(appShortcutCreator: AppShortcutCreator, appBuildConfig: AppBuildConfig): LifecycleObserver {
+    fun provideAppShortcutCreatorObserver(appShortcutCreator: AppShortcutCreator, appBuildConfig: AppBuildConfig): MainProcessLifecycleObserver {
         return AppShortcutCreatorLifecycleObserver(appShortcutCreator, appBuildConfig)
     }
 }
@@ -55,7 +54,7 @@ class AppShortcutCreatorModule {
 class AppShortcutCreatorLifecycleObserver(
     private val appShortcutCreator: AppShortcutCreator,
     private val appBuildConfig: AppBuildConfig,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
     @UiThread
     @Suppress("NewApi") // we use appBuildConfig
     override fun onCreate(owner: LifecycleOwner) {

--- a/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
+++ b/app/src/main/java/com/duckduckgo/app/httpsupgrade/HttpsUpgrader.kt
@@ -18,12 +18,11 @@ package com.duckduckgo.app.httpsupgrade
 
 import android.net.Uri
 import androidx.annotation.WorkerThread
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.isHttps
 import com.duckduckgo.app.global.toHttps
 import com.duckduckgo.app.httpsupgrade.store.HttpsFalsePositivesDao
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
@@ -57,7 +56,7 @@ interface HttpsUpgrader {
 )
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class HttpsUpgraderImpl @Inject constructor(
     private val bloomFactory: HttpsBloomFilterFactory,
@@ -65,7 +64,7 @@ class HttpsUpgraderImpl @Inject constructor(
     private val userAllowListDao: UserWhitelistDao,
     private val toggle: FeatureToggle,
     private val https: Https,
-) : HttpsUpgrader, DefaultLifecycleObserver {
+) : HttpsUpgrader, MainProcessLifecycleObserver {
 
     private var bloomFilter: BloomFilter? = null
     private val bloomReloadLock = ReentrantLock()

--- a/app/src/main/java/com/duckduckgo/app/job/AndroidWorkScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/AndroidWorkScheduler.kt
@@ -16,12 +16,11 @@
 
 package com.duckduckgo.app.job
 
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DefaultDispatcherProvider
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.notification.AndroidNotificationScheduler
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -33,7 +32,7 @@ import timber.log.Timber
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class AndroidWorkScheduler @Inject constructor(
@@ -41,7 +40,7 @@ class AndroidWorkScheduler @Inject constructor(
     private val notificationScheduler: AndroidNotificationScheduler,
     private val jobCleaner: JobCleaner,
     private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider(),
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onResume(owner: LifecycleOwner) {
         Timber.v("Scheduling work")

--- a/app/src/main/java/com/duckduckgo/app/job/AppConfigurationSyncer.kt
+++ b/app/src/main/java/com/duckduckgo/app/job/AppConfigurationSyncer.kt
@@ -20,13 +20,12 @@ import android.annotation.SuppressLint
 import androidx.annotation.CheckResult
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
 import com.duckduckgo.app.global.job.AppConfigurationSyncWorkRequestBuilder
 import com.duckduckgo.app.global.job.AppConfigurationSyncWorkRequestBuilder.Companion.APP_CONFIG_SYNC_WORK_TAG
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -47,7 +46,7 @@ class AppConfigurationSyncerModule {
         appConfigurationSyncWorkRequestBuilder: AppConfigurationSyncWorkRequestBuilder,
         workManager: WorkManager,
         appConfigurationDownloader: ConfigurationDownloader,
-    ): LifecycleObserver {
+    ): MainProcessLifecycleObserver {
         return AppConfigurationSyncer(appConfigurationSyncWorkRequestBuilder, workManager, appConfigurationDownloader)
     }
 }
@@ -57,7 +56,7 @@ class AppConfigurationSyncer(
     private val appConfigurationSyncWorkRequestBuilder: AppConfigurationSyncWorkRequestBuilder,
     private val workManager: WorkManager,
     private val appConfigurationDownloader: ConfigurationDownloader,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     @SuppressLint("CheckResult")
     @UiThread

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
@@ -24,12 +24,11 @@ import android.content.Context
 import android.os.Build.VERSION_CODES.O
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationManagerCompat
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.notification.model.Channel
 import com.duckduckgo.app.notification.model.NotificationPlugin
 import com.duckduckgo.app.notification.model.SchedulableNotificationPlugin
@@ -47,7 +46,7 @@ import timber.log.Timber
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class NotificationRegistrar @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
@@ -59,7 +58,7 @@ class NotificationRegistrar @Inject constructor(
     private val schedulableNotificationPluginPoint: PluginPoint<SchedulableNotificationPlugin>,
     private val notificationPluginPoint: PluginPoint<NotificationPlugin>,
     private val appBuildConfig: AppBuildConfig,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     object NotificationId {
         const val ClearData = 100

--- a/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
@@ -17,14 +17,12 @@
 package com.duckduckgo.app.pixels
 
 import android.content.Context
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.browser.WebViewVersionProvider
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.WEBVIEW_VERSION
 import com.duckduckgo.di.scopes.AppScope
@@ -37,7 +35,7 @@ import timber.log.Timber
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class EnqueuedPixelWorker @Inject constructor(
@@ -45,30 +43,27 @@ class EnqueuedPixelWorker @Inject constructor(
     private val pixel: Provider<Pixel>,
     private val unsentForgetAllPixelStore: UnsentForgetAllPixelStore,
     private val webViewVersionProvider: WebViewVersionProvider,
-) : LifecycleEventObserver {
+) : MainProcessLifecycleObserver {
 
     private var launchedByFireAction: Boolean = false
 
-    override fun onStateChanged(
-        source: LifecycleOwner,
-        event: Lifecycle.Event,
-    ) {
-        if (event == Lifecycle.Event.ON_CREATE) {
-            scheduleWorker(workManager)
-            launchedByFireAction = isLaunchByFireAction()
-        } else if (event == Lifecycle.Event.ON_START) {
-            if (launchedByFireAction) {
-                // skip the next on_start if branch
-                Timber.i("Suppressing app launch pixel")
-                launchedByFireAction = false
-                return
-            }
-            Timber.i("Sending app launch pixel")
-            pixel.get().fire(
-                pixel = AppPixelName.APP_LAUNCH,
-                parameters = mapOf(WEBVIEW_VERSION to webViewVersionProvider.getMajorVersion()),
-            )
+    override fun onCreate(owner: LifecycleOwner) {
+        scheduleWorker(workManager)
+        launchedByFireAction = isLaunchByFireAction()
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        if (launchedByFireAction) {
+            // skip the next on_start if branch
+            Timber.i("Suppressing app launch pixel")
+            launchedByFireAction = false
+            return
         }
+        Timber.i("Sending app launch pixel")
+        pixel.get().fire(
+            pixel = AppPixelName.APP_LAUNCH,
+            parameters = mapOf(WEBVIEW_VERSION to webViewVersionProvider.getMajorVersion()),
+        )
     }
 
     private fun isLaunchByFireAction(): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/privacy/cleanup/TrackersDbCleanerScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/cleanup/TrackersDbCleanerScheduler.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.app.privacy.cleanup
 
 import android.content.Context
 import androidx.annotation.WorkerThread
-import androidx.lifecycle.*
+import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -27,6 +27,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.dao.VpnTrackerDao
@@ -49,7 +50,7 @@ class TrackersDbCleanerSchedulerModule {
     @IntoSet
     fun provideDeviceShieldNotificationScheduler(
         workManager: WorkManager,
-    ): LifecycleObserver {
+    ): MainProcessLifecycleObserver {
         return TrackersDbCleanerScheduler(workManager)
     }
 
@@ -57,7 +58,7 @@ class TrackersDbCleanerSchedulerModule {
     fun providesVpnTrackerDao(vpnDatabase: VpnDatabase): VpnTrackerDao = vpnDatabase.vpnTrackerDao()
 }
 
-class TrackersDbCleanerScheduler(private val workManager: WorkManager) : DefaultLifecycleObserver {
+class TrackersDbCleanerScheduler(private val workManager: WorkManager) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         Timber.v("Scheduling Trackers Blocked DB cleaner")

--- a/app/src/main/java/com/duckduckgo/app/surrogates/ResourceSurrogateLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/surrogates/ResourceSurrogateLoader.kt
@@ -18,10 +18,9 @@ package com.duckduckgo.app.surrogates
 
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.surrogates.store.ResourceSurrogateDataStore
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -34,13 +33,13 @@ import timber.log.Timber
 @WorkerThread
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class ResourceSurrogateLoader @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val resourceSurrogates: ResourceSurrogates,
     private val surrogatesDataStore: ResourceSurrogateDataStore,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         appCoroutineScope.launch { loadData() }

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -16,9 +16,9 @@
 
 package com.duckduckgo.app.tabs.db
 
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
@@ -31,7 +31,7 @@ import kotlinx.coroutines.withContext
 class TabsDbSanitizer @Inject constructor(
     private val tabRepository: TabRepository,
     private val dispatchers: DispatcherProvider,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onStart(owner: LifecycleOwner) {
         runBlocking {

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
@@ -18,12 +18,11 @@ package com.duckduckgo.app.trackerdetection
 
 import android.content.Context
 import androidx.annotation.WorkerThread
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.trackerdetection.api.TdsJson
 import com.duckduckgo.app.trackerdetection.db.TdsCnameEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
@@ -42,7 +41,7 @@ import timber.log.Timber
 @WorkerThread
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class TrackerDataLoader @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
@@ -55,7 +54,7 @@ class TrackerDataLoader @Inject constructor(
     private val context: Context,
     private val appDatabase: AppDatabase,
     private val moshi: Moshi,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         appCoroutineScope.launch { loadData() }

--- a/app/src/main/java/com/duckduckgo/app/usage/app/AppDaysUsedRecorder.kt
+++ b/app/src/main/java/com/duckduckgo/app/usage/app/AppDaysUsedRecorder.kt
@@ -16,8 +16,8 @@
 
 package com.duckduckgo.app.usage.app
 
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -25,7 +25,7 @@ import timber.log.Timber
 class AppDaysUsedRecorder(
     private val appDaysUsedRepository: AppDaysUsedRepository,
     private val appCoroutineScope: CoroutineScope,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onStart(owner: LifecycleOwner) {
         appCoroutineScope.launch {

--- a/app/src/main/java/com/duckduckgo/app/usage/di/AppUsageModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/usage/di/AppUsageModule.kt
@@ -16,8 +16,8 @@
 
 package com.duckduckgo.app.usage.di
 
-import androidx.lifecycle.LifecycleObserver
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.usage.app.AppDaysUsedDao
 import com.duckduckgo.app.usage.app.AppDaysUsedDatabaseRepository
 import com.duckduckgo.app.usage.app.AppDaysUsedRecorder
@@ -38,7 +38,7 @@ class AppUsageModule {
     fun appDaysUsedRecorderObserver(
         appDaysUsedRepository: AppDaysUsedRepository,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
-    ): LifecycleObserver {
+    ): MainProcessLifecycleObserver {
         return AppDaysUsedRecorder(appDaysUsedRepository, appCoroutineScope)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/widget/FavoritesObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/FavoritesObserver.kt
@@ -19,10 +19,10 @@ package com.duckduckgo.app.widget
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.bookmarks.model.FavoritesRepository
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.widget.SearchAndFavoritesWidget
 import dagger.SingleInstanceIn
@@ -35,7 +35,7 @@ class FavoritesObserver @Inject constructor(
     context: Context,
     private val favoritesRepository: FavoritesRepository,
     private val appCoroutineScope: CoroutineScope,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     private val instance = AppWidgetManager.getInstance(context)
     private val componentName = ComponentName(context, SearchAndFavoritesWidget::class.java)

--- a/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
@@ -22,10 +22,9 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import android.widget.Toast
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.widget.AppWidgetManagerAddWidgetLauncher.Companion.ACTION_ADD_WIDGET
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -34,12 +33,12 @@ import javax.inject.Inject
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class WidgetAddedReceiver @Inject constructor(
     private val context: Context,
-) : BroadcastReceiver(), DefaultLifecycleObserver {
+) : BroadcastReceiver(), MainProcessLifecycleObserver {
 
     companion object {
         val IGNORE_MANUFACTURERS_LIST = listOf("samsung", "huawei")

--- a/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.pixels
 
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
@@ -49,7 +48,7 @@ class EnqueuedPixelWorkerTest {
     @Test
     fun whenOnCreateAndPendingPixelCountClearDataThenScheduleWorkerToFireMf() {
         whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(2)
-        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
+        enqueuedPixelWorker.onCreate(lifecycleOwner)
 
         verify(workManager).enqueueUniquePeriodicWork(
             eq("com.duckduckgo.pixels.enqueued.worker"),
@@ -61,7 +60,7 @@ class EnqueuedPixelWorkerTest {
     @Test
     fun whenOnCreateAndPendingPixelCountClearDataIsZeroThenDoNotFireMf() {
         whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(0)
-        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
+        enqueuedPixelWorker.onCreate(lifecycleOwner)
 
         verify(pixel, never()).fire(AppPixelName.FORGET_ALL_EXECUTED)
     }
@@ -71,8 +70,8 @@ class EnqueuedPixelWorkerTest {
         whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(1)
         whenever(unsentForgetAllPixelStore.lastClearTimestamp).thenReturn(System.currentTimeMillis())
 
-        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
-        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)
+        enqueuedPixelWorker.onCreate(lifecycleOwner)
+        enqueuedPixelWorker.onStart(lifecycleOwner)
 
         verify(pixel, never()).fire(AppPixelName.APP_LAUNCH)
     }
@@ -82,8 +81,8 @@ class EnqueuedPixelWorkerTest {
         whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(1)
         whenever(webViewVersionProvider.getMajorVersion()).thenReturn("91")
 
-        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
-        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)
+        enqueuedPixelWorker.onCreate(lifecycleOwner)
+        enqueuedPixelWorker.onStart(lifecycleOwner)
 
         verify(pixel).fire(
             AppPixelName.APP_LAUNCH,
@@ -97,9 +96,9 @@ class EnqueuedPixelWorkerTest {
         whenever(unsentForgetAllPixelStore.lastClearTimestamp).thenReturn(System.currentTimeMillis())
         whenever(webViewVersionProvider.getMajorVersion()).thenReturn("91")
 
-        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_CREATE)
-        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)
-        enqueuedPixelWorker.onStateChanged(lifecycleOwner, Lifecycle.Event.ON_START)
+        enqueuedPixelWorker.onCreate(lifecycleOwner)
+        enqueuedPixelWorker.onStart(lifecycleOwner)
+        enqueuedPixelWorker.onStart(lifecycleOwner)
 
         verify(pixel).fire(
             AppPixelName.APP_LAUNCH,

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifierWorker.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifierWorker.kt
@@ -17,8 +17,6 @@
 package com.duckduckgo.cookies.impl.features.firstparty
 
 import android.content.Context
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
@@ -28,6 +26,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.cookies.api.CookiesFeatureName
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
@@ -63,13 +62,13 @@ class FirstPartyCookiesModifierWorker(
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class FirstPartyCookiesModifierWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
     private val toggle: FeatureToggle,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     private val workerRequest = PeriodicWorkRequestBuilder<FirstPartyCookiesModifierWorker>(1, DAYS)
         .addTag(FIRST_PARTY_COOKIES_EXPIRE_WORKER_TAG)

--- a/di/src/main/java/com/duckduckgo/app/lifecycle/MainProcessLifecycleObserver.kt
+++ b/di/src/main/java/com/duckduckgo/app/lifecycle/MainProcessLifecycleObserver.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.lifecycle
+
+import android.annotation.SuppressLint
+import androidx.lifecycle.DefaultLifecycleObserver
+
+@SuppressLint("NoLifecycleObserver")
+interface MainProcessLifecycleObserver : DefaultLifecycleObserver

--- a/di/src/main/java/com/duckduckgo/app/lifecycle/VpnProcessLifecycleObserver.kt
+++ b/di/src/main/java/com/duckduckgo/app/lifecycle/VpnProcessLifecycleObserver.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.lifecycle
+
+interface VpnProcessLifecycleObserver {
+    fun onVpnProcessCreated()
+}

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
@@ -21,11 +21,10 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Environment
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.downloads.api.*
@@ -40,7 +39,7 @@ import timber.log.Timber
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class FileDownloadNotificationActionReceiver @Inject constructor(
@@ -51,7 +50,7 @@ class FileDownloadNotificationActionReceiver @Inject constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val pixel: Pixel,
-) : BroadcastReceiver(), DefaultLifecycleObserver {
+) : BroadcastReceiver(), MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)

--- a/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedWorker.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/FingerprintProtectionSeedWorker.kt
@@ -17,8 +17,6 @@
 package com.duckduckgo.fingerprintprotection.impl
 
 import android.content.Context
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
@@ -28,6 +26,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.fingerprintprotection.store.seed.FingerprintProtectionSeedRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -59,13 +58,13 @@ class FingerprintProtectionSeedWorker(
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class FingerprintProtectionSeedWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
     private val fingerprintProtectionSeedRepository: FingerprintProtectionSeedRepository,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     private val workerRequest = PeriodicWorkRequestBuilder<FingerprintProtectionSeedWorker>(1, DAYS)
         .addTag(FINGERPRINT_PROTECTION_SEED_WORKER_TAG)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserver.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/observers/LocalPrivacyConfigObserver.kt
@@ -18,11 +18,10 @@ package com.duckduckgo.privacy.config.impl.observers
 
 import android.content.Context
 import androidx.annotation.WorkerThread
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.impl.PrivacyConfigPersister
 import com.duckduckgo.privacy.config.impl.R
@@ -39,14 +38,14 @@ import kotlinx.coroutines.launch
 @SingleInstanceIn(AppScope::class)
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class LocalPrivacyConfigObserver @Inject constructor(
     private val context: Context,
     private val privacyConfigPersister: PrivacyConfigPersister,
     @AppCoroutineScope val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         coroutineScope.launch(dispatcherProvider.io()) { loadPrivacyConfig() }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/workers/RemoteConfigDownloadWorker.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/workers/RemoteConfigDownloadWorker.kt
@@ -17,8 +17,6 @@
 package com.duckduckgo.privacy.config.impl.workers
 
 import android.content.Context
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
@@ -28,6 +26,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.impl.PrivacyConfigDownloader
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -62,12 +61,12 @@ class PrivacyConfigDownloadWorker(
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class PrivacyConfigDownloadWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         Timber.v("Scheduling remote config worker")

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigDownloadScheduler.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigDownloadScheduler.kt
@@ -17,14 +17,11 @@
 package com.duckduckgo.remote.messaging.impl
 
 import android.content.Context
-import androidx.lifecycle.Lifecycle.Event
-import androidx.lifecycle.Lifecycle.Event.ON_CREATE
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.util.concurrent.TimeUnit
@@ -57,19 +54,14 @@ class RemoteMessagingConfigDownloadWorker(
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class RemoteMessagingConfigDownloadScheduler @Inject constructor(
     private val workManager: WorkManager,
-) : LifecycleEventObserver {
+) : MainProcessLifecycleObserver {
 
-    override fun onStateChanged(
-        source: LifecycleOwner,
-        event: Event,
-    ) {
-        if (event == ON_CREATE) {
-            scheduleDownload()
-        }
+    override fun onCreate(owner: LifecycleOwner) {
+        scheduleDownload()
     }
 
     private fun scheduleDownload() {

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/AtbInitializer.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/AtbInitializer.kt
@@ -17,9 +17,9 @@
 package com.duckduckgo.app.statistics
 
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import kotlinx.coroutines.CoroutineScope
@@ -41,7 +41,7 @@ class AtbInitializer(
     private val statisticsDataStore: StatisticsDataStore,
     private val statisticsUpdater: StatisticsUpdater,
     private val listeners: Set<AtbInitializerListener>,
-) : DefaultLifecycleObserver {
+) : MainProcessLifecycleObserver {
 
     override fun onResume(owner: LifecycleOwner) {
         appCoroutineScope.launch { initialize() }

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
@@ -17,12 +17,10 @@
 package com.duckduckgo.app.statistics.api
 
 import android.content.Context
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.util.concurrent.TimeUnit
@@ -31,19 +29,14 @@ import timber.log.Timber
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 class OfflinePixelScheduler @Inject constructor(
     private val workManager: WorkManager,
-) : LifecycleEventObserver {
+) : MainProcessLifecycleObserver {
 
-    override fun onStateChanged(
-        source: LifecycleOwner,
-        event: Lifecycle.Event,
-    ) {
-        if (event == Lifecycle.Event.ON_CREATE) {
-            scheduleOfflinePixels()
-        }
+    override fun onCreate(owner: LifecycleOwner) {
+        scheduleOfflinePixels()
     }
 
     private fun scheduleOfflinePixels() {

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelSender.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/PixelSender.kt
@@ -16,10 +16,9 @@
 
 package com.duckduckgo.app.statistics.api
 
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.device.DeviceInfo
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.app.statistics.config.StatisticsLibraryConfig
 import com.duckduckgo.app.statistics.model.PixelEntity
@@ -36,7 +35,7 @@ import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import timber.log.Timber
 
-interface PixelSender : DefaultLifecycleObserver {
+interface PixelSender : MainProcessLifecycleObserver {
     fun sendPixel(
         pixelName: String,
         parameters: Map<String, String>,
@@ -56,7 +55,7 @@ interface PixelSender : DefaultLifecycleObserver {
 )
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
 class RxPixelSender @Inject constructor(

--- a/traces/traces-impl/src/main/java/com/duckduckgo/app/traces/AppStartUpTracer.kt
+++ b/traces/traces-impl/src/main/java/com/duckduckgo/app/traces/AppStartUpTracer.kt
@@ -21,10 +21,8 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.os.Debug
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.traces.api.StartupTraces
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -35,20 +33,15 @@ import javax.inject.Inject
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = LifecycleObserver::class,
+    boundType = MainProcessLifecycleObserver::class,
 )
-class AppStartUpTracer @Inject constructor() : ContentProvider(), LifecycleEventObserver {
+class AppStartUpTracer @Inject constructor() : ContentProvider(), MainProcessLifecycleObserver {
 
     // content provide shall have empty constructor
     private val startupTraces: StartupTraces by lazy { RealStartupTraces(context!!.applicationContext) }
 
-    override fun onStateChanged(
-        source: LifecycleOwner,
-        event: Lifecycle.Event,
-    ) {
-        if (event == Lifecycle.Event.ON_START) {
-            Debug.stopMethodTracing()
-        }
+    override fun onStart(owner: LifecycleOwner) {
+        Debug.stopMethodTracing()
     }
 
     override fun onCreate(): Boolean {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203579111292639/f

### Description
See [asana task](https://app.asana.com/0/488551667048375/1203579111292639/f) for better description

### Steps to test this PR

_Ensure all observers are migrated_
- [x] In this branch, change DuckDuckApplication.kt:55 as follows
```diff
    @Inject
-   lateinit var primaryLifecycleObserverPluginPoint: PluginPoint<MainProcessLifecycleObserver>
+   lateinit var primaryLifecycleObserverPluginPoint: PluginPoint<LifecycleObserver>
```
- [x] In `PrimaryProcessLifecycleObserverPluginPoint` change the following
```diff
@ContributesPluginPoint(
    scope = AppScope::class,
-   boundType = MainProcessLifecycleObserver::class,
+   boundType = LifecycleObserver::class,
)
```
- [x] Build and install
- [x] Launch the app and ensure no log with `Registering application lifecycle observer...` appears
- [x] Undo change in the first step
- [x] build, install and launch the app
- [x] Verify logs for `Registering application lifecycle observer...` appear correctly

_Test VPN process lifecycle_
- [x] install from this branch (no modifications)
- [x] filter logcat by `VPN log|Registering LogcatLogger`
- [x] launch the app
- [x] verify the log `Registering LogcatLogger` appears and the `VPN log` do appear
- [x] enable AppTP
- [x] verify both `Registering LogcatLogger` and the `VPN log` logs appear
- [x] disable AppTP and clear logs
- [x] re-enable AppTP
- [x] verify the log `Registering LogcatLogger` no longer appears however the `VPN log` do appear
