### PR TITLE
Remove AppTP waitlist notification channel

### DIFF
--- a/app-tracking-protection/vpn-impl/lint-baseline.xml
+++ b/app-tracking-protection/vpn-impl/lint-baseline.xml
@@ -1794,17 +1794,6 @@
 
     <issue
         id="UnusedResources"
-        message="The resource `R.string.atp_WaitlistActivityWaitlistTitle` appears to be unused"
-        errorLine1="    &lt;string name=&quot;atp_WaitlistActivityWaitlistTitle&quot;>App Tracking Protection waitlist&lt;/string>"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings-vpn.xml"
-            line="249"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
         message="The resource `R.string.atp_WaitlistNotificationTitle` appears to be unused"
         errorLine1="    &lt;string name=&quot;atp_WaitlistNotificationTitle&quot;>Your App Tracking Protection Invitation is Here!&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">

--- a/app-tracking-protection/vpn-impl/src/main/res/values-bg/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-bg/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection работи на Вашето устройство и не изпраща личните Ви данни от устройството към DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Списък с чакащи за App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Вашата покана за App Tracking Protection пристигна!</string>
     <string name="atp_WaitlistNotificationDescription">Присъединихте се към списъка с чакащи и поискахте да Ви уведомим, когато дойде Вашият ред да изпробвате нашата функция App Tracking Protection. Докоснете, за да видите поканата.</string>
     <string name="atp_WaitlistStatusNotJoined">Една лесна стъпка за подобряване на поверителността в приложенията!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-cs/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-cs/strings-vpn.xml
