### PR TITLE
Fix internal dev interceptor

### DIFF
--- a/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/plugins/ApiDevPrivacyConfigInterceptor.kt
+++ b/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/plugins/ApiDevPrivacyConfigInterceptor.kt
@@ -44,11 +44,10 @@ class ApiDevPrivacyConfigInterceptor @Inject constructor(
 
         if (url.toString().contains(PRIVACY_REMOTE_CONFIG_URL) && canUrlBeChanged) {
             request.url(storedUrl!!)
-        } else {
-            request.url(PRIVACY_REMOTE_CONFIG_URL)
+            return chain.proceed(request.build())
         }
 
-        return chain.proceed(request.build())
+        return chain.proceed(chain.request())
     }
 
     override fun getInterceptor(): Interceptor {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203779625126900/f 

### Description
Fixed bug affecting nightlies and internal builds caused by interceptor overriding all request URLs.
Related to: https://github.com/duckduckgo/Android/pull/2650

### Steps to test this PR

_Feature 1_
- [x] Install from the internal flavour, this should not be available in other flavour
- [x] Go to settings -> developer settings -> Override Privacy Remote Config URL
- [x] Toggle by default should be false
- [x] Enable the toggle 
- [x] Enter a valid URL 
- [x] Mesage should be removed
- [x] Restart the app so the new config can be download
- [x] Check the new config has been saved
- [x] ➡️ Ensure no other requests are affected

_Test download_
- [x] open the app
- [x] search for "cats"
- [x] go to Images
- [x] choose one of the images and long press on it
- [x] choose to download the image
- [x] download succeeeds