### PR TITLE
AppTP: Remove the kotlin-android-extensions plugin

### DIFF
--- a/app-tracking-protection/vpn-impl/build.gradle
+++ b/app-tracking-protection/vpn-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'kotlin-android-extensions'
+    id 'kotlin-parcelize'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1203985450170811/f

### Description
Removed kotlin-android-extensions plugin from AppTP code.

### Steps to test this PR

- [x] Checkout this branch.
- [x] Do a `./gradlew clean assembleID` or `./gradlew clean assemblePR`. You should see it builds successfully. 
- [x] [Optional] Open the app and enable App Tracking Protection. See everything works as expected.

### NO UI changes
