### PR TITLE
Migrate TrackingProtectionAppsAdapter

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionAppsAdapter.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionAppsAdapter.kt
@@ -145,7 +145,7 @@ class TrackingProtectionAppViewHolder(val binding: RowExclusionListAppBinding) :
             }
         } else {
             if (excludedAppInfo.isExcluded) {
-                binding.deviceShieldAppExclusionReason.text = itemView.context.getString(R.string.atp_ExcludedReasonManuallyDisabled)
+                binding.deviceShieldAppExclusionReason.text = context.getString(R.string.atp_ExcludedReasonManuallyDisabled)
                 binding.deviceShieldAppExclusionReason.show()
                 binding.deviceShieldAppEntryWarningIcon.setImageDrawable(
                     ContextCompat.getDrawable(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionAppsAdapter.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionAppsAdapter.kt
@@ -133,7 +133,7 @@ class TrackingProtectionAppViewHolder(val binding: RowExclusionListAppBinding) :
                 )
                 binding.deviceShieldAppEntryWarningIcon.show()
             } else {
-                binding.deviceShieldAppExclusionReason.text = itemView.context.getString(R.string.atp_ExcludedReasonManuallyEnabled)
+                binding.deviceShieldAppExclusionReason.text = context.getString(R.string.atp_ExcludedReasonManuallyEnabled)
                 binding.deviceShieldAppExclusionReason.show()
                 binding.deviceShieldAppEntryWarningIcon.setImageDrawable(
                     ContextCompat.getDrawable(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionAppsAdapter.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionAppsAdapter.kt
@@ -123,7 +123,7 @@ class TrackingProtectionAppViewHolder(val binding: RowExclusionListAppBinding) :
         if (excludedAppInfo.isProblematic()) {
             if (excludedAppInfo.isExcluded) {
                 binding.deviceShieldAppExclusionReason.text =
-                    getAppExcludingReasonText(itemView.context, excludedAppInfo.knownProblem)
+                    getAppExcludingReasonText(context, excludedAppInfo.knownProblem)
                 binding.deviceShieldAppExclusionReason.show()
                 binding.deviceShieldAppEntryWarningIcon.setImageDrawable(
                     ContextCompat.getDrawable(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionAppsAdapter.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionAppsAdapter.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.mobile.android.vpn.apps.ui
 
 import android.content.Context
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
@@ -31,7 +30,7 @@ import com.duckduckgo.mobile.android.vpn.R
 import com.duckduckgo.mobile.android.vpn.apps.AppsProtectionType
 import com.duckduckgo.mobile.android.vpn.apps.AppsProtectionType.AppInfoType
 import com.duckduckgo.mobile.android.vpn.apps.TrackingProtectionAppInfo
-import kotlinx.android.synthetic.main.row_exclusion_list_app.view.*
+import com.duckduckgo.mobile.android.vpn.databinding.RowExclusionListAppBinding
 
 class TrackingProtectionAppsAdapter(val listener: AppProtectionListener) :
     RecyclerView.Adapter<TrackingProtectionAppViewHolder>() {
@@ -60,8 +59,7 @@ class TrackingProtectionAppsAdapter(val listener: AppProtectionListener) :
         viewType: Int,
     ): TrackingProtectionAppViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val view = inflater.inflate(R.layout.row_exclusion_list_app, parent, false)
-        return TrackingProtectionAppViewHolder(view)
+        return TrackingProtectionAppViewHolder(binding = RowExclusionListAppBinding.inflate(inflater, parent, false))
     }
 
     override fun onBindViewHolder(
@@ -109,8 +107,8 @@ interface AppProtectionListener {
     )
 }
 
-class TrackingProtectionAppViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    private val context = itemView.context
+class TrackingProtectionAppViewHolder(val binding: RowExclusionListAppBinding) : RecyclerView.ViewHolder(binding.root) {
+    private val context = binding.root.context
 
     fun bind(
         isListEnabled: Boolean,
@@ -118,57 +116,57 @@ class TrackingProtectionAppViewHolder(itemView: View) : RecyclerView.ViewHolder(
         position: Int,
         listener: AppProtectionListener,
     ) {
-        val appIcon = itemView.context.packageManager.safeGetApplicationIcon(excludedAppInfo.packageName)
-        itemView.deviceShieldAppEntryIcon.setImageDrawable(appIcon)
-        itemView.deviceShieldAppEntryName.text = excludedAppInfo.name
+        val appIcon = context.packageManager.safeGetApplicationIcon(excludedAppInfo.packageName)
+        binding.deviceShieldAppEntryIcon.setImageDrawable(appIcon)
+        binding.deviceShieldAppEntryName.text = excludedAppInfo.name
 
         if (excludedAppInfo.isProblematic()) {
             if (excludedAppInfo.isExcluded) {
-                itemView.deviceShieldAppExclusionReason.text =
+                binding.deviceShieldAppExclusionReason.text =
                     getAppExcludingReasonText(itemView.context, excludedAppInfo.knownProblem)
-                itemView.deviceShieldAppExclusionReason.show()
-                itemView.deviceShieldAppEntryWarningIcon.setImageDrawable(
+                binding.deviceShieldAppExclusionReason.show()
+                binding.deviceShieldAppEntryWarningIcon.setImageDrawable(
                     ContextCompat.getDrawable(
                         context,
                         getAppExcludingReasonIcon(excludedAppInfo.knownProblem),
                     ),
                 )
-                itemView.deviceShieldAppEntryWarningIcon.show()
+                binding.deviceShieldAppEntryWarningIcon.show()
             } else {
-                itemView.deviceShieldAppExclusionReason.text = itemView.context.getString(R.string.atp_ExcludedReasonManuallyEnabled)
-                itemView.deviceShieldAppExclusionReason.show()
-                itemView.deviceShieldAppEntryWarningIcon.setImageDrawable(
+                binding.deviceShieldAppExclusionReason.text = itemView.context.getString(R.string.atp_ExcludedReasonManuallyEnabled)
+                binding.deviceShieldAppExclusionReason.show()
+                binding.deviceShieldAppEntryWarningIcon.setImageDrawable(
                     ContextCompat.getDrawable(
                         context,
                         R.drawable.ic_apptp_link,
                     ),
                 )
-                itemView.deviceShieldAppEntryWarningIcon.show()
+                binding.deviceShieldAppEntryWarningIcon.show()
             }
         } else {
             if (excludedAppInfo.isExcluded) {
-                itemView.deviceShieldAppExclusionReason.text = itemView.context.getString(R.string.atp_ExcludedReasonManuallyDisabled)
-                itemView.deviceShieldAppExclusionReason.show()
-                itemView.deviceShieldAppEntryWarningIcon.setImageDrawable(
+                binding.deviceShieldAppExclusionReason.text = itemView.context.getString(R.string.atp_ExcludedReasonManuallyDisabled)
+                binding.deviceShieldAppExclusionReason.show()
+                binding.deviceShieldAppEntryWarningIcon.setImageDrawable(
                     ContextCompat.getDrawable(
                         context,
                         R.drawable.ic_apptp_link,
                     ),
                 )
-                itemView.deviceShieldAppEntryWarningIcon.show()
+                binding.deviceShieldAppEntryWarningIcon.show()
             } else {
-                itemView.deviceShieldAppExclusionReason.gone()
-                itemView.deviceShieldAppEntryWarningIcon.gone()
+                binding.deviceShieldAppExclusionReason.gone()
+                binding.deviceShieldAppEntryWarningIcon.gone()
             }
         }
 
         if (isListEnabled) {
-            itemView.deviceShieldAppEntryShieldEnabled.quietlySetIsChecked(!excludedAppInfo.isExcluded) { _, enabled ->
+            binding.deviceShieldAppEntryShieldEnabled.quietlySetIsChecked(!excludedAppInfo.isExcluded) { _, enabled ->
                 listener.onAppProtectionChanged(excludedAppInfo, enabled, position)
             }
         } else {
-            itemView.deviceShieldAppEntryShieldEnabled.isClickable = false
-            itemView.deviceShieldAppEntryShieldEnabled.quietlySetIsChecked(!excludedAppInfo.isExcluded, null)
+            binding.deviceShieldAppEntryShieldEnabled.isClickable = false
+            binding.deviceShieldAppEntryShieldEnabled.quietlySetIsChecked(!excludedAppInfo.isExcluded, null)
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203984881672161/f

### Description
Removed usage of `kotlinx.android.synthetic` in `TrackingProtectionAppsAdapter`.

### Steps to test this PR

- [x] Install from this branch.
- [x] Enable AppTP from Settings.
- [x] Wait until you see some trackers on `App Tracking Protection` screen.
- [x] On `App Tracking Protection`  scroll down to `Having issues with an app?` and tap on it.
- [x] On `Recent App Activity` everything should work as expected: you can see the list, enable / disable apps.

### NO UI changes

