### PR TITLE
Add a fastlane check to release notes length

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,6 +20,7 @@
     releaseNotesFileHiring = "../app/version/release-notes-hiring"
     releaseNotesFileSuffix = "../app/version/release-notes-suffix"
     releaseNotesLocales= ["en-US", "en-GB", "en-CA"]
+    releaseNotesMaxLength = 500
     errorMessageCancelled = "Release cancelled 😢"
     asanaBridgeInstallationProblem = "Android Asana Release Bridge not installed or configured correctly - see https://app.asana.com/0/0/1203116937958001/f for instructions"
 
@@ -35,7 +36,10 @@ platform :android do
     releaseNotesHiring = File.read(releaseNotesFileHiring)
 
     formatted = "#{releaseNotesBodyHeader}\n#{releaseNotesBody}#{releaseNotesHiring}\n\n#{releaseNotesSuffixHeader}\n#{releaseNotesSuffix}"
+
+    validateReleaseNotes(releaseNotes: formatted)
     UI.message("\n#{formatted}")
+
     formatted
 
   end
@@ -230,7 +234,7 @@ platform :android do
             existingReleaseNotes = File.read(releaseNotesFileBody)
 
             # This handles the flow when no options were passed. We will prompt the user for input.
-            if notes_type == nil && custom_release_notes == nil then
+            releaseNotes = if (notes_type == nil && custom_release_notes == nil) then
                 commits = changelog_from_git_commits(
                     between: [last_git_tag, "HEAD"],
                     pretty: "- %s",
@@ -244,7 +248,7 @@ platform :android do
                     "Bug fixes and other improvements",
                     ]
 
-                rl = retrieve_notes_for_type(
+                retrieve_notes_for_type(
                     notes_type: choice,
                     existingReleaseNotes: existingReleaseNotes
                 )
@@ -264,6 +268,17 @@ platform :android do
                     )
                 end
 
+            end
+
+            validateReleaseNotes(releaseNotes: releaseNotes)
+            releaseNotes
+        end
+
+        desc "Validates the release notes to ensure they are suitable for the Play Store"
+        private_lane :validateReleaseNotes do |options|
+            releaseNotesLength = options[:releaseNotes].length
+            if (releaseNotesLength > releaseNotesMaxLength)
+                UI.user_error!("Release notes are too long for Play Store (#{releaseNotesLength} characters). Max size allowed: #{releaseNotesMaxLength}")
             end
         end
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1202728801491382/f

### Description
Adds check in fastlane to ensure release notes aren't bigger than max supported length in Play Store.

The check is triggered from the following lanes:
- `deploy_playstore` (which will call `update_fastlane_release_notes`, which calls `release_notes_playstore`)
- `hotfix-start` (which calls `determine_release_notes`)
- `release` (which calls `determine_release_notes`)

This means Fastlane will fail if the release notes are too long, when you are attempting:
- to construct a release locally using `fastlane release`
- to construct a release using CI (using `fastlane release` with CI providing the release notes)
- to deploy to the Play Store from CI (using `fastlane deploy_playstore`)
- to start a new hotfix (using `fastlane hotfix-start`)

which I think covers all the bases.

### Steps to test this PR

**For ease of testing**
- Change line 231 to make the lane publicly callable `private_lane` --> `lane`

#### Testing when notes are below limit

##### No parameters
- [x] Call `fastlane determine_release_notes` with no parameters. Choose option 1. Verify it finishes successfully
- [x] Call `fastlane determine_release_notes` with no parameters. Choose option 2 and enter short notes. Verify it finishes successfully
- [x] Call `fastlane determine_release_notes` with no parameters. Choose option 3. Verify it finishes successfully

##### With release notes params provided
- [x] Run `fastlane determine_release_notes release_notes:hello`. Verify it finishes successfully


#### Testing when notes are above limit

Modify line 23 to have a really small max length (e.g., 5)

##### No parameters
- [x] Call `fastlane determine_release_notes` with no parameters. Choose option 1. Verify it fails.
- [x] Call `fastlane determine_release_notes` with no parameters. Choose option 2 and longer notes than the max length. Verify it fails.
- [x] Call `fastlane determine_release_notes` with no parameters. Choose option 3. Verify it fails.

##### With release notes params provided
- [x] Run `fastlane determine_release_notes release_notes:HelloWorld`. Verify it fails


#### QA for the other changes
- I wouldn't recommend running `release` or `deploy_playstore` manually to test this out, as it will require stubbing out various lines to make it safe to call
- Instead, recommend sense-checking the changes look good