### PR TITLE
Change the way we store URLs in autofill

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/global/UriExtensionTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/UriExtensionTest.kt
@@ -257,14 +257,6 @@ class UriExtensionTest {
     }
 
     @Test
-    fun whenUriExtractSchemeAndDomainThenReturnOnlySchemeAndDomain() {
-        assertEquals("https://www.foo.com", "https://www.foo.com/path/to/foo?key=value".extractSchemeAndDomain())
-        assertEquals("https://www.foo.com", "www.foo.com/path/to/foo?key=value".extractSchemeAndDomain())
-        assertEquals("https://foo.com", "foo.com/path/to/foo?key=value".extractSchemeAndDomain())
-        assertEquals("http://foo.com", "http://foo.com/path/to/foo?key=value".extractSchemeAndDomain())
-    }
-
-    @Test
     fun whenUriExtractDomainThenReturnDomainOnly() {
         assertEquals("www.foo.com", "https://www.foo.com/path/to/foo?key=value".extractDomain())
         assertEquals("www.foo.com", "www.foo.com/path/to/foo?key=value".extractDomain())

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/urlmatcher/AutofillUrlMatcher.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/urlmatcher/AutofillUrlMatcher.kt
@@ -23,5 +23,11 @@ interface AutofillUrlMatcher {
         savedSite: ExtractedUrlParts,
     ): Boolean
 
+    /**
+     * This method tries to clean up a raw URL.
+     * @return a `String` containing host:port for the given raw URL.
+     */
+    fun cleanRawUrl(rawUrl: String): String
+
     data class ExtractedUrlParts(val eTldPlus1: String?, val subdomain: String?)
 }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcher.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcher.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.store.urlmatcher
 
+import androidx.core.net.toUri
 import com.duckduckgo.app.global.extractDomain
 import com.duckduckgo.autofill.api.urlmatcher.AutofillUrlMatcher
 import com.duckduckgo.autofill.api.urlmatcher.AutofillUrlMatcher.ExtractedUrlParts
