### PR TITLE
Compare URLs using etld+1

### DIFF
--- a/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/RequestFiltererImpl.kt
+++ b/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/RequestFiltererImpl.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import timber.log.Timber
 
 @ContributesBinding(AppScope::class)
@@ -59,7 +60,10 @@ class RequestFiltererImpl @Inject constructor(
         val origin = request.requestHeaders[ORIGIN]
         val referer = request.requestHeaders[REFERER]
 
-        if (documentUrl != previousPage) {
+        val currentTopDomain = documentUrl.toHttpUrl().topPrivateDomain()
+        val previousTopDomain = previousPage?.toHttpUrl()?.topPrivateDomain()
+
+        if (currentTopDomain != previousTopDomain) {
             referer?.let {
                 return compareUrl(it)
             }

--- a/request-filterer/request-filterer-impl/src/test/java/com/duckduckgo/request/filterer/impl/RequestFiltererImplTest.kt
+++ b/request-filterer/request-filterer-impl/src/test/java/com/duckduckgo/request/filterer/impl/RequestFiltererImplTest.kt
@@ -152,6 +152,17 @@ class RequestFiltererImplTest {
     }
 
     @Test
+    fun whenDocumentUrlMatchesPreviousETLDPlusOneThenReturnFalse() {
+        val previousUrl = "http://example.com"
+        val documentUrl = "http://test.example.com"
+        whenever(mockRequest.requestHeaders).thenReturn(mapOf(REFERER to previousUrl))
+        requestFilterer.registerOnPageCreated(previousUrl)
+        requestFilterer.registerOnPageCreated(documentUrl)
+
+        assertFalse(requestFilterer.shouldFilterOutRequest(mockRequest, documentUrl))
+    }
+
+    @Test
     fun whenRequestRefererHeaderDoesNotMatchPreviousUrlThenReturnFalse() {
         val previousUrl = "http://example.com"
         val documentUrl = "http://test.com"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203855283561828/f 

### Description
This PR uses eTLD+1 to compare URLs rather than trying to match full URLs in the request filterer

### Steps to test this PR

_Feature_
- [ ] Go to foxnews.com
- [ ] Click on any link
- [ ] Website should load without any issues
- [ ] Go to bing.com
- [ ] Go to wikipedia.org
- [ ] We should not have trackers blocked in the privacy dashboard

