### PR TITLE
ADS: Make TextAlertDialog Cancellable

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -605,6 +605,7 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.rateAppDialogTitle)
             .setMessage(R.string.rateAppDialogMessage)
+            .setCancellable(true)
             .setPositiveButton(R.string.rateAppDialogPositiveButton)
             .setNegativeButton(R.string.rateAppDialogNegativeButton)
             .addEventListener(
@@ -620,6 +621,9 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
                     override fun onDialogShown() {
                         viewModel.onAppRatingDialogShown(promptCount)
                     }
+                    override fun onDialogCancelled() {
+                        viewModel.onUserCancelledRateAppDialog(promptCount)
+                    }
                 },
             )
             .show()
@@ -629,6 +633,7 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.giveFeedbackDialogTitle)
             .setMessage(R.string.giveFeedbackDialogMessage)
+            .setCancellable(true)
             .setPositiveButton(R.string.giveFeedbackDialogPositiveButton)
             .setNegativeButton(R.string.giveFeedbackDialogNegativeButton)
             .addEventListener(
@@ -643,6 +648,9 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
 
                     override fun onDialogShown() {
                         viewModel.onGiveFeedbackDialogShown(promptCount)
+                    }
+                    override fun onDialogCancelled() {
+                        viewModel.onUserCancelledGiveFeedbackDialog(promptCount)
                     }
                 },
             )

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -27,7 +27,6 @@ import android.view.KeyEvent
 import android.view.View
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
-import androidx.fragment.app.DialogFragment
 import androidx.webkit.ServiceWorkerClientCompat
 import androidx.webkit.ServiceWorkerControllerCompat
 import androidx.webkit.WebViewFeature
@@ -577,7 +576,7 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.appEnjoymentDialogTitle)
             .setMessage(R.string.appEnjoymentDialogMessage)
-            .setCancellable(false)
+            .setCancellable(true)
             .setPositiveButton(R.string.appEnjoymentDialogPositiveButton)
             .setNegativeButton(R.string.appEnjoymentDialogNegativeButton)
             .addEventListener(
@@ -594,7 +593,7 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
                         viewModel.onAppEnjoymentDialogShown(promptCount)
                     }
 
-                    override fun onDialogDismissed() {
+                    override fun onDialogCancelled() {
                         viewModel.onUserCancelledAppEnjoymentDialog(promptCount)
                     }
                 },
@@ -648,11 +647,6 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
                 },
             )
             .show()
-    }
-
-    private fun showAppEnjoymentPrompt(prompt: DialogFragment) {
-        (supportFragmentManager.findFragmentByTag(APP_ENJOYMENT_DIALOG_TAG) as? DialogFragment)?.dismissNow()
-        prompt.show(supportFragmentManager, APP_ENJOYMENT_DIALOG_TAG)
     }
 
     private fun hideWebContent() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -577,6 +577,7 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.appEnjoymentDialogTitle)
             .setMessage(R.string.appEnjoymentDialogMessage)
+            .setCancellable(false)
             .setPositiveButton(R.string.appEnjoymentDialogPositiveButton)
             .setNegativeButton(R.string.appEnjoymentDialogNegativeButton)
             .addEventListener(
@@ -591,6 +592,10 @@ open class BrowserActivity : DuckDuckGoActivity(), CoroutineScope by MainScope()
 
                     override fun onDialogShown() {
                         viewModel.onAppEnjoymentDialogShown(promptCount)
+                    }
+
+                    override fun onDialogDismissed() {
+                        viewModel.onUserCancelledAppEnjoymentDialog(promptCount)
                     }
                 },
             )

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -260,6 +260,4 @@ class BrowserViewModel @Inject constructor(
             pixel.fire(AppPixelName.SHORTCUT_OPENED)
         }
     }
-
-
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -38,9 +38,11 @@ import com.duckduckgo.app.pixels.AppPixelName.APP_ENJOYMENT_DIALOG_USER_CANCELLE
 import com.duckduckgo.app.pixels.AppPixelName.APP_ENJOYMENT_DIALOG_USER_ENJOYING
 import com.duckduckgo.app.pixels.AppPixelName.APP_ENJOYMENT_DIALOG_USER_NOT_ENJOYING
 import com.duckduckgo.app.pixels.AppPixelName.APP_FEEDBACK_DIALOG_SHOWN
+import com.duckduckgo.app.pixels.AppPixelName.APP_FEEDBACK_DIALOG_USER_CANCELLED
 import com.duckduckgo.app.pixels.AppPixelName.APP_FEEDBACK_DIALOG_USER_DECLINED_FEEDBACK
 import com.duckduckgo.app.pixels.AppPixelName.APP_FEEDBACK_DIALOG_USER_GAVE_FEEDBACK
 import com.duckduckgo.app.pixels.AppPixelName.APP_RATING_DIALOG_SHOWN
