### PR TITLE
Fix flaky test expected value

### DIFF
--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortCalculatorTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortCalculatorTest.kt
@@ -87,7 +87,7 @@ class RealCohortCalculatorTest {
     @Test
     fun whenLocalDate4WeeksAgoThenReturnWeeklyCohort() {
         val date = LocalDate.now().minusWeeks(4)
-        val year = date.year
+        val year = date.get(IsoFields.WEEK_BASED_YEAR)
         assertEquals("$year-week-${date.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)}", cohortCalculator.calculateCohortForDate(date))
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203837698579470/f

### Description
`whenLocalDate4WeeksAgoThenReturnWeeklyCohort` should assert on week based year and not year directly.
Not doing so makes the expected value to be wrong in cases where the date is a date in a year but falling into a previous year week, like 2023-01-01

### Steps to test this PR
PR Unit tests should pass as it was submitted the same day that caused the failure, ie. 2023-01-29

- [ ] change `whenLocalDate4WeeksAgoThenReturnWeeklyCohort` date to be `LocalDate.of(2023, 1, 29)`
- [ ] verify test passes
