### PR TITLE
Implement notifications for [Experiment] Increase retention through AppTP promotions

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -338,6 +338,8 @@ interface DeviceShieldPixels {
     fun didPressOnAppTpEnabledCtaButton()
 
     fun reportErrorCreatingVpnNetworkStack()
+
+    fun didOpenVpnOnboardingFromNotification(pixelName: String)
 }
 
 @ContributesBinding(AppScope::class)
@@ -747,6 +749,10 @@ class RealDeviceShieldPixels @Inject constructor(
     override fun reportErrorCreatingVpnNetworkStack() {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR_DAILY)
         firePixel(DeviceShieldPixelNames.ATP_REPORT_VPN_NETWORK_STACK_CREATE_ERROR)
+    }
+
+    override fun didOpenVpnOnboardingFromNotification(pixelName: String) {
+        firePixel(pixelName)
     }
 
     private fun firePixel(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingActivity.kt
@@ -70,6 +70,10 @@ class VpnOnboardingActivity : DuckDuckGoActivity() {
         setContentView(binding.root)
         configureUI()
         observeViewModel()
+
+        intent?.getStringExtra(LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
+            viewModel.onLaunchedFromNotification(it)
+        }
     }
 
     private fun configureUI() {
@@ -299,6 +303,8 @@ class VpnOnboardingActivity : DuckDuckGoActivity() {
 
     companion object {
         private const val REQUEST_ASK_VPN_PERMISSION = 101
+
+        const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
 
         fun intent(context: Context): Intent {
             return Intent(context, VpnOnboardingActivity::class.java)

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingViewModel.kt
@@ -118,6 +118,10 @@ class VpnOnboardingViewModel @Inject constructor(
             command.send(newCommand)
         }
     }
+
+    fun onLaunchedFromNotification(pixelName: String) {
+        deviceShieldPixels.didOpenVpnOnboardingFromNotification(pixelName)
+    }
 }
 
 sealed class Command {

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
@@ -306,6 +306,14 @@ class RealDeviceShieldPixelsTest {
         verify(pixel).fire(DeviceShieldPixelNames.ATP_REPORT_UNPROTECTED_APPS_BUCKET_DAILY.notificationVariant(bucketSize))
     }
 
+    @Test
+    fun whenReportUnprotectedAppsBucketCalledThenFirePixel() {
+        val pixelName = "pixel_name"
+        deviceShieldPixels.didOpenVpnOnboardingFromNotification(pixelName)
+
+        verify(pixel).fire(pixelName)
+    }
+
     private fun DeviceShieldPixelNames.notificationVariant(variant: Int): String {
         return String.format(Locale.US, pixelName, variant)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
@@ -45,6 +45,7 @@ class AndroidNotificationSchedulerTest {
 
     private val clearNotification: SchedulableNotification = mock()
     private val privacyNotification: SchedulableNotification = mock()
+    private val mockEnableAppTpNotification: SchedulableNotification = mock()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private lateinit var workManager: WorkManager
@@ -58,6 +59,7 @@ class AndroidNotificationSchedulerTest {
             workManager,
             clearNotification,
             privacyNotification,
+            mockEnableAppTpNotification,
         )
     }
 
@@ -73,7 +75,48 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenPrivacyNotificationClearDataCanShowThenPrivacyNotificationIsScheduled() = runTest {
+    fun whenEnableAppTpNotificationPrivacyNotificationClearDataCanShowThenEnableAppTpNotificationIsScheduled() = runTest {
+        whenever(mockEnableAppTpNotification.canShow()).thenReturn(true)
+        whenever(privacyNotification.canShow()).thenReturn(true)
+        whenever(clearNotification.canShow()).thenReturn(true)
+        testee.scheduleNextNotification()
+
+        assertNotificationScheduled(EnableAppTpNotificationWorker::class.javaObjectType.name)
+    }
+
+    @Test
+    fun whenEnableAppTpNotificationPrivacyNotificationCanShowButClearDataCannotThenEnableAppTpNotificationIsScheduled() = runTest {
+        whenever(mockEnableAppTpNotification.canShow()).thenReturn(true)
+        whenever(privacyNotification.canShow()).thenReturn(true)
+        whenever(clearNotification.canShow()).thenReturn(false)
+        testee.scheduleNextNotification()
+
+        assertNotificationScheduled(EnableAppTpNotificationWorker::class.javaObjectType.name)
+    }
+
+    @Test
+    fun whenEnableAppTpNotificationCanShowButPrivacyNotificationCannotThenEnableAppTpNotificationIsScheduled() = runTest {
+        whenever(mockEnableAppTpNotification.canShow()).thenReturn(true)
+        whenever(privacyNotification.canShow()).thenReturn(false)
+        whenever(clearNotification.canShow()).thenReturn(true)
+        testee.scheduleNextNotification()
+
+        assertNotificationScheduled(EnableAppTpNotificationWorker::class.javaObjectType.name)
+    }
+
+    @Test
+    fun whenEnableAppTpNotificationCanShowButPrivacyNotificationClearDataCannotThenEnableAppTpNotificationIsScheduled() = runTest {
+        whenever(mockEnableAppTpNotification.canShow()).thenReturn(true)
+        whenever(privacyNotification.canShow()).thenReturn(false)
+        whenever(clearNotification.canShow()).thenReturn(false)
+        testee.scheduleNextNotification()
+
+        assertNotificationScheduled(EnableAppTpNotificationWorker::class.javaObjectType.name)
+    }
+
+    @Test
+    fun whenEnableAppTpNotificationCannotShowAndPrivacyNotificationClearNotificationCanShowThenPrivacyNotificationIsScheduled() = runTest {
+        whenever(mockEnableAppTpNotification.canShow()).thenReturn(false)
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(true)
         testee.scheduleNextNotification()
@@ -82,7 +125,8 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenPrivacyNotificationCanShowButClearDataCannotThenPrivacyNotificationIsScheduled() = runTest {
+    fun whenEnableAppTpNotificationClearNotificationCannotShowAndPrivacyNotificationCanShowThenPrivacyNotificationIsScheduled() = runTest {
+        whenever(mockEnableAppTpNotification.canShow()).thenReturn(false)
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(false)
         testee.scheduleNextNotification()
@@ -91,7 +135,8 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenPrivacyNotificationCannotShowAndClearNotificationCanShowThenClearNotificationIsScheduled() = runTest {
+    fun whenEnableAppTpNotificationPrivacyNotificationCannotShowAndClearNotificationCanShowThenClearDataNotificationIsScheduled() = runTest {
+        whenever(mockEnableAppTpNotification.canShow()).thenReturn(false)
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(true)
         testee.scheduleNextNotification()
@@ -100,9 +145,10 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun whenPrivacyNotificationAndClearNotificationCannotShowThenNoNotificationScheduled() = runTest {
+    fun whenPrivacyNotificationAndClearNotificationAndEnableAppTpNotificationCannotShowThenNoNotificationScheduled() = runTest {
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(false)
+        whenever(mockEnableAppTpNotification.canShow()).thenReturn(false)
         testee.scheduleNextNotification()
 
         assertNoNotificationScheduled()

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
@@ -79,6 +79,7 @@ class AndroidNotificationSchedulerTest {
         whenever(mockEnableAppTpNotification.canShow()).thenReturn(true)
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(true)
+
         testee.scheduleNextNotification()
 
         assertNotificationScheduled(EnableAppTpNotificationWorker::class.javaObjectType.name)
@@ -89,6 +90,7 @@ class AndroidNotificationSchedulerTest {
         whenever(mockEnableAppTpNotification.canShow()).thenReturn(true)
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(false)
+
         testee.scheduleNextNotification()
 
         assertNotificationScheduled(EnableAppTpNotificationWorker::class.javaObjectType.name)
@@ -99,6 +101,7 @@ class AndroidNotificationSchedulerTest {
         whenever(mockEnableAppTpNotification.canShow()).thenReturn(true)
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(true)
+
         testee.scheduleNextNotification()
 
         assertNotificationScheduled(EnableAppTpNotificationWorker::class.javaObjectType.name)
@@ -109,6 +112,7 @@ class AndroidNotificationSchedulerTest {
         whenever(mockEnableAppTpNotification.canShow()).thenReturn(true)
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(false)
+
         testee.scheduleNextNotification()
 
         assertNotificationScheduled(EnableAppTpNotificationWorker::class.javaObjectType.name)
@@ -119,6 +123,7 @@ class AndroidNotificationSchedulerTest {
         whenever(mockEnableAppTpNotification.canShow()).thenReturn(false)
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(true)
+
         testee.scheduleNextNotification()
 
         assertNotificationScheduled(PrivacyNotificationWorker::class.javaObjectType.name)
@@ -129,6 +134,7 @@ class AndroidNotificationSchedulerTest {
         whenever(mockEnableAppTpNotification.canShow()).thenReturn(false)
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(false)
+
         testee.scheduleNextNotification()
 
         assertNotificationScheduled(PrivacyNotificationWorker::class.javaObjectType.name)
@@ -139,6 +145,7 @@ class AndroidNotificationSchedulerTest {
         whenever(mockEnableAppTpNotification.canShow()).thenReturn(false)
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(true)
+
         testee.scheduleNextNotification()
 
         assertNotificationScheduled(ClearDataNotificationWorker::class.javaObjectType.name)
@@ -149,6 +156,7 @@ class AndroidNotificationSchedulerTest {
         whenever(privacyNotification.canShow()).thenReturn(false)
         whenever(clearNotification.canShow()).thenReturn(false)
         whenever(mockEnableAppTpNotification.canShow()).thenReturn(false)
+
         testee.scheduleNextNotification()
 
         assertNoNotificationScheduled()

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
@@ -46,6 +46,7 @@ class EnableAppTpNotificationTest {
     fun whenNotificationNotSeenAndOneEasyStepForPrivacyNotificationEnabledThenCanShowIsTrue() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(false)
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zm" })
+
         assertTrue(testee.canShow())
     }
 
@@ -53,6 +54,7 @@ class EnableAppTpNotificationTest {
     fun whenNotificationNotSeenAndNextLevelPrivacyNotificationEnabledThenCanShowIsTrue() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(false)
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zn" })
+
         assertTrue(testee.canShow())
     }
 
@@ -60,12 +62,14 @@ class EnableAppTpNotificationTest {
     fun whenNotificationNotSeenAndOtherEnabledThenCanShowIsFalse() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(false)
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "ze" })
+
         assertFalse(testee.canShow())
     }
 
     @Test
     fun whenNotificationAlreadySeenThenCanShowIsFalse() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(true)
+
         assertFalse(testee.canShow())
     }
 
@@ -81,6 +85,7 @@ class EnableAppTpNotificationTest {
     @Test
     fun whenOneEasyStepForPrivacyNotificationNotEnabledThenReturnNextLevelPrivacySpecification() = runTest {
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zn" })
+
         val spec = testee.buildSpecification()
 
         assertTrue(spec is NextLevelPrivacySpecification)

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
@@ -43,9 +43,24 @@ class EnableAppTpNotificationTest {
     }
 
     @Test
-    fun whenNotificationNotSeenThenCanShowIsTrue() = runTest {
+    fun whenNotificationNotSeenAndOneEasyStepForPrivacyNotificationEnabledThenCanShowIsTrue() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(false)
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zm" })
         assertTrue(testee.canShow())
+    }
+
+    @Test
+    fun whenNotificationNotSeenAndNextLevelPrivacyNotificationEnabledThenCanShowIsTrue() = runTest {
+        whenever(mockNotificationsDao.exists(any())).thenReturn(false)
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zn" })
+        assertTrue(testee.canShow())
+    }
+
+    @Test
+    fun whenNotificationNotSeenAndOtherEnabledThenCanShowIsFalse() = runTest {
+        whenever(mockNotificationsDao.exists(any())).thenReturn(false)
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "ze" })
+        assertFalse(testee.canShow())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.notification.model
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.notification.db.NotificationDao
+import com.duckduckgo.app.statistics.VariantManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EnableAppTpNotificationTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val mockNotificationsDao: NotificationDao = mock()
+    private val mockVariantManager: VariantManager = mock()
+
+    private lateinit var testee: EnableAppTpNotification
+
+    @Before
+    fun setup() {
+        testee = EnableAppTpNotification(context, mockNotificationsDao, mockVariantManager)
+    }
+
+    @Test
+    fun whenNotificationNotSeenThenCanShowIsTrue() = runTest {
+        whenever(mockNotificationsDao.exists(any())).thenReturn(false)
+        assertTrue(testee.canShow())
+    }
+
+    @Test
+    fun whenNotificationAlreadySeenThenCanShowIsFalse() = runTest {
+        whenever(mockNotificationsDao.exists(any())).thenReturn(true)
+        assertFalse(testee.canShow())
+    }
+
+    @Test
+    fun whenOneEasyStepForPrivacyNotificationEnabledThenReturnOneEasyStepForPrivacySpecification() = runTest {
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zm" })
+
+        val spec = testee.buildSpecification()
+
+        assertTrue(spec is OneEasyStepForPrivacySpecification)
+    }
+
+    @Test
+    fun whenOneEasyStepForPrivacyNotificationNotEnabledThenReturnNextLevelPrivacySpecification() = runTest {
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zn" })
+        val spec = testee.buildSpecification()
+
+        assertTrue(spec is NextLevelPrivacySpecification)
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.app.notification.model
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
@@ -34,12 +36,21 @@ class EnableAppTpNotificationTest {
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val mockNotificationsDao: NotificationDao = mock()
     private val mockVariantManager: VariantManager = mock()
+    private val mockVpnFeaturesRegistry: VpnFeaturesRegistry = mock()
 
     private lateinit var testee: EnableAppTpNotification
 
     @Before
     fun setup() {
-        testee = EnableAppTpNotification(context, mockNotificationsDao, mockVariantManager)
+        testee = EnableAppTpNotification(context, mockNotificationsDao, mockVariantManager, mockVpnFeaturesRegistry)
+    }
+
+    @Test
+    fun whenAppTPEnabledThenCanShowIsFalse() = runTest {
+        whenever(mockNotificationsDao.exists(any())).thenReturn(false)
+        whenever(mockVpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)).thenReturn(true)
+
+        assertFalse(testee.canShow())
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -25,10 +25,12 @@ import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.notification.*
 import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.ClearDataNotification
+import com.duckduckgo.app.notification.model.EnableAppTpNotification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.notification.model.SchedulableNotificationPlugin
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.di.scopes.AppScope
 import dagger.Module
 import dagger.Provides
@@ -74,16 +76,27 @@ object NotificationModule {
     }
 
     @Provides
+    fun provideEnableAppTpNotification(
+        context: Context,
+        notificationDao: NotificationDao,
+        variantManager: VariantManager,
+    ): EnableAppTpNotification {
+        return EnableAppTpNotification(context, notificationDao, variantManager)
+    }
+
+    @Provides
     @SingleInstanceIn(AppScope::class)
     fun providesNotificationScheduler(
         workManager: WorkManager,
         clearDataNotification: ClearDataNotification,
         privacyProtectionNotification: PrivacyProtectionNotification,
+        enableAppTpNotification: EnableAppTpNotification,
     ): AndroidNotificationScheduler {
         return NotificationScheduler(
             workManager,
             clearDataNotification,
             privacyProtectionNotification,
+            enableAppTpNotification,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
@@ -80,8 +81,9 @@ object NotificationModule {
         context: Context,
         notificationDao: NotificationDao,
         variantManager: VariantManager,
+        vpnFeaturesRegistry: VpnFeaturesRegistry,
     ): EnableAppTpNotification {
-        return EnableAppTpNotification(context, notificationDao, variantManager)
+        return EnableAppTpNotification(context, notificationDao, variantManager, vpnFeaturesRegistry)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
@@ -64,7 +64,8 @@ class NotificationRegistrar @Inject constructor(
         const val PrivacyProtection = 101
         const val Article = 103 // 102 was used for the search notification hence using 103 moving forward
         const val AppFeature = 104
-        // 105 and 106 where already used previously
+        const val OneEasyStepForPrivacy = 107 // 105 and 106 where already used previously
+        const val NextLevelPrivacy = 108
     }
 
     object ChannelType {

--- a/app/src/main/java/com/duckduckgo/app/notification/model/EnableAppTpNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/EnableAppTpNotification.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEv
 import com.duckduckgo.app.notification.NotificationRegistrar
 import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.isNextLevelPrivacyNotificationEnabled
 import com.duckduckgo.app.statistics.isOneEasyStepForPrivacyNotificationEnabled
 import timber.log.Timber
 
@@ -40,6 +41,10 @@ class EnableAppTpNotification(
     override suspend fun canShow(): Boolean {
         if (notificationDao.exists(id)) {
             Timber.v("Notification already seen")
+            return false
+        }
+
+        if (!variantManager.isOneEasyStepForPrivacyNotificationEnabled() && !variantManager.isNextLevelPrivacyNotificationEnabled()) {
             return false
         }
 

--- a/app/src/main/java/com/duckduckgo/app/notification/model/EnableAppTpNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/EnableAppTpNotification.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.notification.model
+
+import android.content.Context
+import android.os.Bundle
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.APPTP_LAUNCH
+import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.CANCEL
+import com.duckduckgo.app.notification.NotificationRegistrar
+import com.duckduckgo.app.notification.db.NotificationDao
+import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.isOneEasyStepForPrivacyNotificationEnabled
+import timber.log.Timber
+
+class EnableAppTpNotification(
+    private val context: Context,
+    private val notificationDao: NotificationDao,
+    private val variantManager: VariantManager,
+) : SchedulableNotification {
+
+    override val id = "com.duckduckgo.protection.enableapptp"
+    override val launchIntent = APPTP_LAUNCH
+    override val cancelIntent = CANCEL
+
+    override suspend fun canShow(): Boolean {
+        if (notificationDao.exists(id)) {
+            Timber.v("Notification already seen")
+            return false
+        }
+
+        return true
+    }
+
+    override suspend fun buildSpecification(): NotificationSpec {
+        return if (variantManager.isOneEasyStepForPrivacyNotificationEnabled()) {
+            OneEasyStepForPrivacySpecification(context)
+        } else {
+            NextLevelPrivacySpecification(context)
+        }
+    }
+}
+
+class OneEasyStepForPrivacySpecification(context: Context) : NotificationSpec {
+    override val channel = NotificationRegistrar.ChannelType.TUTORIALS
+    override val systemId = NotificationRegistrar.NotificationId.OneEasyStepForPrivacy
+    override val name = "One easy step for app privacy"
+    override val icon = com.duckduckgo.mobile.android.R.drawable.notification_logo
+    override val title: String = context.getString(R.string.enableAppTpNotificationEasyStepTitle)
+    override val description: String = context.getString(R.string.enableAppTpNotificationEasyStepDescription)
+    override val launchButton: String? = null
+    override val closeButton: String? = null
+    override val pixelSuffix = "OneEasyStepForPrivacy"
+    override val autoCancel = true
+    override val bundle: Bundle = Bundle()
+    override val color: Int = com.duckduckgo.mobile.android.R.color.ic_launcher_red_background
+}
+
+class NextLevelPrivacySpecification(context: Context) : NotificationSpec {
+    override val channel = NotificationRegistrar.ChannelType.TUTORIALS
+    override val systemId = NotificationRegistrar.NotificationId.NextLevelPrivacy
+    override val name = "Take your privacy to the next level"
+    override val icon = com.duckduckgo.mobile.android.R.drawable.notification_logo
+    override val title: String = context.getString(R.string.enableAppTpNotificationNextLevelTitle)
+    override val description: String = context.getString(R.string.enableAppTpNotificationNextLevelDescription)
+    override val launchButton: String? = null
+    override val closeButton: String? = null
+    override val pixelSuffix = "NextLevelPrivacy"
+    override val autoCancel = true
+    override val bundle: Bundle = Bundle()
+    override val color: Int = com.duckduckgo.mobile.android.R.color.ic_launcher_red_background
+}

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -44,4 +44,15 @@
     <string name="syncSettingsEntry">Sync</string>
     <string name="syncSettingsDisabled">Off</string>
     <string name="syncSettingsEnabled">On</string>
+
+    <!-- AppTP Retention Experiment Notifications-->
+    <string name="enableAppTpNotificationEasyStepTitle">One easy step for app privacy</string>
+    <string name="enableAppTpNotificationEasyStepDescription">Enable App Tracking Protection to block trackers hiding in apps, even when you aren’t using your phone.</string>
+    <string name="enableAppTpNotificationNextLevelTitle">Take your privacy to the next level</string>
+    <string name="enableAppTpNotificationNextLevelDescription">Enable App Tracking Protection to block trackers hiding in apps, even when you aren’t using your phone.</string>
+
+    <!-- AppTP Retention Experiment Dax Dialog -->
+    <string name="daxDialogAppTpRetentionText"><![CDATA[You\'re now blocking trackers across the web 🎉<br/><br/>I can also block trackers hiding in your other apps, even when you aren\'t using your phone.]]></string>
+    <string name="daxDialogAppTpRetentionPrimaryButtonText">Enable App Tracking Protection</string>
+    <string name="daxDialogAppTpRetentionSecondaryButtonText">Not Now</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -44,15 +44,4 @@
     <string name="syncSettingsEntry">Sync</string>
     <string name="syncSettingsDisabled">Off</string>
     <string name="syncSettingsEnabled">On</string>
-
-    <!-- AppTP Retention Experiment Notifications-->
-    <string name="enableAppTpNotificationEasyStepTitle">One easy step for app privacy</string>
-    <string name="enableAppTpNotificationEasyStepDescription">Enable App Tracking Protection to block trackers hiding in apps, even when you aren’t using your phone.</string>
-    <string name="enableAppTpNotificationNextLevelTitle">Take your privacy to the next level</string>
-    <string name="enableAppTpNotificationNextLevelDescription">Enable App Tracking Protection to block trackers hiding in apps, even when you aren’t using your phone.</string>
-
-    <!-- AppTP Retention Experiment Dax Dialog -->
-    <string name="daxDialogAppTpRetentionText"><![CDATA[You\'re now blocking trackers across the web 🎉<br/><br/>I can also block trackers hiding in your other apps, even when you aren\'t using your phone.]]></string>
-    <string name="daxDialogAppTpRetentionPrimaryButtonText">Enable App Tracking Protection</string>
-    <string name="daxDialogAppTpRetentionSecondaryButtonText">Not Now</string>
 </resources>

--- a/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -103,7 +103,7 @@ class VariantManagerTest {
     fun appTPPromotionsControlVariantHasExpectedWeightAndNoFeatures() {
         val variant = variants.first { it.key == "ze" }
 
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(0, variant.features.size)
     }
 
@@ -111,7 +111,7 @@ class VariantManagerTest {
     fun appTPPromotionsOneEasyStepForPrivacyRemoteMessageVariantHasExpectedWeightAndFeatures() {
         val variant = variants.first { it.key == "zh" }
 
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(OneEasyStepForPrivacyRemoteMessage))
     }
@@ -120,7 +120,7 @@ class VariantManagerTest {
     fun appTPPromotionsBlockingTrackersAcrossWebRemoteMessageVariantHasExpectedWeightAndFeatures() {
         val variant = variants.first { it.key == "zi" }
 
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(BlockingTrackersAcrossWebRemoteMessage))
     }
@@ -129,7 +129,7 @@ class VariantManagerTest {
     fun appTPPromotionsNextLevelPrivacyRemoteMessageVariantHasExpectedWeightAndFeatures() {
         val variant = variants.first { it.key == "zl" }
 
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(NextLevelPrivacyRemoteMessage))
     }
@@ -138,7 +138,7 @@ class VariantManagerTest {
     fun appTPPromotionsOneEasyStepForPrivacyNotificationVariantHasExpectedWeightAndFeatures() {
         val variant = variants.first { it.key == "zm" }
 
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(OneEasyStepForPrivacyNotification))
     }
@@ -147,7 +147,7 @@ class VariantManagerTest {
     fun appTPPromotionsNextLevelPrivacyNotificationVariantHasExpectedWeightAndFeatures() {
         val variant = variants.first { it.key == "zn" }
 
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(NextLevelPrivacyNotification))
     }
@@ -156,7 +156,7 @@ class VariantManagerTest {
     fun appTPPromotionsDaxDialogMessageVariantHasExpectedWeightAndFeatures() {
         val variant = variants.first { it.key == "zo" }
 
-        assertEqualsDouble(1.0, variant.weight)
+        assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(DaxDialogMessage))
     }

--- a/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -19,10 +19,10 @@ package com.duckduckgo.app.statistics
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.BlockingTrackersAcrossWebRemoteMessage
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.CookiePromptManagementExperiment
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OnboardingCustomizationExperiment
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.DaxDialogMessage
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NextLevelPrivacyNotification
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NextLevelPrivacyRemoteMessage
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OnboardingCustomizationExperiment
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OneEasyStepForPrivacyNotification
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OneEasyStepForPrivacyRemoteMessage
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OptimiseOnboardingExperiment

--- a/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -17,8 +17,14 @@
 package com.duckduckgo.app.statistics
 
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.BlockingTrackersAcrossWebRemoteMessage
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.CookiePromptManagementExperiment
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OnboardingCustomizationExperiment
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.DaxDialogMessage
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NextLevelPrivacyNotification
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NextLevelPrivacyRemoteMessage
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OneEasyStepForPrivacyNotification
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OneEasyStepForPrivacyRemoteMessage
 import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OptimiseOnboardingExperiment
 import org.junit.Assert.*
 import org.junit.Test
@@ -91,6 +97,68 @@ class VariantManagerTest {
         assertEqualsDouble(0.0, variant.weight)
         assertEquals(1, variant.features.size)
         assertTrue(variant.hasFeature(OnboardingCustomizationExperiment))
+    }
+
+    @Test
+    fun appTPPromotionsControlVariantHasExpectedWeightAndNoFeatures() {
+        val variant = variants.first { it.key == "ze" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(0, variant.features.size)
+    }
+
+    @Test
+    fun appTPPromotionsOneEasyStepForPrivacyRemoteMessageVariantHasExpectedWeightAndFeatures() {
+        val variant = variants.first { it.key == "zh" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertTrue(variant.hasFeature(OneEasyStepForPrivacyRemoteMessage))
+    }
+
+    @Test
+    fun appTPPromotionsBlockingTrackersAcrossWebRemoteMessageVariantHasExpectedWeightAndFeatures() {
+        val variant = variants.first { it.key == "zi" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertTrue(variant.hasFeature(BlockingTrackersAcrossWebRemoteMessage))
+    }
+
+    @Test
+    fun appTPPromotionsNextLevelPrivacyRemoteMessageVariantHasExpectedWeightAndFeatures() {
+        val variant = variants.first { it.key == "zl" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertTrue(variant.hasFeature(NextLevelPrivacyRemoteMessage))
+    }
+
+    @Test
+    fun appTPPromotionsOneEasyStepForPrivacyNotificationVariantHasExpectedWeightAndFeatures() {
+        val variant = variants.first { it.key == "zm" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertTrue(variant.hasFeature(OneEasyStepForPrivacyNotification))
+    }
+
+    @Test
+    fun appTPPromotionsNextLevelPrivacyNotificationVariantHasExpectedWeightAndFeatures() {
+        val variant = variants.first { it.key == "zn" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertTrue(variant.hasFeature(NextLevelPrivacyNotification))
+    }
+
+    @Test
+    fun appTPPromotionsDaxDialogMessageVariantHasExpectedWeightAndFeatures() {
+        val variant = variants.first { it.key == "zo" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertTrue(variant.hasFeature(DaxDialogMessage))
     }
 
     @Test

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -77,13 +77,13 @@ interface VariantManager {
             Variant(key = "mj", weight = 0.0, features = listOf(VariantFeature.OnboardingCustomizationExperiment), filterBy = { noFilter() }),
 
             // Experiment: Increase retention through AppTP promotions
-            Variant(key = "ze", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "zh", weight = 1.0, features = listOf(OneEasyStepForPrivacyRemoteMessage), filterBy = { noFilter() }),
-            Variant(key = "zi", weight = 1.0, features = listOf(BlockingTrackersAcrossWebRemoteMessage), filterBy = { noFilter() }),
-            Variant(key = "zl", weight = 1.0, features = listOf(NextLevelPrivacyRemoteMessage), filterBy = { noFilter() }),
-            Variant(key = "zm", weight = 1.0, features = listOf(OneEasyStepForPrivacyNotification), filterBy = { noFilter() }),
-            Variant(key = "zn", weight = 1.0, features = listOf(NextLevelPrivacyNotification), filterBy = { noFilter() }),
-            Variant(key = "zo", weight = 1.0, features = listOf(DaxDialogMessage), filterBy = { noFilter() }),
+            Variant(key = "ze", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "zh", weight = 0.0, features = listOf(OneEasyStepForPrivacyRemoteMessage), filterBy = { noFilter() }),
+            Variant(key = "zi", weight = 0.0, features = listOf(BlockingTrackersAcrossWebRemoteMessage), filterBy = { noFilter() }),
+            Variant(key = "zl", weight = 0.0, features = listOf(NextLevelPrivacyRemoteMessage), filterBy = { noFilter() }),
+            Variant(key = "zm", weight = 0.0, features = listOf(OneEasyStepForPrivacyNotification), filterBy = { noFilter() }),
+            Variant(key = "zn", weight = 0.0, features = listOf(NextLevelPrivacyNotification), filterBy = { noFilter() }),
+            Variant(key = "zo", weight = 0.0, features = listOf(DaxDialogMessage), filterBy = { noFilter() }),
         )
 
         val REFERRER_VARIANTS = listOf(

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -77,13 +77,13 @@ interface VariantManager {
             Variant(key = "mj", weight = 0.0, features = listOf(VariantFeature.OnboardingCustomizationExperiment), filterBy = { noFilter() }),
 
             // Experiment: Increase retention through AppTP promotions
-            Variant(key = "ze", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "zh", weight = 0.0, features = listOf(OneEasyStepForPrivacyRemoteMessage), filterBy = { noFilter() }),
-            Variant(key = "zi", weight = 0.0, features = listOf(BlockingTrackersAcrossWebRemoteMessage), filterBy = { noFilter() }),
-            Variant(key = "zl", weight = 0.0, features = listOf(NextLevelPrivacyRemoteMessage), filterBy = { noFilter() }),
-            Variant(key = "zm", weight = 0.0, features = listOf(OneEasyStepForPrivacyNotification), filterBy = { noFilter() }),
-            Variant(key = "zn", weight = 0.0, features = listOf(NextLevelPrivacyNotification), filterBy = { noFilter() }),
-            Variant(key = "zo", weight = 0.0, features = listOf(DaxDialogMessage), filterBy = { noFilter() }),
+            Variant(key = "ze", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "zh", weight = 1.0, features = listOf(OneEasyStepForPrivacyRemoteMessage), filterBy = { noFilter() }),
+            Variant(key = "zi", weight = 1.0, features = listOf(BlockingTrackersAcrossWebRemoteMessage), filterBy = { noFilter() }),
+            Variant(key = "zl", weight = 1.0, features = listOf(NextLevelPrivacyRemoteMessage), filterBy = { noFilter() }),
+            Variant(key = "zm", weight = 1.0, features = listOf(OneEasyStepForPrivacyNotification), filterBy = { noFilter() }),
+            Variant(key = "zn", weight = 1.0, features = listOf(NextLevelPrivacyNotification), filterBy = { noFilter() }),
+            Variant(key = "zo", weight = 1.0, features = listOf(DaxDialogMessage), filterBy = { noFilter() }),
         )
 
         val REFERRER_VARIANTS = listOf(

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -19,6 +19,12 @@ package com.duckduckgo.app.statistics
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.VariantManager.Companion.referrerVariant
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.BlockingTrackersAcrossWebRemoteMessage
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.DaxDialogMessage
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NextLevelPrivacyNotification
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NextLevelPrivacyRemoteMessage
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OneEasyStepForPrivacyNotification
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.OneEasyStepForPrivacyRemoteMessage
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import java.util.*
@@ -32,6 +38,13 @@ interface VariantManager {
         object CookiePromptManagementExperiment : VariantFeature()
         object OptimiseOnboardingExperiment : VariantFeature()
         object OnboardingCustomizationExperiment : VariantFeature()
+
+        object OneEasyStepForPrivacyRemoteMessage : VariantFeature()
+        object BlockingTrackersAcrossWebRemoteMessage : VariantFeature()
+        object NextLevelPrivacyRemoteMessage : VariantFeature()
+        object OneEasyStepForPrivacyNotification : VariantFeature()
+        object NextLevelPrivacyNotification : VariantFeature()
+        object DaxDialogMessage : VariantFeature()
     }
 
     companion object {
@@ -62,6 +75,15 @@ interface VariantManager {
             ),
             Variant(key = "mi", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
             Variant(key = "mj", weight = 0.0, features = listOf(VariantFeature.OnboardingCustomizationExperiment), filterBy = { noFilter() }),
+
+            // Experiment: Increase retention through AppTP promotions
+            Variant(key = "ze", weight = 0.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "zh", weight = 0.0, features = listOf(OneEasyStepForPrivacyRemoteMessage), filterBy = { noFilter() }),
+            Variant(key = "zi", weight = 0.0, features = listOf(BlockingTrackersAcrossWebRemoteMessage), filterBy = { noFilter() }),
+            Variant(key = "zl", weight = 0.0, features = listOf(NextLevelPrivacyRemoteMessage), filterBy = { noFilter() }),
+            Variant(key = "zm", weight = 0.0, features = listOf(OneEasyStepForPrivacyNotification), filterBy = { noFilter() }),
+            Variant(key = "zn", weight = 0.0, features = listOf(NextLevelPrivacyNotification), filterBy = { noFilter() }),
+            Variant(key = "zo", weight = 0.0, features = listOf(DaxDialogMessage), filterBy = { noFilter() }),
         )
 
         val REFERRER_VARIANTS = listOf(
@@ -264,6 +286,13 @@ fun VariantManager.isOptimiseOnboardingExperimentEnabled() =
 
 fun VariantManager.isOnboardingCustomizationExperimentEnabled() =
     this.getVariant().hasFeature(VariantManager.VariantFeature.OnboardingCustomizationExperiment)
+
+fun VariantManager.isOneEasyStepForPrivacyRemoteMessageEnabled() = this.getVariant().hasFeature(OneEasyStepForPrivacyRemoteMessage)
+fun VariantManager.isBlockingTrackersAcrossWebRemoteMessageEnabled() = this.getVariant().hasFeature(BlockingTrackersAcrossWebRemoteMessage)
+fun VariantManager.isNextLevelPrivacyRemoteMessageEnabled() = this.getVariant().hasFeature(NextLevelPrivacyRemoteMessage)
+fun VariantManager.isOneEasyStepForPrivacyNotificationEnabled() = this.getVariant().hasFeature(OneEasyStepForPrivacyNotification)
+fun VariantManager.isNextLevelPrivacyNotificationEnabled() = this.getVariant().hasFeature(NextLevelPrivacyNotification)
+fun VariantManager.isDaxDialogMessageEnabled() = this.getVariant().hasFeature(DaxDialogMessage)
 
 /**
  * A variant which can be used for experimentation.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204241239463176/f

### Description
Added all variants. Implemented the 2 notifications for variants `zm`/`zn`.

### Steps to test this PR

_Variant zm_
- [x] Checkout from this branch.
- [x] Go to this line https://github.com/duckduckgo/Android/blob/feature/ana/implementation_for_experiment_increase_retention_through_apptp_promotions_variants/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt#L58 and replace `TimeUnit.DAYS` with `TimeUnit.MINUTES`.
- [x] Go to this line https://github.com/duckduckgo/Android/blob/feature/ana/implementation_for_experiment_increase_retention_through_apptp_promotions_variants/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt#L101 and replace `2L` with `1L`.
- [x] Go to this line https://github.com/duckduckgo/Android/blob/feature/ana/implementation_for_experiment_increase_retention_through_apptp_promotions_variants/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt#L84 and change the `weight` of the variant (`zm`) to `1.0`. Change all other weights to `0.0` in this file to make sure you'll land on `zm`.
- [x] Fresh install on a device and make sure you allow notifications if you're using Android 13.
- [x] Put the app in background and wait one minute.
- [x] Notice the notification is displayed with title `One easy step for app privacy` and description `Enable App Tracking Protection to block trackers hiding in apps, even when you aren’t using your phone.`.
- [x] Check logcat for this pixel `mnot_s_OneEasyStepForPrivacy`.
- [x] Tap on the notification and notice the app is opened / brought to foreground and you see the AppTP onboarding screen.
- [x] Check logcat for this pixel `mnot_l_OneEasyStepForPrivacy`.
- [x] Notice the notification disappeared after it was tapped.
- [x] Go to app info and clear storage.
- [x] Open the app and make sure you allow notifications if you're using Android 13.
- [x] Put the app in background and wait one minute.
- [x] Once the notification is displayed, dismiss it.
- [x] Check logcat for this pixel `mnot_c_OneEasyStepForPrivacy`.
- [x] Go to app info and clear storage.
- [x] Open the app and make sure you allow notifications if you're using Android 13.
- [x] Enable AppTP.
- [x] Put the app in background and wait one minute or more.
- [x] You should not see the notification to enable AppTP.

_Variant zn_
- [x] Checkout from this branch.
- [x] Go to this line https://github.com/duckduckgo/Android/blob/feature/ana/implementation_for_experiment_increase_retention_through_apptp_promotions_variants/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt#L58 and replace `TimeUnit.DAYS` with `TimeUnit.MINUTES`.
- [x] Go to this line https://github.com/duckduckgo/Android/blob/feature/ana/implementation_for_experiment_increase_retention_through_apptp_promotions_variants/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt#L101 and replace `2L` with `1L`.
- [x] Go to this line https://github.com/duckduckgo/Android/blob/feature/ana/implementation_for_experiment_increase_retention_through_apptp_promotions_variants/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt#L85 and change the `weight` of the variant (`zn`) to `1.0`. Change all other weights to `0.0` in this file to make sure you'll land on `zn`.
- [x] Fresh install on a device and make sure you allow notifications if you're using Android 13.
- [x] Put the app in background and wait one minute.
- [x] Notice the notification is displayed with title `Take your privacy to the next level` and description `Enable App Tracking Protection to block trackers hiding in apps, even when you aren’t using your phone.`.
- [x] Check logcat for this pixel `mnot_s_NextLevelPrivacy`.
- [x] Tap on the notification and notice the app is opened / brought to foreground and you see the AppTP onboarding screen.
- [x] Check logcat for this pixel `mnot_l_NextLevelPrivacy`.
- [x] Notice the notification disappeared after it was tapped.
- [x] Go to app info and clear storage.
- [x] Open the app and make sure you allow notifications if you're using Android 13.
- [x] Put the app in background and wait one minute.
- [x] Once the notification is displayed, dismiss it.
- [x] Check logcat for this pixel `mnot_c_NextLevelPrivacy`.
- [x] Go to app info and clear storage.
- [x] Open the app and make sure you allow notifications if you're using Android 13.
- [x] Enable AppTP.
- [x] Put the app in background and wait one minute or more.
- [x] You should not see the notification to enable AppTP.

### UI changes
| Variant zm notification  | Variant zn notification |
| ------ | ----- |
|![one_easy_step_notification](https://user-images.githubusercontent.com/7963079/230159982-89b9ecdc-62d9-4a4b-9338-a3c9680362fa.png)|![next_level_notification](https://user-images.githubusercontent.com/7963079/230160003-5f6f994d-c605-4fdb-bafc-a4143b19ae09.png)|
