### PR TITLE
Check if CNAME request URL is in allow list

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
@@ -617,7 +617,7 @@ class WebViewRequestInterceptorTest {
 
         val uri = "host.com".toUri()
         whenever(mockRequest.url).thenReturn(uri)
-        whenever(mockCloakedCnameDetector.detectCnameCloakedHost(any())).thenReturn(null)
+        whenever(mockCloakedCnameDetector.detectCnameCloakedHost(anyString(), any())).thenReturn(null)
 
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -626,7 +626,7 @@ class WebViewRequestInterceptorTest {
             webViewClientListener = null,
         )
 
-        verify(mockCloakedCnameDetector).detectCnameCloakedHost(uri)
+        verify(mockCloakedCnameDetector).detectCnameCloakedHost("foo.com", uri)
         assertRequestCanContinueToLoad(response)
     }
 
@@ -638,7 +638,7 @@ class WebViewRequestInterceptorTest {
 
         val uri = "host.com".toUri()
         whenever(mockRequest.url).thenReturn(uri)
-        whenever(mockCloakedCnameDetector.detectCnameCloakedHost(any())).thenReturn("uncloaked-host.com")
+        whenever(mockCloakedCnameDetector.detectCnameCloakedHost(anyString(), any())).thenReturn("uncloaked-host.com")
 
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -647,7 +647,7 @@ class WebViewRequestInterceptorTest {
             webViewClientListener = null,
         )
 
-        verify(mockCloakedCnameDetector).detectCnameCloakedHost(uri)
+        verify(mockCloakedCnameDetector).detectCnameCloakedHost("foo.com", uri)
         assertRequestCanContinueToLoad(response)
     }
 
