### PR TITLE
Upgrade version.androidx.work - AppTP should not specify a different version as that is not used

### DIFF
--- a/app-tracking-protection/vpn-impl/build.gradle
+++ b/app-tracking-protection/vpn-impl/build.gradle
@@ -38,10 +38,6 @@ android {
     }
 }
 
-ext {
-    workManager = "2.5.0-beta01"
-}
-
 dependencies {
     anvil project(path: ':anvil-compiler')
     implementation project(path: ':anvil-annotations')
@@ -113,7 +109,7 @@ dependencies {
 
     // WorkManager
     implementation AndroidX.work.runtimeKtx
-    implementation "androidx.work:work-multiprocess:$workManager"
+    implementation "androidx.work:work-multiprocess:_"
     testImplementation AndroidX.work.testing
     implementation AndroidX.work.rxJava2
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1201421366311638/f

### Description
Removed different work manager version from vpn-impl.

### Steps to test this PR

Develop
- [ ] Checkout from develop, sync project with gradle files.
- [ ] Look at the androidx.work versions used `./gradlew app:dependencies | grep androidx.work:work-multiprocess:` and notice `androidx.work:work-multiprocess:2.5.0-beta01 -> 2.7.1` in the results.

This branch
- [ ] Checkout from this branch, sync project with gradle files.
- [ ] Look at the androidx.work versions used `./gradlew app:dependencies | grep androidx.work:work-multiprocess:` and notice only 2.7.1 is used.

### NO UI changes
