### PR TITLE
Ensure our app is not mistaken by 3rd party VPN app

### DIFF
--- a/app-tracking-protection/vpn-api-test/src/main/java/com/duckduckgo/mobile/android/vpn/FakeVpnFeaturesRegistry.kt
+++ b/app-tracking-protection/vpn-api-test/src/main/java/com/duckduckgo/mobile/android/vpn/FakeVpnFeaturesRegistry.kt
@@ -33,6 +33,10 @@ class FakeVpnFeaturesRegistry : VpnFeaturesRegistry {
         return features.contains(feature.featureName)
     }
 
+    override fun isAnyFeatureRegistered(): Boolean {
+        return features.isNotEmpty()
+    }
+
     override suspend fun refreshFeature(feature: VpnFeature) {
         // no-op
     }

--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistry.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistry.kt
@@ -44,6 +44,11 @@ interface VpnFeaturesRegistry {
     fun isFeatureRegistered(feature: VpnFeature): Boolean
 
     /**
+     * @return returns `true` if there's any feature currently using the VPN, `false` otherwise
+     */
+    fun isAnyFeatureRegistered(): Boolean
+
+    /**
      * Refreshing the feature will cause the VPN to be stopped/restarted if it is enabled and the feature is already registered.
      */
     suspend fun refreshFeature(feature: VpnFeature)

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
@@ -74,6 +74,10 @@ internal class VpnFeaturesRegistryImpl(
         return registeredFeatures().contains(feature.featureName) && vpnServiceWrapper.isServiceRunning()
     }
 
+    override fun isAnyFeatureRegistered(): Boolean {
+        return registeredFeatures().isNotEmpty() && vpnServiceWrapper.isServiceRunning()
+    }
+
     override suspend fun refreshFeature(feature: VpnFeature) {
         vpnServiceWrapper.restartVpnService(forceRestart = false)
     }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/network/RealVpnDetector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/network/RealVpnDetector.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
@@ -28,9 +29,13 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 class RealVpnDetector @Inject constructor(
     private val context: Context,
+    private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : VpnDetector {
 
     override fun isVpnDetected(): Boolean {
+        // if we're the ones using the VPN, no VPN is detected
+        if (vpnFeaturesRegistry.isAnyFeatureRegistered()) return false
+
         val connectivityManager = context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val activeNetwork = connectivityManager.activeNetwork
         return connectivityManager.getNetworkCapabilities(activeNetwork)?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ?: false

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImplTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImplTest.kt
@@ -79,6 +79,28 @@ class VpnFeaturesRegistryImplTest {
     }
 
     @Test
+    fun whenIsAnyFeatureRegisteredAndFeaturesAreNotRegisteredThenReturnFalse() {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+    }
+
+    @Test
+    fun whenIsAnyFeatureRegisteredAndFeaturesAreRegisteredThenReturnTrue() {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+
+        assertTrue(vpnFeaturesRegistry.isAnyFeatureRegistered())
+        assertTrue(vpnServiceWrapper.isServiceRunning())
+    }
+
+    @Test
+    fun whenIsAnyFeatureRegisteredAndFeaturesAreRegisteredAndVpnDisabledThenReturnFalse() {
+        vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
+        vpnServiceWrapper.stopService()
+
+        assertFalse(vpnFeaturesRegistry.isAnyFeatureRegistered())
+        assertFalse(vpnServiceWrapper.isServiceRunning())
+    }
+
+    @Test
     fun whenUnregisterFeatureThenFeatureIsUnregistered() {
         vpnFeaturesRegistry.registerFeature(TestVpnFeatures.FOO)
         vpnFeaturesRegistry.unregisterFeature(TestVpnFeatures.FOO)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203683437079065/f

### Description
Ensure our app is not mistakenly recognise as 3rd party VPN app using the VPN slot.


Please see the [asana task](https://app.asana.com/0/488551667048375/1203683437079065/f) for more context

### Steps to test this PR

- [ ] install 3rd party VPN app
- [ ] install from this branch
- [ ] enable appTP (through onboarding)
- [ ] disable AppTP
- [ ] enable the 3rd party VPN app
- [ ] enable appTP
- [ ] verify the conflict dialog "Your VPN app may be disconnected..." shows
- [ ] verify the "additional tests" under the [asana task](https://app.asana.com/0/488551667048375/1203683437079065/f) pass as well