@@ -254,7 +254,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection funguje ve tvém zařízení a neodesílá osobní údaje ze zařízení do služby DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Čekací seznam App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Tvoje pozvánka do App Tracking Protection je tady!</string>
     <string name="atp_WaitlistNotificationDescription">Přidal(a) ses na seznam čekajících a požádal(a) nás, abychom tě upozornili, až budeš na řadě a budeš moct vyzkoušet App Tracking Protection. Klepnutím zobrazíš pozvánku.</string>
     <string name="atp_WaitlistStatusNotJoined">Jeden snadný krok pro větší soukromí v aplikacích!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-da/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-da/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection fungerer på din enhed og sender ikke dine personlige data fra din enhed til DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Venteliste til App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Her er din invitation til App Tracking Protection!</string>
     <string name="atp_WaitlistNotificationDescription">Du her tilmeldt dig ventelisten og bad os om at give dig besked, når det er din tur til at prøve App Tracking Protection. Tryk for at se din invitation.</string>
     <string name="atp_WaitlistStatusNotJoined">Et nemt skridt mod at få bedre privatliv i apps!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-de/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-de/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection arbeitet auf deinem Gerät und sendet deine persönlichen Daten nicht von deinem Gerät an DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Warteliste für App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Deine Einladung zu App Tracking Protection ist da!</string>
     <string name="atp_WaitlistNotificationDescription">Du hast dich auf die Warteliste setzen lassen und uns darum gebeten, dich zu benachrichtigen, wenn auch du App Tracking Protection testen kannst. Tippe hier, um deine Einladung zu öffnen.</string>
     <string name="atp_WaitlistStatusNotJoined">Ein einfacher Schritt für mehr Datenschutz in Apps!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-el/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-el/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">Η Προστασία παρακολούθησης από εφαρμογές λειτουργεί στη συσκευή σας και δεν αποστέλλει τα προσωπικά δεδομένα σας εκτός της συσκευής σας, στο DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Λίστα αναμονής για την Προστασία παρακολούθησης από εφαρμογές</string>
     <string name="atp_WaitlistNotificationTitle">Η πρόσκλησή σας για την Προστασία παρακολούθησης από εφαρμογές είναι εδώ!</string>
     <string name="atp_WaitlistNotificationDescription">Εγγραφήκατε στη λίστα αναμονής και μας ζητήσατε να σας ενημερώσουμε για το πότε θα είναι η σειρά σας να δοκιμάσετε τη λειτουργία μας Προστασία παρακολούθησης από εφαρμογές. Πατήστε για να δείτε την πρόσκλησή σας.</string>
     <string name="atp_WaitlistStatusNotJoined">Ένα εύκολο βήμα για καλύτερο απόρρητο των εφαρμογών!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-es/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-es/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection funciona en tu dispositivo y no envía los datos personales de tu dispositivo a DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Lista de espera de App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">¡Tu invitación a App Tracking Protection ya está aquí!</string>
     <string name="atp_WaitlistNotificationDescription">Te has unido a la lista de espera y nos has pedido que te avisemos cuando te toque probar nuestra función App Tracking Protection. Toca para ver tu invitación.</string>
     <string name="atp_WaitlistStatusNotJoined">¡Un sencillo paso para mejorar la privacidad de las aplicaciones!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-et/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-et/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">Rakenduse jälgimise kaitse töötab seadmes ja ei saada sinu isikuandmeid seadmest välja DuckDuckGo\'le.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Rakenduse jälgimise kaitse ootenimekiri</string>
     <string name="atp_WaitlistNotificationTitle">Sinu rakenduse jälgimise kaitse kutse on siin.</string>
     <string name="atp_WaitlistNotificationDescription">Liitusid ootenimekirjaga ja palusid meil sind teavitada, kui on sinu kord proovida meie rakenduse jälgimise kaitse funktsiooni. Kutse vaatamiseks puuduta siin.</string>
     <string name="atp_WaitlistStatusNotJoined">Üks lihtne samm parema rakenduse privaatsuse saavutamiseks.</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-fi/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-fi/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection toimii laitteessasi, eikä lähetä henkilökohtaisia tietojasi laitteeltasi DuckDuckGolle.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">App Tracking Protection -jonotuslista</string>
     <string name="atp_WaitlistNotificationTitle">App Tracking Protection -kutsusi on täällä!</string>
     <string name="atp_WaitlistNotificationDescription">Liityit odotuslistalle ja pyysit meitä ilmoittamaan, kun on sinun vuorosi kokeilla App Tracking Protection -ominaisuuttamme. Näytä kutsu napauttamalla.</string>
     <string name="atp_WaitlistStatusNotJoined">Yksi helppo askel kohti parempaa sovellusten tietosuojaa!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-fr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-fr/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection fonctionne localement et ne transmet pas les données personnelles de votre appareil à DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Liste d\'attente d\'App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Vous avez reçu une invitation à essayer App Tracking Protection !</string>
     <string name="atp_WaitlistNotificationDescription">Vous vous étiez inscrit(e) sur la liste d\'attente et souhaitiez savoir quand vous pourriez tester notre fonctionnalité App Tracking Protection. Appuyez pour voir votre invitation.</string>
     <string name="atp_WaitlistStatusNotJoined">Un geste simple pour mieux préserver la confidentialité des applications !</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-hr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-hr/strings-vpn.xml
@@ -254,7 +254,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection radi na tvom uređaju i ne šalje tvoje osobne podatke s tvog uređaja DuckDuckGou.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Lista čekanja za zaštitu od praćenja aplikacija - App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Tvoja pozivnica za App Tracking Protection je ovdje!</string>
     <string name="atp_WaitlistNotificationDescription">Pridružio si se listi čekanja i zatražio da te obavijestimo kada dođeš na red za isprobavanje naše značajke App Tracking Protection. Dodirni za prikaz svoje pozivnice.</string>
     <string name="atp_WaitlistStatusNotJoined">Jedan jednostavan korak za bolju privatnost aplikacija!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-hu/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-hu/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">Az alkalmazáskövetés elleni védelem a készülékeden működik, és nem küld személyes adatokat a készülékedről a DuckDuckGónak.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Alkalmazáskövetés elleni védelem várólistája</string>
     <string name="atp_WaitlistNotificationTitle">Megérkezett az alkalmazáskövetés elleni védelmi meghívója!</string>
     <string name="atp_WaitlistNotificationDescription">Feliratkoztál a várólistára, és arra kértél minket, hogy értesítsünk, amikor rád kerül a sor, hogy kipróbálhasd az alkalmazáskövetés elleni védelmi funkciót. Koppints a meghívó megtekintéséhez.</string>
     <string name="atp_WaitlistStatusNotJoined">Egyetlen egyszerű lépés az alkalmazások jobb védelme érdekében!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-it/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-it/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection funziona sul tuo dispositivo e non invia i tuoi dati personali dal tuo dispositivo a DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Lista d\'attesa App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Il tuo invito App Tracking Protection è arrivato.</string>
     <string name="atp_WaitlistNotificationDescription">Hai effettuato l\'iscrizione alla lista d\'attesa e ci hai chiesto di avvisarti quando sarà il tuo turno di provare la nostra funzionalità App Tracking Protection. Tocca per visualizzare l\'invito.</string>
     <string name="atp_WaitlistStatusNotJoined">Un passaggio semplice per migliorare la privacy delle app!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-lt/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-lt/strings-vpn.xml
