### PR TITLE
Fix isPermissionsRejectedForever() for camera permission

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SystemPermissionsHelper.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SystemPermissionsHelper.kt
@@ -50,6 +50,7 @@ class SystemPermissionsHelperImpl @Inject constructor(
 
     private lateinit var permissionLauncher: ActivityResultLauncher<String>
     private lateinit var multiplePermissionsLauncher: ActivityResultLauncher<Array<String>>
+    private var currentPermissionRequested: String? = null
 
     override fun hasMicPermissionsGranted(): Boolean =
         ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED &&
@@ -74,6 +75,7 @@ class SystemPermissionsHelperImpl @Inject constructor(
 
     override fun requestPermission(permission: String) {
         if (this::permissionLauncher.isInitialized) {
+            currentPermissionRequested = permission
             permissionLauncher.launch(permission)
         } else {
             throw IllegalAccessException("registerPermissionLaunchers() needs to be called before requestPermission()")
@@ -82,6 +84,7 @@ class SystemPermissionsHelperImpl @Inject constructor(
 
     override fun requestMultiplePermissions(permissions: Array<String>) {
         if (this::multiplePermissionsLauncher.isInitialized) {
+            currentPermissionRequested = permissions.first()
             multiplePermissionsLauncher.launch(permissions)
         } else {
             throw IllegalAccessException("registerPermissionLaunchers() needs to be called before requestMultiplePermissions()")
@@ -89,5 +92,5 @@ class SystemPermissionsHelperImpl @Inject constructor(
     }
 
     override fun isPermissionsRejectedForever(activity: Activity): Boolean =
-        !ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
+        currentPermissionRequested?.let { !ActivityCompat.shouldShowRequestPermissionRationale(activity, it) } ?: true
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204096490114621/f

### Description
Fix inconsistency when not allowing camera permissions for the first time.
- First time user doesn't allow -> Show snackbar
- Second time user doesn't allow -> Show settings dialog

### Steps to test this PR
__Microphone_
- Uninstall previous version of Android app if already have permission configurations (or just clear storage on Settings)
- Install from this branch
- Go to `www.mictest.cc`
- Tap on "Test my mic" button -> Rationale dialog appears
- Tap on "Allow" option -> System permission prompt appears
- Select "Don't Allow" option
- [x] Check Snackbar appears
- Reload the page and tap on "Test my mic" button **again** -> Rationale dialog appears
- Tap on "Allow" option **again** -> System permission prompt appears
- Select "Don't Allow" option
- [x] Check Open Settings dialog appears

__Camera_
- Go to `www.webcamtest.cc`
- Tap on "Test my cam" button -> Rationale dialog appears
- Tap on "Allow" option -> System permission prompt appears
- Select "Don't Allow" option
- [x] Check Snackbar appears
- Reload the page and tap on "Test my cam" button **again** -> Rationale dialog appears
- Tap on "Allow" option **again** -> System permission prompt appears
- Select "Don't Allow" option
- [x] Check Open Settings dialog appears


### No UI changes
