### PR TITLE
Default Browser on Launch

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ ext {
 }
 
 android {
-    ndkVersion '21.0.6113669'
+    ndkVersion '21.4.7075529'
     defaultConfig {
         applicationId "com.duckduckgo.mobile.android"
         minSdk min_sdk

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -184,6 +184,8 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
             Timber.i("Automatic data clearer not yet finished, so deferring processing of intent")
             lastIntent = intent
         }
+
+        viewModel.launchFromThirdParty()
     }
 
     private fun initializeServiceWorker() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.BrowserViewModel.Command.Refresh
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.rating.ui.AppEnjoymentDialogFragment
 import com.duckduckgo.app.browser.rating.ui.GiveFeedbackDialogFragment
@@ -36,6 +37,7 @@ import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
 import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.di.scopes.ActivityScope
@@ -53,6 +55,7 @@ class BrowserViewModel @Inject constructor(
     private val dataClearer: DataClearer,
     private val appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
     private val appEnjoymentUserEventRecorder: AppEnjoymentUserEventRecorder,
+    private val defaultBrowserDetector: DefaultBrowserDetector,
     private val dispatchers: DispatcherProvider,
     private val pixel: Pixel,
 ) : AppEnjoymentDialogFragment.Listener,
@@ -155,6 +158,13 @@ class BrowserViewModel @Inject constructor(
     suspend fun onOpenFavoriteFromWidget(query: String) {
         pixel.fire(AppPixelName.APP_FAVORITES_ITEM_WIDGET_LAUNCH)
         tabRepository.selectByUrlOrNewTab(queryUrlConverter.convertQueryToUrl(query))
+    }
+
+    fun launchFromThirdParty() {
+        pixel.fire(
+            AppPixelName.APP_THIRD_PARTY_LAUNCH,
+            mapOf(PixelParameter.DEFAULT_BROWSER to defaultBrowserDetector.isDefaultBrowser().toString()),
+        )
     }
 
     suspend fun onTabsUpdated(tabs: List<TabEntity>?) {

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -75,6 +75,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     APP_EMPTY_VIEW_WIDGET_LAUNCH(pixelName = "m_sfew_l"),
     APP_ASSIST_LAUNCH(pixelName = "m_a_l"),
     APP_SYSTEM_SEARCH_BOX_LAUNCH(pixelName = "m_ssb_l"),
+    APP_THIRD_PARTY_LAUNCH(pixelName = "m_third_party_launch"),
     INTERSTITIAL_LAUNCH_BROWSER_QUERY(pixelName = "m_i_lbq"),
     INTERSTITIAL_LAUNCH_DEVICE_APP(pixelName = "m_i_sda"),
     INTERSTITIAL_LAUNCH_DAX(pixelName = "m_i_ld"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
@@ -21,9 +21,11 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.browser.WebViewVersionProvider
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.DEFAULT_BROWSER
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.WEBVIEW_VERSION
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -43,6 +45,7 @@ class EnqueuedPixelWorker @Inject constructor(
     private val pixel: Provider<Pixel>,
     private val unsentForgetAllPixelStore: UnsentForgetAllPixelStore,
     private val webViewVersionProvider: WebViewVersionProvider,
+    private val defaultBrowserDetector: DefaultBrowserDetector,
 ) : MainProcessLifecycleObserver {
 
     private var launchedByFireAction: Boolean = false
@@ -62,7 +65,10 @@ class EnqueuedPixelWorker @Inject constructor(
         Timber.i("Sending app launch pixel")
         pixel.get().fire(
             pixel = AppPixelName.APP_LAUNCH,
-            parameters = mapOf(WEBVIEW_VERSION to webViewVersionProvider.getMajorVersion()),
+            parameters = mapOf(
+                WEBVIEW_VERSION to webViewVersionProvider.getMajorVersion(),
+                DEFAULT_BROWSER to defaultBrowserDetector.isDefaultBrowser().toString(),
+            ),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
 import com.duckduckgo.app.browser.WebViewVersionProvider
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import org.junit.Before
@@ -32,6 +33,7 @@ class EnqueuedPixelWorkerTest {
     private val unsentForgetAllPixelStore: UnsentForgetAllPixelStore = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
     private val webViewVersionProvider: WebViewVersionProvider = mock()
+    private val defaultBrowserDetector: DefaultBrowserDetector = mock()
 
     private lateinit var enqueuedPixelWorker: EnqueuedPixelWorker
 
@@ -42,6 +44,7 @@ class EnqueuedPixelWorkerTest {
             { pixel },
             unsentForgetAllPixelStore,
             webViewVersionProvider,
+            defaultBrowserDetector,
         )
     }
 
@@ -80,13 +83,17 @@ class EnqueuedPixelWorkerTest {
     fun whenOnStartAndAppLaunchThenSendAppLaunchPixel() {
         whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(1)
         whenever(webViewVersionProvider.getMajorVersion()).thenReturn("91")
+        whenever(defaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
 
         enqueuedPixelWorker.onCreate(lifecycleOwner)
         enqueuedPixelWorker.onStart(lifecycleOwner)
 
         verify(pixel).fire(
             AppPixelName.APP_LAUNCH,
-            mapOf(Pixel.PixelParameter.WEBVIEW_VERSION to "91"),
+            mapOf(
+                Pixel.PixelParameter.WEBVIEW_VERSION to "91",
+                Pixel.PixelParameter.DEFAULT_BROWSER to "false",
+            ),
         )
     }
 
@@ -95,6 +102,7 @@ class EnqueuedPixelWorkerTest {
         whenever(unsentForgetAllPixelStore.pendingPixelCountClearData).thenReturn(1)
         whenever(unsentForgetAllPixelStore.lastClearTimestamp).thenReturn(System.currentTimeMillis())
         whenever(webViewVersionProvider.getMajorVersion()).thenReturn("91")
+        whenever(defaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
 
         enqueuedPixelWorker.onCreate(lifecycleOwner)
         enqueuedPixelWorker.onStart(lifecycleOwner)
@@ -102,7 +110,10 @@ class EnqueuedPixelWorkerTest {
 
         verify(pixel).fire(
             AppPixelName.APP_LAUNCH,
-            mapOf(Pixel.PixelParameter.WEBVIEW_VERSION to "91"),
+            mapOf(
+                Pixel.PixelParameter.WEBVIEW_VERSION to "91",
+                Pixel.PixelParameter.DEFAULT_BROWSER to "false",
+            ),
         )
     }
 }

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -76,6 +76,7 @@ interface Pixel {
         const val LAST_USED_DAY = "duck_address_last_used"
         const val WEBVIEW_VERSION = "webview_version"
         const val OS_VERSION = "os_version"
+        const val DEFAULT_BROWSER = "default_browser"
     }
 
     object PixelValues {


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1174433894299346/1203763177144100

### Description
This PR modifies the launch pixel to understand if we are the default browser, and creates a new pixel to be launched when another app opens us.

### Steps to test this PR

_App Launch_
- [x] Fresh install
- [x] Filter logs by `Pixel sent: ml with params.`
- [x] Check that you see in the logs `Pixel sent: ml with params: {params: {webview_version=X, default_browser=false}`.
- [x] Set browser as default
- [x] Force close the app and open it up again
- [x] Check that you see in the logs `Pixel sent: ml with params: {params: {webview_version=X, default_browser=true}`.

_Third party launch (as default browser)_
- [x] Browser as default
- [x] Filter logs by `Pixel sent: m_third_party_launch with params.`
- [x] Open any web link in another app  (Twitter for example)
- [x] DDG should open
- [x] Check that you see in the logs `Pixel sent: m_third_party_launch with params: {params: { default_browser=true}`.

_Third party launch (as default browser)_
- [x] Browser not as default
- [x] Filter logs by `Pixel sent: m_third_party_launch with params.`
- [x] Identify a web link and "Open In" selecting DuckDuckGo
- [x] DDG should open
- [x] Check that you see in the logs `Pixel sent: m_third_party_launch with params: {params: { default_browser=false}`.