@@ -254,7 +254,6 @@
     <string name="atp_FAQSixthText">Apsauga nuo programėlių sekimo veikia jūsų prietaise ir nesiunčia jūsų asmeninių duomenų iš prietaiso į „DuckDuckGo“.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Apsaugos nuo programėlių sekimo laukiančiųjų sąrašas</string>
     <string name="atp_WaitlistNotificationTitle">Jūsų apsaugos nuo programėlių sekimo kvietimas yra čia!</string>
     <string name="atp_WaitlistNotificationDescription">Jūs prisijungėte prie laukimo sąrašo ir paprašėte mūsų informuoti jus, kai ateis eilė išbandyti mūsų el. pašto apsaugos funkciją. Bakstelėkite norėdami peržiūrėti savo kvietimą.</string>
     <string name="atp_WaitlistStatusNotJoined">Vienas paprastas žingsnis siekiant geresnio programos privatumo!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-lv/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-lv/strings-vpn.xml
@@ -248,7 +248,6 @@
     <string name="atp_FAQSixthText">Lietotņu pretizsekošanas aizsardzība darbojas tavā ierīcē un nesūta tavus personiskos datus no ierīces uz DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Lietotņu pretizsekošanas aizsardzības gaidīšanas saraksts</string>
     <string name="atp_WaitlistNotificationTitle">Tavs Lietotņu pretizsekošanas aizsardzības ielūgums ir klāt!</string>
     <string name="atp_WaitlistNotificationDescription">Tu pievienojies gaidīšanas sarakstam un lūdzi mūs informēt, kad pienāks tava kārta izmēģināt mūsu Lietotņu pretizsekošanas aizsardzības funkciju. Pieskaries, lai skatītu savu uzaicinājumu.</string>
     <string name="atp_WaitlistStatusNotJoined">Viens vienkāršs solis labākam lietotņu privātumam!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-nb/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-nb/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection kjører på enheten og sender ikke personopplysninger fra enheten til DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Venteliste for App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Invitasjonen til App Tracking Protection er kommet!</string>
     <string name="atp_WaitlistNotificationDescription">Du satte deg på ventelisten og ba oss om å varsle deg når det var din tur til å prøve App Tracking Protection-funksjonen. Trykk for se invitasjonen din.</string>
     <string name="atp_WaitlistStatusNotJoined">Ett enkelt trinn til bedre personvern for apper!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-nl/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-nl/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection werkt op je apparaat en stuurt je persoonlijke gegevens niet van je apparaat naar DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Wachtlijst voor App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Je hebt een uitnodiging voor App Tracking Protection ontvangen!</string>
     <string name="atp_WaitlistNotificationDescription">Je hebt je ingeschreven voor de wachtlijst en ons gevraagd je te laten weten wanneer je aan de beurt bent om onze functie App Tracking Protection uit te proberen. Tik om je uitnodiging te bekijken.</string>
     <string name="atp_WaitlistStatusNotJoined">Eén eenvoudige stap voor meer privacy in apps!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-pl/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-pl/strings-vpn.xml
