### PR TITLE
Android: Icon padding for buttons is too small 

### DIFF
--- a/common-ui/src/main/res/values/widgets.xml
+++ b/common-ui/src/main/res/values/widgets.xml
@@ -169,6 +169,7 @@
     <style name="Widget.DuckDuckGo.DaxButton.TextButton" parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:textAppearance">?attr/textAppearanceButton</item>
         <item name="shapeAppearance">?shapeAppearanceSmallComponent</item>
+        <item name="iconPadding">@dimen/keyline_2</item>
     </style>
 
     <style name="Widget.DuckDuckGo.DaxButton.TextButton.Primary">
@@ -191,6 +192,7 @@
         <item name="strokeColor">@color/button_secondary_stroke_selector</item>
         <item name="rippleColor">@color/button_secondary_ripple_selector</item>
         <item name="iconTint">@color/button_secondary_text_color_selector</item>
+        <item name="iconPadding">@dimen/keyline_2</item>
     </style>
 
     <style name="Widget.DuckDuckGo.DaxButton.Ghost" parent="Widget.MaterialComponents.Button.TextButton">
@@ -198,6 +200,7 @@
         <item name="backgroundTint">@color/button_ghost_container_selector</item>
         <item name="rippleColor">@color/button_ghost_ripple_selector</item>
         <item name="iconTint">@color/button_secondary_text_color_selector</item>
+        <item name="iconPadding">@dimen/keyline_2</item>
     </style>
 
     <style name="Widget.DuckDuckGo.DaxButton.DestructiveGhost" parent="Widget.MaterialComponents.Button.TextButton">
@@ -205,6 +208,7 @@
         <item name="backgroundTint">@color/button_destructive_ghost_container_selector</item>
         <item name="rippleColor">@color/button_desctructive_ghost_ripple_selector</item>
         <item name="iconTint">@color/button_destructive_ghost_text_color_selector</item>
+        <item name="iconPadding">@dimen/keyline_2</item>
     </style>
 
     <style name="Widget.DuckDuckGo.Button" parent="Widget.AppCompat.Button.Borderless">


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203838208769837/f

### Description
Updated the default icon padding for buttons to match the design.

### Steps to test this PR

- [x] Install from this branch.
- [x] Open the app and go to `App Components Design Preview` -> `Buttons`
- [x] Check the icon padding is as expected (see the `Primary Small` button with the icon on the left).

### UI changes
| Before  | After |
| ------ | ----- |
|![Screenshot_20230126_161121](https://user-images.githubusercontent.com/7963079/214890832-ab17bfbd-6dc1-4dcb-8d22-840e48641626.png)|![Screenshot_20230126_161711](https://user-images.githubusercontent.com/7963079/214890878-bab6afaa-9803-488b-b02f-1c60e18a1887.png)|
