### PR TITLE
Memoize sorted plugins in plugin points

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesPluginPointCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesPluginPointCodeGenerator.kt
@@ -83,6 +83,22 @@ class ContributesPluginPointCodeGenerator : CodeGenerator {
                             .addModifiers(KModifier.PRIVATE)
                             .build(),
                     )
+                    .addProperty(
+                        PropertySpec
+                            .builder(
+                                "sortedPlugins",
+                                kotlinCollectionFqName.asClassName(module).parameterizedBy(pluginClassName)
+                            )
+                            .addModifiers(KModifier.PRIVATE)
+                            .delegate(
+                                CodeBlock.builder()
+                                    .beginControlFlow("lazy")
+                                    .add("plugins.toList().sortedBy { it.javaClass.name }")
+                                    .endControlFlow()
+                                    .build()
+                            )
+                            .build()
+                    )
                     .addFunction(
                         FunSpec.builder("getPlugins")
                             .addModifiers(KModifier.OVERRIDE)
@@ -90,7 +106,7 @@ class ContributesPluginPointCodeGenerator : CodeGenerator {
                             .addComment("Sort plugins by class name to ensure execution consistency")
                             .addCode(
                                 """
-                                    return plugins.toList().sortedBy { it.javaClass.name }
+                                    return sortedPlugins
                                 """.trimIndent(),
                             )
                             .build(),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1203874493929848/f

### Description
Memoize the sorted plugins to avoid sorting every time `getPlugins()` is called.

### Steps to test this PR
- [x] Smoke tests for the app and AppTP
- [x] Run `./gradlew clean;rm -rf build-cache/
- [x] Run `./gradlew :vpn-impl:assemble`
- [x] verify the generated `./app-tracking-protection/vpn-impl/build/anvil/src-gen-debug/com/duckduckgo/mobile/android/vpn/integration/VpnNetworkStackPluginPoint_PluginPoint.kt` contains the `sortedPlugins` property by lazy `plugins.toList().sortedBy { it.javaClass.name }}` and it's returned in `getPlugins()` as expected
