### PR TITLE
Android: Crash in PrivacyConfigDatabaseKt$MIGRATION_10_11$

### DIFF
--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
@@ -87,7 +87,7 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
 
 val MIGRATION_10_11 = object : Migration(10, 11) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("DROP TABLE autofill_exceptions")
+        database.execSQL("DROP TABLE IF EXISTS `autofill_exceptions`")
         database.execSQL("DELETE FROM privacy_config")
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204030500871801/f

### Description
Updated migration_10_11 in PrivacyConfigDatabase to drop the autofill_exceptions table if it exists.

### Steps to test this PR

This crash cannot be reproduced on emulators / pixel devices. Also, there are no reports on Pixel devices.
- [ ] Install from an old build where the table doesn't exist (e.g 5.116.0) and open the app.
- [ ] Update from this branch and open the app.
- [ ] Notice the app doesn't crash.

### NO UI changes
