### PR TITLE
Restrict password entry to single lines in DaxTextInput view

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
@@ -100,7 +100,7 @@ class DaxTextInput @JvmOverloads constructor(
             binding.internalEditText.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
                 if (hasFocus) {
                     if (isPassword) {
-                        showPassword()
+                        showPassword(isEditing = true)
                     }
                     binding.internalEditText.showKeyboard()
                 } else {
@@ -201,15 +201,21 @@ class DaxTextInput @JvmOverloads constructor(
             if (isPasswordShown) {
                 hidePassword()
             } else {
-                showPassword()
+                showPassword(isEditing = binding.internalEditText.hasFocus())
             }
         }
     }
 
-    private fun showPassword() {
+    private fun showPassword(isEditing: Boolean) {
         isPasswordShown = true
         binding.internalPasswordIcon.setImageResource(R.drawable.ic_password_hide)
-        binding.internalEditText.inputType = EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE
+
+        val inputType = if (isEditing) {
+            EditorInfo.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+        } else {
+            EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE
+        }
+        binding.internalEditText.inputType = inputType
         binding.internalEditText.transformationMethod = null
         binding.internalEditText.setSelection(binding.internalEditText.length())
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204136779081352/f

### Description
When editing a passwords we want to restrict input to single lines only (a multi-line password doesn't make sense). However when viewing a long password we do want the text field to expand vertically to show it all (as having to horizontally scroll to see the full password is painful). This PR:
- restricts the password field to a single line **when editing** it
- restricts the password field to a single line when the password is hidden
- allows the password field to grow vertically to reveal the whole password when the password has been revealed, only if non editing it

### Steps to test this PR

- [x] Visit autofill credential management screen, and add a login with a **long password**
- [x] Save it, and verify that when viewing the new login, the password is hidden by default and it is single line only
- [x] Tap the eye icon to reveal the password; verify the full password is shown expanding the view vertically to show it all
- [x] Edit that login, and verify that the default edit view is that the password is hidden and single line
- [x] Tap the password field (somewhere on the `******`); verify the password is revealed, and is **single line**
- [x] Try to add a new line (e.g., press return key); verify it doesn't let you (and just skips to next field)
- [x] Tap the eye icon to reveal password; verify the password is visible and it is **multi-line**
- [x] Tap on the revealed password; verify it **switches to single-line input** when it gains focus