### PR TITLE
Update reference tests to latest version

### DIFF
--- a/app/src/androidTest/resources/reference_tests/domain_matching_tests.json
+++ b/app/src/androidTest/resources/reference_tests/domain_matching_tests.json
@@ -270,10 +270,7 @@
                 "siteURL": "https://ok-subdomain.also-site-that-tracks.com",
                 "requestURL": "https://sometimes-bad.third-party.site/option-blocking-only",
                 "requestType": "image",
-                "expectAction": "ignore",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "ignore"
             },
             {
                 "name": "don't block tracker with site matching options domains but not types",
@@ -294,10 +291,7 @@
                 "siteURL": "https://example.com",
                 "requestURL": "https://sometimes-bad.third-party.site/option-blocking-only",
                 "requestType": "image",
-                "expectAction": "ignore",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "ignore"
             },
             {
                 "name": "block default block tracker matching option domains",
@@ -327,20 +321,14 @@
                 "siteURL": "https://example2.com",
                 "requestURL": "https://options1.test/script.js",
                 "requestType": "script",
-                "expectAction": "ignore",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "ignore"
             },
             {
                 "name": "options1 - block on catch ignore after options",
                 "siteURL": "https://example.com",
                 "requestURL": "https://options1.test/script2.js",
                 "requestType": "script",
-                "expectAction": "block",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "block"
             },
             {
                 "name": "options2 - block on matching options with surrogate",
@@ -356,40 +344,28 @@
                 "siteURL": "https://example2.com",
                 "requestURL": "https://options2.test/script.js",
                 "requestType": "script",
-                "expectAction": "ignore",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "ignore"
             },
             {
                 "name": "options2 - block on matching options (fallthrough subpath)",
                 "siteURL": "https://example3.com",
                 "requestURL": "https://options2.test/script.js",
                 "requestType": "script",
-                "expectAction": "block",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "block"
             },
             {
                 "name": "options2 - block on matching options (fallthrough)",
                 "siteURL": "https://example2.com",
                 "requestURL": "https://options2.test/script2.js",
                 "requestType": "script",
-                "expectAction": "block",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "block"
             },
             {
                 "name": "options2 - block on matching options (subpath match)",
                 "siteURL": "https://example3.com",
                 "requestURL": "https://options2.test/script2.js",
                 "requestType": "script",
-                "expectAction": "block",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "block"
             }
         ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.7.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1680011318"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1680186782"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -88,7 +88,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#f60435779b89bd05dbd6116a341689b6c8370f8f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#f3351d1569739d08d71da6d85f95b946ee80c686",
       "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.1",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.7.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1680011318"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1680186782"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [x] All tests must pass