@@ -63,6 +64,13 @@ class AutofillDomainNameUrlMatcher @Inject constructor() : AutofillUrlMatcher {
         return identicalSubdomains(visitedSite, savedSite) ||
             specialHandlingForWwwSubdomainOnSavedSite(visitedSite, savedSite) ||
             savedSiteHasNoSubdomain(savedSite)
+    }
+
+    override fun cleanRawUrl(rawUrl: String): String {
+        val uri = rawUrl.normalizeScheme().toUri()
+        val host = uri.host ?: return rawUrl
+        val port = if (uri.port != -1) ":${uri.port}" else ""
+        return "$host$port"
     }
 
     private fun identicalEffectiveTldPlusOne(

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -208,7 +208,7 @@ class SecureStoreBackedAutofillStoreTest {
     @Test
     fun whenPasswordIsUpdatedThenUpdatedOnlyMatchingCredential() = runTest {
         setupTesteeWithAutofillAvailable()
-        val url = "https://example.com"
+        val url = "example.com"
         storeCredentials(1, url, "username1", "password123")
         storeCredentials(2, url, "username2", "password456")
         storeCredentials(3, url, "username3", "password789")
@@ -229,9 +229,28 @@ class SecureStoreBackedAutofillStoreTest {
     }
 
     @Test
-    fun whenUsernameIsUpdatedForUrlThenUpdatedOnlyMatchingCredential() = runTest {
+    fun whenDomainIsUpdatedTheCleanRawUrl() = runTest {
         setupTesteeWithAutofillAvailable()
         val url = "https://example.com"
+        storeCredentials(1, url, "username1", "password123")
+        val credentials = LoginCredentials(
+            domain = "https://www.example.com/test/path",
+            username = "username1",
+            password = "newpassword",
+            id = 1,
+        )
+
+        testee.updateCredentials(credentials)
+
+        testee.getCredentials(url).run {
+            this.assertHasLoginCredentials("www.example.com", "username1", "newpassword", UPDATED_INITIAL_LAST_UPDATED)
+        }
+    }
+
+    @Test
+    fun whenUsernameIsUpdatedForUrlThenUpdatedOnlyMatchingCredential() = runTest {
+        setupTesteeWithAutofillAvailable()
+        val url = "example.com"
         storeCredentials(1, url, null, "password123")
         storeCredentials(2, url, "username2", "password456")
         storeCredentials(3, url, "username3", "password789")
@@ -254,8 +273,8 @@ class SecureStoreBackedAutofillStoreTest {
     @Test
     fun whenUsernameMissingForAnotherUrlThenNoUpdatesMade() = runTest {
         setupTesteeWithAutofillAvailable()
-        val urlStored = "https://example.com"
-        val newDomain = "https://test.com"
+        val urlStored = "example.com"
+        val newDomain = "test.com"
         storeCredentials(1, urlStored, null, "password123")
 
         val credentials = LoginCredentials(domain = newDomain, username = "username1", password = "password123", id = 1)
@@ -270,7 +289,7 @@ class SecureStoreBackedAutofillStoreTest {
     @Test
     fun whenSaveCredentialsThenReturnSavedOnGetCredentials() = runTest {
         setupTesteeWithAutofillAvailable()
-        val url = "https://example.com"
+        val url = "example.com"
         val credentials = LoginCredentials(
             domain = url,
             username = "username1",
@@ -278,13 +297,13 @@ class SecureStoreBackedAutofillStoreTest {
         )
         testee.saveCredentials(url, credentials)
 
-        assertEquals(credentials.copy(lastUpdatedMillis = UPDATED_INITIAL_LAST_UPDATED), testee.getCredentials(url)[0])
+        assertEquals(credentials.copy(domain = "example.com", lastUpdatedMillis = UPDATED_INITIAL_LAST_UPDATED), testee.getCredentials(url)[0])
     }
 
     @Test
     fun whenSaveCredentialsForFirstTimeThenDisableShowOnboardingFlag() = runTest {
         setupTesteeWithAutofillAvailable()
-        val url = "https://example.com"
+        val url = "example.com"
         val credentials = LoginCredentials(
             domain = url,
             username = "username1",
@@ -297,7 +316,7 @@ class SecureStoreBackedAutofillStoreTest {
     @Test
     fun whenPasswordIsDeletedThenRemoveCredentialFromStore() = runTest {
         setupTesteeWithAutofillAvailable()
-        val url = "https://example.com"
+        val url = "example.com"
         storeCredentials(1, url, "username1", "password123")
         storeCredentials(2, url, "username2", "password456")
         storeCredentials(3, url, "username3", "password789")
@@ -313,7 +332,7 @@ class SecureStoreBackedAutofillStoreTest {
     @Test
     fun whenCredentialWithIdIsStoredTheReturnCredentialsOnGetCredentialsWithId() = runTest {
         setupTesteeWithAutofillAvailable()
-        val url = "https://example.com"
+        val url = "example.com"
         storeCredentials(1, url, "username1", "password123")
         storeCredentials(2, url, "username2", "password456")
 

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcherTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcherTest.kt
@@ -224,4 +224,22 @@ class AutofillDomainNameUrlMatcherTest {
         val visitedSite = testee.extractUrlPartsForAutofill("example.com")
         assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
     }
+
+    @Test
+    fun whenCleanRawUrlThenReturnOnlySchemeAndDomain() {
+        assertEquals("www.foo.com", testee.cleanRawUrl("https://www.foo.com/path/to/foo?key=value"))
+        assertEquals("www.fuu.foo.com", testee.cleanRawUrl("https://www.fuu.foo.com/path/to/foo?key=value"))
+        assertEquals("foo.com", testee.cleanRawUrl("http://foo.com/path/to/foo?key=value"))
+        assertEquals("fuu.foo.com", testee.cleanRawUrl("http://fuu.foo.com/path/to/foo?key=value"))
+        assertEquals("foo.com:9000", testee.cleanRawUrl("http://foo.com:9000/path/to/foo?key=value"))
+        assertEquals("fuu.foo.com:9000", testee.cleanRawUrl("http://fuu.foo.com:9000/path/to/foo?key=value"))
+        assertEquals("faa.fuu.foo.com:9000", testee.cleanRawUrl("http://faa.fuu.foo.com:9000/path/to/foo?key=value"))
+        assertEquals("foo.com", testee.cleanRawUrl("foo.com/path/to/foo"))
+        assertEquals("www.foo.com", testee.cleanRawUrl("www.foo.com/path/to/foo"))
+        assertEquals("foo.com", testee.cleanRawUrl("foo.com"))
+        assertEquals("foo.com:9000", testee.cleanRawUrl("foo.com:9000"))
+        assertEquals("fuu.foo.com", testee.cleanRawUrl("fuu.foo.com"))
+        assertEquals("fuu.foo.com:9000", testee.cleanRawUrl("fuu.foo.com:9000"))
+        assertEquals("RandomText", testee.cleanRawUrl("thisIs@RandomText"))
+    }
 }

--- a/common/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -182,13 +182,6 @@ fun Uri.getEncodedQueryParameters(key: String?): List<String> {
     return Collections.unmodifiableList(values)
 }
 
-fun String.extractSchemeAndDomain(): String? {
-    val uri = this.toUri()
-    val scheme = uri.scheme ?: return "https://$this".extractSchemeAndDomain()
-    val domain = uri.domain() ?: return null
-    return "$scheme://$domain"
-}
-
 fun String.extractDomain(): String? {
     return if (this.startsWith("http")) {
         this.toUri().domain()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203892213154867/f 

### Description
This PR changes the way that we store URls in autofill to only store host:port

### Steps to test this PR

- [x] Go to `https://fill.dev/form/login-simple`
- [x] Login and store the credentials
- [x] Check that the website URL that was store is `fill.dev`
- [x] Check the tests to make sure we also store the port when it exists and also the full host when it contains a subdomain(s)

