### PR TITLE
Android: Replace secondary button with ghost button

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/res/layout/content_vpn_always_on_alert.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/content_vpn_always_on_alert.xml
@@ -83,7 +83,7 @@
             android:text="@string/atp_PromoteAlwaysOnDialogSettings"
         />
 
-        <com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
+        <com.duckduckgo.mobile.android.ui.view.button.DaxButtonGhost
             android:id="@+id/notNowButton"
             app:buttonSize="large"
             android:layout_width="match_parent"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1204228915007823/f

### Description
Replaced button style in Set Always-on bottom sheet.

### Steps to test this PR

- [ ] Install from this branch.
- [ ] Enable AppTP.
- [ ] Disable AppTP.
- [ ] Enable AppTP.
- [ ] Disable AppTP.
- [ ] You should see the prompt to enable Always ON and the second button should be a `ghost button`.

### UI changes
| Before  (Light mode)| After (Light mode) |
| ------ | ----- |
|![always_on_before_light](https://user-images.githubusercontent.com/7963079/226712105-7e2139b4-aaa7-49fc-abda-50cd6acdfd0a.png)|![always_on_after_light](https://user-images.githubusercontent.com/7963079/226712137-5d66272b-7ca8-40a5-89dc-6e1f21fb461a.png)|


| Before  (Dark mode)| After (Dark mode) |
| ------ | ----- |
|![always_on_before_dark](https://user-images.githubusercontent.com/7963079/226712206-3a7c0be6-5faa-4ef8-8b34-69c10fa92d7d.png)|![always_on_after_dark](https://user-images.githubusercontent.com/7963079/226712215-8b87a9cc-c368-4127-947a-f041c481ed1b.png)|



