### PR TITLE
Ignore same entity CNAMEs

### DIFF
--- a/app/src/androidTest/resources/reference_tests/domain_matching_tests.json
+++ b/app/src/androidTest/resources/reference_tests/domain_matching_tests.json
@@ -134,8 +134,7 @@
                 "requestType": "script",
                 "expectAction": "ignore",
                 "exceptPlatforms": [
-                    "ios-browser",
-                    "android-browser"
+                    "ios-browser"
                 ]
             },
             {

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetector.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.trackerdetection
 
 import android.net.Uri
+import com.duckduckgo.app.global.UrlScheme
 import com.duckduckgo.app.trackerdetection.db.TdsCnameEntityDao
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -41,6 +42,11 @@ class CloakedCnameDetectorImpl @Inject constructor(
                 Timber.v("$host is a CNAME cloaked host. Uncloaked host name: $uncloakedHostName")
                 url.path?.let { path ->
                     uncloakedHostName += path
+                }
+                uncloakedHostName = if (url.scheme != null) {
+                    "${url.scheme}://$uncloakedHostName"
+                } else {
+                    "${UrlScheme.http}://$uncloakedHostName"
                 }
                 return uncloakedHostName
             }

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetectorImplTest.kt
@@ -48,7 +48,15 @@ class CloakedCnameDetectorImplTest {
     fun whenDetectCnameAndCnameDetectedThenReturnUncloakedHost() {
         whenever(mockUri.host).thenReturn("host.com")
         whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
-        assertEquals("uncloaked-host.com", testee.detectCnameCloakedHost(mockUri))
+        assertEquals("http://uncloaked-host.com", testee.detectCnameCloakedHost(mockUri))
+    }
+
+    @Test
+    fun whenDetectCnameAndCnameDetectedAndHasSchemeThenReturnUncloakedHostWithScheme() {
+        whenever(mockUri.host).thenReturn("host.com")
+        whenever(mockUri.scheme).thenReturn("https")
+        whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
+        assertEquals("https://uncloaked-host.com", testee.detectCnameCloakedHost(mockUri))
     }
 
     @Test
@@ -63,6 +71,15 @@ class CloakedCnameDetectorImplTest {
         whenever(mockUri.host).thenReturn("host.com")
         whenever(mockUri.path).thenReturn("/path")
         whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
-        assertEquals("uncloaked-host.com/path", testee.detectCnameCloakedHost(mockUri))
+        assertEquals("http://uncloaked-host.com/path", testee.detectCnameCloakedHost(mockUri))
+    }
+
+    @Test
+    fun whenDetectCnameAndCnameDetectedAndHasSchemeAndPathThenReturnUncloakedHostWithSchemeAndPathAppended() {
+        whenever(mockUri.host).thenReturn("host.com")
+        whenever(mockUri.path).thenReturn("/path")
+        whenever(mockUri.scheme).thenReturn("https")
+        whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
+        assertEquals("https://uncloaked-host.com/path", testee.detectCnameCloakedHost(mockUri))
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203532296782616/f

### Description
This PR: 
- Appends the scheme of the request URL when a CNAME tracker is detected
- Enables the corresponding domain reference test to ignore same entity CNAME trackers

### Steps to test this PR
- [ ] All domain reference tests should pass