@@ -657,7 +657,7 @@ class WebViewRequestInterceptorTest {
 
         val uri = "host.com".toUri()
         whenever(mockRequest.url).thenReturn(uri)
-        whenever(mockCloakedCnameDetector.detectCnameCloakedHost(any())).thenReturn("uncloaked-host.com")
+        whenever(mockCloakedCnameDetector.detectCnameCloakedHost(anyString(), any())).thenReturn("uncloaked-host.com")
 
         val response = testee.shouldIntercept(
             request = mockRequest,
@@ -666,7 +666,7 @@ class WebViewRequestInterceptorTest {
             webViewClientListener = null,
         )
 
-        verify(mockCloakedCnameDetector).detectCnameCloakedHost(uri)
+        verify(mockCloakedCnameDetector).detectCnameCloakedHost("foo.com", uri)
         assertCancelledResponse(response)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -170,7 +170,7 @@ class DomainsReferenceTest(private val testCase: TestCase) {
             gpc = mockGpc,
             userAgentProvider = userAgentProvider,
             adClickManager = mockAdClickManager,
-            cloakedCnameDetector = CloakedCnameDetectorImpl(tdsCnameEntityDao),
+            cloakedCnameDetector = CloakedCnameDetectorImpl(tdsCnameEntityDao, mockTrackerAllowlist),
             requestFilterer = mockRequestFilterer,
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
@@ -167,7 +167,7 @@ class WebViewRequestInterceptor(
             trackingEvent.status == TrackerStatus.ALLOWED ||
             trackingEvent.status == TrackerStatus.SAME_ENTITY_ALLOWED
         ) {
-            cloakedCnameDetector.detectCnameCloakedHost(request.url)?.let { uncloakedHost ->
+            cloakedCnameDetector.detectCnameCloakedHost(documentUrl, request.url)?.let { uncloakedHost ->
                 trackingEvent(request, documentUrl, webViewClientListener, false, uncloakedHost)?.let { cloakedTrackingEvent ->
                     if (cloakedTrackingEvent.status == TrackerStatus.BLOCKED) {
                         return blockRequest(cloakedTrackingEvent, request, webViewClientListener)

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetector.kt
@@ -20,22 +20,26 @@ import android.net.Uri
 import com.duckduckgo.app.global.UrlScheme
 import com.duckduckgo.app.trackerdetection.db.TdsCnameEntityDao
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.TrackerAllowlist
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
 import timber.log.Timber
 
 interface CloakedCnameDetector {
-    fun detectCnameCloakedHost(url: Uri): String?
+    fun detectCnameCloakedHost(documentUrl: String?, url: Uri): String?
 }
 
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class CloakedCnameDetectorImpl @Inject constructor(
     private val tdsCnameEntityDao: TdsCnameEntityDao,
+    private val trackerAllowlist: TrackerAllowlist,
 ) : CloakedCnameDetector {
 
-    override fun detectCnameCloakedHost(url: Uri): String? {
+    override fun detectCnameCloakedHost(documentUrl: String?, url: Uri): String? {
+        if (documentUrl != null && trackerAllowlist.isAnException(documentUrl, url.toString())) return null
+
         url.host?.let { host ->
             tdsCnameEntityDao.get(host)?.let { cnameEntity ->
                 var uncloakedHostName = cnameEntity.uncloakedHostName

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetectorImplTest.kt
@@ -19,10 +19,12 @@ package com.duckduckgo.app.trackerdetection
 import android.net.Uri
 import com.duckduckgo.app.trackerdetection.db.TdsCnameEntityDao
 import com.duckduckgo.app.trackerdetection.model.TdsCnameEntity
+import com.duckduckgo.privacy.config.api.TrackerAllowlist
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -31,24 +33,25 @@ class CloakedCnameDetectorImplTest {
 
     private lateinit var testee: CloakedCnameDetector
     private val mockCnameEntityDao: TdsCnameEntityDao = mock()
+    private val mockTrackerAllowList: TrackerAllowlist = mock()
     private val mockUri: Uri = mock()
 
     @Before
     fun setup() {
-        testee = CloakedCnameDetectorImpl(mockCnameEntityDao)
+        testee = CloakedCnameDetectorImpl(mockCnameEntityDao, mockTrackerAllowList)
     }
 
     @Test
     fun whenDetectCnameAndHostIsNullThenReturnNull() {
         whenever(mockUri.host).thenReturn(null)
-        assertNull(testee.detectCnameCloakedHost(mockUri))
+        assertNull(testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
     @Test
     fun whenDetectCnameAndCnameDetectedThenReturnUncloakedHost() {
         whenever(mockUri.host).thenReturn("host.com")
         whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
-        assertEquals("http://uncloaked-host.com", testee.detectCnameCloakedHost(mockUri))
+        assertEquals("http://uncloaked-host.com", testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
     @Test
@@ -56,14 +59,14 @@ class CloakedCnameDetectorImplTest {
         whenever(mockUri.host).thenReturn("host.com")
         whenever(mockUri.scheme).thenReturn("https")
         whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
-        assertEquals("https://uncloaked-host.com", testee.detectCnameCloakedHost(mockUri))
+        assertEquals("https://uncloaked-host.com", testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
     @Test
     fun whenDetectCnameAndCnameNotDetectedThenReturnNull() {
         whenever(mockUri.host).thenReturn("host.com")
         whenever(mockCnameEntityDao.get(any())).thenReturn(null)
-        assertEquals(null, testee.detectCnameCloakedHost(mockUri))
+        assertEquals(null, testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
     @Test
@@ -71,7 +74,7 @@ class CloakedCnameDetectorImplTest {
         whenever(mockUri.host).thenReturn("host.com")
         whenever(mockUri.path).thenReturn("/path")
         whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
-        assertEquals("http://uncloaked-host.com/path", testee.detectCnameCloakedHost(mockUri))
+        assertEquals("http://uncloaked-host.com/path", testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
     @Test
@@ -80,6 +83,12 @@ class CloakedCnameDetectorImplTest {
         whenever(mockUri.path).thenReturn("/path")
         whenever(mockUri.scheme).thenReturn("https")
         whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
-        assertEquals("https://uncloaked-host.com/path", testee.detectCnameCloakedHost(mockUri))
+        assertEquals("https://uncloaked-host.com/path", testee.detectCnameCloakedHost("foo.com", mockUri))
+    }
+
+    @Test
+    fun whenRequestUrlIsInAllowListThenReturnNull() {
+        whenever(mockTrackerAllowList.isAnException(anyString(), anyString())).thenReturn(true)
+        assertEquals(null, testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203771754388225/f

### Description
Checks the request URL against the tracker allow-list before doing CNAME detection.

### Steps to test this PR
- [ ] ~From develop, go to https://accounts.nintendo.com.~
- [ ] ~The page should be blank.~ (This page will load correctly on develop now that https://github.com/duckduckgo/privacy-configuration/pull/634 has been merged).
- [x] Check out this branch.
- [x] Go to https://accounts.nintendo.com.
- [x] The page should load correctly.

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20230119_132147](https://user-images.githubusercontent.com/3471025/213454085-bb33a1e1-6435-4d9e-9778-32dd7bca278d.png)|![Screenshot_20230119_132406](https://user-images.githubusercontent.com/3471025/213454112-bca59610-0499-4114-aea2-55a83655bee4.png)