+import com.duckduckgo.app.pixels.AppPixelName.APP_RATING_DIALOG_USER_CANCELLED
 import com.duckduckgo.app.pixels.AppPixelName.APP_RATING_DIALOG_USER_DECLINED_RATING
 import com.duckduckgo.app.pixels.AppPixelName.APP_RATING_DIALOG_USER_GAVE_RATING
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -237,6 +239,11 @@ class BrowserViewModel @Inject constructor(
         launch { appEnjoymentUserEventRecorder.userDeclinedToRateApp(promptCount) }
     }
 
+    fun onUserCancelledRateAppDialog(promptCount: PromptCount) {
+        firePixelWithPromptCount(APP_RATING_DIALOG_USER_CANCELLED, promptCount)
+        launch { appEnjoymentUserEventRecorder.userDeclinedToRateApp(promptCount) }
+    }
+
     fun onUserSelectedToGiveFeedback(promptCount: PromptCount) {
         firePixelWithPromptCount(APP_FEEDBACK_DIALOG_USER_GAVE_FEEDBACK, promptCount)
         command.value = Command.LaunchFeedbackView
@@ -246,6 +253,11 @@ class BrowserViewModel @Inject constructor(
 
     fun onUserDeclinedToGiveFeedback(promptCount: PromptCount) {
         firePixelWithPromptCount(APP_FEEDBACK_DIALOG_USER_DECLINED_FEEDBACK, promptCount)
+        launch { appEnjoymentUserEventRecorder.onUserDeclinedToGiveFeedback(promptCount) }
+    }
+
+    fun onUserCancelledGiveFeedbackDialog(promptCount: PromptCount) {
+        firePixelWithPromptCount(APP_FEEDBACK_DIALOG_USER_CANCELLED, promptCount)
         launch { appEnjoymentUserEventRecorder.onUserDeclinedToGiveFeedback(promptCount) }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
 import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.APP_ENJOYMENT_DIALOG_SHOWN
+import com.duckduckgo.app.pixels.AppPixelName.APP_ENJOYMENT_DIALOG_USER_CANCELLED
 import com.duckduckgo.app.pixels.AppPixelName.APP_ENJOYMENT_DIALOG_USER_ENJOYING
 import com.duckduckgo.app.pixels.AppPixelName.APP_ENJOYMENT_DIALOG_USER_NOT_ENJOYING
 import com.duckduckgo.app.pixels.AppPixelName.APP_FEEDBACK_DIALOG_SHOWN
@@ -248,10 +249,17 @@ class BrowserViewModel @Inject constructor(
         launch { appEnjoymentUserEventRecorder.onUserDeclinedToGiveFeedback(promptCount) }
     }
 
+    fun onUserCancelledAppEnjoymentDialog(promptCount: PromptCount) {
+        firePixelWithPromptCount(APP_ENJOYMENT_DIALOG_USER_CANCELLED, promptCount)
+        launch { appEnjoymentUserEventRecorder.onUserDeclinedToSayIfEnjoyingApp(promptCount) }
+    }
+
     fun onOpenShortcut(url: String) {
         launch(dispatchers.io()) {
             tabRepository.selectByUrlOrNewTab(queryUrlConverter.convertQueryToUrl(url))
             pixel.fire(AppPixelName.SHORTCUT_OPENED)
         }
     }
+
+
 }

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/dialogs/DialogsFragment.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/dialogs/DialogsFragment.kt
@@ -115,6 +115,34 @@ class DialogsFragment : Fragment() {
                     .show()
             }
         }
+
+        view.findViewById<Button>(R.id.textAlertDialogCancellable)?.let {
+            it.setOnClickListener {
+                TextAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.text_dialog_title)
+                    .setMessage(R.string.text_dialog_message)
+                    .setCancellable(true)
+                    .setPositiveButton(R.string.text_dialog_positive)
+                    .setNegativeButton(R.string.text_dialog_negative)
+                    .addEventListener(
+                        object : TextAlertDialogBuilder.EventListener() {
+                            override fun onPositiveButtonClicked() {
+                                Snackbar.make(it, "Positive Button Clicked", Snackbar.LENGTH_SHORT).show()
+                            }
+
+                            override fun onNegativeButtonClicked() {
+                                Snackbar.make(it, "Negative Button Clicked", Snackbar.LENGTH_SHORT).show()
+                            }
+
+                            override fun onDialogCancelled() {
+                                Snackbar.make(it, "Dialog cancelled", Snackbar.LENGTH_SHORT).show()
+                            }
+                        },
+                    )
+                    .show()
+            }
+        }
+
         view.findViewById<Button>(R.id.stackedAlertDialogWithImageButton)?.let {
             it.setOnClickListener {
                 StackedAlertDialogBuilder(requireContext())

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/BackKeyListener.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/BackKeyListener.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.view.dialog
+
+import android.content.DialogInterface
+import android.view.KeyEvent
+
+class BackKeyListener(private val onBackPressed: () -> Unit) : DialogInterface.OnKeyListener {
+
+    override fun onKey(
+        dialog: DialogInterface?,
+        keyCode: Int,
+        event: KeyEvent?,
+    ): Boolean {
+        if (isBackKey(keyCode, event)) {
+            onBackPressed.invoke()
+            dialog?.dismiss()
+            return true
+        }
+        return false
+    }
+
+    private fun isBackKey(
+        keyCode: Int,
+        event: KeyEvent?,
+    ): Boolean {
+        return (keyCode == KeyEvent.KEYCODE_BACK && event?.action == KeyEvent.ACTION_UP)
+    }
+}

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -109,11 +109,13 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             .setView(binding.root)
             .setCancelable(isCancellable)
             .apply {
-                setOnKeyListener(
-                    BackKeyListener {
-                        listener.onDialogCancelled()
-                    },
-                )
+                if (isCancellable) {
+                    setOnKeyListener(
+                        BackKeyListener {
+                            listener.onDialogCancelled()
+                        },
+                    )
+                }
             }
         dialog = dialogBuilder.create()
         setViews(binding, dialog!!)

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -31,6 +31,7 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     abstract class EventListener {
         open fun onDialogShown() {}
         open fun onDialogDismissed() {}
+        open fun onDialogCancelled() {}
         open fun onPositiveButtonClicked() {}
         open fun onNegativeButtonClicked() {}
     }
@@ -106,9 +107,13 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
 
         val dialogBuilder = MaterialAlertDialogBuilder(context, R.style.Widget_DuckDuckGo_Dialog)
             .setView(binding.root)
+            .setCancelable(isCancellable)
             .apply {
-                setCancelable(isCancellable)
-                setOnDismissListener { listener.onDialogDismissed() }
+                setOnKeyListener(
+                    BackKeyListener {
+                        listener.onDialogCancelled()
+                    },
+                )
             }
         dialog = dialogBuilder.create()
         setViews(binding, dialog!!)

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -52,6 +52,9 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     var negativeButtonText: CharSequence = ""
         private set
 
+    var isCancellable: Boolean = false
+        private set
+
     fun setHeaderImageResource(@DrawableRes drawableId: Int): TextAlertDialogBuilder {
         headerImageDrawableId = drawableId
         return this
@@ -87,6 +90,11 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         return this
     }
 
+    fun setCancellable(cancellable: Boolean): TextAlertDialogBuilder {
+        isCancellable = cancellable
+        return this
+    }
+
     fun addEventListener(eventListener: EventListener): TextAlertDialogBuilder {
         listener = eventListener
         return this
@@ -99,7 +107,7 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         val dialogBuilder = MaterialAlertDialogBuilder(context, R.style.Widget_DuckDuckGo_Dialog)
             .setView(binding.root)
             .apply {
-                setCancelable(false)
+                setCancelable(isCancellable)
                 setOnDismissListener { listener.onDialogDismissed() }
             }
         dialog = dialogBuilder.create()

--- a/common-ui/src/main/res/layout/fragment_components_dialogs.xml
+++ b/common-ui/src/main/res/layout/fragment_components_dialogs.xml
@@ -50,6 +50,14 @@
                 android:layout_height="wrap_content"/>
 
         <com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
+            android:id="@+id/textAlertDialogCancellable"
+            app:buttonSize="large"
+            android:text="Text Alert Dialog Cancellable"
+            android:layout_marginTop="16dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+        <com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
                 app:buttonSize="large"
                 android:id="@+id/stackedAlertDialogWithImageButton"
                 android:layout_width="match_parent"


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1157893581871903/1203893894847062

### Description
This PR makes the TextAlertDialog cancellable. 
We also want to revert the changes in the AppEnjoyment flow, and leave it as it was before.

### Steps to test this PR

_App Components Preview_
- [ ] Open App Component Preview from Settings
- [ ] Navigate to Dialogs
- [ ] Tap on Text Alert Dialog Dismissible
- [ ] Verify tapping outside dialog dismissed it, but no snackbar is visible
- [ ] Verify tapping back key dialog dismissed it and shows snackbar