### PR TITLE
Create pluginpoint for reminder notifs

### DIFF
--- a/app-tracking-protection/vpn-api-test/src/main/java/com/duckduckgo/mobile/android/vpn/service/FakeVpnReminderNotificationContentPlugin.kt
+++ b/app-tracking-protection/vpn-api-test/src/main/java/com/duckduckgo/mobile/android/vpn/service/FakeVpnReminderNotificationContentPlugin.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service
+
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationContent
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationPriority
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.Type
+
+class FakeVpnReminderNotificationContentPlugin constructor(
+    private val type: Type,
+    private val priority: NotificationPriority = NotificationPriority.NORMAL,
+) : VpnReminderNotificationContentPlugin {
+
+    override fun getContent(): NotificationContent? = null
+
+    override fun getType(): Type = this.type
+
+    override fun getPriority(): NotificationPriority {
+        return this.priority
+    }
+}

--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnReminderNotificationContentPlugin.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnReminderNotificationContentPlugin.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service
+
+import android.app.PendingIntent
+import androidx.annotation.LayoutRes
+import androidx.core.app.NotificationCompat
+
+interface VpnReminderNotificationContentPlugin {
+    /**
+     * This method could be called to get the plugin's corresponding NotificationContent
+     *
+     * @return shall return the content of the notification or null if the plugin does not want to show content in the notification.
+     */
+    fun getContent(): NotificationContent?
+
+    /**
+     * The VPN will call this method to select what plugin will be displayed in the notification.
+     * To select a proper priority:
+     * - check the priority of any other plugins
+     * - check with product/design what should be the priority of your plugin w.r.t. other plugins
+     *
+     * @return shall return the priority of the plugin.
+     */
+    fun getPriority(): NotificationPriority
+
+    /**
+     * This method will be called to select the specific Type of reminder notification that vpn wants to show.
+     *
+     * @return shall return the type of the reminder notification plugin.
+     */
+    fun getType(): Type
+
+    data class NotificationContent(
+        val isSilent: Boolean,
+        val shouldAutoCancel: Boolean?,
+        @LayoutRes val customViewLayout: Int,
+        val onNotificationPressIntent: PendingIntent?,
+        val notificationAction: List<NotificationCompat.Action>,
+    ) {
+        companion object {
+            val EMPTY = NotificationContent(
+                isSilent = false,
+                shouldAutoCancel = null,
+                customViewLayout = -1,
+                onNotificationPressIntent = null,
+                notificationAction = emptyList(),
+            )
+        }
+    }
+
+    enum class Type {
+        DISABLED,
+        REVOKED,
+    }
+
+    enum class NotificationPriority {
+        LOW,
+        NORMAL,
+        HIGH,
+        VERY_HIGH,
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpDisabledContentPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpDisabledContentPlugin.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service.notification
+
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationContent
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationPriority
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationPriority.NORMAL
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.Type
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.Type.DISABLED
+import com.duckduckgo.mobile.android.vpn.ui.notification.NotificationActionReportIssue
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class AppTpDisabledContentPlugin @Inject constructor(
+    private val context: Context,
+) : VpnReminderNotificationContentPlugin {
+    private val notificationPendingIntent by lazy { getAppTPNotificationPressIntent(context) }
+    private val notificationActionPendingIntent by lazy { getAppTPStartIntent(context) }
+
+    override fun getContent(): NotificationContent? {
+        return NotificationContent(
+            isSilent = true,
+            shouldAutoCancel = null,
+            customViewLayout = R.layout.notification_device_shield_disabled,
+            onNotificationPressIntent = notificationPendingIntent,
+            notificationAction = listOf(
+                NotificationCompat.Action(
+                    R.drawable.ic_vpn_notification_24,
+                    context.getString(R.string.atp_EnableCTA),
+                    notificationActionPendingIntent,
+                ),
+                NotificationActionReportIssue.reportIssueNotificationAction(context),
+            ),
+        )
+    }
+
+    override fun getPriority(): NotificationPriority {
+        return NORMAL
+    }
+
+    override fun getType(): Type = DISABLED
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpReminderNotificationUtils.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpReminderNotificationUtils.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service.notification
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.TaskStackBuilder
+import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderReceiver
+import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTrackerActivity
+
+internal fun getAppTPNotificationPressIntent(context: Context): PendingIntent? {
+    return TaskStackBuilder.create(context).run {
+        addNextIntentWithParentStack(DeviceShieldTrackerActivity.intent(context = context))
+        getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+    }
+}
+
+internal fun getAppTPStartIntent(context: Context): PendingIntent? {
+    return Intent(context, VpnReminderReceiver::class.java).let { intent ->
+        intent.action = TrackerBlockingVpnService.ACTION_VPN_REMINDER_RESTART
+        PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpRevokedContentPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpRevokedContentPlugin.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service.notification
+
+import android.content.Context
+import androidx.core.app.NotificationCompat.Action
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.R.drawable
+import com.duckduckgo.mobile.android.vpn.R.string
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationContent
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationPriority
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationPriority.NORMAL
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.Type
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.Type.REVOKED
+import com.duckduckgo.mobile.android.vpn.ui.notification.NotificationActionReportIssue
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class AppTpRevokedContentPlugin @Inject constructor(
+    private val context: Context,
+) : VpnReminderNotificationContentPlugin {
+    private val notificationPendingIntent by lazy { getAppTPNotificationPressIntent(context) }
+    private val notificationActionPendingIntent by lazy { getAppTPStartIntent(context) }
+
+    override fun getContent(): NotificationContent? {
+        return NotificationContent(
+            isSilent = true,
+            shouldAutoCancel = null,
+            customViewLayout = R.layout.notification_device_shield_revoked,
+            onNotificationPressIntent = notificationPendingIntent,
+            notificationAction = listOf(
+                Action(
+                    drawable.ic_vpn_notification_24,
+                    context.getString(string.atp_EnableCTA),
+                    notificationActionPendingIntent,
+                ),
+                NotificationActionReportIssue.reportIssueNotificationAction(context),
+            ),
+        )
+    }
+
+    override fun getPriority(): NotificationPriority {
+        return NORMAL
+    }
+
+    override fun getType(): Type = REVOKED
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/VpnReminderNotificationContentPluginPoint.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/VpnReminderNotificationContentPluginPoint.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service.notification
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = VpnReminderNotificationContentPlugin::class,
+)
+@Suppress("unused")
+interface VpnReminderNotificationContentPluginPoint
+
+fun PluginPoint<VpnReminderNotificationContentPlugin>.getHighestPriorityPluginForType(
+    type: VpnReminderNotificationContentPlugin.Type,
+): VpnReminderNotificationContentPlugin? {
+    return runCatching {
+        getPlugins().filter { it.getType() == type }.maxByOrNull { it.getPriority().ordinal }
+    }.getOrNull()
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/VpnReminderNotificationBuilder.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/VpnReminderNotificationBuilder.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.ui.notification
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import android.widget.RemoteViews
+import androidx.core.app.NotificationCompat
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface VpnReminderNotificationBuilder {
+    fun buildReminderNotification(
+        vpnNotification: VpnReminderNotificationContentPlugin.NotificationContent,
+    ): Notification
+}
+
+@ContributesBinding(AppScope::class)
+class RealVpnReminderNotificationBuilder @Inject constructor(
+    private val context: Context,
+) : VpnReminderNotificationBuilder {
+
+    private fun registerAlertChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (notificationManager.getNotificationChannel(AndroidDeviceShieldAlertNotificationBuilder.VPN_ALERTS_CHANNEL_ID) == null) {
+                val channel = NotificationChannel(
+                    VPN_ALERTS_CHANNEL_ID,
+                    VPN_ALERTS_CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                )
+                channel.description = VPN_ALERTS_CHANNEL_DESCRIPTION
+                notificationManager.createNotificationChannel(channel)
+                notificationManager.isNotificationPolicyAccessGranted
+            }
+        }
+    }
+
+    override fun buildReminderNotification(
+        vpnNotification: VpnReminderNotificationContentPlugin.NotificationContent,
+    ): Notification {
+        registerAlertChannel(context)
+        val notificationLayout = RemoteViews(context.packageName, vpnNotification.customViewLayout)
+
+        val builder = NotificationCompat.Builder(context, VPN_ALERTS_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_device_shield_notification_logo)
+            .setStyle(NotificationCompat.DecoratedCustomViewStyle())
+            .setContentIntent(vpnNotification.onNotificationPressIntent)
+            .setCustomContentView(notificationLayout)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setSilent(vpnNotification.isSilent)
+
+        vpnNotification.notificationAction.forEach {
+            builder.addAction(it)
+        }
+
+        vpnNotification.shouldAutoCancel?.let {
+            builder.setAutoCancel(it)
+        }
+
+        return builder.build()
+    }
+
+    companion object {
+        private const val VPN_ALERTS_CHANNEL_DESCRIPTION = "Alerts from App Tracking Protection"
+        private const val VPN_ALERTS_CHANNEL_ID = "com.duckduckgo.mobile.android.vpn.notification.alerts"
+        private const val VPN_ALERTS_CHANNEL_NAME = "App Tracking Protection Alerts"
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/notification/VpnReminderNotificationContentPluginKtTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/notification/VpnReminderNotificationContentPluginKtTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.service.notification
+
+import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.mobile.android.vpn.service.FakeVpnReminderNotificationContentPlugin
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationPriority.HIGH
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationPriority.LOW
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.NotificationPriority.NORMAL
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.Type.DISABLED
+import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationContentPlugin.Type.REVOKED
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VpnReminderNotificationContentPluginKtTest {
+    @Test
+    fun whenEmptyPluginPointThenReturnNull() {
+        assertNull(createPluginPoint(emptyList()).getHighestPriorityPluginForType(REVOKED))
+    }
+
+    @Test
+    fun whenPluginForTypeAvailableThenReturnPLugin() {
+        val plugin = createPluginPoint(
+            listOf(
+                FakeVpnReminderNotificationContentPlugin(type = DISABLED, NORMAL),
+            ),
+        ).getHighestPriorityPluginForType(DISABLED)
+
+        assertEquals(DISABLED, plugin?.getType())
+    }
+
+    @Test
+    fun whenNoPluginsForTypeThenReturnNull() {
+        val plugin = createPluginPoint(
+            listOf(
+                FakeVpnReminderNotificationContentPlugin(type = REVOKED, NORMAL),
+            ),
+        ).getHighestPriorityPluginForType(DISABLED)
+
+        assertNull(plugin)
+    }
+
+    @Test
+    fun whenMultiplePluginsForTypeThenReturnHighestPriority() {
+        val plugin = createPluginPoint(
+            listOf(
+                FakeVpnReminderNotificationContentPlugin(type = DISABLED, NORMAL),
+                FakeVpnReminderNotificationContentPlugin(type = DISABLED, LOW),
+                FakeVpnReminderNotificationContentPlugin(type = DISABLED, HIGH),
+            ),
+        ).getHighestPriorityPluginForType(DISABLED)
+
+        assertEquals(HIGH, plugin?.getPriority())
+    }
+
+    private fun createPluginPoint(plugins: List<VpnReminderNotificationContentPlugin>): PluginPoint<VpnReminderNotificationContentPlugin> {
+        return object : PluginPoint<VpnReminderNotificationContentPlugin> {
+            override fun getPlugins(): Collection<VpnReminderNotificationContentPlugin> {
+                return plugins
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204088747317856/f

### Description
This PR includes introducing content plugins for VPN reminder notifications. See more in task for info.

### Steps to test this PR

_Disable AppTP_
- [x] Install build
- [x] Enable AppTP
- [x] Disable AppTP
- [x] Verify that disabled notif is shown

_Schedule notif_
- [x] Modify `DeviceShieldReminderNotificationScheduler` line `160` to be `SECONDS` instead of `HOURS`.
- [x] Install build
- [x] Enable AppTP
- [x] Disable AppTP
- [x] Remove existing disabled notification
- [x] Remove app from background (Show all apps and then remove DDG)
- [x] Wait for 20 seconds
- [x] Verify that disabled notification is shown again

_Update App_
- [x] Install develop
- [x] Enable AppTP
- [x] Install from this branch
- [x] Disable AppTP
- [x] Verify that disabled notif is shown

_Revoke Notification_
- [x] install from this branch
- [x] enable AppTP
- [x] install another 3rd party VPN app
- [x] enable the 3rd party VPN app
- [x] verify AppTP is disabled and revoke notification appears
- [x] tap on revoke notification
- [x] verify it links to AppTP activity screen
