### PR TITLE
Create the feature flag code generator

### DIFF
--- a/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesRemoteFeature.kt
+++ b/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesRemoteFeature.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.anvil.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Anvil annotation to generate remote features
+ *
+ * Usage:
+ * ```kotlin
+ * @ContributesRemoteFeature(
+ *   scope = AppScope::class,
+ *   featureName = "myFeatureName",
+ *   settingsStore = MyFeatureSettingsStore::class,
+ *   exceptionStore = MyFeatureExceptionStore::class,
+ * )
+ * interface MyFeature {
+ *
+ * }
+ * ```
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ContributesRemoteFeature(
+    /** The scope in which to include this contributed PluginPoint */
+    val scope: KClass<*>,
+
+    /**
+     * Type that the feature will be bound to
+     */
+    val boundType: KClass<*> = Unit::class,
+
+    /** The name of the remote feature */
+    val featureName: String,
+
+    /** The class that implements the [RemoteFeatureSettingsStore] interface */
+    val settingsStore: KClass<*> = Unit::class,
+
+    /** The class that implements the [RemoteFeatureExceptionStore] interface */
+    val exceptionsStore: KClass<*> = Unit::class,
+)

--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -1,0 +1,816 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.anvil.compiler
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.feature.toggles.api.*
+import com.google.auto.service.AutoService
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.anvil.annotations.ExperimentalAnvilApi
+import com.squareup.anvil.compiler.api.*
+import com.squareup.anvil.compiler.internal.asClassName
+import com.squareup.anvil.compiler.internal.buildFile
+import com.squareup.anvil.compiler.internal.fqName
+import com.squareup.anvil.compiler.internal.reference.*
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import dagger.BindsOptionalOf
+import dagger.Provides
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtFile
+
+@OptIn(ExperimentalAnvilApi::class)
+@AutoService(CodeGenerator::class)
+class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
+
+    private val settingsStorePresent = AtomicBoolean(true)
+    private val exceptionStorePresent = AtomicBoolean(true)
+
+    override fun isApplicable(context: AnvilContext): Boolean = true
+
+    override fun generateCode(codeGenDir: File, module: ModuleDescriptor, projectFiles: Collection<KtFile>): Collection<GeneratedFile> {
+        return projectFiles.classAndInnerClassReferences(module)
+            .toList()
+            .filter { it.isAnnotatedWith(ContributesRemoteFeature::class.fqName) }
+            .onEach { validateRemoteFeatureInterface(it, module) }
+            .flatMap {
+                listOf(
+                    generateRemoteFeature(it, codeGenDir, module),
+                    generateFeatureToggleProxy(it, codeGenDir, module),
+//                    generateOptionalBindings(it, codeGenDir, module),
+                )
+            }
+            .toList()
+    }
+
+    private fun generateFeatureToggleProxy(vmClass: ClassReference.Psi, codeGenDir: File, module: ModuleDescriptor): GeneratedFile {
+        val generatedPackage = vmClass.packageFqName.toString()
+        val generatedClassName = "${vmClass.shortName}_ProxyModule"
+        val annotation = vmClass.annotations.first { it.fqName == ContributesRemoteFeature::class.fqName }
+        val boundType = annotation.boundTypeOrNull() ?: vmClass
+        val scope = vmClass.annotations.first { it.fqName == ContributesRemoteFeature::class.fqName }.scopeOrNull()!!
+        val featureName = annotation.featureNameOrNull()
+
+        val content = FileSpec.buildFile(generatedPackage, generatedClassName) {
+            addType(
+                TypeSpec.objectBuilder(generatedClassName)
+                    .addAnnotation(AnnotationSpec.builder(dagger.Module::class).build())
+                    .addAnnotation(
+                        AnnotationSpec
+                            .builder(ContributesTo::class).addMember("scope = %T::class", scope.asClassName())
+                            .build(),
+                    )
+                    .addFunction(
+                        FunSpec.builder("provides${boundType.shortName}")
+                            .addAnnotation(Provides::class.asClassName())
+                            .addAnnotation(
+                                AnnotationSpec.builder(singleInstanceAnnotationFqName.asClassName(module))
+                                    .addMember("scope = %T::class", scope.asClassName())
+                                    .build(),
+                            )
+                            .addParameter(
+                                ParameterSpec
+                                    .builder("toggleStore", Toggle.Store::class.asClassName())
+                                    .addAnnotation(
+                                        AnnotationSpec.builder(RemoteFeatureStoreNamed::class.asClassName())
+                                            .addMember("value = %T::class", boundType.asClassName())
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
+                            .addParameter("appBuildConfig", appBuildConfig.asClassName(module))
+                            .addCode(
+                                """
+                            return %T.Builder()
+                                .store(toggleStore)
+                                .appVersionProvider({ appBuildConfig.versionCode })
+                                .featureName(%S)
+                                .build()
+                                .create(%T::class.java)
+                                """.trimIndent(),
+                                FeatureToggles::class.asClassName(),
+                                featureName,
+                                boundType.asClassName(),
+                            )
+                            .returns(boundType.asClassName())
+                            .build(),
+                    ).apply {
+                        if (!settingsStorePresent.get()) {
+                            addFunction(
+                                FunSpec.builder("providesNoopSettingsStore")
+                                    .addAnnotation(Provides::class.asClassName())
+                                    .addAnnotation(
+                                        AnnotationSpec.builder(RemoteFeatureStoreNamed::class.asClassName())
+                                            .addMember("value = %T::class", boundType.asClassName())
+                                            .build(),
+                                    )
+                                    .addCode(
+                                        CodeBlock.of(
+                                            """
+                                                return %T.EMPTY_STORE
+                                            """.trimIndent(),
+                                            FeatureSettings::class.asClassName(),
+                                        ),
+                                    )
+                                    .returns(FeatureSettings.Store::class.asClassName())
+                                    .build(),
+                            )
+                        }
+                        if (!exceptionStorePresent.get()) {
+                            addFunction(
+                                FunSpec.builder("providesNoopExceptionsStore")
+                                    .addAnnotation(Provides::class.asClassName())
+                                    .addAnnotation(
+                                        AnnotationSpec.builder(RemoteFeatureStoreNamed::class.asClassName())
+                                            .addMember("value = %T::class", boundType.asClassName())
+                                            .build(),
+                                    )
+                                    .addCode(
+                                        CodeBlock.of(
+                                            """
+                                                return %T.EMPTY_STORE
+                                            """.trimIndent(),
+                                            FeatureExceptions::class.asClassName(),
+                                        ),
+                                    )
+                                    .returns(FeatureExceptions.Store::class.asClassName())
+                                    .build(),
+                            )
+                        }
+                    }
+                    .build(),
+            )
+        }
+
+        return createGeneratedFile(codeGenDir, generatedPackage, generatedClassName, content)
+    }
+
+    private fun generateRemoteFeature(vmClass: ClassReference.Psi, codeGenDir: File, module: ModuleDescriptor): GeneratedFile {
+        val generatedPackage = vmClass.packageFqName.toString()
+        val generatedClassName = "${vmClass.shortName}_RemoteFeature"
+        val annotation = vmClass.annotations.first { it.fqName == ContributesRemoteFeature::class.fqName }
+        val boundType = annotation.boundTypeOrNull() ?: vmClass
+        val featureName = vmClass.annotations.first { it.fqName == ContributesRemoteFeature::class.fqName }.featureNameOrNull()!!
+        val scope = vmClass.annotations.first { it.fqName == ContributesRemoteFeature::class.fqName }.scopeOrNull()!!
+
+        val content = FileSpec.buildFile(generatedPackage, generatedClassName) {
+            addType(
+                TypeSpec.classBuilder(generatedClassName)
+                    .addAnnotations(
+                        listOf(
+                            AnnotationSpec
+                                .builder(ContributesMultibinding::class)
+                                .addMember("scope = %T::class", scope.asClassName())
+                                .addMember("boundType = %T::class", privacyFeaturePlugin.asClassName(module))
+                                .addMember("ignoreQualifier = true")
+                                .build(),
+                            AnnotationSpec
+                                .builder(ContributesBinding::class)
+                                .addMember("scope = %T::class", scope.asClassName())
+                                .addMember("boundType = %T::class", Toggle.Store::class.asClassName())
+                                .build(),
+                            AnnotationSpec
+                                .builder(RemoteFeatureStoreNamed::class).addMember("value = %T::class", boundType.asClassName())
+                                .build(),
+                            AnnotationSpec
+                                .builder(singleInstanceAnnotationFqName.asClassName(module))
+                                .addMember("scope = %T::class", scope.asClassName())
+                                .build(),
+                        ),
+                    )
+                    .addSuperinterface(privacyFeaturePlugin.asClassName(module))
+                    .addSuperinterface(Toggle.Store::class.asClassName())
+                    .primaryConstructor(
+                        FunSpec.constructorBuilder()
+                            .addAnnotation(AnnotationSpec.builder(Inject::class).build())
+                            .addParameter(
+                                ParameterSpec
+                                    .builder(
+                                        "exceptionStore",
+                                        FeatureExceptions.Store::class,
+                                    )
+                                    .addAnnotation(
+                                        AnnotationSpec
+                                            .builder(RemoteFeatureStoreNamed::class).addMember("value = %T::class", boundType.asClassName())
+                                            .build(),
+
+                                    )
+                                    .build(),
+                            )
+                            .addParameter(
+                                ParameterSpec
+                                    .builder(
+                                        "settingsStore",
+                                        FeatureSettings.Store::class,
+                                    )
+                                    .addAnnotation(
+                                        AnnotationSpec
+                                            .builder(RemoteFeatureStoreNamed::class).addMember("value = %T::class", boundType.asClassName())
+                                            .build(),
+
+                                    )
+                                    .build(),
+                            )
+                            .addParameter("feature", dagger.Lazy::class.asClassName().parameterizedBy(boundType.asClassName()))
+                            .addParameter("appBuildConfig", appBuildConfig.asClassName(module))
+                            .addParameter("context", context.asClassName(module))
+                            .build(),
+                    )
+                    .addProperty(
+                        PropertySpec
+                            .builder(
+                                "exceptionStore",
+                                FeatureExceptions.Store::class,
+                                KModifier.PRIVATE,
+                            )
+                            .initializer("exceptionStore")
+                            .build(),
+                    )
+                    .addProperty(
+                        PropertySpec
+                            .builder(
+                                "settingsStore",
+                                FeatureSettings.Store::class,
+                                KModifier.PRIVATE,
+                            )
+                            .initializer("settingsStore")
+                            .build(),
+                    )
+                    .addProperty(
+                        PropertySpec.builder("feature", dagger.Lazy::class.asClassName().parameterizedBy(boundType.asClassName()), KModifier.PRIVATE)
+                            .initializer("feature")
+                            .build(),
+                    )
+                    .addProperty(
+                        PropertySpec.builder("appBuildConfig", appBuildConfig.asClassName(module), KModifier.PRIVATE)
+                            .initializer("appBuildConfig")
+                            .build(),
+                    )
+                    .addProperty(
+                        PropertySpec.builder("context", context.asClassName(module), KModifier.PRIVATE)
+                            .initializer("context")
+                            .build(),
+                    )
+                    .addProperty(
+                        PropertySpec.builder("moshi", moshi.asClassName(module), KModifier.PRIVATE)
+                            .initializer("Moshi.Builder().add(%T()).build()", jsonObjectAdapter.asClassName(module))
+                            .build(),
+                    )
+                    .addProperty(createSharedPreferencesProperty(generatedPackage, featureName, module))
+                    .addProperty(createFeatureNameProperty(featureName))
+                    .addFunction(createStoreOverride(module))
+                    .addFunctions(createToggleStoreImplementation(module))
+                    .addFunction(createCompareAndSetHash())
+                    .addFunction(createParseJsonFun(module))
+                    .addFunction(createParseExceptions(module))
+                    .addFunction(createInvokeMethod(boundType))
+                    .addType(createJsonToggleDataClass(generatedPackage, module))
+                    .addType(createJsonFeatureDataClass(generatedPackage, module))
+                    .addType(createJsonExceptionDataClass(generatedPackage, module))
+                    .addType(createJsonObjectAdapterClass(generatedPackage, module))
+                    .build(),
+            )
+        }
+
+        return createGeneratedFile(codeGenDir, generatedPackage, generatedClassName, content)
+    }
+
+    private fun generateOptionalBindings(vmClass: ClassReference.Psi, codeGenDir: File, module: ModuleDescriptor): GeneratedFile {
+        val generatedPackage = vmClass.packageFqName.toString()
+        val generatedClassName = "${vmClass.shortName}_OptionalBindings_Module"
+        val annotation = vmClass.annotations.first { it.fqName == ContributesRemoteFeature::class.fqName }
+        val boundType = annotation.boundTypeOrNull() ?: vmClass
+        val scope = vmClass.annotations.first { it.fqName == ContributesRemoteFeature::class.fqName }.scopeOrNull()!!
+
+        val content = FileSpec.buildFile(generatedPackage, generatedClassName) {
+            addType(
+                TypeSpec.classBuilder(generatedClassName)
+                    .addModifiers(KModifier.ABSTRACT)
+                    .addAnnotation(AnnotationSpec.builder(dagger.Module::class).build())
+                    .addAnnotation(
+                        AnnotationSpec
+                            .builder(ContributesTo::class).addMember("scope = %T::class", scope.asClassName())
+                            .build(),
+                    )
+                    .addFunction(
+                        FunSpec.builder("bindOptionalSettingsStore")
+                            .addModifiers(KModifier.ABSTRACT)
+                            .addAnnotation(BindsOptionalOf::class.asClassName())
+                            .addAnnotation(
+                                AnnotationSpec.builder(RemoteFeatureStoreNamed::class.asClassName())
+                                    .addMember("value = %T::class", boundType.asClassName())
+                                    .build(),
+                            )
+                            .returns(FeatureSettings.Store::class.java.asClassName())
+                            .build(),
+                    )
+                    .addFunction(
+                        FunSpec.builder("bindOptionalExceptionsStore")
+                            .addModifiers(KModifier.ABSTRACT)
+                            .addAnnotation(BindsOptionalOf::class.asClassName())
+                            .addAnnotation(
+                                AnnotationSpec.builder(RemoteFeatureStoreNamed::class.asClassName())
+                                    .addMember("value = %T::class", boundType.asClassName())
+                                    .build(),
+                            )
+                            .returns(FeatureExceptions.Store::class.java.asClassName())
+                            .build(),
+                    )
+                    .build(),
+            )
+        }
+
+        return createGeneratedFile(codeGenDir, generatedPackage, generatedClassName, content)
+    }
+
+    private fun createFeatureNameProperty(featureName: String): PropertySpec {
+        return PropertySpec.builder("featureName", String::class.asClassName())
+            .addModifiers(KModifier.OVERRIDE)
+            .initializer(CodeBlock.of("%S", featureName))
+            .build()
+    }
+
+    private fun createSharedPreferencesProperty(generatedPackage: String, featureName: String, module: ModuleDescriptor): PropertySpec {
+        val filename = "$generatedPackage.$featureName.remote.feature"
+        return PropertySpec.builder("preferences", sharedPreferences.asClassName(module))
+            .addModifiers(KModifier.PRIVATE)
+            .getter(
+                FunSpec.builder("get()")
+                    .addCode(CodeBlock.of("return context.getSharedPreferences(%S, Context.MODE_PRIVATE)", filename))
+                    .build(),
+            )
+            .build()
+    }
+
+    private fun createStoreOverride(module: ModuleDescriptor): FunSpec {
+        return FunSpec.builder("store")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter(ParameterSpec.builder("featureName", String::class.asClassName()).build())
+            .addParameter(ParameterSpec.builder("jsonString", String::class.asClassName()).build())
+            .addCode(
+                """
+                if (featureName == this.featureName) {
+                    val feature = parseJson(jsonString) ?: return false
+                    
+                    if (compareAndSetHash(feature.hash)) return true
+        
+                    val exceptions = parseExceptions(feature)
+                    exceptionStore.insertAll(exceptions)
+        
+                    val isEnabled = (feature.state == "enabled") || (appBuildConfig.flavor == %T && feature.state == "internal")
+                    this.feature.get().invokeMethod("self").setEnabled(Toggle.State(isEnabled, feature.minSupportedVersion))
+        
+                    // Handle sub-features
+                    feature.features?.forEach { subfeature ->
+                        subfeature.value.let { jsonObject ->
+                            val jsonToggle = JsonToggle(jsonObject)
+                            this.feature.get().invokeMethod(subfeature.key).setEnabled(
+                                Toggle.State(
+                                    enable = jsonToggle.state == "enabled" || (appBuildConfig.flavor == %T && jsonToggle.state == "internal"),
+                                    minSupportedVersion = jsonToggle.minSupportedVersion,
+                                ),
+                            )
+                        }
+                    }
+        
+                    // handle settings
+                    feature.settings?.let {
+                        settingsStore.store(featureName, it.toString())
+                    }
+        
+                    return true
+                }
+                return false
+                """.trimIndent(),
+                buildFlavorInternal.asClassName(module),
+                buildFlavorInternal.asClassName(module),
+            )
+            .returns(Boolean::class.asClassName())
+            .build()
+    }
+
+    private fun createToggleStoreImplementation(module: ModuleDescriptor): List<FunSpec> {
+        return listOf(
+            FunSpec.builder("set")
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter("key", String::class.asClassName())
+                .addParameter("state", Toggle.State::class.asClassName())
+                .addCode(
+                    CodeBlock.of(
+                        """
+                            val jsonAdapter = moshi.adapter(%T::class.java)
+                            preferences.edit().putString(key, jsonAdapter.toJson(state)).apply()
+                        """.trimIndent(),
+                        Toggle.State::class.asClassName(),
+                    ),
+                )
+                .build(),
+            FunSpec.builder("get")
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter("key", String::class.asClassName())
+                .addCode(
+                    CodeBlock.of(
+                        """
+                            val jsonAdapter = moshi.adapter(%T::class.java)
+                            return jsonAdapter.fromJson(preferences.getString(key, null))
+                        """.trimIndent(),
+                        Toggle.State::class.asClassName(),
+                    ),
+                )
+                .returns(Toggle.State::class.asClassName().copy(nullable = true))
+                .build(),
+        )
+    }
+
+    private fun createCompareAndSetHash(): FunSpec {
+        return FunSpec.builder("compareAndSetHash")
+            .addModifiers(KModifier.PRIVATE)
+            .addParameter("hash", String::class.asClassName().copy(nullable = true))
+            .addCode(
+                CodeBlock.builder()
+                    .add(
+                        """
+                            if (hash == null) return false 
+                            val currentHash = preferences.getString("hash", null)
+                            if (hash == currentHash) return true
+                            preferences.edit().putString("hash", hash).apply()
+                            return false
+                        """.trimIndent(),
+                    )
+                    .build(),
+            )
+            .returns(Boolean::class)
+            .build()
+    }
+
+    private fun createParseJsonFun(module: ModuleDescriptor): FunSpec {
+        return FunSpec.builder("parseJson")
+            .addModifiers(KModifier.PRIVATE)
+            .addParameter("jsonString", String::class.asClassName())
+            .addCode(
+                CodeBlock.builder()
+                    .add(
+                        """
+                            val jsonAdapter = moshi.adapter(JsonFeature::class.java)
+                            return jsonAdapter.fromJson(jsonString)
+                        """.trimIndent(),
+                    ).build(),
+            )
+            .returns(FqName("JsonFeature").asClassName(module).copy(nullable = true))
+            .build()
+    }
+
+    private fun createParseExceptions(module: ModuleDescriptor): FunSpec {
+        return FunSpec.builder("parseExceptions")
+            .addModifiers(KModifier.PRIVATE)
+            .addParameter("jsonFeature", FqName("JsonFeature").asClassName(module).copy(nullable = true))
+            .addCode(
+                CodeBlock.builder()
+                    .add(
+                        """
+                            val featureExceptions = mutableListOf<%T>()
+                            jsonFeature?.exceptions?.map { ex ->
+                                featureExceptions.add(%T(ex.domain, ex.reason))
+                            }
+                            return featureExceptions.toList()
+                        """.trimIndent(),
+                        FeatureExceptions.FeatureException::class.fqName.asClassName(module),
+                        FeatureExceptions.FeatureException::class.fqName.asClassName(module),
+                    ).build(),
+            )
+            .returns(List::class.asClassName().parameterizedBy(FeatureExceptions.FeatureException::class.asClassName()))
+            .build()
+    }
+
+    private fun createInvokeMethod(boundType: ClassReference): FunSpec {
+        return FunSpec.builder("invokeMethod")
+            .receiver(boundType.asClassName())
+            .addParameter("name", String::class)
+            .addCode(
+                """
+                return kotlin.runCatching { this.javaClass.getDeclaredMethod(name) }.getOrNull()?.let { m ->
+                    m.invoke(this)
+                } as Toggle
+                """.trimIndent(),
+            )
+            .returns(Toggle::class)
+            .build()
+    }
+
+    private fun createJsonToggleDataClass(generatedPackage: String, module: ModuleDescriptor): TypeSpec {
+        return TypeSpec.classBuilder(FqName("$generatedPackage.JsonToggle").asClassName(module))
+            .addModifiers(KModifier.PRIVATE)
+            .addModifiers(KModifier.DATA)
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter(
+                        "map",
+                        Map::class.asClassName().parameterizedBy(String::class.asClassName(), Any::class.asClassName().copy(nullable = true)),
+                    )
+                    .build(),
+            )
+            // Property map that matches params to generate data class
+            .addProperty(
+                PropertySpec
+                    .builder(
+                        "map",
+                        Map::class.asClassName().parameterizedBy(String::class.asClassName(), Any::class.asClassName().copy(nullable = true)),
+                    )
+                    .initializer("map")
+                    .build(),
+            )
+            .addProperty(
+                PropertySpec
+                    .builder(
+                        "attributes",
+                        Map::class.asClassName().parameterizedBy(String::class.asClassName(), Any::class.asClassName().copy(nullable = true)),
+                    )
+                    .addModifiers(KModifier.PRIVATE)
+                    .initializer(CodeBlock.of("map.withDefault { null }"))
+                    .build(),
+            )
+            .addProperty(
+                PropertySpec
+                    .builder("state", String::class.asClassName().copy(nullable = true))
+                    .delegate("attributes")
+                    .build(),
+            )
+            .addProperty(
+                PropertySpec
+                    .builder("minSupportedVersion", Int::class.asClassName().copy(nullable = true))
+                    .delegate("attributes")
+                    .build(),
+            )
+            .build()
+    }
+
+    private fun createJsonFeatureDataClass(generatedPackage: String, module: ModuleDescriptor): TypeSpec {
+        return TypeSpec.classBuilder(FqName("$generatedPackage.JsonFeature").asClassName(module))
+            .addModifiers(KModifier.PRIVATE)
+            .addModifiers(KModifier.DATA)
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("state", String::class.asClassName().copy(nullable = true))
+                    .addParameter("hash", String::class.asClassName().copy(nullable = true))
+                    .addParameter("minSupportedVersion", Int::class.asClassName().copy(nullable = true))
+                    .addParameter("settings", FqName("org.json.JSONObject").asClassName(module).copy(nullable = true))
+                    .addParameter(
+                        ParameterSpec
+                            .builder(
+                                "exceptions",
+                                List::class.asClassName().parameterizedBy(FqName("JsonException").asClassName(module)),
+                            )
+                            .build(),
+                    )
+                    .addParameter(
+                        ParameterSpec
+                            .builder(
+                                "features",
+                                Map::class.asClassName().parameterizedBy(
+                                    String::class.asClassName(),
+                                    Map::class.asClassName().parameterizedBy(
+                                        String::class.asClassName(),
+                                        Any::class.asClassName().copy(nullable = true),
+                                    ),
+                                ).copy(nullable = true),
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            // properties that match params to generate data class
+            .addProperty(PropertySpec.builder("state", String::class.asClassName().copy(nullable = true)).initializer("state").build())
+            .addProperty(PropertySpec.builder("hash", String::class.asClassName().copy(nullable = true)).initializer("hash").build())
+            .addProperty(
+                PropertySpec.builder("minSupportedVersion", Int::class.asClassName().copy(nullable = true)).initializer("minSupportedVersion").build(),
+            )
+            .addProperty(
+                PropertySpec.builder("settings", FqName("org.json.JSONObject").asClassName(module).copy(nullable = true)).initializer("settings").build(),
+            )
+            .addProperty(
+                PropertySpec.builder(
+                    "exceptions",
+                    List::class.asClassName().parameterizedBy(FqName("JsonException").asClassName(module)),
+                ).initializer("exceptions")
+                    .build(),
+            )
+            .addProperty(
+                PropertySpec
+                    .builder(
+                        "features",
+                        Map::class.asClassName().parameterizedBy(
+                            String::class.asClassName(),
+                            Map::class.asClassName().parameterizedBy(String::class.asClassName(), Any::class.asClassName().copy(nullable = true)),
+                        ).copy(nullable = true),
+                    )
+                    .initializer("features")
+                    .build(),
+            )
+            .build()
+    }
+
+    private fun createJsonExceptionDataClass(generatedPackage: String, module: ModuleDescriptor): TypeSpec {
+        return TypeSpec.classBuilder(FqName("$generatedPackage.JsonException").asClassName(module))
+            .addModifiers(KModifier.PRIVATE)
+            .addModifiers(KModifier.DATA)
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("domain", String::class.asClassName())
+                    .addParameter("reason", String::class.asClassName())
+                    .build(),
+            )
+            .addProperty(PropertySpec.builder("domain", String::class.asClassName()).initializer("domain").build())
+            .addProperty(PropertySpec.builder("reason", String::class.asClassName()).initializer("reason").build())
+            .build()
+    }
+
+    private fun createJsonObjectAdapterClass(generatedPackage: String, module: ModuleDescriptor): TypeSpec {
+        return TypeSpec.classBuilder("JSONObjectAdapter")
+            .addModifiers(KModifier.PRIVATE)
+            .addFunction(
+                FunSpec.builder("fromJson")
+                    .addAnnotation(fromJsonAnnotation.asClassName(module))
+                    .addParameter("reader", JsonReader.asClassName(module))
+                    .addCode(
+                        CodeBlock.of(
+                            """
+                                return (reader.readJsonValue() as? Map<*, *>)?.let { data ->
+                                    try {
+                                        %T(data)
+                                    } catch (e: %T) {
+                                        return null
+                                    }
+                                }
+                            """.trimIndent(),
+                            JSONObject.asClassName(module),
+                            JSONException.asClassName(module),
+                        ),
+                    )
+                    .returns(JSONObject.asClassName(module).copy(nullable = true))
+                    .build(),
+            )
+            .addFunction(
+                FunSpec.builder("toJson")
+                    .addAnnotation(toJsonAnnotation.asClassName(module))
+                    .addParameter("writer", JsonWriter.asClassName(module))
+                    .addParameter("value", JSONObject.asClassName(module).copy(nullable = true))
+                    .addCode(
+                        CodeBlock.of(
+                            """
+                                value?.let { writer.run { value(%T().writeUtf8(value.toString())) } }
+                            """.trimIndent(),
+                            okioBuffer.asClassName(module),
+                        ),
+                    )
+                    .build(),
+            )
+            .build()
+    }
+
+    private fun validateRemoteFeatureInterface(vmClass: ClassReference.Psi, module: ModuleDescriptor) {
+        // validate type must be an interface
+        if (!vmClass.isInterface()) {
+            throw AnvilCompilationException(
+                "${vmClass.fqName} must be an interface",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
+
+        // validate only ContributesRemoteFeature and/or Suppress is added
+        val invalidAnnotations = vmClass.annotations.filter {
+            it.fqName != ContributesRemoteFeature::class.fqName
+        }.filter {
+            it.fqName != Suppress::class.fqName
+        }
+        if (invalidAnnotations.isNotEmpty()) {
+            throw AnvilCompilationException(
+                "${vmClass.fqName} can only be annotated with @ContributesRemoteFeature or @Suppress",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
+
+        // Validate ContributesRemoteFeature annotation
+        val annotation = vmClass.annotations.first { it.fqName == ContributesRemoteFeature::class.fqName }
+        if (annotation.scopeOrNull(0) == null) {
+            throw AnvilCompilationException(
+                "${vmClass.fqName} annotated with @ContributesRemoteFeature must define [scope]",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
+        if (annotation.featureNameOrNull() == null) {
+            throw AnvilCompilationException(
+                "${vmClass.fqName} annotated with @ContributesRemoteFeature must define [featureName]",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
+        with(annotation.settingsStoreOrNull()) {
+            if (this == null) {
+                settingsStorePresent.set(false)
+            } else if (this.directSuperTypeReferences().none { it.asClassReferenceOrNull()?.fqName == FeatureSettings.Store::class.fqName }) {
+                throw AnvilCompilationException(
+                    "${vmClass.fqName} [settingsStore] must extend [FeatureSettings.Store]",
+                    element = vmClass.clazz.identifyingElement,
+                )
+            }
+        }
+        with(annotation.exceptionsStore()) {
+            if (this == null) {
+                exceptionStorePresent.set(false)
+            } else if (this.directSuperTypeReferences().none { it.asClassReferenceOrNull()?.fqName == FeatureExceptions.Store::class.fqName }) {
+                throw AnvilCompilationException(
+                    "${vmClass.fqName} [settingsStore] must extend [FeatureExceptions.Store]",
+                    element = vmClass.clazz.identifyingElement,
+                )
+            }
+        }
+
+        // shadow vmClass in case we have a bound type
+        val boundType = annotation.boundTypeOrNull() ?: vmClass
+
+        // validate all functions must return [Toggle]
+        if (boundType.declaredFunctions().any { it.returnType().asClassReferenceOrNull()?.fqName != Toggle::class.fqName }) {
+            throw AnvilCompilationException(
+                "${boundType.fqName} can only contain functions that return [Toggle]",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
+        // validate functions can't have parameters
+        if (boundType.declaredFunctions().any { it.parameters.isNotEmpty() }) {
+            throw AnvilCompilationException(
+                "${boundType.fqName} can only contain functions without parameters",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
+
+        // validate functions must be annotated with DefaultValue
+        if (boundType.declaredFunctions().any { !it.isAnnotatedWith(Toggle.DefaultValue::class.fqName) }) {
+            throw AnvilCompilationException(
+                "All functions in ${boundType.fqName} must be annotated with [Toggle.DefaultValue]",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
+
+        // validate function self() must be present
+        if (boundType.declaredFunctions().none { it.name == "self" }) {
+            throw AnvilCompilationException(
+                "${boundType.fqName} must have a function self()",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
+    }
+
+    private fun AnnotationReference.featureNameOrNull(): String? {
+        return argumentAt("featureName", 2)?.value()
+    }
+    private fun AnnotationReference.settingsStoreOrNull(): ClassReference? {
+        return argumentAt("settingsStore", 3)?.value()
+    }
+    private fun AnnotationReference.exceptionsStore(): ClassReference? {
+        return argumentAt("exceptionsStore", 4)?.value()
+    }
+
+    private fun ClassReference.declaredFunctions(): List<FunctionReference> {
+        return functions
+            .filter { it.name != "equals" }
+            .filter { it.name != "hashCode" }
+            .filter { it.name != "toString" }
+    }
+
+    companion object {
+        private val sharedPreferences = FqName("android.content.SharedPreferences")
+        private val context = FqName("android.content.Context")
+        private val privacyFeaturePlugin = FqName("com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin")
+        private val appBuildConfig = FqName("com.duckduckgo.appbuildconfig.api.AppBuildConfig")
+        private val buildFlavorInternal = FqName("com.duckduckgo.appbuildconfig.api.BuildFlavor.INTERNAL")
+        private val moshi = FqName("com.squareup.moshi.Moshi")
+        private val jsonObjectAdapter = FqName("JSONObjectAdapter")
+        private val singleInstanceAnnotationFqName = FqName("dagger.SingleInstanceIn")
+        private val fromJsonAnnotation = FqName("com.squareup.moshi.FromJson")
+        private val toJsonAnnotation = FqName("com.squareup.moshi.ToJson")
+        private val JSONObject = FqName("org.json.JSONObject")
+        private val JSONException = FqName("org.json.JSONException")
+        private val JsonWriter = FqName("com.squareup.moshi.JsonWriter")
+        private val JsonReader = FqName("com.squareup.moshi.JsonReader")
+        private val okioBuffer = FqName("okio.Buffer")
+    }
+}

--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -351,7 +351,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
     }
 
     private fun createSharedPreferencesProperty(generatedPackage: String, featureName: String, module: ModuleDescriptor): PropertySpec {
-        val filename = "$generatedPackage.$featureName.remote.feature"
+        val filename = "com.duckduckgo.feature.toggle.$featureName"
         return PropertySpec.builder("preferences", sharedPreferences.asClassName(module))
             .addModifiers(KModifier.PRIVATE)
             .getter(
@@ -395,7 +395,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
         
                     // handle settings
                     feature.settings?.let {
-                        settingsStore.store(featureName, it.toString())
+                        settingsStore.store(it.toString())
                     }
         
                     return true
@@ -432,7 +432,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                     CodeBlock.of(
                         """
                             val jsonAdapter = moshi.adapter(%T::class.java)
-                            return jsonAdapter.fromJson(preferences.getString(key, null))
+                            return kotlin.runCatching { jsonAdapter.fromJson(preferences.getString(key, null)) }.getOrNull()
                         """.trimIndent(),
                         Toggle.State::class.asClassName(),
                     ),

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -183,6 +183,7 @@ dependencies {
     internalImplementation project(':vpn-internal')
 
     implementation project(':feature-toggles-api')
+    testImplementation project(':feature-toggles-test')
     implementation project(':feature-toggles-impl')
     implementation project(':privacy-config-api')
     implementation project(':privacy-config-impl')

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureExceptions.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureExceptions.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.duckduckgo.feature.toggles.api
+
+object FeatureExceptions {
+    interface Store {
+        fun insertAll(exception: List<FeatureException>)
+    }
+
+    data class FeatureException(val domain: String, val reason: String)
+
+    val EMPTY_STORE = object : Store {
+        override fun insertAll(exception: List<FeatureException>) {}
+    }
+}

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureSettings.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureSettings.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.duckduckgo.feature.toggles.api
+
+object FeatureSettings {
+    interface Store {
+        fun store(
+            featureName: String,
+            jsonString: String,
+        )
+    }
+
+    val EMPTY_STORE = object : Store {
+        override fun store(featureName: String, jsonString: String) {}
+    }
+}

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureSettings.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureSettings.kt
@@ -18,12 +18,11 @@ package com.duckduckgo.feature.toggles.api
 object FeatureSettings {
     interface Store {
         fun store(
-            featureName: String,
             jsonString: String,
         )
     }
 
     val EMPTY_STORE = object : Store {
-        override fun store(featureName: String, jsonString: String) {}
+        override fun store(jsonString: String) {}
     }
 }

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggle.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggle.kt
@@ -17,6 +17,10 @@
 package com.duckduckgo.feature.toggles.api
 
 /** Any feature toggles implemented in any module should implement [FeatureToggle] */
+@Deprecated(
+    message = "Use the new feature flag framework, https://app.asana.com/0/1202552961248957/1203898052213029/f",
+    level = DeprecationLevel.WARNING,
+)
 interface FeatureToggle {
     /**
      * This method takes a [featureName] and optionally a default value.

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -38,7 +38,19 @@ class FeatureToggles private constructor(
         fun store(store: Toggle.Store) = apply { this.store = store }
         fun appVersionProvider(appVersionProvider: () -> Int) = apply { this.appVersionProvider = appVersionProvider }
         fun featureName(featureName: String) = apply { this.featureName = featureName }
-        fun build() = FeatureToggles(this.store!!, appVersionProvider, featureName!!)
+        fun build(): FeatureToggles {
+            val missing = StringBuilder()
+            if (this.store == null) {
+                missing.append("store")
+            }
+            if (this.featureName == null) {
+                missing.append(", featureName ")
+            }
+            if (missing.isNotBlank()) {
+                throw IllegalArgumentException("This following parameters can't be null: $missing")
+            }
+            return FeatureToggles(this.store!!, appVersionProvider, featureName!!)
+        }
     }
 
     fun <T> create(toggles: Class<T>): T {

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.api
+
+import java.lang.IllegalArgumentException
+import java.lang.IllegalStateException
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+class FeatureToggles private constructor(
+    private val store: Toggle.Store,
+    private val appVersionProvider: () -> Int,
+    private val featureName: String,
+) {
+
+    private val featureToggleCache = mutableMapOf<Method, Toggle>()
+
+    data class Builder(
+        private var store: Toggle.Store? = null,
+        private var appVersionProvider: () -> Int = { Int.MAX_VALUE },
+        private var featureName: String? = null,
+    ) {
+
+        fun store(store: Toggle.Store) = apply { this.store = store }
+        fun appVersionProvider(appVersionProvider: () -> Int) = apply { this.appVersionProvider = appVersionProvider }
+        fun featureName(featureName: String) = apply { this.featureName = featureName }
+        fun build() = FeatureToggles(this.store!!, appVersionProvider, featureName!!)
+    }
+
+    fun <T> create(toggles: Class<T>): T {
+        validateFeatureInterface(toggles)
+
+        return Proxy.newProxyInstance(
+            toggles.classLoader,
+            arrayOf(toggles),
+        ) { _, method, args ->
+            validateMethod(method, args.orEmpty())
+
+            if (method.declaringClass === Any::class.java) {
+                return@newProxyInstance method.invoke(this, args) as T
+            }
+            return@newProxyInstance loadToggleMethod(method)
+        } as T
+    }
+
+    private fun loadToggleMethod(method: Method): Toggle {
+        synchronized(featureToggleCache) {
+            featureToggleCache[method]?.let { return it }
+
+            val defaultValue = try {
+                method.getAnnotation(Toggle.DefaultValue::class.java).defaultValue
+            } catch (t: Throwable) {
+                throw IllegalStateException("Feature toggle methods shall have annotated default value")
+            }
+
+            return ToggleImpl(store, getToggleNameForMethod(method), defaultValue, appVersionProvider).also { featureToggleCache[method] = it }
+        }
+    }
+
+    private fun validateFeatureInterface(feature: Class<*>) {
+        if (!feature.isInterface) {
+            throw IllegalArgumentException("Feature declarations must be interfaces")
+        }
+    }
+
+    private fun getToggleNameForMethod(method: Method): String {
+        if (method.name != "self") return "${featureName}_${method.name}"
+
+        // This can throw but should never happen as it's guarded by codegen as well
+        return featureName
+    }
+
+    private fun validateMethod(method: Method, args: Array<out Any>) {
+        if (method.returnType != Toggle::class.java) {
+            throw IllegalArgumentException("Feature method return types must be Toggle")
+        }
+
+        if (args.isNotEmpty()) {
+            throw IllegalArgumentException("Feature methods must not have arguments")
+        }
+    }
+}
+
+interface Toggle {
+    fun isEnabled(): Boolean
+
+    fun setEnabled(state: State)
+
+    data class State(
+        val enable: Boolean = false,
+        val minSupportedVersion: Int? = null,
+        val enabledOverrideValue: Boolean? = null,
+    )
+
+    interface Store {
+        fun set(key: String, state: State)
+
+        fun get(key: String): State?
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    @Retention(AnnotationRetention.RUNTIME)
+    annotation class DefaultValue(
+        val defaultValue: Boolean,
+    )
+}
+
+internal class ToggleImpl constructor(
+    private val store: Toggle.Store,
+    private val key: String,
+    private val defaultValue: Boolean,
+    private val appVersionProvider: () -> Int,
+) : Toggle {
+    override fun isEnabled(): Boolean {
+        store.get(key)?.let { state ->
+            return state.enable && appVersionProvider.invoke() >= (state.minSupportedVersion ?: 0)
+        } ?: return defaultValue
+    }
+
+    override fun setEnabled(state: Toggle.State) {
+        store.set(key, state)
+    }
+}

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureTogglesPlugin.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureTogglesPlugin.kt
@@ -20,6 +20,10 @@ package com.duckduckgo.feature.toggles.api
  * Features that can be enabled/disabled should implement this plugin. The associated plugin point
  * will call the plugins when the [FeatureToggle] API is used
  */
+@Deprecated(
+    message = "Use the new feature flag framework, https://app.asana.com/0/1202552961248957/1203898052213029/f",
+    level = DeprecationLevel.WARNING,
+)
 interface FeatureTogglesPlugin {
     /**
      * This method will return whether the plugin knows about the [featureName] in which case will

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/RemoteFeatureStoreNamed.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/RemoteFeatureStoreNamed.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.api
+
+import javax.inject.Qualifier
+import kotlin.reflect.KClass
+
+@Qualifier
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RemoteFeatureStoreNamed(
+    val value: KClass<*> = Unit::class,
+)

--- a/feature-toggles/feature-toggles-impl/build.gradle
+++ b/feature-toggles/feature-toggles-impl/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation project(path: ':di')
     implementation project(path: ':common')
     implementation project(path: ':feature-toggles-api')
-    implementation project(path: ':feature-toggles-test')
 
     implementation Kotlin.stdlib.jdk7
     implementation AndroidX.appCompat
@@ -40,6 +39,7 @@ dependencies {
     implementation AndroidX.core.ktx
 
     // Testing dependencies
+    testImplementation project(path: ':feature-toggles-test')
     testImplementation project(path: ':common-test')
     testImplementation Testing.junit4
 }

--- a/feature-toggles/feature-toggles-impl/build.gradle
+++ b/feature-toggles/feature-toggles-impl/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(path: ':di')
     implementation project(path: ':common')
     implementation project(path: ':feature-toggles-api')
+    implementation project(path: ':feature-toggles-test')
 
     implementation Kotlin.stdlib.jdk7
     implementation AndroidX.appCompat

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealFeatureTogglesImpl.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealFeatureTogglesImpl.kt
@@ -47,4 +47,4 @@ class RealFeatureToggleImpl @Inject constructor(private val featureTogglesPlugin
     boundType = FeatureTogglesPlugin::class,
 )
 @Suppress("unused")
-interface FeatureTogglesPluginPoint
+private interface FeatureTogglesPluginPoint

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
@@ -95,21 +95,25 @@ class FeatureTogglesTest {
         feature.suspendFun()
     }
 
-    @Test(expected = NullPointerException::class)
-    fun wheInvalidFeatureClassThenThrow() {
+    @Test(expected = IllegalArgumentException::class)
+    fun whenValidFeatureAndMissingFeatureNameBuilderParameterThenThrow() {
         FeatureToggles.Builder()
             .store(FakeToggleStore())
             .appVersionProvider { versionProvider.version }
             .build()
-            .create(InvalidTestFeature::class.java)
+            .create(TestFeature::class.java)
             .self()
     }
-}
 
-// It's invalid because it's not annotated with FeatureName to indicate global feature
-interface InvalidTestFeature {
-    @Toggle.DefaultValue(true)
-    fun self(): Toggle
+    @Test(expected = IllegalArgumentException::class)
+    fun whenValidFeatureAndMissingStoreBuilderParameterThenThrow() {
+        FeatureToggles.Builder()
+            .featureName("test")
+            .appVersionProvider { versionProvider.version }
+            .build()
+            .create(TestFeature::class.java)
+            .self()
+    }
 }
 
 interface TestFeature {
@@ -122,6 +126,8 @@ interface TestFeature {
     @Toggle.DefaultValue(true)
     fun enabledByDefault(): Toggle
     fun noDefaultValue(): Toggle
+
+    @Toggle.DefaultValue(true)
     fun wrongReturnValue(): Boolean
 
     @Toggle.DefaultValue(true)

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.api
+
+import java.lang.IllegalStateException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class FeatureTogglesTest {
+
+    private lateinit var feature: TestFeature
+    private lateinit var versionProvider: FakeAppVersionProvider
+
+    @Before
+    fun setup() {
+        versionProvider = FakeAppVersionProvider()
+        feature = FeatureToggles.Builder()
+            .store(FakeToggleStore())
+            .appVersionProvider { versionProvider.version }
+            .featureName("test")
+            .build()
+            .create(TestFeature::class.java)
+    }
+
+    @Test
+    fun whenDisableByDefaultThenReturnDisabled() {
+        assertFalse(feature.disableByDefault().isEnabled())
+    }
+
+    @Test
+    fun whenDisableByDefaultAndSetEnabledThenReturnEnabled() {
+        feature.disableByDefault().setEnabled(Toggle.State(enable = true))
+        assertTrue(feature.disableByDefault().isEnabled())
+    }
+
+    @Test
+    fun whenEnabledByDefaultThenReturnEnabled() {
+        assertTrue(feature.enabledByDefault().isEnabled())
+    }
+
+    @Test
+    fun whenEnabledByDefaultAndSetDisabledThenReturnDisabled() {
+        feature.enabledByDefault().setEnabled(Toggle.State(enable = false))
+        assertFalse(feature.disableByDefault().isEnabled())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun whenNoDefaultValueThenThrow() {
+        feature.noDefaultValue().isEnabled()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun whenWrongReturnValueThenThrow() {
+        feature.wrongReturnValue()
+    }
+
+    @Test
+    fun whenNotAllowedMinVersionThenReturnDisabled() {
+        versionProvider.version = 10
+        feature.enabledByDefault().setEnabled(Toggle.State(enable = true, minSupportedVersion = 11))
+        assertFalse(feature.enabledByDefault().isEnabled())
+    }
+
+    @Test
+    fun whenAllowedMinVersionThenReturnDisabled() {
+        versionProvider.version = 10
+        feature.enabledByDefault().setEnabled(Toggle.State(enable = true, minSupportedVersion = 9))
+        assertTrue(feature.enabledByDefault().isEnabled())
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException::class)
+    fun whenMethodWithArgumentsThenThrow() {
+        feature.methodWithArguments("")
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException::class)
+    fun whenSuspendFunctionThenThrow() = runTest {
+        feature.suspendFun()
+    }
+
+    @Test(expected = NullPointerException::class)
+    fun wheInvalidFeatureClassThenThrow() {
+        FeatureToggles.Builder()
+            .store(FakeToggleStore())
+            .appVersionProvider { versionProvider.version }
+            .build()
+            .create(InvalidTestFeature::class.java)
+            .self()
+    }
+}
+
+// It's invalid because it's not annotated with FeatureName to indicate global feature
+interface InvalidTestFeature {
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
+}
+
+interface TestFeature {
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun disableByDefault(): Toggle
+
+    @Toggle.DefaultValue(true)
+    fun enabledByDefault(): Toggle
+    fun noDefaultValue(): Toggle
+    fun wrongReturnValue(): Boolean
+
+    @Toggle.DefaultValue(true)
+    fun methodWithArguments(arg: String)
+
+    @Toggle.DefaultValue(true)
+    suspend fun suspendFun(): Toggle
+}
+
+private class FakeAppVersionProvider {
+    var version = Int.MAX_VALUE
+}

--- a/feature-toggles/feature-toggles-test/build.gradle
+++ b/feature-toggles/feature-toggles-test/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 DuckDuckGo
+ * Copyright (c) 2023 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,26 +17,12 @@
 plugins {
     id 'java-library'
     id 'kotlin'
-    id 'kotlin-kapt'
 }
 
 apply from: "$rootProject.projectDir/code-formatting.gradle"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
-    implementation project(path: ':anvil-annotations')
-
-    api "com.squareup.anvil:compiler-api:${anvil_version}"
-    implementation("com.squareup.anvil:compiler-utils:${anvil_version}")
-    implementation("com.squareup:kotlinpoet:1.11.0")
-    implementation Google.dagger
-    implementation project(":feature-toggles-api")
-
-    compileOnly "com.google.auto.service:auto-service-annotations:1.0"
-    kapt "com.google.auto.service:auto-service:1.0"
+    implementation project(':feature-toggles-api')
+    implementation Kotlin.stdlib.jdk7
+    implementation KotlinX.coroutines.core
 }
-

--- a/feature-toggles/feature-toggles-test/src/main/java/com/duckduckgo/feature/toggles/api/FakeToggleStore.kt
+++ b/feature-toggles/feature-toggles-test/src/main/java/com/duckduckgo/feature/toggles/api/FakeToggleStore.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.api
+
+class FakeToggleStore : Toggle.Store {
+    private val map = mutableMapOf<String, Toggle.State>()
+
+    override fun set(key: String, state: Toggle.State) {
+        map[key] = state
+    }
+
+    override fun get(key: String): Toggle.State? {
+        return map[key]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203898052213031/f

### Description
See [asana task](https://app.asana.com/0/1202552961248957/1203898052213029/f) for full background.

The PR adds a code generator for (remote) feature flags. 

For instance, the following remote feature:

```json
{
  "myFeatureName": {
    "exceptions": [...],
    "state": "enabled",
    "settings": {...},
    "features": {
      "remoteFeatureName": {
        "state": "disabled"
      }
    }
    "hash": "..."
  }
}
```

can be represented with the following code:

```kotlin
@ContributesRemoteFeature(
    scope = AppScope::class,
    featureName = "name",
//    settingsStore = MyFeatureFeatureSettingStore::class,
//    exceptionsStore = MyFeatureFeatureExceptionStore::class,
)
class MyRemoteFeature {
  @Toggle.DefaultValue(false)
  fun self(): Toggle

  @Toggle.DefaultValue(false)
  fun remoteFeatureName(): Toggle
}

class MyFeatureFeatureToggleStore : Toggle.Store {...}

class MyFeatureFeatureSettingStore : RemoteFeatureSettingsStore {...}

class MyFeatureFeatureExceptionStore : RemoteFeatureExceptionStore {...}

```

Where:
* the `MyRemoteFeature` will be the class used to check the state of the flags
* the `MyRemoteFeature` shall be annotated with `FeatureName` that will specify the name of the global feature
* the `MyRemoteFeature` shall be annotated with `ContributesRemoteFeature` for the code to be generated and shall specify
  * Dagger scope
  * `settingsStore` class that shall implement `RemoteFeatureSettingsStore` interface (Optional)
  * `exceptionStore` class that shall implement `RemoteFeatureExceptionStore` interface (Optional)
  * _NOTE: settings and exceptions store are optional. If not provided, neither will be stored_
* all methods in `MyRemoteFeature` shall return `Toggle`
* the `MyRemoteFeature` class shall contain one method called `self()`
  * this method will return the state of the global `featureName`
* the `MyRemoteFeature` may content other methods, dubbed after the sub-feature name that will also return `Toggle`


The codegen adds validation checks to ensure the correctness of the feature interfaces

After, to use the feature one can do the following:

```kotlin
private val feature: MyRemoteFeature

feature.self().isEnabled()
feature.self().setEnabled(state)

feature.remoteFeatureName().isEnabled()
feature.remoteFeatureName().setEnabled(state)
```

### How does this work?
The magic is done in two steps:
* `ContributesRemoteFeatureCodeGenerator` class is triggered by interfaces annotated with `ContributesRemoteFeature` that represent the feature. 
  * generates and contributes a `PrivacyFeaturePlugin` that will do the proper parsing for the feature
  * generates a dynamic proxy for the feature flag interface. This proxy intercepts all interface function calls and then checks the state of the toggles in the `Toggle.Store`
* finally, the proxy implementation leaves in `FeatureToggles` class

### Steps to test this PR

_Test App/Autofill_
- [x] smoke test the app and autofill to ensure nothing changed

