### PR TITLE
Update content scope scripts to latest version

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -4657,8 +4657,8 @@
 
   var cookie = /*#__PURE__*/Object.freeze({
     __proto__: null,
-    load: load$1,
     init: init$e,
+    load: load$1,
     update: update
   });
 
@@ -6786,6 +6786,20 @@
   let matchAllStackDomains = false;
   let taintCheck = false;
   let initialCreateElement;
+  let tagModifiers = {};
+
+  /**
+   * @param {string} tagName
+   * @param {'property' | 'attribute' | 'handler' | 'listener'} filterName
+   * @param {string} key
+   * @returns {boolean}
+   */
+  function shouldFilterKey (tagName, filterName, key) {
+      if (filterName === 'attribute') {
+          key = key.toLowerCase();
+      }
+      return tagModifiers?.[tagName]?.filters?.[filterName]?.includes(key)
+  }
 
   let elementRemovalTimeout;
   const featureName = 'runtimeChecks';
@@ -6819,12 +6833,15 @@
       monitorProperties (el) {
           // Mutation oberver and observedAttributes don't work on property accessors
           // So instead we need to monitor all properties on the prototypes and forward them to the real element
-          const propertyNames = [];
+          let propertyNames = [];
           let proto = Object.getPrototypeOf(el);
           while (proto && proto !== Object.prototype) {
               propertyNames.push(...Object.getOwnPropertyNames(proto));
               proto = Object.getPrototypeOf(proto);
           }
+          const classMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
+          // Filter away the methods we don't want to monitor from our own class
+          propertyNames = propertyNames.filter(prop => !classMethods.includes(prop));
           propertyNames.forEach(prop => {
               if (prop === 'constructor') return
               // May throw, but this is best effort monitoring.
@@ -6834,6 +6851,7 @@
                           return el[prop]
                       },
                       set (value) {
+                          if (shouldFilterKey(this.#tagName, 'property', prop)) return
                           el[prop] = value;
                       }
                   });
@@ -6856,16 +6874,19 @@
 
           // Reflect all attrs to the new element
           for (const attribute of this.getAttributeNames()) {
+              if (shouldFilterKey(this.#tagName, 'attribute', attribute)) continue
               el.setAttribute(attribute, this.getAttribute(attribute));
           }
 
           // Reflect all props to the new element
           for (const param of Object.keys(this)) {
+              if (shouldFilterKey(this.#tagName, 'property', param)) continue
               el[param] = this[param];
           }
 
           // Reflect all listeners to the new element
           for (const [...args] of this.#listeners) {
+              if (shouldFilterKey(this.#tagName, 'listener', args[0])) continue
               el.addEventListener(...args);
           }
           this.#listeners = [];
@@ -6873,6 +6894,7 @@
           // Reflect all 'on' event handlers to the new element
           for (const propName in this) {
               if (propName.startsWith('on')) {
+                  if (shouldFilterKey(this.#tagName, 'handler', propName)) continue
                   const prop = this[propName];
                   if (typeof prop === 'function') {
                       el[propName] = prop;
@@ -6905,6 +6927,7 @@
       }
 
       setAttribute (name, value) {
+          if (shouldFilterKey(this.#tagName, 'attribute', name)) return
           const el = this.getElement();
           if (el) {
               return el.setAttribute(name, value)
@@ -6913,6 +6936,7 @@
       }
 
       removeAttribute (name) {
+          if (shouldFilterKey(this.#tagName, 'attribute', name)) return
           const el = this.getElement();
           if (el) {
               return el.removeAttribute(name)
@@ -6921,6 +6945,7 @@
       }
 
       addEventListener (...args) {
+          if (shouldFilterKey(this.#tagName, 'listener', args[0])) return
           const el = this.getElement();
           if (el) {
               return el.addEventListener(...args)
@@ -6929,6 +6954,7 @@
       }
 
       removeEventListener (...args) {
+          if (shouldFilterKey(this.#tagName, 'listener', args[0])) return
           const el = this.getElement();
           if (el) {
               return el.removeEventListener(...args)
@@ -7054,6 +7080,7 @@
       matchAllStackDomains = getFeatureSettingEnabled(featureName, args, 'matchAllStackDomains');
       stackDomains = getFeatureSetting(featureName, args, 'stackDomains') || [];
       elementRemovalTimeout = getFeatureSetting(featureName, args, 'elementRemovalTimeout') || 1000;
+      tagModifiers = getFeatureSetting(featureName, args, 'tagModifiers') || {};
 
       overrideCreateElement();
 
@@ -7064,8 +7091,8 @@
 
   var runtimeChecks = /*#__PURE__*/Object.freeze({
     __proto__: null,
-    load: load,
-    init: init$2
+    init: init$2,
+    load: load
   });
 
   /**
@@ -7265,6 +7292,7 @@
       const videoTracks = new Set();
       const audioTracks = new Set();
 
+      // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
       function getTracks (permission) {
           switch (permission) {
           case Permission.Camera:
@@ -7592,11 +7620,11 @@
       if (isGloballyDisabled(processedConfig)) {
           return
       }
-      // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
+
       contentScopeFeatures.load({
           platform: processedConfig.platform
       });
-      // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
+
       contentScopeFeatures.init(processedConfig);
 
       // Not supported:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.1.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.2.2",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.1",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1676380910"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#b48a927cbf453def2094119dfff7cbdf8d0cc91c",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60b9a4c2bbafe45f5d6fd1a5fa5389e5c133730a",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -261,9 +261,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -1045,9 +1045,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.4.tgz",
-      "integrity": "sha512-5yEGuZ3DZradbogeYQ1NaGz7rXVBDWujWlx1PT8efXO6Txn+eWbfKqB2bTDVmFXmePFkoLU6XI8UektMIEA0ug==",
+      "version": "5.16.5",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
+      "integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.1.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.2.2",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.1",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1676380910"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass