### PR TITLE
Fix for webUrl detection for local named computers

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/global/UriStringTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/UriStringTest.kt
@@ -293,4 +293,29 @@ class UriStringTest {
     fun whenGivenNumberThenIsWebUrlIsFalse() {
         assertFalse(isWebUrl("33"))
     }
+
+    @Test
+    fun whenNamedLocalMachineWithSchemeAndPortThenIsTrue() {
+        assertTrue(isWebUrl("http://raspberrypi:8080"))
+    }
+
+    @Test
+    fun whenNamedLocalMachineWithNoSchemeAndPortThenIsFalse() {
+        assertFalse(isWebUrl("raspberrypi:8080"))
+    }
+
+    @Test
+    fun whenNamedLocalMachineWithSchemeNoPortThenIsTrue() {
+        assertTrue(isWebUrl("http://raspberrypi"))
+    }
+
+    @Test
+    fun whenStartsWithSiteSpecificSearchThenIsFalse() {
+        assertFalse(isWebUrl("site:example.com"))
+    }
+
+    @Test
+    fun whenSchemeIsValidFtpButNotHttpThenNot() {
+        assertFalse(isWebUrl("ftp://example.com"))
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203568844801448/f

### Description
Tweaks the logic used to determine if an inputted query is a web URL or not; better handling for a query like `http://raspberrypi` or `http://raspberry:8080` (has a scheme, does not have a TLD) to navigate rather than search.

### Steps to test this PR

- [ ] Input `http://raspberry` in the omnibar; verify it tries to **navigate** to this
- [ ] Input `http://raspberry:8080` in the omnibar; verify it tries to **navigate** to this
- [ ] Input `https://raspberry:8080` in the omnibar; verify it tries to **navigate** to this
- [ ] Input `192.168.0.100`; verify it tries to **navigate**
- [ ] Input `http://192.168.0.100`; verify it tries to **navigate**
- [ ] Input `192.168.0.100`; verify it tries to **navigate**
- [ ] Input `raspberry` in the omnibar; verify it performs a **search**
- [ ] Input `ftp://raspberrypi`; verify it says it can't handle this type of link

- [ ] Repeat any of the above tests you can from an external app link. e.g., write a text message containing the link and open the link in our browser; verifying the behaviour is still correct when coming from an external app
