### PR TITLE
System Default as default theme instead of Light

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/Theming.kt
@@ -28,6 +28,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.ui.Theming.Constants.BROADCAST_THEME_CHANGED
+import com.duckduckgo.mobile.android.ui.Theming.Constants.FIXED_THEME_ACTIVITIES
 
 enum class DuckDuckGoTheme {
     SYSTEM_DEFAULT,
@@ -65,11 +66,14 @@ object Theming {
 
     object Constants {
         const val BROADCAST_THEME_CHANGED = "BROADCAST_THEME_CHANGED"
+        val FIXED_THEME_ACTIVITIES = listOf("com.duckduckgo.app.onboarding.ui.OnboardingActivity")
     }
 }
 
 fun AppCompatActivity.applyTheme(theme: DuckDuckGoTheme): BroadcastReceiver? {
-    setTheme(getThemeId(theme))
+    if (!FIXED_THEME_ACTIVITIES.contains(this.localClassName)) {
+        setTheme(getThemeId(theme))
+    }
     return registerForThemeChangeBroadcast()
 }
 

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/store/ThemingSharedPreferences.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/store/ThemingSharedPreferences.kt
@@ -39,7 +39,7 @@ class ThemingSharedPreferences @Inject constructor(
 
     private fun selectedThemeSavedValue(): DuckDuckGoTheme {
         val savedValue = preferences.getString(KEY_THEME, null)
-        return themePrefMapper.themeFrom(savedValue, DuckDuckGoTheme.LIGHT)
+        return themePrefMapper.themeFrom(savedValue, DuckDuckGoTheme.SYSTEM_DEFAULT)
     }
 
     private val preferences: SharedPreferences


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1174433894299346/1204115829299957

### Description
We want to ensure that the user's device selected theme is respected in DDG. For that, we are not defaulting to the System Default theme instead of Light. Dax Onboarding will always happen in Light theme, but the Browser and other screens will default to whatever the user selected.

### Steps to test this PR

_Light theme as default_
- [x] Set your phone in Light theme
- [x] Open DDG
- [x] Check that Dax Onboarding happens in Light theme
- [x] Check that Browser is in Light Theme

_Dark theme as default_
- [x] Set your phone in Dark theme
- [x] Open DDG
- [x] Check that Dax Onboarding happens in Light theme
- [x] Check that Browser is in Dark Theme