### PR TITLE
Tweak autofill dialog title style

### DIFF
--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
@@ -66,22 +66,26 @@
 
     </LinearLayout>
 
-    <TextView
-            tools:ignore="DeprecatedWidgetInXml"
-            android:id="@+id/dialogTitle"
-            style="@style/AutofillDialogHeadlineStyle"
-            android:text="@string/saveLoginDialogFirstTimeOnboardingExplanationTitle"
-            android:breakStrategy="balanced"
-            app:layout_constraintEnd_toEndOf="@id/guidelineEnd"
-            app:layout_constraintStart_toStartOf="@id/guidelineStart"
-            app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer"/>
+    <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:id="@+id/dialogTitle"
+        android:breakStrategy="balanced"
+        android:text="@string/saveLoginDialogFirstTimeOnboardingExplanationTitle"
+        android:layout_marginTop="@dimen/keyline_5"
+        android:gravity="center_horizontal"
+        app:layout_constraintEnd_toEndOf="@id/guidelineEnd"
+        app:layout_constraintStart_toStartOf="@id/guidelineStart"
+        app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer"
+        app:typography="h2" />
+
 
     <TextView
             tools:ignore="DeprecatedWidgetInXml"
             android:id="@+id/onboardingSubtitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
+            android:layout_marginTop="@dimen/keyline_5"
             android:text="@string/saveLoginDialogOnboardingExplanationSubtitle"
             android:textAlignment="center"
             android:textColor="?autofillDialogOnboardingExplanationColor"
@@ -95,8 +99,8 @@
             android:layout_width="0dp"
             app:buttonSize="large"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_5"
             android:layout_marginStart="40dp"
-            android:layout_marginTop="30dp"
             android:layout_marginEnd="40dp"
             android:text="@string/saveLoginDialogButtonSave"
             app:layout_constraintEnd_toEndOf="parent"
@@ -109,7 +113,6 @@
             android:id="@+id/cancelButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
             app:buttonSize="large"
             android:text="@string/saveLoginDialogNotNow"
             app:layout_constraintEnd_toEndOf="@id/saveLoginButton"

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
@@ -58,11 +58,13 @@
                 style="@style/AutofillDialogFaviconStyle"
                 tools:src="@drawable/ic_red_dax"/>
 
-        <TextView
-                tools:ignore="DeprecatedWidgetInXml"
-                android:id="@+id/siteName"
-                style="@style/AutofillDialogSiteTitleStyle"
-                tools:text="duckduckgo.com"/>
+        <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+            android:id="@+id/siteName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/keyline_2"
+            app:typography="h5"
+            tools:text="duckduckgo.com" />
 
     </LinearLayout>
 

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_select_credentials_tooltip.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_select_credentials_tooltip.xml
@@ -43,10 +43,12 @@
             android:importantForAccessibility="no"
             tools:src="@drawable/ic_red_dax" />
 
-        <TextView
-            tools:ignore="DeprecatedWidgetInXml"
+        <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
             android:id="@+id/siteName"
-            style="@style/AutofillDialogSiteTitleStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/keyline_2"
+            app:typography="h5"
             tools:text="duckduckgo.com" />
 
     </LinearLayout>

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_select_credentials_tooltip.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_select_credentials_tooltip.xml
@@ -51,15 +51,18 @@
 
     </LinearLayout>
 
-    <TextView
-        tools:ignore="DeprecatedWidgetInXml"
+    <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:id="@+id/useLoginTitle"
-        style="@style/AutofillDialogHeadlineStyle"
         android:text="@string/useSavedLoginDialogTitle"
+        android:layout_marginTop="@dimen/keyline_5"
+        android:gravity="center_horizontal"
         app:layout_constraintBottom_toTopOf="@id/availableCredentialsRecycler"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer" />
+        app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer"
+        app:typography="h2" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/availableCredentialsRecycler"

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
@@ -50,15 +50,18 @@
 
     </LinearLayout>
 
-
-    <TextView
-        tools:ignore="DeprecatedWidgetInXml"
+    <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:id="@+id/dialogTitle"
-        style="@style/AutofillDialogHeadlineStyle"
         android:text="@string/updateLoginDialogTitle"
+        android:layout_marginTop="@dimen/keyline_5"
+        android:gravity="center_horizontal"
+        app:layout_constraintBottom_toTopOf="@id/updatedFieldPreview"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer" />
+        app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer"
+        app:typography="h2" />
 
     <TextView
         tools:ignore="DeprecatedWidgetInXml"
@@ -82,7 +85,7 @@
         app:buttonSize="large"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="@dimen/keyline_5"
         android:text="@string/updateLoginDialogButtonUpdatePassword"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -94,7 +97,6 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:buttonSize="large"
-        android:layout_marginTop="10dp"
         android:text="@string/updateLoginDialogButtonNotNow"
         app:layout_constraintEnd_toEndOf="@id/updateCredentialsButton"
         app:layout_constraintStart_toStartOf="@id/updateCredentialsButton"

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
@@ -42,10 +42,12 @@
             style="@style/AutofillDialogFaviconStyle"
             tools:src="@drawable/ic_red_dax" />
 
-        <TextView
-            tools:ignore="DeprecatedWidgetInXml"
+        <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
             android:id="@+id/siteName"
-            style="@style/AutofillDialogSiteTitleStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/keyline_2"
+            app:typography="h5"
             tools:text="duckduckgo.com" />
 
     </LinearLayout>

--- a/autofill/autofill-impl/src/main/res/values/styles.xml
+++ b/autofill/autofill-impl/src/main/res/values/styles.xml
@@ -39,15 +39,6 @@
         <item name="android:importantForAccessibility">no</item>
     </style>
 
-    <style name="AutofillDialogSiteTitleStyle">
-        <item name="android:layout_marginEnd">8dp</item>
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:textSize">14sp</item>
-        <item name="android:textStyle">bold</item>
-        <item name="android:textColor">?daxColorPrimaryText</item>
-    </style>
-
     <style name="AutofillDialogCloseButton">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>

--- a/autofill/autofill-impl/src/main/res/values/styles.xml
+++ b/autofill/autofill-impl/src/main/res/values/styles.xml
@@ -48,16 +48,6 @@
         <item name="android:textColor">?daxColorPrimaryText</item>
     </style>
 
-    <style name="AutofillDialogHeadlineStyle">
-        <item name="android:layout_width">0dp</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:gravity">center_horizontal</item>
-        <item name="android:textSize">20sp</item>
-        <item name="android:textStyle">bold</item>
-        <item name="android:layout_marginTop">24sp</item>
-        <item name="android:textColor">?autofillDialogTitleColor</item>
-    </style>
-
     <style name="AutofillDialogCloseButton">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204065996696681/f

### Description
Update the style used for the autofill dialog titles (for saving, for updating and for selecting a saved credential):

- updates dialogs to use `DaxTextView` for its title
- using `h2` type as per designs

### Steps to test this PR

Complete the following, and verify the title in each of the dialogs looks like the design (linked in the asana task)

- [ ] Save a login 
- [ ] Update a login
- [ ] Visit a site with a saved login