### PR TITLE
Create asana task when nightly workflows fail

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -78,3 +78,14 @@ jobs:
           name: ${{ github.sha }}
           app-file: apk/release.apk
           workspace: .maestro/release_tests
+
+      - name: Create Asana task when workflow failed
+        if: ${{ failure() }}
+        uses: honeycombio/gha-create-asana-task@main
+        with:
+          asana-secret: ${{ secrets.GH_ASANA_SECRET }}
+          asana-workspace-id: ${{ secrets.GH_ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section-id: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-task-name: GH Workflow Failure - End to end tests
+          asana-task-description: The end to end workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,11 +53,9 @@ jobs:
           arguments: jvm_tests
 
       - name: Bundle the JVM checks report
-        if: always()
         run: find . -type d -name 'reports' | zip -@ -r unit-tests-report.zip
 
       - name: Upload the JVM checks report
-        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: unit-tests-report
@@ -127,12 +125,26 @@ jobs:
           arguments: runFlankAndroidTests
 
       - name: Bundle the Android CI tests report
-        if: always()
         run: find . -type d -name 'fladleResults' | zip -@ -r android-tests-report.zip
 
       - name: Upload the Android CI tests report
-        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: android-tests-report
           path: android-tests-report.zip
+
+  create_task_when_failed:
+    name: Create Asana task when workflow failed
+    runs-on: ubuntu-latest
+    needs: [code_formatting, unit_tests, lint, android_tests]
+    if: ${{ failure() }}
+    steps:
+      - name: Create Asana task when workflow failed
+        uses: honeycombio/gha-create-asana-task@main
+        with:
+          asana-secret: ${{ secrets.GH_ASANA_SECRET }}
+          asana-workspace-id: ${{ secrets.GH_ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section-id: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-task-name: GH Workflow Failure - Nightly
+          asana-task-description: The nightly workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -42,12 +42,21 @@ jobs:
           arguments: runFlankPrivacyTests
 
       - name: Bundle the Android CI tests report
-        if: always()
         run: find . -type d -name 'fladleResults' | zip -@ -r android-tests-report.zip
 
       - name: Upload the Android CI tests report
-        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: android-tests-report
           path: android-tests-report.zip
+
+      - name: Create Asana task when workflow failed
+        if: ${{ failure() }}
+        uses: honeycombio/gha-create-asana-task@main
+        with:
+          asana-secret: ${{ secrets.GH_ASANA_SECRET }}
+          asana-workspace-id: ${{ secrets.GH_ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section-id: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-task-name: GH Workflow Failure - Privacy tests
+          asana-task-description: The privacy workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -59,3 +59,15 @@ jobs:
             
             This PR updates the reference tests dependency to the latest available version and copies the necessary files.
             - [ ] All tests must pass
+
+      - name: Create Asana task when workflow failed
+        if: ${{ failure() }}
+        uses: honeycombio/gha-create-asana-task@main
+        with:
+          asana-secret: ${{ secrets.GH_ASANA_SECRET }}
+          asana-workspace-id: ${{ secrets.GH_ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section-id: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-task-name: GH Workflow Failure - Update reference tests
+          asana-task-description: The update reference tests workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203673701090347/f
### Description
This PR creates an Asana task whenever a nightly workflow fails

### Steps to test this PR
For failure examples see:
1. https://github.com/duckduckgo/Android/actions/runs/3875092919 and https://app.asana.com/0/414730916066338/1203675428838182/f
2. https://github.com/duckduckgo/Android/actions/runs/3875095333 and https://app.asana.com/0/414730916066338/1203675149404753/f
