### PR TITLE
Remove experimental FB pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -98,8 +98,6 @@ import com.duckduckgo.app.location.GeoLocationPermissions
 import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.location.data.LocationPermissionsRepository
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.pixels.AppPixelName.FACEBOOK_LOGIN_BREAKAGE_INVESTIGATION
-import com.duckduckgo.app.pixels.AppPixelName.FACEBOOK_LOGIN_ERROR_BREAKAGE_INVESTIGATION
 import com.duckduckgo.app.privacy.db.NetworkLeaderboardDao
 import com.duckduckgo.app.privacy.db.UserWhitelistDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -1152,28 +1150,14 @@ class BrowserTabViewModel @Inject constructor(
         command.value = ShowWebContent
     }
 
-    private fun sendBrokenFBLoginPixels(previousUrl: String?, url: String) {
-        // User lands on failed FB login due to WebView incompatibility
-        if (previousUrl != url && url.contains("LOGIN_DISABLED_FROM_WEBVIEW")) {
-            pixel.fire(FACEBOOK_LOGIN_ERROR_BREAKAGE_INVESTIGATION)
-        }
-        if (previousUrl != url && url.contains("facebook.com/login.php")) {
-            pixel.fire(FACEBOOK_LOGIN_BREAKAGE_INVESTIGATION)
-        }
-    }
-
     private fun pageChanged(
         url: String,
         title: String?,
     ) {
         Timber.v("Page changed: $url")
-        val previousUrl = site?.url
-
         hasCtaBeenShownForCurrentPage.set(false)
         buildSiteFactory(url, title)
         setAdClickActiveTabData(url)
-
-        sendBrokenFBLoginPixels(previousUrl, url)
 
         val currentOmnibarViewState = currentOmnibarViewState()
         val omnibarText = omnibarTextForUrl(url)

--- a/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
@@ -64,8 +64,6 @@ class AtbAndAppVersionPixelRemovalInterceptor @Inject constructor() : Intercepto
             AppPixelName.EMAIL_USE_ADDRESS.pixelName,
             AppPixelName.EMAIL_COPIED_TO_CLIPBOARD.pixelName,
             "m_atp_unprotected_apps_bucket_",
-            AppPixelName.FACEBOOK_LOGIN_ERROR_BREAKAGE_INVESTIGATION.pixelName,
-            AppPixelName.FACEBOOK_LOGIN_BREAKAGE_INVESTIGATION.pixelName,
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -250,7 +250,4 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     REMOTE_MESSAGE_SECONDARY_ACTION_CLICKED("m_remote_message_secondary_action_clicked"),
 
     CREATE_BLOOM_FILTER_ERROR("m_create_bloom_filter_error"),
-
-    FACEBOOK_LOGIN_ERROR_BREAKAGE_INVESTIGATION("m_facebook_login_error_breakage_investigation"),
-    FACEBOOK_LOGIN_BREAKAGE_INVESTIGATION("m_facebook_login_breakage_investigation"),
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/69071770703008/1203490334991976/f 

### Description
This PR rollbacks the changes done in https://github.com/duckduckgo/Android/pull/2601

### Steps to test this PR

_Feature 1_
- [x] Install the app and go to `instagram.com`
- [x] Click on Login
- [x] Click on `Continue using Facebook`
- [x] You should eventually see the FB page for WebView unsupported
- [x] Pixels `m_facebook_login_breakage_investigation` and `m_facebook_login_error_breakage_investigation` should not be sent