@@ -254,7 +254,6 @@
     <string name="atp_FAQSixthText">Ochrona przed śledzeniem przez aplikacje działa na Twoim urządzeniu i nie wysyła Twoich danych osobowych poza urządzenie do DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Lista oczekujących na ochronę przed śledzeniem przez aplikacje</string>
     <string name="atp_WaitlistNotificationTitle">Oto Twoje zaproszenie do ochrony przed śledzeniem przez aplikacje!</string>
     <string name="atp_WaitlistNotificationDescription">Jesteś już na liście oczekujących i powiadomimy Cię, gdy nadejdzie Twoja kolej na wypróbowanie funkcji ochrony przed śledzeniem przez aplikacje. Dotknij, aby wyświetlić swoje zaproszenie.</string>
     <string name="atp_WaitlistStatusNotJoined">Jeden prosty krok ku większej ochronie prywatności w aplikacjach!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-pt/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-pt/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">A App Tracking Protection funciona no teu dispositivo e não envia informações pessoais para o DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Lista de espera da App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Aqui está o teu convite para a App Tracking Protection!</string>
     <string name="atp_WaitlistNotificationDescription">Entraste na lista de espera e pediste para te notificarmos quando puderes experimentar a funcionalidade App Tracking Protection. Toca para veres o teu convite.</string>
     <string name="atp_WaitlistStatusNotJoined">Um passo simples para melhorar a privacidade das aplicações!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-ro/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-ro/strings-vpn.xml
@@ -248,7 +248,6 @@
     <string name="atp_FAQSixthText">Protecția împotriva urmăririi de către aplicație funcționează pe dispozitivul tău și nu trimite datele tale personale de pe dispozitiv către DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Lista de așteptare pentru Protecția împotriva urmăririi de către aplicație</string>
     <string name="atp_WaitlistNotificationTitle">Invitația ta pentru Protecția împotriva urmăririi de către aplicație este aici!</string>
     <string name="atp_WaitlistNotificationDescription">Te-ai alăturat listei de așteptare și ne-ai solicitat să te anunțăm când este rândul tău să încerci funcția noastră de protecție a comunicațiilor prin e-mail. Atinge pentru a vizualiza invitația ta.</string>
     <string name="atp_WaitlistStatusNotJoined">Un pas ușor pentru o mai bună confidențialitate a aplicațiilor!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-ru/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-ru/strings-vpn.xml
@@ -254,7 +254,6 @@
     <string name="atp_FAQSixthText">Защита от слежки работает на вашем устройстве и не передает ваши личные данные в DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Очередь на защиту от слежки</string>
     <string name="atp_WaitlistNotificationTitle">Вы получили приглашение воспользоваться защитой от слежки!</string>
     <string name="atp_WaitlistNotificationDescription">Ранее вы просили добавить вас в список ожидания, чтобы мы сообщили, когда вам станет доступна защита от слежки. Нажмите, чтобы открыть приглашение.</string>
     <string name="atp_WaitlistStatusNotJoined">Один простой шаг для надежной защиты данных!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-sk/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-sk/strings-vpn.xml
@@ -254,7 +254,6 @@
     <string name="atp_FAQSixthText">Ochrana pred sledovaním aplikácií funguje vo vašom zariadení a neodosiela vaše osobné údaje zo zariadenia do DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Zoznam čakateľov na ochranu pred sledovaním aplikácií</string>
     <string name="atp_WaitlistNotificationTitle">Vaša pozvánka na ochranu pred sledovaním aplikácie je tu!</string>
     <string name="atp_WaitlistNotificationDescription">Pridali ste sa na zoznam čakateľov a požiadali ste nás, aby sme vás upozornili, keď na vás príde rad a budete si môcť vyskúšať našu ochranu e‑mailu. Klepnutím zobrazíte vašu pozvánku.</string>
     <string name="atp_WaitlistStatusNotJoined">Jeden jednoduchý krok pre lepšie súkromie aplikácie!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-sl/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-sl/strings-vpn.xml
