### PR TITLE
Update content scope scripts to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.1.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.1",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.3",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1676380910"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60b9a4c2bbafe45f5d6fd1a5fa5389e5c133730a",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5434ffe98a21256187700d7c142a00b12336a952",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.1.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.1",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.3",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1676380910"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass