### PR TITLE
Implementation task: Add pixel (updated to use OS version)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
@@ -35,7 +35,8 @@ class WelcomePageModule {
         context: Context,
         pixel: Pixel,
         defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
-    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialog)
+        appBuildConfig: AppBuildConfig,
+    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialog, appBuildConfig)
 
     @Provides
     fun defaultRoleBrowserDialog(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
 
@@ -32,6 +33,7 @@ class DefaultBrowserPageViewModel @Inject constructor(
     private val defaultBrowserDetector: DefaultBrowserDetector,
     private val pixel: Pixel,
     private val installStore: AppInstallStore,
+    private val appBuildConfig: AppBuildConfig,
 ) : ViewModel() {
 
     sealed class ViewState {
@@ -171,6 +173,7 @@ class DefaultBrowserPageViewModel @Inject constructor(
             val params = mapOf(
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to originValue,
+                Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to appBuildConfig.isAndroid13OrAbove().toString(),
             )
             pixel.fire(AppPixelName.DEFAULT_BROWSER_SET, params)
         } else {
@@ -195,6 +198,8 @@ class DefaultBrowserPageViewModel @Inject constructor(
             viewState.value = createViewState
         }
     }
+
+    private fun AppBuildConfig.isAndroid13OrAbove(): Boolean = sdkInt >= android.os.Build.VERSION_CODES.TIRAMISU
 
     companion object {
         const val MAX_DIALOG_ATTEMPTS = 2

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -33,6 +34,7 @@ class WelcomePageViewModel(
     private val context: Context,
     private val pixel: Pixel,
     private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
+    private val appBuildConfig: AppBuildConfig,
 ) : ViewModel() {
 
     fun reduce(event: WelcomePageView.Event): Flow<WelcomePageView.State> {
@@ -64,7 +66,10 @@ class WelcomePageViewModel(
 
         pixel.fire(
             AppPixelName.DEFAULT_BROWSER_SET,
-            mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString()),
+            mapOf(
+                Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
+                Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to appBuildConfig.isAndroid13OrAbove().toString(),
+            ),
         )
 
         emit(WelcomePageView.State.Finish)
@@ -77,11 +82,16 @@ class WelcomePageViewModel(
 
         pixel.fire(
             AppPixelName.DEFAULT_BROWSER_NOT_SET,
-            mapOf(Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString()),
+            mapOf(
+                Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
+                Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to appBuildConfig.isAndroid13OrAbove().toString(),
+            ),
         )
 
         emit(WelcomePageView.State.Finish)
     }
+
+    private fun AppBuildConfig.isAndroid13OrAbove(): Boolean = sdkInt >= android.os.Build.VERSION_CODES.TIRAMISU
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -90,6 +100,7 @@ class WelcomePageViewModelFactory(
     private val context: Context,
     private val pixel: Pixel,
     private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
+    private val appBuildConfig: AppBuildConfig,
 ) : ViewModelProvider.NewInstanceFactory() {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -100,6 +111,7 @@ class WelcomePageViewModelFactory(
                     context,
                     pixel,
                     defaultRoleBrowserDialog,
+                    appBuildConfig,
                 )
                 else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -63,6 +63,7 @@ interface Pixel {
         const val SHOWED_BOOKMARKS = "sb"
         const val DEFAULT_BROWSER_BEHAVIOUR_TRIGGERED = "bt"
         const val DEFAULT_BROWSER_SET_FROM_ONBOARDING = "fo"
+        const val DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE = "os_version_13_or_above"
         const val DEFAULT_BROWSER_SET_ORIGIN = "dbo"
         const val CTA_SHOWN = "cta"
         const val SERP_QUERY_CHANGED = "1"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203712351528765/f

### Description
Added `os_version_13_or_above` param for `m_db_s` and `m_db_ns` pixels fired from onboarding only.

### Steps to test this PR

Android 13 

- Scenario: Set DDG as default browser from obnoarding
- [x] Fresh install from this branch.
- [x] Look at the logs and filter by `Pixel sent: m_db_s with params`.
- [x] Start onboarding and notice the `Set DDG as default browser`. Choose to set it.
- [x] Check that you see in the logs `Pixel sent: m_db_s with params: {fo=true, os_version_13_or_above=true}`.


- Scenario: Set DDG as browser from Settings
- [x] Go to the Settings screen from the menu.
- [x] Notice the `Set as Default Browser` toggle is ON. Toggle OFF / choose a different default browser and go back.
- [x] Change the toggle to ON and set DDG as default browser. 
- [x] Check that you see in the logs `Pixel sent: m_db_s with params: {fo=false}`.


- Scenario: Don't set DDG as default browser from obnoarding
- [x] Fresh install from this branch.
- [x] Look at the logs and filter by `Pixel sent: m_db_ns with params`.
- [x] Start onboarding and notice the `Set DDG as default browser`. Choose and set any other browser as default.
- [x] Check that you see in the logs `Pixel sent: m_db_ns with params: {fo=true, os_version_13_or_above=true}`.


Any version strictly below Android 13

- Scenario: Set DDG as default browser from obnoarding
- [x] Fresh install from this branch.
- [x] Look at the logs and filter by `Pixel sent: m_db_s with params`.
- [x] Start onboarding and notice the `Set DDG as default browser`. Choose to set it.
- [x] Check that you see in the logs `Pixel sent: m_db_s with params: {fo=true, dbo=d, os_version_13_or_above=false}`.


- Scenario: Set DDG as browser from Settings
- [x] Go to the Settings screen from the menu.
- [x] Notice the `Set as Default Browser` toggle is ON. Toggle OFF / choose a different default browser and go back.
- [x] Change the toggle to ON and set DDG as default browser. 
- [x] Check that you see in the logs `Pixel sent: m_db_s with params: {fo=false}`.


- Scenario: Don't set DDG as default browser from obnoarding
- [x] Fresh install from this branch.
- [x] Look at the logs and filter by `Pixel sent: m_db_ns with params`.
- [x] Start onboarding and notice the `Set DDG as default browser`. Choose and set any other browser as default.
- [x] Check that you see in the logs `Pixel sent: m_db_ns with params: {fo=true, os_version_13_or_above=false}`.

### NO UI changes
