### PR TITLE
Migrate DownloadConfirmationFragment to viewBinding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/DownloadConfirmationFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DownloadConfirmationFragment.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.databinding.DownloadConfirmationBinding
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.downloads.impl.FilenameExtractor
@@ -30,7 +31,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
 import java.io.File
 import javax.inject.Inject
-import kotlinx.android.synthetic.main.download_confirmation.view.*
 import timber.log.Timber
 
 @InjectWith(FragmentScope::class)
@@ -57,11 +57,11 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View? {
-        val view = inflater.inflate(R.layout.download_confirmation, container, false)
+    ): View {
+        val binding = DownloadConfirmationBinding.inflate(inflater, container, false)
         setupDownload()
-        setupViews(view)
-        return view
+        setupViews(binding)
+        return binding.root
     }
 
     private fun setupDownload() {
@@ -75,14 +75,14 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
         }
     }
 
-    private fun setupViews(view: View) {
+    private fun setupViews(binding: DownloadConfirmationBinding) {
         val fileName = file?.name ?: ""
-        view.downloadMessage.text = fileName
-        view.continueDownload.setOnClickListener {
+        binding.downloadMessage.text = fileName
+        binding.continueDownload.setOnClickListener {
             listener.continueDownload(pendingDownload)
             dismiss()
         }
-        view.cancel.setOnClickListener {
+        binding.cancel.setOnClickListener {
             Timber.i("Cancelled download for url ${pendingDownload.url}")
             listener.cancelDownload()
             dismiss()

--- a/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesActivity.kt
@@ -36,7 +36,6 @@ import com.duckduckgo.mobile.android.ui.view.dialog.RadioListAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
-import kotlinx.android.synthetic.main.item_autocomplete_bookmark_suggestion.*
 
 @InjectWith(ActivityScope::class)
 class FireproofWebsitesActivity : DuckDuckGoActivity() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1203887624504456/f

### Description
Migrate DownloadConfirmationFragment from kotlin synthetic and remove unused import from other class

### Steps to test this PR

- Install from this branch
- Download any document from the browser
- [x] Check bottom sheet dialog looks as expected and works well

### No UI changes
