### PR TITLE
Consider ports for autofill matching and for displaying logins

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/urlmatcher/AutofillUrlMatcher.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/urlmatcher/AutofillUrlMatcher.kt
@@ -29,5 +29,9 @@ interface AutofillUrlMatcher {
      */
     fun cleanRawUrl(rawUrl: String): String
 
-    data class ExtractedUrlParts(val eTldPlus1: String?, val subdomain: String?)
+    data class ExtractedUrlParts(
+        val eTldPlus1: String?,
+        val subdomain: String?,
+        val port: Int? = null,
+    )
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/LoginCredentialTitleExtractor.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/LoginCredentialTitleExtractor.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.autofill.impl.ui.credential.management
 
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.urlmatcher.AutofillUrlMatcher
-import com.duckduckgo.autofill.api.urlmatcher.AutofillUrlMatcher.ExtractedUrlParts
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -38,14 +37,8 @@ class TitleOrDomainExtractor @Inject constructor(
             return title
         }
 
-        return urlMatcher.extractUrlPartsForAutofill(credential.domain).format()
-    }
-
-    private fun ExtractedUrlParts.format(): String {
-        return if (subdomain.isNullOrBlank()) {
-            eTldPlus1 ?: ""
-        } else {
-            "$subdomain.$eTldPlus1"
-        }
+        return credential.domain?.let {
+            urlMatcher.cleanRawUrl(it)
+        } ?: ""
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionMatcherTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionMatcherTest.kt
@@ -77,6 +77,34 @@ class SuggestionMatcherTest {
         assertEquals(1, suggestions.size)
     }
 
+    @Test
+    fun whenPortIncludedInSavedSiteAndNotInVisitedSiteThenNotASuggestion() {
+        val creds = listOf(creds("example.com:8080"))
+        val suggestions = testee.getSuggestions("example.com", creds)
+        assertEquals(0, suggestions.size)
+    }
+
+    @Test
+    fun whenPortIncludedInVisitedSiteAndNotInSavedSiteThenNotASuggestion() {
+        val creds = listOf(creds("example.com"))
+        val suggestions = testee.getSuggestions("example.com:8080", creds)
+        assertEquals(0, suggestions.size)
+    }
+
+    @Test
+    fun whenPortIncludedInVisitedSiteDiffersFromPortInSavedSiteThenNotASuggestion() {
+        val creds = listOf(creds("example.com:9000"))
+        val suggestions = testee.getSuggestions("example.com:8080", creds)
+        assertEquals(0, suggestions.size)
+    }
+
+    @Test
+    fun whenPortIncludedInVisitedSiteMatchesPortInSavedSiteThenNotASuggestion() {
+        val creds = listOf(creds("example.com:9000"))
+        val suggestions = testee.getSuggestions("example.com:9000", creds)
+        assertEquals(1, suggestions.size)
+    }
+
     private fun creds(domain: String): LoginCredentials {
         return LoginCredentials(id = 0, domain = domain, username = "username", password = "password")
     }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -200,7 +200,7 @@ class SecureStoreBackedAutofillStore(
         username: String?,
         password: String?,
     ): ContainsCredentialsResult {
-        val url = autofillUrlMatcher.cleanRawUrl(rawUrl) ?: return NoMatch
+        val url = autofillUrlMatcher.cleanRawUrl(rawUrl)
         val credentials = secureStorage.websiteLoginDetailsWithCredentialsForDomain(url).firstOrNull() ?: return NoMatch
 
         var exactMatchFound = false

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcherTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcherTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.autofill.store.urlmatcher
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.api.urlmatcher.AutofillUrlMatcher.ExtractedUrlParts
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -177,6 +178,34 @@ class AutofillDomainNameUrlMatcherTest {
     }
 
     @Test
+    fun whenSavedSiteMatchesVisitedExceptForPortThenNotMatchingForAutofill() {
+        val savedSite = ExtractedUrlParts(eTldPlus1 = "example.com", subdomain = null, port = 8000)
+        val visitedSite = ExtractedUrlParts(eTldPlus1 = "example.com", subdomain = null, port = 1000)
+        assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteMatchesVisitedAndEqualPortsThenMatchingForAutofill() {
+        val savedSite = ExtractedUrlParts(eTldPlus1 = "example.com", subdomain = null, port = 8000)
+        val visitedSite = ExtractedUrlParts(eTldPlus1 = "example.com", subdomain = null, port = 8000)
+        assertTrue(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteMatchesVisitedAndSavedSiteMissingPortThenNotMatchingForAutofill() {
+        val savedSite = ExtractedUrlParts(eTldPlus1 = "example.com", subdomain = null, port = null)
+        val visitedSite = ExtractedUrlParts(eTldPlus1 = "example.com", subdomain = null, port = 8000)
+        assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
+    fun whenSavedSiteMatchesVisitedAndVisitedSiteMissingPortThenNotMatchingForAutofill() {
+        val savedSite = ExtractedUrlParts(eTldPlus1 = "example.com", subdomain = null, port = 8000)
+        val visitedSite = ExtractedUrlParts(eTldPlus1 = "example.com", subdomain = null, port = null)
+        assertFalse(testee.matchingForAutofill(visitedSite, savedSite))
+    }
+
+    @Test
     fun whenSavedSiteContainsUppercaseWwwSubdomainAndVisitedSiteDoesNotThenMatchingForAutofill() {
         val savedSite = testee.extractUrlPartsForAutofill("WWW.example.com")
         val visitedSite = testee.extractUrlPartsForAutofill("example.com")
@@ -239,6 +268,10 @@ class AutofillDomainNameUrlMatcherTest {
         assertEquals("foo.com", testee.cleanRawUrl("foo.com"))
         assertEquals("foo.com:9000", testee.cleanRawUrl("foo.com:9000"))
         assertEquals("fuu.foo.com", testee.cleanRawUrl("fuu.foo.com"))
+        assertEquals("192.168.0.1", testee.cleanRawUrl("192.168.0.1"))
+        assertEquals("192.168.0.1:9000", testee.cleanRawUrl("192.168.0.1:9000"))
+        assertEquals("192.168.0.1", testee.cleanRawUrl("http://192.168.0.1"))
+        assertEquals("192.168.0.1:9000", testee.cleanRawUrl("http://192.168.0.1:9000"))
         assertEquals("fuu.foo.com:9000", testee.cleanRawUrl("fuu.foo.com:9000"))
         assertEquals("RandomText", testee.cleanRawUrl("thisIs@RandomText"))
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203892213154868/f

### Description
Considers port numbers when comparing urls, and displays port number in the UI if set.

### Steps to test this PR

#### Testing when saved site contains a port
- [x] Add a login for `fill.dev`
- [x] Visit `fill.dev/form/login-simple` and verify it offers to autofill as normal
- [x] Open credential management screen; verify it is listed as a `suggested` site
- [x] Edit the login and append a port to the URL (e.g., `fill.dev:9000`)
- [x] Verify the port number is visible in the list item url (assuming a title isn't given)
- [x] Visit the login page again (refreshing if required); verify you are **not prompted** to autofill (as ports don't match)
- [x] Open credential management screen; verify it is **not** listed as a `suggested` site


#### Testing when visited site contains a port
This is harder, unless you happen to know a publicly accessible website which uses a non-standard web port. If not, simulate the test by hardcoding a URL for the current site when launching creds management screen. 
- [x] `return AutofillManagementActivity.intentShowSuggestion(context, "fill.dev:9000")` on `AutofillManagementActivity`, line 346
- [x] Open credential management screen; verify it is listed as a `suggested` site