### PR TITLE
Update reference tests to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.4.1",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.3.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1673617287"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1673957896"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -84,7 +84,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#4fdbbb6641703f96dcad5d2d9dfee439cf8edd54",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#8e8e1bf5eb2f6e384aad0bf13261ad4f149ba9f9",
       "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1139,8 +1139,8 @@
       "from": "@duckduckgo/privacy-dashboard@github:duckduckgo/privacy-dashboard#1.3.0"
     },
     "@duckduckgo/privacy-reference-tests": {
-      "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#4fdbbb6641703f96dcad5d2d9dfee439cf8edd54",
-      "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#1673617287"
+      "version": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#8e8e1bf5eb2f6e384aad0bf13261ad4f149ba9f9",
+      "from": "@duckduckgo/privacy-reference-tests@github:duckduckgo/privacy-reference-tests#1673957896"
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.1.1",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#3.4.1",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.3.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1673617287"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1673957896"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [ ] All tests must pass