### PR TITLE
Always show longer-form onboarding-style autofill save dialog

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
@@ -37,7 +37,8 @@ class AutofillSavingCredentialsViewModel @Inject constructor(
     lateinit var autofillStore: AutofillStore
 
     fun showOnboarding(): Boolean {
-        return autofillStore.showOnboardingWhenOfferingToSaveLogin
+        // hardcoding this to always show onboarding-style dialog for now; instead of querying autofillStore.showOnboardingWhenOfferingToSaveLogin
+        return true
     }
 
     fun determineTextResources(credentials: LoginCredentials): DisplayStringResourceIds {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
@@ -62,34 +62,6 @@ class AutofillSavingCredentialsViewModelTest {
     }
 
     @Test
-    fun whenNotShowingOnboardingAndUsernamePresentThenTitleResourceIsSaveLogin() {
-        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
-        val expectedResource = R.string.saveLoginDialogTitle
-        assertEquals(expectedResource, testee.determineTextResources(usernamePresent()).title)
-    }
-
-    @Test
-    fun whenNotShowingOnboardingAndUsernamePresentThenCtaButtonResourceIsSaveLogin() {
-        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
-        val expectedResource = R.string.saveLoginDialogButtonSave
-        assertEquals(expectedResource, testee.determineTextResources(usernamePresent()).ctaButton)
-    }
-
-    @Test
-    fun whenNotShowingOnboardingAndUsernameMissingThenTitleResourceIsSavePassword() {
-        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
-        val expectedResource = R.string.saveLoginMissingUsernameDialogTitle
-        assertEquals(expectedResource, testee.determineTextResources(usernameMissing()).title)
-    }
-
-    @Test
-    fun whenNotShowingOnboardingAndUsernameMissingThenCtaButtonResourceIsSavePassword() {
-        whenever(mockStore.showOnboardingWhenOfferingToSaveLogin).thenReturn(false)
-        val expectedResource = R.string.saveLoginMissingUsernameDialogButtonSave
-        assertEquals(expectedResource, testee.determineTextResources(usernameMissing()).ctaButton)
-    }
-
-    @Test
     fun whenUserPromptedToSaveThenFlagSet() = runTest {
         testee.userPromptedToSaveCredentials()
         verify(mockStore).hasEverBeenPromptedToSaveLogin = true


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204099438373198/f

### Description
Switches to ensure autofill save dialog prompt always includes the extra _onboarding_ text for now.

### Steps to test this PR

- [x] Clean install
- [x] Attempt to login into a site which will prompt you to save credentials
- [x] Verify title of the dialog is: `Do you want DuckDuckGo to save your Login?`
- [x] Verify the subtitle of the dialog is visible, and is: `Logins are stored securely on this device only, and can be managed from the Autofill menu in Settings.`
- [x] Save the login
- [x] Repeat so you are prompted again
- [x] Verify the dialog is the same as before (i.e., that the above verify steps are still correct)