### PR TITLE
Followup: New temporary pixels for "Notify Me" component / Follow-up: remove parameter for Android13

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -203,8 +203,5 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
     ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR("m_atp_ev_apptp_create_network_stack_error_c"),
     ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR_DAILY("m_atp_ev_apptp_create_network_stack_error_d"),
 
-    ATP_DID_PRESS_NOTIFY_ME_BUTTON("m_notify_me_component_notify_me_button_pressed"),
-    ATP_DID_PRESS_NOTIFY_ME_DISMISS_BUTTON("m_notify_me_component_close_button_pressed"),
-
     ;
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -338,10 +338,6 @@ interface DeviceShieldPixels {
     fun didPressOnAppTpEnabledCtaButton()
 
     fun reportErrorCreatingVpnNetworkStack()
-
-    fun didPressOnNotifyMeButton(metadata: Map<String, String>)
-
-    fun didPressOnNotifyMeDismissButton(metadata: Map<String, String>)
 }
 
 @ContributesBinding(AppScope::class)
@@ -751,14 +747,6 @@ class RealDeviceShieldPixels @Inject constructor(
     override fun reportErrorCreatingVpnNetworkStack() {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR_DAILY)
         firePixel(DeviceShieldPixelNames.ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR)
-    }
-
-    override fun didPressOnNotifyMeButton(metadata: Map<String, String>) {
-        firePixel(DeviceShieldPixelNames.ATP_DID_PRESS_NOTIFY_ME_BUTTON, metadata)
-    }
-
-    override fun didPressOnNotifyMeDismissButton(metadata: Map<String, String>) {
-        firePixel(DeviceShieldPixelNames.ATP_DID_PRESS_NOTIFY_ME_DISMISS_BUTTON, metadata)
     }
 
     private fun firePixel(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -155,14 +155,6 @@ class DeviceShieldTrackerActivity :
         binding.ctaShowAll.setOnClickListener {
             viewModel.onViewEvent(ViewEvent.LaunchMostRecentActivity)
         }
-
-        binding.deviceShieldTrackerNotifyMe.onNotifyMeClicked {
-            viewModel.onViewEvent(ViewEvent.NotifyMeClicked)
-        }
-
-        binding.deviceShieldTrackerNotifyMe.onDismissClicked {
-            viewModel.onViewEvent(ViewEvent.NotifyMeDismissClicked)
-        }
     }
 
     override fun onActivityResult(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModel.kt
@@ -154,8 +154,6 @@ class DeviceShieldTrackerActivityViewModel @Inject constructor(
             ViewEvent.PromoteAlwaysOnCancelled -> onAlwaysOnPromotionDialogCancelled()
             is ViewEvent.AlwaysOnInitialState -> onAlwaysOnInitialState(viewEvent.alwaysOnState)
             ViewEvent.LaunchTrackingProtectionExclusionListActivity -> sendCommand(Command.LaunchTrackingProtectionExclusionListActivity)
-            ViewEvent.NotifyMeClicked -> firePixel(viewEvent)
-            ViewEvent.NotifyMeDismissClicked -> firePixel(viewEvent)
         }
     }
 
@@ -192,15 +190,6 @@ class DeviceShieldTrackerActivityViewModel @Inject constructor(
             if (alwaysOnState.enabled && alwaysOnState.lockedDown) {
                 sendCommand(Command.ShowAlwaysOnLockdownWarningDialog)
             }
-        }
-    }
-
-    private fun firePixel(viewEvent: ViewEvent) {
-        val metadata = mapOf(PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_NAME to PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_VALUE)
-        if (viewEvent == ViewEvent.NotifyMeClicked) {
-            deviceShieldPixels.didPressOnNotifyMeButton(metadata)
-        } else if (viewEvent == ViewEvent.NotifyMeDismissClicked) {
-            deviceShieldPixels.didPressOnNotifyMeDismissButton(metadata)
         }
     }
 
@@ -245,8 +234,6 @@ class DeviceShieldTrackerActivityViewModel @Inject constructor(
         object RemoveFeature : ViewEvent()
         object StartVpn : ViewEvent()
         object AskToRemoveFeature : ViewEvent()
-        object NotifyMeClicked : ViewEvent()
-        object NotifyMeDismissClicked : ViewEvent()
 
         object PromoteAlwaysOnOpenSettings : ViewEvent()
         object PromoteAlwaysOnCancelled : ViewEvent()
@@ -273,11 +260,6 @@ class DeviceShieldTrackerActivityViewModel @Inject constructor(
         object CloseScreen : Command()
         object OpenVpnSettings : Command()
         object ShowAppTpEnabledCta : Command()
-    }
-
-    companion object {
-        internal const val PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_NAME = "from_screen"
-        internal const val PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_VALUE = "apptp"
     }
 }
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNamesTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNamesTest.kt
@@ -16,19 +16,14 @@
 
 package com.duckduckgo.mobile.android.vpn.pixels
 
-import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixelNames.ATP_DID_PRESS_NOTIFY_ME_BUTTON
-import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixelNames.ATP_DID_PRESS_NOTIFY_ME_DISMISS_BUTTON
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DeviceShieldPixelNamesTest {
     @Test
     fun allAppTrackingProtectionPixelsShallBePrefixed() {
-        DeviceShieldPixelNames.values()
-            // These 2 pixels have the same names across browser and AppTP and should not have the "m_atp" prefix.
-            .filter { it != ATP_DID_PRESS_NOTIFY_ME_BUTTON && it != ATP_DID_PRESS_NOTIFY_ME_DISMISS_BUTTON }
-            .map { it.pixelName }.forEach { pixel ->
-                assertTrue(pixel.startsWith("m_atp"))
-            }
+        DeviceShieldPixelNames.values().map { it.pixelName }.forEach { pixel ->
+            assertTrue(pixel.startsWith("m_atp"))
+        }
     }
 }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModelTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModelTest.kt
