### PR TITLE
Remove synthetics from BrowserTabFragment

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -44,6 +44,7 @@ import android.webkit.WebView.HitTestResult
 import android.webkit.WebView.HitTestResult.*
 import android.widget.Button
 import android.widget.EditText
+import android.widget.FrameLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.AnyThread
@@ -438,6 +439,8 @@ class BrowserTabFragment :
 
     private lateinit var quickAccessItems: IncludeQuickAccessItemsBinding
 
+    private lateinit var webViewContainer: FrameLayout
+
     private val findInPage
         get() = omnibar.findInPage
 
@@ -606,6 +609,7 @@ class BrowserTabFragment :
         super.onActivityCreated(savedInstanceState)
         omnibar = IncludeOmnibarToolbarBinding.bind(binding.rootView)
         quickAccessItems = IncludeQuickAccessItemsBinding.bind(binding.rootView)
+        webViewContainer = binding.webViewContainer
         configureObservers()
         configurePrivacyShield()
         configureWebView()
@@ -2352,7 +2356,7 @@ class BrowserTabFragment :
     }
 
     private fun destroyWebView() {
-        binding.webViewContainer?.removeAllViews()
+        webViewContainer.removeAllViews()
         webView?.destroy()
         webView = null
     }

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -59,7 +59,9 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:visibility="visible" />
 
-    <include layout="@layout/include_new_browser_tab"
+    <include
+        android:id="@+id/includeNewBrowserTab"
+        layout="@layout/include_new_browser_tab"
         android:visibility="gone"/>
 
     <FrameLayout

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -75,6 +75,7 @@
         </LinearLayout>
 
         <include
+            android:id="@+id/includeDaxDialogCta"
             layout="@layout/include_dax_dialog_cta"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/include_omnibar_toolbar.xml
+++ b/app/src/main/res/layout/include_omnibar_toolbar.xml
@@ -281,6 +281,7 @@
             </FrameLayout>
 
             <include
+                android:id="@+id/findInPage"
                 layout="@layout/include_find_in_page"
                 android:layout_width="0dp"
                 android:layout_height="?attr/actionBarSize"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203992423492236/f

### Description
Removes Kotlin synthetics from the `BrowserTabFragment`.

### Steps to test this PR
- [x] Smoke test
