### PR TITLE
Fire error pixel only when onCreaterVpn() is failure

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -168,7 +168,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
         AndroidInjection.inject(this)
 
         logcat { "VPN log onCreate, creating the ${vpnNetworkStack.name} network stack" }
-        vpnNetworkStack.onCreateVpn().getOrNull()?.let {
+        if (vpnNetworkStack.onCreateVpn().isFailure) {
             // report and proceed
             deviceShieldPixels.reportErrorCreatingVpnNetworkStack()
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203919191204179/f

### Description
m_atp_ev_apptp_create_network_stack_error should only be sent when onCreateVpn is failure

### Steps to test this PR
Smoke test AppTP
