### PR TITLE
Call stopvpn upon tun iface creation

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -259,6 +259,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
         if (tunInterface == null) {
             logcat(LogPriority.ERROR) { "Failed to establish the TUN interface" }
             deviceShieldPixels.vpnEstablishTunInterfaceError()
+            stopVpn(VpnStopReason.ERROR, false)
             return@withContext
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1203972982741396/f

### Description
When we fail crating the `tun` iface, we also need to call `stopVpn` otherwise we may get stuck in ENABLING state

### Steps to test this PR
NA just code review and AppTP smoke tests
