### PR TITLE
Add confirmation dialog before deleting a login

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -54,6 +54,7 @@ import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsVie
 import com.duckduckgo.autofill.impl.ui.credential.management.sorting.InitialExtractor
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.R.dimen
+import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.view.text.DaxTextInput
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
@@ -133,8 +134,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
             }
 
             R.id.view_menu_delete -> {
-                viewModel.onDeleteCurrentCredentials()
-                viewModel.onExitCredentialMode()
+                launchDeleteLoginConfirmationDialog()
                 true
             }
 
@@ -157,6 +157,25 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
         configureUiEventHandlers()
         disableSystemAutofillServiceOnPasswordField()
         initialiseToolbar()
+    }
+
+    private fun launchDeleteLoginConfirmationDialog() {
+        this.context?.let {
+            TextAlertDialogBuilder(it)
+                .setTitle(R.string.autofillDeleteLoginDialogTitle)
+                .setDestructiveButtons(true)
+                .setPositiveButton(R.string.autofillDeleteLoginDialogDelete)
+                .setNegativeButton(R.string.autofillDeleteLoginDialogCancel)
+                .addEventListener(
+                    object : TextAlertDialogBuilder.EventListener() {
+                        override fun onPositiveButtonClicked() {
+                            viewModel.onDeleteCurrentCredentials()
+                            viewModel.onExitCredentialMode()
+                        }
+                    },
+                )
+                .show()
+        }
     }
 
     private fun startEditTextWatchers() {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.autofill.impl.ui.credential.management.suggestion.Suggesti
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.R as CommonR
 import com.duckduckgo.mobile.android.ui.view.SearchBar
+import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
@@ -265,12 +266,30 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
             onContextMenuItemClicked = {
                 when (it) {
                     is Edit -> viewModel.onEditCredentials(it.credentials)
-                    is Delete -> viewModel.onDeleteCredentials(it.credentials)
+                    is Delete -> launchDeleteLoginConfirmationDialog(it.credentials)
                     is CopyUsername -> onCopyUsername(it.credentials)
                     is CopyPassword -> onCopyPassword(it.credentials)
                 }
             },
         ).also { binding.logins.adapter = it }
