### PR TITLE
Reveal password in DaxTextInput when editing

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
@@ -97,7 +97,14 @@ class DaxTextInput @JvmOverloads constructor(
 
             binding.internalEditText.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
                 if (hasFocus) {
-                    showKeyboard()
+                    if (isPassword) {
+                        showPassword()
+                    }
+                    binding.internalEditText.showKeyboard()
+                } else {
+                    if (isPassword) {
+                        hidePassword()
+                    }
                 }
             }
 
@@ -174,17 +181,28 @@ class DaxTextInput @JvmOverloads constructor(
             }
         }
         binding.internalPasswordIcon.setOnClickListener {
-            isPasswordShown = !isPasswordShown
             if (isPasswordShown) {
-                binding.internalPasswordIcon.setImageResource(R.drawable.ic_password_hide)
-                binding.internalEditText.inputType = EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE
-                binding.internalEditText.transformationMethod = null
+                hidePassword()
             } else {
-                binding.internalPasswordIcon.setImageResource(R.drawable.ic_password_show)
-                binding.internalEditText.inputType = EditorInfo.TYPE_TEXT_VARIATION_PASSWORD
-                binding.internalEditText.transformationMethod = transformationMethod
+                showPassword()
             }
         }
+    }
+
+    private fun showPassword() {
+        isPasswordShown = true
+        binding.internalPasswordIcon.setImageResource(R.drawable.ic_password_hide)
+        binding.internalEditText.inputType = EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE
+        binding.internalEditText.transformationMethod = null
+        binding.internalEditText.setSelection(binding.internalEditText.length())
+    }
+
+    private fun hidePassword() {
+        isPasswordShown = false
+        binding.internalPasswordIcon.setImageResource(R.drawable.ic_password_show)
+        binding.internalEditText.inputType = EditorInfo.TYPE_TEXT_VARIATION_PASSWORD
+        binding.internalEditText.transformationMethod = transformationMethod
+        binding.internalEditText.setSelection(binding.internalEditText.length())
     }
 
     private fun setupTextMode(inputType: Type) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201131549756894/f

### Description
Automatically reveals the password when editing the password field, which uses the `DaxInputText` view.

### Steps to test this PR

- [x] save a login credential
- [x] visit the credential management screen, tap on the login to view details
- [x] verify the password is concealed by default
- [x] tap on the field; verify it doesn't reveal the password
- [x] tap on the hide/show password toggle; verify it correctly toggles on and off as it should
- [x] edit the credential and tap on the password field; verify it reveals the password if it was previously hidden
- [x] tap on another field; verify the password field is concealed