@@ -29,8 +29,6 @@ import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnStore
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTrackerActivityViewModel.BannerState
-import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTrackerActivityViewModel.Companion.PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_NAME
-import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTrackerActivityViewModel.Companion.PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_VALUE
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTrackerActivityViewModel.ViewEvent
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -341,31 +339,5 @@ class DeviceShieldTrackerActivityViewModelTest {
         val bannerState = viewModel.bannerState()
 
         assertEquals(BannerState.OnboardingBanner, bannerState)
-    }
-
-    @Test
-    fun whenUserClickedOnNotifyMeThenPixelIsSentWithCorrectParams() = runBlocking {
-        viewModel.commands().test {
-            viewModel.onViewEvent(ViewEvent.NotifyMeClicked)
-
-            verify(deviceShieldPixels).didPressOnNotifyMeButton(
-                mapOf(PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_NAME to PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_VALUE),
-            )
-
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenUserClickedOnDismissNotifyMeThenPixelIsSentWithCorrectParams() = runBlocking {
-        viewModel.commands().test {
-            viewModel.onViewEvent(ViewEvent.NotifyMeDismissClicked)
-
-            verify(deviceShieldPixels).didPressOnNotifyMeDismissButton(
-                mapOf(PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_NAME to PIXEL_PARAM_NOTIFY_ME_FROM_SCREEN_VALUE),
-            )
-
-            cancelAndConsumeRemainingEvents()
-        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsAdapter.kt
@@ -192,14 +192,6 @@ class DownloadsAdapter @Inject constructor(
                     }
                 },
             )
-
-            binding.root.onNotifyMeClicked {
-                listener.onNotifyMeButtonClicked()
-            }
-
-            binding.root.onDismissClicked {
-                listener.onNotifyMeDismissButtonClicked()
-            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsItemListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsItemListener.kt
@@ -29,8 +29,4 @@ interface DownloadsItemListener {
     fun onCancelItemClicked(item: DownloadItem)
 
     fun onItemVisibilityChanged(visible: Boolean)
-
-    fun onNotifyMeButtonClicked()
-
-    fun onNotifyMeDismissButtonClicked()
 }

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsViewModel.kt
@@ -32,10 +32,6 @@ import com.duckduckgo.app.downloads.DownloadsViewModel.Command.OpenFile
 import com.duckduckgo.app.downloads.DownloadsViewModel.Command.ShareFile
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.formatters.time.TimeDiffFormatter
-import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.NOTIFY_ME_FROM_SCREEN
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.NOTIFY_ME_DOWNLOADS_SCREEN
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.downloads.api.DownloadsRepository
 import com.duckduckgo.downloads.api.model.DownloadItem
@@ -60,7 +56,6 @@ class DownloadsViewModel @Inject constructor(
     private val timeDiffFormatter: TimeDiffFormatter,
     private val downloadsRepository: DownloadsRepository,
     private val dispatcher: DispatcherProvider,
-    private val pixel: Pixel,
 ) : ViewModel(), DownloadsItemListener {
 
     data class ViewState(
@@ -203,14 +198,6 @@ class DownloadsViewModel @Inject constructor(
         viewModelScope.launch {
             showNotifyMe.emit(visible)
         }
-    }
-
-    override fun onNotifyMeButtonClicked() {
-        pixel.fire(AppPixelName.NOTIFY_ME_BUTTON_PRESSED, mapOf(NOTIFY_ME_FROM_SCREEN to NOTIFY_ME_DOWNLOADS_SCREEN))
-    }
-
-    override fun onNotifyMeDismissButtonClicked() {
-        pixel.fire(AppPixelName.NOTIFY_ME_DISMISS_BUTTON_PRESSED, mapOf(NOTIFY_ME_FROM_SCREEN to NOTIFY_ME_DOWNLOADS_SCREEN))
     }
 
     private fun DownloadItem.mapToDownloadViewItem(): DownloadViewItem = Item(this)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
@@ -35,8 +35,7 @@ class WelcomePageModule {
         context: Context,
         pixel: Pixel,
         defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
-        appBuildConfig: AppBuildConfig,
-    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialog, appBuildConfig)
+    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialog)
 
     @Provides
     fun defaultRoleBrowserDialog(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
 
@@ -33,7 +32,6 @@ class DefaultBrowserPageViewModel @Inject constructor(
     private val defaultBrowserDetector: DefaultBrowserDetector,
     private val pixel: Pixel,
     private val installStore: AppInstallStore,
-    private val appBuildConfig: AppBuildConfig,
 ) : ViewModel() {
 
     sealed class ViewState {
@@ -173,7 +171,6 @@ class DefaultBrowserPageViewModel @Inject constructor(
             val params = mapOf(
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to originValue,
-                Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to appBuildConfig.isAndroid13OrAbove().toString(),
             )
             pixel.fire(AppPixelName.DEFAULT_BROWSER_SET, params)
         } else {
@@ -198,8 +195,6 @@ class DefaultBrowserPageViewModel @Inject constructor(
             viewState.value = createViewState
         }
     }
-
-    private fun AppBuildConfig.isAndroid13OrAbove(): Boolean = sdkInt >= android.os.Build.VERSION_CODES.TIRAMISU
 
     companion object {
         const val MAX_DIALOG_ATTEMPTS = 2

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -34,7 +33,6 @@ class WelcomePageViewModel(
     private val context: Context,
     private val pixel: Pixel,
     private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
-    private val appBuildConfig: AppBuildConfig,
 ) : ViewModel() {
 
     fun reduce(event: WelcomePageView.Event): Flow<WelcomePageView.State> {
@@ -68,7 +66,6 @@ class WelcomePageViewModel(
             AppPixelName.DEFAULT_BROWSER_SET,
             mapOf(
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
-                Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to appBuildConfig.isAndroid13OrAbove().toString(),
             ),
         )
 
@@ -84,14 +81,11 @@ class WelcomePageViewModel(
             AppPixelName.DEFAULT_BROWSER_NOT_SET,
             mapOf(
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
-                Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to appBuildConfig.isAndroid13OrAbove().toString(),
             ),
         )
 
         emit(WelcomePageView.State.Finish)
     }
-
-    private fun AppBuildConfig.isAndroid13OrAbove(): Boolean = sdkInt >= android.os.Build.VERSION_CODES.TIRAMISU
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -100,7 +94,6 @@ class WelcomePageViewModelFactory(
     private val context: Context,
     private val pixel: Pixel,
     private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
-    private val appBuildConfig: AppBuildConfig,
 ) : ViewModelProvider.NewInstanceFactory() {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -111,7 +104,6 @@ class WelcomePageViewModelFactory(
                     context,
                     pixel,
                     defaultRoleBrowserDialog,
-                    appBuildConfig,
                 )
                 else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -247,7 +247,4 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     REMOTE_MESSAGE_SECONDARY_ACTION_CLICKED("m_remote_message_secondary_action_clicked"),
 
     CREATE_BLOOM_FILTER_ERROR("m_create_bloom_filter_error"),
-
-    NOTIFY_ME_BUTTON_PRESSED("m_notify_me_component_notify_me_button_pressed"),
-    NOTIFY_ME_DISMISS_BUTTON_PRESSED("m_notify_me_component_close_button_pressed"),
 }

--- a/app/src/test/java/com/duckduckgo/app/downloads/DownloadsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/downloads/DownloadsViewModelTest.kt
@@ -33,10 +33,6 @@ import com.duckduckgo.app.downloads.DownloadsViewModel.Command.ShareFile
 import com.duckduckgo.app.global.R as CommonR
 import com.duckduckgo.app.global.formatters.time.RealTimeDiffFormatter
 import com.duckduckgo.app.global.formatters.time.TimeDiffFormatter
-import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.NOTIFY_ME_FROM_SCREEN
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.NOTIFY_ME_DOWNLOADS_SCREEN
 import com.duckduckgo.downloads.api.DownloadsRepository
 import com.duckduckgo.downloads.api.model.DownloadItem
 import com.duckduckgo.downloads.store.DownloadStatus.FINISHED
@@ -64,7 +60,6 @@ class DownloadsViewModelTest {
     var coroutineRule = CoroutineTestRule()
 
     private val mockDownloadsRepository: DownloadsRepository = mock()
-    private val mockPixel: Pixel = mock()
 
     private val context: Context = mock()
 
@@ -74,7 +69,6 @@ class DownloadsViewModelTest {
                 FakeTimeDiffFormatter(TODAY, RealTimeDiffFormatter(context)),
                 mockDownloadsRepository,
                 coroutineRule.testDispatcherProvider,
-                mockPixel,
             )
         model
     }
@@ -339,24 +333,6 @@ class DownloadsViewModelTest {
                 CancelDownload(item),
                 awaitItem(),
             )
-        }
-    }
-
-    @Test
-    fun whenNotifyMeButtonClickedThenPixelIsSentWithCorrectParams() = runTest {
-        testee.onNotifyMeButtonClicked()
-
-        testee.commands().test {
-            verify(mockPixel).fire(AppPixelName.NOTIFY_ME_BUTTON_PRESSED, mapOf(NOTIFY_ME_FROM_SCREEN to NOTIFY_ME_DOWNLOADS_SCREEN))
-        }
-    }
-
-    @Test
-    fun whenNotifyMeDismissButtonClickedThenPixelIsSentWithCorrectParams() = runTest {
-        testee.onNotifyMeDismissButtonClicked()
-
-        testee.commands().test {
-            verify(mockPixel).fire(AppPixelName.NOTIFY_ME_DISMISS_BUTTON_PRESSED, mapOf(NOTIFY_ME_FROM_SCREEN to NOTIFY_ME_DOWNLOADS_SCREEN))
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/global/api/AtpPixelRemovalInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/api/AtpPixelRemovalInterceptorTest.kt
@@ -43,9 +43,6 @@ class AtpPixelRemovalInterceptorTest {
     companion object {
         private const val PIXEL_TEMPLATE = "https://improving.duckduckgo.com/t/%s_android_phone?atb=v255-7zu&appVersion=5.74.0&test=1"
 
-        private val PIXELS_WITH_ATB_INFO = listOf<String>(
-            DeviceShieldPixelNames.ATP_DID_PRESS_NOTIFY_ME_BUTTON.pixelName,
-            DeviceShieldPixelNames.ATP_DID_PRESS_NOTIFY_ME_DISMISS_BUTTON.pixelName,
-        )
+        private val PIXELS_WITH_ATB_INFO = listOf<String>()
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
@@ -28,7 +28,6 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DEFAULT_BROWSER_DIALOG
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DEFAULT_BROWSER_SETTINGS
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -58,9 +57,6 @@ class DefaultBrowserPageViewModelTest {
     @Mock
     private lateinit var mockCommandObserver: Observer<Command>
 
-    @Mock
-    private lateinit var mockAppBuildConfig: AppBuildConfig
-
     @Captor
     private lateinit var commandCaptor: ArgumentCaptor<Command>
 
@@ -69,7 +65,7 @@ class DefaultBrowserPageViewModelTest {
     @Before
     fun setup() {
         MockitoAnnotations.openMocks(this)
-        testee = DefaultBrowserPageViewModel(mockDefaultBrowserDetector, mockPixel, mockInstallStore, mockAppBuildConfig)
+        testee = DefaultBrowserPageViewModel(mockDefaultBrowserDetector, mockPixel, mockInstallStore)
         testee.command.observeForever(mockCommandObserver)
     }
 
@@ -95,7 +91,7 @@ class DefaultBrowserPageViewModelTest {
     fun whenInitializingIfThereIsADefaultBrowserThenShowSettingsUI() {
         whenever(mockDefaultBrowserDetector.hasDefaultBrowser()).thenReturn(true)
 
-        testee = DefaultBrowserPageViewModel(mockDefaultBrowserDetector, mockPixel, mockInstallStore, mockAppBuildConfig)
+        testee = DefaultBrowserPageViewModel(mockDefaultBrowserDetector, mockPixel, mockInstallStore)
 
         assertTrue(viewState() is DefaultBrowserSettingsUI)
     }
@@ -104,7 +100,7 @@ class DefaultBrowserPageViewModelTest {
     fun whenInitializingIfThereIsNotADefaultBrowserThenShowDialogUI() {
         whenever(mockDefaultBrowserDetector.hasDefaultBrowser()).thenReturn(false)
 
-        testee = DefaultBrowserPageViewModel(mockDefaultBrowserDetector, mockPixel, mockInstallStore, mockAppBuildConfig)
+        testee = DefaultBrowserPageViewModel(mockDefaultBrowserDetector, mockPixel, mockInstallStore)
 
         assertTrue(viewState() is DefaultBrowserDialogUI)
     }
@@ -222,34 +218,14 @@ class DefaultBrowserPageViewModelTest {
     }
 
     @Test
-    fun whenUserSetDDGAsDefaultFromDialogOnAndroid13ThenContinueToBrowserAndFirePixelWithCorrectParams() {
+    fun whenUserSetDDGAsDefaultFromDialogThenContinueToBrowserAndFirePixel() {
         val params = mapOf(
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to DEFAULT_BROWSER_DIALOG,
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to true.toString(),
         )
         testee.loadUI()
         testee.onDefaultBrowserClicked()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(mockAppBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.TIRAMISU)
-
-        testee.handleResult(Origin.InternalBrowser)
-
-        assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
-        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_SET, params)
-    }
-
-    @Test
-    fun whenUserSetDDGAsDefaultFromDialogOnAndroid12ThenContinueToBrowserAndFirePixelWithCorrectParams() {
-        val params = mapOf(
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to DEFAULT_BROWSER_DIALOG,
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to false.toString(),
-        )
-        testee.loadUI()
-        testee.onDefaultBrowserClicked()
-        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(mockAppBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.S)
 
         testee.handleResult(Origin.InternalBrowser)
 
@@ -320,36 +296,15 @@ class DefaultBrowserPageViewModelTest {
     }
 
     @Test
-    fun whenUserSetDDGAsDefaultOnAndroid13ThenContinueToBrowserAndFirePixelWithCorrectParams() {
+    fun whenUserSetDDGAsDefaultThenContinueToBrowser() {
         val params = mapOf(
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to Pixel.PixelValues.DEFAULT_BROWSER_EXTERNAL,
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to true.toString(),
         )
         testee.loadUI()
         testee.onDefaultBrowserClicked()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
         whenever(mockDefaultBrowserDetector.hasDefaultBrowser()).thenReturn(true)
-        whenever(mockAppBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.TIRAMISU)
-
-        testee.handleResult(Origin.ExternalBrowser)
-
-        assertTrue(captureCommands().lastValue is Command.ContinueToBrowser)
-        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_SET, params)
-    }
-
-    @Test
-    fun whenUserSetDDGAsDefaultOnAndroid12ThenContinueToBrowserAndFirePixelWithCorrectParams() {
-        val params = mapOf(
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to Pixel.PixelValues.DEFAULT_BROWSER_EXTERNAL,
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to false.toString(),
-        )
-        testee.loadUI()
-        testee.onDefaultBrowserClicked()
-        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(mockDefaultBrowserDetector.hasDefaultBrowser()).thenReturn(true)
-        whenever(mockAppBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.S)
 
         testee.handleResult(Origin.ExternalBrowser)
 
@@ -383,35 +338,15 @@ class DefaultBrowserPageViewModelTest {
     }
 
     @Test
-    fun whenUserSelectedDDGAsDefaultInSettingsScreenOnAndroid13ThenFirePixelWithCorrectParams() {
+    fun whenUserSelectedDDGAsDefaultInSettingsScreenThenFirePixel() {
         whenever(mockDefaultBrowserDetector.hasDefaultBrowser()).thenReturn(true)
         val params = mapOf(
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
             Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to DEFAULT_BROWSER_SETTINGS,
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to true.toString(),
         )
         testee.loadUI()
         testee.onDefaultBrowserClicked()
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(mockAppBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.TIRAMISU)
-
-        testee.handleResult(Origin.Settings)
-
-        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_SET, params)
-    }
-
-    @Test
-    fun whenUserSelectedDDGAsDefaultInSettingsScreenOnAndroid12ThenFirePixelWithCorrectParams() {
-        whenever(mockDefaultBrowserDetector.hasDefaultBrowser()).thenReturn(true)
-        val params = mapOf(
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to DEFAULT_BROWSER_SETTINGS,
-            Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to false.toString(),
-        )
-        testee.loadUI()
-        testee.onDefaultBrowserClicked()
-        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(mockAppBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.S)
 
         testee.handleResult(Origin.Settings)
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -66,9 +65,6 @@ class WelcomePageViewModelTest {
     @Mock
     private lateinit var defaultRoleBrowserDialog: DefaultRoleBrowserDialog
 
-    @Mock
-    private lateinit var appBuildConfig: AppBuildConfig
-
     private val events = ConflatedBroadcastChannel<WelcomePageView.Event>()
 
     lateinit var viewModel: WelcomePageViewModel
@@ -83,7 +79,6 @@ class WelcomePageViewModelTest {
             context = mock(),
             pixel = pixel,
             defaultRoleBrowserDialog = defaultRoleBrowserDialog,
-            appBuildConfig = appBuildConfig,
         )
 
         viewEvents = events.asFlow().flatMapLatest { viewModel.reduce(it) }
@@ -132,8 +127,7 @@ class WelcomePageViewModelTest {
     }
 
     @Test
-    fun whenOnDefaultBrowserSetOnAndroid13ThenCallDialogShownFireWithCorrectParamsAndFinish() = runTest {
-        whenever(appBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.TIRAMISU)
+    fun whenOnDefaultBrowserSetThenCallDialogShownFireAndFinish() = runTest {
         events.send(WelcomePageView.Event.OnDefaultBrowserSet)
 
         viewEvents.test {
@@ -143,33 +137,13 @@ class WelcomePageViewModelTest {
                 AppPixelName.DEFAULT_BROWSER_SET,
                 mapOf(
                     Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
-                    Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to true.toString(),
                 ),
             )
         }
     }
 
     @Test
-    fun whenOnDefaultBrowserSetOnAndroid12ThenCallDialogShownFireWithCorrectParamsAndFinish() = runTest {
-        whenever(appBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.S)
-        events.send(WelcomePageView.Event.OnDefaultBrowserSet)
-
-        viewEvents.test {
-            assertTrue(awaitItem() == WelcomePageView.State.Finish)
-            verify(defaultRoleBrowserDialog).dialogShown()
-            verify(pixel).fire(
-                AppPixelName.DEFAULT_BROWSER_SET,
-                mapOf(
-                    Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
-                    Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to false.toString(),
-                ),
-            )
-        }
-    }
-
-    @Test
-    fun whenOnDefaultBrowserNotSetOnAndroid13ThenCallDialogShownFireWithCorrectParamsAndFinish() = runTest {
-        whenever(appBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.TIRAMISU)
+    fun whenOnDefaultBrowserNotSetThenCallDialogShownFireAndFinish() = runTest {
         events.send(WelcomePageView.Event.OnDefaultBrowserNotSet)
 
         viewEvents.test {
@@ -179,25 +153,6 @@ class WelcomePageViewModelTest {
                 AppPixelName.DEFAULT_BROWSER_NOT_SET,
                 mapOf(
                     Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
-                    Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to true.toString(),
-                ),
-            )
-        }
-    }
-
-    @Test
-    fun whenOnDefaultBrowserNotSetOnAndroid12ThenCallDialogShownFireWithCorrectParamsAndFinish() = runTest {
-        whenever(appBuildConfig.sdkInt).thenReturn(android.os.Build.VERSION_CODES.S)
-        events.send(WelcomePageView.Event.OnDefaultBrowserNotSet)
-
-        viewEvents.test {
-            assertTrue(awaitItem() == WelcomePageView.State.Finish)
-            verify(defaultRoleBrowserDialog).dialogShown()
-            verify(pixel).fire(
-                AppPixelName.DEFAULT_BROWSER_NOT_SET,
-                mapOf(
-                    Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
-                    Pixel.PixelParameter.DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE to false.toString(),
                 ),
             )
         }

--- a/app/src/test/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
@@ -20,8 +20,6 @@ import com.duckduckgo.app.anr.AnrPixelName
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixelNames
-import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixelNames.ATP_DID_PRESS_NOTIFY_ME_BUTTON
-import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixelNames.ATP_DID_PRESS_NOTIFY_ME_DISMISS_BUTTON
 import org.junit.Assert.fail
 import org.junit.Test
 
@@ -42,11 +40,7 @@ class PixelNameTest {
         }
         DeviceShieldPixelNames.values().forEach {
             if (!existingNames.add(it.pixelName)) {
-                // This if statement was added as we know these 2 pixels are duplicated in AppPixelName and DeviceShieldPixelNames.
-                // These are temporary and the below condition will be removed along with the pixels.
-                if (it != ATP_DID_PRESS_NOTIFY_ME_BUTTON && it != ATP_DID_PRESS_NOTIFY_ME_DISMISS_BUTTON) {
-                    fail("Duplicate pixel name in DeviceShieldPixelNames: ${it.pixelName}")
-                }
+                fail("Duplicate pixel name in DeviceShieldPixelNames: ${it.pixelName}")
             }
         }
         AnrPixelName.values().forEach {

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -63,7 +63,6 @@ interface Pixel {
         const val SHOWED_BOOKMARKS = "sb"
         const val DEFAULT_BROWSER_BEHAVIOUR_TRIGGERED = "bt"
         const val DEFAULT_BROWSER_SET_FROM_ONBOARDING = "fo"
-        const val DEFAULT_BROWSER_SET_ON_ANDROID_13_OR_ABOVE = "os_version_13_or_above"
         const val DEFAULT_BROWSER_SET_ORIGIN = "dbo"
         const val CTA_SHOWN = "cta"
         const val SERP_QUERY_CHANGED = "1"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL:  
https://app.asana.com/0/69071770703008/1203884929941926/f
https://app.asana.com/0/69071770703008/1203353347663734/f

### Description
Removed temporary pixels added as part of notifications permissions changes on Android 13.
- Pixel `m_notify_me_component_notify_me_button_pressed` (AppTP & Browser)
- Pixel `m_notify_me_component_close_button_pressed` (AppTP & Browser)
- Param `os_version_13_or_above` set from onboarding when default browser set / not set (Browser)

### Steps to test this PR

DDG set as default browser
- [x] Install from this branch.
- [x] Filter logcat by `Pixel sent`.
- [ ] Start onboarding and notice the `Set DDG as default browser`. Choose to set it.
- [x] Check that you see in the logs `Pixel sent: m_db_s with params: {fo=true}`. It does not contain the `os_version_13_or_above` param.


DDG NOT set as default browser + notify me 
- [x] Install from this branch and don't allow notifications (if on Android 13, else disable notifications).
- [x] Filter logcat by `Pixel sent`.
- [x] Start onboarding and notice the `Set DDG as default browser`.  Choose and set any other browser as default.
- [x] Check that you see in the logs `Pixel sent: m_db_ns with params: {fo=true}`. It does not contain the `os_version_13_or_above` param.
- [x] Go to the `Downloads` screen.
- [x] Notice the `Notify Me` component.
- [x] Tap on `Notify Me` button. Don't allow notifications.
- [x] Check that the `m_notify_me_component_notify_me_button_pressed` pixel is never sent.
- [x] Tap on the close button on `Notify Me` component.
- [x] Check that the `m_notify_me_component_close_button_pressed` pixel is never sent.
- [x] Enable AppTP.
- [x] Notice the `Notify Me` component.
- [x] Tap on `Notify Me` button. Don't allow notifications.
- [x] Check that the `m_notify_me_component_notify_me_button_pressed` pixel is never sent.
- [x] Tap on the close button on `Notify Me` component.
- [x] Check that the `m_notify_me_component_close_button_pressed` pixel is never sent.

### NO UI changes
