### PR TITLE
Improve the way we choose the favicon placeholder letter for autofill screens

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManager.kt
@@ -209,9 +209,10 @@ class DuckDuckGoFaviconManager constructor(
     }
 
     override fun generateDefaultFavicon(
+        placeholder: String?,
         domain: String,
     ): Drawable {
-        return generateDefaultDrawable(context, domain)
+        return generateDefaultDrawable(context, domain, placeholder)
     }
 
     private suspend fun saveFavicon(

--- a/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.browser.certificates.rootstore.IsrgRootX1
 import com.duckduckgo.app.browser.certificates.rootstore.IsrgRootX2
 import java.io.InputStream
 import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.tls.HandshakeCertificates
@@ -42,6 +43,7 @@ class GlobalGlideModule : AppGlideModule() {
         registry: Registry,
     ) {
         val okHttpClientBuilder = OkHttpClient.Builder()
+            .connectTimeout(700, MILLISECONDS) // rather than 10 seconds
             .addInterceptor { chain: Interceptor.Chain ->
                 val request = chain.request()
 

--- a/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/image/GlobalGlideModule.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.app.browser.certificates.rootstore.IsrgRootX1
 import com.duckduckgo.app.browser.certificates.rootstore.IsrgRootX2
 import java.io.InputStream
 import java.security.cert.X509Certificate
-import java.util.concurrent.TimeUnit.MILLISECONDS
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.tls.HandshakeCertificates
@@ -43,7 +42,6 @@ class GlobalGlideModule : AppGlideModule() {
         registry: Registry,
     ) {
         val okHttpClientBuilder = OkHttpClient.Builder()
-            .connectTimeout(700, MILLISECONDS) // rather than 10 seconds
             .addInterceptor { chain: Interceptor.Chain ->
                 val request = chain.request()
 

--- a/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
@@ -36,8 +36,9 @@ import okio.ByteString.Companion.encodeUtf8
 fun ImageView.loadFavicon(
     file: File,
     domain: String,
+    placeholder: String? = null,
 ) {
-    val defaultDrawable = generateDefaultDrawable(this.context, domain)
+    val defaultDrawable = generateDefaultDrawable(this.context, domain, placeholder)
     Glide.with(context).clear(this@loadFavicon)
     Glide.with(context)
         .load(file)
@@ -52,8 +53,9 @@ fun ImageView.loadFavicon(
 fun ImageView.loadFavicon(
     bitmap: Bitmap?,
     domain: String,
+    placeholder: String? = null,
 ) {
-    val defaultDrawable = generateDefaultDrawable(this.context, domain)
+    val defaultDrawable = generateDefaultDrawable(this.context, domain, placeholder)
     Glide.with(context).clear(this)
     Glide.with(context)
         .load(bitmap)

--- a/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
@@ -69,15 +69,27 @@ fun ImageView.loadDefaultFavicon(domain: String) {
     this.setImageDrawable(generateDefaultDrawable(this.context, domain))
 }
 
+/**
+ * Generates a default drawable which has a colored background with a character drawn centrally on top
+ * The given domain is used to generate a related background color.
+ * If an `overridePlaceholderCharacter` is specified, it will be used for the placeholder character
+ * If no `overridePlaceholderCharacter` is specified, the placeholder character will be extracted from the domain
+ */
 fun generateDefaultDrawable(
     context: Context,
     domain: String,
+    overridePlaceholderCharacter: String? = null,
 ): Drawable {
     return object : Drawable() {
         private val baseHost: String = domain.toUri().baseHost ?: ""
 
-        private val letter
-            get() = baseHost.firstOrNull()?.toString()?.uppercase(Locale.getDefault()) ?: ""
+        private val letter: String
+            get() {
+                if (overridePlaceholderCharacter != null) {
+                    return overridePlaceholderCharacter
+                }
+                return baseHost.firstOrNull()?.toString()?.uppercase(Locale.getDefault()) ?: ""
+            }
 
         private val faviconDefaultCornerRadius = context.resources.getDimension(CommonR.dimen.mediumShapeCornerRadius)
         private val faviconDefaultSize = context.resources.getDimension(CommonR.dimen.savedSiteGridItemFavicon)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.autofill.impl.ui.credential.management
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
@@ -65,6 +66,7 @@ class AutofillSettingsViewModel @Inject constructor(
     private val pixel: Pixel,
     private val dispatchers: DispatcherProvider,
     private val credentialListFilter: CredentialListFilter,
+    private val faviconManager: FaviconManager,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -286,10 +288,8 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     fun onDeleteCurrentCredentials() {
-        val credentialsId = getCurrentCredentials()?.id ?: return
-
-        viewModelScope.launch(dispatchers.default()) {
-            autofillStore.deleteCredentials(credentialsId)
+        getCurrentCredentials()?.let {
+            onDeleteCredentials(it)
         }
     }
 
@@ -297,6 +297,9 @@ class AutofillSettingsViewModel @Inject constructor(
         val credentialsId = loginCredentials.id ?: return
 
         viewModelScope.launch(dispatchers.default()) {
+            loginCredentials.domain?.let {
+                faviconManager.deletePersistedFavicon(it)
+            }
             autofillStore.deleteCredentials(credentialsId)
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -363,18 +363,19 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
         invalidateMenu()
     }
 
-    private suspend fun preloadFavicon(credentials: LoginCredentials) {
+    private suspend fun showPlaceholderFavicon(credentials: LoginCredentials) {
         withContext(dispatchers.io()) {
             val size = resources.getDimensionPixelSize(dimen.toolbarIconSize)
             val placeholder = generateDefaultFavicon(credentials, size)
+            val favicon = BitmapDrawable(resources, placeholder)
             withContext(dispatchers.main()) {
-                getActionBar()?.setLogo(BitmapDrawable(resources, placeholder))
+                getActionBar()?.setLogo(favicon)
             }
         }
     }
     private fun loadDomainFavicon(credentials: LoginCredentials) {
         lifecycleScope.launch(dispatchers.io()) {
-            preloadFavicon(credentials)
+            showPlaceholderFavicon(credentials)
             generateFaviconFromDomain(credentials)?.let {
                 withContext(dispatchers.main()) {
                     getActionBar()?.setLogo(it)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.DuckDuckGoFragment
 import com.duckduckgo.app.global.FragmentViewModelFactory
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
@@ -42,6 +43,7 @@ import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementR
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter.ContextMenuAction.Edit
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel
 import com.duckduckgo.autofill.impl.ui.credential.management.sorting.CredentialGrouper
+import com.duckduckgo.autofill.impl.ui.credential.management.sorting.InitialExtractor
 import com.duckduckgo.autofill.impl.ui.credential.management.suggestion.SuggestionListBuilder
 import com.duckduckgo.autofill.impl.ui.credential.management.suggestion.SuggestionMatcher
 import com.duckduckgo.di.scopes.FragmentScope
@@ -70,6 +72,12 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
 
     @Inject
     lateinit var suggestionListBuilder: SuggestionListBuilder
+
+    @Inject
+    lateinit var initialExtractor: InitialExtractor
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     val viewModel by lazy {
         ViewModelProvider(requireActivity(), viewModelFactory)[AutofillSettingsViewModel::class.java]
@@ -234,8 +242,10 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     private fun configureRecyclerView() {
         adapter = AutofillManagementRecyclerAdapter(
             this,
+            dispatchers = dispatchers,
             faviconManager = faviconManager,
             grouper = credentialGrouper,
+            initialExtractor = initialExtractor,
             suggestionListBuilder = suggestionListBuilder,
             onCredentialSelected = this::onCredentialsSelected,
             onContextMenuItemClicked = {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.impl.ui.credential.management
 
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.store.AutofillStore
@@ -53,6 +54,7 @@ class AutofillSettingsViewModelTest {
     private val pixel: Pixel = mock()
     private val deviceAuthenticator: DeviceAuthenticator = mock()
     private val credentialListFilter: CredentialListFilter = mock()
+    private val faviconManager: FaviconManager = mock()
     private val testee = AutofillSettingsViewModel(
         autofillStore = mockStore,
         clipboardInteractor = clipboardInteractor,
@@ -60,6 +62,7 @@ class AutofillSettingsViewModelTest {
         pixel = pixel,
         dispatchers = coroutineTestRule.testDispatcherProvider,
         credentialListFilter = credentialListFilter,
+        faviconManager = faviconManager,
     )
 
     @Test

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcher.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcher.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.store.urlmatcher
 
 import androidx.core.net.toUri
 import com.duckduckgo.app.global.extractDomain
+import com.duckduckgo.app.global.normalizeScheme
 import com.duckduckgo.autofill.api.urlmatcher.AutofillUrlMatcher
 import com.duckduckgo.autofill.api.urlmatcher.AutofillUrlMatcher.ExtractedUrlParts
 import javax.inject.Inject
@@ -78,13 +79,6 @@ class AutofillDomainNameUrlMatcher @Inject constructor() : AutofillUrlMatcher {
         savedSite: ExtractedUrlParts,
     ): Boolean {
         return visitedSite.eTldPlus1.equals(savedSite.eTldPlus1, ignoreCase = true)
-    }
-
-    private fun String.normalizeScheme(): String {
-        if (!startsWith("https://") && !startsWith("http://")) {
-            return "https://$this"
-        }
-        return this
     }
 
     private fun unextractable(): ExtractedUrlParts {

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcher.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/urlmatcher/AutofillDomainNameUrlMatcher.kt
@@ -38,7 +38,7 @@ class AutofillDomainNameUrlMatcher @Inject constructor() : AutofillUrlMatcher {
             val subdomain = determineSubdomain(domain, eTldPlus1)
             ExtractedUrlParts(eTldPlus1, subdomain, port)
         } catch (e: IllegalArgumentException) {
-            Timber.w("Unable to parse e-tld+1 from $originalUrl")
+            Timber.d("Unable to parse e-tld+1 from [%s]", originalUrl)
             unextractable()
         }
     }

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
@@ -45,6 +45,7 @@ interface FaviconManager {
         tabId: String? = null,
         url: String,
         view: ImageView,
+        placeholder: String? = null,
     )
 
     suspend fun loadToViewFromLocalWithPlaceholder(
@@ -54,6 +55,11 @@ interface FaviconManager {
     )
 
     suspend fun loadFromDisk(
+        tabId: String?,
+        url: String,
+    ): Bitmap?
+
+    suspend fun loadFromDiskOrFallback(
         tabId: String?,
         url: String,
     ): Bitmap?

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
@@ -74,7 +74,13 @@ interface FaviconManager {
 
     suspend fun deleteAllTemp()
 
+    /**
+     * Generates a drawable which can be used as a placeholder for a favicon when a real one cannot be found
+     * @param placeholder the placeholder text to be used. if null, the placeholder letter will be extracted from the domain
+     * @param domain the domain of the site for which the favicon is being generated, used to generate background color
+     */
     fun generateDefaultFavicon(
+        placeholder: String?,
         domain: String,
     ): Drawable
 }

--- a/common/src/main/java/com/duckduckgo/app/global/UriExtension.kt
+++ b/common/src/main/java/com/duckduckgo/app/global/UriExtension.kt
@@ -189,3 +189,10 @@ fun String.extractDomain(): String? {
         "https://$this".extractDomain()
     }
 }
+
+fun String.normalizeScheme(): String {
+    if (!startsWith("https://") && !startsWith("http://")) {
+        return "https://$this"
+    }
+    return this
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1203994780181874/f

### Description
Updates the favicon placeholder used when we can't get a real favicon in the autofill management screens. 

### Steps to test this PR

Note, favicons won't show immediately for a manually added site, so you will typically see the placeholder in these scenarios (they'll be cached after next visiting that site so it will show thereafter).

For each of the following; verify the favicon placeholder is correct in **both** management list screen and when clicking into the details for that credential.

- [x] Add a login with only a text-based title (e.g. "example); verify the first letter of the title is used "e" for placeholder
- [x] Add a login with only a numerical title (e.g., 192); verify the `#` placeholder is used
- [x] Add a login with only a simple domain (e.g., `example.com`; verify `E` used as placeholder
- [x] Add a login with only a subdomain (e.g., `foo.example.com`; verify first letter of E-TLD+1 used as placeholder (e.g., "E")
- [x] Add a login with both title and url; verify the first letter of the title is used