### PR TITLE
Use random uuid when account created

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
@@ -17,9 +17,7 @@
 package com.duckduckgo.sync.impl
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.os.Build
-import android.provider.Settings
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
@@ -36,7 +34,6 @@ interface SyncDeviceIds {
 class AppSyncDeviceIds
 @Inject
 constructor(
-    private val context: Context,
     private val syncStore: SyncStore,
 ) : SyncDeviceIds {
     override fun userId(): String {
@@ -61,7 +58,7 @@ constructor(
         var deviceName = syncStore.deviceId
         if (deviceName != null) return deviceName
 
-        deviceName  = UUID.randomUUID().toString()
+        deviceName = UUID.randomUUID().toString()
         return deviceName
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
@@ -61,9 +61,7 @@ constructor(
         var deviceName = syncStore.deviceId
         if (deviceName != null) return deviceName
 
-        deviceName =
-            Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
-                ?: "UNKNOWN"
+        deviceName  = UUID.randomUUID().toString()
         return deviceName
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.sync.impl.AppSyncDeviceIds
 import com.duckduckgo.sync.store.SyncStore
 import org.junit.Assert.assertEquals
@@ -25,7 +24,6 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
 
 @RunWith(AndroidJUnit4::class)
 class AppSyncDeviceIdsTest {
@@ -33,21 +31,21 @@ class AppSyncDeviceIdsTest {
     @Test
     fun whenUserIdExistsInStoreThenReturnsStoredValue() {
         val syncStore = getFakeSyncStore()
-        val appSyncDeviceIds = AppSyncDeviceIds(mock(), syncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(syncStore)
         assertEquals(syncStore.userId, appSyncDeviceIds.userId())
     }
 
     @Test
     fun whenDeviceIdExistsInStoreThenReturnsStoredValue() {
         val syncStore = getFakeSyncStore()
-        val appSyncDeviceIds = AppSyncDeviceIds(mock(), syncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(syncStore)
         assertEquals(syncStore.deviceId, appSyncDeviceIds.deviceId())
     }
 
     @Test
     fun whenDeviceNameExistsInStoreThenReturnsStoredValue() {
         val syncStore = getFakeSyncStore()
-        val appSyncDeviceIds = AppSyncDeviceIds(mock(), syncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(syncStore)
         assertEquals(syncStore.deviceName, appSyncDeviceIds.deviceName())
     }
 
@@ -56,7 +54,7 @@ class AppSyncDeviceIdsTest {
         val emptySyncStore = getFakeEmptySyncStore()
         assertNull(emptySyncStore.userId)
 
-        val appSyncDeviceIds = AppSyncDeviceIds(InstrumentationRegistry.getInstrumentation().context, emptySyncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore)
 
         val userId = appSyncDeviceIds.userId()
         assertTrue(userId.isNotEmpty())
@@ -67,7 +65,7 @@ class AppSyncDeviceIdsTest {
         val emptySyncStore = getFakeEmptySyncStore()
         assertNull(emptySyncStore.deviceId)
 
-        val appSyncDeviceIds = AppSyncDeviceIds(InstrumentationRegistry.getInstrumentation().context, emptySyncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore)
 
         val deviceId = appSyncDeviceIds.deviceId()
         assertTrue(deviceId.isNotEmpty())
@@ -77,8 +75,7 @@ class AppSyncDeviceIdsTest {
     fun whenDeviceNameDoesNotExistInStoreThenNewIdIsReturned() {
         val emptySyncStore = getFakeEmptySyncStore()
         assertNull(emptySyncStore.deviceName)
-        val appSyncDeviceIds =
-            AppSyncDeviceIds(InstrumentationRegistry.getInstrumentation().context, emptySyncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore)
 
         val deviceName = appSyncDeviceIds.deviceName()
         assertTrue(deviceName.isNotEmpty())


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1204039315134731/f

### Description

Uses a random UUID as device Id when creating account.

### Steps to test this PR

_Feature 1_
- [x] go to sync settings
- [x] create account
- [x] take note of the device id (it will have a uuid format)
- [x] delete account
- [x] create a new account
- [x] device id will be a new one

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
