### PR TITLE
Flag our internal password field as unimportant for autofill

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.autofill.ui.credential.management.viewing
 
 import android.graphics.drawable.BitmapDrawable
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -138,6 +140,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
         requireActivity().addMenuProvider(this)
         observeViewModel()
         configureUiEventHandlers()
+        disableSystemAutofillServiceOnPasswordField()
         initialiseToolbar()
     }
 
@@ -307,6 +310,12 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
         if (processed) {
             Timber.v("Processed command $command")
             viewModel.commandProcessed(command)
+        }
+    }
+
+    private fun disableSystemAutofillServiceOnPasswordField() {
+        if (VERSION.SDK_INT >= VERSION_CODES.O) {
+            binding.passwordEditText.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203722243925031/f

### Description
Prevents our internal edittext field used for passwords from triggering the os-level autofill service.

### Steps to test this PR
- Hard to reproduce this, so sanity check the change makes sense is ok
