### PR TITLE
AppTP Bug: Can't access Tracker activity from 7 days ago

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedFragment.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedFragment.kt
@@ -207,7 +207,7 @@ class DeviceShieldActivityFeedFragment : DuckDuckGoFragment() {
     companion object {
         private val defaultConfig = ActivityFeedConfig(
             maxRows = Int.MAX_VALUE,
-            timeWindow = 5,
+            timeWindow = 7,
             timeWindowUnits = TimeUnit.DAYS,
             showTimeWindowHeadings = true,
         )

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -101,7 +101,7 @@ class DeviceShieldTrackerActivity :
 
     private val feedConfig = DeviceShieldActivityFeedFragment.ActivityFeedConfig(
         maxRows = MIN_ROWS_FOR_ALL_ACTIVITY,
-        timeWindow = 5,
+        timeWindow = 7,
         timeWindowUnits = TimeUnit.DAYS,
         showTimeWindowHeadings = false,
     )

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModelTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModelTest.kt
@@ -244,7 +244,10 @@ class DeviceShieldActivityFeedViewModelTest {
     }
 
     companion object {
-        private val timeWindow = TimeWindow(1, DAYS)
+        private val timeWindow = TimeWindow(
+            config.timeWindow.toLong(),
+            config.timeWindowUnits,
+        )
     }
 }
 
@@ -365,7 +368,7 @@ private val trackerFeedDataWithOneTracker = TrackerFeedItem.TrackerFeedData(
 
 private val config = DeviceShieldActivityFeedFragment.ActivityFeedConfig(
     maxRows = Int.MAX_VALUE,
-    timeWindow = 5,
+    timeWindow = 1,
     timeWindowUnits = DAYS,
     showTimeWindowHeadings = false,
 )


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1203207391719615/f

### Description
Updated timeWindow to 7 days.

### Steps to test this PR

Check the issue in develop
- [x] Install from develop
- [x] Go to App Inspection and select New Query, select `vpn.db` and run the below queries (you have to run them one by one as running multiple queries is not supported)
INSERT INTO vpn_tracker VALUES(1380307511,'data.flurry.com','Verizon Media','Verizon Media','2023-02-19T11:42:18','2023-02-19',33,'com.socialnmobile.dictapps.notepad.color.note','ColorNote');
INSERT INTO vpn_tracker VALUES(1380307511,'data.flurry.com','Verizon Media','Verizon Media','2023-02-17T11:47:00','2023-02-17',60,'com.socialnmobile.dictapps.notepad.color.note','ColorNote');
INSERT INTO vpn_tracker VALUES(456730748,'www.google-analytics.com','Google LLC','Google','2023-02-19T11:43:08','2023-02-19',6,'com.soundcloud.android','SoundCloud');
INSERT INTO vpn_tracker VALUES(456730748,'g.doubleclick.net','Google LLC','Google','2023-02-19T11:43:14','2023-02-19',18,'com.hecorat.screenrecorder.free','AZ Screen Recorder');
INSERT INTO vpn_tracker VALUES(456730748,'pagead2.googlesyndication.com','Google LLC','Google','2023-02-16T11:43:32','2023-02-16',50,'com.hecorat.screenrecorder.free','AZ Screen Recorder');
INSERT INTO vpn_tracker VALUES(456730748,'firebaselogging-pa.googleapis.com','Google LLC','Google','2023-02-19T11:43:51','2023-02-19',9,'com.soundcloud.android','SoundCloud');
INSERT INTO vpn_tracker VALUES(456730748,'firebaselogging-pa.googleapis.com','Google LLC','Google','2023-02-18T11:43:59','2023-02-18',1,'com.soundcloud.android','SoundCloud');
INSERT INTO vpn_tracker VALUES(456730748,'firebaselogging-pa.googleapis.com','Google LLC','Google','2023-02-17T11:44:35','2023-02-17',7,'com.zhiliaoapp.musically','TikTok');
- [x] Enable App Tracking Protection
- [x] Notice there is no activity, however you can see in the `Past 7 Days` section at the top `BLOCKED 67 attempts` `ACROSS 3 Apps`. See screenshots attached. 

Check the fix
- [x] Update from this branch
- [x] Enable App Tracking Protection
- [x] Notice you see activity until 6 days ago. See screenshots attached. 


### NO UI changes, the screenshots show the data displayed after increasing the time window.
| Develop  | This branch |
| ------ | ----- |
|![develop_no_activity](https://user-images.githubusercontent.com/7963079/221181293-1cb9979a-069d-4a3e-a85c-410eec36e321.png)|![this_branch_activity](https://user-images.githubusercontent.com/7963079/221181303-3767ddb4-2231-49f6-bd64-b83a8ad095a3.png)|



