### PR TITLE
Replace usages of MainScope with more modern equivalents

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -27,8 +27,8 @@ import android.view.LayoutInflater
 import androidx.core.content.ContextCompat
 import androidx.core.view.doOnDetach
 import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
 import com.airbnb.lottie.RenderMode
-import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.IncludeDaxDialogCtaBinding
 import com.duckduckgo.app.browser.databinding.SheetFireClearDataBinding
 import com.duckduckgo.app.cta.ui.CtaViewModel
@@ -49,7 +49,6 @@ import com.duckduckgo.mobile.android.ui.view.show
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 
 private const val ANIMATION_MAX_SPEED = 1.4f
@@ -64,7 +63,7 @@ class FireDialog(
     private val settingsDataStore: SettingsDataStore,
     private val userEventsStore: UserEventsStore,
     private val appCoroutineScope: CoroutineScope,
-) : BottomSheetDialog(context, com.duckduckgo.mobile.android.R.style.Widget_DuckDuckGo_FireDialog), CoroutineScope by MainScope() {
+) : BottomSheetDialog(context, com.duckduckgo.mobile.android.R.style.Widget_DuckDuckGo_FireDialog) {
 
     private lateinit var binding: SheetFireClearDataBinding
     private lateinit var fireCtaBinding: IncludeDaxDialogCtaBinding
@@ -96,7 +95,7 @@ class FireDialog(
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        launch {
+        lifecycleScope.launch {
             ctaViewModel.getFireDialogCta()?.let {
                 configureFireDialogCta(it)
             }

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.launch
 
 import android.os.Bundle
+import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
@@ -25,7 +26,6 @@ import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 
 @InjectWith(ActivityScope::class)
@@ -42,7 +42,7 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
 
         configureObservers()
 
-        MainScope().launch { viewModel.determineViewToShow() }
+        lifecycleScope.launch { viewModel.determineViewToShow() }
     }
 
     private fun configureObservers() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203802507890823/f

### Description
Older code had used `MainScope` directly to get a `CoroutineScope`, because it pre-dated AndroidX providing coroutine support into most of the Android components (e.g., lifecycle-aware `lifecycleScope`).

In most places, direct use of `MainScope` can be replaced with `lifecycleScope` where it is available.

There are a few subtle differences (but should be positive, or at least neutral, changes):

- `lifecycleScope` coroutines will be cancelled appropriately with lifecycle changes. With `MainScope`, that wasn't the case and we should have been cleaning up after ourselves manually e.g., in `onDestroy()` but never were.
- `MainScope` uses `Dispatchers.Main` by default, whereas `lifecycleScope` uses `Dispatchers.Main.immediate`. The latter should result in work launched on the main dispatcher, when already on the main thread, to happen immediately instead of being queued for execution shortly. In reality, this is likely entirely negligible. 

### Steps to test this PR

Mostly smoke testing around a few key areas:
- [x] Onboarding (making sure onboarding shown first time in the app and then the browser tab activity thereafter)
- [x] In `BrowserTabActivity`:
    - [x] long press on a link to open a tab in the background
    - [x] opening an external link works (e.g., write a hyperlink in a text message, click it and select our browser)
    - [x] add the widget when you have no favourites, test the "favourites onboarding" flow
    - [x] opening a favourite from widget works 
- [x] FireDialog works as expected