### PR TITLE
Android bug: Tapping on notifications doesn't open the app

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -72,7 +72,6 @@ import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.privacy.dashboard.impl.ui.PrivacyDashboardHybridActivity
 import javax.inject.Inject
-import kotlin.collections.ArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -155,6 +154,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
         viewModel.awaitClearDataFinishedNotification()
         initializeServiceWorker()
+
+        intent?.getStringExtra(LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
+            viewModel.onLaunchedFromNotification(it)
+        }
     }
 
     override fun onStop() {
@@ -525,6 +528,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         const val NOTIFY_DATA_CLEARED_EXTRA = "NOTIFY_DATA_CLEARED_EXTRA"
         const val LAUNCH_FROM_DEFAULT_BROWSER_DIALOG = "LAUNCH_FROM_DEFAULT_BROWSER_DIALOG"
         const val LAUNCH_FROM_FAVORITES_WIDGET = "LAUNCH_FROM_FAVORITES_WIDGET"
+        const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
 
         private const val APP_ENJOYMENT_DIALOG_TAG = "AppEnjoyment"
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -272,4 +272,8 @@ class BrowserViewModel @Inject constructor(
             pixel.fire(AppPixelName.SHORTCUT_OPENED)
         }
     }
+
+    fun onLaunchedFromNotification(pixelSuffix: String) {
+        pixel.fire(pixelSuffix)
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -273,7 +273,7 @@ class BrowserViewModel @Inject constructor(
         }
     }
 
