### PR TITLE
Encrypt device info on auth flows

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/EncodingExtension.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/EncodingExtension.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import android.util.Base64
+
+internal fun String.encodeB64(): String {
+    return Base64.encodeToString(this.toByteArray(), Base64.DEFAULT)
+}
+
+internal fun String.decodeB64(): String {
+    return String(Base64.decode(this, Base64.DEFAULT))
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
@@ -73,10 +73,11 @@ constructor(
     }
 }
 
+private val mobileRegex = Regex("(phone|tablet)", RegexOption.IGNORE_CASE)
+private val desktopRegex = Regex("(desktop)", RegexOption.IGNORE_CASE)
+
 data class DeviceType(val deviceFactor: String = "") {
     fun type(): Type {
-        val mobileRegex = Regex("(phone|tablet)", RegexOption.IGNORE_CASE)
-        val desktopRegex = Regex("(desktop)", RegexOption.IGNORE_CASE)
         return when {
             deviceFactor.contains(mobileRegex) -> MOBILE
             deviceFactor.contains(desktopRegex) -> DESKTOP

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
@@ -18,7 +18,10 @@ package com.duckduckgo.sync.impl
 
 import android.annotation.SuppressLint
 import android.os.Build
+import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Type.MOBILE
+import com.duckduckgo.sync.impl.Type.UNKNOWN
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import java.util.*
@@ -28,6 +31,7 @@ interface SyncDeviceIds {
     fun userId(): String
     fun deviceName(): String
     fun deviceId(): String
+    fun deviceType(): DeviceType
 }
 
 @ContributesBinding(AppScope::class)
@@ -35,6 +39,7 @@ class AppSyncDeviceIds
 @Inject
 constructor(
     private val syncStore: SyncStore,
+    private val deviceInfo: DeviceInfo,
 ) : SyncDeviceIds {
     override fun userId(): String {
         var userId = syncStore.userId
@@ -61,4 +66,26 @@ constructor(
         deviceId = UUID.randomUUID().toString()
         return deviceId
     }
+
+    override fun deviceType(): DeviceType {
+        return DeviceType("android_${deviceInfo.formFactor().description}")
+    }
+}
+
+data class DeviceType(val platform: String = "") {
+    fun type(): Type {
+        val mobileRegex = Regex("(phone|tablet)", RegexOption.IGNORE_CASE)
+        return when {
+            platform.contains(mobileRegex) -> MOBILE
+            platform.isEmpty() -> UNKNOWN
+            else -> UNKNOWN
+        }
+    }
+}
+
+enum class Type {
+    MOBILE,
+    UNKNOWN,
+    DESKTOP,
+    ;
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncDeviceId.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.os.Build
 import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Type.DESKTOP
 import com.duckduckgo.sync.impl.Type.MOBILE
 import com.duckduckgo.sync.impl.Type.UNKNOWN
 import com.duckduckgo.sync.store.SyncStore
@@ -68,16 +69,18 @@ constructor(
     }
 
     override fun deviceType(): DeviceType {
-        return DeviceType("android_${deviceInfo.formFactor().description}")
+        return DeviceType(deviceInfo.formFactor().description)
     }
 }
 
-data class DeviceType(val platform: String = "") {
+data class DeviceType(val deviceFactor: String = "") {
     fun type(): Type {
         val mobileRegex = Regex("(phone|tablet)", RegexOption.IGNORE_CASE)
+        val desktopRegex = Regex("(desktop)", RegexOption.IGNORE_CASE)
         return when {
-            platform.contains(mobileRegex) -> MOBILE
-            platform.isEmpty() -> UNKNOWN
+            deviceFactor.contains(mobileRegex) -> MOBILE
+            deviceFactor.contains(desktopRegex) -> DESKTOP
+            deviceFactor.isEmpty() -> UNKNOWN
             else -> UNKNOWN
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
@@ -71,7 +71,7 @@ class AppSyncRepository @Inject constructor(
         val deviceName = syncDeviceIds.deviceName()
         val deviceType = syncDeviceIds.deviceType()
         val encryptedDeviceName = nativeLib.encryptData(deviceName, account.primaryKey).encryptedData
-        val encryptedDeviceType = nativeLib.encryptData(deviceType.platform, account.primaryKey).encryptedData
+        val encryptedDeviceType = nativeLib.encryptData(deviceType.deviceFactor, account.primaryKey).encryptedData
 
         val result = syncApi.createAccount(
             account.userId,
@@ -294,7 +294,7 @@ class AppSyncRepository @Inject constructor(
         if (preLogin.result != 0L) return Result.Error(code = preLogin.result.toInt(), reason = "Login account keys failed")
 
         val deviceType = syncDeviceIds.deviceType()
-        val encryptedDeviceType = nativeLib.encryptData(deviceType.platform, preLogin.primaryKey).encryptedData
+        val encryptedDeviceType = nativeLib.encryptData(deviceType.deviceFactor, preLogin.primaryKey).encryptedData
 
         val result = syncApi.login(
             userID = userId,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
@@ -258,6 +258,8 @@ class AppSyncRepository @Inject constructor(
     override fun getConnectedDevices(): Result<List<ConnectedDevice>> {
         val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
             ?: return Result.Error(reason = "Token Empty")
+        val primaryKey = syncStore.primaryKey.takeUnless { it.isNullOrEmpty() }
+            ?: return Result.Error(reason = "PrimaryKey not found")
 
         return when (val result = syncApi.getDevices(token)) {
             is Result.Error -> {
@@ -270,10 +272,10 @@ class AppSyncRepository @Inject constructor(
                     result.data.map {
                         ConnectedDevice(
                             thisDevice = syncStore.deviceId == it.deviceId,
-                            deviceName = nativeLib.decryptData(it.deviceName, syncStore.primaryKey!!).decryptedData,
+                            deviceName = nativeLib.decryptData(it.deviceName, primaryKey).decryptedData,
                             deviceId = it.deviceId,
                             deviceType = it.deviceType.takeUnless { it.isNullOrEmpty() }?.let { encryptedDeviceType ->
-                                DeviceType(nativeLib.decryptData(encryptedDeviceType, syncStore.primaryKey!!).decryptedData)
+                                DeviceType(nativeLib.decryptData(encryptedDeviceType, primaryKey).decryptedData)
                             } ?: DeviceType(),
                         )
                     },

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
@@ -212,7 +212,7 @@ class AppSyncRepository @Inject constructor(
                 userID = userId,
                 hashedPassword = preLogin.passwordHash,
                 deviceId = deviceId,
-                deviceName = deviceName,
+                deviceName = nativeLib.encrypt(deviceName, syncStore.secretKey!!).encryptedData,
             )
 
         return when (result) {
@@ -234,7 +234,7 @@ class AppSyncRepository @Inject constructor(
     }
 
     override fun removeAccount() {
-        syncStore.clearAll(keepRecoveryCode = false)
+        syncStore.clearAll(keepRecoveryCode = true)
     }
 
     override fun logout(deviceId: String): Result<Boolean> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -72,6 +72,7 @@ data class Login(
     @field:Json(name = "hashed_password") val hashedPassword: String,
     @field:Json(name = "device_id") val deviceId: String,
     @field:Json(name = "device_name") val deviceName: String,
+    @field:Json(name = "device_type") val deviceType: String,
 )
 
 data class Signup(
@@ -80,6 +81,7 @@ data class Signup(
     @field:Json(name = "protected_encryption_key") val protectedEncryptionKey: String,
     @field:Json(name = "device_id") val deviceId: String,
     @field:Json(name = "device_name") val deviceName: String,
+    @field:Json(name = "device_type") val deviceType: String,
 )
 
 data class Logout(
@@ -117,6 +119,7 @@ data class DeviceEntries(
 data class Device(
     @field:Json(name = "device_id") val deviceId: String,
     @field:Json(name = "device_name") val deviceName: String,
+    @field:Json(name = "device_type") val deviceType: String?,
     @field:Json(name = "jw_iat") val jwIat: String,
 )
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -31,6 +31,7 @@ interface SyncApi {
         protectedEncryptionKey: String,
         deviceId: String,
         deviceName: String,
+        deviceType: String,
     ): Result<AccountCreatedResponse>
 
     fun login(
@@ -38,6 +39,7 @@ interface SyncApi {
         hashedPassword: String,
         deviceId: String,
         deviceName: String,
+        deviceType: String,
     ): Result<LoginResponse>
 
     fun logout(
@@ -68,6 +70,7 @@ class SyncServiceRemote @Inject constructor(private val syncService: SyncService
         protectedEncryptionKey: String,
         deviceId: String,
         deviceName: String,
+        deviceType: String,
     ): Result<AccountCreatedResponse> {
         val response = runCatching {
             val call = syncService.signup(
@@ -77,6 +80,7 @@ class SyncServiceRemote @Inject constructor(private val syncService: SyncService
                     protectedEncryptionKey = protectedEncryptionKey,
                     deviceId = deviceId,
                     deviceName = deviceName,
+                    deviceType = deviceType,
                 ),
             )
             call.execute()
@@ -176,6 +180,7 @@ class SyncServiceRemote @Inject constructor(private val syncService: SyncService
         hashedPassword: String,
         deviceId: String,
         deviceName: String,
+        deviceType: String,
     ): Result<LoginResponse> {
         val response = runCatching {
             val call = syncService.login(
@@ -184,6 +189,7 @@ class SyncServiceRemote @Inject constructor(private val syncService: SyncService
                     hashedPassword = hashedPassword,
                     deviceId = deviceId,
                     deviceName = deviceName,
+                    deviceType = deviceType,
                 ),
             )
             call.execute()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -96,7 +96,7 @@ class AppSyncDeviceIdsTest {
         val deviceType = appSyncDeviceIds.deviceType()
 
         assertEquals(deviceType.type(), Type.MOBILE)
-        assertEquals(deviceType.platform, "android_phone")
+        assertEquals(deviceType.deviceFactor, "phone")
     }
 
     private fun getFakeSyncStore(): SyncStore {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -17,35 +17,41 @@
 package com.duckduckgo.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.sync.impl.AppSyncDeviceIds
+import com.duckduckgo.sync.impl.Type
 import com.duckduckgo.sync.store.SyncStore
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
 class AppSyncDeviceIdsTest {
 
+    private var deviceInfo: DeviceInfo = mock()
+
     @Test
     fun whenUserIdExistsInStoreThenReturnsStoredValue() {
         val syncStore = getFakeSyncStore()
-        val appSyncDeviceIds = AppSyncDeviceIds(syncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(syncStore, deviceInfo)
         assertEquals(syncStore.userId, appSyncDeviceIds.userId())
     }
 
     @Test
     fun whenDeviceIdExistsInStoreThenReturnsStoredValue() {
         val syncStore = getFakeSyncStore()
-        val appSyncDeviceIds = AppSyncDeviceIds(syncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(syncStore, deviceInfo)
         assertEquals(syncStore.deviceId, appSyncDeviceIds.deviceId())
     }
 
     @Test
     fun whenDeviceNameExistsInStoreThenReturnsStoredValue() {
         val syncStore = getFakeSyncStore()
-        val appSyncDeviceIds = AppSyncDeviceIds(syncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(syncStore, deviceInfo)
         assertEquals(syncStore.deviceName, appSyncDeviceIds.deviceName())
     }
 
@@ -54,7 +60,7 @@ class AppSyncDeviceIdsTest {
         val emptySyncStore = getFakeEmptySyncStore()
         assertNull(emptySyncStore.userId)
 
-        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore, deviceInfo)
 
         val userId = appSyncDeviceIds.userId()
         assertTrue(userId.isNotEmpty())
@@ -65,7 +71,7 @@ class AppSyncDeviceIdsTest {
         val emptySyncStore = getFakeEmptySyncStore()
         assertNull(emptySyncStore.deviceId)
 
-        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore, deviceInfo)
 
         val deviceId = appSyncDeviceIds.deviceId()
         assertTrue(deviceId.isNotEmpty())
@@ -75,10 +81,22 @@ class AppSyncDeviceIdsTest {
     fun whenDeviceNameDoesNotExistInStoreThenNewIdIsReturned() {
         val emptySyncStore = getFakeEmptySyncStore()
         assertNull(emptySyncStore.deviceName)
-        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore)
+        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore, deviceInfo)
 
         val deviceName = appSyncDeviceIds.deviceName()
         assertTrue(deviceName.isNotEmpty())
+    }
+
+    @Test
+    fun whenPlatformTypeIsAndroidPhoneThenDeviceTypeMobile() {
+        val emptySyncStore = getFakeEmptySyncStore()
+        whenever(deviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
+        val appSyncDeviceIds = AppSyncDeviceIds(emptySyncStore, deviceInfo)
+
+        val deviceType = appSyncDeviceIds.deviceType()
+
+        assertEquals(deviceType.type(), Type.MOBILE)
+        assertEquals(deviceType.platform, "android_phone")
     }
 
     private fun getFakeSyncStore(): SyncStore {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
@@ -42,8 +42,8 @@ object TestSyncFixtures {
     const val password = "password"
     const val deviceId = "deviceId"
     const val deviceName = "deviceName"
-    const val devicePlatformType = "android_phone"
-    val deviceType = DeviceType(devicePlatformType)
+    const val deviceFactor = "phone"
+    val deviceType = DeviceType(deviceFactor)
     const val token = "token"
     const val primaryKey = "primaryKey"
     const val stretchedPrimaryKey = "primaryKey"
@@ -70,7 +70,7 @@ object TestSyncFixtures {
         passwordHash = "",
     )
     val accountCreated = AccountCreatedResponse(userId, token)
-    val signUpRequest = Signup(userId, hashedPassword, protectedEncryptionKey, deviceId, deviceName, devicePlatformType)
+    val signUpRequest = Signup(userId, hashedPassword, protectedEncryptionKey, deviceId, deviceName, deviceFactor)
     val signupSuccess: Response<AccountCreatedResponse> = Response.success(accountCreated)
     const val duplicateUsercCodeErr = 409
     const val duplicateUserMessageErr = "Invalid hashed_password. Must be 32 bytes encoded in Base64URL."
@@ -134,11 +134,11 @@ object TestSyncFixtures {
         hashedPassword = hashedPassword,
         deviceId = deviceId,
         deviceName = deviceName,
-        deviceType = devicePlatformType,
+        deviceType = deviceFactor,
     )
     val loginSuccessResponse: Response<LoginResponse> = Response.success(loginResponseBody)
 
-    val listOfDevices = listOf(Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = devicePlatformType))
+    val listOfDevices = listOf(Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor))
     val deviceResponse = DeviceResponse(DeviceEntries(listOfDevices))
     val getDevicesBodySuccessResponse: Response<DeviceResponse> = Response.success(deviceResponse)
     val getDevicesBodyErrorResponse: Response<DeviceResponse> = Response.error(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.sync.impl.LoginResponse
 import com.duckduckgo.sync.impl.Logout
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Signup
+import com.duckduckgo.sync.impl.encodeB64
 import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 
@@ -109,6 +110,8 @@ object TestSyncFixtures {
 
     val jsonRecoveryKey = "{\"recovery\":{\"primary_key\":\"$primaryKey\",\"user_id\":\"$userId\"}}"
     val jsonConnectKey = "{\"connect\":{\"device_id\":\"$deviceId\",\"secret_key\":\"$primaryKey\"}}"
+    val jsonRecoveryKeyEncoded = jsonRecoveryKey.encodeB64()
+    val jsonConnectKeyEncoded = jsonConnectKey.encodeB64()
     val connectKeys = ConnectKeys(0L, publicKey = primaryKey, secretKey = secretKey)
     val validLoginKeys = LoginKeys(result = 0L, passwordHash = hashedPassword, stretchedPrimaryKey = stretchedPrimaryKey, primaryKey = primaryKey)
     val failedLoginKeys = LoginKeys(result = 9L, passwordHash = "", stretchedPrimaryKey = "", primaryKey = "")

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.Device
 import com.duckduckgo.sync.impl.DeviceEntries
 import com.duckduckgo.sync.impl.DeviceResponse
+import com.duckduckgo.sync.impl.DeviceType
 import com.duckduckgo.sync.impl.Login
 import com.duckduckgo.sync.impl.LoginResponse
 import com.duckduckgo.sync.impl.Logout
@@ -40,6 +41,8 @@ object TestSyncFixtures {
     const val password = "password"
     const val deviceId = "deviceId"
     const val deviceName = "deviceName"
+    const val devicePlatformType = "android_phone"
+    val deviceType = DeviceType(devicePlatformType)
     const val token = "token"
     const val primaryKey = "primaryKey"
     const val stretchedPrimaryKey = "primaryKey"
@@ -66,7 +69,7 @@ object TestSyncFixtures {
         passwordHash = "",
     )
     val accountCreated = AccountCreatedResponse(userId, token)
-    val signUpRequest = Signup(userId, hashedPassword, protectedEncryptionKey, deviceId, deviceName)
+    val signUpRequest = Signup(userId, hashedPassword, protectedEncryptionKey, deviceId, deviceName, devicePlatformType)
     val signupSuccess: Response<AccountCreatedResponse> = Response.success(accountCreated)
     const val duplicateUsercCodeErr = 409
     const val duplicateUserMessageErr = "Invalid hashed_password. Must be 32 bytes encoded in Base64URL."
@@ -123,10 +126,16 @@ object TestSyncFixtures {
         "{\"error\":\"$invalidMessageErr\"}".toResponseBody(),
     )
     val loginFailed = Result.Error(code = wrongCredentialsCodeErr, reason = wrongCredentialsMessageErr)
-    val loginRequestBody = Login(userId = userId, hashedPassword = hashedPassword, deviceId = deviceId, deviceName = deviceName)
+    val loginRequestBody = Login(
+        userId = userId,
+        hashedPassword = hashedPassword,
+        deviceId = deviceId,
+        deviceName = deviceName,
+        deviceType = devicePlatformType,
+    )
     val loginSuccessResponse: Response<LoginResponse> = Response.success(loginResponseBody)
 
-    val listOfDevices = listOf(Device(deviceId = deviceId, deviceName = deviceName, jwIat = ""))
+    val listOfDevices = listOf(Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = devicePlatformType))
     val deviceResponse = DeviceResponse(DeviceEntries(listOfDevices))
     val getDevicesBodySuccessResponse: Response<DeviceResponse> = Response.success(deviceResponse)
     val getDevicesBodyErrorResponse: Response<DeviceResponse> = Response.error(
@@ -136,7 +145,7 @@ object TestSyncFixtures {
 
     val getDevicesSuccess = Result.Success(listOfDevices)
     val getDevicesError = Result.Error(code = invalidCodeErr, reason = invalidMessageErr)
-    val listOfConnectedDevices = listOf(ConnectedDevice(thisDevice = true, deviceName = deviceName, deviceId = deviceId))
+    val listOfConnectedDevices = listOf(ConnectedDevice(thisDevice = true, deviceName = deviceName, deviceId = deviceId, deviceType = deviceType))
 
     val connectKey = ConnectKey(encryptedRecoveryCode)
     const val keysNotFoundErr = "connection_keys_not_found"

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncRepositoryTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.sync.impl
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedFailDupUser
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedSuccess
 import com.duckduckgo.sync.TestSyncFixtures.accountKeys
@@ -36,8 +37,9 @@ import com.duckduckgo.sync.TestSyncFixtures.getDevicesError
 import com.duckduckgo.sync.TestSyncFixtures.getDevicesSuccess
 import com.duckduckgo.sync.TestSyncFixtures.hashedPassword
 import com.duckduckgo.sync.TestSyncFixtures.invalidDecryptedSecretKey
-import com.duckduckgo.sync.TestSyncFixtures.jsonConnectKey
+import com.duckduckgo.sync.TestSyncFixtures.jsonConnectKeyEncoded
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKey
+import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
 import com.duckduckgo.sync.TestSyncFixtures.listOfConnectedDevices
 import com.duckduckgo.sync.TestSyncFixtures.loginFailed
 import com.duckduckgo.sync.TestSyncFixtures.loginSuccess
@@ -60,6 +62,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -68,6 +71,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
+@RunWith(AndroidJUnit4::class)
 class AppSyncRepositoryTest {
 
     private var nativeLib: SyncLib = mock()
@@ -232,7 +236,7 @@ class AppSyncRepositoryTest {
         prepareForLoginSuccess()
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
 
-        val result = syncRepo.login(jsonRecoveryKey)
+        val result = syncRepo.login(jsonRecoveryKeyEncoded)
 
         assertEquals(Result.Success(true), result)
         verify(syncStore).userId = userId
@@ -271,7 +275,7 @@ class AppSyncRepositoryTest {
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(failedLoginKeys)
 
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
-        val result = syncRepo.login(jsonRecoveryKey)
+        val result = syncRepo.login(jsonRecoveryKeyEncoded)
 
         assertTrue(result is Result.Error)
     }
@@ -299,7 +303,7 @@ class AppSyncRepositoryTest {
         whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, devicePlatformType)).thenReturn(loginFailed)
 
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
-        val result = syncRepo.login(jsonRecoveryKey)
+        val result = syncRepo.login(jsonRecoveryKeyEncoded)
 
         assertTrue(result is Result.Error)
     }
@@ -353,7 +357,7 @@ class AppSyncRepositoryTest {
 
         val result = syncRepo.getRecoveryCode()
 
-        assertEquals(jsonRecoveryKey, result)
+        assertEquals(jsonRecoveryKeyEncoded, result)
     }
 
     @Test
@@ -373,7 +377,7 @@ class AppSyncRepositoryTest {
 
         val result = syncRepo.getConnectQR() as Success
 
-        assertEquals(jsonConnectKey, result.data)
+        assertEquals(jsonConnectKeyEncoded, result.data)
     }
 
     @Test
@@ -383,7 +387,7 @@ class AppSyncRepositoryTest {
         whenever(syncApi.connect(token, deviceId, encryptedRecoveryCode)).thenReturn(Result.Success(true))
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
 
-        val result = syncRepo.connectDevice(jsonConnectKey)
+        val result = syncRepo.connectDevice(jsonConnectKeyEncoded)
 
         verify(syncApi).connect(token, deviceId, encryptedRecoveryCode)
         assertTrue(result is Success)
@@ -401,7 +405,7 @@ class AppSyncRepositoryTest {
         whenever(syncApi.connect(token, deviceId, encryptedRecoveryCode)).thenReturn(Result.Success(true))
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
 
-        val result = syncRepo.connectDevice(jsonConnectKey)
+        val result = syncRepo.connectDevice(jsonConnectKeyEncoded)
 
         verify(syncApi).connect(token, deviceId, encryptedRecoveryCode)
         assertTrue(result is Success)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncRepositoryTest.kt
@@ -27,9 +27,9 @@ import com.duckduckgo.sync.TestSyncFixtures.connectKeys
 import com.duckduckgo.sync.TestSyncFixtures.decryptedSecretKey
 import com.duckduckgo.sync.TestSyncFixtures.deleteAccountInvalid
 import com.duckduckgo.sync.TestSyncFixtures.deleteAccountSuccess
+import com.duckduckgo.sync.TestSyncFixtures.deviceFactor
 import com.duckduckgo.sync.TestSyncFixtures.deviceId
 import com.duckduckgo.sync.TestSyncFixtures.deviceName
-import com.duckduckgo.sync.TestSyncFixtures.devicePlatformType
 import com.duckduckgo.sync.TestSyncFixtures.deviceType
 import com.duckduckgo.sync.TestSyncFixtures.encryptedRecoveryCode
 import com.duckduckgo.sync.TestSyncFixtures.failedLoginKeys
@@ -286,7 +286,7 @@ class AppSyncRepositoryTest {
         prepareToProvideDeviceIds()
         prepareForEncryption()
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
-        whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, devicePlatformType)).thenReturn(loginFailed)
+        whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, deviceFactor)).thenReturn(loginFailed)
 
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
         val result = syncRepo.login()
@@ -300,7 +300,7 @@ class AppSyncRepositoryTest {
         prepareForEncryption()
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
         whenever(nativeLib.decrypt(encryptedData = protectedEncryptionKey, secretKey = stretchedPrimaryKey)).thenReturn(decryptedSecretKey)
-        whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, devicePlatformType)).thenReturn(loginFailed)
+        whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, deviceFactor)).thenReturn(loginFailed)
 
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
         val result = syncRepo.login(jsonRecoveryKeyEncoded)
@@ -315,7 +315,7 @@ class AppSyncRepositoryTest {
         prepareForEncryption()
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
         whenever(nativeLib.decrypt(encryptedData = protectedEncryptionKey, secretKey = stretchedPrimaryKey)).thenReturn(invalidDecryptedSecretKey)
-        whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, devicePlatformType)).thenReturn(loginSuccess)
+        whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, deviceFactor)).thenReturn(loginSuccess)
 
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
         val result = syncRepo.login()
@@ -443,7 +443,7 @@ class AppSyncRepositoryTest {
         whenever(syncDeviceIds.deviceName()).thenReturn(deviceName)
         whenever(syncDeviceIds.deviceType()).thenReturn(deviceType)
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
-        whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, devicePlatformType)).thenReturn(loginSuccess)
+        whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, deviceFactor)).thenReturn(loginSuccess)
     }
 
     private fun givenAuthenticatedDevice() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncRepositoryTest.kt
@@ -48,6 +48,8 @@ import com.duckduckgo.sync.TestSyncFixtures.stretchedPrimaryKey
 import com.duckduckgo.sync.TestSyncFixtures.token
 import com.duckduckgo.sync.TestSyncFixtures.userId
 import com.duckduckgo.sync.TestSyncFixtures.validLoginKeys
+import com.duckduckgo.sync.crypto.DecryptResult
+import com.duckduckgo.sync.crypto.EncryptResult
 import com.duckduckgo.sync.crypto.SyncLib
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.store.SyncStore
@@ -91,6 +93,7 @@ class AppSyncRepositoryTest {
     @Test
     fun whenCreateAccountFailsThenReturnError() {
         prepareToProvideDeviceIds()
+        whenever(nativeLib.encryptData(anyString(), primaryKey = eq(primaryKey))).thenReturn(EncryptResult(0L, deviceName))
         whenever(nativeLib.generateAccountKeys(userId = anyString(), password = anyString())).thenReturn(accountKeys)
         whenever(syncApi.createAccount(anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(accountCreatedFailDupUser)
@@ -275,6 +278,7 @@ class AppSyncRepositoryTest {
     fun whenLoginFailsThenReturnError() {
         whenever(syncStore.recoveryCode).thenReturn(jsonRecoveryKey)
         prepareToProvideDeviceIds()
+        whenever(nativeLib.encryptData(anyString(), primaryKey = eq(primaryKey))).thenReturn(EncryptResult(0L, deviceName))
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
         whenever(nativeLib.decrypt(encryptedData = protectedEncryptionKey, secretKey = stretchedPrimaryKey)).thenReturn(decryptedSecretKey)
         whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName)).thenReturn(loginFailed)
@@ -288,6 +292,7 @@ class AppSyncRepositoryTest {
     @Test
     fun whenLoginFromQRFailsThenReturnError() {
         prepareToProvideDeviceIds()
+        whenever(nativeLib.encryptData(anyString(), primaryKey = eq(primaryKey))).thenReturn(EncryptResult(0L, deviceName))
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
         whenever(nativeLib.decrypt(encryptedData = protectedEncryptionKey, secretKey = stretchedPrimaryKey)).thenReturn(decryptedSecretKey)
         whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName)).thenReturn(loginFailed)
@@ -302,6 +307,7 @@ class AppSyncRepositoryTest {
     fun whenDecryptSecretKeyFailsThenReturnError() {
         whenever(syncStore.recoveryCode).thenReturn(jsonRecoveryKey)
         prepareToProvideDeviceIds()
+        whenever(nativeLib.encryptData(anyString(), primaryKey = eq(primaryKey))).thenReturn(EncryptResult(0L, deviceName))
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
         whenever(nativeLib.decrypt(encryptedData = protectedEncryptionKey, secretKey = stretchedPrimaryKey)).thenReturn(invalidDecryptedSecretKey)
         whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName)).thenReturn(loginSuccess)
@@ -315,7 +321,9 @@ class AppSyncRepositoryTest {
     @Test
     fun getConnectedDevicesSucceedsThenReturnSuccess() {
         whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
         whenever(syncStore.deviceId).thenReturn(deviceId)
+        whenever(nativeLib.decryptData(anyString(), primaryKey = eq(primaryKey))).thenReturn(DecryptResult(0L, deviceName))
         whenever(syncApi.getDevices(anyString())).thenReturn(getDevicesSuccess)
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
 
@@ -405,6 +413,7 @@ class AppSyncRepositoryTest {
         whenever(syncStore.primaryKey).thenReturn(primaryKey)
         whenever(syncStore.secretKey).thenReturn(secretKey)
         whenever(syncApi.connectDevice(deviceId)).thenReturn(connectDeviceSuccess)
+        whenever(nativeLib.encryptData(anyString(), primaryKey = eq(primaryKey))).thenReturn(EncryptResult(0L, deviceName))
         whenever(nativeLib.sealOpen(encryptedRecoveryCode, primaryKey, secretKey)).thenReturn(jsonRecoveryKey)
         val syncRepo = AppSyncRepository(syncDeviceIds, nativeLib, syncApi, syncStore)
 
@@ -429,6 +438,8 @@ class AppSyncRepositoryTest {
         whenever(syncDeviceIds.deviceName()).thenReturn(deviceName)
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
         whenever(nativeLib.decrypt(encryptedData = protectedEncryptionKey, secretKey = stretchedPrimaryKey)).thenReturn(decryptedSecretKey)
+        whenever(nativeLib.decryptData(anyString(), primaryKey = eq(primaryKey))).thenReturn(DecryptResult(0L, deviceName))
+        whenever(nativeLib.encryptData(anyString(), primaryKey = eq(primaryKey))).thenReturn(EncryptResult(0L, deviceName))
         whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName)).thenReturn(loginSuccess)
     }
 
@@ -448,6 +459,7 @@ class AppSyncRepositoryTest {
     }
 
     private fun prepareForCreateAccountSuccess() {
+        whenever(nativeLib.encryptData(anyString(), primaryKey = eq(primaryKey))).thenReturn(EncryptResult(0L, deviceName))
         whenever(nativeLib.generateAccountKeys(userId = anyString(), password = anyString())).thenReturn(accountKeys)
         whenever(syncApi.createAccount(anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(Result.Success(AccountCreatedResponse(userId, token)))

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.sync.TestSyncFixtures.deviceId
 import com.duckduckgo.sync.TestSyncFixtures.deviceLogoutBody
 import com.duckduckgo.sync.TestSyncFixtures.deviceLogoutResponse
 import com.duckduckgo.sync.TestSyncFixtures.deviceName
+import com.duckduckgo.sync.TestSyncFixtures.devicePlatformType
 import com.duckduckgo.sync.TestSyncFixtures.encryptedRecoveryCode
 import com.duckduckgo.sync.TestSyncFixtures.getDevicesBodyErrorResponse
 import com.duckduckgo.sync.TestSyncFixtures.getDevicesBodySuccessResponse
@@ -76,7 +77,7 @@ class SyncServiceRemoteTest {
         whenever(call.execute()).thenReturn(signupSuccess)
 
         val result = with(accountKeys) {
-            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName)
+            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName, devicePlatformType)
         }
 
         assertEquals(accountCreatedSuccess, result)
@@ -90,7 +91,7 @@ class SyncServiceRemoteTest {
         whenever(call.execute()).thenReturn(signupFailInvalid)
 
         val result = with(accountKeys) {
-            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName)
+            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName, devicePlatformType)
         }
 
         assertEquals(accountCreatedFailInvalid, result)
@@ -104,7 +105,7 @@ class SyncServiceRemoteTest {
         whenever(call.execute()).thenReturn(signupFailDuplicatedUser)
 
         val result = with(accountKeys) {
-            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName)
+            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName, devicePlatformType)
         }
 
         assertEquals(accountCreatedFailDupUser, result)
@@ -165,7 +166,7 @@ class SyncServiceRemoteTest {
         whenever(syncService.login(loginRequestBody)).thenReturn(call)
         whenever(call.execute()).thenReturn(loginSuccessResponse)
 
-        val result = syncRemote.login(userId, hashedPassword, deviceId, deviceName)
+        val result = syncRemote.login(userId, hashedPassword, deviceId, deviceName, devicePlatformType)
 
         assertEquals(loginSuccess, result)
     }
@@ -177,7 +178,7 @@ class SyncServiceRemoteTest {
         whenever(syncService.login(loginRequestBody)).thenReturn(call)
         whenever(call.execute()).thenReturn(loginFailedInvalidResponse)
 
-        val result = syncRemote.login(userId, hashedPassword, deviceId, deviceName)
+        val result = syncRemote.login(userId, hashedPassword, deviceId, deviceName, devicePlatformType)
 
         assertEquals(loginError, result)
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.sync.impl
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedFailDupUser
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedFailInvalid
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedSuccess
@@ -59,12 +60,14 @@ import com.duckduckgo.sync.TestSyncFixtures.token
 import com.duckduckgo.sync.TestSyncFixtures.userId
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import retrofit2.Call
 
+@RunWith(AndroidJUnit4::class)
 class SyncServiceRemoteTest {
 
     private val syncService: SyncService = mock()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
@@ -34,11 +34,11 @@ import com.duckduckgo.sync.TestSyncFixtures.deleteAccountError
 import com.duckduckgo.sync.TestSyncFixtures.deleteAccountInvalid
 import com.duckduckgo.sync.TestSyncFixtures.deleteAccountResponse
 import com.duckduckgo.sync.TestSyncFixtures.deleteAccountSuccess
+import com.duckduckgo.sync.TestSyncFixtures.deviceFactor
 import com.duckduckgo.sync.TestSyncFixtures.deviceId
 import com.duckduckgo.sync.TestSyncFixtures.deviceLogoutBody
 import com.duckduckgo.sync.TestSyncFixtures.deviceLogoutResponse
 import com.duckduckgo.sync.TestSyncFixtures.deviceName
-import com.duckduckgo.sync.TestSyncFixtures.devicePlatformType
 import com.duckduckgo.sync.TestSyncFixtures.encryptedRecoveryCode
 import com.duckduckgo.sync.TestSyncFixtures.getDevicesBodyErrorResponse
 import com.duckduckgo.sync.TestSyncFixtures.getDevicesBodySuccessResponse
@@ -80,7 +80,7 @@ class SyncServiceRemoteTest {
         whenever(call.execute()).thenReturn(signupSuccess)
 
         val result = with(accountKeys) {
-            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName, devicePlatformType)
+            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName, deviceFactor)
         }
 
         assertEquals(accountCreatedSuccess, result)
@@ -94,7 +94,7 @@ class SyncServiceRemoteTest {
         whenever(call.execute()).thenReturn(signupFailInvalid)
 
         val result = with(accountKeys) {
-            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName, devicePlatformType)
+            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName, deviceFactor)
         }
 
         assertEquals(accountCreatedFailInvalid, result)
@@ -108,7 +108,7 @@ class SyncServiceRemoteTest {
         whenever(call.execute()).thenReturn(signupFailDuplicatedUser)
 
         val result = with(accountKeys) {
-            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName, devicePlatformType)
+            syncRemote.createAccount(userId, passwordHash, protectedSecretKey, deviceId, deviceName, deviceFactor)
         }
 
         assertEquals(accountCreatedFailDupUser, result)
@@ -169,7 +169,7 @@ class SyncServiceRemoteTest {
         whenever(syncService.login(loginRequestBody)).thenReturn(call)
         whenever(call.execute()).thenReturn(loginSuccessResponse)
 
-        val result = syncRemote.login(userId, hashedPassword, deviceId, deviceName, devicePlatformType)
+        val result = syncRemote.login(userId, hashedPassword, deviceId, deviceName, deviceFactor)
 
         assertEquals(loginSuccess, result)
     }
@@ -181,7 +181,7 @@ class SyncServiceRemoteTest {
         whenever(syncService.login(loginRequestBody)).thenReturn(call)
         whenever(call.execute()).thenReturn(loginFailedInvalidResponse)
 
-        val result = syncRemote.login(userId, hashedPassword, deviceId, deviceName, devicePlatformType)
+        val result = syncRemote.login(userId, hashedPassword, deviceId, deviceName, deviceFactor)
 
         assertEquals(loginError, result)
     }

--- a/sync/sync-lib/src/main/java/com/duckduckgo/sync/crypto/SyncNativeLib.kt
+++ b/sync/sync-lib/src/main/java/com/duckduckgo/sync/crypto/SyncNativeLib.kt
@@ -49,6 +49,16 @@ interface SyncLib {
         primaryKey: String,
         secretKey: String,
     ): String
+
+    fun decryptData(
+        rawData: String,
+        primaryKey: String,
+    ): DecryptResult
+
+    fun encryptData(
+        rawData: String,
+        primaryKey: String,
+    ): EncryptResult
 }
 
 class SyncNativeLib constructor(context: Context) : SyncLib {
@@ -116,7 +126,7 @@ class SyncNativeLib constructor(context: Context) : SyncLib {
         val secretKeyByteArray = secretKey.decodeKey()
         val decryptedData = ByteArray(encryptedDataByteArray.size - getEncryptedExtraBytes())
 
-            val result: Long = decrypt(decryptedData, encryptedDataByteArray, secretKeyByteArray)
+        val result: Long = decrypt(decryptedData, encryptedDataByteArray, secretKeyByteArray)
 
         return DecryptResult(
             result = result,
@@ -154,6 +164,38 @@ class SyncNativeLib constructor(context: Context) : SyncLib {
         return EncryptResult(
             result = result,
             encryptedData = encryptedDataByteArray.encodeKey(),
+        )
+    }
+
+    override fun encryptData(
+        rawData: String,
+        primaryKey: String,
+    ): EncryptResult {
+        val rawDataByteArray = rawData.decodeText()
+        val secretKeyByteArray = primaryKey.decodeKey()
+        val encryptedDataByteArray = ByteArray(rawDataByteArray.size + getEncryptedExtraBytes())
+
+        val result: Long = encrypt(encryptedDataByteArray, rawDataByteArray, secretKeyByteArray)
+
+        return EncryptResult(
+            result = result,
+            encryptedData = encryptedDataByteArray.encodeKey(),
+        )
+    }
+
+    override fun decryptData(
+        encryptedData: String,
+        primaryKey: String,
+    ): DecryptResult {
+        val encryptedDataByteArray = encryptedData.decodeKey()
+        val secretKeyByteArray = primaryKey.decodeKey()
+        val decryptedData = ByteArray(encryptedDataByteArray.size - getEncryptedExtraBytes())
+
+        val result: Long = decrypt(decryptedData, encryptedDataByteArray, secretKeyByteArray)
+
+        return DecryptResult(
+            result = result,
+            decryptedData = decryptedData.encodeText(),
         )
     }
 

--- a/sync/sync-lib/src/main/java/com/duckduckgo/sync/crypto/SyncNativeLib.kt
+++ b/sync/sync-lib/src/main/java/com/duckduckgo/sync/crypto/SyncNativeLib.kt
@@ -116,7 +116,7 @@ class SyncNativeLib constructor(context: Context) : SyncLib {
         val secretKeyByteArray = secretKey.decodeKey()
         val decryptedData = ByteArray(encryptedDataByteArray.size - getEncryptedExtraBytes())
 
-        val result: Long = decrypt(decryptedData, encryptedDataByteArray, secretKeyByteArray)
+            val result: Long = decrypt(decryptedData, encryptedDataByteArray, secretKeyByteArray)
 
         return DecryptResult(
             result = result,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1201493110486074/1203835825731590/f 

### Description
Encrypts device info (name and type) on all auth flows.
Also changes QR format to follow b64 encoding

### Steps to test this PR
(you will need 2 devices to test some of the auth flows)

_create account and login_
- [x] install app on device A and device B
- [x] device A(unauthenticated): go to settings -> sync -> create account
- [x] device A(authenticated): show QR code
- [x] device B(unauthenticated): go to settings -> sync
- [x] device B: read QR code
- [x] device B: scan QR code from device A
- [x] device B(authenticated): ensure login success

_connect_ (device B should have a camera)
- [x] install app on device A and device B (both need to be unauthenticated, go to settings -> sync -> reset button)
- [x] device A(unauthenticated): go to settings -> sync
- [x] device A: click on "connect (show QR)" (it will start polling data)
- [x] device B(unauthenticated, with camera!): go to settings -> sync
- [x] device B: click on "connect (read QR)"
- [x] device B: scan QR code from device A
- [x] device B(authenticated): ensure an account is created (account data will appear at the top)
- [x] device A: ensure it joins the same account (can take 7 seconds) (account data will appear at the top)

