### PR TITLE
Subtitle on auth dialogs should be different depending on use case

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autofill/AutofillCredentialsSelectionResultHandler.kt
@@ -42,7 +42,7 @@ import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Error
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Success
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.UserCancelled
-import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL_TO_USE_CREDENTIALS
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -75,7 +75,7 @@ class AutofillCredentialsSelectionResultHandler @Inject constructor(
         val selectedCredentials = result.getParcelable<LoginCredentials>(CredentialAutofillPickerDialog.KEY_CREDENTIALS) ?: return
 
         pixel.fire(AUTOFILL_AUTHENTICATION_TO_AUTOFILL_SHOWN)
-        deviceAuthenticator.authenticate(AUTOFILL, browserTabFragment) {
+        deviceAuthenticator.authenticate(AUTOFILL_TO_USE_CREDENTIALS, browserTabFragment) {
             when (it) {
                 Success -> {
                     Timber.v("Autofill: user selected credential to use, and successfully authenticated")

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -59,7 +59,7 @@ import com.duckduckgo.deviceauth.api.DeviceAuthenticator
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Error
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.Success
 import com.duckduckgo.deviceauth.api.DeviceAuthenticator.AuthResult.UserCancelled
-import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL_TO_ACCESS_CREDENTIALS
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.ui.view.SearchBar
@@ -123,7 +123,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
     private fun launchDeviceAuth() {
         viewModel.lock()
 
-        deviceAuthenticator.authenticate(AUTOFILL, this) {
+        deviceAuthenticator.authenticate(AUTOFILL_TO_ACCESS_CREDENTIALS, this) {
             when (it) {
                 Success -> onAuthenticationSuccessful()
                 UserCancelled -> onAuthenticationCancelled()

--- a/device-auth/device-auth-api/src/main/java/com/duckduckgo/deviceauth/api/DeviceAuthenticator.kt
+++ b/device-auth/device-auth-api/src/main/java/com/duckduckgo/deviceauth/api/DeviceAuthenticator.kt
@@ -52,6 +52,7 @@ interface DeviceAuthenticator {
     }
 
     enum class Features {
-        AUTOFILL,
+        AUTOFILL_TO_USE_CREDENTIALS,
+        AUTOFILL_TO_ACCESS_CREDENTIALS,
     }
 }

--- a/device-auth/device-auth-impl/build.gradle
+++ b/device-auth/device-auth-impl/build.gradle
@@ -33,11 +33,17 @@ dependencies {
 
     testImplementation Testing.junit4
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+    testImplementation project(path: ':common-test')
 }
 
 android {
     anvil {
         generateDaggerFactories = true // default is false
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
     }
   namespace 'com.duckduckgo.deviceauth.impl'
 }

--- a/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticator.kt
+++ b/device-auth/device-auth-impl/src/main/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticator.kt
@@ -73,6 +73,7 @@ class RealDeviceAuthenticator @Inject constructor(
     private fun getAuthText(
         feature: Features,
     ): Int = when (feature) {
-        Features.AUTOFILL -> R.string.autofill_auth_text
+        Features.AUTOFILL_TO_USE_CREDENTIALS -> R.string.autofill_auth_text_for_using
+        Features.AUTOFILL_TO_ACCESS_CREDENTIALS -> R.string.autofill_auth_text_for_access
     }
 }

--- a/device-auth/device-auth-impl/src/main/res/values-bg/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-bg/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Отключете устройството, за да използвате запазените данни за вход.</string>
     <string name="biometric_prompt_title">Автоматичното попълване е заключено</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-cs/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-cs/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Jestli chceš používat svá uložená jména a hesla, zařízení odemkni.</string>
     <string name="biometric_prompt_title">Automatické vyplňování je zamčené</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-da/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-da/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Lås enheden op for at bruge dine gemte logins.</string>
     <string name="biometric_prompt_title">Automatisk udfyldning låst</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-de/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-de/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Schalte das Gerät frei, um deine gespeicherten Logins zu verwenden.</string>
     <string name="biometric_prompt_title">Automatisches Ausfüllen gesperrt</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-el/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-el/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Ξεκλειδώστε τη συσκευή για να χρησιμοποιήσετε τα αποθηκευμένα στοιχεία σύνδεσής σας.</string>
     <string name="biometric_prompt_title">Η αυτόματη συμπλήρωση είναι κλειδωμένη</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-es/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-es/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Desbloquea el dispositivo para usar tus inicios de sesión guardados.</string>
     <string name="biometric_prompt_title">Función de autocompletar bloqueada</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-et/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-et/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Salvestatud sisselogimisandmete kasutamiseks ava seade.</string>
     <string name="biometric_prompt_title">Automaatsisestus on lukustatud</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-fi/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-fi/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Avaa laite, jotta voit käyttää tallennettuja kirjautumistietoja.</string>
     <string name="biometric_prompt_title">Automaattinen täyttö lukittu</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-fr/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-fr/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Déverrouillez l\'appareil pour utiliser vos identifiants enregistrés.</string>
     <string name="biometric_prompt_title">Saisie automatique verrouillée</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-hr/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-hr/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Otključaj uređaj za korištenje spremljenih prijava.</string>
     <string name="biometric_prompt_title">Automatsko popunjavanje zaključano</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-hu/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-hu/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">A mentett bejelentkezések használatához oldd fel az eszköz zárolását.</string>
     <string name="biometric_prompt_title">Automatikus kitöltés zárolva</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-it/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-it/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Sblocca il dispositivo per utilizzare gli accessi salvati.</string>
     <string name="biometric_prompt_title">Compilazione automatica bloccata</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-lt/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-lt/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Atrakinkite įrenginį, kad galėtumėte naudoti išsaugotus prisijungimus.</string>
     <string name="biometric_prompt_title">Automatinis užpildymas užrakintas</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-nb/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-nb/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Lås opp enheten for å bruke lagrede pålogginger.</string>
     <string name="biometric_prompt_title">Autofyll er låst</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-nl/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-nl/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Ontgrendel apparaat om je opgeslagen aanmeldgegevens te gebruiken.</string>
     <string name="biometric_prompt_title">Automatisch invullen vergrendeld</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-pl/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-pl/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Odblokuj urządzenie, aby użyć zapisanych loginów.</string>
     <string name="biometric_prompt_title">Automatyczne wypełnianie zablokowane</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-pt/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-pt/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Desbloqueia o dispositivo para utilizares os teus inícios de sessão guardados.</string>
     <string name="biometric_prompt_title">Preenchimento automático bloqueado</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-ro/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-ro/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Deblochează dispozitivul pentru a utiliza datele de conectare salvate.</string>
     <string name="biometric_prompt_title">Completare automată blocată</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-ru/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-ru/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Чтобы использовать сохраненные учетные данные, разблокируйте устройство.</string>
     <string name="biometric_prompt_title">Автозаполнение заблокировано</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-sk/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-sk/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Na použite uložených prihlásení odomknite zariadenie.</string>
     <string name="biometric_prompt_title">Automatické dopĺňanie je uzamknuté</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-sl/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-sl/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Odklenite napravo, če želite uporabiti shranjene podatke za prijavo.</string>
     <string name="biometric_prompt_title">Samodejno izpolnjevanje je zaklenjeno</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-sv/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-sv/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Lås upp enheten för att använda dina sparade inloggningar.</string>
     <string name="biometric_prompt_title">Automatisk ifyllning låst</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-tr/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-tr/strings-device-auth.xml
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Kayıtlı girişlerinizi kullanmak için cihazın kilidini açın.</string>
     <string name="biometric_prompt_title">Otomatik Doldurma Kilitli</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values/donottranslate.xml
+++ b/device-auth/device-auth-impl/src/main/res/values/donottranslate.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2022 DuckDuckGo
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,8 +13,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<!-- smartling.entity_escaping = false -->
-<!-- smartling.instruction_attributes = instruction -->
+
 <resources>
-    <string name="biometric_prompt_title">Automātiskā aizpildīšana bloķēta</string>
+    <string name="autofill_auth_text_for_using">Unlock device to use your saved Logins.</string>
+    <string name="autofill_auth_text_for_access">Unlock device to access saved Logins.</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values/strings-device-auth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,6 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofill_auth_text">Unlock device to use your saved logins.</string>
     <string name="biometric_prompt_title">Logins Locked</string>
 </resources>

--- a/device-auth/device-auth-impl/src/test/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticatorTest.kt
+++ b/device-auth/device-auth-impl/src/test/java/com/duckduckgo/deviceauth/impl/RealDeviceAuthenticatorTest.kt
@@ -20,7 +20,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.deviceauth.api.AutofillAuthorizationGracePeriod
-import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL_TO_ACCESS_CREDENTIALS
+import com.duckduckgo.deviceauth.api.DeviceAuthenticator.Features.AUTOFILL_TO_USE_CREDENTIALS
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -93,23 +94,41 @@ class RealDeviceAuthenticatorTest {
     }
 
     @Test
-    fun whenAuthenticateIsCalledWithFragmentThenLaunchAuthLauncher() {
-        testee.authenticate(AUTOFILL, fragment) {}
+    fun whenAuthenticateToAccessCredentialsIsCalledWithFragmentThenLaunchAuthLauncher() {
+        testee.authenticate(AUTOFILL_TO_ACCESS_CREDENTIALS, fragment) {}
 
-        verify(authLauncher).launch(eq(R.string.autofill_auth_text), eq(fragment), any())
+        verify(authLauncher).launch(eq(R.string.autofill_auth_text_for_access), eq(fragment), any())
     }
 
     @Test
-    fun whenAuthenticateIsCalledWithActivityThenLaunchAuthLauncher() {
-        testee.authenticate(AUTOFILL, fragment) {}
-
-        verify(authLauncher).launch(eq(R.string.autofill_auth_text), eq(fragment), any())
+    fun whenAuthenticateToUseCredentialsIsCalledWithFragmentThenLaunchAuthLauncher() {
+        testee.authenticate(AUTOFILL_TO_USE_CREDENTIALS, fragment) {}
+        verify(authLauncher).launch(eq(R.string.autofill_auth_text_for_using), eq(fragment), any())
     }
 
     @Test
-    fun whenAuthGracePeriodActiveThenNoDeviceAuthLaunched() {
+    fun whenAuthenticateToAccessCredentialsIsCalledWithActivityThenLaunchAuthLauncher() {
+        testee.authenticate(AUTOFILL_TO_ACCESS_CREDENTIALS, fragment) {}
+        verify(authLauncher).launch(eq(R.string.autofill_auth_text_for_access), eq(fragment), any())
+    }
+
+    @Test
+    fun whenAuthenticateToUseCredentialsIsCalledWithActivityThenLaunchAuthLauncher() {
+        testee.authenticate(AUTOFILL_TO_USE_CREDENTIALS, fragment) {}
+        verify(authLauncher).launch(eq(R.string.autofill_auth_text_for_using), eq(fragment), any())
+    }
+
+    @Test
+    fun whenAuthGracePeriodActiveThenNoDeviceAuthLaunchedWhenUsingCredentials() {
         whenever(autofillAuthorizationGracePeriod.isAuthRequired()).thenReturn(false)
-        testee.authenticate(AUTOFILL, fragmentActivity) {}
+        testee.authenticate(AUTOFILL_TO_USE_CREDENTIALS, fragmentActivity) {}
+        verifyAuthNotLaunched()
+    }
+
+    @Test
+    fun whenAuthGracePeriodActiveThenNoDeviceAuthLaunchedWhenAccessingCredentials() {
+        whenever(autofillAuthorizationGracePeriod.isAuthRequired()).thenReturn(false)
+        testee.authenticate(AUTOFILL_TO_ACCESS_CREDENTIALS, fragmentActivity) {}
         verifyAuthNotLaunched()
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1203115518054842/1204258140066144/f

### Description
Updates text shown when autofill authentication dialog is showing, depending on the use case:
- Accessing the credential management screen: `Unlock device to access saved Logins.`
- Trying to inject credentials into webpage: `Unlock device to use your saved Logins.`

Translations to follow in a separate PR; there is a string removed across all languages as it will be re-translated in the follow up PR.

### Steps to test this PR

- [x] Visit the credential management screen (overflow-->Logins)
- [x] (If you have no logins, you won't be prompted to auth so manually add one then exit screen. Do `#1` again)
- [x] When prompted to authenticate, verify the text reads `Unlock device to access saved Logins.`
- [x] Visit https://fill.dev/form/login-simple and attempt a login; save the credentials when prompted
- [x] Go back and accept the prompt to use a saved login
- [x] When prompted to authenticate, verify the text reads `Unlock device to use your saved Logins.`
