### PR TITLE
Update reference tests to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.3",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1676380910"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1678188750"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -84,7 +84,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#5a7ea321332f60aec9fa6395ad85098edc87e93e",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#7b4ad91de2d67123d4b5d10ccb3ac0565abfd355",
       "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.3.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.3.3",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1676380910"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1678188750"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [x] All tests must pass