### PR TITLE
Update 'not now' buttons on autofill dialog to ghost style

### DIFF
--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
@@ -111,7 +111,7 @@
             app:layout_constraintWidth_max="300dp"
             app:layout_constraintWidth_percent="0.8"/>
 
-    <com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
+    <com.duckduckgo.mobile.android.ui.view.button.DaxButtonGhost
             android:id="@+id/cancelButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
@@ -94,7 +94,7 @@
         app:layout_constraintTop_toBottomOf="@id/updatedFieldPreview"
         app:layout_constraintWidth_percent="0.8" />
 
-    <com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
+    <com.duckduckgo.mobile.android.ui.view.button.DaxButtonGhost
         android:id="@+id/cancelButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204135366588345/f

### Description
Updates the button styles used on the "Not now" buttons for saving/update credential

### Steps to test this PR
- [x] attempt to login at https://fill.dev/form/login-simple; verify the "not now" button has no border
- [x] save the login, then attempt to login again with the same username but different password; verify the "not now" button has no border
