### PR TITLE
Fix sort order for autofill suggested sites

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementRecyclerAdapter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementRecyclerAdapter.kt
@@ -204,11 +204,11 @@ class AutofillManagementRecyclerAdapter(
     @SuppressLint("NotifyDataSetChanged")
     fun updateLogins(
         unsortedCredentials: List<LoginCredentials>,
-        suggestions: List<LoginCredentials>,
+        unsortedSuggestions: List<LoginCredentials>,
     ) {
         val newList = mutableListOf<ListItem>()
 
-        val suggestionsListItems = suggestionListBuilder.build(suggestions)
+        val suggestionsListItems = suggestionListBuilder.build(unsortedSuggestions)
         val groupedCredentials = grouper.group(unsortedCredentials)
 
         newList.addAll(suggestionsListItems)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionListBuilder.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionListBuilder.kt
@@ -23,16 +23,22 @@ import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementR
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem.CredentialListItem.SuggestedCredential
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem.Divider
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem.GroupHeading
+import com.duckduckgo.autofill.impl.ui.credential.management.sorting.CredentialListSorter
 import javax.inject.Inject
 
-class SuggestionListBuilder @Inject constructor(private val context: Context) {
+class SuggestionListBuilder @Inject constructor(
+    private val context: Context,
+    private val sorter: CredentialListSorter,
+) {
 
-    fun build(suggestions: List<LoginCredentials>): List<ListItem> {
+    fun build(unsortedSuggestions: List<LoginCredentials>): List<ListItem> {
         val list = mutableListOf<ListItem>()
 
-        if (suggestions.isNotEmpty()) {
+        if (unsortedSuggestions.isNotEmpty()) {
+            val sortedSuggestions = sorter.sort(unsortedSuggestions)
+
             list.add(GroupHeading(context.getString(string.credentialManagementSuggestionsLabel)))
-            list.addAll(suggestions.map { SuggestedCredential(it) })
+            list.addAll(sortedSuggestions.map { SuggestedCredential(it) })
             list.add(Divider)
         }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionListBuilderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionListBuilderTest.kt
@@ -20,6 +20,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter.ListItem
+import com.duckduckgo.autofill.impl.ui.credential.management.sorting.CredentialListSorterByTitleAndDomain
+import com.duckduckgo.autofill.store.urlmatcher.AutofillDomainNameUrlMatcher
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -28,7 +30,10 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class SuggestionListBuilderTest {
 
-    val testee = SuggestionListBuilder(context = InstrumentationRegistry.getInstrumentation().targetContext)
+    val testee = SuggestionListBuilder(
+        context = InstrumentationRegistry.getInstrumentation().targetContext,
+        sorter = CredentialListSorterByTitleAndDomain(AutofillDomainNameUrlMatcher()),
+    )
 
     @Test
     fun whenNoSuggestionThenEmptyListReturned() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204135364308878/f

### Description
Ensures that the logins appearing in the suggested sites section of credential management are sorted by the same sorting rules the rest of the list is.

### Steps to test this PR

From credential management screen, manually add the following logins: 
- [ ] (title=`news`, website=nytimes.com, username=_anything_, password=_anything_)
- [ ] (title=`entertainment`, website=nytimes.com, username=_anything_, password=_anything_)
- [ ] (title=`LEAVE EMPTY`, website=nytimes.com, username=_anything_, password=_anything_)

Visit nytimes.com and then access autofill from the overflow menu
- [ ] In suggested sites, verify `entertainment` shown above `news`, and that `nytimes.com` entry is last
- [ ] Verify the same order in the rest of the list 