### PR TITLE
Fix favorites popup menu still showing after reorder drag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/favorites/FavoritesQuickAccessAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favorites/FavoritesQuickAccessAdapter.kt
@@ -161,6 +161,7 @@ class FavoritesQuickAccessAdapter(
                 onMenuItemClicked(view.findViewById(R.id.delete)) { onDeleteClicked(item) }
             }
             popupMenu.showAnchoredToView(binding.root, anchor)
+            this.popupMenu = popupMenu
         }
 
         override fun onDragStarted() {


### PR DESCRIPTION
Task/Issue URL: N/A

### Description

Fixes an issue where the popup menu on favorites items would not dismiss after reorder drag. The `popupMenu` variable is now assigned in the `showOverflowMenu` function.

### Steps to test this PR

Run on device/emulator.

### UI changes

| Before  | After |
| ------ | ----- |
| ![before](https://user-images.githubusercontent.com/12491712/214262075-04d23bb4-6ce3-467e-8dba-36ad934e342e.gif) | ![after](https://user-images.githubusercontent.com/12491712/214262134-2c108978-3818-4e15-8fce-9ae4e748f814.gif) |
