### PR TITLE
Remove location disabled pixel when there's not dialog prompt

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1141,7 +1141,7 @@ class BrowserTabFragment :
     ) {
         if (locationPermissionsHaveNotBeenGranted()) {
             if (deniedForever) {
-                viewModel.onSystemLocationPermissionDeniedOneTime()
+                viewModel.onSystemLocationPermissionDeniedForever()
             } else {
                 showSystemLocationPermissionDialog(domain)
             }
@@ -2443,7 +2443,7 @@ class BrowserTabFragment :
                     if (ActivityCompat.shouldShowRequestPermissionRationale(requireActivity(), Manifest.permission.ACCESS_FINE_LOCATION)) {
                         viewModel.onSystemLocationPermissionDeniedOneTime()
                     } else {
-                        viewModel.onSystemLocationPermissionDeniedForever()
+                        viewModel.onSystemLocationPermissionDeniedTwice()
                     }
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1595,9 +1595,14 @@ class BrowserTabViewModel @Inject constructor(
         onSiteLocationPermissionAlwaysDenied()
     }
 
+    fun onSystemLocationPermissionDeniedTwice() {
+        pixel.fire(AppPixelName.PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE)
+        onSystemLocationPermissionDeniedForever()
+    }
+
     fun onSystemLocationPermissionDeniedForever() {
         appSettingsPreferencesStore.appLocationPermissionDeniedForever = true
-        onSystemLocationPermissionDeniedOneTime()
+        onSiteLocationPermissionAlwaysDenied()
     }
 
     private fun registerSiteVisit() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1204082334468711/f

### Description
We don't send `location_disabled` pixel anymore when the permission has been revoked forever by the user

### Steps to test this PR
- Uninstall previous version of Android app if already have permission configurations (or just clear storage on Settings)
- Install form this branch
- Navigate to maps.google.com
- Tap on "Your Location 🎯" button -> Dialog prompt appears
- Tap on "Enable" option -> System permission prompt appears
- Select "Don't Allow" option
- [x] Check pixel `m_pc_s_l_d` is fired
- Tap on "Your Location 🎯" button **again** -> Dialog prompt appears
- Tap on "Enable" option **again**-> System permission prompt appears
- Select "Don't Allow" option **again**
- [x] Check pixel `m_pc_s_l_d` is fired **again**
- Tap on "Your Location 🎯" button **(for the 3rd time)**
- [x] Check pixel `m_pc_s_l_d` is **NOT** fired

### No UI changes
