### PR TITLE
Fix crash when accessing settings (nightly builds)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/sync/FakeDeviceSyncState.kt
+++ b/app/src/main/java/com/duckduckgo/app/sync/FakeDeviceSyncState.kt
@@ -26,7 +26,8 @@ import javax.inject.*
  */
 @ContributesBinding(
     scope = AppScope::class,
-    priority = ContributesBinding.Priority.NORMAL,
+    // mitigation for https://app.asana.com/0/414730916066338/1204248963638410/f
+    priority = ContributesBinding.Priority.HIGHEST,
 )
 class FakeDeviceSyncState @Inject constructor() : DeviceSyncState {
     override fun isFeatureEnabled(): Boolean = false

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AppDeviceSyncState.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AppDeviceSyncState.kt
@@ -27,7 +27,8 @@ import javax.inject.*
 @ContributesBinding(
     scope = AppScope::class,
     boundType = DeviceSyncState::class,
-    priority = ContributesBinding.Priority.HIGHEST,
+    // mitigation for https://app.asana.com/0/414730916066338/1204248963638410/f
+    priority = ContributesBinding.Priority.NORMAL,
 )
 class AppDeviceSyncState @Inject constructor(
     private val appBuildConfig: AppBuildConfig,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1204248963638410/f 

### Description
Just mitigation for nightly builds crashing when accessing settings.

### Steps to test this PR

_Feature 1_
- [x] Go to https://app.asana.com/0/0/1204248963638410/1204249674828557/f
- [x] Access jenkins
- [x] Download internal nightly build
- [x] test settings doesn't crash

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
