### PR TITLE
Fix issue downloading files as blob on some sites (#2599)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -997,6 +997,11 @@ class BrowserTabFragment :
                 openAppLink(it.appLink)
             }
 
+            //Blob. Handle download file request
+            is Command.HandleDownloadFileAppLink -> {
+                requestFileDownload(it.dataUrl, null, it.mimeType, true)
+            }
+
             is Command.HandleNonHttpAppLink -> {
                 openExternalDialog(
                     intent = it.nonHttpAppLink.intent,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -357,6 +357,9 @@ class BrowserTabViewModel @Inject constructor(
             val fileChooserParams: WebChromeClient.FileChooserParams,
         ) : Command()
 
+        //Blob. Handle download file request
+        class HandleDownloadFileAppLink(val dataUrl: String, val mimeType: String) : Command()
+
         class HandleNonHttpAppLink(
             val nonHttpAppLink: NonHttpAppLink,
             val headers: Map<String, String>,
@@ -1628,6 +1631,13 @@ class BrowserTabViewModel @Inject constructor(
     @AnyThread
     override fun sendSmsRequested(telephoneNumber: String) {
         command.postValue(SendSms(telephoneNumber))
+    }
+
+    //Blob. Handle download file request
+    @AnyThread
+    override fun handleDownloadFileAppLink(dataUrl: String, mimeType: String): Boolean {
+        command.postValue(HandleDownloadFileAppLink(dataUrl, mimeType))
+        return true
     }
 
     override fun surrogateDetected(surrogate: SurrogateResponse) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -147,6 +147,14 @@ class BrowserWebViewClient(
                     }
                     true
                 }
+                //Blob. Handle download file request
+                is SpecialUrlDetector.UrlType.DownloadFileLink -> {
+                    Timber.i("Found blob download file app link for ${urlType.dataUrl}")
+                    webViewClientListener?.let { listener ->
+                        return listener.handleDownloadFileAppLink(urlType.dataUrl, urlType.contentType)
+                    }
+                    true
+                }
                 is SpecialUrlDetector.UrlType.Unknown -> {
                     Timber.w("Unable to process link type for ${urlType.uriString}")
                     webView.originalUrl?.let {

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -63,6 +63,9 @@ interface WebViewClientListener {
         isForMainFrame: Boolean,
     ): Boolean
 
+    //Blob. Handle download file request
+    fun handleDownloadFileAppLink(dataUrl: String, mimeType: String): Boolean
+
     fun handleNonHttpAppLink(nonHttpAppLink: SpecialUrlDetector.UrlType.NonHttpAppLink): Boolean
     fun handleCloakedAmpLink(initialUrl: String)
     fun startProcessingTrackingLink()

--- a/app/src/main/res/raw/blob_converter.js
+++ b/app/src/main/res/raw/blob_converter.js
@@ -26,17 +26,22 @@
         if (this.status == 200) {
             var blob = this.response;
             var reader = new FileReader();
-            reader.readAsDataURL(blob);
             reader.onloadend = function() {
                 dataUrl = reader.result;
-                BlobConverter.convertBlobToDataUri(dataUrl, '%contentType%');
+                window.location.href='ddg:download-file/%contentType%&'+encodeURIComponent(dataUrl);
             }
             reader.onerror = function() {
-                BlobConverter.convertBlobToDataUri('error', '%contentType%');
+                console.error('error, download file of type %contentType%');
+                alert('${getString(R.string.downloadsDownloadGenericErrorMessage)}')
             }
+            reader.readAsDataURL(blob);
         } else {
-            BlobConverter.convertBlobToDataUri('error', '%contentType%');
+            console.error('error, download file of type %contentType%');
+            alert('${getString(R.string.downloadsDownloadGenericErrorMessage)}')
         }
+    };
+    xhr.onerror = function() {
+        alert('${getString(R.string.downloadsDownloadGenericErrorMessage)}')
     };
     xhr.send();
 })();


### PR DESCRIPTION

Task/Issue URL: https://github.com/duckduckgo/Android/issues/2599

### Description
Fix issue downloading files as blob on some sites which need to show several pages during the download process.

### Steps to test this PR

_Feature 1_
- Connect to a Web site such as the CAF's site: https://www.caf.fr/ or the website: https://attestation-vaccin.ameli.fr/
- Try to download an attestion document
- The PDF file is well downloaded and can be retrieved from the Downloads screen

### Changes
| Before  | After |
| ------ | ----- |
The file was not downloaded wihout even a error message shown to the user|The file is well downloaded and can be viewed from the Downloads screen|