@@ -254,7 +254,6 @@
     <string name="atp_FAQSixthText">Zaščita pred sledenjem aplikacijam App Tracking Protection deluje v vaši napravi in vaših osebnih podatkov ne pošilja iz naprave v DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Čakalna lista za zaščito pred sledenjem aplikacijam App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Vaše povabilo za zaščito pred sledenjem aplikacijam App Tracking Protection je tu!</string>
     <string name="atp_WaitlistNotificationDescription">Pridružili ste se čakalnemu seznamu in prosili, da vas obvestimo, ko boste na vrsti za preizkus naše funkcije zaščite e-pošte. Dotaknite se za ogled vabila.</string>
     <string name="atp_WaitlistStatusNotJoined">En enostaven korak za boljšo zasebnost aplikacij!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-sv/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-sv/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection fungerar på din enhet och skickar inte dina personuppgifter från enheten till DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Väntelista för App Tracking Protection</string>
     <string name="atp_WaitlistNotificationTitle">Din inbjudan till App Tracking Protection är här!</string>
     <string name="atp_WaitlistNotificationDescription">Du ställde dig på väntelistan och bad oss meddela dig när det har blivit din tur att testa funktionen App Tracking Protection. Tryck för att visa din inbjudan.</string>
     <string name="atp_WaitlistStatusNotJoined">Ett enkelt steg för bättre appintegritet!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-tr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-tr/strings-vpn.xml
@@ -242,7 +242,6 @@
     <string name="atp_FAQSixthText">Uygulama İzleme Koruması, cihazınızda çalışır ve kişisel verilerinizi cihazınızdan DuckDuckGo\'ya göndermez.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">Uygulama İzleme Koruması bekleme listesi</string>
     <string name="atp_WaitlistNotificationTitle">Uygulama İzleme Koruması Davetiyeniz Burada!</string>
     <string name="atp_WaitlistNotificationDescription">Bekleme listesine katılarak Uygulama İzleme Koruması özelliğini deneme sırası size geldiğinde sizi bilgilendirmemizi istediniz. Davetiyenizi görüntülemek için dokunun.</string>
     <string name="atp_WaitlistStatusNotJoined">Daha iyi uygulama gizliliği için tek bir kolay adım!</string>

--- a/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
@@ -245,7 +245,6 @@
     <string name="atp_FAQSixthText">App Tracking Protection works on your device and doesn’t send your personal data off your device to DuckDuckGo.</string>
 
     <!--  App Tracking Protection Waitlist -->
-    <string name="atp_WaitlistActivityWaitlistTitle">App Tracking Protection waitlist</string>
     <string name="atp_WaitlistNotificationTitle">Your App Tracking Protection Invitation is Here!</string>
     <string name="atp_WaitlistNotificationDescription">You joined the waitlist and asked us to notify you when it\'s your turn to try our App Tracking Protection feature. Tap to view your invitation.</string>
     <string name="atp_WaitlistStatusNotJoined">One easy step for better app privacy!</string>

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
@@ -37,7 +37,6 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.R as VpnR
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -65,7 +64,6 @@ class NotificationRegistrar @Inject constructor(
         const val PrivacyProtection = 101
         const val Article = 103 // 102 was used for the search notification hence using 103 moving forward
         const val AppFeature = 104
-        const val EmailWaitlist = 106 // 105 was used for the UOA notification
     }
 
     object ChannelType {
@@ -73,11 +71,6 @@ class NotificationRegistrar @Inject constructor(
             "com.duckduckgo.tutorials",
             R.string.notificationChannelTutorials,
             NotificationManagerCompat.IMPORTANCE_DEFAULT,
-        )
-        val APP_TP_WAITLIST = Channel(
-            "com.duckduckgo.apptp",
-            VpnR.string.atp_WaitlistActivityWaitlistTitle,
-            NotificationManagerCompat.IMPORTANCE_HIGH,
         )
         // Do not add new channels here, instead follow https://app.asana.com/0/1125189844152671/1201842645469204
     }
@@ -99,7 +92,6 @@ class NotificationRegistrar @Inject constructor(
 
     private val channels = listOf(
         ChannelType.TUTORIALS,
-        ChannelType.APP_TP_WAITLIST,
     )
 
     private fun registerApp() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203701902138004/f

### Description
Remove the unused AppTP waitlist notification channel

### Steps to test this PR

_Before_
- [ ] install application from develop
- [ ] long press on app icon and go to App info -> notifications
- [ ] "app Tracking Protection waitlist" notification channel should appear

_After_
- [ ] install application from develop
- [ ] long press on app icon and go to App info -> notifications
- [ ] "app Tracking Protection waitlist" notification channel should NOT appear
