### PR TITLE
Avoid emitting same state multiple times

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -57,14 +57,16 @@ import com.duckduckgo.mobile.android.R.dimen
 import com.duckduckgo.mobile.android.ui.view.text.DaxTextInput
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
-import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
+@ExperimentalCoroutinesApi
 @InjectWith(FragmentScope::class)
 class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_autofill_management_edit_mode), MenuProvider {
 
@@ -290,18 +292,20 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
 
         viewModel.viewState
             .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
-            .conflate()
+            .transformLatest {
+                emit(it.credentialMode)
+            }
             .distinctUntilChanged()
-            .onEach { state ->
-                when (state.credentialMode) {
+            .onEach { credentialMode ->
+                when (credentialMode) {
                     is Viewing -> {
-                        populateFields(state.credentialMode.credentialsViewed)
-                        showViewMode(state.credentialMode.credentialsViewed)
+                        populateFields(credentialMode.credentialsViewed)
+                        showViewMode(credentialMode.credentialsViewed)
                         invalidateMenu()
                     }
 
                     is EditingExisting -> {
-                        initializeEditStateIfNecessary(state.credentialMode)
+                        initializeEditStateIfNecessary(credentialMode)
                         updateToolbarForEdit()
                     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204067551190951/f 

### Description
This PR avoids emitting the same state several times which can cause the app to crash when creating a drawable

### Steps to test this PR
- [ ] In `AutofillManagementCredentialsMode` line 303 add a log statement whenever the state matches Viewing just above `populateFields`. 
- [ ] Launch the app and try to store a login to `pinterest.com` manually.
- [ ] The log statement should only show up once after saving the login.
- [ ] Press back and go back to the logins list screen
- [ ] Add another login manually
- [ ] The log statement should only show up once after saving the login.
