### PR TITLE
Android: Update Notifications permissions Maestro tests

### DIFF
--- a/.maestro/notifications_permissions_android13_plus/1_-_permissions_allowed.yaml
+++ b/.maestro/notifications_permissions_android13_plus/1_-_permissions_allowed.yaml
@@ -3,21 +3,27 @@ appId: com.duckduckgo.mobile.android
 - launchApp:
     clearState: true
     stopApp: true
+    permissions:
+      notifications: allow
 - assertVisible:
     text: ".*Allow DuckDuckGo to send you notifications.*"
-- tapOn: "Allow"
+    optional: true
+- tapOn:
+    text: "Allow"
+    optional: true
 - assertVisible:
     text: ".*Welcome to DuckDuckGo!.*"
+    optional: true
 - assertVisible:
     text: ".*Not to worry! Searching and browsing privately.*"
 - tapOn: "let's do it!"
 - tapOn: "cancel"
 - assertVisible:
-      text: ".*I'll also upgrade the security of your connection if possible.*"
+    text: ".*I'll also upgrade the security of your connection if possible.*"
 - tapOn:
-      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
 - tapOn:
-      text: "Downloads"
+    text: "Downloads"
 - assertVisible:
     text: ".*No files downloaded yet.*"
 - assertNotVisible:

--- a/.maestro/notifications_permissions_android13_plus/2_-_permissions_denied.yaml
+++ b/.maestro/notifications_permissions_android13_plus/2_-_permissions_denied.yaml
@@ -3,11 +3,17 @@ appId: com.duckduckgo.mobile.android
 - launchApp:
     clearState: true
     stopApp: true
+    permissions:
+      notifications: deny
 - assertVisible:
     text: ".*Allow DuckDuckGo to send you notifications.*"
-- tapOn: "Don’t allow"
+    optional: true
+- tapOn:
+    text: "Don’t allow"
+    optional: true
 - assertVisible:
     text: ".*Welcome to DuckDuckGo!.*"
+    optional: true
 - assertVisible:
     text: ".*Not to worry! Searching and browsing privately.*"
 - tapOn: "let's do it!"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1204131202912041/f

### Description
Updated the maestro notification permissions tests.

### Steps to test this PR

Run the below maestro tests using `1.24.0`:
- [ ] .maestro/notifications_permissions_android13_plus/1_-_permissions_allowed.yaml
- [ ] .maestro/notifications_permissions_android13_plus/2_-_permissions_denied.yaml

Note: This will be merged after maestro cloud is updated to use `1.24.0`.

### NO UI changes
