### PR TITLE
Honour autofill flag

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -420,7 +420,7 @@ class BrowserTabViewModelTest {
             userStageStore = mockUserStageStore,
             tabRepository = mockTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
-            duckDuckGoUrlDetector = DuckDuckGoUrlDetector(),
+            duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),
             appTheme = mockAppTheme,
         )
 
@@ -441,7 +441,7 @@ class BrowserTabViewModelTest {
         testee = BrowserTabViewModel(
             statisticsUpdater = mockStatisticsUpdater,
             queryUrlConverter = mockOmnibarConverter,
-            duckDuckGoUrlDetector = DuckDuckGoUrlDetector(),
+            duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),
             siteFactory = siteFactory,
             tabRepository = mockTabRepository,
             userWhitelistDao = mockUserWhitelistDao,

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -23,7 +23,7 @@ import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.InstantSchedulersRule
-import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
@@ -156,7 +156,7 @@ class CtaViewModelTest {
             userStageStore = mockUserStageStore,
             tabRepository = mockTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
-            duckDuckGoUrlDetector = DuckDuckGoUrlDetector(),
+            duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),
             appTheme = mockAppTheme,
         )
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/email/EmailInjectorJsTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/EmailInjectorJsTest.kt
@@ -22,7 +22,7 @@ import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.autofill.FileBasedJavascriptInjector
 import com.duckduckgo.app.autofill.JavascriptInjector
