### PR TITLE
Bug: Dark mode not respected in WebView

### DIFF
--- a/common-ui/src/main/res/values-v23/design-system-theming.xml
+++ b/common-ui/src/main/res/values-v23/design-system-theming.xml
@@ -18,7 +18,7 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Platform.V23.Theme.DuckDuckGo" parent="Theme.MaterialComponents.Light.NoActionBar">
+    <style name="Platform.V23.Theme.DuckDuckGo" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Controls whether status bar icons are light/dark - `minSdkVersion 23`-->
         <item name="android:windowLightStatusBar">?attr/preferDarkStatusBarIcons</item>
         <item name="preferDarkNavigationBarIcons">false</item>

--- a/common-ui/src/main/res/values/design-system-theming.xml
+++ b/common-ui/src/main/res/values/design-system-theming.xml
@@ -23,7 +23,7 @@
     <attr name="preferredNavigationBarColor" format="color" />
 
     <!-- The platform theme is where OS version specific flags are used. -->
-    <style name="Platform.V23.Theme.DuckDuckGo" parent="Theme.MaterialComponents.Light.NoActionBar"/>
+    <style name="Platform.V23.Theme.DuckDuckGo" parent="Theme.MaterialComponents.DayNight.NoActionBar"/>
 
     <style name="Platform.Theme.DuckDuckGo" parent="Platform.V23.Theme.DuckDuckGo">
         <item name="android:windowActivityTransitions" tools:ignore="NewApi">true</item>
@@ -124,6 +124,7 @@
 
     <!-- The app theme will mostly contain values for colour attributes -->
     <style name="Theme.DuckDuckGo.Dark" parent="Theme.DuckDuckGo">
+        <item name="android:isLightTheme" tools:ignore="NewApi">false</item>
         <item name="preferDarkStatusBarIcons">false</item>
         <item name="preferDarkNavigationBarIcons">false</item>
 
@@ -194,6 +195,7 @@
     </style>
 
     <style name="Theme.DuckDuckGo.Light" parent="Theme.DuckDuckGo">
+        <item name="android:isLightTheme" tools:ignore="NewApi">true</item>
         <item name="preferDarkStatusBarIcons">true</item>
         <item name="preferDarkNavigationBarIcons">true</item>
 

--- a/versions.properties
+++ b/versions.properties
@@ -43,7 +43,7 @@ version.androidx.test.rules=1.5.0
 
 version.androidx.test.runner=1.5.1
 
-version.androidx.webkit=1.4.0
+version.androidx.webkit=1.6.0
 
 version.androidx.work=2.7.1
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1204003071445738/f

### Description
Updated to use the `DayNight` base theme. Increased `webkit` version. Added `android:isLightTheme` with appropriate values in both light and dark themes.

Fixes https://github.com/duckduckgo/Android/issues/2878

### Steps to test this PR

Check the issue
- [x] Install from develop on a device with OS version 11+
- [x] Switch the theme to "Dark" / "System Default" (in this case make sure your phone had Dark mode ON) from Settings
- [x] Search for something (e.g cats)
- [x] Notice the search results page is light 

Check the fix
- [x] Install from develop on a device with OS version 11+
- [x] Switch the theme to "Dark" / "System Default" (in this case make sure your phone had Dark mode ON) from Settings
- [x] Search for something (e.g cats)
- [x] Notice the search results page is dark 

### NO UI changes

![Android 13](https://user-images.githubusercontent.com/7963079/222149168-3f28ebf6-fac7-4723-8261-149202a28ffa.png)

![Android 13 - issue](https://user-images.githubusercontent.com/7963079/222150103-a4ec9c73-3b51-40b1-b1da-6aecd7135d84.png)


