### PR TITLE
Android: Ripple not displayed on the whole item

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -152,7 +152,7 @@ class DeviceShieldTrackerActivity :
             viewModel.onViewEvent(ViewEvent.AskToRemoveFeature)
         }
 
-        binding.ctaShowAll.setClickListener {
+        binding.ctaShowAll.setOnClickListener {
             viewModel.onViewEvent(ViewEvent.LaunchMostRecentActivity)
         }
 

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_activity.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_activity.xml
@@ -121,15 +121,20 @@
                     android:layout_height="0dp"
                     android:layout_weight="1" />
 
-                <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
+                <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
                     android:id="@+id/cta_show_all"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingStart="56dp"
+                    android:layout_marginBottom="@dimen/keyline_4"
+                    android:background="?attr/selectableItemBackground"
+                    android:gravity="center_vertical"
+                    android:minHeight="@dimen/keyline_7"
+                    android:paddingStart="72dp"
                     android:paddingTop="@dimen/keyline_2"
+                    android:paddingEnd="@dimen/keyline_4"
                     android:paddingBottom="@dimen/keyline_2"
-                    android:visibility="gone"
-                    app:primaryText="@string/atp_ActivityCtaShowAll" />
+                    android:text="@string/atp_ActivityCtaShowAll"
+                    android:visibility="gone" />
 
                 <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
                     android:layout_width="match_parent"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1200905986587319/1204131202912051/f

### Description
Fixed ripple on view all recent activity item (replaced `OneLineListItem` with `DaxTextView` as pe updated design).

### Steps to test this PR

- [x] Install from this branch.
- [x] Enable AppTP.
- [x] On `App Tracking protection` screen (main AppTP screen) once you have more than 5 items in the `Activity` you should see the `View All Recent Activity` item.
- [x] Tap on `View All Recent Activity` item and notice the ripple is displayed over the whole item.

### UI changes
| Before  | After |
| ------ | ----- |
|![view_all_recent_activity_tapped_before](https://user-images.githubusercontent.com/7963079/224310217-ec2cc9e3-8af9-4c07-94fc-7377819b85b9.png)|![view_all_recent_activity_tapped_after](https://user-images.githubusercontent.com/7963079/224310894-c0000576-abd1-4533-8a07-f1bf1c7a9a69.png)|