-import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.autofill.api.Autofill
@@ -45,7 +45,14 @@ class EmailInjectorJsTest {
     @Before
     fun setup() {
         testee =
-            EmailInjectorJs(mockEmailManager, DuckDuckGoUrlDetector(), mockDispatcherProvider, mockFeatureToggle, javascriptInjector, mockAutofill)
+            EmailInjectorJs(
+                mockEmailManager,
+                DuckDuckGoUrlDetectorImpl(),
+                mockDispatcherProvider,
+                mockFeatureToggle,
+                javascriptInjector,
+                mockAutofill,
+            )
 
         whenever(mockFeatureToggle.isFeatureEnabled(AutofillFeatureName.Autofill.value)).thenReturn(true)
         whenever(mockAutofill.isAnException(any())).thenReturn(false)

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
@@ -19,25 +19,28 @@ package com.duckduckgo.app.browser
 import android.net.Uri
 import com.duckduckgo.app.global.AppUrl
 import com.duckduckgo.app.global.AppUrl.ParamKey
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
-class DuckDuckGoUrlDetector @Inject constructor() {
+@ContributesBinding(AppScope::class)
+class DuckDuckGoUrlDetectorImpl @Inject constructor() : DuckDuckGoUrlDetector {
 
-    fun isDuckDuckGoEmailUrl(url: String): Boolean {
+    override fun isDuckDuckGoEmailUrl(url: String): Boolean {
         val uri = url.toUri()
         val firstSegment = uri.pathSegments.firstOrNull()
         return isDuckDuckGoUrl(url) && firstSegment == AppUrl.Url.EMAIL_SEGMENT
     }
 
-    fun isDuckDuckGoUrl(uri: String): Boolean {
-        return AppUrl.Url.HOST == uri.toUri().host
+    override fun isDuckDuckGoUrl(url: String): Boolean {
+        return AppUrl.Url.HOST == url.toUri().host
     }
 
-    fun isDuckDuckGoQueryUrl(uri: String): Boolean {
+    override fun isDuckDuckGoQueryUrl(uri: String): Boolean {
         return isDuckDuckGoUrl(uri) && hasQuery(uri)
     }
 
-    fun isDuckDuckGoStaticUrl(uri: String): Boolean {
+    override fun isDuckDuckGoStaticUrl(uri: String): Boolean {
         return isDuckDuckGoUrl(uri) && matchesStaticPage(uri)
     }
 
@@ -53,12 +56,12 @@ class DuckDuckGoUrlDetector @Inject constructor() {
         return uri.toUri().queryParameterNames.contains(ParamKey.QUERY)
     }
 
-    fun extractQuery(uriString: String): String? {
+    override fun extractQuery(uriString: String): String? {
         val uri = uriString.toUri()
         return uri.getQueryParameter(ParamKey.QUERY)
     }
 
-    fun isDuckDuckGoVerticalUrl(uri: String): Boolean {
+    override fun isDuckDuckGoVerticalUrl(uri: String): Boolean {
         return isDuckDuckGoUrl(uri) && hasVertical(uri)
     }
 
@@ -66,7 +69,7 @@ class DuckDuckGoUrlDetector @Inject constructor() {
         return uri.toUri().queryParameterNames.contains(ParamKey.VERTICAL)
     }
 
-    fun extractVertical(uriString: String): String? {
+    override fun extractVertical(uriString: String): String? {
         val uri = uriString.toUri()
         return uri.getQueryParameter(ParamKey.VERTICAL)
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
@@ -44,7 +44,7 @@ class DuckDuckGoRequestRewriterTest {
     fun before() {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.DEFAULT_VARIANT)
         whenever(mockAppReferrerDataStore.installedFromEuAuction).thenReturn(false)
-        testee = DuckDuckGoRequestRewriter(DuckDuckGoUrlDetector(), mockStatisticsStore, mockVariantManager, mockAppReferrerDataStore)
+        testee = DuckDuckGoRequestRewriter(DuckDuckGoUrlDetectorImpl(), mockStatisticsStore, mockVariantManager, mockAppReferrerDataStore)
         builder = Uri.Builder()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
@@ -29,7 +29,7 @@ class DuckDuckGoUrlDetectorTest {
 
     @Before
     fun setup() {
-        testee = DuckDuckGoUrlDetector()
+        testee = DuckDuckGoUrlDetectorImpl()
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -37,7 +37,12 @@ class QueryUrlConverterTest {
     private var mockStatisticsStore: StatisticsDataStore = mock()
     private val variantManager: VariantManager = mock()
     private val mockAppReferrerDataStore: AppReferrerDataStore = mock()
-    private val requestRewriter = DuckDuckGoRequestRewriter(DuckDuckGoUrlDetector(), mockStatisticsStore, variantManager, mockAppReferrerDataStore)
+    private val requestRewriter = DuckDuckGoRequestRewriter(
+        DuckDuckGoUrlDetectorImpl(),
+        mockStatisticsStore,
+        variantManager,
+        mockAppReferrerDataStore,
+    )
     private val testee: QueryUrlConverter = QueryUrlConverter(requestRewriter)
 
     @Before

--- a/app/src/test/java/com/duckduckgo/app/email/EmailJavascriptInterfaceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/email/EmailJavascriptInterfaceTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.app.email
 import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
 import com.duckduckgo.autofill.api.Autofill
 import com.duckduckgo.autofill.api.AutofillFeatureName
 import com.duckduckgo.feature.toggles.api.FeatureToggle
@@ -54,7 +54,7 @@ class EmailJavascriptInterfaceTest {
         testee = EmailJavascriptInterface(
             mockEmailManager,
             mockWebView,
-            DuckDuckGoUrlDetector(),
+            DuckDuckGoUrlDetectorImpl(),
             coroutineRule.testDispatcherProvider,
             mockFeatureToggle,
             mockAutofill,

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/configuration/InlineBrowserAutofillConfiguratorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/configuration/InlineBrowserAutofillConfiguratorTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.configuration
+
+import android.webkit.WebView
+import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.autofill.JavascriptInjector
+import com.duckduckgo.autofill.api.Autofill
+import com.duckduckgo.autofill.api.AutofillFeatureName
+import com.duckduckgo.feature.toggles.api.FeatureToggle
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class InlineBrowserAutofillConfiguratorTest {
+
+    @get:Rule var coroutineRule = CoroutineTestRule()
+
+    private lateinit var inlineBrowserAutofillConfigurator: InlineBrowserAutofillConfigurator
+
+    private val autofillRuntimeConfigProvider: AutofillRuntimeConfigProvider = mock()
+    private val javascriptInjector: JavascriptInjector = mock()
+    private val autofill: Autofill = mock()
+    private val featureToggle: FeatureToggle = mock()
+    private val webView: WebView = mock()
+
+    @Before
+    fun before() = runTest {
+        whenever(javascriptInjector.getFunctionsJS()).thenReturn("")
+        whenever(autofillRuntimeConfigProvider.getRuntimeConfiguration(any(), any())).thenReturn("")
+
+        inlineBrowserAutofillConfigurator = InlineBrowserAutofillConfigurator(
+            autofillRuntimeConfigProvider,
+            javascriptInjector,
+            TestScope(),
+            coroutineRule.testDispatcherProvider,
+            autofill,
+            featureToggle,
+        )
+    }
+
+    @Test
+    fun whenFeatureIsNotEnabledThenDoNotInject() {
+        givenFeatureIsDisabled()
+        inlineBrowserAutofillConfigurator.configureAutofillForCurrentPage(webView, "https://example.com")
+
+        verify(webView, never()).evaluateJavascript("javascript:", null)
+    }
+
+    @Test
+    fun whenFeatureIsEnabledAndUrlIsExceptionThenDoNotInject() {
+        givenUrlIsAnException()
+        givenFeatureIsEnabled()
+        inlineBrowserAutofillConfigurator.configureAutofillForCurrentPage(webView, "https://example.com")
+
+        verify(webView, never()).evaluateJavascript("javascript:", null)
+    }
+
+    @Test
+    fun whenFeatureIsEnabledAndUrlIsNotExceptionThenInject() {
+        givenUrlIsNotAnException()
+        givenFeatureIsEnabled()
+        inlineBrowserAutofillConfigurator.configureAutofillForCurrentPage(webView, "https://example.com")
+
+        verify(webView).evaluateJavascript("javascript:", null)
+    }
+
+    private fun givenUrlIsAnException() {
+        whenever(autofill.isAnException(any())).thenReturn(true)
+    }
+
+    private fun givenUrlIsNotAnException() {
+        whenever(autofill.isAnException(any())).thenReturn(false)
+    }
+
+    private fun givenFeatureIsEnabled() {
+        whenever(featureToggle.isFeatureEnabled(AutofillFeatureName.Autofill.value, true)).thenReturn(true)
+    }
+
+    private fun givenFeatureIsDisabled() {
+        whenever(featureToggle.isFeatureEnabled(AutofillFeatureName.Autofill.value, true)).thenReturn(false)
+    }
+}

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+/** Public interface for DuckDuckGoUrlDetector */
+interface DuckDuckGoUrlDetector {
+
+    /**
+     * This method takes a [url] and returns `true` or `false`.
+     * @return `true` if the given [url] belongs to the DuckDuckGo email domain and `false`
+     * otherwise.
+     */
+    fun isDuckDuckGoEmailUrl(url: String): Boolean
+
+    /**
+     * This method takes a [url] and returns `true` or `false`.
+     * @return `true` if the given [url] belongs to the DuckDuckGo domain and `false`
+     * otherwise.
+     */
+    fun isDuckDuckGoUrl(url: String): Boolean
+
+    /**
+     * This method takes a [uri] and returns `true` or `false`.
+     * @return `true` if the given [uri] is a DuckDuckGo query and `false`
+     * otherwise.
+     */
+    fun isDuckDuckGoQueryUrl(uri: String): Boolean
+
+    /**
+     * This method takes a [uri] and returns `true` or `false`.
+     * @return `true` if the given [uri] is a DuckDuckGo static URL and `false`
+     * otherwise.
+     */
+    fun isDuckDuckGoStaticUrl(uri: String): Boolean
+
+    /**
+     * This method takes a [uriString] and returns a [String?]
+     * @return the query of a given uri and null if it cannot find it.
+     */
+    fun extractQuery(uriString: String): String?
+
+    /**
+     * This method takes a [uri] and returns `true` or `false`.
+     * @return `true` if the given [uri] is a DuckDuckGo vertical URL and `false`
+     * otherwise.
+     */
+    fun isDuckDuckGoVerticalUrl(uri: String): Boolean
+
+    /**
+     * This method takes a [uriString] and returns a [String?]
+     * @return the vertical of a given uri and null if it cannot find it.
+     */
+    fun extractVertical(uriString: String): String?
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203800330887198/f 

### Description
This PR is to honour the autofill remote feature flag

### Steps to test this PR

_Autofill is disabled/enabled_
- [x] Install from this branch using the internal flavour
- [x] In the dev settings you can override the privacy remote config URL and use something like https://jsonblob.com/ and its api https://jsonblob.com/api/jsonblob/ID_HERE or use Charles to override the config. Remember to update the version in the config so changes take effect and to restart the app to force the re-download.
- [x] Play with the autofill value to enable/disable the feature and check that the code is not injected.
- [x] Go to `github.com` and the duck logo should show only if the feature is enable
- [x] Go to any website to login and the autofill prompt should happen or not depending on the autofill flag value.