### PR TITLE
Update copy, as per copy review

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -22,7 +22,7 @@
     <string name="autofillLoginUpdatedSnackbarMessage">Login updated</string>
     <string name="autofillDisableAutofillPromptTitle">Do you want to keep saving Logins?</string>
     <string name="autofillDisableAutofillPromptMessage">You can disable this at any time in Settings.</string>
-    <string name="autofillDisableAutofillPromptPositiveButton">Keep using</string>
+    <string name="autofillDisableAutofillPromptPositiveButton">Keep Saving</string>
     <string name="autofillDisableAutofillPromptNegativeButton">Disable</string>
 
     <!-- We won't have a translation for this, to be used later. -->

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/updating/AutofillUpdatingExistingCredentialViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/updating/AutofillUpdatingExistingCredentialViewModel.kt
@@ -18,14 +18,21 @@ package com.duckduckgo.autofill.impl.ui.credential.updating
 
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
-import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
 
 @ContributesViewModel(FragmentScope::class)
 class AutofillUpdatingExistingCredentialViewModel @Inject constructor() : ViewModel() {
 
-    fun convertPasswordToMaskedView(credentials: LoginCredentials): String {
-        return credentials.password?.toCharArray()?.joinToString(separator = "") { "•" } ?: ""
+    fun ellipsizeIfNecessary(username: String): String {
+        return if (username.length > USERNAME_MAX_LENGTH) {
+            username.take(USERNAME_MAX_LENGTH - 1) + Typography.ellipsis
+        } else {
+            username
+        }
+    }
+
+    companion object {
+        private const val USERNAME_MAX_LENGTH = 50
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/updating/AutofillUpdatingExistingCredentialsDialogFragment.kt
@@ -113,7 +113,11 @@ class AutofillUpdatingExistingCredentialsDialogFragment : BottomSheetDialogFragm
     ) {
         binding.dialogTitle.text = when (updateType) {
             CredentialUpdateType.Username -> getString(R.string.updateLoginDialogTitleUpdateUsername)
-            CredentialUpdateType.Password -> getString(R.string.updateLoginDialogTitle)
+            CredentialUpdateType.Password -> {
+                val username = (getCredentialsToSave().username ?: "")
+                val usernameLine = viewModel.ellipsizeIfNecessary(username)
+                getString(R.string.updateLoginDialogTitleLine, usernameLine)
+            }
         }
     }
 
@@ -148,9 +152,9 @@ class AutofillUpdatingExistingCredentialsDialogFragment : BottomSheetDialogFragm
         credentials: LoginCredentials,
         updateType: CredentialUpdateType,
     ) {
-        binding.updatedFieldPreview.text = when (updateType) {
+        binding.dialogSubtitle.text = when (updateType) {
             CredentialUpdateType.Username -> credentials.username
-            CredentialUpdateType.Password -> viewModel.convertPasswordToMaskedView(credentials)
+            CredentialUpdateType.Password -> getString(R.string.updateLoginUpdatePasswordExplanation)
         }
     }
 

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_update_existing_credentials.xml
@@ -58,31 +58,30 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:id="@+id/dialogTitle"
-            android:text="@string/updateLoginDialogTitle"
             android:layout_marginTop="@dimen/keyline_5"
+            android:layout_marginStart="@dimen/keyline_4"
+            android:layout_marginEnd="@dimen/keyline_4"
+            tools:text="Update password for\nUSERNAME?"
             android:gravity="center_horizontal"
-            app:layout_constraintBottom_toTopOf="@id/updatedFieldPreview"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/dialogSubtitle"
+            app:layout_constraintEnd_toEndOf="@id/updateCredentialsButton"
+            app:layout_constraintStart_toStartOf="@id/updateCredentialsButton"
             app:layout_constraintTop_toBottomOf="@id/siteDetailsContainer"
             app:typography="h2" />
 
-        <TextView
-            tools:ignore="DeprecatedWidgetInXml"
-            android:id="@+id/updatedFieldPreview"
+        <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+            android:id="@+id/dialogSubtitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
             android:enabled="false"
-            android:importantForAccessibility="no"
-            android:importantForAutofill="no"
-            android:textAlignment="center"
-            android:textColor="?attr/daxColorPrimaryText"
-            android:textSize="14sp"
+            android:gravity="center_horizontal"
+            app:layout_constraintWidth_percent="0.75"
+            app:typography="body2"
             app:layout_constraintEnd_toEndOf="@id/updateCredentialsButton"
             app:layout_constraintStart_toStartOf="@id/updateCredentialsButton"
             app:layout_constraintTop_toBottomOf="@id/dialogTitle"
-            tools:text="•••••••" />
+            tools:text="@string/updateLoginUpdatePasswordExplanation" />
 
         <com.duckduckgo.mobile.android.ui.view.button.DaxButtonPrimary
             android:id="@+id/updateCredentialsButton"
@@ -93,7 +92,7 @@
             android:text="@string/updateLoginDialogButtonUpdatePassword"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/updatedFieldPreview"
+            app:layout_constraintTop_toBottomOf="@id/dialogSubtitle"
             app:layout_constraintWidth_percent="0.8" />
 
         <com.duckduckgo.mobile.android.ui.view.button.DaxButtonGhost

--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">От този уебсайт</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">От %1$s</string>
 
-    <string name="updateLoginDialogTitle">Актуализиране на паролата?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Актуализиране на паролата</string>
     <string name="updateLoginDialogButtonNotNow">Не сега</string>
 

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Z této webové stránky</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Ze stránky %1$ss</string>
 
-    <string name="updateLoginDialogTitle">Aktualizovat heslo?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Aktualizuj si heslo</string>
     <string name="updateLoginDialogButtonNotNow">Teď ne</string>
 

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Fra dette websted</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Fra %1$s</string>
 
-    <string name="updateLoginDialogTitle">Opdater adgangskode?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Opdater adgangskode</string>
     <string name="updateLoginDialogButtonNotNow">Ikke nu</string>
 

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Von dieser Website</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Von %1$s</string>
 
-    <string name="updateLoginDialogTitle">Passwort aktualisieren?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Passwort aktualisieren</string>
     <string name="updateLoginDialogButtonNotNow">Jetzt nicht</string>
 

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Από αυτόν τον ιστότοπο</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Από %1$s</string>
 
-    <string name="updateLoginDialogTitle">Ενημέρωση κωδικού πρόσβασης;</string>
     <string name="updateLoginDialogButtonUpdatePassword">Ενημέρωση κωδικού πρόσβασης</string>
     <string name="updateLoginDialogButtonNotNow">Όχι τώρα</string>
 

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Desde este sitio web</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Desde %1$s</string>
 
-    <string name="updateLoginDialogTitle">¿Actualizar contraseña?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Actualizar contraseña</string>
     <string name="updateLoginDialogButtonNotNow">Ahora no</string>
 

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Sellelt veebisaidilt</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Saidilt %1$s</string>
 
-    <string name="updateLoginDialogTitle">Kas värskendada parooli?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Värskenda parooli</string>
     <string name="updateLoginDialogButtonNotNow">Mitte praegu</string>
 

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Tältä sivustolta</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Sivustolta %1$s</string>
 
-    <string name="updateLoginDialogTitle">Päivitetäänkö salasana?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Päivitä salasana</string>
     <string name="updateLoginDialogButtonNotNow">Ei nyt</string>
 

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">À partir de ce site Web</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">À partir de %1$s</string>
 
-    <string name="updateLoginDialogTitle">Modifier le mot de passe ?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Modifier le mot de passe</string>
     <string name="updateLoginDialogButtonNotNow">Pas maintenant</string>
 

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">S ove web lokacije</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">S %1$s</string>
 
-    <string name="updateLoginDialogTitle">Želiš li ažurirati lozinku?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Ažuriraj lozinku</string>
     <string name="updateLoginDialogButtonNotNow">Ne sada</string>
 

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Erről a webhelyről</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Innen: %1$s</string>
 
-    <string name="updateLoginDialogTitle">Frissíted a jelszót?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Jelszó frissítése</string>
     <string name="updateLoginDialogButtonNotNow">Most nem</string>
 

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Da questo sito web</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Da %1$s</string>
 
-    <string name="updateLoginDialogTitle">Aggiornare password?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Aggiorna password</string>
     <string name="updateLoginDialogButtonNotNow">Non adesso</string>
 

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Iš šios svetainės</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Iš %1$s</string>
 
-    <string name="updateLoginDialogTitle">Atnaujinti slaptažodį?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Atnaujinti slaptažodį</string>
     <string name="updateLoginDialogButtonNotNow">Ne dabar</string>
 

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">No šīs vietnes</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">No %1$s</string>
 
-    <string name="updateLoginDialogTitle">Atjaunināt paroli?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Atjaunināt paroli</string>
     <string name="updateLoginDialogButtonNotNow">Ne tagad</string>
 

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Fra dette nettstedet</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Fra %1$s</string>
 
-    <string name="updateLoginDialogTitle">Vil du oppdatere passordet?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Oppdater passordet</string>
     <string name="updateLoginDialogButtonNotNow">Ikke nå</string>
 

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Van deze website</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Van %1$s</string>
 
-    <string name="updateLoginDialogTitle">Wachtwoord bijwerken?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Wachtwoord bijwerken</string>
     <string name="updateLoginDialogButtonNotNow">Niet nu</string>
 

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Z tej strony</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Z %1$s</string>
 
-    <string name="updateLoginDialogTitle">Zaktualizować hasło?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Aktualizuj hasło</string>
     <string name="updateLoginDialogButtonNotNow">Nie teraz</string>
 

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Deste site</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">De %1$s</string>
 
-    <string name="updateLoginDialogTitle">Atualizar palavra-passe?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Atualizar palavra-passe</string>
     <string name="updateLoginDialogButtonNotNow">Agora não</string>
 

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">De pe acest site web</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Din %1$s</string>
 
-    <string name="updateLoginDialogTitle">Actualizezi parola?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Actualizează parola</string>
     <string name="updateLoginDialogButtonNotNow">Nu acum</string>
 

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">С этого сайта</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">С %1$s</string>
 
-    <string name="updateLoginDialogTitle">Обновить пароль?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Обновить пароль</string>
     <string name="updateLoginDialogButtonNotNow">Не сейчас</string>
 

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Z tejto webovej lokality</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Z adresy %1$s</string>
 
-    <string name="updateLoginDialogTitle">Aktualizovať heslo?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Aktualizovať heslo</string>
     <string name="updateLoginDialogButtonNotNow">Teraz nie</string>
 

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">S tega spletnega mesta</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">S spletnega mesta %1$s</string>
 
-    <string name="updateLoginDialogTitle">Želite posodobiti geslo?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Posodobitev gesla</string>
     <string name="updateLoginDialogButtonNotNow">Ne zdaj</string>
 

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Från den här webbplatsen</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">Från %1$s</string>
 
-    <string name="updateLoginDialogTitle">Uppdatera lösenord?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Uppdatera lösenord</string>
     <string name="updateLoginDialogButtonNotNow">Inte nu</string>
 

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -38,7 +38,6 @@
     <string name="useSavedLoginDialogGroupThisWebsite">Bu Web Sitesinden</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">%1$s adresinden</string>
 
-    <string name="updateLoginDialogTitle">Şifre Güncellensin mi?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Şifreyi Güncelle</string>
     <string name="updateLoginDialogButtonNotNow">Şimdi Değil</string>
 

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -15,5 +15,6 @@
   -->
 
 <resources>
-
+    <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user's username for this site">Update password for \n%1$s?</string>
+    <string name="updateLoginUpdatePasswordExplanation" >DuckDuckGo will update this stored Login on your device.</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -23,8 +23,8 @@
     <string name="managementDisabledModeSubtitle">A device lock pattern, PIN, or biometrics is required to protect your Logins.</string>
     <string name="managementDisabledModeTitle">Secure your device to save Logins</string>
 
-    <string name="saveLoginDialogTitle">Save Login?</string>
-    <string name="saveLoginMissingUsernameDialogTitle">Save Password?</string>
+    <string name="saveLoginDialogTitle">Save login?</string>
+    <string name="saveLoginMissingUsernameDialogTitle">Save password?</string>
     <string name="saveLoginDialogButtonSave">Save Login</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Save Password</string>
     <string name="saveLoginDialogNotNow">Not Now</string>
@@ -38,11 +38,10 @@
     <string name="useSavedLoginDialogGroupThisWebsite">From This Website</string>
     <string name="useSavedLoginDialogFromDomainLabel" instruction="Placeholder is the URL of a website">From %1$s</string>
 
-    <string name="updateLoginDialogTitle">Update Password?</string>
     <string name="updateLoginDialogButtonUpdatePassword">Update Password</string>
     <string name="updateLoginDialogButtonNotNow">Not Now</string>
 
-    <string name="updateLoginDialogTitleUpdateUsername">Update Username?</string>
+    <string name="updateLoginDialogTitleUpdateUsername">Update username?</string>
     <string name="updateLoginDialogButtonUpdateUsername">Update Username</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Close Autofill Dialog</string>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -32,7 +32,7 @@
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Do you want DuckDuckGo to save your Login?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">More Options</string>
 
-    <string name="useSavedLoginDialogTitle">Use a Saved Login?</string>
+    <string name="useSavedLoginDialogTitle">Use a saved Login?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Login for %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Login for site</string>
     <string name="useSavedLoginDialogGroupThisWebsite">From This Website</string>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -28,7 +28,7 @@
     <string name="saveLoginDialogButtonSave">Save Login</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Save Password</string>
     <string name="saveLoginDialogNotNow">Not Now</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo will securely store this Login on your device. You can manage saved Logins in Settings.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Logins are stored securely on this device only, and can be managed from the Logins menu in Settings.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Do you want DuckDuckGo to save your Login?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">More Options</string>
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/updating/AutofillUpdatingExistingCredentialViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/updating/AutofillUpdatingExistingCredentialViewModelTest.kt
@@ -16,8 +16,8 @@
 
 package com.duckduckgo.autofill.impl.ui.credential.updating
 
-import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -26,20 +26,33 @@ class AutofillUpdatingExistingCredentialViewModelTest {
     private val testee = AutofillUpdatingExistingCredentialViewModel()
 
     @Test
-    fun whenCredentialsAreEmptyThenEmptyStringReturned() {
-        val credentials = credentials(password = "")
-        val actual = testee.convertPasswordToMaskedView(credentials)
-        assertTrue(actual.isEmpty())
+    fun whenUsernameIsShortThenNoEllipsizing() {
+        val result = testee.ellipsizeIfNecessary("foo")
+        result.assertDoesNotEndInEllipsis()
+        assertEquals("foo", result)
     }
 
     @Test
-    fun whenCredentialsAreNotEmptyThenMaskedCharactersReturned() {
-        val credentials = credentials(password = "hello")
-        val actual = testee.convertPasswordToMaskedView(credentials)
-        assertEquals("•••••", actual)
+    fun whenUsernameIsExactlyOnLimitThenNoEllipsizing() {
+        val usernameExactlyAsLongAsLimit = "A".repeat(50)
+        val result = testee.ellipsizeIfNecessary(usernameExactlyAsLongAsLimit)
+        result.assertDoesNotEndInEllipsis()
+        assertEquals(usernameExactlyAsLongAsLimit, result)
     }
 
-    private fun credentials(password: String?): LoginCredentials {
-        return LoginCredentials(password = password, username = null, domain = null)
+    @Test
+    fun whenUsernameIsLongerThanLimitThenEllipsizing() {
+        val usernameLongerThanLimit = "A".repeat(51)
+        val result = testee.ellipsizeIfNecessary(usernameLongerThanLimit)
+        result.assertEndsInEllipsis()
+        assertEquals(50, result.length)
+    }
+
+    private fun String.assertEndsInEllipsis() {
+        assertTrue(endsWith(Typography.ellipsis))
+    }
+
+    private fun String.assertDoesNotEndInEllipsis() {
+        assertFalse(endsWith(Typography.ellipsis))
     }
 }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -211,9 +211,9 @@ class SecureStoreBackedAutofillStore(
         credentials.forEach {
             urlMatch = true
 
-            if (it.details.username == null && it.password != null && it.password == password) {
+            if (usernameMissing(it, username, password)) {
                 missingUsername = true
-            } else if (it.details.username == username) {
+            } else if (usernameMatch(it, username)) {
                 usernameMatchFound = true
                 if (it.password == password) {
                     exactMatchFound = true
@@ -221,7 +221,7 @@ class SecureStoreBackedAutofillStore(
             }
         }
 
-        return if (exactMatchFound) {
+        val matchType = if (exactMatchFound) {
             ContainsCredentialsResult.ExactMatch
         } else if (usernameMatchFound) {
             ContainsCredentialsResult.UsernameMatch
@@ -232,6 +232,27 @@ class SecureStoreBackedAutofillStore(
         } else {
             NoMatch
         }
+
+        Timber.v("Determined match type is %s", matchType.javaClass.simpleName)
+        return matchType
+    }
+
+    private fun usernameMatch(
+        it: WebsiteLoginDetailsWithCredentials,
+        username: String?,
+    ): Boolean {
+        return it.details.username != null && it.details.username == username
+    }
+
+    private fun usernameMissing(
+        it: WebsiteLoginDetailsWithCredentials,
+        username: String?,
+        password: String?,
+    ): Boolean {
+        return it.details.username == null &&
+            !username.isNullOrEmpty() &&
+            it.password != null &&
+            it.password == password
     }
 
     private fun WebsiteLoginDetailsWithCredentials.toLoginCredentials(): LoginCredentials {

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStore.kt
@@ -238,21 +238,21 @@ class SecureStoreBackedAutofillStore(
     }
 
     private fun usernameMatch(
-        it: WebsiteLoginDetailsWithCredentials,
+        credentials: WebsiteLoginDetailsWithCredentials,
         username: String?,
     ): Boolean {
-        return it.details.username != null && it.details.username == username
+        return credentials.details.username != null && credentials.details.username == username
     }
 
     private fun usernameMissing(
-        it: WebsiteLoginDetailsWithCredentials,
+        credentials: WebsiteLoginDetailsWithCredentials,
         username: String?,
         password: String?,
     ): Boolean {
-        return it.details.username == null &&
+        return credentials.details.username == null &&
             !username.isNullOrEmpty() &&
-            it.password != null &&
-            it.password == password
+            credentials.password != null &&
+            credentials.password == password
     }
 
     private fun WebsiteLoginDetailsWithCredentials.toLoginCredentials(): LoginCredentials {

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -184,6 +184,14 @@ class SecureStoreBackedAutofillStoreTest {
     }
 
     @Test
+    fun whenXXX() = runTest {
+        setupTesteeWithAutofillAvailable()
+        storeCredentials(1, "https://example.com", username = null, password = "password")
+        val result = testee.containsCredentials("example.com", username = null, password = "differentPassword")
+        assertUrlOnlyMatch(result)
+    }
+
+    @Test
     fun whenPasswordIsUpdatedForUrlThenUpdatedOnlyMatchingCredential() = runTest {
         setupTesteeWithAutofillAvailable()
         val url = "https://example.com"
@@ -467,23 +475,23 @@ class SecureStoreBackedAutofillStoreTest {
     }
 
     private fun assertNotMatch(result: ContainsCredentialsResult) {
-        assertTrue(String.format("Expected NoMatch but was %s", result), result is NoMatch)
+        assertTrue(String.format("Expected NoMatch but was %s", result.javaClass.simpleName), result is NoMatch)
     }
 
     private fun assertUrlOnlyMatch(result: ContainsCredentialsResult) {
-        assertTrue(String.format("Expected UrlOnlyMatch but was %s", result), result is UrlOnlyMatch)
+        assertTrue(String.format("Expected UrlOnlyMatch but was %s", result.javaClass.simpleName), result is UrlOnlyMatch)
     }
 
     private fun assertUsernameMissing(result: ContainsCredentialsResult) {
-        assertTrue(String.format("Expected UsernameMissing but was %s", result), result is UsernameMissing)
+        assertTrue(String.format("Expected UsernameMissing but was %s", result.javaClass.simpleName), result is UsernameMissing)
     }
 
     private fun assertUsernameMatch(result: ContainsCredentialsResult) {
-        assertTrue(String.format("Expected UsernameMatch but was %s", result), result is UsernameMatch)
+        assertTrue(String.format("Expected UsernameMatch but was %s", result.javaClass.simpleName), result is UsernameMatch)
     }
 
     private fun assertExactMatch(result: ContainsCredentialsResult) {
-        assertTrue(String.format("Expected ExactMatch but was %s", result), result is ExactMatch)
+        assertTrue(String.format("Expected ExactMatch but was %s", result.javaClass.simpleName), result is ExactMatch)
     }
 
     private suspend fun storeCredentials(

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -184,7 +184,7 @@ class SecureStoreBackedAutofillStoreTest {
     }
 
     @Test
-    fun whenXXX() = runTest {
+    fun whenStoredCredentialMissingUsernameAndStoringACredentialWithNoUsernameThenUrlOnlyMatch() = runTest {
         setupTesteeWithAutofillAvailable()
         storeCredentials(1, "https://example.com", username = null, password = "password")
         val result = testee.containsCredentials("example.com", username = null, password = "differentPassword")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204249507177252/f

### Description
Updates some copy, as was highlighted in copy review.

- Update dialog title to have desired casing
- Update onboardindg subtitle
- Update button on prompt to disable autofill to read "Keep Saving" instead of "Keep using"
- Update the dialog for updating password to add more explanation, and include username in title

Translations to follow in another PR.

### Steps to test this PR

- [x] Visit https://fill.dev/form/login-simple and attempt a login with any credentials; verify that the dialog which appears offering to save the login has this updated explanation: `Logins are stored securely on this device only, and can be managed from the Logins menu in Settings.`
- [x] Save the login and go back to the login page again (and refresh)
- [x] Verify that the dialog which appears offering to autofill the login has the word `saved` in all lowercase. Dismiss the dialog
- [x] Try another login, but this time enter the same username as you already have saved with a **different password**; verify the "update password" dialog includes the username in the title and has the new copy for the explanation: `DuckDuckGo will update this stored Login on your device.`
- [x] Repeat the above (save a login, then login again with a different password for it) with a **long username** (over 50 characters); verify it ellipsizes the username while preserving the final `?` at the end of the string
