### PR TITLE
Migrate PastWeekTrackerActivityContentView

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/PastWeekTrackerActivityContentView.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/PastWeekTrackerActivityContentView.kt
@@ -18,12 +18,11 @@ package com.duckduckgo.mobile.android.vpn.ui.tracker_activity
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
-import android.view.View
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
+import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.mobile.android.vpn.R
-import kotlinx.android.synthetic.main.view_device_shield_past_week_activity_content.view.*
+import com.duckduckgo.mobile.android.vpn.databinding.ViewDeviceShieldPastWeekActivityContentBinding
 
 class PastWeekTrackerActivityContentView : FrameLayout {
 
@@ -46,36 +45,34 @@ class PastWeekTrackerActivityContentView : FrameLayout {
         attributes.recycle()
     }
 
-    private val root: View by lazy {
-        LayoutInflater.from(context).inflate(R.layout.view_device_shield_past_week_activity_content, this, true)
-    }
+    private val binding: ViewDeviceShieldPastWeekActivityContentBinding by viewBinding()
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        root.isVisible = true
+        binding.root.isVisible = true
     }
 
     var count: String
         get() {
-            return root.content_text.text.toString()
+            return binding.contentText.text.toString()
         }
         set(value) {
-            root.content_text.text = value
+            binding.contentText.text = value
         }
 
     var text: String
         get() {
-            return root.content_title.text.toString()
+            return binding.contentTitle.text.toString()
         }
         set(value) {
-            root.content_title.text = value
+            binding.contentTitle.text = value
         }
 
     var footer: String
         get() {
-            return root.content_footer.text.toString()
+            return binding.contentFooter.text.toString()
         }
         set(value) {
-            root.content_footer.text = value
+            binding.contentFooter.text = value
         }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203984881672167/f

### Description
Removed usage of `kotlinx.android.synthetic` from `PastWeekTrackerActivityContentView`.

### Steps to test this PR

- [x] Install from this branch.
- [x] Enable AppTP from Settings.
- [x] Wait until you see some trackers on `App Tracking Protection` screen.
- [x] On `App Tracking Protection`  see that under the `Past 7 Days` section the 2 views are properly displayed: `Blocked xx Tracking Attempts` and `Across xx Apps`.

### NO UI changes