+    }
+
+    private fun launchDeleteLoginConfirmationDialog(loginCredentials: LoginCredentials) {
+        this.context?.let {
+            TextAlertDialogBuilder(it)
+                .setTitle(R.string.autofillDeleteLoginDialogTitle)
+                .setDestructiveButtons(true)
+                .setPositiveButton(R.string.autofillDeleteLoginDialogDelete)
+                .setNegativeButton(R.string.autofillDeleteLoginDialogCancel)
+                .addEventListener(
+                    object : TextAlertDialogBuilder.EventListener() {
+                        override fun onPositiveButtonClicked() {
+                            viewModel.onDeleteCredentials(loginCredentials)
+                        }
+                    },
+                )
+                .show()
+        }
     }
 
     private fun onCredentialsSelected(credentials: LoginCredentials) {

--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Автоматично попълване на данни за вход</string>
+    <string name="autofillManagementScreenTitle">Данни за вход</string>
 
     <string name="managementDisabledModeCta"><b>Настройване в Настройки</b></string>
-    <string name="managementDisabledModeSubtitle">Изисква се шаблон за заключване на устройството, ПИН код или биометрични данни, за да защитите информацията си за вход с автоматично попълване.</string>
-    <string name="managementDisabledModeTitle">Защитете устройството си, за да използвате автоматично попълване</string>
+    <string name="managementDisabledModeSubtitle">За защита на данните за вход е необходимо да зададете модел за заключване, ПИН код или биометрични данни.</string>
+    <string name="managementDisabledModeTitle">Защитете устройството, за да можете да запазвате данни за вход</string>
 
     <string name="saveLoginDialogTitle">Запазване на данните за вход?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Запазване на паролата?</string>
     <string name="saveLoginDialogButtonSave">Запазване на данните за вход</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Запазване на паролата</string>
     <string name="saveLoginDialogNotNow">Не сега</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo ще съхранява тези данни за вход на сигурно място на Вашето устройство. Можете да управлявате запазените данни за вход в Настройки.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Данните за вход се съхраняват защитени само на това устройство и могат да се управляват от менюто Данни за вход в Настройки.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Искате ли DuckDuckGo да запази данните за вход?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Повече опции</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Изчистване на въведеното търсене</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Няма резултати за \'%1$s\'</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Отмени</string>
+    <string name="autofillDeleteLoginDialogDelete">Изтрий</string>
+    <string name="autofillDeleteLoginDialogTitle">Сигурни ли сте, че искате да изтриете тези данни за вход?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Automatické vyplňování přihlašovacích údajů</string>
+    <string name="autofillManagementScreenTitle">Přihlášení</string>
 
     <string name="managementDisabledModeCta"><b>Nastavit v Nastaveních</b></string>
-    <string name="managementDisabledModeSubtitle">Na ochranu automaticky vyplňovaných přihlašovacích údajů je nutný vzor zámku zařízení, kód PIN nebo biometrické ověření.</string>
-    <string name="managementDisabledModeTitle">Pokud chceš automatické vyplňování používat, zabezpeč své zařízení</string>
+    <string name="managementDisabledModeSubtitle">Na ochranu přihlašovacích údajů se vyžaduje gesto zámku obrazovky, PIN nebo biometrické ověření.</string>
+    <string name="managementDisabledModeTitle">Zabezpeč si zařízení, ať si můžeš ukládat přihlašovací údaje</string>
 
     <string name="saveLoginDialogTitle">Uložit přihlašovací údaje?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Uložit heslo?</string>
     <string name="saveLoginDialogButtonSave">Uložit přihlašovací údaje</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Uložit heslo</string>
     <string name="saveLoginDialogNotNow">Teď ne</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo tyto přihlašovací údaje bezpečně uloží do tvého zařízení. Uložená přihlášení můžeš spravovat v Nastaveních.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Přihlašovací údaje jsou bezpečně uložené jen na tomhle zařízení a dají se spravovat v nabídce Přihlášení v Nastavení.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Má DuckDuckGo uložit přihlašovací údaje?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Další možnosti</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Vymazat vyhledávací vstup</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Žádné výsledky pro dotaz „%1$s“</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Zrušit</string>
+    <string name="autofillDeleteLoginDialogDelete">Smazat</string>
+    <string name="autofillDeleteLoginDialogTitle">Opravdu chceš tohle přihlášení smazat?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -17,22 +17,22 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Automatisk udfyldning ved login</string>
+    <string name="autofillManagementScreenTitle">Logins</string>
 
     <string name="managementDisabledModeCta"><b>Konfigurer i Indstillinger</b></string>
-    <string name="managementDisabledModeSubtitle">Der kræves et låsemønster, en pinkode eller biometri for at beskytte dine oplysninger om automatisk udfyldning.</string>
-    <string name="managementDisabledModeTitle">Beskyt din enhed for at bruge automatisk udfyldning</string>
+    <string name="managementDisabledModeSubtitle">Der kræves et låsemønster, en pinkode eller biometri for at beskytte dine logins.</string>
+    <string name="managementDisabledModeTitle">Beskyt din enhed for at gemme logins</string>
 
     <string name="saveLoginDialogTitle">Gem login?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Gem adgangskode?</string>
     <string name="saveLoginDialogButtonSave">Gem login</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Gem adgangskode</string>
     <string name="saveLoginDialogNotNow">Ikke nu</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo gemmer dette login sikkert på din enhed. Du kan administrere gemte logins i Indstillinger.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Logins gemmes kun sikkert på denne enhed og kan administreres fra menuen Automatisk udfyldning i Indstillinger.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Skal DuckDuckGo gemme dit login?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Flere muligheder</string>
 
-    <string name="useSavedLoginDialogTitle">Brug et gemt login?</string>
+    <string name="useSavedLoginDialogTitle">Vil du bruge et gemt login?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Login til %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Login til websted</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Fra dette websted</string>
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Ryd søgeinput</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Ingen resultater for \"%1$s\"</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Annuller</string>
+    <string name="autofillDeleteLoginDialogDelete">Slet</string>
+    <string name="autofillDeleteLoginDialogTitle">Er du sikker på, at du vil slette dette login?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Anmeldedaten automatisch ausfüllen</string>
+    <string name="autofillManagementScreenTitle">Anmeldungen</string>
 
     <string name="managementDisabledModeCta"><b>In den Einstellungen einrichten</b></string>
-    <string name="managementDisabledModeSubtitle">Ein Entsperrmuster, eine PIN oder biometrische Daten sind erforderlich, um deine Anmeldedaten für das automatische Ausfüllen zu schützen.</string>
-    <string name="managementDisabledModeTitle">Sichere dein Gerät, um das automatische Ausfüllen zu verwenden</string>
+    <string name="managementDisabledModeSubtitle">Es sind ein Entsperrmuster, eine PIN oder biometrische Daten erforderlich, um deine Anmeldedaten zu schützen.</string>
+    <string name="managementDisabledModeTitle">Sichere dein Gerät, um Anmeldungen zu speichern</string>
 
     <string name="saveLoginDialogTitle">Anmeldedaten speichern?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Passwort speichern?</string>
     <string name="saveLoginDialogButtonSave">Anmeldedaten speichern</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Passwort speichern</string>
     <string name="saveLoginDialogNotNow">Jetzt nicht</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo speichert diese Anmeldedaten sicher auf deinem Gerät. Du kannst die gespeicherten Anmeldedaten in den Einstellungen verwalten.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Anmeldedaten werden nur auf diesem Gerät sicher gespeichert und können über das Anmeldedaten-Menü in den Einstellungen verwaltet werden.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Möchtest du, dass DuckDuckGo deine Anmeldedaten speichert?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Weitere Optionen</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Sucheingabe löschen</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Keine Ergebnisse für „%1$s“</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Abbrechen</string>
+    <string name="autofillDeleteLoginDialogDelete">Löschen</string>
+    <string name="autofillDeleteLoginDialogTitle">Möchtest du diese Anmeldedaten wirklich löschen?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Συνδέσεις αυτόματης συμπλήρωσης</string>
+    <string name="autofillManagementScreenTitle">Συνδέσεις</string>
 
     <string name="managementDisabledModeCta"><b>Προσαρμογή στις Ρυθμίσεις</b></string>
-    <string name="managementDisabledModeSubtitle">Για προστασία της Αυτόματης συμπλήρωσης στοιχείων σύνδεσης απαιτείται μοτίβο κλειδώματος συσκευής, PIN ή βιομετρικά στοιχεία.</string>
-    <string name="managementDisabledModeTitle">Ασφαλίστε τη συσκευή σας για χρήση της Αυτόματης συμπλήρωσης</string>
+    <string name="managementDisabledModeSubtitle">Για προστασία των «Συνδέσεών» σας απαιτείται μοτίβο κλειδώματος συσκευής, PIN ή βιομετρικά στοιχεία.</string>
+    <string name="managementDisabledModeTitle">Ασφαλίστε τη συσκευή σας για να αποθηκεύετε τις «Συνδέσεις»</string>
 
     <string name="saveLoginDialogTitle">Αποθήκευση σύνδεσης;</string>
     <string name="saveLoginMissingUsernameDialogTitle">Αποθήκευση κωδικού πρόσβασης;</string>
     <string name="saveLoginDialogButtonSave">Αποθήκευση σύνδεσης</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Αποθήκευση κωδικού πρόσβασης</string>
     <string name="saveLoginDialogNotNow">Όχι τώρα</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">Το DuckDuckGo θα αποθηκεύσει με ασφάλεια αυτά τα στοιχεία σύνδεσης στη συσκευή σας. Μπορείτε να διαχειριστείτε τα αποθηκευμένα στοιχεία σύνδεσής σας από τις Ρυθμίσεις.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Οι συνδέσεις αποθηκεύονται με ασφάλεια μόνο σε αυτή τη συσκευή και η διαχείρισή τους γίνεται από το μενού Συνδέσεις, στις Ρυθμίσεις.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Θέλετε να αποθηκεύσει το DuckDuckGo τη σύνδεσή σας;</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Περισσότερες επιλογές</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Εκκαθάριση εισαγωγής αναζήτησης</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Δεν υπάρχουν αποτελέσματα για «%1$s»</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Ακύρωση</string>
+    <string name="autofillDeleteLoginDialogDelete">Διαγραφή</string>
+    <string name="autofillDeleteLoginDialogTitle">Θέλετε σίγουρα να διαγράψετε αυτά τα στοιχεία σύνδεσης;</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Autocompletar inicios de sesión</string>
+    <string name="autofillManagementScreenTitle">Inicios de sesión</string>
 
     <string name="managementDisabledModeCta"><b>Configurar en Ajustes</b></string>
-    <string name="managementDisabledModeSubtitle">Se requiere un patrón de bloqueo del dispositivo, un PIN o datos biométricos para proteger tus datos de Autocompletar de inicio de sesión.</string>
-    <string name="managementDisabledModeTitle">Asegura tu dispositivo para usar Autocompletar</string>
+    <string name="managementDisabledModeSubtitle">Se requiere un patrón de bloqueo del dispositivo, un PIN o datos biométricos para proteger tus inicios de sesión.</string>
+    <string name="managementDisabledModeTitle">Protege tu dispositivo para guardar los inicios de sesión</string>
 
     <string name="saveLoginDialogTitle">¿Guardar inicio de sesión?</string>
     <string name="saveLoginMissingUsernameDialogTitle">¿Guardar contraseña?</string>
     <string name="saveLoginDialogButtonSave">Guardar inicio de sesión</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Guardar contraseña</string>
     <string name="saveLoginDialogNotNow">Ahora no</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo almacenará este inicio de sesión en tu dispositivo de forma segura. Puedes gestionar los inicios de sesión guardados en Ajustes.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Los inicios de sesión se almacenan de forma segura solo en este dispositivo y se pueden administrar desde el menú de Inicios de Sesión en Ajustes.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">¿Quieres que DuckDuckGo guarde tu inicio de sesión?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Más opciones</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Borrar búsqueda</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Sin resultados para «%1$s»</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Cancelar</string>
+    <string name="autofillDeleteLoginDialogDelete">Eliminar</string>
+    <string name="autofillDeleteLoginDialogTitle">¿Seguro que quieres eliminar este inicio de sesión?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Sisesta sisselogimisandmed automaatselt</string>
+    <string name="autofillManagementScreenTitle">Sisselogimine</string>
 
     <string name="managementDisabledModeCta"><b>Seadista sätetes</b></string>
-    <string name="managementDisabledModeSubtitle">Automaatse sisselogimise andmete kaitsmiseks on vaja seadme lukustusmustrit, PIN-koodi või biomeetriat.</string>
-    <string name="managementDisabledModeTitle">Automaatse täitmise kasutamiseks taga seadme kaitse</string>
+    <string name="managementDisabledModeSubtitle">Sisselogimise kaitsmiseks on vaja seadme lukustusmustrit, PIN-koodi või biomeetriat.</string>
+    <string name="managementDisabledModeTitle">Sisselogimise salvestamiseks kaitske oma seadet</string>
 
     <string name="saveLoginDialogTitle">Kas salvestada sisselogimisandmed?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Kas salvestada parool?</string>
     <string name="saveLoginDialogButtonSave">Salvesta sisselogimisandmed</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Salvesta parool</string>
     <string name="saveLoginDialogNotNow">Mitte praegu</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo salvestab need sisselogimisandmed turvaliselt sinu seadmes. Salvestatud sisselogimisandmeid saad hallata seadetes.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Sisselogimisandmed salvestatakse turvaliselt ainult selles seadmes ja neid saab hallata sätete menüüst Sisselogimisandmed.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Kas soovid, et DuckDuckGo salvestaks sinu sisselogimisandmed?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Veel valikuid</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Tühjenda otsingusisend</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Päringule „%1$s” ei leitud tulemusi</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Loobu</string>
+    <string name="autofillDeleteLoginDialogDelete">Kustuta</string>
+    <string name="autofillDeleteLoginDialogTitle">Kas oled kindel, et soovid need sisselogimisandmed kustutada?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Täytä kirjautumistiedot automaattisesti</string>
+    <string name="autofillManagementScreenTitle">Kirjautumistiedot</string>
 
     <string name="managementDisabledModeCta"><b>Määritä Asetuksissa</b></string>
-    <string name="managementDisabledModeSubtitle">Automaattisen täytön kirjautumistietojen suojaamiseen tarvitaan laitteen lukituskuvio, PIN-koodi tai biometriset tiedot.</string>
-    <string name="managementDisabledModeTitle">Suojaa laitteesi automaattisen täytön käyttöä varten</string>
+    <string name="managementDisabledModeSubtitle">Kirjautumistietojen suojaamiseen tarvitaan laitteen lukituskuvio, PIN-koodi tai biometriset tiedot.</string>
+    <string name="managementDisabledModeTitle">Suojaa laitteesi kirjautumistietojen tallentamiseksi</string>
 
     <string name="saveLoginDialogTitle">Tallennetaanko kirjautumistiedot?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Tallennetaanko salasana?</string>
     <string name="saveLoginDialogButtonSave">Tallenna kirjautumistiedot</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Tallenna salasana</string>
     <string name="saveLoginDialogNotNow">Ei nyt</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo tallentaa nämä kirjautumistiedot turvallisesti laitteellesi. Voit hallita tallennettuja kirjautumistietoja asetuksissa.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Kirjautumistiedot tallennetaan turvallisesti vain tähän laitteeseen. Niitä voi hallita asetusten kirjautumistiedot-valikosta.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Haluatko, että DuckDuckGo tallentaa kirjautumistietosi?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Lisää vaihtoehtoja</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Tyhjennä hakusyöte</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Ei tuloksia haulla \'%1$s\'</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Peruuta</string>
+    <string name="autofillDeleteLoginDialogDelete">Poista</string>
+    <string name="autofillDeleteLoginDialogTitle">Haluatko varmasti poistaa nämä kirjautumistiedot?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Saisie automatique des identifiants</string>
+    <string name="autofillManagementScreenTitle">Identifiants</string>
 
     <string name="managementDisabledModeCta"><b>Configurer dans les paramètres</b></string>
-    <string name="managementDisabledModeSubtitle">Un schéma de verrouillage de l\'appareil, un code PIN ou des données biométriques sont nécessaires pour protéger les informations relatives à la saisie automatique de vos identifiants.</string>
-    <string name="managementDisabledModeTitle">Sécurisez votre appareil pour utiliser la saisie automatique</string>
+    <string name="managementDisabledModeSubtitle">Un schéma de verrouillage de l\'appareil, un code PIN ou des données biométriques sont nécessaires pour protéger vos identifiants.</string>
+    <string name="managementDisabledModeTitle">Sécurisez votre appareil pour enregistrer des identifiants</string>
 
     <string name="saveLoginDialogTitle">Enregistrer l\'identifiant ?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Enregistrer le mot de passe ?</string>
     <string name="saveLoginDialogButtonSave">Enregistrer l\'identifiant</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Enregistrer le mot de passe</string>
     <string name="saveLoginDialogNotNow">Pas maintenant</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo stockera cet identifiant en toute sécurité sur votre appareil. Vous pouvez gérer les identifiants enregistrés dans les paramètres.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Les identifiants sont stockés en toute sécurité sur cet appareil uniquement et peuvent être gérés à partir du menu Identifiants dans Paramètres.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Voulez-vous que DuckDuckGo enregistre votre identifiant ?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Plus d\'options</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Effacer la recherche</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Aucun résultat pour « %1$s »</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Annuler</string>
+    <string name="autofillDeleteLoginDialogDelete">Supprimer</string>
+    <string name="autofillDeleteLoginDialogTitle">Voulez-vous vraiment supprimer cet identifiant ?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Automatsko popunjavanje prijave</string>
+    <string name="autofillManagementScreenTitle">Prijave</string>
 
     <string name="managementDisabledModeCta"><b>Odredi u Postavkama</b></string>
-    <string name="managementDisabledModeSubtitle">Niz za zaključavanje uređaja, PIN ili biometrija potrebni su za zaštitu vaših podataka za prijavu s automatskim popunjavanjem.</string>
-    <string name="managementDisabledModeTitle">Osigurajte svoj uređaj za korištenje automatskog popunjavanja</string>
+    <string name="managementDisabledModeSubtitle">Uzorak za zaključavanje uređaja, PIN ili biometrija potrebni su za zaštitu vaših prijava.</string>
+    <string name="managementDisabledModeTitle">Osigurajte svoj uređaj da biste spremili prijave</string>
 
     <string name="saveLoginDialogTitle">Želiš li spremiti prijavu?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Želiš li spremiti lozinku?</string>
     <string name="saveLoginDialogButtonSave">Spremi prijavu</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Spremi lozinku</string>
     <string name="saveLoginDialogNotNow">Ne sada</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo će sigurno spremiti ovu prijavu na tvoj uređaj. Spremljenim prijavama možeš upravljati u Postavkama.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Prijave se sigurno spremaju samo na ovom uređaju i njima se može upravljati iz izbornika Automatsko popunjavanje u Postavkama.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Želiš li da DuckDuckGo spremi tvoju prijavu?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Dodatne mogućnosti</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Obriši unos pretraživanja</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nema rezultata za \"%1$s\"</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Odustani</string>
+    <string name="autofillDeleteLoginDialogDelete">Izbriši</string>
+    <string name="autofillDeleteLoginDialogTitle">Jesi li siguran da želiš izbrisati ovu prijavu?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Bejelentkezési adatok automatikus kitöltése</string>
+    <string name="autofillManagementScreenTitle">Bejelentkezések</string>
 
     <string name="managementDisabledModeCta"><b>Beállítás a Beállításokban</b></string>
-    <string name="managementDisabledModeSubtitle">Az automatikus bejelentkezési adatok védelméhez az eszközzár mintája, PIN-kód vagy biometrikus adatok szükségesek.</string>
-    <string name="managementDisabledModeTitle">Tedd biztonságossá a készülékedet az automatikus kitöltés használatához</string>
+    <string name="managementDisabledModeSubtitle">A bejelentkezések védelméhez az eszköz zárolási mintája, PIN-kód vagy biometrikus adatok szükségesek.</string>
+    <string name="managementDisabledModeTitle">Tedd biztonságossá a készülékedet a bejelentkezések mentéséhez</string>
 
     <string name="saveLoginDialogTitle">Mented a bejelentkezést?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Mented a jelszót?</string>
     <string name="saveLoginDialogButtonSave">Bejelentkezés mentése</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Jelszó mentése</string>
     <string name="saveLoginDialogNotNow">Most nem</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">A DuckDuckGo biztonságosan tárolja ezen bejelentkezési adatokat az eszközödön. A mentett bejelentkezési adatokat a Beállításokban kezelheted.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">A bejelentkezési adatok csak ezen az eszközön lesznek biztonságosan tárolva, és a Beállítások &gt; Bejelentkezések menüpontban kezelhetők.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">A DuckDuckGo mentse a bejelentkezést?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">További lehetőségek</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Megadott keresés törlése</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nincs találat erre: „%1$s”</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Mégsem</string>
+    <string name="autofillDeleteLoginDialogDelete">Törlés</string>
+    <string name="autofillDeleteLoginDialogTitle">Biztosan törlöd ezen bejelentkezési adatokat?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Compilazione automatica dei dati di accesso</string>
+    <string name="autofillManagementScreenTitle">Accessi</string>
 
     <string name="managementDisabledModeCta"><b>Configura in Impostazioni</b></string>
-    <string name="managementDisabledModeSubtitle">Una sequenza di blocco del dispositivo, un PIN o dati biometrici sono necessari per proteggere i dettagli di accesso della compilazione automatica.</string>
-    <string name="managementDisabledModeTitle">Proteggi il tuo dispositivo per utilizzare la compilazione automatica</string>
+    <string name="managementDisabledModeSubtitle">Per proteggere i tuoi accessi sono necessari una sequenza di blocco del dispositivo, un PIN o dati biometrici.</string>
+    <string name="managementDisabledModeTitle">Proteggi il tuo dispositivo per salvare gli accessi</string>
 
     <string name="saveLoginDialogTitle">Salvare dati di accesso?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Salvare password?</string>
     <string name="saveLoginDialogButtonSave">Salva dati di accesso</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Salva password</string>
     <string name="saveLoginDialogNotNow">Non adesso</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo salverà in modo sicuro questi dati di accesso sul tuo dispositivo. Puoi gestire i dati di accesso salvati in Impostazioni.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">I dati di accesso sono archiviati in modo sicuro solo su questo dispositivo e possono essere gestiti dal menu Accessi, all\'interno di Impostazioni.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Vuoi che DuckDuckGo salvi i dati di accesso?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Altre opzioni</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Elimina input di ricerca</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nessun risultato per \"%1$s\"</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Annulla</string>
+    <string name="autofillDeleteLoginDialogDelete">Cancella</string>
+    <string name="autofillDeleteLoginDialogTitle">Vuoi davvero eliminare questi dati di accesso?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Automatiškai užpildyti prisijungimus</string>
+    <string name="autofillManagementScreenTitle">Prisijungimai</string>
 
     <string name="managementDisabledModeCta"><b>Nustatyti nustatymuose</b></string>
-    <string name="managementDisabledModeSubtitle">Norint apsaugoti automatinio pildymo prisijungimo duomenis, reikia naudoti įrenginio užrakinimo šabloną, PIN kodą arba biometrinius duomenis.</string>
-    <string name="managementDisabledModeTitle">Apsaugokite įrenginį, kad galėtumėte naudoti automatinį pildymą</string>
+    <string name="managementDisabledModeSubtitle">Prisijungimams apsaugoti reikia naudoti prietaiso užrakinimo šabloną, PIN kodą arba biometrinius duomenis.</string>
+    <string name="managementDisabledModeTitle">Apsaugokite įrenginį, kad išsaugotumėte prisijungimus</string>
 
     <string name="saveLoginDialogTitle">Išsaugoti prisijungimą?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Išsaugoti slaptažodį?</string>
     <string name="saveLoginDialogButtonSave">Išsaugoti prisijungimą</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Išsaugoti slaptažodį</string>
     <string name="saveLoginDialogNotNow">Ne dabar</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">„DuckDuckGo“ saugiai išsaugos šį prisijungimą jūsų įrenginyje. Išsaugotus prisijungimus galite tvarkyti nustatymuose.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Prisijungimai saugiai laikomi tik šiame įrenginyje, o juos galima tvarkyti nustatymuose, prisijungimų meniu.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Ar norite, kad „DuckDuckGo“ išsaugotų jūsų prisijungimą?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Daugiau parinkčių</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Išvalyti paieškos įvestį</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Rezultatų pagal paiešką „%1$s“ nerasta</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Atšaukti</string>
+    <string name="autofillDeleteLoginDialogDelete">Trinti</string>
+    <string name="autofillDeleteLoginDialogTitle">Ar tikrai norite ištrinti šį prisijungimą?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Automātiski aizpildīt pieteikšanās datus</string>
+    <string name="autofillManagementScreenTitle">Pieteikšanās dati</string>
 
     <string name="managementDisabledModeCta"><b>Iestati sadaļā Iestatījumi</b></string>
-    <string name="managementDisabledModeSubtitle">Lai aizsargātu automātiskās pierakstīšanās datus, ir nepieciešama ierīces bloķēšanas figūra, PIN kods vai biometriskie dati.</string>
-    <string name="managementDisabledModeTitle">Aizsargā savu ierīci, lai izmantotu automātisko aizpildi</string>
+    <string name="managementDisabledModeSubtitle">Lai aizsargātu jūsu pieteikšanās datus, ir nepieciešama ierīces bloķēšanas figūra, PIN kods vai biometriskā aizsardzība.</string>
+    <string name="managementDisabledModeTitle">Aizsargājiet savu ierīci, lai saglabātu pieteikšanās datus</string>
 
     <string name="saveLoginDialogTitle">Saglabāt pieteikšanās datus?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Saglabāt paroli?</string>
     <string name="saveLoginDialogButtonSave">Saglabāt pieteikšanās datus</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Saglabāt paroli</string>
     <string name="saveLoginDialogNotNow">Ne tagad</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo droši saglabās šos pieteikšanās datus tavā ierīcē. Saglabātos pieteikšanās datus vari pārvaldīt sadaļā Iestatījumi.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Pieteikšanās dati tiek droši saglabāti tikai šajā ierīcē, un tos var pārvaldīt no iestatījumu izvēlnes Pieteikšanās dati.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Vai vēlies, lai DuckDuckGo saglabātu tavus pieteikšanās datus?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Citas iespējas</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Notīrīt meklēšanas ievadi</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Vaicājumam “%1$s” nav rezultātu</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Atcelt</string>
+    <string name="autofillDeleteLoginDialogDelete">Dzēst</string>
+    <string name="autofillDeleteLoginDialogTitle">Vai tiešām vēlies dzēst šos pieteikšanās datus?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Fyll inn pålogginger automatisk</string>
+    <string name="autofillManagementScreenTitle">Pålogginger</string>
 
     <string name="managementDisabledModeCta"><b>Konfigurer i Innstillinger</b></string>
-    <string name="managementDisabledModeSubtitle">Du trenger låsemønster, PIN-kode eller biometri på enheten for å beskytte påloggingsinformasjonen din når du bruker Autofyll.</string>
-    <string name="managementDisabledModeTitle">Sikre enheten din for å bruke Autofyll</string>
+    <string name="managementDisabledModeSubtitle">Du trenger låsemønster, PIN-kode eller biometri på enheten for å beskytte påloggingene dine.</string>
+    <string name="managementDisabledModeTitle">Sikre enheten din for å lagre pålogginger</string>
 
     <string name="saveLoginDialogTitle">Vil du lagre påloggingen?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Vil du lagre passordet?</string>
     <string name="saveLoginDialogButtonSave">Lagre påloggingen</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Lagre passordet</string>
     <string name="saveLoginDialogNotNow">Ikke nå</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo lagrer denne påloggingen på en sikker måte på enheten din. Du kan administrere lagrede pålogginger i innstillingene.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Pålogginger lagres bare på denne enheten og kan administreres i påloggingsmenyen i innstillinger.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Vil du at DuckDuckGo skal lagre påloggingen din?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Flere alternativer</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Tøm søkefeltet</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Ingen resultater for «%1$s»</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Avbryt</string>
+    <string name="autofillDeleteLoginDialogDelete">Slett</string>
+    <string name="autofillDeleteLoginDialogTitle">Er du sikker på at du vil slette denne påloggingen?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Login met automatisch invullen</string>
+    <string name="autofillManagementScreenTitle">Aanmeldgegevens</string>
 
     <string name="managementDisabledModeCta"><b>Instellen in Instellingen</b></string>
-    <string name="managementDisabledModeSubtitle">Een vergrendelingspatroon, pincode of biometrische gegevens zijn noodzakelijk om uw inloggegevens voor automatisch invullen te beschermen.</string>
-    <string name="managementDisabledModeTitle">Beveilig je apparaat om automatisch invullen te gebruiken</string>
+    <string name="managementDisabledModeSubtitle">Een vergrendelingspatroon, pincode of biometrische gegevens zijn noodzakelijk om je aanmeldgegevens te beschermen.</string>
+    <string name="managementDisabledModeTitle">Beveilig je apparaat om aanmeldgegevens op te slaan</string>
 
-    <string name="saveLoginDialogTitle">Login opslaan?</string>
+    <string name="saveLoginDialogTitle">Aanmeldgegevens opslaan?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Wachtwoord opslaan?</string>
     <string name="saveLoginDialogButtonSave">Login opslaan</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Wachtwoord opslaan</string>
     <string name="saveLoginDialogNotNow">Niet nu</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo slaat deze aanmeldgegevens veilig op je apparaat op. Je kunt opgeslagen aanmeldgegevens beheren in Instellingen.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Aanmeldgegevens worden enkel op dit apparaat veilig opgeslagen en kunnen worden beheerd via het menu Aanmeldgegevens in Instellingen.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Wil je dat DuckDuckGo je login opslaat?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Meer opties</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Zoekinvoer wissen</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Geen resultaten voor \'%1$s\'</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Annuleren</string>
+    <string name="autofillDeleteLoginDialogDelete">Verwijderen</string>
+    <string name="autofillDeleteLoginDialogTitle">Weet je zeker dat je deze aanmeldgegevens wilt verwijderen?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Autouzupełnianie logowania</string>
+    <string name="autofillManagementScreenTitle">Dane logowania</string>
 
     <string name="managementDisabledModeCta"><b>Dostosuj ustawienia</b></string>
-    <string name="managementDisabledModeSubtitle">Aby chronić automatycznie uzupełniane dane logowania, korzystaj z blokady urządzenia za pomocą wzoru, kodu PIN lub danych biometrycznych.</string>
-    <string name="managementDisabledModeTitle">Zabezpiecz swoje urządzenie, aby korzystać z funkcji autouzupełniania</string>
+    <string name="managementDisabledModeSubtitle">Aby chronić dane logowania, korzystaj z blokady urządzenia za pomocą wzoru, kodu PIN lub danych biometrycznych.</string>
+    <string name="managementDisabledModeTitle">Zabezpiecz urządzenie, aby chronić dane logowania</string>
 
     <string name="saveLoginDialogTitle">Zapisać logowanie?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Zapisać hasło?</string>
     <string name="saveLoginDialogButtonSave">Zapisz logowanie</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Zapisz hasło</string>
     <string name="saveLoginDialogNotNow">Nie teraz</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo będzie bezpiecznie przechowywać ten login na Twoim urządzeniu. Zapisanymi loginami możesz zarządzać w ustawieniach.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Dane logowania są bezpiecznie przechowywane wyłącznie na tym urządzeniu i można nimi zarządzać w sekcji Loginy menu Ustawienia.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Czy chcesz zapisać dane logowania w DuckDuckGo?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Więcej opcji</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Usuń treść wyszukiwania</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nie znaleziono wyników dla frazy „%1$s”</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Anuluj</string>
+    <string name="autofillDeleteLoginDialogDelete">Usuń</string>
+    <string name="autofillDeleteLoginDialogTitle">Na pewno chcesz usunąć ten login?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Preenchimento automático de inícios de sessão</string>
+    <string name="autofillManagementScreenTitle">Inícios de sessão</string>
 
     <string name="managementDisabledModeCta"><b>Configura nas Definições</b></string>
-    <string name="managementDisabledModeSubtitle">É necessário um padrão de bloqueio do dispositivo, um PIN ou dados biométricos para proteger os teus dados de início de sessão com preenchimento automático.</string>
-    <string name="managementDisabledModeTitle">Protege o teu dispositivo para usares o preenchimento automático</string>
+    <string name="managementDisabledModeSubtitle">É necessário um padrão de bloqueio de dispositivo, PIN ou biometria para proteger os teus inícios de sessão.</string>
+    <string name="managementDisabledModeTitle">Proteger o dispositivo para guardar inícios de sessão</string>
 
     <string name="saveLoginDialogTitle">Guardar início de sessão?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Guardar palavra-passe?</string>
     <string name="saveLoginDialogButtonSave">Guardar início de sessão</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Guardar palavra-passe</string>
     <string name="saveLoginDialogNotNow">Agora não</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">O DuckDuckGo vai armazenar este início de sessão em segurança no teu dispositivo. Podes gerir os inícios de sessão guardados nas Definições.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Os inícios de sessão são armazenados com segurança apenas neste dispositivo, e podes efetuar a gestão dos mesmos a partir do menu de Inícios de sessão nas Definições.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Queres que o DuckDuckGo guarde o teu início de sessão?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Mais opções</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Limpar introdução da pesquisa</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nenhum resultado para \"%1$s\"</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Cancelar</string>
+    <string name="autofillDeleteLoginDialogDelete">Eliminar</string>
+    <string name="autofillDeleteLoginDialogTitle">Tens a certeza de que pretendes eliminar este início de sessão?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Completare automată la autentificare</string>
+    <string name="autofillManagementScreenTitle">Conectări</string>
 
     <string name="managementDisabledModeCta"><b>Configurează în Setări</b></string>
-    <string name="managementDisabledModeSubtitle">Este necesar un model de blocare a dispozitivului, un cod PIN sau date biometrice pentru a-ți proteja detaliile de autentificare prin completarea automată.</string>
-    <string name="managementDisabledModeTitle">Asigură-ți dispozitivul pentru a utiliza completarea automată</string>
+    <string name="managementDisabledModeSubtitle">Este necesar un model de blocare a dispozitivului, un cod PIN sau date biometrice pentru a-ți proteja conectările.</string>
+    <string name="managementDisabledModeTitle">Securizează-ți dispozitivul pentru a salva conectările</string>
 
     <string name="saveLoginDialogTitle">Salvezi autentificarea?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Salvezi parola?</string>
     <string name="saveLoginDialogButtonSave">Salvează autentificarea</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Salvează parola</string>
     <string name="saveLoginDialogNotNow">Nu acum</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo va stoca în siguranță aceste date de conectare pe dispozitivul tău. Din Setări poți gestiona datele de conectare salvate.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Datele de conectare sunt stocate în siguranță doar pe acest dispozitiv și pot fi gestionate din meniul Date de conectare din Setări.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Dorești ca DuckDuckGo să îți salveze datele de autentificare?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Mai multe opțiuni</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Șterge datele introduse pentru căutare</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nu există rezultate pentru „%1$s”</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Anulare</string>
+    <string name="autofillDeleteLoginDialogDelete">Ștergere</string>
+    <string name="autofillDeleteLoginDialogTitle">Sigur vrei să ștergi aceste date de autentificare?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Автозаполнение логинов</string>
+    <string name="autofillManagementScreenTitle">Логины</string>
 
     <string name="managementDisabledModeCta"><b>Откройте «Настройки»</b></string>
-    <string name="managementDisabledModeSubtitle">Для защиты автоматически заполняемой учетной информации нужны биометрические данные, графический ключ или ПИН-код.</string>
-    <string name="managementDisabledModeTitle">Защитите свое устройство, чтобы использовать автозаполнение</string>
+    <string name="managementDisabledModeSubtitle">Для защиты логинов требуются биометрические данные, графический ключ или ПИН-код.</string>
+    <string name="managementDisabledModeTitle">Защитите свое устройство, чтобы сохранять логины</string>
 
     <string name="saveLoginDialogTitle">Сохранить логин?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Сохранить пароль?</string>
     <string name="saveLoginDialogButtonSave">Сохранить логин</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Сохранить пароль</string>
     <string name="saveLoginDialogNotNow">Не сейчас</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo безопасно сохранит этот логин на вашем устройстве. Сохраненными учетными данными можно управлять в «Настройках».</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Логины надежно хранятся только на этом устройстве. Ими можно управлять в меню «Логины» в «Настройках».</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Хотите, чтобы DuckDuckGo сохранил логин?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Другие параметры</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Сбросить поисковый запрос</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Поиск «%1$s» не дал результатов</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Отменить</string>
+    <string name="autofillDeleteLoginDialogDelete">Удалить</string>
+    <string name="autofillDeleteLoginDialogTitle">Действительно удалить этот логин?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Automatické vyplňovanie prihlasovacích údajov</string>
+    <string name="autofillManagementScreenTitle">Prihlasovacie údaje</string>
 
     <string name="managementDisabledModeCta"><b>Nastaviť v Nastaveniach</b></string>
-    <string name="managementDisabledModeSubtitle">Na ochranu vašich prihlasovacích údajov pri automatickom vypĺňaní sa vyžaduje vzor uzamknutia zariadenia, kód PIN alebo biometrické údaje.</string>
-    <string name="managementDisabledModeTitle">Zabezpečte svoje zariadenie, aby ste mohli používať automatické vypĺňanie</string>
+    <string name="managementDisabledModeSubtitle">Na ochranu vašich prihlasovacích údajov sa vyžaduje vzor uzamknutia zariadenia, kód PIN alebo biometrické údaje.</string>
+    <string name="managementDisabledModeTitle">Zabezpečte svoje zariadenie a uložte prihlasovacie údaje</string>
 
     <string name="saveLoginDialogTitle">Uložiť prihlasovacie údaje?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Uložiť heslo?</string>
     <string name="saveLoginDialogButtonSave">Uložiť prihlasovacie údaje</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Uložiť heslo</string>
     <string name="saveLoginDialogNotNow">Teraz nie</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo toto prihlásenie zabezpečene uloží vo vašom zariadení. Uložené prihlásenia môžete spravovať v Nastaveniach.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Prihlasovacie údaje sú zabezpečene uložené len v tomto zariadení a môžete ich spravovať v ponuke Prihlasovacie údaje v Nastaveniach.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Chcete, aby DuckDuckGo uložil vaše prihlasovacie údaje?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Ďalšie možnosti</string>
 
@@ -41,7 +41,7 @@
     <string name="updateLoginDialogButtonUpdatePassword">Aktualizovať heslo</string>
     <string name="updateLoginDialogButtonNotNow">Teraz nie</string>
 
-    <string name="updateLoginDialogTitleUpdateUsername">Aktualizovať používateľské meno?</string>
+    <string name="updateLoginDialogTitleUpdateUsername">Aktualizovať meno používateľa?</string>
     <string name="updateLoginDialogButtonUpdateUsername">Aktualizovať používateľské meno</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Zavrieť dialógové okno automatického vypĺňania</string>
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Vymazať hľadaný výraz</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Žiadne výsledky pre „%1$s”</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Zrušiť</string>
+    <string name="autofillDeleteLoginDialogDelete">Odstrániť</string>
+    <string name="autofillDeleteLoginDialogTitle">Naozaj chcete odstrániť tieto prihlasovacie údaje?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Samodejno izpolnjevanje obrazcev za prijavo</string>
+    <string name="autofillManagementScreenTitle">Prijave</string>
 
     <string name="managementDisabledModeCta"><b>Nastavitev v nastavitvah</b></string>
-    <string name="managementDisabledModeSubtitle">Za zaščito podatkov samodejnega izpolnjevanja prijave je potreben vzorec za zaklepanje naprave, koda PIN ali biometrični podatki.</string>
-    <string name="managementDisabledModeTitle">Zaščitite svojo napravo za uporabo samodejnega izpolnjevanja</string>
+    <string name="managementDisabledModeSubtitle">Za zaščito prijav je potreben vzorec za zaklepanje naprave, koda PIN ali biometrični podatki.</string>
+    <string name="managementDisabledModeTitle">Zavarujte svojo napravo, če želite shraniti prijave</string>
 
     <string name="saveLoginDialogTitle">Želite shraniti prijavo?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Želite shraniti geslo?</string>
     <string name="saveLoginDialogButtonSave">Shrani prijavo</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Shrani geslo</string>
     <string name="saveLoginDialogNotNow">Ne zdaj</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo bo te podatke za prijavo varno shranil v vaši napravi. Shranjene podatke za prijavo lahko upravljate v nastavitvah.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Prijave so varno shranjene samo v tej napravi in jih lahko upravljate v meniju Prijave v Nastavitvah.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Ali želite, da DuckDuckGo shrani vašo prijavo?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Več možnosti</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Počisti vhod iskanja</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Ni rezultatov za »%1$s«</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Prekliči</string>
+    <string name="autofillDeleteLoginDialogDelete">Izbriši</string>
+    <string name="autofillDeleteLoginDialogTitle">Ali ste prepričani, da želite izbrisati te podatke za prijavo?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Fyll i inloggningar automatiskt</string>
+    <string name="autofillManagementScreenTitle">Inloggningar</string>
 
     <string name="managementDisabledModeCta"><b>Konfigurera i Inställningar</b></string>
-    <string name="managementDisabledModeSubtitle">För att skydda dina uppgifter för automatisk ifyllning krävs ett enhetslåsmönster, en PIN-kod eller biometri.</string>
-    <string name="managementDisabledModeTitle">Säkra din enhet för att använda automatisk ifyllning</string>
+    <string name="managementDisabledModeSubtitle">För att skydda dina inloggningar krävs ett enhetslåsmönster, en PIN-kod eller biometri.</string>
+    <string name="managementDisabledModeTitle">Säkra din enhet för att spara inloggningar</string>
 
     <string name="saveLoginDialogTitle">Spara inloggning?</string>
     <string name="saveLoginMissingUsernameDialogTitle">Spara lösenord?</string>
     <string name="saveLoginDialogButtonSave">Spara inloggning</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Spara lösenord</string>
     <string name="saveLoginDialogNotNow">Inte nu</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo lagrar denna inloggning säkert på din enhet. Du kan hantera sparade inloggningar i Inställningar.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Inloggningar lagras säkert, enbart på den här enheten, och kan hanteras genom menyn Inloggningar i inställningarna.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">Vill du att DuckDuckGo ska spara din inloggning?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Fler alternativ</string>
 
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Rensa sökfältet</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Inga resultat för ”%1$s”</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Avbryt</string>
+    <string name="autofillDeleteLoginDialogDelete">Ta bort</string>
+    <string name="autofillDeleteLoginDialogTitle">Är du säker på att du vill radera inloggningen?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -17,18 +17,18 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="autofillManagementScreenTitle">Girişleri Otomatik Doldur</string>
+    <string name="autofillManagementScreenTitle">Giriş bilgileri</string>
 
     <string name="managementDisabledModeCta"><b>Ayarlarda Ayarlama</b></string>
-    <string name="managementDisabledModeSubtitle">Otomatik Doldurulan Giriş bilgilerinizin güvenliğini sağlamak için bir cihaz kilidi deseni, PIN veya biyometrik veri gereklidir.</string>
-    <string name="managementDisabledModeTitle">Cihazınızı Otomatik Doldurma özelliğini kullanmak için güvenli hâle getirin</string>
+    <string name="managementDisabledModeSubtitle">Giriş bilgilerinizin güvenliğini sağlamak için bir cihaz kilidi deseni, PIN veya biyometrik veri gereklidir.</string>
+    <string name="managementDisabledModeTitle">Giriş bilgilerini kaydetmek için cihazınızın güvenliğini sağlayın</string>
 
-    <string name="saveLoginDialogTitle">Giriş Kaydedilsin mi?</string>
-    <string name="saveLoginMissingUsernameDialogTitle">Şifre Kaydedilsin mi?</string>
+    <string name="saveLoginDialogTitle">Giriş kaydedilsin mi?</string>
+    <string name="saveLoginMissingUsernameDialogTitle">Şifre kaydedilsin mi?</string>
     <string name="saveLoginDialogButtonSave">Girişi Kaydet</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Şifre Kaydet</string>
     <string name="saveLoginDialogNotNow">Şimdi Değil</string>
-    <string name="saveLoginDialogOnboardingExplanationSubtitle">DuckDuckGo bu Girişi cihazınızda güvenli bir şekilde saklayacaktır. Kayıtlı Girişleri Ayarlar\'dan yönetebilirsiniz.</string>
+    <string name="saveLoginDialogOnboardingExplanationSubtitle">Giriş bilgileri yalnızca bu cihazda güvenli bir şekilde saklanır ve Ayarlar\'daki Giriş Bilgileri menüsünden yönetilebilir.</string>
     <string name="saveLoginDialogFirstTimeOnboardingExplanationTitle">DuckDuckGo\'nun Girişinizi kaydetmesini istiyor musunuz?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Diğer Seçenekler</string>
 
@@ -41,7 +41,7 @@
     <string name="updateLoginDialogButtonUpdatePassword">Şifreyi Güncelle</string>
     <string name="updateLoginDialogButtonNotNow">Şimdi Değil</string>
 
-    <string name="updateLoginDialogTitleUpdateUsername">Kullanıcı Adı Güncellensin mi?</string>
+    <string name="updateLoginDialogTitleUpdateUsername">Kullanıcı adı güncellensin mi?</string>
     <string name="updateLoginDialogButtonUpdateUsername">Kullanıcı Adını Güncelle</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Otomatik Doldurma İletişim Kutusunu Kapat</string>
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Arama girişini temizle</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">\'%1$s\' için sonuç yok</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Vazgeç</string>
+    <string name="autofillDeleteLoginDialogDelete">Sil</string>
+    <string name="autofillDeleteLoginDialogTitle">Bu Girişi silmek istediğinizden emin misiniz?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -19,4 +19,8 @@
     <string name="updateLoginUpdatePasswordExplanation" >DuckDuckGo will update this stored Login on your device.</string>
     <string name="autofillManagementUsernameCopied">Username copied</string>
     <string name="autofillManagementPasswordCopied">Password copied</string>
+
+    <string name="autofillDeleteLoginDialogCancel">Cancel</string>
+    <string name="autofillDeleteLoginDialogDelete">Delete</string>
+    <string name="autofillDeleteLoginDialogTitle">Are you sure you want to delete this Login?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -19,8 +19,4 @@
     <string name="updateLoginUpdatePasswordExplanation" >DuckDuckGo will update this stored Login on your device.</string>
     <string name="autofillManagementUsernameCopied">Username copied</string>
     <string name="autofillManagementPasswordCopied">Password copied</string>
-
-    <string name="autofillDeleteLoginDialogCancel">Cancel</string>
-    <string name="autofillDeleteLoginDialogDelete">Delete</string>
-    <string name="autofillDeleteLoginDialogTitle">Are you sure you want to delete this Login?</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -71,4 +71,7 @@
     <string name="autofillManagementSearchClearDescription">Clear search input</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for 'kittens'">No results for \'%1$s\'</string>
 
+    <string name="autofillDeleteLoginDialogCancel">Cancel</string>
+    <string name="autofillDeleteLoginDialogDelete">Delete</string>
+    <string name="autofillDeleteLoginDialogTitle">Are you sure you want to delete this Login?</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-bg/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-bg/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Автоматичното попълване е заключено</string>
+    <string name="biometric_prompt_title">Данните за вход са заключени</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-cs/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-cs/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatické vyplňování je zamčené</string>
+    <string name="biometric_prompt_title">Přihlašovací údaje uzamčeny</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-da/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-da/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatisk udfyldning låst</string>
+    <string name="biometric_prompt_title">Logins låst</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-de/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-de/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatisches Ausfüllen gesperrt</string>
+    <string name="biometric_prompt_title">Anmeldungen gesperrt</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-el/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-el/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Η αυτόματη συμπλήρωση είναι κλειδωμένη</string>
+    <string name="biometric_prompt_title">Κλειδωμένες «Συνδέσεις»</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-es/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-es/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Función de autocompletar bloqueada</string>
+    <string name="biometric_prompt_title">Inicios de sesión bloqueados</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-et/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-et/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automaatsisestus on lukustatud</string>
+    <string name="biometric_prompt_title">Sisselogimine on lukustatud</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-fi/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-fi/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automaattinen täyttö lukittu</string>
+    <string name="biometric_prompt_title">Kirjautumistiedot lukittu</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-fr/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-fr/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Saisie automatique verrouillée</string>
+    <string name="biometric_prompt_title">Identifiants verrouillés</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-hr/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-hr/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatsko popunjavanje zaključano</string>
+    <string name="biometric_prompt_title">Prijave zaključane</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-hu/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-hu/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatikus kitöltés zárolva</string>
+    <string name="biometric_prompt_title">Bejelentkezések zárolva</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-it/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-it/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Compilazione automatica bloccata</string>
+    <string name="biometric_prompt_title">Accessi bloccati</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-lt/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-lt/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatinis užpildymas užrakintas</string>
+    <string name="biometric_prompt_title">Prisijungimai užrakinti</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-lv/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-lv/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automātiskā aizpildīšana bloķēta</string>
+    <string name="biometric_prompt_title">Pieteikšanās dati bloķēti</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-nb/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-nb/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Autofyll er låst</string>
+    <string name="biometric_prompt_title">Pålogginger er låst</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-nl/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-nl/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatisch invullen vergrendeld</string>
+    <string name="biometric_prompt_title">Aanmeldgegevens vergrendeld</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-pl/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-pl/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatyczne wypełnianie zablokowane</string>
+    <string name="biometric_prompt_title">Zablokowane dane logowania</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-pt/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-pt/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Preenchimento automático bloqueado</string>
+    <string name="biometric_prompt_title">Inícios de sessão bloqueados</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-ro/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-ro/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Completare automată blocată</string>
+    <string name="biometric_prompt_title">Conectări blocate</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-ru/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-ru/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Автозаполнение заблокировано</string>
+    <string name="biometric_prompt_title">Логины заблокированы</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-sk/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-sk/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatické dopĺňanie je uzamknuté</string>
+    <string name="biometric_prompt_title">Prihlasovacie údaje sú uzamknuté</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-sl/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-sl/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Samodejno izpolnjevanje je zaklenjeno</string>
+    <string name="biometric_prompt_title">Prijave so zaklenjene</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-sv/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-sv/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Automatisk ifyllning låst</string>
+    <string name="biometric_prompt_title">Inloggningar låsta</string>
 </resources>

--- a/device-auth/device-auth-impl/src/main/res/values-tr/strings-device-auth.xml
+++ b/device-auth/device-auth-impl/src/main/res/values-tr/strings-device-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 DuckDuckGo
+  ~ Copyright (c) 2023 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="biometric_prompt_title">Otomatik Doldurma Kilitli</string>
+    <string name="biometric_prompt_title">Giriş Bilgileri Kilitli</string>
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1203822806345703/1204225031981470/f 

### Description
This PR adds a confirmation dialog before deleting a login

### Steps to test this PR

- [ ] Build the app using the internal build
- [ ] Add a login manually
- [ ] In the list of saved logins, click on the 3 dots and then delete.
- [ ] A confirmation dialog should show up, clicking delete should delete the login.
- [ ] Add another login 
- [ ] In the list of saved logins click on the login.
- [ ] In the detail screen click on the 3 dots and then delete.
- [ ] A confirmation dialog should show up, click delete should delete the login. 

