### PR TITLE
Update copy strings to fix capitalisation

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/res/values-tr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-tr/strings-vpn.xml
@@ -337,8 +337,8 @@
     <!--  App Tracking Protection Disable VPN Dialog -->
     <string name="atp_DisableConfirmationDialogTitle">Uygulama İzleme Koruması devre dışı bırakılsın mı?</string>
     <string name="atp_DisableConfirmationDialogMessage">Belirli bir uygulamayla ilgili bir sorun fark ettiyseniz, bunun yerine o uygulama için korumayı yönetebilirsiniz.</string>
-    <string name="atp_DisableConfirmationDisableApp">Bir uygulama için devre dışı bırak</string>
-    <string name="atp_DisableConfirmationDisableAllApps">Tüm uygulamalar için devre dışı bırak</string>
+    <string name="atp_DisableConfirmationDisableApp">Bir Uygulama için Devre Dışı Bırak</string>
+    <string name="atp_DisableConfirmationDisableAllApps">Tüm Uygulamalar için Devre Dışı Bırak</string>
     <string name="atp_DisableConfirmationCancel">İptal</string>
 
     <!--  App Tracking Protection VPN Conflict Dialog -->

--- a/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
@@ -340,8 +340,8 @@
     <!--  App Tracking Protection Disable VPN Dialog -->
     <string name="atp_DisableConfirmationDialogTitle">Disable App Tracking Protection?</string>
     <string name="atp_DisableConfirmationDialogMessage">If you noticed a problem with a specific app, you can manage protection for that app instead.</string>
-    <string name="atp_DisableConfirmationDisableApp">Disable for one app</string>
-    <string name="atp_DisableConfirmationDisableAllApps">Disable for all apps</string>
+    <string name="atp_DisableConfirmationDisableApp">Disable for One App</string>
+    <string name="atp_DisableConfirmationDisableAllApps">Disable for All Apps</string>
     <string name="atp_DisableConfirmationCancel">Cancel</string>
 
     <!--  App Tracking Protection VPN Conflict Dialog -->

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Попълнете анкетата</string>
     <string name="surveyCtaDismissButton">Не, благодаря</string>
     <string name="surveyActivityTitle">Потребителска анкета</string>
-    <string name="surveyTitle">АНКЕТА НА DUCKDUCKGO</string>
+    <string name="surveyTitle">Анкета на DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Отхвърляне на анкетата</string>
     <string name="surveyLoadingErrorTitle">О, не!</string>
     <string name="surveyLoadingErrorText">В момента анкетата ни не се зарежда.\n Моля, опитайте отново по-късно.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Други проблеми</string>
 
     <string name="openEndedInputHint">Моля, бъдете колкото може по-конкретни</string>
-    <string name="submitFeedback">ИЗПРАТИ</string>
+    <string name="submitFeedback">Изпрати</string>
 
     <string name="tellUsHowToImprove">Моля, кажете ни какво можем да подобрим.</string>
     <string name="thanksForTheFeedback">Благодарим за отзивите!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Кое Ви беше най-приятно?</string>
     <string name="awesomeToHear">Страхотно е да чуем това!</string>
     <string name="shareTheLoveWithARating">Моля, споделете вашето харесване като оцените в Play Store.</string>
-    <string name="rateTheApp">ОЦЕНКА НА ПРИЛОЖЕНИЕТО</string>
-    <string name="declineFurtherFeedback">НЕ БЛАГОДАРЯ, ПРИКЛЮЧИХ</string>
+    <string name="rateTheApp">Оценка на приложението</string>
+    <string name="declineFurtherFeedback">Не, благодаря, приключих</string>
     <string name="whichBrokenSites">Къде виждате тези проблеми?</string>
     <string name="whichBrokenSitesHint">В кой уебсайт има проблеми?</string>
     <string name="feedbackSpecificAsPossible">Моля, бъдете колкото може по-конкретни</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">От това устройство</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Търсене или въвеждане на URL адрес</font></string>
     <string name="systemSearchAppNotFound">Приложението не може да бъде намерено</string>
     <string name="systemSearchOnboardingText">Благодарим ви, че избрахте DuckDuckGo!\nС използването на нашата търсачка или приложение вашите търсения са защитени.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Приложението също:</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -649,7 +649,7 @@
     <!-- smartling.character_limit = 160 -->
     <string name="autoconsentDialogDescription">Искате ли да се справя с това вместо Вас? Мога да се опитам да намаля бисквитките до минимум, да увелича поверителността и да скрия подобни изскачащи прозорци.</string>
     <!-- smartling.character_limit = 42 -->
-    <string name="autoconsentPrimaryCta">Управление на прозорци за бисквитки</string>
+    <string name="autoconsentPrimaryCta">Управлявай прозорците за бисквитки</string>
     <!-- smartling.character_limit = 42 -->
     <string name="autoconsentSecondaryCta">Не, благодаря</string>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -104,7 +104,7 @@
     <string name="faviconContentDescription">Favicon</string>
     <string name="closeContentDescription">Zavřít</string>
     <string name="closeAllTabsMenuItem">Zavřít všechny karty</string>
-    <string name="closeTab">Zavřít karta</string>
+    <string name="closeTab">Zavřít kartu</string>
     <string name="tabClosed">Karta zavřená</string>
     <string name="tabClosedUndo">Vrátit</string>
     <string name="downloadsMenuItemTitle">Stahování</string>
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Zúčastnit se průzkumu</string>
     <string name="surveyCtaDismissButton">Ne, děkuji</string>
     <string name="surveyActivityTitle">Průzkum uživatelů</string>
-    <string name="surveyTitle">PRŮZKUM DUCKDUCKGO</string>
+    <string name="surveyTitle">Průzkum DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Odmítnout průzkum</string>
     <string name="surveyLoadingErrorTitle">Ale ne!</string>
     <string name="surveyLoadingErrorText">Náš průzkum se momentálně nenačítá.\nZkuste to prosím později.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Další problémy</string>
 
     <string name="openEndedInputHint">Buďte co nejkonkrétnější.</string>
-    <string name="submitFeedback">ODESLAT</string>
+    <string name="submitFeedback">Odeslat</string>
 
     <string name="tellUsHowToImprove">Řekněte nám prosím, co můžeme zlepšit.</string>
     <string name="thanksForTheFeedback">Děkujeme za zpětnou vazbu!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Co se vám líbilo?</string>
     <string name="awesomeToHear">To rádi slyšíme!</string>
     <string name="shareTheLoveWithARating">Podělte se prosím o pozitiva hodnocením na Play Store.</string>
-    <string name="rateTheApp">OHODNOŤTE APLIKACI</string>
-    <string name="declineFurtherFeedback">NE, DĚKUJI, JSEM HOTOV/A.</string>
+    <string name="rateTheApp">Ohodnoťte aplikaci</string>
+    <string name="declineFurtherFeedback">Ne, děkuji, jsme hotoví</string>
     <string name="whichBrokenSites">Kde jste narazili na tyto problémy?</string>
     <string name="whichBrokenSitesHint">Které webové stránky mají problémy?</string>
     <string name="feedbackSpecificAsPossible">Buďte co nejkonkrétnější.</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Z tohoto zařízení</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Vyhledat nebo zadat URL</font></string>
     <string name="systemSearchAppNotFound">Aplikace nebyla nalezena</string>
     <string name="systemSearchOnboardingText">Děkujeme, že jste si vybrali DuckDuckGo!\nPři použití našeho vyhledávání nebo aplikace jsou od tohoto okamžiku Vaše vyhledávání chráněna.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Aplikace DuckDuckGo také:</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -657,7 +657,7 @@
     <!-- smartling.character_limit = 160 -->
     <string name="autoconsentDialogDescription">Mám ho vyřešit za tebe? Můžu zkusit vybrat jen nezbytné soubory cookie, maximalizovat ochranu soukromí a podobná vyskakovací okna odteď skrývat.</string>
     <!-- smartling.character_limit = 42 -->
-    <string name="autoconsentPrimaryCta">Správa vyskakovacích oken ohledně cookies</string>
+    <string name="autoconsentPrimaryCta">Spravovat vyskakovací okna ohledně cookies</string>
     <!-- smartling.character_limit = 42 -->
     <string name="autoconsentSecondaryCta">Ne, děkuji</string>
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -104,7 +104,7 @@
     <string name="faviconContentDescription">Favicon</string>
     <string name="closeContentDescription">Luk</string>
     <string name="closeAllTabsMenuItem">Luk alle faner</string>
-    <string name="closeTab">Luk fane</string>
+    <string name="closeTab">Luk fanen</string>
     <string name="tabClosed">Fanen er lukket</string>
     <string name="tabClosedUndo">Fortryd</string>
     <string name="downloadsMenuItemTitle">Downloads</string>
@@ -243,9 +243,9 @@
     <string name="surveyCtaTitle">Hjælp os med at forbedre appen!</string>
     <string name="surveyCtaDescription">Deltag i vores korte undersøgelse, og del din feedback.</string>
     <string name="surveyCtaLaunchButton">Deltag i undersøgelsen</string>
-    <string name="surveyCtaDismissButton">Nej tak.</string>
+    <string name="surveyCtaDismissButton">Nej tak</string>
     <string name="surveyActivityTitle">Brugerundersøgelse</string>
-    <string name="surveyTitle">DUCKDUCKGO-UNDERSØGELSE</string>
+    <string name="surveyTitle">DuckDuckGo-undersøgelse</string>
     <string name="surveyDismissContentDescription">Afvis undersøgelse</string>
     <string name="surveyLoadingErrorTitle">Åh, nej!</string>
     <string name="surveyLoadingErrorText">Vores undersøgelse kan ikke indlæses i øjeblikket.\nForsøg igen senere.</string>
@@ -269,7 +269,7 @@
     <!-- App Enjoyment / Rating / Feedback -->
     <string name="appEnjoymentDialogTitle">Nyder du DuckDuckGo?</string>
     <string name="appEnjoymentDialogMessage">Vi vil rigtig gerne vide, hvad du synes.</string>
-    <string name="appEnjoymentDialogPositiveButton">Jeg kan godt lide den.</string>
+    <string name="appEnjoymentDialogPositiveButton">Jeg kan godt lide den</string>
     <string name="appEnjoymentDialogNegativeButton">Den skal forbedres</string>
 
     <string name="rateAppDialogTitle">Bedøm appen</string>
@@ -373,7 +373,7 @@
     <string name="awesomeToHear">Fantastisk at høre!</string>
     <string name="shareTheLoveWithARating">Del kærligheden ved at bedømme os i Play Store.</string>
     <string name="rateTheApp">Bedøm appen</string>
-    <string name="declineFurtherFeedback">NEJ TAK, JEG ER FÆRDIG.</string>
+    <string name="declineFurtherFeedback">Nej tak, jeg er færdig</string>
     <string name="whichBrokenSites">Hvor oplever du disse problemer?</string>
     <string name="whichBrokenSitesHint">Hvilket websted har problemer?</string>
     <string name="feedbackSpecificAsPossible">Vær så specifik som muligt</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Fra denne enhed</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Søg eller indtast URL</font></string>
     <string name="systemSearchAppNotFound">Appen kunne ikke findes</string>
     <string name="systemSearchOnboardingText">Tak, fordi du valgte DuckDuckGo!\nNår du bruger vores søgning eller app, er dine søgninger beskyttet.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">DuckDuckGo-appen kan også:</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">An der Umfrage teilnehmen</string>
     <string name="surveyCtaDismissButton">Nein, danke</string>
     <string name="surveyActivityTitle">Benutzerumfrage</string>
-    <string name="surveyTitle">DUCKDUCKGO-UMFRAGE</string>
+    <string name="surveyTitle">Duckduckgo-Umfrage</string>
     <string name="surveyDismissContentDescription">Umfrage verwerfen</string>
     <string name="surveyLoadingErrorTitle">Oh nein!</string>
     <string name="surveyLoadingErrorText">Unsere Umfrage kann derzeit nicht geladen werden.\nBitte versuche es zu einem späteren Zeitpunkt erneut.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Andere Probleme</string>
 
     <string name="openEndedInputHint">Bitte sei so genau wie möglich</string>
-    <string name="submitFeedback">ABSCHICKEN</string>
+    <string name="submitFeedback">Abschicken</string>
 
     <string name="tellUsHowToImprove">Teile uns bitte mit, was wir verbessern können.</string>
     <string name="thanksForTheFeedback">Vielen Dank für dein Feedback!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Was hat dir gefallen?</string>
     <string name="awesomeToHear">Das freut uns!</string>
     <string name="shareTheLoveWithARating">Bitte teile deine Begeisterung mit einer Bewertung im Play Store.</string>
-    <string name="rateTheApp">APP BEWERTEN</string>
-    <string name="declineFurtherFeedback">NEIN DANKE, ICH BIN FERTIG</string>
+    <string name="rateTheApp">App bewerten</string>
+    <string name="declineFurtherFeedback">Nein danke, ich bin fertig</string>
     <string name="whichBrokenSites">Wo treten diese Probleme auf?</string>
     <string name="whichBrokenSitesHint">Auf welcher Website gibt es Probleme?</string>
     <string name="feedbackSpecificAsPossible">Bitte sei so genau wie möglich</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Von diesem Gerät</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">URL eingeben oder suchen</font></string>
     <string name="systemSearchAppNotFound">Die Anwendung konnte nicht gefunden werden.</string>
     <string name="systemSearchOnboardingText">Vielen Dank, dass du dich für DuckDuckGo entschieden hast!\nWenn du jetzt unsere Suche oder App verwendest, sind deine Suchanfragen geschützt.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Das kann die DuckDuckGo App auch:</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Πάρτε μέρος στην έρευνα</string>
     <string name="surveyCtaDismissButton">Όχι, ευχαριστώ</string>
     <string name="surveyActivityTitle">Έρευνα χρηστών</string>
-    <string name="surveyTitle">ΕΡΕΥΝΑ DUCKDUCKGO</string>
+    <string name="surveyTitle">Έρευνα DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Απόρριψη έρευνας</string>
     <string name="surveyLoadingErrorTitle">Ωχ, όχι!</string>
     <string name="surveyLoadingErrorText">Η έρευνά μας δεν φορτώνει αυτήν τη στιγμή.\nΠροσπαθήστε ξανά αργότερα.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Άλλα προβλήματα</string>
 
     <string name="openEndedInputHint">Να είστε όσο το δυνατόν πιο συγκεκριμένοι</string>
-    <string name="submitFeedback">ΥΠΟΒΟΛΗ</string>
+    <string name="submitFeedback">Υποβολή</string>
 
     <string name="tellUsHowToImprove">Πείτε μας πού μπορούμε να βελτιωθούμε.</string>
     <string name="thanksForTheFeedback">Ευχαριστούμε για τα σχόλιά σας!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Ποια στοιχεία απολαμβάνετε;</string>
     <string name="awesomeToHear">Αυτό μας κάνει πολύ χαρούμενους!</string>
     <string name="shareTheLoveWithARating">Δείξτε την αγάπη σας αξιολογώντας μας στο Play Store.</string>
-    <string name="rateTheApp">ΑΞΙΟΛΟΓΗΣΗ ΕΦΑΡΜΟΓΗΣ</string>
-    <string name="declineFurtherFeedback">ΟΧΙ ΕΥΧΑΡΙΣΤΩ, ΤΕΛΕΙΩΣΑ</string>
+    <string name="rateTheApp">Αξιολόγηση εφαρμογής</string>
+    <string name="declineFurtherFeedback">Όχι, ευχαριστώ, τελείωσα</string>
     <string name="whichBrokenSites">Πού βλέπετε τα προβλήματα αυτά;</string>
     <string name="whichBrokenSitesHint">Ποιος ιστότοπος παρουσιάζει προβλήματα;</string>
     <string name="feedbackSpecificAsPossible">Να είστε όσο το δυνατόν πιο συγκεκριμένοι</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Από αυτή τη συσκευή</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Αναζήτηση ή πληκτρολόγηση διεύθυνσης URL</font></string>
     <string name="systemSearchAppNotFound">Η εφαρμογή δεν βρέθηκε</string>
     <string name="systemSearchOnboardingText">Ευχαριστώ που επιλέξατε το DuckDuckGo!\nΤώρα, όταν χρησιμοποιείτε την αναζήτηση ή την εφαρμογή μας, οι αναζητήσεις σας προστατεύονται.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Η εφαρμογή DuckDuckGo επίσης:</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Responder a la encuesta</string>
     <string name="surveyCtaDismissButton">No, gracias</string>
     <string name="surveyActivityTitle">Encuesta de usuario</string>
-    <string name="surveyTitle">ENCUESTA DE DUCKDUCKGO</string>
+    <string name="surveyTitle">Encuesta de DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Omitir encuesta</string>
     <string name="surveyLoadingErrorTitle">¡Vaya!</string>
     <string name="surveyLoadingErrorText">Nuestra encuesta no se ha podido cargar en este momento.\nVuelve a intentarlo más tarde.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Otros problemas</string>
 
     <string name="openEndedInputHint">Concreta lo máximo posible</string>
-    <string name="submitFeedback">ENVIAR</string>
+    <string name="submitFeedback">Enviar</string>
 
     <string name="tellUsHowToImprove">Dinos cómo podemos mejorar.</string>
     <string name="thanksForTheFeedback">Gracias por compartir tu opinión.</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">¿Qué te ha gustado?</string>
     <string name="awesomeToHear">¡Es fantástico oír eso!</string>
     <string name="shareTheLoveWithARating">Comparte tu entusiasmo calificando la aplicación en la Play Store.</string>
-    <string name="rateTheApp">CALIFICAR LA APLICACIÓN</string>
-    <string name="declineFurtherFeedback">NO GRACIAS, HE TERMINADO</string>
+    <string name="rateTheApp">Valora la aplicación</string>
+    <string name="declineFurtherFeedback">No gracias, he terminado</string>
     <string name="whichBrokenSites">¿Dónde surgen estos problemas?</string>
     <string name="whichBrokenSitesHint">¿Qué sitio web no funciona correctamente?</string>
     <string name="feedbackSpecificAsPossible">Concreta lo máximo posible</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Desde este dispositivo</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Buscar o escribir la URL</font></string>
     <string name="systemSearchAppNotFound">No se pudo encontrar la aplicación</string>
     <string name="systemSearchOnboardingText">¡Gracias por elegir DuckDuckGo!\nAhora, cuando uses nuestra búsqueda o aplicación, tus búsquedas estarán protegidas.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">La aplicación de DuckDuckGo también:</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -243,9 +243,9 @@
     <string name="surveyCtaTitle">Aidake meil rakendust täiustada!</string>
     <string name="surveyCtaDescription">Vasta meie lühikesele küsitlusele ja jaga oma tagasisidet.</string>
     <string name="surveyCtaLaunchButton">Vastake küsitlusele</string>
-    <string name="surveyCtaDismissButton">Ei aitäh</string>
+    <string name="surveyCtaDismissButton">Ei, aitäh</string>
     <string name="surveyActivityTitle">Kasutajaküsitlus</string>
-    <string name="surveyTitle">DUCKDUCKGO KÜSITLUS</string>
+    <string name="surveyTitle">DuckDuckGo küsitlus</string>
     <string name="surveyDismissContentDescription">Loobu küsitlusest</string>
     <string name="surveyLoadingErrorTitle">Oh ei!</string>
     <string name="surveyLoadingErrorText">Meie küsitlust praegu laadida ei õnnestunud.\nPalun proovige hiljem uuesti.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Teised probleemid</string>
 
     <string name="openEndedInputHint">Palun ole võimalikult konkreetne</string>
-    <string name="submitFeedback">ESITA</string>
+    <string name="submitFeedback">Esita</string>
 
     <string name="tellUsHowToImprove">Palun öelge meile, mida saaksime täiustada.</string>
     <string name="thanksForTheFeedback">Aitäh tagasiside eest!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Mida olete nautinud?</string>
     <string name="awesomeToHear">Vinge kuulda!</string>
     <string name="shareTheLoveWithARating">Jagage armastust Play Store\'i hinnanguga.</string>
-    <string name="rateTheApp">HINDA RAKENDUST</string>
-    <string name="declineFurtherFeedback">EI, AITÄH, OLEN VALMIS</string>
+    <string name="rateTheApp">Hinda rakendust</string>
+    <string name="declineFurtherFeedback">Ei, aitäh. Olen valmis</string>
     <string name="whichBrokenSites">Kus te neid probleeme näete?</string>
     <string name="whichBrokenSitesHint">Millisel veebisaidil on probleeme?</string>
     <string name="feedbackSpecificAsPossible">Palun olge võimalikult konkreetne</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Sellest seadmest</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Otsige või tippige URL</font></string>
     <string name="systemSearchAppNotFound">Rakendust ei leitud</string>
     <string name="systemSearchOnboardingText">Täname, et valisite DuckDuckGo!\nNüüd, kui kasutate meie otsingut või rakendust, on teie otsingud kaitstud.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Peale selle DuckDuckGo rakendus:</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Muut ongelmat</string>
 
     <string name="openEndedInputHint">Kerro mahdollisimman tarkasti</string>
-    <string name="submitFeedback">LÄHETÄ</string>
+    <string name="submitFeedback">Lähetä</string>
 
     <string name="tellUsHowToImprove">Kerro meille, mitä voimme parantaa.</string>
     <string name="thanksForTheFeedback">Kiitos palautteesta!</string>
@@ -372,7 +372,7 @@
     <string name="whatHaveYouBeenEnjoying">Mistä olet nauttinut?</string>
     <string name="awesomeToHear">Mahtava kuulla!</string>
     <string name="shareTheLoveWithARating">Jaathan kehusi Play Store -arviolla.</string>
-    <string name="rateTheApp">ARVIOI SOVELLUS</string>
+    <string name="rateTheApp">Arvioi sovellus</string>
     <string name="declineFurtherFeedback">EI KIITOS, TÄMÄ RIITTI</string>
     <string name="whichBrokenSites">Missä näitä ongelmia esiintyy?</string>
     <string name="whichBrokenSitesHint">Millä verkkosivustolla on ongelmia?</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Tästä laitteesta</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Hae tai kirjoita URL</font></string>
     <string name="systemSearchAppNotFound">Sovellusta ei löytynyt</string>
     <string name="systemSearchOnboardingText">Kiitos, että valitsit DuckDuckGon!\nKun nyt käytät hakua tai sovellusta, hakusi ovat suojattuja.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">DuckDuckGo-sovellus myös:</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Participer à l\'enquête</string>
     <string name="surveyCtaDismissButton">Non merci</string>
     <string name="surveyActivityTitle">Enquête auprès des utilisateurs</string>
-    <string name="surveyTitle">ENQUÊTE DUCKDUCKGO</string>
+    <string name="surveyTitle">Enquête DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Ignorer l\'enquête</string>
     <string name="surveyLoadingErrorTitle">Oh non !</string>
     <string name="surveyLoadingErrorText">Notre enquête ne charge pas pour le moment.\nVeuillez réessayer plus tard.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Autres problèmes</string>
 
     <string name="openEndedInputHint">Veuillez être aussi précis que possible</string>
-    <string name="submitFeedback">ENVOYER</string>
+    <string name="submitFeedback">Envoyer</string>
 
     <string name="tellUsHowToImprove">Dites-nous ce que nous pouvons améliorer.</string>
     <string name="thanksForTheFeedback">Merci pour vos commentaires !</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Qu\'avez-vous apprécié ?</string>
     <string name="awesomeToHear">Nous sommes heureux de l\'apprendre !</string>
     <string name="shareTheLoveWithARating">Veuillez partager votre appréciation en donnant une note sur le Play Store.</string>
-    <string name="rateTheApp">NOTER L\'APPLICATION</string>
-    <string name="declineFurtherFeedback">NON MERCI, J\'AI TERMINÉ</string>
+    <string name="rateTheApp">Noter l\'application</string>
+    <string name="declineFurtherFeedback">Non merci, j\'ai terminé</string>
     <string name="whichBrokenSites">Où voyez-vous ces problèmes ?</string>
     <string name="whichBrokenSitesHint">Quel site rencontre des problèmes ?</string>
     <string name="feedbackSpecificAsPossible">Veuillez être aussi précis que possible</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Depuis cet appareil</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Faire des recherches ou saisir l\'URL</font></string>
     <string name="systemSearchAppNotFound">Impossible de trouver l\'application</string>
     <string name="systemSearchOnboardingText">Merci d\'avoir choisi DuckDuckGo!\nDésormais, lorsque vous utilisez notre outil de recherche ou notre application, vos recherches sont protégées.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">L\'application DuckDuckGo offre également les fonctionnalités suivantes :</string>
@@ -408,7 +407,7 @@
     <string name="daxDialogGotIt">J\'ai compris</string>
     <string name="hideTipsTitle">Masquer les conseils restants ?</string>
     <string name="hideTipsText">Il n\'y en a que quelques-uns et nous avons essayé de les rendre aussi utiles que possible.</string>
-    <string name="hideTipsButton">Masquer les conseils pour toujours</string>
+    <string name="hideTipsButton">Masquer les conseils définitivement</string>
 
     <!-- New Onboarding Experience -->
     <string name="onboardingWelcomeTitle">"Bienvenue sur DuckDuckGo !"</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Ispuni anketu</string>
     <string name="surveyCtaDismissButton">Ne, hvala</string>
     <string name="surveyActivityTitle">Anketa o korisniku</string>
-    <string name="surveyTitle">ANKETA DUCKDUCKGO</string>
+    <string name="surveyTitle">Anketa DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Odbaci anketu</string>
     <string name="surveyLoadingErrorTitle">O, ne!</string>
     <string name="surveyLoadingErrorText">Anketa se trenutačno ne učitava.\nPokušaj ponovno kasnije.</string>
@@ -270,7 +270,7 @@
     <string name="appEnjoymentDialogTitle">Sviđa li ti se DuckDuckGo?</string>
     <string name="appEnjoymentDialogMessage">Voljeli bismo znati što misliš.</string>
     <string name="appEnjoymentDialogPositiveButton">Sviđa mi se</string>
-    <string name="appEnjoymentDialogNegativeButton">Treba ga doraditi</string>
+    <string name="appEnjoymentDialogNegativeButton">Treba doradu</string>
 
     <string name="rateAppDialogTitle">Ocijeni aplikaciju</string>
     <string name="rateAppDialogMessage">Tvoje su povratne informacije važne. Pokaži svoju ljubav recenzijom.</string>
@@ -361,19 +361,19 @@
     <string name="otherMainReasonTitleShort">Ostali problemi</string>
 
     <string name="openEndedInputHint">Budi što precizniji/a</string>
-    <string name="submitFeedback">POŠALJI</string>
+    <string name="submitFeedback">Pošalji</string>
 
     <string name="tellUsHowToImprove">Reci nam što možemo poboljšati.</string>
     <string name="thanksForTheFeedback">Hvala na povratnim informacijama!</string>
     <string name="feedbackNegativeMainReasonPageSubtitle">Što te najviše frustrira?</string>
-    <string name="feedbackNegativeMainReasonPageTitle">Žao nam je što to čujemo</string>
+    <string name="feedbackNegativeMainReasonPageTitle">Žao nam je to čuti</string>
     <string name="feedbackShareDetails">Podijeli pojedinosti</string>
     <string name="sharePositiveFeedbackWithTheTeam">Želiš li s timom podijeliti neke pojedinosti?</string>
     <string name="whatHaveYouBeenEnjoying">Što ti se sviđalo?</string>
     <string name="awesomeToHear">Divno je to čuti!</string>
     <string name="shareTheLoveWithARating">Pokaži ljubav ocjenom u trgovini Play.</string>
-    <string name="rateTheApp">OCIJENI APLIKACIJU</string>
-    <string name="declineFurtherFeedback">NE, HVALA; ZAVRŠIO/LA SAM</string>
+    <string name="rateTheApp">Ocijeni aplikaciju</string>
+    <string name="declineFurtherFeedback">Ne, hvala, to je sve</string>
     <string name="whichBrokenSites">Gdje vidiš te probleme?</string>
     <string name="whichBrokenSitesHint">Koje web-mjesto ima problema?</string>
     <string name="feedbackSpecificAsPossible">Budi što precizniji/a</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Sa ovog uređaja</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Traži ili upiši URL adresu</font></string>
     <string name="systemSearchAppNotFound">Aplikaciju nije bilo moguće pronaći</string>
     <string name="systemSearchOnboardingText">Hvala što si odabrao/la DuckDuckGo!\nSada kada koristiš našu tražilicu ili aplikaciju, tvoje su pretrage zaštićene.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Aplikacija DuckDuckGo također:</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Kérdőív kitöltése</string>
     <string name="surveyCtaDismissButton">Nem, köszönöm</string>
     <string name="surveyActivityTitle">Felhasználói kérdőív</string>
-    <string name="surveyTitle">DUCKDUCKGO FELHASZNÁLÓI KÉRDŐÍV</string>
+    <string name="surveyTitle">DuckDuckGo kérdőív</string>
     <string name="surveyDismissContentDescription">Kérdőív elutasítása</string>
     <string name="surveyLoadingErrorTitle">Jaj, ne!</string>
     <string name="surveyLoadingErrorText">A kérdőívünk jelenleg nem töltődik be.\nKérjük, próbáld meg később.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Egyéb problémák</string>
 
     <string name="openEndedInputHint">Kérjük, a lehető legpontosabban írj meg mindent</string>
-    <string name="submitFeedback">KÜLDÉS</string>
+    <string name="submitFeedback">Küldés</string>
 
     <string name="tellUsHowToImprove">Kérjük, mondd el, min tudunk még javítani.</string>
     <string name="thanksForTheFeedback">Köszönjük a visszajelzést!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Mi tetszett?</string>
     <string name="awesomeToHear">Örömmel halljuk!</string>
     <string name="shareTheLoveWithARating">Ha tetszik az alkalmazás, kérjük, oszd meg véleményed a Play Áruházban.</string>
-    <string name="rateTheApp">ALKALMAZÁS ÉRTÉKELÉSE</string>
-    <string name="declineFurtherFeedback">NEM, KÖSZÖNÖM, VÉGEZTEM.</string>
+    <string name="rateTheApp">Alkalmazás értékelése</string>
+    <string name="declineFurtherFeedback">Nem, köszönöm, végeztem</string>
     <string name="whichBrokenSites">Hol látod ezeket a problémákat?</string>
     <string name="whichBrokenSitesHint">Melyik weboldalon vannak problémák?</string>
     <string name="feedbackSpecificAsPossible">Kérjük, a lehető legpontosabban írj meg mindent</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Ebből az eszközből</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Keresés vagy URL beírása</font></string>
     <string name="systemSearchAppNotFound">Az alkalmazás nem található</string>
     <string name="systemSearchOnboardingText">Köszönjük, hogy a DuckDuckGo-t választottad!\nMost, amikor a mi keresésünket vagy az alkalmazásunkat használod, a kereséseid védettek.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">A DuckDuckGo alkalmazás is:</string>
@@ -408,7 +407,7 @@
     <string name="daxDialogGotIt">Megvan</string>
     <string name="hideTipsTitle">Elrejted a többi tippet?</string>
     <string name="hideTipsText">Csak néhány van, és megpróbáltuk őket informatívvá tenni.</string>
-    <string name="hideTipsButton">Ötletek elrejtése örökre</string>
+    <string name="hideTipsButton">Tippek elrejtése örökre</string>
 
     <!-- New Onboarding Experience -->
     <string name="onboardingWelcomeTitle">"Üdvözlünk a DuckDuckGo-ban!"</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -649,7 +649,7 @@
     <!-- smartling.character_limit = 160 -->
     <string name="autoconsentDialogDescription">Vuoi che me ne occupi io? Posso cercare di ridurre al minimo i cookie, massimizzare la privacy e nascondere i popup come questo.</string>
     <!-- smartling.character_limit = 42 -->
-    <string name="autoconsentPrimaryCta">Gestione dei popup dei cookie</string>
+    <string name="autoconsentPrimaryCta">Gestisci i popup dei cookie</string>
     <!-- smartling.character_limit = 42 -->
     <string name="autoconsentSecondaryCta">No, grazie</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -270,7 +270,7 @@
     <string name="appEnjoymentDialogTitle">Ti piace DuckDuckGo?</string>
     <string name="appEnjoymentDialogMessage">Ci piacerebbe sapere cosa ne pensi.</string>
     <string name="appEnjoymentDialogPositiveButton">Mi piace</string>
-    <string name="appEnjoymentDialogNegativeButton">Deve essere migliorata</string>
+    <string name="appEnjoymentDialogNegativeButton">Ha bisogno di miglioramenti</string>
 
     <string name="rateAppDialogTitle">Valuta l\'app</string>
     <string name="rateAppDialogMessage">Il tuo feedback ci interessa. Condividi il tuo apprezzamento con una recensione.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Altri problemi</string>
 
     <string name="openEndedInputHint">Sii quanto più specifico possibile</string>
-    <string name="submitFeedback">INVIA</string>
+    <string name="submitFeedback">Invia</string>
 
     <string name="tellUsHowToImprove">Dicci cosa potremmo migliorare.</string>
     <string name="thanksForTheFeedback">Grazie per il tuo feedback!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Cosa ti è piaciuto?</string>
     <string name="awesomeToHear">Fantastico!</string>
     <string name="shareTheLoveWithARating">Condividi il tuo parere positivo valutando l\'app in Play Store.</string>
-    <string name="rateTheApp">VALUTA L\'APP</string>
-    <string name="declineFurtherFeedback">NO, GRAZIE</string>
+    <string name="rateTheApp">Valuta l\'app</string>
+    <string name="declineFurtherFeedback">No grazie</string>
     <string name="whichBrokenSites">Dove hai notato questi problemi?</string>
     <string name="whichBrokenSitesHint">Quale sito web presenta problemi?</string>
     <string name="feedbackSpecificAsPossible">Sii quanto più specifico possibile</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Da questo dispositivo</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Cerca o inserisci URL</font></string>
     <string name="systemSearchAppNotFound">Impossibile trovare l\'applicazione</string>
     <string name="systemSearchOnboardingText">Grazie per aver scelto DuckDuckGo!\nOra, quando usi il nostro motore di ricerca o la nostra app, le tue ricerche sono protette.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Inoltre, l\'app DuckDuckGo:</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Dalyvauti apklausoje</string>
     <string name="surveyCtaDismissButton">Ne, dėkoju</string>
     <string name="surveyActivityTitle">Naudotojų apklausa</string>
-    <string name="surveyTitle">„DUCKDUCKGO“ APKLAUSA</string>
+    <string name="surveyTitle">„DuckDuckGo“ apklausa</string>
     <string name="surveyDismissContentDescription">Išjungti apklausą</string>
     <string name="surveyLoadingErrorTitle">Ak, ne!</string>
     <string name="surveyLoadingErrorText">Mūsų apklausa šiuo metu neįkeliama.\nBandykite dar kartą vėliau.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Kitos problemos</string>
 
     <string name="openEndedInputHint">Nurodykite kuo konkrečiau</string>
-    <string name="submitFeedback">PATEIKTI</string>
+    <string name="submitFeedback">Pateikti</string>
 
     <string name="tellUsHowToImprove">Papasakokite, ką galime patobulinti.</string>
     <string name="thanksForTheFeedback">Dėkojame už atsiliepimą!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Kas jums patiko?</string>
     <string name="awesomeToHear">Nuostabu tai girdėti!</string>
     <string name="shareTheLoveWithARating">Įvertinkite mus „Play Store“ parduotuvėje.</string>
-    <string name="rateTheApp">ĮVERTINKITE PROGRAMĄ</string>
-    <string name="declineFurtherFeedback">AČIŪ, NE, AŠ BAIGIAU.</string>
+    <string name="rateTheApp">Įvertinkite programą</string>
+    <string name="declineFurtherFeedback">Ačiū, ne, aš baigiau</string>
     <string name="whichBrokenSites">Kur susiduriate su šiomis problemomis?</string>
     <string name="whichBrokenSitesHint">Kokioje svetainėje susidūrėte su problema?</string>
     <string name="feedbackSpecificAsPossible">Nurodykite kuo konkrečiau</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Iš šio įrenginio</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Ieškoti arba įvesti URL</font></string>
     <string name="systemSearchAppNotFound">Nepavyko rasti programos</string>
     <string name="systemSearchOnboardingText">Dėkojame, kad pasirinkote „DuckDuckGo“!\nDabar, kai naudojate mūsų paieškos funkciją ar programėlę, jūsų paieškos yra apsaugotos.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">„DuckDuckGo“ programėlė taip pat:</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Citas problēmas</string>
 
     <string name="openEndedInputHint">Lūdzu, norādiet pēc iespējas precīzāk</string>
-    <string name="submitFeedback">IESNIEGT</string>
+    <string name="submitFeedback">Iesniegt</string>
 
     <string name="tellUsHowToImprove">Lūdzu, pastāsti, ko mēs varam uzlabot.</string>
     <string name="thanksForTheFeedback">Paldies tev par atsauksmēm!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Kas tev patika?</string>
     <string name="awesomeToHear">Prieks dzirdēt!</string>
     <string name="shareTheLoveWithARating">Dalies savā priekā, novērtējot to Play veikalā.</string>
-    <string name="rateTheApp">NOVĒRTĒT LIETOTNI</string>
-    <string name="declineFurtherFeedback">NĒ, PALDIES! ES PABEIDZU.</string>
+    <string name="rateTheApp">Novērtēt lietotni</string>
+    <string name="declineFurtherFeedback">NĒ, PALDIES! MAN PIETIEK.</string>
     <string name="whichBrokenSites">Kur tu redzi šīs problēmas?</string>
     <string name="whichBrokenSitesHint">Kurai vietnei ir problēmas?</string>
     <string name="feedbackSpecificAsPossible">Lūdzu, norādi pēc iespējas precīzāk</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">No šīs ierīces</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Meklē vai ieraksti URL</font></string>
     <string name="systemSearchAppNotFound">Lietojumprogrammu nevarēja atrast</string>
     <string name="systemSearchOnboardingText">Paldies, ka izvēlējies DuckDuckGo!\nTagad, izmantojot mūsu meklētāju vai lietotni, tavi meklējumi tiks aizsargāti.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Tāpat DuckDuckGo lietotne:</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Delta i spørreundersøkelsen</string>
     <string name="surveyCtaDismissButton">Nei takk</string>
     <string name="surveyActivityTitle">Spørreundersøkelse</string>
-    <string name="surveyTitle">DUCKDUCKGO-SPØRREUNDERSØKELSE</string>
+    <string name="surveyTitle">DuckDuckGo-undersøkelse</string>
     <string name="surveyDismissContentDescription">Avvis spørreundersøkelsen</string>
     <string name="surveyLoadingErrorTitle">Å nei!</string>
     <string name="surveyLoadingErrorText">Spørreundersøkelsen vår laster ikke for øyeblikket.\nPrøv igjen senere.</string>
@@ -269,7 +269,7 @@
     <!-- App Enjoyment / Rating / Feedback -->
     <string name="appEnjoymentDialogTitle">Liker du DuckDuckGo?</string>
     <string name="appEnjoymentDialogMessage">Vi vil gjerne høre hva du mener.</string>
-    <string name="appEnjoymentDialogPositiveButton">Jeg liker den</string>
+    <string name="appEnjoymentDialogPositiveButton">Jeg liker dette</string>
     <string name="appEnjoymentDialogNegativeButton">Det trengs forbedringer</string>
 
     <string name="rateAppDialogTitle">Vurder appen</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Andre problemer</string>
 
     <string name="openEndedInputHint">Vær så spesifikk som mulig</string>
-    <string name="submitFeedback">SEND</string>
+    <string name="submitFeedback">Send</string>
 
     <string name="tellUsHowToImprove">Fortell oss hva vi kan forbedre.</string>
     <string name="thanksForTheFeedback">Takk for tilbakemeldingen!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Hva liker du?</string>
     <string name="awesomeToHear">Flott å høre!</string>
     <string name="shareTheLoveWithARating">Vurder oss i Play-butikken – det blir vi glade for!</string>
-    <string name="rateTheApp">VURDER APPEN</string>
-    <string name="declineFurtherFeedback">NEI TAKK, JEG ER FERDIG</string>
+    <string name="rateTheApp">Vurder app</string>
+    <string name="declineFurtherFeedback">Nei takk, jeg er ferdig</string>
     <string name="whichBrokenSites">Når opplever du disse problemene?</string>
     <string name="whichBrokenSitesHint">Hvilket nettsted har problemer?</string>
     <string name="feedbackSpecificAsPossible">Vær så spesifikk som mulig</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Fra denne enheten</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Søk eller skriv URL</font></string>
     <string name="systemSearchAppNotFound">Programmet ble ikke funnet</string>
     <string name="systemSearchOnboardingText">Takk for at du valgte DuckDuckGo!\nNår du bruker vårt søk eller app, er søkene dine beskyttet.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">DuckDuckGo-appen kan også:</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Vul de enquête in</string>
     <string name="surveyCtaDismissButton">Nee, bedankt</string>
     <string name="surveyActivityTitle">Gebruikersenquête</string>
-    <string name="surveyTitle">ENQUÊTE DUCKDUCKGO</string>
+    <string name="surveyTitle">Enquête DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Enquête negeren</string>
     <string name="surveyLoadingErrorTitle">Oh nee!</string>
     <string name="surveyLoadingErrorText">Onze enquête kan momenteel niet worden geladen.\nProbeer het later opnieuw.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Andere problemen</string>
 
     <string name="openEndedInputHint">Wees zo specifiek mogelijk</string>
-    <string name="submitFeedback">VERZENDEN</string>
+    <string name="submitFeedback">Verzend</string>
 
     <string name="tellUsHowToImprove">Vertel ons wat we kunnen verbeteren.</string>
     <string name="thanksForTheFeedback">Bedankt voor de feedback!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Wat vond je goed?</string>
     <string name="awesomeToHear">Super om te horen!</string>
     <string name="shareTheLoveWithARating">Laat zien hoe blij je ermee bent door ons te beoordelen in de Play Store.</string>
-    <string name="rateTheApp">APP BEOORDELEN</string>
-    <string name="declineFurtherFeedback">NEE BEDANKT, IK BEN KLAAR</string>
+    <string name="rateTheApp">Beoordeel app</string>
+    <string name="declineFurtherFeedback">Nee bedankt, ik ben klaar</string>
     <string name="whichBrokenSites">Waar zie je deze problemen?</string>
     <string name="whichBrokenSitesHint">Welke website heeft problemen?</string>
     <string name="feedbackSpecificAsPossible">Wees zo specifiek mogelijk</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Van dit apparaat</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">URL typen of zoeken</font></string>
     <string name="systemSearchAppNotFound">Toepassing kon niet worden gevonden</string>
     <string name="systemSearchOnboardingText">Bedankt dat je voor DuckDuckGo heeft gekozen!\nAls je nu onze zoekmachine of app gebruikt, zijn je zoekopdrachten beschermd.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">De DuckDuckGo-app:</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Weź udział w ankiecie</string>
     <string name="surveyCtaDismissButton">Nie, dziękuję</string>
     <string name="surveyActivityTitle">Ankieta użytkownika</string>
-    <string name="surveyTitle">ANKIETA DUCKDUCKGO</string>
+    <string name="surveyTitle">Ankieta DuckFuckGo</string>
     <string name="surveyDismissContentDescription">Zignoruj ankietę</string>
     <string name="surveyLoadingErrorTitle">O nie!</string>
     <string name="surveyLoadingErrorText">Nasza ankieta nie wczytuje się.\nSpróbuj ponownie później.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Inne problemy</string>
 
     <string name="openEndedInputHint">Podaj jak najdokładniejsze informacje</string>
-    <string name="submitFeedback">PRZEŚLIJ</string>
+    <string name="submitFeedback">Wyślij</string>
 
     <string name="tellUsHowToImprove">Powiedz nam, co możemy poprawić.</string>
     <string name="thanksForTheFeedback">Dzięki za opinię!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Co Ci się podoba?</string>
     <string name="awesomeToHear">Świetnie!</string>
     <string name="shareTheLoveWithARating">Podziel się swoimi wrażeniami, oceniając nas w Play Store.</string>
-    <string name="rateTheApp">OCEŃ APLIKACJĘ</string>
-    <string name="declineFurtherFeedback">NIE, DZIĘKUJĘ, SKOŃCZYŁEM(-AM)</string>
+    <string name="rateTheApp">Oceń aplikację</string>
+    <string name="declineFurtherFeedback">Nie, dziękuję, skończyłem(-am)</string>
     <string name="whichBrokenSites">Gdzie dostrzegasz te problemy?</string>
     <string name="whichBrokenSitesHint">Z jaką stroną związane są problemy?</string>
     <string name="feedbackSpecificAsPossible">Podaj jak najdokładniejsze informacje</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Z tego urządzenia</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Wyszukaj lub wpisz adres URL</font></string>
     <string name="systemSearchAppNotFound">Nie można znaleźć aplikacji</string>
     <string name="systemSearchOnboardingText">Dziękujemy za wybranie DuckDuckGo!\nTeraz, gdy korzystasz z naszej wyszukiwarki lub aplikacji, Twoje wyszukiwania są chronione.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Ponadto aplikacja DuckDuckGo:</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Responder ao inquérito</string>
     <string name="surveyCtaDismissButton">Não, obrigado</string>
     <string name="surveyActivityTitle">Inquérito aos utilizadores</string>
-    <string name="surveyTitle">INQUÉRITO DO DUCKDUCKGO</string>
+    <string name="surveyTitle">Inquérito do DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Ignorar inquérito</string>
     <string name="surveyLoadingErrorTitle">Oh, não!</string>
     <string name="surveyLoadingErrorText">O nosso inquérito não pode ser carregado neste momento.\nVolte a tentar mais tarde.</string>
@@ -270,7 +270,7 @@
     <string name="appEnjoymentDialogTitle">Está a gostar do DuckDuckGo?</string>
     <string name="appEnjoymentDialogMessage">Adoravamos saber o que pensa.</string>
     <string name="appEnjoymentDialogPositiveButton">Gosto</string>
-    <string name="appEnjoymentDialogNegativeButton">Precisa de ser trabalhado</string>
+    <string name="appEnjoymentDialogNegativeButton">Precisa de ser trabalhada</string>
 
     <string name="rateAppDialogTitle">Classifique a aplicação</string>
     <string name="rateAppDialogMessage">Os seus comentários são importantes. Partilhe o que gosta com uma análise.</string>
@@ -373,7 +373,7 @@
     <string name="awesomeToHear">É fantástico saber isso!</string>
     <string name="shareTheLoveWithARating">Partilhe o que gosta com a classificação na Play Store.</string>
     <string name="rateTheApp">Classificar a aplicação</string>
-    <string name="declineFurtherFeedback">NÃO, OBRIGADO. JÁ TERMINEI</string>
+    <string name="declineFurtherFeedback">Não, obrigado, já terminei</string>
     <string name="whichBrokenSites">Onde está a ver esses problemas?</string>
     <string name="whichBrokenSitesHint">Que website tem problemas?</string>
     <string name="feedbackSpecificAsPossible">Seja o mais específico possível</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Deste dispositivo</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Pesquisar ou escrever URL</font></string>
     <string name="systemSearchAppNotFound">Não foi possível encontrar a aplicação</string>
     <string name="systemSearchOnboardingText">Obrigado por escolher o DuckDuckGo!\nAgora as suas pesquisas estão protegidas ao usar a nossa pesquisa ou aplicação.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">A aplicação DuckDuckGo também:</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -653,7 +653,7 @@
     <!-- smartling.character_limit = 160 -->
     <string name="autoconsentDialogDescription">Vrei să mă ocup de asta pentru tine? Pot să încerc să minimizez numărul de module cookie, să maximizez confidențialitatea și să ascund ferestrele pop-up precum aceasta.</string>
     <!-- smartling.character_limit = 42 -->
-    <string name="autoconsentPrimaryCta">Gestionare pop-up-uri pentru module cookie</string>
+    <string name="autoconsentPrimaryCta">Gestionează pop-up-uri module cookie</string>
     <!-- smartling.character_limit = 42 -->
     <string name="autoconsentSecondaryCta">Nu, mulțumesc</string>
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -104,7 +104,7 @@
     <string name="faviconContentDescription">Favicon</string>
     <string name="closeContentDescription">Închidere</string>
     <string name="closeAllTabsMenuItem">Închide toate filele</string>
-    <string name="closeTab">Închide</string>
+    <string name="closeTab">Închidere filă</string>
     <string name="tabClosed">Filă închisă</string>
     <string name="tabClosedUndo">Anulează</string>
     <string name="downloadsMenuItemTitle">Descărcări</string>
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Participă la sondaj</string>
     <string name="surveyCtaDismissButton">Nu, mulțumesc</string>
     <string name="surveyActivityTitle">Sondajul utilizatorului</string>
-    <string name="surveyTitle">SONDAJ DUCKDUCKGO</string>
+    <string name="surveyTitle">Sondaj DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Renunță la sondaj</string>
     <string name="surveyLoadingErrorTitle">Oh, nu!</string>
     <string name="surveyLoadingErrorText">Sondajul nostru nu se încarcă.\nTe rugăm să încercerci din nou, mai târziu.</string>
@@ -366,14 +366,14 @@
     <string name="tellUsHowToImprove">Te rugăm să ne spui ce putem îmbunătăți.</string>
     <string name="thanksForTheFeedback">Îți mulțumim pentru feedback!</string>
     <string name="feedbackNegativeMainReasonPageSubtitle">Ce aspect te deranjează cel mai tare?</string>
-    <string name="feedbackNegativeMainReasonPageTitle">Ne pare rău să auzim aceasta</string>
+    <string name="feedbackNegativeMainReasonPageTitle">Ne pare rău de experiența ta</string>
     <string name="feedbackShareDetails">Trimite detalii</string>
     <string name="sharePositiveFeedbackWithTheTeam">Există detalii pe care dorești să le împărtășești echipei?</string>
     <string name="whatHaveYouBeenEnjoying">Ce ți-a plăcut?</string>
     <string name="awesomeToHear">Ne bucurăm să auzim aceasta!</string>
     <string name="shareTheLoveWithARating">Te rugăm să împărtășești experiența ta, evaluând aplicația în Play Store.</string>
     <string name="rateTheApp">Evaluează aplicația</string>
-    <string name="declineFurtherFeedback">NU, MULȚUMESC, AM TERMINAT</string>
+    <string name="declineFurtherFeedback">Nu mulțumesc, am terminat</string>
     <string name="whichBrokenSites">Unde vezi aceste probleme?</string>
     <string name="whichBrokenSitesHint">Ce site web are probleme?</string>
     <string name="feedbackSpecificAsPossible">Te rugăm să furnizezi detalii cât mai concrete</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">De pe acest dispozitiv</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Căutare sau tastare URL</font></string>
     <string name="systemSearchAppNotFound">Aplicația nu a fost găsită</string>
     <string name="systemSearchOnboardingText">Mulțumim pentru că ai ales DuckDuckGo!\nAcum, când utilizezi căutarea sau aplicația noastră, căutările tale sunt protejate.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">De asemenea, aplicația DuckDuckGo:</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -657,7 +657,7 @@
     <!-- smartling.character_limit = 160 -->
     <string name="autoconsentDialogDescription">Хотите, чтобы такие окна закрывались автоматически? Мы можем попытаться минимизировать выбор куки-файлов для большей безопасности ваших данных и автоматически закрывать такие окна.</string>
     <!-- smartling.character_limit = 42 -->
-    <string name="autoconsentPrimaryCta">Управление окнами выбора куки-файлов</string>
+    <string name="autoconsentPrimaryCta">Управлять окнами выбора куки-файлов</string>
     <!-- smartling.character_limit = 42 -->
     <string name="autoconsentSecondaryCta">Нет, спасибо</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Участвовать в опросе</string>
     <string name="surveyCtaDismissButton">Нет, спасибо</string>
     <string name="surveyActivityTitle">Опрос пользователей</string>
-    <string name="surveyTitle">ОПРОС DUCKDUCKGO</string>
+    <string name="surveyTitle">Опрос DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Закрыть опрос</string>
     <string name="surveyLoadingErrorTitle">О нет!</string>
     <string name="surveyLoadingErrorText">Сейчас невозможно загрузить опрос.\nПовторите попытку позже.</string>
@@ -269,8 +269,8 @@
     <!-- App Enjoyment / Rating / Feedback -->
     <string name="appEnjoymentDialogTitle">Нравится DuckDuckGo?</string>
     <string name="appEnjoymentDialogMessage">Мы будем рады услышать ваше мнение.</string>
-    <string name="appEnjoymentDialogPositiveButton">Мне нравится приложение</string>
-    <string name="appEnjoymentDialogNegativeButton">Приложение нужно доработать</string>
+    <string name="appEnjoymentDialogPositiveButton">Мне нравится</string>
+    <string name="appEnjoymentDialogNegativeButton">Нужно доработать</string>
 
     <string name="rateAppDialogTitle">Оцените приложение</string>
     <string name="rateAppDialogMessage">Ваше мнение важно для нас. Пожалуйста, оставьте свой отзыв.</string>
@@ -361,19 +361,19 @@
     <string name="otherMainReasonTitleShort">Другие проблемы</string>
 
     <string name="openEndedInputHint">Опишите максимально подробно</string>
-    <string name="submitFeedback">ОТПРАВИТЬ</string>
+    <string name="submitFeedback">Подтвердить</string>
 
     <string name="tellUsHowToImprove">Что мы можем улучшить?</string>
     <string name="thanksForTheFeedback">Спасибо за отзыв!</string>
     <string name="feedbackNegativeMainReasonPageSubtitle">Что именно вам не понравилось?</string>
-    <string name="feedbackNegativeMainReasonPageTitle">Очень жаль.</string>
+    <string name="feedbackNegativeMainReasonPageTitle">Очень жаль</string>
     <string name="feedbackShareDetails">Добавить комментарий</string>
     <string name="sharePositiveFeedbackWithTheTeam">Хотите добавить комментарий для нашей команды разработчиков?</string>
     <string name="whatHaveYouBeenEnjoying">Что вам больше всего понравилось?</string>
     <string name="awesomeToHear">Приятно слышать!</string>
     <string name="shareTheLoveWithARating">Пожалуйста, оцените наше приложение в Play Store.</string>
-    <string name="rateTheApp">ОЦЕНИТЬ</string>
-    <string name="declineFurtherFeedback">НЕТ, СПАСИБО</string>
+    <string name="rateTheApp">Оценить приложение</string>
+    <string name="declineFurtherFeedback">Нет, спасибо</string>
     <string name="whichBrokenSites">Где возникают эти проблемы?</string>
     <string name="whichBrokenSitesHint">На каком сайте возникли проблемы?</string>
     <string name="feedbackSpecificAsPossible">Опишите максимально подробно</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">С этого устройства</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Введите поисковый запрос или адрес сайта</font></string>
     <string name="systemSearchAppNotFound">Приложение не найдено</string>
     <string name="systemSearchOnboardingText">Спасибо, что выбрали DuckDuckGo!\nТеперь информация о ваших поисковых запросах под надежной защитой.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Приложение DuckDuckGo также:</string>
@@ -408,7 +407,7 @@
     <string name="daxDialogGotIt">Понятно</string>
     <string name="hideTipsTitle">Скрыть другие подсказки?</string>
     <string name="hideTipsText">Их немного, и мы постарались сделать их информативными.</string>
-    <string name="hideTipsButton">Скрыть подсказки навсегда</string>
+    <string name="hideTipsButton">Скрыть подсказки насовсем</string>
 
     <!-- New Onboarding Experience -->
     <string name="onboardingWelcomeTitle">"Добро пожаловать в DuckDuckGo!"</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -657,7 +657,7 @@
     <!-- smartling.character_limit = 160 -->
     <string name="autoconsentDialogDescription">Chceš, aby som to riešil za teba? Môžem sa pokúsiť minimalizovať súbory cookie, maximalizovať ochranu súkromia a skryť kontextové okná, ako sú tieto.</string>
     <!-- smartling.character_limit = 42 -->
-    <string name="autoconsentPrimaryCta">Správa kontextových okien súborov cookie</string>
+    <string name="autoconsentPrimaryCta">Spravovať kontextové okná súborov cookie</string>
     <!-- smartling.character_limit = 42 -->
     <string name="autoconsentSecondaryCta">Nie, ďakujem</string>
 

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -104,7 +104,7 @@
     <string name="faviconContentDescription">Favicon</string>
     <string name="closeContentDescription">Zatvoriť</string>
     <string name="closeAllTabsMenuItem">Zatvoriť všetky karty</string>
-    <string name="closeTab">Zatvoriť karta</string>
+    <string name="closeTab">Zavrieť kartu</string>
     <string name="tabClosed">Karta bola zatvorená</string>
     <string name="tabClosedUndo">Vrátenie späť</string>
     <string name="downloadsMenuItemTitle">Stiahnuté</string>
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Zúčastniť sa prieskumu</string>
     <string name="surveyCtaDismissButton">Nie, ďakujem</string>
     <string name="surveyActivityTitle">Používateľský prieskum</string>
-    <string name="surveyTitle">PRIESKUM DUCKDUCKGO</string>
+    <string name="surveyTitle">Prieskum DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Zavrieť prieskum</string>
     <string name="surveyLoadingErrorTitle">Ale nie!</string>
     <string name="surveyLoadingErrorText">Prieskum sa momentálne nenačítava.\nSkúste to znova neskôr.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Iné problémy</string>
 
     <string name="openEndedInputHint">Buďte čo najkonkrétnejší</string>
-    <string name="submitFeedback">Potvrdiť</string>
+    <string name="submitFeedback">Odoslať</string>
 
     <string name="tellUsHowToImprove">Povedzte nám, čo sa dá zdokonaliť.</string>
     <string name="thanksForTheFeedback">Ďakujeme za spätnú väzbu!</string>
@@ -373,7 +373,7 @@
     <string name="awesomeToHear">Tešíme sa z toho!</string>
     <string name="shareTheLoveWithARating">Podeľte sa o svoju spokojnosť hodnotením v Obchode Play.</string>
     <string name="rateTheApp">Hodnotiť aplikáciu</string>
-    <string name="declineFurtherFeedback">NIE, ĎAKUJEM, SKONČIL SOM.</string>
+    <string name="declineFurtherFeedback">Nie, ďakujem. Skončil som.</string>
     <string name="whichBrokenSites">Kde ste si všimli tieto problémy?</string>
     <string name="whichBrokenSitesHint">Ktorá webová stránka má problémy?</string>
     <string name="feedbackSpecificAsPossible">Buďte čo najkonkrétnejší</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Z tohto zariadenia</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Vyhľadať alebo zadať webovú adresu</font></string>
     <string name="systemSearchAppNotFound">Aplikáciu sa nepodarilo nájsť</string>
     <string name="systemSearchOnboardingText">Ďakujeme, že ste si vybrali aplikáciu DuckDuckGo!\nPri použití nášho vyhľadávača alebo aplikácie je vaše vyhľadávanie chránené.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Aplikácia DuckDuckGo tiež:</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -657,7 +657,7 @@
     <!-- smartling.character_limit = 160 -->
     <string name="autoconsentDialogDescription">Želite, da jih uredim namesto vas? Poskušam zmanjšati piškotke, povečati zasebnost in skriti pojavna okna, kot so ta.</string>
     <!-- smartling.character_limit = 42 -->
-    <string name="autoconsentPrimaryCta">Upravljanje pojavnih oken za piškotke</string>
+    <string name="autoconsentPrimaryCta">Upravljaj pojavna okna za piškotke</string>
     <!-- smartling.character_limit = 42 -->
     <string name="autoconsentSecondaryCta">Ne, hvala</string>
 

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Izpolnite anketo</string>
     <string name="surveyCtaDismissButton">Ne, hvala</string>
     <string name="surveyActivityTitle">Uporabniška anketa</string>
-    <string name="surveyTitle">ANKETA DUCKDUCKGO</string>
+    <string name="surveyTitle">Anketa DuckDuckGo</string>
     <string name="surveyDismissContentDescription">Opustite anketo</string>
     <string name="surveyLoadingErrorTitle">O, ne!</string>
     <string name="surveyLoadingErrorText">Naša anketa se trenutno ne nalaga.\nPoskusite ponovno pozneje.</string>
@@ -270,7 +270,7 @@
     <string name="appEnjoymentDialogTitle">Uživate z DuckDuckGo?</string>
     <string name="appEnjoymentDialogMessage">Zanima nas, kaj si mislite.</string>
     <string name="appEnjoymentDialogPositiveButton">Všeč mi je</string>
-    <string name="appEnjoymentDialogNegativeButton">Potrebno bo delo</string>
+    <string name="appEnjoymentDialogNegativeButton">Potrebna je obdelava</string>
 
     <string name="rateAppDialogTitle">Ocenite aplikacijo</string>
     <string name="rateAppDialogMessage">Vaše povratne informacije so pomembne. Če vam je všeč, navedite to v mnenju.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Druge težave</string>
 
     <string name="openEndedInputHint">Bodite čim bolj natančni</string>
-    <string name="submitFeedback">POŠLJI</string>
+    <string name="submitFeedback">Potrdi</string>
 
     <string name="tellUsHowToImprove">Povejte nam, kaj lahko izboljšamo.</string>
     <string name="thanksForTheFeedback">Hvala za povratne informacije!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Kaj vam je bilo všeč?</string>
     <string name="awesomeToHear">To je super slišati!</string>
     <string name="shareTheLoveWithARating">Če vam je všeč, navedite to v oceni Play Store.</string>
-    <string name="rateTheApp">OCENITE APLIKACIJO</string>
-    <string name="declineFurtherFeedback">NE, HVALA, KONČAL SEM</string>
+    <string name="rateTheApp">Oceni aplikacijo</string>
+    <string name="declineFurtherFeedback">Ne, hvala, končano je</string>
     <string name="whichBrokenSites">Kje vidite te težave?</string>
     <string name="whichBrokenSitesHint">Katero spletno mesto ima težave?</string>
     <string name="feedbackSpecificAsPossible">Bodite čim bolj natančni</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Iz te naprave</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Iščite z iskalnikom ali vnesite URL</font></string>
     <string name="systemSearchAppNotFound">Prošnje ni bilo mogoče najti</string>
     <string name="systemSearchOnboardingText">Hvala, ker ste izbrali DuckDuckGo!\nZdaj, ko uporabljate naše iskalnike ali aplikacijo, so vaša iskanja zaščitena.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Tudi aplikacija DuckDuckGo:</string>
@@ -408,7 +407,7 @@
     <string name="daxDialogGotIt">Razumem</string>
     <string name="hideTipsTitle">Skrij preostale nasvete?</string>
     <string name="hideTipsText">Le nekaj jih je in poskušali smo jih narediti informativne.</string>
-    <string name="hideTipsButton">Skrivaj nasvete za vedno</string>
+    <string name="hideTipsButton">Skrij nasvete za vedno</string>
 
     <!-- New Onboarding Experience -->
     <string name="onboardingWelcomeTitle">"Dobrodošli v aplikaciji DUCKDUCKGO"</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -245,7 +245,7 @@
     <string name="surveyCtaLaunchButton">Delta i undersökningen</string>
     <string name="surveyCtaDismissButton">Nej tack</string>
     <string name="surveyActivityTitle">Användarundersökning</string>
-    <string name="surveyTitle">DUCKDUCKGO-UNDERSÖKNING</string>
+    <string name="surveyTitle">DuckDuckGo-undersökning</string>
     <string name="surveyDismissContentDescription">Avvisa undersökning</string>
     <string name="surveyLoadingErrorTitle">Åh nej!</string>
     <string name="surveyLoadingErrorText">Vår undersökning kan inte läsas in just nu.\nFörsök igen senare.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Andra problem</string>
 
     <string name="openEndedInputHint">Beskriv så noggrant som möjligt</string>
-    <string name="submitFeedback">SKICKA</string>
+    <string name="submitFeedback">Skicka</string>
 
     <string name="tellUsHowToImprove">Berätta vad vi kan förbättra.</string>
     <string name="thanksForTheFeedback">Tack för din återkoppling!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Vad har du uppskattat med appen?</string>
     <string name="awesomeToHear">Kul att höra!</string>
     <string name="shareTheLoveWithARating">Dela din uppskattning, betygsätt appen på Play Store.</string>
-    <string name="rateTheApp">BETYGSÄTT APPEN</string>
-    <string name="declineFurtherFeedback">NEJ TACK, JAG ÄR KLAR</string>
+    <string name="rateTheApp">Betygsätt appen</string>
+    <string name="declineFurtherFeedback">Nej tack, jag är klar</string>
     <string name="whichBrokenSites">Var ser du dessa problem?</string>
     <string name="whichBrokenSitesHint">På vilken webbplats finns problemen?</string>
     <string name="feedbackSpecificAsPossible">Beskriv så noggrant som möjligt</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Från den här enheten</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Sök eller skriv in URL</font></string>
     <string name="systemSearchAppNotFound">Appen kunde inte hittas</string>
     <string name="systemSearchOnboardingText">Tack för att du valde DuckDuckGo!\nNär du använder vår sökning eller app är dina sökningar skyddade.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">Annat som DuckDuckGo-appen gör:</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -104,7 +104,7 @@
     <string name="faviconContentDescription">Favicon</string>
     <string name="closeContentDescription">Kapat</string>
     <string name="closeAllTabsMenuItem">Tüm Sekmeleri Kapat</string>
-    <string name="closeTab">Sekmeyi kapat</string>
+    <string name="closeTab">Sekmeyi Kapat</string>
     <string name="tabClosed">Sekme kapatıldı</string>
     <string name="tabClosedUndo">Geri al</string>
     <string name="downloadsMenuItemTitle">İndirilenler</string>
@@ -243,9 +243,9 @@
     <string name="surveyCtaTitle">Uygulamayı geliştirmemize yardımcı olun!</string>
     <string name="surveyCtaDescription">Kısa anketimize katılın ve geri bildiriminizi paylaşın.</string>
     <string name="surveyCtaLaunchButton">Ankete katıl</string>
-    <string name="surveyCtaDismissButton">Hayır teşekkürler</string>
+    <string name="surveyCtaDismissButton">Hayır Teşekkürler</string>
     <string name="surveyActivityTitle">Kullanıcı Anketi</string>
-    <string name="surveyTitle">DUCKDUCKGO ANKETİ</string>
+    <string name="surveyTitle">DuckDuckGo Anketi</string>
     <string name="surveyDismissContentDescription">Anketi kapat</string>
     <string name="surveyLoadingErrorTitle">Olamaz!</string>
     <string name="surveyLoadingErrorText">Anketimiz şu anda yüklenemiyor.\nLütfen daha sonra tekrar deneyin.</string>
@@ -270,7 +270,7 @@
     <string name="appEnjoymentDialogTitle">DuckDuckGo\'yu sevdiniz mi?</string>
     <string name="appEnjoymentDialogMessage">Düşüncelerinizi öğrenmek isteriz.</string>
     <string name="appEnjoymentDialogPositiveButton">Sevdim</string>
-    <string name="appEnjoymentDialogNegativeButton">Üzerinde çalışılmalı</string>
+    <string name="appEnjoymentDialogNegativeButton">Üzerinde Çalışılmalı</string>
 
     <string name="rateAppDialogTitle">Uygulamayı değerlendir</string>
     <string name="rateAppDialogMessage">Görüşleriniz önemli. Lütfen bir inceleme yazın.</string>
@@ -361,7 +361,7 @@
     <string name="otherMainReasonTitleShort">Diğer Sorunlar</string>
 
     <string name="openEndedInputHint">Lütfen mümkün olduğunca spesifik olun</string>
-    <string name="submitFeedback">GÖNDER</string>
+    <string name="submitFeedback">Gönder</string>
 
     <string name="tellUsHowToImprove">Lütfen neyi geliştirebileceğimizi bize bildirin.</string>
     <string name="thanksForTheFeedback">Geri dönüşünüz için teşekkür ederiz!</string>
@@ -372,8 +372,8 @@
     <string name="whatHaveYouBeenEnjoying">Nelerden hoşlandınız?</string>
     <string name="awesomeToHear">Bunu Duymak Harika!</string>
     <string name="shareTheLoveWithARating">Lütfen Play Store\'da değerlendirin.</string>
-    <string name="rateTheApp">UYGULAMAYI DEĞERLENDİR</string>
-    <string name="declineFurtherFeedback">HAYIR TEŞEKKÜR EDERİM</string>
+    <string name="rateTheApp">Uygulamayı Değerlendir</string>
+    <string name="declineFurtherFeedback">Hayır Teşekkür Ederim</string>
     <string name="whichBrokenSites">Bu sorunları nerede görüyorsunuz?</string>
     <string name="whichBrokenSitesHint">Hangi web sitesinde sorunlar var?</string>
     <string name="feedbackSpecificAsPossible">Lütfen mümkün olduğunca spesifik olun</string>
@@ -389,7 +389,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">Bu cihazdan</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">URL\'yi arayın veya bir URL yazın</font></string>
     <string name="systemSearchAppNotFound">Uygulama bulunamadı</string>
     <string name="systemSearchOnboardingText">DuckDuckGo\'yu seçtiğiniz için teşekkürler!\nArama motorumuzu veya uygulamamızı kullanırken tüm aramalarınız güvende.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">DuckDuckGo uygulaması ayrıca:</string>
@@ -408,7 +407,7 @@
     <string name="daxDialogGotIt">Anladım</string>
     <string name="hideTipsTitle">Kalan ipuçları gizlensin mi?</string>
     <string name="hideTipsText">Sadece birkaç tane var ve onları da bilgilendirici hâle getirmeye çalıştık.</string>
-    <string name="hideTipsButton">İpuçlarını sonsuza kadar gizle</string>
+    <string name="hideTipsButton">İpuçlarını Sonsuza Kadar Gizle</string>
 
     <!-- New Onboarding Experience -->
     <string name="onboardingWelcomeTitle">"DuckDuckGo'ya Hoş Geldiniz!"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,7 +246,7 @@
     <string name="surveyCtaLaunchButton">Take the Survey</string>
     <string name="surveyCtaDismissButton">No Thanks</string>
     <string name="surveyActivityTitle">User Survey</string>
-    <string name="surveyTitle">DuckDuckGo survey</string>
+    <string name="surveyTitle">DuckDuckGo Survey</string>
     <string name="surveyDismissContentDescription">Dismiss survey</string>
     <string name="surveyLoadingErrorTitle">Oh no!</string>
     <string name="surveyLoadingErrorText">Our survey is not currently loading.\nPlease try again later.</string>
@@ -367,7 +367,7 @@
     <string name="tellUsHowToImprove">Please tell us what we can improve.</string>
     <string name="thanksForTheFeedback">Thanks for the feedback!</string>
     <string name="feedbackNegativeMainReasonPageSubtitle">What is your frustration most related to?</string>
-    <string name="feedbackNegativeMainReasonPageTitle">We\'re Sorry To Hear That</string>
+    <string name="feedbackNegativeMainReasonPageTitle">We\'re Sorry to Hear That</string>
     <string name="feedbackShareDetails">Share Details</string>
     <string name="sharePositiveFeedbackWithTheTeam">Are there any details you\'d like to share with the team?</string>
     <string name="whatHaveYouBeenEnjoying">What have you been enjoying?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="faviconContentDescription">Favicon</string>
     <string name="closeContentDescription">Close</string>
     <string name="closeAllTabsMenuItem">Close All Tabs</string>
-    <string name="closeTab">Close tab</string>
+    <string name="closeTab">Close Tab</string>
     <string name="tabClosed">Tab closed</string>
     <string name="tabClosedUndo">Undo</string>
     <string name="downloadsMenuItemTitle">Downloads</string>
@@ -244,9 +244,9 @@
     <string name="surveyCtaTitle">Help us improve the app!</string>
     <string name="surveyCtaDescription">Take our short survey and share your feedback.</string>
     <string name="surveyCtaLaunchButton">Take the Survey</string>
-    <string name="surveyCtaDismissButton">No thanks</string>
+    <string name="surveyCtaDismissButton">No Thanks</string>
     <string name="surveyActivityTitle">User Survey</string>
-    <string name="surveyTitle">DUCKDUCKGO SURVEY</string>
+    <string name="surveyTitle">DuckDuckGo survey</string>
     <string name="surveyDismissContentDescription">Dismiss survey</string>
     <string name="surveyLoadingErrorTitle">Oh no!</string>
     <string name="surveyLoadingErrorText">Our survey is not currently loading.\nPlease try again later.</string>
@@ -270,8 +270,8 @@
     <!-- App Enjoyment / Rating / Feedback -->
     <string name="appEnjoymentDialogTitle">Enjoying DuckDuckGo?</string>
     <string name="appEnjoymentDialogMessage">We\'d love to know what you think.</string>
-    <string name="appEnjoymentDialogPositiveButton">I like it</string>
-    <string name="appEnjoymentDialogNegativeButton">It needs work</string>
+    <string name="appEnjoymentDialogPositiveButton">I Like It</string>
+    <string name="appEnjoymentDialogNegativeButton">It Needs Work</string>
 
     <string name="rateAppDialogTitle">Rate the app</string>
     <string name="rateAppDialogMessage">Your feedback matters. Please share the love with a review.</string>
@@ -362,7 +362,7 @@
     <string name="otherMainReasonTitleShort">Other Issues</string>
 
     <string name="openEndedInputHint">Please be as specific as possible</string>
-    <string name="submitFeedback">SUBMIT</string>
+    <string name="submitFeedback">Submit</string>
 
     <string name="tellUsHowToImprove">Please tell us what we can improve.</string>
     <string name="thanksForTheFeedback">Thanks for the feedback!</string>
@@ -373,8 +373,8 @@
     <string name="whatHaveYouBeenEnjoying">What have you been enjoying?</string>
     <string name="awesomeToHear">Awesome to Hear!</string>
     <string name="shareTheLoveWithARating">Please share the love by rating on the Play Store.</string>
-    <string name="rateTheApp">RATE APP</string>
-    <string name="declineFurtherFeedback">NO THANKS, I\'M DONE</string>
+    <string name="rateTheApp">Rate App</string>
+    <string name="declineFurtherFeedback">No Thanks, I\'m Done</string>
     <string name="whichBrokenSites">Where are you seeing these issues?</string>
     <string name="whichBrokenSitesHint">Which website has issues?</string>
     <string name="feedbackSpecificAsPossible">Please be as specific as possible</string>
@@ -390,7 +390,6 @@
 
     <!-- System Search-->
     <string name="systemSearchDeviceAppLabel">From this device</string>
-    <string name="systemSearchOmnibarInputHint"><font size="13">Search or type URL</font></string>
     <string name="systemSearchAppNotFound">Application could not be found</string>
     <string name="systemSearchOnboardingText">Thanks for choosing DuckDuckGo!\nNow, when using our search or app, your searches are protected.</string>
     <string name="systemSearchOnboardingFeaturesIntroText">The DuckDuckGo app also:</string>
@@ -409,7 +408,7 @@
     <string name="daxDialogGotIt">Got It</string>
     <string name="hideTipsTitle">Hide remaining tips?</string>
     <string name="hideTipsText">There are only a few, and we tried to make them informative.</string>
-    <string name="hideTipsButton">Hide tips forever</string>
+    <string name="hideTipsButton">Hide Tips Forever</string>
 
     <!-- New Onboarding Experience -->
     <string name="onboardingWelcomeTitle">"Welcome to DuckDuckGo!"</string>

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -30,7 +30,7 @@
     <string name="saveLoginDialogButtonSave">Uložit přihlašovací údaje</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Uložit heslo</string>
     <string name="saveLoginDialogNotNow">Teď ne</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">Přihlašovací údaje jsou bezpečně uložené pouze v tomhle zařízení a dají se spravovat v nabídce Automatické vyplňování v Nastaveních.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo tyto přihlašovací údaje bezpečně uloží do tvého zařízení. Uložená přihlášení můžeš spravovat v Nastaveních.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Má DuckDuckGo uložit přihlašovací údaje?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Další možnosti</string>
 

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -30,7 +30,7 @@
     <string name="saveLoginDialogButtonSave">Anmeldedaten speichern</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Passwort speichern</string>
     <string name="saveLoginDialogNotNow">Jetzt nicht</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">Anmeldedaten werden nur auf diesem Gerät sicher gespeichert und können über das Menü Autovervollständigen in den Einstellungen verwaltet werden.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo speichert diese Anmeldedaten sicher auf deinem Gerät. Du kannst die gespeicherten Anmeldedaten in den Einstellungen verwalten.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Möchtest du, dass DuckDuckGo deine Anmeldedaten speichert?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Weitere Optionen</string>
 

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -30,7 +30,7 @@
     <string name="saveLoginDialogButtonSave">Spremi prijavu</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Spremi lozinku</string>
     <string name="saveLoginDialogNotNow">Ne sada</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">Prijave se sigurno pohranjuju samo na ovom uređaju i njima se može upravljati iz izbornika Automatsko popunjavanje u Postavkama.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo će sigurno spremiti ovu prijavu na tvoj uređaj. Spremljenim prijavama možeš upravljati u Postavkama.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Želiš li da DuckDuckGo spremi tvoju prijavu?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Dodatne mogućnosti</string>
 

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -30,7 +30,7 @@
     <string name="saveLoginDialogButtonSave">Salva dati di accesso</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Salva password</string>
     <string name="saveLoginDialogNotNow">Non adesso</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">I dati di accesso sono archiviati in modo sicuro solo su questo dispositivo e possono essere gestiti dal menu Compilazione automatica, all\'interno di Impostazioni.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo salverà in modo sicuro questi dati di accesso sul tuo dispositivo. Puoi gestire i dati di accesso salvati in Impostazioni.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Vuoi che DuckDuckGo salvi i dati di accesso?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Altre opzioni</string>
 

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -30,7 +30,7 @@
     <string name="saveLoginDialogButtonSave">Guardar início de sessão</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Guardar palavra-passe</string>
     <string name="saveLoginDialogNotNow">Agora não</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">Os inícios de sessão são armazenados com segurança apenas neste dispositivo e podes efetuar a gestão dos mesmo a partir do menu de Preenchimento automático nas Definições.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">O DuckDuckGo vai armazenar este início de sessão em segurança no teu dispositivo. Podes gerir os inícios de sessão guardados nas Definições.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Queres que o DuckDuckGo guarde o teu início de sessão?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Mais opções</string>
 

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -30,7 +30,7 @@
     <string name="saveLoginDialogButtonSave">Girişi Kaydet</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Şifre Kaydet</string>
     <string name="saveLoginDialogNotNow">Şimdi Değil</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">Girişler yalnızca bu cihazda güvenli bir şekilde saklanır ve Ayarlar\'daki Otomatik Doldurma menüsünden yönetilebilir.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo bu Girişi cihazınızda güvenli bir şekilde saklayacaktır. Kayıtlı Girişleri Ayarlar\'dan yönetebilirsiniz.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">DuckDuckGo\'nun Girişinizi kaydetmesini istiyor musunuz?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Diğer Seçenekler</string>
 

--- a/macos/macos-impl/src/main/res/layout/activity_macos.xml
+++ b/macos/macos-impl/src/main/res/layout/activity_macos.xml
@@ -73,6 +73,20 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/statusTitle"/>
 
+            <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+                android:id="@+id/waitlistDescriptionLink"
+                app:typography="body1_bold"
+                android:textColor="?daxColorAccentBlue"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="24dp"
+                android:layout_marginEnd="24dp"
+                android:text="@string/macos_description_link"
+                android:textAlignment="center"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/waitlistDescription"/>
+
             <com.duckduckgo.mobile.android.ui.view.button.DaxButtonPrimary
                     android:id="@+id/shareButton"
                     android:layout_width="match_parent"
@@ -84,7 +98,7 @@
                     app:buttonSize="large"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/waitlistDescription"/>
+                    app:layout_constraintTop_toBottomOf="@+id/waitlistDescriptionLink"/>
 
             <com.duckduckgo.mobile.android.ui.view.button.DaxButtonGhost
                 android:id="@+id/lookingForWindowsVersionButton"

--- a/macos/macos-impl/src/main/res/values-bg/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-bg/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Вземете DuckDuckGo за Mac!</string>
 
     <string name="macos_share_title">Споделяне на връзка</string>
-    <string name="macos_description_text">DuckDuckGo за Mac притежава необходимата скорост, както и очакваните от Вас функции на браузъра, и предлага най-добрите в този клас елементи за защита.\n\nНа устройството с Mac отворете:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo за Mac притежава необходимата скорост, както и очакваните от Вас функции на браузъра, и предлага най-добрите в този клас елементи за защита.\n\nНа Вашия Mac отидете на:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Готови ли сте да започнете поверително сърфиране на Mac?\n\nПосетете този URL адрес на устройство с Mac, за да изтеглите приложението:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Търсите версията за Windows?</string>

--- a/macos/macos-impl/src/main/res/values-cs/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-cs/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Pořiď si DuckDuckGo pro Mac!</string>
 
     <string name="macos_share_title">Sdílet odkaz</string>
-    <string name="macos_description_text">DuckDuckGo pro Mac má rychlost, kterou potřebuješ, funkce prohlížeče, které očekáváš, a obsahuje naše nejlepší nástroje na ochranu soukromí.\n\nNa Macu přejdi na adresu:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo pro Mac má rychlost, kterou potřebuješ, funkce prohlížeče, které očekáváš, a hlavně naše nejlepší nástroje na ochranu soukromí.\n\nNa Macu otevři:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Chceš si na Macu prohlížet web v naprostém soukromí?\n\nAplikaci si do Macu stáhneš z téhle adresy:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Hledáš verzi pro Windows?</string>

--- a/macos/macos-impl/src/main/res/values-da/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-da/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Prøv DuckDuckGo til Mac!</string>
 
     <string name="macos_share_title">Del link</string>
-    <string name="macos_description_text">DuckDuckGo til Mac har den hastighed, du har brug for, de browserfunktioner, du forventer, og leveres spækket med vores bedste privatlivsartikler i klassen.\n\nPå din Mac skal du gå til:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo til Mac har den hastighed, du har brug for, de browserfunktioner, du forventer, og leveres spækket med vores bedste privatlivsartikler i klassen.\n\nPå din Mac skal du gå til:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Er du klar til at begynde at browse privat på Mac?\n\nBesøg denne URL på din Mac for at downloade:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Leder du efter Windows-versionen?</string>

--- a/macos/macos-impl/src/main/res/values-de/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-de/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Hole dir DuckDuckGo für Mac!</string>
 
     <string name="macos_share_title">Link teilen</string>
-    <string name="macos_description_text">DuckDuckGo für Mac hat die Geschwindigkeit, die du brauchst, die Browserfunktionen, die du erwartest, und ist vollgepackt mit unseren grundlegenden Funktionen für den Datenschutz.Rufe auf deinem Mac Folgendes auf:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo für Mac hat die Geschwindigkeit, die du brauchst, die Browserfunktionen, die du erwartest, und ist vollgepackt mit unseren grundlegenden Funktionen für den Datenschutz.\n\nRufe auf deinem Mac Folgendes auf:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Bereit, privat auf dem Mac zu browsen?\n\nRufe für den Download diese URL auf deinem Mac auf:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Suchst du nach der Windows-Version?</string>

--- a/macos/macos-impl/src/main/res/values-el/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-el/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Αποκτήστε το DuckDuckGo για Mac!</string>
 
     <string name="macos_share_title">Κοινή χρήση συνδέσμου</string>
-    <string name="macos_description_text">Το DuckDuckGo για Mac έχει την ταχύτητα που χρειάζεστε, τις λειτουργίες περιήγησης που αναμένετε και περιλαμβάνει τις καλύτερες δυνατότητες απορρήτου στην κατηγορία μας.\n\nΣτον Mac σας, μεταβείτε στη διεύθυνση:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">Το DuckDuckGo για Mac έχει την ταχύτητα που χρειάζεστε, τις λειτουργίες περιήγησης που αναμένετε και περιλαμβάνει τις καλύτερες δυνατότητες απορρήτου στην κατηγορία μας.\n\nΣτον Mac σας, μεταβείτε στη διεύθυνση:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Έτοιμοι να αρχίσετε μια ιδιωτική περιήγηση σε Mac; \n\nΕπισκεφτείτε αυτήν τη διεύθυνση URL στον Mac σας για να κάνετε λήψη:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Αναζητάτε την έκδοση των Windows;</string>

--- a/macos/macos-impl/src/main/res/values-es/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-es/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">¡Consigue DuckDuckGo para Mac!</string>
 
     <string name="macos_share_title">Compartir enlace</string>
-    <string name="macos_description_text">DuckGo para Mac tiene la velocidad que necesitas, las funciones de navegador que esperas y viene repleta de nuestros mejores esenciales de privacidad.\n\nEn tu Mac, ve a:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo para Mac tiene la velocidad que necesitas, las funciones de navegador que esperas y viene repleto de nuestros mejores esenciales de privacidad.\n\nEn tu Mac, ve a:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">¿Todo listo para empezar a navegar de forma privada en Mac?\n\nVisita esta URL en tu Mac para descargarlo:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">¿Buscas la versión para Windows?</string>

--- a/macos/macos-impl/src/main/res/values-et/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-et/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Hangi DuckDuckGo for Mac!</string>
 
     <string name="macos_share_title">Jaga linki</string>
-    <string name="macos_description_text">DuckDuckGo for Mac on täpselt nii kiire kui vaja, ootuspäraste sirvimisfunktsioonidega ja täis meie tippklassi privaatsuselemente.\n\nAva oma Macis aadress:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo for Mac on täpselt nii kiire kui vaja, ootuspäraste brauserifunktsioonidega ja meie tippklassi privaatsuselementidest tulvil.\n\nAva oma Macis:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Kas oled valmis Macis privaatselt sirvima?\n\nAllalaadimiseks ava oma Macis see URL:\nhttps://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Kas otsid Windowsi versiooni?</string>

--- a/macos/macos-impl/src/main/res/values-fi/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-fi/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Kokeile Macin DuckDuckGota!</string>
 
     <string name="macos_share_title">Jaa linkki</string>
-    <string name="macos_description_text">Macin DuckDuckGo-sovellus tarjoaa kaipaamaasi nopeutta, odottamasi selaustoiminnot ja luokkansa parhaat tietosuojaominaisuudet.\n\nSiirry Mac-laitteellasi osoitteeseen:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">Macin DuckDuckGo-sovellus tarjoaa kaipaamaasi nopeutta, odottamasi selaustoiminnot ja luokkansa parhaat tietosuojaominaisuudet.\n\nSiirry Mac-tietokoneellasi osoitteeseen:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Oletko valmis aloittamaan yksityisen selaamisen Macilla?\n\nLataa sovellus Mac-laitteellesi osoitteesta:\nhttps://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Etsitkö Windows-versiota?</string>

--- a/macos/macos-impl/src/main/res/values-fr/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-fr/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Procurez-vous DuckDuckGo pour Mac !</string>
 
     <string name="macos_share_title">Partager le lien</string>
-    <string name="macos_description_text">DuckDuckGo pour Mac répond à vos besoins de rapidité et de fonctionnalités de navigation, et dispose des meilleurs outils de leur catégorie pour protéger votre vie privée.\n\nSur votre Mac, accédez à :\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo pour Mac répond à vos besoins de rapidité et de fonctionnalités de navigation, et dispose des meilleurs outils de leur catégorie pour protéger votre vie privée.\n\nSur votre Mac, accédez à :</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Prêt(e) à naviguer incognito sur Mac ?\n\nAccédez à cette URL sur votre Mac pour télécharger l\'application :\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Vous cherchez la version Windows ?</string>

--- a/macos/macos-impl/src/main/res/values-hr/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-hr/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Nabavi DuckDuckGo za Mac!</string>
 
     <string name="macos_share_title">Podijeli poveznicu</string>
-    <string name="macos_description_text">Aplikacija DuckDuckGo za Mac pruža ti potrebnu brzinu i značajke pretraživanja kakve očekuješ, a isporučuje se s našim najboljim alatima za privatnost u svojoj klasi - privacy essentials.\n\nNa svom Macu idi na: \n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">Aplikacija DuckDuckGo za Mac pruža ti potrebnu brzinu i značajke pretraživanja kakve očekuješ, a isporučuje se s našim najboljim alatima za privatnost u svojoj klasi - privacy essentials.\n\nNa Macu idi na:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Jesi li spreman za početak privatnog pretraživanja na Macu?\n\nPosjeti ovaj URL na svom Macu za preuzimanje:\nhttps://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Tražiš verziju za Windows?</string>

--- a/macos/macos-impl/src/main/res/values-hu/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-hu/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Szered meg a DuckDuckGo Mac verzióját!</string>
 
     <string name="macos_share_title">Link megosztása</string>
-    <string name="macos_description_text">A DuckDuckGo Mac verziója gyors, böngészési funkciókban gazdag, és kategóriája legjobb adatvédelmi megoldásait kínálja.Mac számítógépén lépj a következő címre:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">A DuckDuckGo Mac verziója gyors, böngészési funkciókban gazdag, és kategóriája legjobb adatvédelmi megoldásait kínálja.\n\nMacen lépj erre az oldalra:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Készen állsz a privát böngészésre a Macen?\n\nA letöltéshez látogass el erre az URL-címre a Macen:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">A Windowsra készült verziót keresed?</string>

--- a/macos/macos-impl/src/main/res/values-it/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-it/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Scarica DuckDuckGo per Mac.</string>
 
     <string name="macos_share_title">Condividi link</string>
-    <string name="macos_description_text">DuckDuckGo per Mac ti offre la velocità di cui hai bisogno, le funzioni per browser che desideri e i migliori strumenti per la privacy.\n\nSul tuo Mac, vai a:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo per Mac ti offre la velocità di cui hai bisogno, le funzioni per browser che desideri e i nostri migliori privacy essentials.\n\nSul tuo Mac, vai su:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Vuoi iniziare a navigare privatamente su Mac?\n\nVisita questo URL sul tuo Mac per scaricare:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Cerchi la versione per Windows?</string>

--- a/macos/macos-impl/src/main/res/values-lt/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-lt/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Gaukite „Mac“ skirtą „DuckDuckGo“!</string>
 
     <string name="macos_share_title">Bendrinti nuorodą</string>
-    <string name="macos_description_text">„Mac“ skirta „DuckDuckGo“ pasižymi jums reikiama sparta, naršyklės funkcijomis ir aukščiausios klasės privatumo įrankiais.\n\n„Mac“ kompiuteryje eikite į:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">„Mac“ skirta „DuckDuckGo“ pasižymi jums reikiama sparta, naršyklės funkcijomis ir aukščiausios klasės privatumo įrankiais.\n\n„Mac“ kompiuteryje eikite į:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Pasiruošę naršyti privačiai „Mac“?\n\nSpustelėkite šį URL „Mac“ kompiuteryje, kad atsisiųstumėte:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Ieškote „Windows“ versijos?</string>

--- a/macos/macos-impl/src/main/res/values-lv/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-lv/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Iegūsti DuckDuckGo Mac datoram!</string>
 
     <string name="macos_share_title">Kopīgot saiti</string>
-    <string name="macos_description_text">DuckDuckGo Mac datoram sniedz nepieciešamo ātrumu, ierastās pārlūkošanas funkcijas un savā klasē labākās privātuma pamatfunkcijas.\n\nSavā Mac datorā dodies uz: \n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo Mac datoram sniedz nepieciešamo ātrumu, ierastās pārlūkošanas funkcijas un savā klasē labākās privātuma pamatfunkcijas.\n\nSavā Mac datorā dodies uz:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Vai esi gatavs sākt privātu pārlūkošanu savā Mac?\n\n Apmeklē šo URL savā Mac datorā, lai lejupielādētu:\nhttps://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Vai meklē Windows versiju?</string>

--- a/macos/macos-impl/src/main/res/values-nb/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-nb/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Skaff deg DuckDuckGo for Mac!</string>
 
     <string name="macos_share_title">Del lenke</string>
-    <string name="macos_description_text">DuckDuckGo for Mac har hastigheten du trenger, nettleserfunksjonene du forventer, og er proppfull av våre førsteklasses Privacy Essentials.På Mac-en din går du til:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo for Mac har hastigheten du trenger, nettleserfunksjonene du forventer, og er proppfull av våre førsteklasses Privacy Essentials.\n\nPå Mac går du til:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Er du klar til å begynne å surfe privat på Mac?\n\nGå til denne URL-adressen på Mac-en din for å laste ned:\nhttps://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Ser du etter Windows-versjonen?</string>

--- a/macos/macos-impl/src/main/res/values-nl/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-nl/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Download DuckDuckGo voor Mac!</string>
 
     <string name="macos_share_title">Link delen</string>
-    <string name="macos_description_text">DuckDuckGo voor Mac heeft de snelheid die je nodig hebt en de browserfuncties die je verwacht, en zit boordevol met onze allerbeste essentiële facetten van privacy.\n\nGa op je Mac naar:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo voor Mac heeft de snelheid die je nodig hebt en de browserfuncties die je verwacht, en zit boordevol met onze allerbeste essentiële facetten van privacy.\n\nGa op je Mac naar:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Klaar om privé te browsen op de Mac?\n\nBezoek deze URL op je Mac om DuckDuckGo te downloaden:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Op zoek naar de versie voor Windows?</string>

--- a/macos/macos-impl/src/main/res/values-pl/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-pl/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Pobierz DuckDuckGo dla komputerów Mac!</string>
 
     <string name="macos_share_title">Udostępnij link</string>
-    <string name="macos_description_text">Aplikacja DuckDuckGo dla komputerów Mac zapewnia szybkość, której potrzebujesz, i niezbędne funkcje przeglądania. Ponadto jest wyposażona w najlepsze w swojej klasie narzędzia do ochrony prywatności.Na komputerze Mac odwiedź stronę:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">Aplikacja DuckDuckGo dla komputerów Mac zapewnia szybkość, której potrzebujesz, i niezbędne funkcje przeglądania. Ponadto jest wyposażona w najlepsze w swojej klasie narzędzia do ochrony prywatności.\n\nNa komputerze Mac przejdź do:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Chcesz rozpocząć prywatne przeglądanie na komputerze Mac?\n\nPrzejdź pod ten adres URL na komputerze Mac, aby pobrać:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Szukasz wersji dla systemu Windows?</string>

--- a/macos/macos-impl/src/main/res/values-pt/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-pt/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Obtenha o DuckDuckGo para Mac!</string>
 
     <string name="macos_share_title">Partilhar ligação</string>
-    <string name="macos_description_text">O DuckDuckGo para Mac tem a velocidade de que necessita, as funcionalidades de navegador que espera e os nossos melhores Privacy Essentials.No seu Mac, aceda a:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">O DuckDuckGo para Mac tem a velocidade de que necessita, as funcionalidades de navegador que espera e os nossos melhores Privacy Essentials.\n\nNo seu Mac, aceda a:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">A postos para navegar em privado no Mac?\n\nVisite este URL no seu Mac para transferir:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Procura a versão para Windows?</string>

--- a/macos/macos-impl/src/main/res/values-ro/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-ro/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Obține DuckDuckGo pentru Mac!</string>
 
     <string name="macos_share_title">Trimite linkul</string>
-    <string name="macos_description_text">DuckDuckGo pentru Mac are viteza de care ai nevoie, funcțiile de răsfoire pe care ți le dorești și este prevăzută cu cele mai bune caracteristici de bază în privința confidențialității din domeniu.\n\nPe dispozitivul Mac, accesează:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo pentru Mac are viteza de care ai nevoie, funcțiile de răsfoire pe care ți le dorești și este prevăzută cu cele mai bune caracteristici de bază în privința confidențialității din domeniu.\n\nPe dispozitivul tău Mac, accesează:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Ești gata să răsfoiești în mod privat pe Mac?\n\nVizitează această adresă URL pe dispozitivul tău Mac pentru a descărca:\nhttps://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Cauți versiunea pentru Windows?</string>

--- a/macos/macos-impl/src/main/res/values-ru/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-ru/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">DuckDuckGo для Mac!</string>
 
     <string name="macos_share_title">Поделиться ссылкой</string>
-    <string name="macos_description_text">Приложение DuckDuckGo для Mac — это высокая скорость, функциональность и беспрецедентная конфиденциальность.\n\nСсылка для загрузки на Mac:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">Приложение DuckDuckGo для Mac — это высокая скорость, функциональность и беспрецедентная конфиденциальность.\n\nПерейдите на компьютере Mac по ссылке:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Конфиденциальность в Интернете на Mac? Не проблема!\n\nЗагрузите наше приложение по ссылке:\nhttps://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Ищете версию для Windows?</string>

--- a/macos/macos-impl/src/main/res/values-sk/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-sk/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Vyskúšajte DuckDuckGo pre Mac!</string>
 
     <string name="macos_share_title">Zdieľať odkaz</string>
-    <string name="macos_description_text">DuckDuckGo pre Mac má rýchlosť, ktorú potrebujete, funkcie prehliadania, ktoré očakávate, a ponúka obsah s našimi prvotriednymi nástrojmi na ochranu súkromia.\n\nV počítači Mac prejdite na: \n <b> <font color="#3969EF"> duckduckgo.com/mac </font> </b></string>
+    <string name="macos_description_text">DuckDuckGo pre Mac má rýchlosť, ktorú potrebujete, funkcie prehliadača, ktoré očakávate, a ponúka obsah s našimi prvotriednymi nástrojmi na ochranu súkromia.\n\nV počítači Mac prejdite na:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Ste pripravení začať so súkromným prehliadaním v počítači Mac?\n\nNa stiahnutie navštívte túto adresu URL vo svojom počítači Mac:\nhttps://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Hľadáte verziu pre systém Windows?</string>

--- a/macos/macos-impl/src/main/res/values-sl/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-sl/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Prenesite DuckDuckGo za računalnike Mac!</string>
 
     <string name="macos_share_title">Daj povezavo v skupno rabo</string>
-    <string name="macos_description_text">DuckDuckGo za računalnike Mac zagotavlja hitrost, ki jo potrebujete, in funkcije brskanja, ki jih pričakujete, ter je opremljen z našimi ključnimi funkcijami zasebnosti, ki so najboljše v tem razredu.V računalniku Mac pojdite na:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo za računalnike Mac zagotavlja hitrost, ki jo potrebujete, in funkcije brskanja, ki jih pričakujete, ter je opremljen z našimi ključnimi funkcijami zasebnosti, ki so najboljše v tem razredu.\n\nV računalniku Mac odprite:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Ste pripravljeni na zasebno brskanje v računalniku Mac? \n\nZa prenos obiščite ta naslov URL v računalniku Mac:\n https://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Iščete različico za sistem Windows?</string>

--- a/macos/macos-impl/src/main/res/values-sv/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-sv/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Skaffa DuckDuckGo för Mac!</string>
 
     <string name="macos_share_title">Dela länk</string>
-    <string name="macos_description_text">DuckDuckGo för Mac har hastigheten du behöver, webbläsarfunktionerna du förväntar dig och våra många förstklassiga integritetsfunktioner.\n\nPå din Mac går du till:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo för Mac har hastigheten du behöver, webbläsarfunktionerna du förväntar dig och våra många förstklassiga integritetsfunktioner.\n\nPå din Mac går du till:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Är du redo att börja surfa privat på din Mac?\n\nLadda ner genom att gå till den här webbadressen på din Mac:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Letar du efter Windows-versionen?</string>

--- a/macos/macos-impl/src/main/res/values-tr/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values-tr/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Mac için DuckDuckGo\'yu edinin!</string>
 
     <string name="macos_share_title">Bağlantıyı paylaş</string>
-    <string name="macos_description_text">Mac için DuckDuckGo, ihtiyacınız olan hız ve beklediğiniz tarayıcı özelliklerinin yanı sıra sınıfındaki en iyi gizlilik özelliklerini (Privacy Essentials) sunuyor.\n\nMac\'inizde şu adrese gidin:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">Mac için DuckDuckGo, ihtiyacınız olan hız ve beklediğiniz tarama özelliklerinin yanı sıra sınıfındaki en iyi gizlilik özelliklerini (Privacy Essentials) sunuyor.\n\nMac cihazınızda şu adrese gidin:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Mac\'te gizliliğinizi koruyarak gezinmeye hazır mısınız?\n\nİndirmek için Mac\'inizde şu URL\'yi ziyaret edin:\nhttps://duckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Windows Sürümünü mü arıyorsunuz?</string>

--- a/macos/macos-impl/src/main/res/values/strings-macos-waitlist.xml
+++ b/macos/macos-impl/src/main/res/values/strings-macos-waitlist.xml
@@ -21,7 +21,8 @@
     <string name="macos_title">Get DuckDuckGo for Mac!</string>
 
     <string name="macos_share_title">Share Link</string>
-    <string name="macos_description_text">DuckDuckGo for Mac has the speed you need, the browser features you expect, and comes packed with our best-in-class privacy essentials.\n\nOn your Mac, go to:\n<b><font color="#3969EF">duckduckgo.com/mac</font></b></string>
+    <string name="macos_description_text">DuckDuckGo for Mac has the speed you need, the browser features you expect, and comes packed with our best-in-class privacy essentials.\n\nOn your Mac, go to:</string>
+    <string name="macos_description_link">duckduckgo.com/mac</string>
     <string name="macos_share_text">Ready to start browsing privately on Mac?\n\nVisit this URL on your Mac to download:\nduckduckgo.com/mac</string>
 
     <string name="macos_waitlist_windows_link">Looking for the Windows Version?</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Weby můžou používat mikrofon, jen když službě DuckDuckGo povolíš žádat o přístup.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Povolit DuckDuckGo žádat na tomto zařízení o přístup k fotoaparátu a mikrofonu</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Weby můžou používat tvůj fotoaparát a mikrofon, jen když službě DuckDuckGo povolíš žádat o přístup.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Otevřené nastavení</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Otevřít nastavení</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Zrušit</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Οι ιστότοποι μπορούν να χρησιμοποιούν το μικρόφωνό σας μόνο εάν επιτρέψετε στο DuckDuckGo να αιτηθεί πρόσβαση.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Επιτρέψτε στο DuckDuckGo να αιτηθεί πρόσβαση στην κάμερα και στο μικρόφωνο της συσκευής αυτής</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Οι ιστότοποι μπορούν να χρησιμοποιούν την κάμερα και το μικρόφωνό σας μόνο εάν επιτρέψετε στο DuckDuckGo να αιτηθεί πρόσβαση.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Άνοιγμα Ρυθμίσεων</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Άνοιγμα ρυθμίσεων</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Ακύρωση</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Saidid saavad sinu mikrofoni kasutada ainult siis, kui lubad DuckDuckGo’l küsida sellele juurdepääsu.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Luba DuckDuckGo’l küsida juurdepääsu selle seadme kaamerale ja mikrofonile</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Saidid saavad sinu kaamerat ja mikrofoni kasutada ainult siis, kui lubad DuckDuckGo’l küsida sellele juurdepääsu.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Ava seaded</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Ava sätted</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Tühista</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Les sites ne peuvent utiliser votre micro que si vous autorisez DuckDuckGo à demander l\'accès.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Autoriser DuckDuckGo à demander l\'accès à l\'appareil photo et au micro sur cet appareil</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Les sites ne peuvent utiliser votre appareil photo et votre micro que si vous autorisez DuckDuckGo à demander l\'accès.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Ouvrez les Paramètres</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Ouvrir les paramètres</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Annuler</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Stranice mogu koristiti tvoj mikrofon samo ako dopustiš DuckDuckGou da zatraži pristup.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Dopusti DuckDuckGou da zatraži pristup kameri i mikrofonu na ovom uređaju</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Stranice mogu koristiti tvoju kameru i mikrofon samo ako dopustiš DuckDuckGou da zatraži pristup.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Otvorite postavke</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Otvori postavke</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Otkaži</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">I siti possono utilizzare il microfono solo se consenti a DuckDuckGo di richiederne l\'accesso.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Consenti a DuckDuckGo di richiedere l\'accesso alla fotocamera e al microfono su questo dispositivo</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">I siti possono utilizzare la fotocamera e il microfono solo se consenti a DuckDuckGo di richiederne l\'accesso.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Apri le impostazioni</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Apri Impostazioni</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Annulla</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Svetainės gali naudoti jūsų mikrofoną tik tuo atveju, jei leisite „DuckDuckGo“ prašyti prieigos.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Leisti „DuckDuckGo“ prašyti prieigos prie kameros ir mikrofono šiame įrenginyje</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Svetainės gali naudoti jūsų kamerą ir mikrofoną tik tada, jei leisite „DuckDuckGo“ prašyti prieigos.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Atidaryti parametrus</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Atidaryti nustatymus</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Atšaukti</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Sites kunnen je microfoon alleen gebruiken als je DuckDuckGo toestaat om toegang te vragen.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">DuckDuckGo toestaan om toegang tot de microfoon en camera op dit apparaat te vragen</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Sites kunnen je camera en microfoon alleen gebruiken als je DuckDuckGo toestaat om toegang te vragen.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Open instellingen</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Open Instellingen</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Annuleren</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Os sites só podem usar o teu microfone se autorizares o DuckDuckGo a pedir acesso.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Permitir que o DuckDuckGo peça acesso à câmara e ao microfone neste dispositivo</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Os sites só podem utilizar a tua câmara e microfone se autorizares o DuckDuckGo a pedir acesso.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Abrir Configurações</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Abrir Definições</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Cancelar</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Если вы разрешите DuckDuckGo запрашивать доступ, сайты смогут использовать только микрофон.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Разрешить DuckDuckGo запрашивать доступ к камере и микрофону на этом устройстве</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Если вы разрешите DuckDuckGo запрашивать доступ, сайты смогут использовать только камеру и микрофон.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Открыть настройки</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Открыть Настройки</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Отменить</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Lokality môžu používať váš mikrofón len vtedy, ak povolíte aplikácii DuckDuckGo žiadať o prístup.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Povoliť aplikácii DuckDuckGo žiadať o prístup k fotoaparátu a mikrofónu v tomto zariadení</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Lokality môžu používať váš fotoaparát a mikrofón len vtedy, ak povolíte aplikácii DuckDuckGo žiadať o prístup.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Otvorte nastavenia</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Otvoriť nastavenia</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Zrušiť</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Siteler mikrofonunuzu yalnızca DuckDuckGo\'nun erişim istemesine izin verirseniz kullanabilir.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">DuckDuckGo\'nun bu cihazda kamera ve mikrofon erişimi istemesine izin ver</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Siteler kameranızı ve mikrofonunuzu yalnızca DuckDuckGo\'nun erişim istemesine izin verirseniz kullanabilir.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Ayarları aç</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Ayarları Aç</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">İptal</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
@@ -33,6 +33,6 @@
     <string name="systemPermissionDialogAudioDeniedContent">Sites can only use your microphone if you allow DuckDuckGo to ask for access.</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedTitle">Allow DuckDuckGo to ask for camera and microphone access on this device</string>
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Sites can only use your camera and microphone if you allow DuckDuckGo to ask for access.</string>
-    <string name="systemPermissionsDeniedDialogPositiveButton">Open settings</string>
+    <string name="systemPermissionsDeniedDialogPositiveButton">Open Settings</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Cancel</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203535193049960/f

### Description
Update copy strings with correct casing

### Steps to test this PR

List of copy changes in https://app.asana.com/0/488551667048375/1203535193049962

_Text color for URL in mac OS screen_
- Install from this branch
- Go to Settings > DuckDuckGo Mac App
- [ ] Check text `duckduckgo.com/mac` color is correct for Light/Dark themes

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20230308_135319_DuckDuckGo](https://user-images.githubusercontent.com/20798495/224091891-83d4c409-e46e-49f5-910e-d8398c0768e3.jpg)|![Screenshot_20230308_135223_DuckDuckGo](https://user-images.githubusercontent.com/20798495/224091879-507631cb-add0-4eeb-b818-b3c833f852ad.jpg)|
![Screenshot_20230308_135312_DuckDuckGo](https://user-images.githubusercontent.com/20798495/224091908-04319a81-20b2-4c87-a239-43ea972f69bf.jpg)|![Screenshot_20230308_135231_DuckDuckGo](https://user-images.githubusercontent.com/20798495/224091936-98d7e700-4dda-488f-b7db-2c2404d304b2.jpg)|