### PR TITLE
ADS: Fix Site Location permission title

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1191,7 +1191,7 @@ class BrowserTabFragment :
         val binding = ContentSiteLocationPermissionDialogBinding.inflate(layoutInflater)
 
         val title = domain.websiteFromGeoLocationsApiOrigin()
-        binding.sitePermissionDialogTitle.text = title
+        binding.sitePermissionDialogTitle.text = getString(R.string.preciseLocationSiteDialogTitle, title, title)
         binding.sitePermissionDialogSubtitle.text = if (title == DDG_DOMAIN) {
             getString(R.string.preciseLocationDDGDialogSubtitle)
         } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1191,7 +1191,7 @@ class BrowserTabFragment :
         val binding = ContentSiteLocationPermissionDialogBinding.inflate(layoutInflater)
 
         val title = domain.websiteFromGeoLocationsApiOrigin()
-        binding.sitePermissionDialogTitle.text = getString(R.string.preciseLocationSiteDialogTitle, title, title)
+        binding.sitePermissionDialogTitle.text = getString(R.string.preciseLocationSiteDialogTitle, title)
         binding.sitePermissionDialogSubtitle.text = if (title == DDG_DOMAIN) {
             getString(R.string.preciseLocationDDGDialogSubtitle)
         } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/inbox/1157893581871899/1203999234891249/1203999234891253


### Description
After updating the Site Permission dialog for location we didn't properly change the title. This PR fixes that.

### Steps to test this PR

_Site Location Permissions_
- [ ] Navigate to any site that requests site permission (Search for "restaurants near me" in SERP)
- [ ] Go through the permission flow
- [ ] Ensure dialog shows proper title

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20230220_103217](https://user-images.githubusercontent.com/531613/220068652-72a39023-f2df-4311-b0b6-7417c680dc91.png)|![Screenshot_20230220_103339](https://user-images.githubusercontent.com/531613/220068642-6fcff34d-fdca-4382-bd23-2256f9417bd1.png)
efore screenshot)|


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203999234891249