-    fun onLaunchedFromNotification(pixelSuffix: String) {
-        pixel.fire(pixelSuffix)
+    fun onLaunchedFromNotification(pixelName: String) {
+        pixel.fire(pixelName)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.notification.model.SchedulableNotificationPlugin
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
 import dagger.Module
 import dagger.Provides
@@ -101,12 +100,11 @@ object NotificationModule {
     @SingleInstanceIn(AppScope::class)
     fun providesNotificationSender(
         context: Context,
-        pixel: Pixel,
         manager: NotificationManagerCompat,
         factory: NotificationFactory,
         notificationDao: NotificationDao,
         pluginPoint: PluginPoint<SchedulableNotificationPlugin>,
     ): NotificationSender {
-        return AppNotificationSender(context, pixel, manager, factory, notificationDao, pluginPoint)
+        return AppNotificationSender(context, manager, factory, notificationDao, pluginPoint)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -129,12 +129,12 @@ class PrivacyNotificationWorker(
     override lateinit var notification: PrivacyProtectionNotification
 }
 
-open class SchedulableNotificationWorker<T : SchedulableNotification>(
+abstract class SchedulableNotificationWorker<T : SchedulableNotification>(
     val context: Context,
     params: WorkerParameters,
 ) : CoroutineWorker(context, params) {
-    open lateinit var notificationSender: NotificationSender
-    open lateinit var notification: T
+    abstract var notificationSender: NotificationSender
+    abstract var notification: T
 
     override suspend fun doWork(): Result {
         notificationSender.sendNotification(notification)

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationFactory.kt
@@ -32,8 +32,8 @@ class NotificationFactory @Inject constructor(
 
     fun createNotification(
         specification: NotificationSpec,
-        launchIntent: PendingIntent,
-        cancelIntent: PendingIntent,
+        launchIntent: PendingIntent?,
+        cancelIntent: PendingIntent?,
     ): Notification {
         val builder = NotificationCompat.Builder(context, specification.channel.id)
             .setPriority(specification.channel.priority)
@@ -44,6 +44,7 @@ class NotificationFactory @Inject constructor(
             .setColor(ContextCompat.getColor(context, specification.color))
             .setContentIntent(launchIntent)
             .setDeleteIntent(cancelIntent)
+            .setAutoCancel(specification.autoCancel)
 
         specification.launchButton?.let {
             builder.addAction(specification.icon, it, launchIntent)

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationHandlerService.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationHandlerService.kt
@@ -21,49 +21,16 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.annotation.VisibleForTesting
-import androidx.core.app.NotificationManagerCompat
 import com.duckduckgo.anvil.annotations.InjectWith
-import com.duckduckgo.app.browser.BrowserActivity
-import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.plugins.PluginPoint
-import com.duckduckgo.app.icon.ui.ChangeIconActivity
-import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.APP_LAUNCH
-import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.CANCEL
-import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.CHANGE_ICON_FEATURE
-import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.CLEAR_DATA_LAUNCH
-import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.WEBSITE
-import com.duckduckgo.app.notification.model.NotificationSpec
+import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.duckduckgo.app.notification.model.SchedulableNotificationPlugin
-import com.duckduckgo.app.notification.model.WebsiteNotificationSpecification
-import com.duckduckgo.app.pixels.AppPixelName.NOTIFICATION_CANCELLED
-import com.duckduckgo.app.pixels.AppPixelName.NOTIFICATION_LAUNCHED
-import com.duckduckgo.app.settings.SettingsActivity
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.ActivityScope
 import dagger.android.AndroidInjection
 import javax.inject.Inject
-import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
 class NotificationHandlerService : IntentService("NotificationHandlerService") {
-
-    @Inject
-    lateinit var pixel: Pixel
-
-    @Inject
-    lateinit var context: Context
-
-    @Inject
-    lateinit var notificationManager: NotificationManagerCompat
-
-    @Inject
-    lateinit var notificationScheduler: AndroidNotificationScheduler
-
-    @Inject
-    lateinit var dispatcher: DispatcherProvider
-
-    @Inject
-    lateinit var taskStackBuilderFactory: TaskStackBuilderFactory
 
     @Inject
     lateinit var schedulableNotificationPluginPoint: PluginPoint<SchedulableNotificationPlugin>
@@ -75,107 +42,21 @@ class NotificationHandlerService : IntentService("NotificationHandlerService") {
 
     @VisibleForTesting
     public override fun onHandleIntent(intent: Intent?) {
-        val pixelSuffix = intent?.getStringExtra(PIXEL_SUFFIX_EXTRA) ?: return
-
-        when (intent.type) {
-            APP_LAUNCH -> onAppLaunched(pixelSuffix)
-            CLEAR_DATA_LAUNCH -> onClearDataLaunched(pixelSuffix)
-            CANCEL -> onCancelled(pixelSuffix)
-            WEBSITE -> onWebsiteNotification(intent, pixelSuffix)
-            CHANGE_ICON_FEATURE -> onCustomizeIconLaunched(pixelSuffix)
-            else -> {
-                schedulableNotificationPluginPoint.getPlugins().forEach {
-                    when (intent.type) {
-                        it.getSchedulableNotification().launchIntent -> {
-                            it.onNotificationLaunched()
-                        }
-                        it.getSchedulableNotification().cancelIntent -> {
-                            it.onNotificationCancelled()
-                        }
-                    }
-                }
-            }
+        if (intent == null) return
+        val notificationJavaClass = intent.type ?: return
+        val notificationPlugin = schedulableNotificationPluginPoint.getPlugins().firstOrNull {
+            notificationJavaClass == it.getSchedulableNotification().javaClass.simpleName
         }
-
-        if (intent.getBooleanExtra(NOTIFICATION_AUTO_CANCEL, true)) {
-            val notificationId = intent.getIntExtra(NOTIFICATION_SYSTEM_ID_EXTRA, 0)
-            clearNotification(notificationId)
-        }
-    }
-
-    private fun onWebsiteNotification(
-        intent: Intent,
-        pixelSuffix: String,
-    ) {
-        val url = intent.getStringExtra(WebsiteNotificationSpecification.WEBSITE_KEY)
-        val newIntent = BrowserActivity.intent(context, queryExtra = url)
-        taskStackBuilderFactory.createTaskBuilder()
-            .addNextIntentWithParentStack(newIntent)
-            .startActivities()
-        onLaunched(pixelSuffix)
-    }
-
-    private fun onCustomizeIconLaunched(pixelSuffix: String) {
-        val intent = ChangeIconActivity.intent(context)
-        taskStackBuilderFactory.createTaskBuilder()
-            .addNextIntentWithParentStack(intent)
-            .startActivities()
-        onLaunched(pixelSuffix)
-    }
-
-    private fun onAppLaunched(pixelSuffix: String) {
-        val intent = BrowserActivity.intent(context, newSearch = true)
-        taskStackBuilderFactory.createTaskBuilder()
-            .addNextIntentWithParentStack(intent)
-            .startActivities()
-        onLaunched(pixelSuffix)
-    }
-
-    private fun onClearDataLaunched(pixelSuffix: String) {
-        Timber.i("Clear Data Launched!")
-        val intent = SettingsActivity.intent(context)
-        taskStackBuilderFactory.createTaskBuilder()
-            .addNextIntentWithParentStack(intent)
-            .startActivities()
-        onLaunched(pixelSuffix)
-    }
-
-    private fun onCancelled(pixelSuffix: String) {
-        pixel.fire("${NOTIFICATION_CANCELLED.pixelName}_$pixelSuffix")
-    }
-
-    private fun onLaunched(pixelSuffix: String) {
-        pixel.fire("${NOTIFICATION_LAUNCHED.pixelName}_$pixelSuffix")
-    }
-
-    private fun clearNotification(notificationId: Int) {
-        notificationManager.cancel(notificationId)
-    }
-
-    object NotificationEvent {
-        const val APP_LAUNCH = "com.duckduckgo.notification.launch.app"
-        const val CLEAR_DATA_LAUNCH = "com.duckduckgo.notification.launch.clearData"
-        const val CANCEL = "com.duckduckgo.notification.cancel"
-        const val WEBSITE = "com.duckduckgo.notification.website"
-        const val CHANGE_ICON_FEATURE = "com.duckduckgo.notification.app.feature.changeIcon"
+        notificationPlugin?.onNotificationCancelled()
     }
 
     companion object {
-        const val PIXEL_SUFFIX_EXTRA = "PIXEL_SUFFIX_EXTRA"
-        const val NOTIFICATION_SYSTEM_ID_EXTRA = "NOTIFICATION_SYSTEM_ID"
-        const val NOTIFICATION_AUTO_CANCEL = "NOTIFICATION_AUTO_CANCEL"
-
-        fun pendingNotificationHandlerIntent(
+        fun pendingCancelNotificationHandlerIntent(
             context: Context,
-            eventType: String,
-            specification: NotificationSpec,
+            notificationJavaClass: Class<SchedulableNotification>,
         ): PendingIntent {
             val intent = Intent(context, NotificationHandlerService::class.java)
-            intent.type = eventType
-            intent.putExtras(specification.bundle)
-            intent.putExtra(PIXEL_SUFFIX_EXTRA, specification.pixelSuffix)
-            intent.putExtra(NOTIFICATION_SYSTEM_ID_EXTRA, specification.systemId)
-            intent.putExtra(NOTIFICATION_AUTO_CANCEL, specification.autoCancel)
+            intent.type = notificationJavaClass.simpleName
             return PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)!!
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/notification/model/AppFeatureNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/AppFeatureNotification.kt
@@ -16,14 +16,22 @@
 
 package com.duckduckgo.app.notification.model
 
+import android.app.PendingIntent
 import android.content.Context
 import android.os.Bundle
 import androidx.annotation.StringRes
-import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.APP_LAUNCH
-import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.CANCEL
+import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.notification.NotificationRegistrar
+import com.duckduckgo.app.notification.TaskStackBuilderFactory
 import com.duckduckgo.app.notification.db.NotificationDao
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.mobile.android.R as CommonR
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 
 class AppFeatureNotification(
     private val context: Context,
@@ -31,12 +39,9 @@ class AppFeatureNotification(
     @StringRes private val title: Int,
     @StringRes private val description: Int,
     private val pixelSuffix: String,
-    override val launchIntent: String = APP_LAUNCH,
 ) : SchedulableNotification {
 
     override val id = "com.duckduckgo.privacy.app.feature.$pixelSuffix"
-
-    override val cancelIntent: String = CANCEL
 
     override suspend fun canShow(): Boolean {
         return !notificationDao.exists(id)
@@ -64,4 +69,50 @@ class AppFeatureNotificationSpecification(
     override val title: String = context.getString(titleRes)
     override val description: String = context.getString(descriptionRes)
     override val color: Int = CommonR.color.ic_launcher_red_background
+}
+
+// This is not used at the moment.
+// @ContributesMultibinding(AppScope::class)
+class AppFeatureNotificationPlugin @Inject constructor(
+    private val context: Context,
+    private val schedulableNotification: AppFeatureNotification,
+    private val taskStackBuilderFactory: TaskStackBuilderFactory,
+    private val pixel: Pixel,
+    private val coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : SchedulableNotificationPlugin {
+
+    override fun getSchedulableNotification(): SchedulableNotification {
+        return schedulableNotification
+    }
+
+    override fun onNotificationCancelled() {
+        pixel.fire(pixelName(AppPixelName.NOTIFICATION_CANCELLED.pixelName))
+    }
+
+    override fun onNotificationShown() {
+        pixel.fire(pixelName(AppPixelName.NOTIFICATION_SHOWN.pixelName))
+    }
+
+    override fun getSpecification(): NotificationSpec {
+        val deferred = coroutineScope.async(dispatcherProvider.io()) {
+            schedulableNotification.buildSpecification()
+        }
+        return runBlocking {
+            deferred.await()
+        }
+    }
+
+    override fun getLaunchIntent(): PendingIntent? {
+        val intent = BrowserActivity.intent(context, newSearch = true).apply {
+            putExtra(BrowserActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME, pixelName(AppPixelName.NOTIFICATION_LAUNCHED.pixelName))
+        }
+        val pendingIntent: PendingIntent? = taskStackBuilderFactory.createTaskBuilder().run {
+            addNextIntentWithParentStack(intent)
+            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        }
+        return pendingIntent
+    }
+
+    private fun pixelName(notificationType: String) = "${notificationType}_${getSpecification().pixelSuffix}"
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/model/AppFeatureNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/AppFeatureNotification.kt
@@ -16,22 +16,12 @@
 
 package com.duckduckgo.app.notification.model
 
-import android.app.PendingIntent
 import android.content.Context
 import android.os.Bundle
 import androidx.annotation.StringRes
-import com.duckduckgo.app.browser.BrowserActivity
-import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.notification.NotificationRegistrar
-import com.duckduckgo.app.notification.TaskStackBuilderFactory
 import com.duckduckgo.app.notification.db.NotificationDao
-import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.mobile.android.R as CommonR
-import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
 
 class AppFeatureNotification(
     private val context: Context,
@@ -69,50 +59,4 @@ class AppFeatureNotificationSpecification(
     override val title: String = context.getString(titleRes)
     override val description: String = context.getString(descriptionRes)
     override val color: Int = CommonR.color.ic_launcher_red_background
-}
-
-// This is not used at the moment.
-// @ContributesMultibinding(AppScope::class)
-class AppFeatureNotificationPlugin @Inject constructor(
-    private val context: Context,
-    private val schedulableNotification: AppFeatureNotification,
-    private val taskStackBuilderFactory: TaskStackBuilderFactory,
-    private val pixel: Pixel,
-    private val coroutineScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
-) : SchedulableNotificationPlugin {
-
-    override fun getSchedulableNotification(): SchedulableNotification {
-        return schedulableNotification
-    }
-
-    override fun onNotificationCancelled() {
-        pixel.fire(pixelName(AppPixelName.NOTIFICATION_CANCELLED.pixelName))
-    }
-
-    override fun onNotificationShown() {
-        pixel.fire(pixelName(AppPixelName.NOTIFICATION_SHOWN.pixelName))
-    }
-
-    override fun getSpecification(): NotificationSpec {
-        val deferred = coroutineScope.async(dispatcherProvider.io()) {
-            schedulableNotification.buildSpecification()
-        }
-        return runBlocking {
-            deferred.await()
-        }
-    }
-
-    override fun getLaunchIntent(): PendingIntent? {
-        val intent = BrowserActivity.intent(context, newSearch = true).apply {
-            putExtra(BrowserActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME, pixelName(AppPixelName.NOTIFICATION_LAUNCHED.pixelName))
-        }
-        val pendingIntent: PendingIntent? = taskStackBuilderFactory.createTaskBuilder().run {
-            addNextIntentWithParentStack(intent)
-            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-        }
-        return pendingIntent
-    }
-
-    private fun pixelName(notificationType: String) = "${notificationType}_${getSpecification().pixelSuffix}"
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/model/PrivacyProtectionNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/PrivacyProtectionNotification.kt
@@ -16,15 +16,25 @@
 
 package com.duckduckgo.app.notification.model
 
+import android.app.PendingIntent
 import android.content.Context
 import android.os.Bundle
+import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.APP_LAUNCH
-import com.duckduckgo.app.notification.NotificationHandlerService.NotificationEvent.CANCEL
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.notification.NotificationRegistrar
+import com.duckduckgo.app.notification.TaskStackBuilderFactory
 import com.duckduckgo.app.notification.db.NotificationDao
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.R as CommonR
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 
 class PrivacyProtectionNotification(
     private val context: Context,
@@ -33,10 +43,6 @@ class PrivacyProtectionNotification(
 ) : SchedulableNotification {
 
     override val id = "com.duckduckgo.privacy.privacyprotection"
-
-    override val launchIntent: String = APP_LAUNCH
-
-    override val cancelIntent: String = CANCEL
 
     override suspend fun canShow(): Boolean {
         return !notificationDao.exists(id)
@@ -83,4 +89,49 @@ class PrivacyProtectionNotificationSpecification(
         private const val TRACKER_THRESHOLD = 2
         private const val UPGRADE_THRESHOLD = 2
     }
+}
+
+@ContributesMultibinding(AppScope::class)
+class PrivacyProtectionNotificationPlugin @Inject constructor(
+    private val context: Context,
+    private val schedulableNotification: PrivacyProtectionNotification,
+    private val taskStackBuilderFactory: TaskStackBuilderFactory,
+    private val pixel: Pixel,
+    private val coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : SchedulableNotificationPlugin {
+
+    override fun getSchedulableNotification(): SchedulableNotification {
+        return schedulableNotification
+    }
+
+    override fun onNotificationCancelled() {
+        pixel.fire(pixelName(AppPixelName.NOTIFICATION_CANCELLED.pixelName))
+    }
+
+    override fun onNotificationShown() {
+        pixel.fire(pixelName(AppPixelName.NOTIFICATION_SHOWN.pixelName))
+    }
+
+    override fun getSpecification(): NotificationSpec {
+        val deferred = coroutineScope.async(dispatcherProvider.io()) {
+            schedulableNotification.buildSpecification()
+        }
+        return runBlocking {
+            deferred.await()
+        }
+    }
+
+    override fun getLaunchIntent(): PendingIntent? {
+        val intent = BrowserActivity.intent(context, newSearch = true).apply {
+            putExtra(BrowserActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME, pixelName(AppPixelName.NOTIFICATION_LAUNCHED.pixelName))
+        }
+        val pendingIntent: PendingIntent? = taskStackBuilderFactory.createTaskBuilder().run {
+            addNextIntentWithParentStack(intent)
+            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        }
+        return pendingIntent
+    }
+
+    private fun pixelName(notificationType: String) = "${notificationType}_${getSpecification().pixelSuffix}"
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/model/WebsiteNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/WebsiteNotification.kt
@@ -16,23 +16,12 @@
 
 package com.duckduckgo.app.notification.model
 
-import android.app.PendingIntent
 import android.content.Context
 import android.os.Bundle
 import androidx.annotation.StringRes
-import com.duckduckgo.app.browser.BrowserActivity
-import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.notification.NotificationRegistrar
-import com.duckduckgo.app.notification.TaskStackBuilderFactory
 import com.duckduckgo.app.notification.db.NotificationDao
-import com.duckduckgo.app.notification.model.WebsiteNotificationSpecification.Companion.WEBSITE_KEY
-import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.mobile.android.R as CommonR
-import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
 
 class WebsiteNotification(
     private val context: Context,
@@ -77,52 +66,4 @@ open class WebsiteNotificationSpecification(
     companion object {
         const val WEBSITE_KEY = "websiteKey"
     }
-}
-
-// This is not used at the moment.
-// @ContributesMultibinding(AppScope::class)
-class WebsiteNotificationPlugin @Inject constructor(
-    private val context: Context,
-    private val schedulableNotification: WebsiteNotification,
-    private val taskStackBuilderFactory: TaskStackBuilderFactory,
-    private val pixel: Pixel,
-    private val coroutineScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
-) : SchedulableNotificationPlugin {
-
-    override fun getSchedulableNotification(): SchedulableNotification {
-        return schedulableNotification
-    }
-
-    override fun onNotificationCancelled() {
-        pixel.fire(pixelName(AppPixelName.NOTIFICATION_CANCELLED.pixelName))
-    }
-
-    override fun onNotificationShown() {
-        pixel.fire(pixelName(AppPixelName.NOTIFICATION_SHOWN.pixelName))
-    }
-
-    override fun getSpecification(): NotificationSpec {
-        val deferred = coroutineScope.async(dispatcherProvider.io()) {
-            schedulableNotification.buildSpecification()
-        }
-        return runBlocking {
-            deferred.await()
-        }
-    }
-
-    override fun getLaunchIntent(): PendingIntent? {
-        val spec = getSpecification()
-        val url = spec.bundle.getString(WEBSITE_KEY)
-        val intent = BrowserActivity.intent(context, queryExtra = url).apply {
-            putExtra(BrowserActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME, pixelName(AppPixelName.NOTIFICATION_LAUNCHED.pixelName))
-        }
-        val pendingIntent: PendingIntent? = taskStackBuilderFactory.createTaskBuilder().run {
-            addNextIntentWithParentStack(intent)
-            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-        }
-        return pendingIntent
-    }
-
-    private fun pixelName(notificationType: String) = "${notificationType}_${getSpecification().pixelSuffix}"
 }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -159,6 +159,10 @@ class SettingsActivity : DuckDuckGoActivity() {
         configureInternalFeatures()
         configureAppLinksSettingVisibility()
         observeViewModel()
+
+        intent?.getStringExtra(BrowserActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
+            viewModel.onLaunchedFromNotification(it)
+        }
     }
 
     override fun onStart() {
@@ -733,6 +737,8 @@ class SettingsActivity : DuckDuckGoActivity() {
         private const val ANDROID_M_APP_NOTIFICATION_SETTINGS = "android.settings.APP_NOTIFICATION_SETTINGS"
         private const val ANDROID_M_APP_PACKAGE = "app_package"
         private const val ANDROID_M_APP_UID = "app_uid"
+
+        const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
 
         fun intent(context: Context): Intent {
             return Intent(context, SettingsActivity::class.java)

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -496,6 +496,10 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { command.send(Command.LaunchSyncSettings) }
     }
 
+    fun onLaunchedFromNotification(pixelSuffix: String) {
+        pixel.fire(pixelSuffix)
+    }
+
     companion object {
         const val EMAIL_PROTECTION_URL = "https://duckduckgo.com/email"
     }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -496,8 +496,8 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { command.send(Command.LaunchSyncSettings) }
     }
 
-    fun onLaunchedFromNotification(pixelSuffix: String) {
-        pixel.fire(pixelSuffix)
+    fun onLaunchedFromNotification(pixelName: String) {
+        pixel.fire(pixelName)
     }
 
     companion object {

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -247,6 +247,14 @@ class BrowserViewModelTest {
         )
     }
 
+    @Test
+    fun whenOnLaunchedFromNotificationCalledWithPixelNameThePixelFired() {
+        val pixelName = "pixel_name"
+        testee.onLaunchedFromNotification(pixelName)
+
+        verify(mockPixel).fire(pixelName)
+    }
+
     companion object {
         const val TAB_ID = "TAB_ID"
     }

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -802,6 +802,14 @@ class SettingsViewModelTest {
         }
     }
 
+    @Test
+    fun whenOnLaunchedFromNotificationCalledWithPixelNameThePixelFired() {
+        val pixelName = "pixel_name"
+        testee.onLaunchedFromNotification(pixelName)
+
+        verify(mockPixel).fire(pixelName)
+    }
+
     private fun givenSelectedFireAnimation(fireAnimation: FireAnimation) {
         whenever(mockAppSettingsDataStore.selectedFireAnimation).thenReturn(fireAnimation)
         whenever(mockAppSettingsDataStore.isCurrentlySelected(fireAnimation)).thenReturn(true)

--- a/browser-api/src/main/java/com/duckduckgo/app/notification/model/SchedulableNotification.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/notification/model/SchedulableNotification.kt
@@ -26,8 +26,6 @@ import androidx.annotation.StringRes
  */
 interface SchedulableNotification {
     val id: String
-    val launchIntent: String
-    val cancelIntent: String
     suspend fun canShow(): Boolean
     suspend fun buildSpecification(): NotificationSpec
 }

--- a/browser-api/src/main/java/com/duckduckgo/app/notification/model/SchedulableNotificationPlugin.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/notification/model/SchedulableNotificationPlugin.kt
@@ -16,10 +16,15 @@
 
 package com.duckduckgo.app.notification.model
 
+import android.app.PendingIntent
+
 interface SchedulableNotificationPlugin {
     fun getSchedulableNotification(): SchedulableNotification
-    fun onNotificationLaunched()
+
+    // TODO onNotificationLaunched is not used at the moment.
+    //    fun onNotificationLaunched()
     fun onNotificationCancelled()
     fun onNotificationShown()
     fun getSpecification(): NotificationSpec
+    fun getLaunchIntent(): PendingIntent?
 }

--- a/windows/windows-impl/src/main/java/com/duckduckgo/windows/impl/waitlist/ui/WindowsWaitlistActivity.kt
+++ b/windows/windows-impl/src/main/java/com/duckduckgo/windows/impl/waitlist/ui/WindowsWaitlistActivity.kt
@@ -87,6 +87,10 @@ class WindowsWaitlistActivity : DuckDuckGoActivity() {
         setContentView(binding.root)
         setupToolbar(toolbar)
         configureUiEventHandlers()
+
+        intent?.getStringExtra(LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
+            viewModel.onLaunchedFromNotification(it)
+        }
     }
 
     private fun configureUiEventHandlers() {
@@ -218,6 +222,7 @@ class WindowsWaitlistActivity : DuckDuckGoActivity() {
 
     companion object {
         const val CLIPBOARD_LABEL = "INVITE_CODE"
+        const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
 
         fun intent(context: Context): Intent {
             return Intent(context, WindowsWaitlistActivity::class.java)

--- a/windows/windows-impl/src/main/java/com/duckduckgo/windows/impl/waitlist/ui/WindowsWaitlistViewModel.kt
+++ b/windows/windows-impl/src/main/java/com/duckduckgo/windows/impl/waitlist/ui/WindowsWaitlistViewModel.kt
@@ -113,7 +113,7 @@ class WindowsWaitlistViewModel @Inject constructor(
         }
     }
 
-    fun onLaunchedFromNotification(pixelSuffix: String) {
-        pixel.fire(pixelSuffix)
+    fun onLaunchedFromNotification(pixelName: String) {
+        pixel.fire(pixelName)
     }
 }

--- a/windows/windows-impl/src/main/java/com/duckduckgo/windows/impl/waitlist/ui/WindowsWaitlistViewModel.kt
+++ b/windows/windows-impl/src/main/java/com/duckduckgo/windows/impl/waitlist/ui/WindowsWaitlistViewModel.kt
@@ -112,4 +112,8 @@ class WindowsWaitlistViewModel @Inject constructor(
             commandChannel.send(GoToMacClientSettings)
         }
     }
+
+    fun onLaunchedFromNotification(pixelSuffix: String) {
+        pixel.fire(pixelSuffix)
+    }
 }

--- a/windows/windows-impl/src/test/java/com/duckduckgo/windows/impl/WindowsWaitlistNotificationPluginTest.kt
+++ b/windows/windows-impl/src/test/java/com/duckduckgo/windows/impl/WindowsWaitlistNotificationPluginTest.kt
@@ -16,22 +16,17 @@
 
 package com.duckduckgo.windows.impl
 
-import android.app.TaskStackBuilder
 import com.duckduckgo.app.notification.TaskStackBuilderFactory
 import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.windows.impl.WindowsPixelNames.WINDOWS_WAITLIST_NOTIFICATION_CANCELLED
-import com.duckduckgo.windows.impl.WindowsPixelNames.WINDOWS_WAITLIST_NOTIFICATION_LAUNCHED
 import com.duckduckgo.windows.impl.WindowsPixelNames.WINDOWS_WAITLIST_NOTIFICATION_SHOWN
 import com.duckduckgo.windows.impl.waitlist.WindowsWaitlistNotificationPlugin
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 
 class WindowsWaitlistNotificationPluginTest {
 
@@ -60,16 +55,5 @@ class WindowsWaitlistNotificationPluginTest {
     fun whenOnNotificationShownThenPixelFired() {
         testee.onNotificationShown()
         verify(mockPixel).fire(WINDOWS_WAITLIST_NOTIFICATION_SHOWN)
-    }
-
-    @Test
-    fun whenOnNotificationLaunchedThenPixelFired() {
-        val stackBuilder: TaskStackBuilder = mock()
-        whenever(mockTaskStackBuilderFactory.createTaskBuilder()).thenReturn(stackBuilder)
-        whenever(stackBuilder.addNextIntentWithParentStack(any())).thenReturn(stackBuilder)
-        doNothing().whenever(stackBuilder).startActivities()
-
-        testee.onNotificationLaunched()
-        verify(mockPixel).fire(WINDOWS_WAITLIST_NOTIFICATION_LAUNCHED)
     }
 }

--- a/windows/windows-impl/src/test/java/com/duckduckgo/windows/impl/ui/WindowsWaitlistViewModelTest.kt
+++ b/windows/windows-impl/src/test/java/com/duckduckgo/windows/impl/ui/WindowsWaitlistViewModelTest.kt
@@ -213,6 +213,14 @@ class WindowsWaitlistViewModelTest {
         }
     }
 
+    @Test
+    fun whenOnLaunchedFromNotificationCalledWithPixelNameThePixelFired() {
+        val pixelName = "pixel_name"
+        testee.onLaunchedFromNotification(pixelName)
+
+        verify(mockPixel).fire(pixelName)
+    }
+
     private fun assertWaitlistWorkerIsEnqueued() {
         val scheduledWorkers = getScheduledWorkers()
         assertFalse(scheduledWorkers.isEmpty())


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204319613139785/f

### Description
Refactored inactive user notifications. Fixed opening the app after tap on notification.

### Steps to test this PR

- [x] Checkout from the branch in the PR.
- [x] Go to this line https://github.com/duckduckgo/Android/blob/fix/ana/android_bug_tapping_on_notifications_doesnt_open_the_app/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt#L56 and replace `TimeUnit.DAYS` with `TimeUnit.MINUTES`.
- [x] Fresh install on a device and make sure you allow notifications if you're using Android 13.
- [x] Put the app in background and wait one minute.
- [x] Once the notification is displayed check logcat for this pixel `mnot_s_pp_0_0`.
- [x] Tap on the notification and notice the app is opened / brought to foreground and you see the browser screen.
- [x] Check logcat for this pixel `mnot_l_pp_0_0`.
- [x] Notice the notification disappeared after it was tapped.
- [x] Go to app info and clear storage.
- [x] Open the app and make sure you allow notifications if you're using Android 13.
- [x] Put the app in background and wait one minute.
- [x] Once the notification is displayed, dismiss it.
- [x] Check logcat for this pixel `mnot_c_pp_0_0`.

### NO UI changes
