### PR TITLE
Report Broken Site screen not symmetrical

### DIFF
--- a/app/src/main/res/layout/content_broken_sites.xml
+++ b/app/src/main/res/layout/content_broken_sites.xml
@@ -58,7 +58,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
             android:layout_marginTop="32dp"
-            android:layout_marginEnd="@dimen/keyline_3"
+            android:layout_marginEnd="20dp"
             android:hint="@string/brokenSitesCategoriesHint"
             app:editable="false"
             app:endIcon="@drawable/ic_chevron_down_24_small"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1203975196513828/f

### Description
Adds matching right padding to "Report Broken Site".

### Steps to test this PR
- [x] Select "Report Broken Site" from the overflow menu.
- [x] Padding should be symmetrical.

### UI changes
| Before  | After |
| ------ | ----- |
![before](https://user-images.githubusercontent.com/3471025/219031198-e560ecd5-e382-47bc-bf66-852f6edbc924.png)|![after](https://user-images.githubusercontent.com/3471025/219031206-aa8205bd-318d-4369-86bd-9dbf24679866.png)|


