### PR TITLE
Fix NoSuchElementException in notification content plugin

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesPluginPointCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesPluginPointCodeGenerator.kt
@@ -87,7 +87,7 @@ class ContributesPluginPointCodeGenerator : CodeGenerator {
                         PropertySpec
                             .builder(
                                 "sortedPlugins",
-                                kotlinCollectionFqName.asClassName(module).parameterizedBy(pluginClassName)
+                                kotlinCollectionFqName.asClassName(module).parameterizedBy(pluginClassName),
                             )
                             .addModifiers(KModifier.PRIVATE)
                             .delegate(
@@ -95,9 +95,9 @@ class ContributesPluginPointCodeGenerator : CodeGenerator {
                                     .beginControlFlow("lazy")
                                     .add("plugins.toList().sortedBy { it.javaClass.name }")
                                     .endControlFlow()
-                                    .build()
+                                    .build(),
                             )
-                            .build()
+                            .build(),
                     )
                     .addFunction(
                         FunSpec.builder("getPlugins")

--- a/app-tracking-protection/vpn-api-test/src/main/java/com/duckduckgo/mobile/android/vpn/service/FakeVpnEnabledNotificationContentPlugin.kt
+++ b/app-tracking-protection/vpn-api-test/src/main/java/com/duckduckgo/mobile/android/vpn/service/FakeVpnEnabledNotificationContentPlugin.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service
+
+import com.duckduckgo.mobile.android.vpn.service.VpnEnabledNotificationContentPlugin.VpnEnabledNotificationPriority
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeVpnEnabledNotificationContentPlugin constructor(
+    private val isActive: Boolean,
+    private val priority: VpnEnabledNotificationPriority = VpnEnabledNotificationPriority.NORMAL,
+) : VpnEnabledNotificationContentPlugin {
+
+    override fun getInitialContent(): VpnEnabledNotificationContentPlugin.VpnEnabledNotificationContent? {
+        return null
+    }
+
+    override fun getUpdatedContent(): Flow<VpnEnabledNotificationContentPlugin.VpnEnabledNotificationContent?> {
+        return flowOf(null)
+    }
+
+    override fun getPriority(): VpnEnabledNotificationPriority {
+        return this.priority
+    }
+
+    override fun isActive(): Boolean = this.isActive
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -553,8 +553,9 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
     }
 
     private fun notifyVpnStart() {
-        val content = vpnEnabledNotificationContentPluginPoint.getHighestPriorityPlugin().getInitialContent()
-        val vpnNotification = content ?: VpnEnabledNotificationContentPlugin.VpnEnabledNotificationContent.EMPTY
+        val vpnNotification =
+            vpnEnabledNotificationContentPluginPoint.getHighestPriorityPlugin()?.getInitialContent()
+                ?: VpnEnabledNotificationContentPlugin.VpnEnabledNotificationContent.EMPTY
 
         startForeground(
             VPN_FOREGROUND_SERVICE_ID,

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnEnabledNotificationContentPluginPoint.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnEnabledNotificationContentPluginPoint.kt
@@ -27,6 +27,6 @@ import com.duckduckgo.di.scopes.VpnScope
 @Suppress("unused")
 interface VpnEnabledNotificationContentPluginPoint
 
-fun PluginPoint<VpnEnabledNotificationContentPlugin>.getHighestPriorityPlugin(): VpnEnabledNotificationContentPlugin {
-    return getPlugins().filter { it.isActive() }.maxBy { it.getPriority().ordinal }
+fun PluginPoint<VpnEnabledNotificationContentPlugin>.getHighestPriorityPlugin(): VpnEnabledNotificationContentPlugin? {
+    return runCatching { getPlugins().filter { it.isActive() }.maxByOrNull { it.getPriority().ordinal } }.getOrNull()
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnTrackerNotificationUpdates.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnTrackerNotificationUpdates.kt
@@ -43,11 +43,13 @@ class VpnTrackerNotificationUpdates @Inject constructor(
 
     override fun onVpnStarted(coroutineScope: CoroutineScope) {
         job += coroutineScope.launch(dispatcherProvider.io()) {
-            val notificationContentFlow = vpnEnabledNotificationContentPluginPoint.getHighestPriorityPlugin().getUpdatedContent()
-            notificationContentFlow.collectLatest { content ->
-                val vpnNotification = content ?: VpnEnabledNotificationContentPlugin.VpnEnabledNotificationContent.EMPTY
+            val notificationContentFlow = vpnEnabledNotificationContentPluginPoint.getHighestPriorityPlugin()?.getUpdatedContent()
+            notificationContentFlow?.let {
+                it.collectLatest { content ->
+                    val vpnNotification = content ?: VpnEnabledNotificationContentPlugin.VpnEnabledNotificationContent.EMPTY
 
-                updateNotification(vpnNotification)
+                    updateNotification(vpnNotification)
+                }
             }
         }
     }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/VpnEnabledNotificationContentPluginPointKtTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/VpnEnabledNotificationContentPluginPointKtTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service
+
+import com.duckduckgo.app.global.plugins.PluginPoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VpnEnabledNotificationContentPluginPointKtTest {
+    @Test
+    fun whenEmptyPluginPointThenReturnNull() {
+        assertNull(createPluginPoint(emptyList()).getHighestPriorityPlugin())
+    }
+
+    @Test
+    fun whenInactivePluginsThenReturnNull() {
+        assertNull(
+            createPluginPoint(
+                listOf(
+                    FakeVpnEnabledNotificationContentPlugin(isActive = false),
+                    FakeVpnEnabledNotificationContentPlugin(isActive = false),
+                ),
+            ).getHighestPriorityPlugin(),
+        )
+    }
+
+    @Test
+    fun whenActivePluginsThenReturnThemInPriorityOrder() {
+        val plugin = createPluginPoint(
+            listOf(
+                FakeVpnEnabledNotificationContentPlugin(isActive = true, VpnEnabledNotificationContentPlugin.VpnEnabledNotificationPriority.NORMAL),
+                FakeVpnEnabledNotificationContentPlugin(isActive = true, VpnEnabledNotificationContentPlugin.VpnEnabledNotificationPriority.LOW),
+                FakeVpnEnabledNotificationContentPlugin(isActive = true, VpnEnabledNotificationContentPlugin.VpnEnabledNotificationPriority.HIGH),
+            ),
+        ).getHighestPriorityPlugin()
+
+        assertEquals(VpnEnabledNotificationContentPlugin.VpnEnabledNotificationPriority.HIGH, plugin?.getPriority())
+    }
+
+    private fun createPluginPoint(plugins: List<VpnEnabledNotificationContentPlugin>): PluginPoint<VpnEnabledNotificationContentPlugin> {
+        return object : PluginPoint<VpnEnabledNotificationContentPlugin> {
+            override fun getPlugins(): Collection<VpnEnabledNotificationContentPlugin> {
+                return plugins
+            }
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203928902312895/f

### Description
See [asana task](https://app.asana.com/0/488551667048375/1203928902312895/f) for description

### Steps to test this PR
_AppTP Notifications_
- [x] fresh install from this branch
- [x] launch app and enable AppTP
- [x] verify ongoing notification shows and text is `Scanning for tracking activity… beep… boop`
- [x] open any one app that tracks
- [x] verify ongoing notification shows and text is `Tracking attempts blocked in 1 app (past hour).`
- [x] open any second app that tracks
- [x] verify ongoing notification shows and text is `Tracking attempts blocked across 2 apps (past hour).`
- [x] Force close the app
- [x] notification should disappear
- [x] re-open app
- [x] verify ongoing notification shows and text is `Tracking attempts blocked across 2 apps (past hour).`
- [x] verify tapping on the notification takes the user to AppTP screen
