### PR TITLE
Suppress fireproof prompts when it would show over (or shortly after) autofill dialog

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -60,6 +60,7 @@ import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.DownloadFile
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.OpenInNewTab
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.applinks.AppLinksHandler
+import com.duckduckgo.app.browser.autofill.AutofillFireproofDialogSuppressor
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.favicon.FaviconSource
 import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter.QuickAccessFavorite
@@ -391,6 +392,8 @@ class BrowserTabViewModelTest {
 
     private val autofillCapabilityChecker: FakeCapabilityChecker = FakeCapabilityChecker(enabled = false)
 
+    private val autofillFireproofDialogSuppressor: AutofillFireproofDialogSuppressor = mock()
+
     @Before
     fun before() {
         MockitoAnnotations.openMocks(this)
@@ -498,6 +501,7 @@ class BrowserTabViewModelTest {
             adClickManager = mockAdClickManager,
             sitePermissionsManager = mockSitePermissionsManager,
             autofillCapabilityChecker = autofillCapabilityChecker,
+            autofillFireproofDialogSuppressor = autofillFireproofDialogSuppressor,
         )
 
         testee.loadData("abc", null, false, false)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1867,7 +1867,15 @@ class BrowserTabFragment :
             }
         }
 
-        setFragmentResultListener(CredentialUpdateExistingCredentialsDialog.resultKey(tabId)) { _, result ->
+        setFragmentResultListener(CredentialSavePickerDialog.resultKeyPromptDismissed(tabId)) { _, _ ->
+            autofillCredentialsSelectionResultHandler.processSaveOrUpdatePromptDismissed()
+        }
+
+        setFragmentResultListener(CredentialUpdateExistingCredentialsDialog.resultKeyPromptDismissed(tabId)) { _, _ ->
+            autofillCredentialsSelectionResultHandler.processSaveOrUpdatePromptDismissed()
+        }
+
+        setFragmentResultListener(CredentialUpdateExistingCredentialsDialog.resultKeyCredentialUpdated(tabId)) { _, result ->
             launch {
                 autofillCredentialsSelectionResultHandler.processUpdateCredentialsResult(result, viewModel)?.let {
                     viewModel.onShowUserCredentialsUpdated(it)
@@ -1919,6 +1927,8 @@ class BrowserTabFragment :
         val url = webView?.url ?: return
         if (url != currentUrl) return
 
+        autofillCredentialsSelectionResultHandler.processSaveOrUpdatePromptShown()
+
         val dialog = credentialAutofillDialogFactory.autofillSavingCredentialsDialog(url, credentials, tabId)
         showDialogHidingPrevious(dialog, CredentialSavePickerDialog.TAG)
     }
@@ -1930,6 +1940,8 @@ class BrowserTabFragment :
         val url = webView?.url ?: return
         if (url != currentUrl) return
 
+        autofillCredentialsSelectionResultHandler.processSaveOrUpdatePromptShown()
+
         val dialog = credentialAutofillDialogFactory.autofillSavingUpdatePasswordDialog(url, credentials, tabId)
         showDialogHidingPrevious(dialog, CredentialUpdateExistingCredentialsDialog.TAG)
     }
@@ -1940,6 +1952,8 @@ class BrowserTabFragment :
     ) {
         val url = webView?.url ?: return
         if (url != currentUrl) return
+
+        autofillCredentialsSelectionResultHandler.processSaveOrUpdatePromptShown()
 
         val dialog = credentialAutofillDialogFactory.autofillSavingUpdateUsernameDialog(url, credentials, tabId)
         showDialogHidingPrevious(dialog, CredentialUpdateExistingCredentialsDialog.TAG)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -58,6 +58,7 @@ import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.NonHttpAppLink
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.applinks.AppLinksHandler
 import com.duckduckgo.app.browser.autofill.AutofillCredentialsSelectionResultHandler
+import com.duckduckgo.app.browser.autofill.AutofillFireproofDialogSuppressor
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.favicon.FaviconSource.ImageFavicon
 import com.duckduckgo.app.browser.favicon.FaviconSource.UrlFavicon
@@ -185,6 +186,7 @@ class BrowserTabViewModel @Inject constructor(
     private val autofillCapabilityChecker: AutofillCapabilityChecker,
     private val adClickManager: AdClickManager,
     private val sitePermissionsManager: SitePermissionsManager,
+    private val autofillFireproofDialogSuppressor: AutofillFireproofDialogSuppressor,
 ) : WebViewClientListener,
     EditSavedSiteListener,
     UrlExtractionListener,
@@ -578,17 +580,25 @@ class BrowserTabViewModel @Inject constructor(
     private val loginDetectionObserver = Observer<LoginDetected> { loginEvent ->
         Timber.i("LoginDetection for $loginEvent")
         viewModelScope.launch(dispatchers.io()) {
+            val canPromptAboutFireproofing = !autofillFireproofDialogSuppressor.isAutofillPreventingFireproofPrompts()
+
             if (!isFireproofWebsite(loginEvent.forwardedToDomain)) {
                 withContext(dispatchers.main()) {
                     val showAutomaticFireproofDialog =
                         settingsDataStore.automaticFireproofSetting == ASK_EVERY_TIME && settingsDataStore.showAutomaticFireproofDialog
                     when {
-                        showAutomaticFireproofDialog ->
-                            command.value = AskToAutomateFireproofWebsite(FireproofWebsiteEntity(loginEvent.forwardedToDomain))
+                        showAutomaticFireproofDialog -> {
+                            if (canPromptAboutFireproofing) {
+                                command.value = AskToAutomateFireproofWebsite(FireproofWebsiteEntity(loginEvent.forwardedToDomain))
+                            }
+                        }
                         settingsDataStore.automaticFireproofSetting == ALWAYS ->
                             fireproofDialogsEventHandler.onUserConfirmedFireproofDialog(loginEvent.forwardedToDomain)
-                        else ->
-                            command.value = AskToFireproofWebsite(FireproofWebsiteEntity(loginEvent.forwardedToDomain))
+                        else -> {
+                            if (canPromptAboutFireproofing) {
+                                command.value = AskToFireproofWebsite(FireproofWebsiteEntity(loginEvent.forwardedToDomain))
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandler.kt
@@ -56,6 +56,7 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val autofillStore: AutofillStore,
     private val pixel: Pixel,
+    private val autofillDialogSuppressor: AutofillFireproofDialogSuppressor,
 ) {
 
     fun processAutofillCredentialSelectionResult(
@@ -101,6 +102,8 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(
         context: Context,
         viewModel: BrowserTabViewModel,
     ) {
+        autofillDialogSuppressor.autofillSaveOrUpdateDialogVisibilityChanged(visible = false)
+
         pixel.fire(AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SHOWN)
         withContext(dispatchers.main()) {
             AlertDialog.Builder(context)
@@ -139,6 +142,8 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(
         result: Bundle,
         credentialSaver: AutofillCredentialSaver,
     ): LoginCredentials? {
+        autofillDialogSuppressor.autofillSaveOrUpdateDialogVisibilityChanged(visible = false)
+
         val selectedCredentials = result.getParcelable<LoginCredentials>(CredentialSavePickerDialog.KEY_CREDENTIALS) ?: return null
         val originalUrl = result.getString(CredentialSavePickerDialog.KEY_URL) ?: return null
         val savedCredentials = credentialSaver.saveCredentials(originalUrl, selectedCredentials)
@@ -152,6 +157,8 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(
         result: Bundle,
         credentialSaver: AutofillCredentialSaver,
     ): LoginCredentials? {
+        autofillDialogSuppressor.autofillSaveOrUpdateDialogVisibilityChanged(visible = false)
+
         val selectedCredentials = result.getParcelable<LoginCredentials>(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIALS) ?: return null
         val originalUrl = result.getString(CredentialUpdateExistingCredentialsDialog.KEY_URL) ?: return null
         val updateType =
@@ -163,6 +170,14 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(
         withContext(dispatchers.main()) {
             viewModel.onRefreshRequested()
         }
+    }
+
+    fun processSaveOrUpdatePromptDismissed() {
+        autofillDialogSuppressor.autofillSaveOrUpdateDialogVisibilityChanged(visible = false)
+    }
+
+    fun processSaveOrUpdatePromptShown() {
+        autofillDialogSuppressor.autofillSaveOrUpdateDialogVisibilityChanged(visible = true)
     }
 
     interface CredentialInjector {

--- a/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillFireproofDialogSuppressor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillFireproofDialogSuppressor.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.autofill
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import timber.log.Timber
+
+interface AutofillFireproofDialogSuppressor {
+    fun isAutofillPreventingFireproofPrompts(): Boolean
+    fun autofillSaveOrUpdateDialogVisibilityChanged(visible: Boolean)
+}
+
+@ContributesBinding(FragmentScope::class)
+@SingleInstanceIn(FragmentScope::class)
+class RealAutofillFireproofDialogSuppressor @Inject constructor(private val timeProvider: TimeProvider) : AutofillFireproofDialogSuppressor {
+
+    private var autofillDialogShowing = false
+    private var lastTimeUserSawAutofillDialog = 0L
+
+    override fun isAutofillPreventingFireproofPrompts(): Boolean {
+        val timeSinceLastDismissed = timeProvider.currentTimeMillis() - lastTimeUserSawAutofillDialog
+        val suppressing = autofillDialogShowing || (timeSinceLastDismissed <= TIME_PERIOD_TO_SUPPRESS_FIREPROOF_PROMPT)
+        Timber.d(
+            "isAutofillPreventingFireproofPrompts: %s (autofillDialogShowing=%s, timeSinceLastDismissed=%sms)",
+            suppressing,
+            autofillDialogShowing,
+            timeSinceLastDismissed,
+        )
+        return suppressing
+    }
+
+    override fun autofillSaveOrUpdateDialogVisibilityChanged(visible: Boolean) {
+        Timber.v("Autofill save/update dialog visibility changed to %s", visible)
+        autofillDialogShowing = visible
+
+        if (!visible) {
+            lastTimeUserSawAutofillDialog = timeProvider.currentTimeMillis()
+        }
+    }
+
+    companion object {
+        private val TIME_PERIOD_TO_SUPPRESS_FIREPROOF_PROMPT = TimeUnit.SECONDS.toMillis(10)
+    }
+}
+
+interface TimeProvider {
+    fun currentTimeMillis(): Long
+}
+
+@ContributesBinding(AppScope::class)
+class SystemCurrentTimeProvider @Inject constructor() : TimeProvider {
+    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandlerTest.kt
@@ -56,6 +56,7 @@ class AutofillCredentialsSelectionResultHandlerTest {
     private val autofillStore: AutofillStore = mock()
     private val pixel: Pixel = mock()
     private val dummyFragment = Fragment()
+    private val autofillDialogSuppressor: AutofillFireproofDialogSuppressor = mock()
     private lateinit var deviceAuthenticator: FakeAuthenticator
     private lateinit var testee: AutofillCredentialsSelectionResultHandler
 
@@ -217,6 +218,20 @@ class AutofillCredentialsSelectionResultHandlerTest {
         verifyAuthenticatorNeverCalled()
     }
 
+    @Test
+    fun whenSaveOrUpdateDialogDismissedThenAutofillDialogSuppressorCalled() = runTest {
+        setupAuthenticatorAlwaysAuth()
+        testee.processSaveOrUpdatePromptDismissed()
+        verify(autofillDialogSuppressor).autofillSaveOrUpdateDialogVisibilityChanged(visible = false)
+    }
+
+    @Test
+    fun whenSaveOrUpdateDialogShownThenAutofillDialogSuppressorCalled() = runTest {
+        setupAuthenticatorAlwaysAuth()
+        testee.processSaveOrUpdatePromptShown()
+        verify(autofillDialogSuppressor).autofillSaveOrUpdateDialogVisibilityChanged(visible = true)
+    }
+
     private suspend fun verifySaveNeverCalled() {
         verify(credentialsSaver, never()).saveCredentials(any(), any())
     }
@@ -307,6 +322,7 @@ class AutofillCredentialsSelectionResultHandlerTest {
             autofillStore = autofillStore,
             appCoroutineScope = this,
             pixel = pixel,
+            autofillDialogSuppressor = autofillDialogSuppressor,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/autofill/RealAutofillFireproofDialogSuppressorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/autofill/RealAutofillFireproofDialogSuppressorTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.autofill
+
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class RealAutofillFireproofDialogSuppressorTest {
+
+    private val timeProvider: TimeProvider = mock()
+    private val testee = RealAutofillFireproofDialogSuppressor(timeProvider)
+
+    @Before
+    fun before() {
+        configureTimeNow()
+    }
+
+    @Test
+    fun whenNoInteractionsThenNotPreventingPrompts() {
+        assertFalse(testee.isAutofillPreventingFireproofPrompts())
+    }
+
+    @Test
+    fun whenSaveOrUpdateDialogVisibleThenPreventingPrompts() {
+        testee.autofillSaveOrUpdateDialogVisibilityChanged(true)
+        assertTrue(testee.isAutofillPreventingFireproofPrompts())
+    }
+
+    @Test
+    fun whenSaveOrUpdateDialogDismissedRecentlyThenPreventingPrompts() {
+        testee.autofillSaveOrUpdateDialogVisibilityChanged(true)
+        testee.autofillSaveOrUpdateDialogVisibilityChanged(false)
+        assertTrue(testee.isAutofillPreventingFireproofPrompts())
+    }
+
+    @Test
+    fun whenSaveOrUpdateDialogDismissedAWhileBackThenPreventingPrompts() {
+        testee.autofillSaveOrUpdateDialogVisibilityChanged(true)
+        testee.autofillSaveOrUpdateDialogVisibilityChanged(false)
+        configureTimeNow(System.currentTimeMillis() + 20_000)
+        assertFalse(testee.isAutofillPreventingFireproofPrompts())
+    }
+
+    private fun configureTimeNow(timeMillis: Long = System.currentTimeMillis()) {
+        whenever(timeProvider.currentTimeMillis()).thenReturn(timeMillis)
+    }
+}

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillCredentialDialogs.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillCredentialDialogs.kt
@@ -29,7 +29,7 @@ interface CredentialAutofillPickerDialog {
 
     companion object {
 
-        fun resultKey(tabId: String) = "$tabId/CredentialAutofillPickerDialogResult"
+        fun resultKey(tabId: String) = "${prefix(tabId, TAG)}/Result"
 
         const val TAG = "CredentialAutofillPickerDialog"
         const val KEY_CANCELLED = "cancelled"
@@ -46,8 +46,9 @@ interface CredentialAutofillPickerDialog {
 interface CredentialSavePickerDialog {
 
     companion object {
-        fun resultKeyUserChoseToSaveCredentials(tabId: String) = "$tabId/CredentialSavePickerDialogResultSave"
-        fun resultKeyShouldPromptToDisableAutofill(tabId: String) = "$tabId/CredentialSavePickerDialogResultShouldPromptToDisableAutofill"
+        fun resultKeyUserChoseToSaveCredentials(tabId: String) = "${prefix(tabId, TAG)}/UserChoseToSave"
+        fun resultKeyShouldPromptToDisableAutofill(tabId: String) = "${prefix(tabId, TAG)}/ShouldPromptToDisableAutofill"
+        fun resultKeyPromptDismissed(tabId: String) = "${prefix(tabId, TAG)}/UserDismissedPrompt"
 
         const val TAG = "CredentialSavePickerDialog"
         const val KEY_URL = "url"
@@ -72,7 +73,8 @@ interface CredentialUpdateExistingCredentialsDialog {
     }
 
     companion object {
-        fun resultKey(tabId: String) = "$tabId/CredentialUpdateExistingCredentialsResult"
+        fun resultKeyCredentialUpdated(tabId: String) = "${prefix(tabId, TAG)}/UserChoseToUpdate"
+        fun resultKeyPromptDismissed(tabId: String) = "${prefix(tabId, TAG)}/UserDismissedPrompt"
 
         const val TAG = "CredentialUpdateExistingCredentialsDialog"
         const val KEY_URL = "url"
@@ -111,4 +113,11 @@ interface CredentialAutofillDialogFactory {
         credentials: LoginCredentials,
         tabId: String,
     ): DialogFragment
+}
+
+private fun prefix(
+    tabId: String,
+    tag: String,
+): String {
+    return "$tabId/$tag"
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
@@ -155,6 +155,9 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
     }
 
     override fun onCancel(dialog: DialogInterface) {
+        // need a reference to this early as it will could null after launching the coroutine
+        val parentFragmentForResult = parentFragment
+
         if (ignoreCancellationEvents) {
             Timber.v("onCancel: Ignoring cancellation event")
             return
@@ -166,7 +169,9 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
             autofillDeclineCounter.userDeclinedToSaveCredentials(getOriginalUrl().extractDomain())
 
             if (autofillDeclineCounter.shouldPromptToDisableAutofill()) {
-                parentFragment?.setFragmentResult(CredentialSavePickerDialog.resultKeyShouldPromptToDisableAutofill(getTabId()), Bundle())
+                parentFragmentForResult?.setFragmentResult(CredentialSavePickerDialog.resultKeyShouldPromptToDisableAutofill(getTabId()), Bundle())
+            } else {
+                parentFragmentForResult?.setFragmentResult(CredentialSavePickerDialog.resultKeyPromptDismissed(getTabId()), Bundle())
             }
         }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
@@ -136,7 +136,7 @@ class AutofillUpdatingExistingCredentialsDialogFragment : BottomSheetDialogFragm
                 it.putParcelable(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIALS, credentials)
                 it.putParcelable(CredentialUpdateExistingCredentialsDialog.KEY_CREDENTIAL_UPDATE_TYPE, getUpdateType())
             }
-            parentFragment?.setFragmentResult(CredentialUpdateExistingCredentialsDialog.resultKey(getTabId()), result)
+            parentFragment?.setFragmentResult(CredentialUpdateExistingCredentialsDialog.resultKeyCredentialUpdated(getTabId()), result)
 
             ignoreCancellationEvents = true
             animateClosed()
@@ -170,7 +170,7 @@ class AutofillUpdatingExistingCredentialsDialogFragment : BottomSheetDialogFragm
         }
 
         Timber.v("onCancel: AutofillUpdatingExistingCredentialsDialogFragment. User declined to update credentials")
-
+        parentFragment?.setFragmentResult(CredentialUpdateExistingCredentialsDialog.resultKeyPromptDismissed(getTabId()), Bundle())
         pixelNameDialogEvent(Dismissed)?.let { pixel.fire(it) }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204135366588349/f

### Description
We don't want the fireproofing prompts and autofill prompts to collide as it hurts the UX to have a barrage of prompts. This PR adds a suppression to fireproofing prompts such that fireproofing prompts will not show:
- if the autofill save/update dialog is currently showing
- if the autofill save/update dialog was shown in the last 10 seconds (counted from time it is dismissed)

### Steps to test this PR

Logcat filter: `canPromptUserAboutFireproofing|RealAutofillFireproofDialogSuppressor`

#### Ensure fireproofing suppressed when autofill save dialog showing
- Visit https://fill.dev/form/login-simple and attempt a login. Don't dismiss the autofill dialog.
- Verify autofill save dialog is showing; also verify in logcat that dialog is showing (`dialog visibility changed to true`)
- Verify fireproofing prompt is **not** shown; also verify in logcat it was suppressed (`isAutofillPreventingFireproofPrompts: true`)
- dismiss autofill save prompt without saving, and go back to login form

#### Ensure fireproofing suppressed when autofill save dialog recently hidden
- repeat the above but this time dismiss the autofill save prompt quickly (ASAP)
- verify fireproofing prompt is suppressed, and logs indicate it's not because autofill dialog is showing but is suppresesed because of the timer e.g., `isAutofillPreventingFireproofPrompts: true (autofillDialogShowing=false, timeSinceLastDismissed=1011ms)`

#### Ensure fireproofing prompt shown when save/update dialog not shown
- Visit https://fill.dev/form/login-simple and attempt a login. Save the login
- Wait 10s
- Visit https://fill.dev/form/login-simple again and autofill using saved login
- Verify fireproofing prompt is shown

#### Ensure fireproofing prompt not shown when updating a password for a login
- Visit https://fill.dev/form/login-simple and attempt a login using the **same username** as is already saved with a **different password**
- Verify you see the "update password" dialog
- Verify fireproofing dialog is suppressed (`isAutofillPreventingFireproofPrompts: true (autofillDialogShowing=true)`)

#### Ensuring firproofing dialog will shown after time elapsed
- change BrowserTabViewModel, add this to line 582 (just after the coroutine launch): `delay(15_000)`
- Visit https://fill.dev/form/login-simple and attempt a login. Immediately dismiss the autofill dialog.
- wait 15s
- verify fireproofing prompt appears