### PR TITLE
Fix: Deny request when system permissions are not allowed

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -35,11 +35,9 @@ import com.google.android.material.snackbar.BaseTransientBottomBar.BaseCallback
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.Snackbar.SnackbarLayout
 import com.squareup.anvil.annotations.ContributesBinding
-import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 @ContributesBinding(FragmentScope::class)
-@SingleInstanceIn(FragmentScope::class)
 class SitePermissionsDialogActivityLauncher @Inject constructor(
     private val systemPermissionsHelper: SystemPermissionsHelper,
     private val sitePermissionsRepository: SitePermissionsRepository,

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.view.toPx
 import com.duckduckgo.site.permissions.api.SitePermissionsDialogLauncher
 import com.duckduckgo.site.permissions.api.SitePermissionsGrantedListener
+import com.google.android.material.snackbar.BaseTransientBottomBar.BaseCallback
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.Snackbar.SnackbarLayout
 import com.squareup.anvil.annotations.ContributesBinding
@@ -230,14 +231,23 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
             layout.setPadding(0, 0, 0, 40.toPx())
         }
         snackbar.apply {
-            setAction(R.string.sitePermissionsDeniedSnackBarAction) {
-                onPermissionAllowed()
-            }
+            setAction(R.string.sitePermissionsDeniedSnackBarAction) { onPermissionAllowed() }
+            addCallback(
+                object : Snackbar.Callback() {
+                    override fun onDismissed(
+                        transientBottomBar: Snackbar?,
+                        event: Int,
+                    ) {
+                        if (event == BaseCallback.DISMISS_EVENT_TIMEOUT) { sitePermissionRequest.deny() }
+                    }
+                },
+            )
             show()
         }
     }
 
     private fun showSystemPermissionsDeniedDialog() {
+        sitePermissionRequest.deny()
         val titleRes = when (permissionRequested) {
             SitePermissionsRequestedType.CAMERA -> R.string.systemPermissionDialogCameraDeniedTitle
             SitePermissionsRequestedType.AUDIO -> R.string.systemPermissionDialogAudioDeniedTitle


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204096490114623/f

### Description
Deny permission request from website when system permissions haven't been allowed

### Steps to test this PR

- Uninstall previous version of Android app if already have permission configurations (or just clear storage on Settings)
- Install from this branch
- Go to `www.mictest.cc`
- Tap on "Test my mic" button -> Rationale dialog appears
- Tap on "Allow" option -> System permission prompt appears
- Select "Don't Allow" option -> Snackbar appears
- [x] Check request is denied after Snackbar is hidden (you'll see a message that mic can't be used within the website)
- Reload the page and tap on "Test my mic" button **again** -> Rationale dialog appears
- Tap on "Allow" option **again** -> System permission prompt appears
- Select "Don't Allow" option -> Open Settings dialog appears
- [x] Check request have been denied

### No UI changes
