### PR TITLE
Migrate AppTPCompanyTrackersActivity

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
@@ -51,7 +51,6 @@ import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.AppTPCompanyTracker
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.AppTPCompanyTrackersViewModel.ViewState
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
-import kotlinx.android.synthetic.main.include_company_trackers_toolbar.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -94,7 +93,7 @@ class AppTPCompanyTrackersActivity : DuckDuckGoActivity() {
         setContentView(binding.root)
         with(binding.includeToolbar) {
             setupToolbar(defaultToolbar)
-            app_name.text = getAppName()
+            appName.text = getAppName()
             Glide.with(applicationContext)
                 .load(packageManager.safeGetApplicationIcon(getPackage()))
                 .error(TextDrawable.asIconDrawable(getAppName()))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203984881672166/f

### Description
Removed usage of `kotlinx.android.synthetic` from `AppTPCompanyTrackersActivity`.

### Steps to test this PR

- [x] Install from this branch.
- [x] Enable AppTP from Settings.
- [x] Wait until you see some trackers on `App Tracking Protection` screen.
- [x] On `App Tracking Protection`  tap on one of the tracking attempts items.
- [x] On the tracking attempts screen notice on the toolbar that the name of app for which the trackers were blocked is correctly displayed.

### NO UI changes
