### PR TITLE
Update content scope scripts to latest version

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/README.md
+++ b/node_modules/@duckduckgo/content-scope-scripts/README.md
@@ -8,13 +8,13 @@ Each platform calls into the API exposed by content-scope-features.js where the 
 
 The exposed API is a global called contentScopeFeatures and has three methods:
 - load
-    - Calls the load method on all of the features
+    - Calls the load method on all the features
 - init
-    - Calls the init method on all of the features
+    - Calls the init method on all the features
     - This should be passed the arguments object which has the following keys:
         - 'platform' which is an object with:
             - 'name' which is a string of 'android', 'ios', 'macos' or 'extension'
-        - 'debug' true if debuging should be enabled
+        - 'debug' true if debugging should be enabled
         - 'globalPrivacyControlValue' false if the user has disabled GPC.
         - 'sessionKey' a unique session based key.
         - 'cookie' TODO
@@ -24,7 +24,7 @@ The exposed API is a global called contentScopeFeatures and has three methods:
             - 'domain' the hostname of the site in the URL bar
             - 'enabledFeatures' this is an array of features/ to enable
 - update
-    - Calls the update method on all of the features
+    - Calls the update method on all the features
 
 ## Features
 
@@ -51,7 +51,7 @@ The [inject/](https://github.com/duckduckgo/content-scope-scripts/tree/main/inje
 - In Firefox the code is loaded as a standard extension content script.
 - For Apple, Windows and Android the code is a UserScript that has some string replacements for properties and loads in as the page scope.
     - Note: currently we don't implement the update calls as it's only required by cookie protections which we don't implement.
-- All other browsers the code is stringified, base64 encoded and injected in as a self deleting <script> tag.
+- All other browsers the code is stringified, base64 encoded and injected in as a self deleting `<script>` tag.
 
 In the built output you will see these dramatic differences in the bundled code which is created into: /build
 
@@ -60,10 +60,10 @@ In the built output you will see these dramatic differences in the bundled code 
 - `$CONTENT_SCOPE$` - raw remote config object
 - `$USER_UNPROTECTED_DOMAINS$` - an array of user allowlisted domains
 - `$USER_PREFERENCES$` - an object containing:
-    - platform: { name: '<ios | macos | extension | android>' }
+    - platform: `{ name: '<ios | macos | extension | android>' }`
     - debug: boolean
     - globalPrivacyControlValue: boolean
-    - sessionKey: <CSRNG UUID 4 string> (used for fingerprinting) - this should regnerate on browser close or every 24 hours.
+    - sessionKey: `<CSRNG UUID 4 string>` (used for fingerprinting) - this should regenerate on browser close or every 24 hours.
 
 ### Features scope injection utilities
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.1.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.5.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.6.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1678981841"
       },
@@ -68,9 +68,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3e9a73f4d90d80af067523d40343822c0a1ee5d3",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#43ab6ed9110afb804922a3de6ccd97ea10ab8bee",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "workspaces": [
+        "packages/special-pages",
+        "packages/messaging"
+      ],
       "dependencies": {
         "seedrandom": "^3.0.5",
         "sjcl": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.1.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.5.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.6.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1678981841"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass