### PR TITLE
AppTP: Change endpoint for blocklist to pull new format

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListService.kt
@@ -24,6 +24,6 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface AppTrackerListService {
-    @GET("https://staticcdn.duckduckgo.com/trackerblocking/appTP/2.0/blocklist.json")
+    @GET("https://staticcdn.duckduckgo.com/trackerblocking/appTP/2.0/android-tds.json")
     fun appTrackerBlocklist(): Call<JsonAppBlockingList>
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListService.kt
@@ -24,6 +24,6 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface AppTrackerListService {
-    @GET("https://staticcdn.duckduckgo.com/trackerblocking/appTB/1.0/blocklist.json")
+    @GET("https://staticcdn.duckduckgo.com/trackerblocking/appTP/2.0/blocklist.json")
     fun appTrackerBlocklist(): Call<JsonAppBlockingList>
 }

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTracker.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTracker.kt
@@ -105,7 +105,7 @@ data class JsonAppBlockingList(
 
 class JsonAppTracker(
     val owner: TrackerOwner,
-    val app: TrackerApp,
+    // val app: TrackerApp,
     @field:Json(name = "default")
     val defaultAction: String? = null,
 )
@@ -120,6 +120,7 @@ data class TrackerOwner(
     val displayName: String,
 )
 
+@Deprecated("This obj is no longer used. Stays to avoid db migration, SQLite doesn't allow renaming columns")
 data class TrackerApp(
     val score: Int,
     val prevalence: Double,

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTracker.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTracker.kt
@@ -105,7 +105,6 @@ data class JsonAppBlockingList(
 
 class JsonAppTracker(
     val owner: TrackerOwner,
-    // val app: TrackerApp,
     @field:Json(name = "default")
     val defaultAction: String? = null,
 )

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParser.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParser.kt
@@ -46,7 +46,7 @@ class AppTrackerJsonParser {
                         hostname = it.key,
                         trackerCompanyId = it.value.owner.name.hashCode(),
                         owner = it.value.owner,
-                        app = it.value.app,
+                        app = TrackerApp(1, 1.0),
                     )
                 }
                 .map { it.value }

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
@@ -31,7 +31,7 @@ class AppTrackerJsonParserTest {
         val blocklist = AppTrackerJsonParser.parseAppTrackerJson(moshi, json)
 
         Assert.assertEquals("1680299195572", blocklist.version)
-        Assert.assertEquals(345, blocklist.trackers.count())
+        Assert.assertEquals(302, blocklist.trackers.count())
         Assert.assertEquals(406, blocklist.packages.count())
         Assert.assertEquals(130, blocklist.entities.count())
     }

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
@@ -31,8 +31,8 @@ class AppTrackerJsonParserTest {
         val blocklist = AppTrackerJsonParser.parseAppTrackerJson(moshi, json)
 
         Assert.assertEquals("1639624032609", blocklist.version)
-        Assert.assertEquals(302, blocklist.trackers.count())
-        Assert.assertEquals(406, blocklist.packages.count())
-        Assert.assertEquals(130, blocklist.entities.count())
+        Assert.assertEquals(260, blocklist.trackers.count())
+        Assert.assertEquals(433, blocklist.packages.count())
+        Assert.assertEquals(128, blocklist.entities.count())
     }
 }

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
@@ -32,7 +32,7 @@ class AppTrackerJsonParserTest {
 
         Assert.assertEquals("1680299195572", blocklist.version)
         Assert.assertEquals(345, blocklist.trackers.count())
-        Assert.assertEquals(406, blocklist.packageNames.count())
+        Assert.assertEquals(406, blocklist.packages.count())
         Assert.assertEquals(130, blocklist.entities.count())
     }
 }

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
@@ -30,9 +30,9 @@ class AppTrackerJsonParserTest {
         val json = loadText(javaClass.classLoader!!, "full_app_trackers_blocklist.json")
         val blocklist = AppTrackerJsonParser.parseAppTrackerJson(moshi, json)
 
-        Assert.assertEquals("1639624032609", blocklist.version)
-        Assert.assertEquals(257, blocklist.trackers.count())
-        Assert.assertEquals(376, blocklist.packages.count())
-        Assert.assertEquals(127, blocklist.entities.count())
+        Assert.assertEquals("1680299195572", blocklist.version)
+        Assert.assertEquals(345, blocklist.trackers.count())
+        Assert.assertEquals(406, blocklist.packageNames.count())
+        Assert.assertEquals(130, blocklist.entities.count())
     }
 }

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerJsonParserTest.kt
@@ -30,7 +30,7 @@ class AppTrackerJsonParserTest {
         val json = loadText(javaClass.classLoader!!, "full_app_trackers_blocklist.json")
         val blocklist = AppTrackerJsonParser.parseAppTrackerJson(moshi, json)
 
-        Assert.assertEquals("1680299195572", blocklist.version)
+        Assert.assertEquals("1639624032609", blocklist.version)
         Assert.assertEquals(302, blocklist.trackers.count())
         Assert.assertEquals(406, blocklist.packages.count())
         Assert.assertEquals(130, blocklist.entities.count())

--- a/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
+++ b/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
@@ -1,6 +1,6 @@
 {
     "readme": "https://github.com/duckduckgo/tracker-blocklists",
-    "version": 1680299195572,
+    "version": 1639624032609,
     "trackers": {
         "15.taboola.com": {
             "owner": {
@@ -9,10 +9,10 @@
             },
             "default": "block"
         },
-        "a.applovin.com": {
+        "a.teads.tv": {
             "owner": {
-                "name": "AppLovin Corporation",
-                "displayName": "AppLovin"
+                "name": "Teads ( Luxenbourg ) SA",
+                "displayName": "Teads"
             },
             "default": "block"
         },
@@ -30,38 +30,24 @@
             },
             "default": "block"
         },
-        "aax-eu.amazon-adsystem.com": {
-            "owner": {
-                "name": "Amazon Technologies, Inc.",
-                "displayName": "Amazon.com"
-            },
-            "default": "block"
-        },
         "aax-us-east.amazon-adsystem.com": {
             "owner": {
                 "name": "Amazon Technologies, Inc.",
-                "displayName": "Amazon.com"
+                "displayName": "Amazon"
             },
             "default": "block"
         },
         "aax.amazon-adsystem.com": {
             "owner": {
                 "name": "Amazon Technologies, Inc.",
-                "displayName": "Amazon.com"
+                "displayName": "Amazon"
             },
             "default": "block"
         },
-        "accounts.google.com": {
-            "owner": {
-                "name": "Google LLC",
-                "displayName": "Google"
-            },
-            "default": "ignore"
-        },
         "acdn.adnxs.com": {
             "owner": {
-                "name": "Microsoft Corporation",
-                "displayName": "Microsoft"
+                "name": "WarnerMedia, LLC",
+                "displayName": "WarnerMedia"
             },
             "default": "block"
         },
@@ -83,13 +69,6 @@
             "owner": {
                 "name": "Amobee, Inc",
                 "displayName": "Amobee"
-            },
-            "default": "block"
-        },
-        "adc3-launch.adcolony.com": {
-            "owner": {
-                "name": "Digital Turbine",
-                "displayName": "AdColony"
             },
             "default": "block"
         },
@@ -121,6 +100,13 @@
             },
             "default": "block"
         },
+        "ads.betweendigital.com": {
+            "owner": {
+                "name": "SSP Network Ltd",
+                "displayName": "SSP Network"
+            },
+            "default": "block"
+        },
         "ads.inmobi.com": {
             "owner": {
                 "name": "InMobi Pte Ltd",
@@ -137,8 +123,8 @@
         },
         "ads.mopub.com": {
             "owner": {
-                "name": "AppLovin Corporation",
-                "displayName": "AppLovin"
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
             },
             "default": "block"
         },
@@ -156,24 +142,10 @@
             },
             "default": "block"
         },
-        "ads.stickyadstv.com": {
-            "owner": {
-                "name": "FreeWheel",
-                "displayName": "FreeWheel"
-            },
-            "default": "block"
-        },
         "ads.tremorhub.com": {
             "owner": {
                 "name": "Telaria",
                 "displayName": "Telaria"
-            },
-            "default": "block"
-        },
-        "ads.undertone.com": {
-            "owner": {
-                "name": "Undertone Networks",
-                "displayName": "Undertone Networks"
             },
             "default": "block"
         },
@@ -198,6 +170,13 @@
             },
             "default": "block"
         },
+        "adsximg.com": {
+            "owner": {
+                "name": "Human Security, Inc.",
+                "displayName": "Human Security"
+            },
+            "default": "ignore"
+        },
         "ag.innovid.com": {
             "owner": {
                 "name": "Innovid Media",
@@ -211,34 +190,6 @@
                 "displayName": "Google"
             },
             "default": "ignore"
-        },
-        "alb.reddit.com": {
-            "owner": {
-                "name": "Reddit Inc.",
-                "displayName": "Reddit"
-            },
-            "default": "block"
-        },
-        "analytics.google.com": {
-            "owner": {
-                "name": "Google LLC",
-                "displayName": "Google"
-            },
-            "default": "ignore"
-        },
-        "analytics.localytics.com": {
-            "owner": {
-                "name": "Upland Software Inc.",
-                "displayName": "Upland Software"
-            },
-            "default": "block"
-        },
-        "analytics.rayjump.com": {
-            "owner": {
-                "name": "Talent Game Box",
-                "displayName": "Talent Game Box"
-            },
-            "default": "block"
         },
         "analytics.tiktok.com": {
             "owner": {
@@ -258,13 +209,6 @@
             "owner": {
                 "name": "Verizon Media",
                 "displayName": "Verizon Media"
-            },
-            "default": "block"
-        },
-        "androidads4-5.adcolony.com": {
-            "owner": {
-                "name": "Digital Turbine",
-                "displayName": "AdColony"
             },
             "default": "block"
         },
@@ -296,24 +240,10 @@
             },
             "default": "block"
         },
-        "api.branch.io": {
+        "api.instabug.com": {
             "owner": {
-                "name": "Branch Metrics, Inc.",
-                "displayName": "Branch Metrics"
-            },
-            "default": "block"
-        },
-        "api.gameanalytics.com": {
-            "owner": {
-                "name": "GameAnalytics ApS",
-                "displayName": "GameAnalytics"
-            },
-            "default": "block"
-        },
-        "api.iterable.com": {
-            "owner": {
-                "name": "Iterable, Inc.",
-                "displayName": "Iterable"
+                "name": "Instabug",
+                "displayName": "Instabug"
             },
             "default": "block"
         },
@@ -331,13 +261,6 @@
             },
             "default": "ignore"
         },
-        "api.mixpanel.com": {
-            "owner": {
-                "name": "Mixpanel, Inc.",
-                "displayName": "Mixpanel"
-            },
-            "default": "block"
-        },
         "api.onesignal.com": {
             "owner": {
                 "name": "OneSignal",
@@ -345,23 +268,9 @@
             },
             "default": "block"
         },
-        "api.permutive.com": {
-            "owner": {
-                "name": "Permutive, Inc.",
-                "displayName": "Permutive"
-            },
-            "default": "block"
-        },
-        "api.revenuecat.com": {
-            "owner": {
-                "name": "RevenueCat",
-                "displayName": "RevenueCat"
-            },
-            "default": "block"
-        },
         "api.rlcdn.com": {
             "owner": {
-                "name": "LiveRamp Holdings, Inc.",
+                "name": "LiveRamp",
                 "displayName": "LiveRamp"
             },
             "default": "block"
@@ -377,13 +286,6 @@
             "owner": {
                 "name": "Tappcelator Media S.L.",
                 "displayName": "Tappx"
-            },
-            "default": "block"
-        },
-        "api.twitter.com": {
-            "owner": {
-                "name": "Twitter, Inc.",
-                "displayName": "Twitter"
             },
             "default": "block"
         },
@@ -408,13 +310,6 @@
             },
             "default": "block"
         },
-        "api3.siftscience.com": {
-            "owner": {
-                "name": "Sift Science, Inc.",
-                "displayName": "Sift Science"
-            },
-            "default": "ignore"
-        },
         "apis.google.com": {
             "owner": {
                 "name": "Google LLC",
@@ -429,13 +324,6 @@
             },
             "default": "block"
         },
-        "app.appsflyer.com": {
-            "owner": {
-                "name": "AppsFlyer",
-                "displayName": "AppsFlyer"
-            },
-            "default": "block"
-        },
         "appmetrica.yandex.net": {
             "owner": {
                 "name": "Yandex LLC",
@@ -443,17 +331,17 @@
             },
             "default": "block"
         },
-        "assets.hcaptcha.com": {
+        "as-sec.casalemedia.com": {
             "owner": {
-                "name": "Intuition Machines, Inc.",
-                "displayName": "Intuition Machines"
+                "name": "Index Exchange, Inc.",
+                "displayName": "Index Exchange"
             },
-            "default": "ignore"
+            "default": "block"
         },
-        "aud.pubmatic.com": {
+        "aws.oath.cloud": {
             "owner": {
-                "name": "PubMatic, Inc.",
-                "displayName": "PubMatic"
+                "name": "Verizon Media",
+                "displayName": "Verizon Media"
             },
             "default": "block"
         },
@@ -492,13 +380,6 @@
             },
             "default": "block"
         },
-        "beacon.riskified.com": {
-            "owner": {
-                "name": "Riskified Ltd.",
-                "displayName": "Riskified"
-            },
-            "default": "ignore"
-        },
         "bh.contextweb.com": {
             "owner": {
                 "name": "Pulsepoint, Inc.",
@@ -513,13 +394,6 @@
             },
             "default": "block"
         },
-        "btlr.sharethrough.com": {
-            "owner": {
-                "name": "Sharethrough, Inc.",
-                "displayName": "Sharethrough"
-            },
-            "default": "block"
-        },
         "bttrack.com": {
             "owner": {
                 "name": "Bidtellect, Inc",
@@ -530,23 +404,9 @@
         "c.amazon-adsystem.com": {
             "owner": {
                 "name": "Amazon Technologies, Inc.",
-                "displayName": "Amazon.com"
+                "displayName": "Amazon"
             },
             "default": "block"
-        },
-        "c.bing.com": {
-            "owner": {
-                "name": "Microsoft Corporation",
-                "displayName": "Microsoft"
-            },
-            "default": "block"
-        },
-        "c.riskified.com": {
-            "owner": {
-                "name": "Riskified Ltd.",
-                "displayName": "Riskified"
-            },
-            "default": "ignore"
         },
         "c1.adform.net": {
             "owner": {
@@ -555,24 +415,10 @@
             },
             "default": "block"
         },
-        "cb.mopub.com": {
+        "cdn.amplitude.com": {
             "owner": {
-                "name": "AppLovin Corporation",
-                "displayName": "AppLovin"
-            },
-            "default": "block"
-        },
-        "cdn-f.adsmoloco.com": {
-            "owner": {
-                "name": "Moloco Inc.",
-                "displayName": "Moloco"
-            },
-            "default": "block"
-        },
-        "cdn-lb.vungle.com": {
-            "owner": {
-                "name": "Vungle Inc",
-                "displayName": "Vungle"
+                "name": "Amplitude",
+                "displayName": "Amplitude"
             },
             "default": "block"
         },
@@ -597,20 +443,6 @@
             },
             "default": "block"
         },
-        "cdn.permutive.com": {
-            "owner": {
-                "name": "Permutive, Inc.",
-                "displayName": "Permutive"
-            },
-            "default": "block"
-        },
-        "cdn.siftscience.com": {
-            "owner": {
-                "name": "Sift Science, Inc.",
-                "displayName": "Sift Science"
-            },
-            "default": "ignore"
-        },
         "cdn.taboola.com": {
             "owner": {
                 "name": "Taboola, Inc.",
@@ -632,6 +464,13 @@
             },
             "default": "block"
         },
+        "ch-vid-events.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
         "ch-wf.taboola.com": {
             "owner": {
                 "name": "Taboola, Inc.",
@@ -639,31 +478,17 @@
             },
             "default": "block"
         },
-        "choices.truste.com": {
-            "owner": {
-                "name": "TrustArc Inc.",
-                "displayName": "TrustArc"
-            },
-            "default": "block"
-        },
-        "click-haproxy.supersonicads.com": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
-            },
-            "default": "block"
-        },
-        "cloud.unity3d.com": {
-            "owner": {
-                "name": "Unity Technologies ApS",
-                "displayName": "Unity"
-            },
-            "default": "block"
-        },
         "cm.everesttech.net": {
             "owner": {
                 "name": "Adobe Inc.",
                 "displayName": "Adobe"
+            },
+            "default": "block"
+        },
+        "cms-xch-chicago.33across.com": {
+            "owner": {
+                "name": "33Across, Inc.",
+                "displayName": "33Across"
             },
             "default": "block"
         },
@@ -681,24 +506,10 @@
             },
             "default": "block"
         },
-        "configure.rayjump.com": {
-            "owner": {
-                "name": "Talent Game Box",
-                "displayName": "Talent Game Box"
-            },
-            "default": "block"
-        },
         "connect.facebook.net": {
             "owner": {
                 "name": "Facebook, Inc.",
                 "displayName": "Facebook"
-            },
-            "default": "block"
-        },
-        "connect.tapjoy.com": {
-            "owner": {
-                "name": "Tapjoy, Inc.",
-                "displayName": "Tapjoy"
             },
             "default": "block"
         },
@@ -744,13 +555,6 @@
             },
             "default": "block"
         },
-        "cs.emxdgt.com": {
-            "owner": {
-                "name": "Engine USA LLC",
-                "displayName": "Engine USA"
-            },
-            "default": "block"
-        },
         "csi.gstatic.com": {
             "owner": {
                 "name": "Google LLC",
@@ -793,13 +597,6 @@
             },
             "default": "block"
         },
-        "data.ad-score.com": {
-            "owner": {
-                "name": "Adscore Technologies DMCC",
-                "displayName": "Adscore"
-            },
-            "default": "block"
-        },
         "data.flurry.com": {
             "owner": {
                 "name": "Verizon Media",
@@ -830,7 +627,7 @@
         },
         "di.rlcdn.com": {
             "owner": {
-                "name": "LiveRamp Holdings, Inc.",
+                "name": "LiveRamp",
                 "displayName": "LiveRamp"
             },
             "default": "block"
@@ -842,17 +639,24 @@
             },
             "default": "block"
         },
-        "dlsdk.appsflyer.com": {
-            "owner": {
-                "name": "AppsFlyer",
-                "displayName": "AppsFlyer"
-            },
-            "default": "block"
-        },
         "dlx.addthis.com": {
             "owner": {
                 "name": "Oracle Corporation",
                 "displayName": "Oracle"
+            },
+            "default": "block"
+        },
+        "dmp.brand-display.com": {
+            "owner": {
+                "name": "Knorex Pte. Ltd.",
+                "displayName": "Knorex"
+            },
+            "default": "block"
+        },
+        "dmx.districtm.io": {
+            "owner": {
+                "name": "District M Inc.",
+                "displayName": "District M"
             },
             "default": "block"
         },
@@ -907,8 +711,8 @@
         },
         "eus.rubiconproject.com": {
             "owner": {
-                "name": "Magnite, Inc.",
-                "displayName": "Magnite"
+                "name": "The Rubicon Project, Inc.",
+                "displayName": "The Rubicon Project"
             },
             "default": "block"
         },
@@ -928,17 +732,10 @@
         },
         "fastlane.rubiconproject.com": {
             "owner": {
-                "name": "Magnite, Inc.",
-                "displayName": "Magnite"
+                "name": "The Rubicon Project, Inc.",
+                "displayName": "The Rubicon Project"
             },
             "default": "block"
-        },
-        "firebaseinstallations.googleapis.com": {
-            "owner": {
-                "name": "Google LLC",
-                "displayName": "Google"
-            },
-            "default": "ignore"
         },
         "firebaselogging-pa.googleapis.com": {
             "owner": {
@@ -982,13 +779,6 @@
             },
             "default": "block"
         },
-        "fundingchoicesmessages.google.com": {
-            "owner": {
-                "name": "Google LLC",
-                "displayName": "Google"
-            },
-            "default": "ignore"
-        },
         "fw.adsafeprotected.com": {
             "owner": {
                 "name": "Integral Ad Science, Inc.",
@@ -1017,6 +807,13 @@
             },
             "default": "block"
         },
+        "go.sonobi.com": {
+            "owner": {
+                "name": "Sonobi, Inc",
+                "displayName": "Sonobi"
+            },
+            "default": "block"
+        },
         "gql.reddit.com": {
             "owner": {
                 "name": "Reddit Inc.",
@@ -1024,12 +821,26 @@
             },
             "default": "ignore"
         },
+        "graph.accountkit.com": {
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook"
+            },
+            "default": "block"
+        },
         "graph.facebook.com": {
             "owner": {
                 "name": "Facebook, Inc.",
                 "displayName": "Facebook"
             },
             "default": "ignore"
+        },
+        "graph.instagram.com": {
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook"
+            },
+            "default": "block"
         },
         "gum.criteo.com": {
             "owner": {
@@ -1042,6 +853,13 @@
             "owner": {
                 "name": "Adobe Inc.",
                 "displayName": "Adobe"
+            },
+            "default": "block"
+        },
+        "hblg.media.net": {
+            "owner": {
+                "name": "Media.net Advertising FZ-LLC",
+                "displayName": "Media.net Advertising"
             },
             "default": "block"
         },
@@ -1080,13 +898,6 @@
             },
             "default": "block"
         },
-        "iab-imp-gateway.supersonicads.com": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
-            },
-            "default": "block"
-        },
         "iad-01.braze.com": {
             "owner": {
                 "name": "Braze, Inc.",
@@ -1103,14 +914,14 @@
         },
         "ib.adnxs.com": {
             "owner": {
-                "name": "Microsoft Corporation",
-                "displayName": "Microsoft"
+                "name": "WarnerMedia, LLC",
+                "displayName": "WarnerMedia"
             },
             "default": "block"
         },
         "id.rlcdn.com": {
             "owner": {
-                "name": "LiveRamp Holdings, Inc.",
+                "name": "LiveRamp",
                 "displayName": "LiveRamp"
             },
             "default": "block"
@@ -1124,7 +935,7 @@
         },
         "idsync.rlcdn.com": {
             "owner": {
-                "name": "LiveRamp Holdings, Inc.",
+                "name": "LiveRamp",
                 "displayName": "LiveRamp"
             },
             "default": "block"
@@ -1171,28 +982,14 @@
             },
             "default": "ignore"
         },
-        "img.riskified.com": {
+        "imprchmp.taboola.com": {
             "owner": {
-                "name": "Riskified Ltd.",
-                "displayName": "Riskified"
-            },
-            "default": "ignore"
-        },
-        "imgs.hcaptcha.com": {
-            "owner": {
-                "name": "Intuition Machines, Inc.",
-                "displayName": "Intuition Machines"
-            },
-            "default": "ignore"
-        },
-        "impression-east.liftoff.io": {
-            "owner": {
-                "name": "Liftoff Mobile, Inc.",
-                "displayName": "Liftoff"
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
             },
             "default": "block"
         },
-        "impression-europe.liftoff.io": {
+        "impression-east.liftoff.io": {
             "owner": {
                 "name": "Liftoff Mobile, Inc.",
                 "displayName": "Liftoff"
@@ -1220,6 +1017,13 @@
             },
             "default": "block"
         },
+        "in.treasuredata.com": {
+            "owner": {
+                "name": "Treasure Data, Inc",
+                "displayName": "Treasure Data"
+            },
+            "default": "block"
+        },
         "ingest.sentry.io": {
             "owner": {
                 "name": "Functional Software, Inc.",
@@ -1231,34 +1035,6 @@
             "owner": {
                 "name": "The Trade Desk Inc",
                 "displayName": "The Trade Desk"
-            },
-            "default": "block"
-        },
-        "internal.unity3d.com": {
-            "owner": {
-                "name": "Unity Technologies ApS",
-                "displayName": "Unity"
-            },
-            "default": "block"
-        },
-        "ipds.adrta.com": {
-            "owner": {
-                "name": "Pixalate, Inc.",
-                "displayName": "Pixalate"
-            },
-            "default": "ignore"
-        },
-        "ipv6.adrta.com": {
-            "owner": {
-                "name": "Pixalate, Inc.",
-                "displayName": "Pixalate"
-            },
-            "default": "ignore"
-        },
-        "is-gateway.supersonicads.com": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
             },
             "default": "block"
         },
@@ -1276,31 +1052,17 @@
             },
             "default": "block"
         },
+        "krk.kargo.com": {
+            "owner": {
+                "name": "Kargo Global, Inc.",
+                "displayName": "Kargo"
+            },
+            "default": "block"
+        },
         "lbs.yandex.net": {
             "owner": {
                 "name": "Yandex LLC",
                 "displayName": "Yandex"
-            },
-            "default": "block"
-        },
-        "lh3.googleusercontent.com": {
-            "owner": {
-                "name": "Google LLC",
-                "displayName": "Google"
-            },
-            "default": "ignore"
-        },
-        "live.chartboost.com": {
-            "owner": {
-                "name": "Take-Two Interactive Software, Inc.",
-                "displayName": "Take-Two Interactive Software"
-            },
-            "default": "block"
-        },
-        "load77.exelator.com": {
-            "owner": {
-                "name": "The Nielsen Company",
-                "displayName": "The Nielsen Company"
             },
             "default": "block"
         },
@@ -1325,13 +1087,6 @@
             },
             "default": "block"
         },
-        "logs.ironsrc.mobi": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
-            },
-            "default": "block"
-        },
         "logx.optimizely.com": {
             "owner": {
                 "name": "Optimizely, Inc.",
@@ -1339,10 +1094,10 @@
             },
             "default": "block"
         },
-        "m.facebook.com": {
+        "lynx.cognitivlabs.com": {
             "owner": {
-                "name": "Facebook, Inc.",
-                "displayName": "Facebook"
+                "name": "Cognitiv Corp.",
+                "displayName": "Cognitiv"
             },
             "default": "block"
         },
@@ -1360,10 +1115,10 @@
             },
             "default": "block"
         },
-        "match.deepintent.com": {
+        "match.bnmla.com": {
             "owner": {
-                "name": "DeepIntent Inc",
-                "displayName": "DeepIntent"
+                "name": "engageBDR",
+                "displayName": "engageBDR"
             },
             "default": "block"
         },
@@ -1378,6 +1133,13 @@
             "owner": {
                 "name": "Yandex LLC",
                 "displayName": "Yandex"
+            },
+            "default": "block"
+        },
+        "mid.rkdms.com": {
+            "owner": {
+                "name": "Merkle Inc",
+                "displayName": "Merkle"
             },
             "default": "block"
         },
@@ -1411,15 +1173,8 @@
         },
         "mpx.mopub.com": {
             "owner": {
-                "name": "AppLovin Corporation",
-                "displayName": "AppLovin"
-            },
-            "default": "block"
-        },
-        "ms.applovin.com": {
-            "owner": {
-                "name": "AppLovin Corporation",
-                "displayName": "AppLovin"
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
             },
             "default": "block"
         },
@@ -1437,17 +1192,10 @@
             },
             "default": "block"
         },
-        "networksdk.ssacdn.com": {
+        "network.bazaarvoice.com": {
             "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
-            },
-            "default": "block"
-        },
-        "notify.bugsnag.com": {
-            "owner": {
-                "name": "Bugsnag Inc.",
-                "displayName": "Bugsnag"
+                "name": "Bazaarvoice, Inc.",
+                "displayName": "Bazaarvoice"
             },
             "default": "block"
         },
@@ -1460,22 +1208,8 @@
         },
         "odr.mookie1.com": {
             "owner": {
-                "name": "WPP plc",
-                "displayName": "WPP"
-            },
-            "default": "block"
-        },
-        "outcome-cdn.supersonicads.com": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
-            },
-            "default": "block"
-        },
-        "outcome-ssp.supersonicads.com": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
+                "name": "Xaxis",
+                "displayName": "Xaxis"
             },
             "default": "block"
         },
@@ -1500,10 +1234,10 @@
             },
             "default": "block"
         },
-        "pad-v3.presage.io": {
+        "p.tvpixel.com": {
             "owner": {
-                "name": "Ogury Limited",
-                "displayName": "Ogury"
+                "name": "Data Plus Math",
+                "displayName": "Data Plus Math"
             },
             "default": "block"
         },
@@ -1516,17 +1250,10 @@
         },
         "pippio.com": {
             "owner": {
-                "name": "LiveRamp Holdings, Inc.",
+                "name": "LiveRamp",
                 "displayName": "LiveRamp"
             },
             "default": "block"
-        },
-        "pix.adrta.com": {
-            "owner": {
-                "name": "Pixalate, Inc.",
-                "displayName": "Pixalate"
-            },
-            "default": "ignore"
         },
         "pixel-sync.sitescout.com": {
             "owner": {
@@ -1537,8 +1264,8 @@
         },
         "pixel-us-east.rubiconproject.com": {
             "owner": {
-                "name": "Magnite, Inc.",
-                "displayName": "Magnite"
+                "name": "The Rubicon Project, Inc.",
+                "displayName": "The Rubicon Project"
             },
             "default": "block"
         },
@@ -1563,13 +1290,6 @@
             },
             "default": "block"
         },
-        "pixel.onaudience.com": {
-            "owner": {
-                "name": "OnAudience Ltd.",
-                "displayName": "OnAudience"
-            },
-            "default": "block"
-        },
         "pixel.parsely.com": {
             "owner": {
                 "name": "Parsely, Inc.",
@@ -1586,8 +1306,8 @@
         },
         "pixel.rubiconproject.com": {
             "owner": {
-                "name": "Magnite, Inc.",
-                "displayName": "Magnite"
+                "name": "The Rubicon Project, Inc.",
+                "displayName": "The Rubicon Project"
             },
             "default": "block"
         },
@@ -1598,20 +1318,6 @@
             },
             "default": "block"
         },
-        "placements.tapjoy.com": {
-            "owner": {
-                "name": "Tapjoy, Inc.",
-                "displayName": "Tapjoy"
-            },
-            "default": "block"
-        },
-        "platform.ssacdn.com": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
-            },
-            "default": "block"
-        },
         "platform.twitter.com": {
             "owner": {
                 "name": "Twitter, Inc.",
@@ -1619,38 +1325,17 @@
             },
             "default": "ignore"
         },
-        "play.google.com": {
-            "owner": {
-                "name": "Google LLC",
-                "displayName": "Google"
-            },
-            "default": "ignore"
-        },
-        "pm-gateway.supersonicads.com": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
-            },
-            "default": "block"
-        },
         "pm.w55c.net": {
             "owner": {
-                "name": "Roku, Inc.",
-                "displayName": "Roku"
-            },
-            "default": "block"
-        },
-        "prebid-server.rubiconproject.com": {
-            "owner": {
-                "name": "Magnite, Inc.",
-                "displayName": "Magnite"
+                "name": "DataXu",
+                "displayName": "DataXu"
             },
             "default": "block"
         },
         "prebid.adnxs.com": {
             "owner": {
-                "name": "Microsoft Corporation",
-                "displayName": "Microsoft"
+                "name": "WarnerMedia, LLC",
+                "displayName": "WarnerMedia"
             },
             "default": "block"
         },
@@ -1658,20 +1343,6 @@
             "owner": {
                 "name": "Smartadserver S.A.S",
                 "displayName": "Smartadserver"
-            },
-            "default": "block"
-        },
-        "prod-a.applovin.com": {
-            "owner": {
-                "name": "AppLovin Corporation",
-                "displayName": "AppLovin"
-            },
-            "default": "block"
-        },
-        "prod-ms.applovin.com": {
-            "owner": {
-                "name": "AppLovin Corporation",
-                "displayName": "AppLovin"
             },
             "default": "block"
         },
@@ -1689,13 +1360,6 @@
             },
             "default": "block"
         },
-        "pt.ispot.tv": {
-            "owner": {
-                "name": "iSpot.tv",
-                "displayName": "iSpot.tv"
-            },
-            "default": "block"
-        },
         "px.moatads.com": {
             "owner": {
                 "name": "Oracle Corporation",
@@ -1710,17 +1374,10 @@
             },
             "default": "block"
         },
-        "q.adrta.com": {
+        "pxl.connexity.net": {
             "owner": {
-                "name": "Pixalate, Inc.",
-                "displayName": "Pixalate"
-            },
-            "default": "ignore"
-        },
-        "r.casalemedia.com": {
-            "owner": {
-                "name": "Index Exchange, Inc.",
-                "displayName": "Index Exchange"
+                "name": "Connexity, Inc.",
+                "displayName": "Connexity"
             },
             "default": "block"
         },
@@ -1731,19 +1388,12 @@
             },
             "default": "block"
         },
-        "rpc.tapjoy.com": {
+        "riskified.com": {
             "owner": {
-                "name": "Tapjoy, Inc.",
-                "displayName": "Tapjoy"
+                "name": "Riskified Ltd.",
+                "displayName": "Riskified"
             },
-            "default": "block"
-        },
-        "rt.applovin.com": {
-            "owner": {
-                "name": "AppLovin Corporation",
-                "displayName": "AppLovin"
-            },
-            "default": "block"
+            "default": "ignore"
         },
         "rtb-csync.smartadserver.com": {
             "owner": {
@@ -1759,10 +1409,24 @@
             },
             "default": "block"
         },
+        "rtb.gumgum.com": {
+            "owner": {
+                "name": "GumGum",
+                "displayName": "GumGum"
+            },
+            "default": "block"
+        },
         "rtb.mfadsrvr.com": {
             "owner": {
                 "name": "IPONWEB GmbH",
                 "displayName": "IPONWEB"
+            },
+            "default": "block"
+        },
+        "rtb.ninthdecimal.com": {
+            "owner": {
+                "name": "NinthDecimal, Inc",
+                "displayName": "NinthDecimal"
             },
             "default": "block"
         },
@@ -1773,24 +1437,17 @@
             },
             "default": "block"
         },
-        "rv-gateway.supersonicads.com": {
+        "s-static.innovid.com": {
             "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
+                "name": "Innovid Media",
+                "displayName": "Innovid Media"
             },
             "default": "block"
-        },
-        "s.adsximg.com": {
-            "owner": {
-                "name": "Human Security, Inc.",
-                "displayName": "Human Security"
-            },
-            "default": "ignore"
         },
         "s.amazon-adsystem.com": {
             "owner": {
                 "name": "Amazon Technologies, Inc.",
-                "displayName": "Amazon.com"
+                "displayName": "Amazon"
             },
             "default": "block"
         },
@@ -1815,17 +1472,10 @@
             },
             "default": "block"
         },
-        "s2s.adjust.com": {
-            "owner": {
-                "name": "Adjust GmbH",
-                "displayName": "Adjust"
-            },
-            "default": "block"
-        },
         "s3.amazonaws.com": {
             "owner": {
                 "name": "Amazon Technologies, Inc.",
-                "displayName": "Amazon.com"
+                "displayName": "Amazon"
             },
             "default": "ignore"
         },
@@ -1857,24 +1507,10 @@
             },
             "default": "block"
         },
-        "sdk-events.inner-active.mobi": {
-            "owner": {
-                "name": "Digital Turbine",
-                "displayName": "AdColony"
-            },
-            "default": "block"
-        },
         "search.spotxchange.com": {
             "owner": {
                 "name": "SpotX, Inc.",
                 "displayName": "SpotX"
-            },
-            "default": "block"
-        },
-        "secure-dcr.imrworldwide.com": {
-            "owner": {
-                "name": "The Nielsen Company",
-                "displayName": "The Nielsen Company"
             },
             "default": "block"
         },
@@ -1887,8 +1523,8 @@
         },
         "secure.adnxs.com": {
             "owner": {
-                "name": "Microsoft Corporation",
-                "displayName": "Microsoft"
+                "name": "WarnerMedia, LLC",
+                "displayName": "WarnerMedia"
             },
             "default": "block"
         },
@@ -1906,20 +1542,6 @@
             },
             "default": "block"
         },
-        "servedby.flashtalking.com": {
-            "owner": {
-                "name": "Flashtalking Inc",
-                "displayName": "Flashtalking"
-            },
-            "default": "block"
-        },
-        "servicebus.windows.net": {
-            "owner": {
-                "name": "Microsoft Corporation",
-                "displayName": "Microsoft"
-            },
-            "default": "ignore"
-        },
         "sessions.bugsnag.com": {
             "owner": {
                 "name": "Bugsnag Inc.",
@@ -1927,24 +1549,17 @@
             },
             "default": "block"
         },
+        "siftscience.com": {
+            "owner": {
+                "name": "Sift Science, Inc.",
+                "displayName": "Sift Science"
+            },
+            "default": "ignore"
+        },
         "simage2.pubmatic.com": {
             "owner": {
                 "name": "PubMatic, Inc.",
                 "displayName": "PubMatic"
-            },
-            "default": "block"
-        },
-        "simage4.pubmatic.com": {
-            "owner": {
-                "name": "PubMatic, Inc.",
-                "displayName": "PubMatic"
-            },
-            "default": "block"
-        },
-        "sonic-us.supersonicads.com": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
             },
             "default": "block"
         },
@@ -2039,10 +1654,10 @@
             },
             "default": "block"
         },
-        "sync.adotmob.com": {
+        "sync.bfmio.com": {
             "owner": {
-                "name": "A.Mob SAS",
-                "displayName": "A.Mob"
+                "name": "Beachfront Media LLC",
+                "displayName": "Beachfront Media"
             },
             "default": "block"
         },
@@ -2050,6 +1665,20 @@
             "owner": {
                 "name": "Lotame Solutions, Inc.",
                 "displayName": "Lotame Solutions"
+            },
+            "default": "block"
+        },
+        "sync.extend.tv": {
+            "owner": {
+                "name": "ZypMedia, Inc.",
+                "displayName": "ZypMedia"
+            },
+            "default": "block"
+        },
+        "sync.intentiq.com": {
+            "owner": {
+                "name": "Intent IQ, LLC",
+                "displayName": "Intent IQ"
             },
             "default": "block"
         },
@@ -2081,6 +1710,13 @@
             },
             "default": "block"
         },
+        "sync1.intentiq.com": {
+            "owner": {
+                "name": "Intent IQ, LLC",
+                "displayName": "Intent IQ"
+            },
+            "default": "block"
+        },
         "syndication.twitter.com": {
             "owner": {
                 "name": "Twitter, Inc.",
@@ -2101,6 +1737,13 @@
                 "displayName": "Twitter"
             },
             "default": "ignore"
+        },
+        "t.myvisualiq.net": {
+            "owner": {
+                "name": "The Nielsen Company",
+                "displayName": "The Nielsen Company"
+            },
+            "default": "block"
         },
         "tags.bluekai.com": {
             "owner": {
@@ -2130,13 +1773,6 @@
             },
             "default": "block"
         },
-        "token.rubiconproject.com": {
-            "owner": {
-                "name": "Magnite, Inc.",
-                "displayName": "Magnite"
-            },
-            "default": "block"
-        },
         "tpc.googlesyndication.com": {
             "owner": {
                 "name": "Google LLC",
@@ -2155,13 +1791,6 @@
             "owner": {
                 "name": "Snap Inc.",
                 "displayName": "Snap"
-            },
-            "default": "block"
-        },
-        "track.atom-data.io": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
             },
             "default": "block"
         },
@@ -2186,20 +1815,6 @@
             },
             "default": "block"
         },
-        "twitter.com": {
-            "owner": {
-                "name": "Twitter, Inc.",
-                "displayName": "Twitter"
-            },
-            "default": "block"
-        },
-        "uk-script.dotmetrics.net": {
-            "owner": {
-                "name": "Dotmetrics",
-                "displayName": "Dotmetrics"
-            },
-            "default": "block"
-        },
         "um.simpli.fi": {
             "owner": {
                 "name": "Simplifi Holdings Inc.",
@@ -2221,17 +1836,10 @@
             },
             "default": "block"
         },
-        "update.googleapis.com": {
-            "owner": {
-                "name": "Google LLC",
-                "displayName": "Google"
-            },
-            "default": "ignore"
-        },
         "us-east-1.amazonaws.com": {
             "owner": {
                 "name": "Amazon Technologies, Inc.",
-                "displayName": "Amazon.com"
+                "displayName": "Amazon"
             },
             "default": "ignore"
         },
@@ -2298,27 +1906,6 @@
             },
             "default": "block"
         },
-        "wins.isprog.com": {
-            "owner": {
-                "name": "ironSource Ltd",
-                "displayName": "ironSource"
-            },
-            "default": "block"
-        },
-        "ws.tapjoyads.com": {
-            "owner": {
-                "name": "Tapjoy, Inc.",
-                "displayName": "Tapjoy"
-            },
-            "default": "block"
-        },
-        "wv.inner-active.mobi": {
-            "owner": {
-                "name": "Digital Turbine",
-                "displayName": "AdColony"
-            },
-            "default": "block"
-        },
         "www.facebook.com": {
             "owner": {
                 "name": "Facebook, Inc.",
@@ -2327,13 +1914,6 @@
             "default": "block"
         },
         "www.google-analytics.com": {
-            "owner": {
-                "name": "Google LLC",
-                "displayName": "Google"
-            },
-            "default": "block"
-        },
-        "www.google.co.uk": {
             "owner": {
                 "name": "Google LLC",
                 "displayName": "Google"
@@ -2353,13 +1933,6 @@
                 "displayName": "Google"
             },
             "default": "block"
-        },
-        "www.googleapis.com": {
-            "owner": {
-                "name": "Google LLC",
-                "displayName": "Google"
-            },
-            "default": "ignore"
         },
         "www.googletagmanager.com": {
             "owner": {
@@ -2389,10 +1962,10 @@
             },
             "default": "block"
         },
-        "www.linkedin.com": {
+        "www.storygize.net": {
             "owner": {
-                "name": "Microsoft Corporation",
-                "displayName": "Microsoft"
+                "name": "Storygize",
+                "displayName": "Storygize"
             },
             "default": "block"
         },
@@ -2402,6 +1975,13 @@
                 "displayName": "Google"
             },
             "default": "ignore"
+        },
+        "www9.smartadserver.com": {
+            "owner": {
+                "name": "Smartadserver S.A.S",
+                "displayName": "Smartadserver"
+            },
+            "default": "block"
         },
         "x.bidswitch.net": {
             "owner": {
@@ -2419,37 +1999,35 @@
         }
     },
     "packageNames": {
-        "air.com.adobe.connectpro": "Adobe Inc.",
-        "amazon.speech.sim": "Amazon Technologies, Inc.",
-        "app.zenly.locator": "Snap Inc.",
-        "co.vine.android": "Twitter, Inc.",
         "com.adjust.insights": "Adjust GmbH",
-        "com.adobe.adobephotoshopfix": "Adobe Inc.",
-        "com.adobe.aem.forms": "Adobe Inc.",
-        "com.adobe.aero.android": "Adobe Inc.",
-        "com.adobe.analyticsdashboards": "Adobe Inc.",
-        "com.adobe.captivateprime": "Adobe Inc.",
-        "com.adobe.cc": "Adobe Inc.",
-        "com.adobe.comp": "Adobe Inc.",
-        "com.adobe.creativeapps.draw": "Adobe Inc.",
-        "com.adobe.creativeapps.gather": "Adobe Inc.",
-        "com.adobe.creativeapps.sketch": "Adobe Inc.",
-        "com.adobe.digitaleditions": "Adobe Inc.",
-        "com.adobe.echosign": "Adobe Inc.",
+        "air.com.adobe.connectpro": "Adobe Inc.",
+        "com.adobe.reader": "Adobe Inc.",
+        "com.adobe.lrmobile": "Adobe Inc.",
+        "com.adobe.scan.android": "Adobe Inc.",
+        "com.adobe.psmobile": "Adobe Inc.",
         "com.adobe.fas": "Adobe Inc.",
+        "com.adobe.spark.post": "Adobe Inc.",
+        "com.adobe.creativeapps.sketch": "Adobe Inc.",
+        "com.adobe.creativeapps.draw": "Adobe Inc.",
+        "com.adobe.photoshopmix": "Adobe Inc.",
+        "com.adobe.cc": "Adobe Inc.",
+        "com.adobe.lens.android": "Adobe Inc.",
+        "com.adobe.premiererush.videoeditor": "Adobe Inc.",
+        "com.adobe.adobephotoshopfix": "Adobe Inc.",
         "com.adobe.ims.accountaccess": "Adobe Inc.",
         "com.adobe.ims.push.android": "Adobe Inc.",
-        "com.adobe.lens.android": "Adobe Inc.",
-        "com.adobe.lrmobile": "Adobe Inc.",
-        "com.adobe.monocle.companion": "Adobe Inc.",
-        "com.adobe.phonegap.app": "Adobe Inc.",
-        "com.adobe.photoshopmix": "Adobe Inc.",
-        "com.adobe.premiererush.videoeditor": "Adobe Inc.",
-        "com.adobe.psmobile": "Adobe Inc.",
-        "com.adobe.reader": "Adobe Inc.",
-        "com.adobe.scan.android": "Adobe Inc.",
-        "com.adobe.spark.post": "Adobe Inc.",
+        "com.adobe.creativeapps.gather": "Adobe Inc.",
+        "com.adobe.digitaleditions": "Adobe Inc.",
+        "com.adobe.echosign": "Adobe Inc.",
         "com.adobe.sparklerandroid": "Adobe Inc.",
+        "com.adobe.comp": "Adobe Inc.",
+        "com.adobe.captivateprime": "Adobe Inc.",
+        "com.adobe.aem.forms": "Adobe Inc.",
+        "com.adobe.phonegap.app": "Adobe Inc.",
+        "com.adobe.analyticsdashboards": "Adobe Inc.",
+        "com.adobe.monocle.companion": "Adobe Inc.",
+        "com.adobe.aero.android": "Adobe Inc.",
+        "amazon.speech.sim": "Amazon Technologies, Inc.",
         "com.amazon.aa": "Amazon Technologies, Inc.",
         "com.amazon.aa.attribution": "Amazon Technologies, Inc.",
         "com.amazon.amazonvideo.livingroom": "Amazon Technologies, Inc.",
@@ -2477,30 +2055,30 @@
         "com.amazon.sellermobile.android": "Amazon Technologies, Inc.",
         "com.amazon.shopperpanel.android.mobile.app": "Amazon Technologies, Inc.",
         "com.amazon.storm.lightning.client.aosp": "Amazon Technologies, Inc.",
-        "com.amazon.venezia": "Amazon Technologies, Inc.",
         "com.amazon.widgets": "Amazon Technologies, Inc.",
         "com.amazon.windowshop": "Amazon Technologies, Inc.",
+        "com.amazon.venezia": "Amazon Technologies, Inc.",
         "com.amazon.ziggy.android": "Amazon Technologies, Inc.",
-        "com.android.chrome": "Google LLC",
-        "com.android.hotwordenrollment.okgoogle": "Google LLC",
-        "com.android.hotwordenrollment.xgoogle": "Google LLC",
-        "com.android.partnerbrowsercustomizations.chromeHomepage": "Google LLC",
-        "com.android.vending": "Google LLC",
-        "com.aol.mobile.aolapp": "Verizon Media",
-        "com.aol.mobile.techcrunch": "Verizon Media",
-        "com.appsflyer.adNetworkTest": "AppsFlyer",
-        "com.appsflyer.afsupportapp": "AppsFlyer",
+        "com.imdb.mobile": "Amazon Technologies, Inc.",
+        "com.imdb.pro.mobile.android": "Amazon Technologies, Inc.",
+        "com.imdbtv.livingroom": "Amazon Technologies, Inc.",
+        "com.ringapp": "Amazon Technologies, Inc.",
+        "in.amazon.mShop.android.shopping": "Amazon Technologies, Inc.",
+        "tv.twitch.android.app": "Amazon Technologies, Inc.",
         "com.appsflyer.analytics": "AppsFlyer",
         "com.appsflyer.android.deviceid": "AppsFlyer",
-        "com.appsflyer.app.ezshop": "AppsFlyer",
         "com.appsflyer.onelinksimulator": "AppsFlyer",
-        "com.azure.authenticator": "Microsoft Corporation",
-        "com.bitstrips.imoji": "Snap Inc.",
-        "com.chrome.beta": "Google LLC",
-        "com.chrome.canary": "Google LLC",
-        "com.chrome.dev": "Google LLC",
-        "com.desk.android": "Salesforce.com, Inc.",
-        "com.facebook.Origami": "Facebook, Inc.",
+        "com.appsflyer.app.ezshop": "AppsFlyer",
+        "com.appsflyer.afsupportapp": "AppsFlyer",
+        "com.appsflyer.adNetworkTest": "AppsFlyer",
+        "io.branch.deviceid": "Branch Metrics, Inc.",
+        "io.branch.android.discovery": "Branch Metrics, Inc.",
+        "io.branch.branchster": "Branch Metrics, Inc.",
+        "io.branch.sample.hellobranch": "Branch Metrics, Inc.",
+        "com.ss.android.ugc.trill": "ByteDance Ltd.",
+        "com.zhiliaoapp.musically": "ByteDance Ltd.",
+        "com.zhiliao.musically.livewallpaper": "ByteDance Ltd.",
+        "com.lemon.lvoverseas": "ByteDance Ltd.",
         "com.facebook.adsmanager": "Facebook, Inc.",
         "com.facebook.analytics": "Facebook, Inc.",
         "com.facebook.appmanager": "Facebook, Inc.",
@@ -2511,6 +2089,7 @@
         "com.facebook.katana": "Facebook, Inc.",
         "com.facebook.lite": "Facebook, Inc.",
         "com.facebook.mlite": "Facebook, Inc.",
+        "com.facebook.Origami": "Facebook, Inc.",
         "com.facebook.orca": "Facebook, Inc.",
         "com.facebook.pages.app": "Facebook, Inc.",
         "com.facebook.services": "Facebook, Inc.",
@@ -2520,13 +2099,26 @@
         "com.facebook.viewpoints": "Facebook, Inc.",
         "com.facebook.work": "Facebook, Inc.",
         "com.facebook.workchat": "Facebook, Inc.",
-        "com.fitbit.FitbitMobile": "Google LLC",
-        "com.flurry.instantapp.test.app": "Verizon Media",
-        "com.foursquare.marsbot": "Foursquare Labs, Inc.",
-        "com.foursquare.pilgrimdemo": "Foursquare Labs, Inc.",
+        "com.instagram.android": "Facebook, Inc.",
+        "com.instagram.boomerang": "Facebook, Inc.",
+        "com.instagram.igtv": "Facebook, Inc.",
+        "com.instagram.layout": "Facebook, Inc.",
+        "com.instagram.threadsapp": "Facebook, Inc.",
+        "com.whatsapp": "Facebook, Inc.",
+        "com.joelapenna.foursquared": "Foursquare Labs, Inc.",
+        "com.sewichi.client.panel": "Foursquare Labs, Inc.",
         "com.foursquare.robin": "Foursquare Labs, Inc.",
-        "com.gamepass": "Microsoft Corporation",
-        "com.gamepass.beta": "Microsoft Corporation",
+        "com.foursquare.pilgrimdemo": "Foursquare Labs, Inc.",
+        "com.foursquare.marsbot": "Foursquare Labs, Inc.",
+        "com.android.hotwordenrollment.okgoogle": "Google LLC",
+        "com.android.hotwordenrollment.xgoogle": "Google LLC",
+        "com.android.partnerbrowsercustomizations.chromeHomepage": "Google LLC",
+        "com.android.chrome": "Google LLC",
+        "com.android.vending": "Google LLC",
+        "com.chrome.beta": "Google LLC",
+        "com.chrome.canary": "Google LLC",
+        "com.chrome.dev": "Google LLC",
+        "com.fitbit.FitbitMobile": "Google LLC",
         "com.google.android.apps.access.wifi.consumer": "Google LLC",
         "com.google.android.apps.adm": "Google LLC",
         "com.google.android.apps.ads.publisher": "Google LLC",
@@ -2572,10 +2164,10 @@
         "com.google.android.apps.photosgo": "Google LLC",
         "com.google.android.apps.plus": "Google LLC",
         "com.google.android.apps.podcasts": "Google LLC",
-        "com.google.android.apps.recorder": "Google LLC",
         "com.google.android.apps.restore": "Google LLC",
-        "com.google.android.apps.santatracker": "Google LLC",
+        "com.google.android.apps.recorder": "Google LLC",
         "com.google.android.apps.setupwizard.searchselector": "Google LLC",
+        "com.google.android.apps.santatracker": "Google LLC",
         "com.google.android.apps.subscriptions.red": "Google LLC",
         "com.google.android.apps.tachyon": "Google LLC",
         "com.google.android.apps.tasks": "Google LLC",
@@ -2587,7 +2179,6 @@
         "com.google.android.apps.walletnfcrel": "Google LLC",
         "com.google.android.apps.wallpaper": "Google LLC",
         "com.google.android.apps.wellbeing": "Google LLC",
-        "com.google.android.apps.work.oobconfig": "Google LLC",
         "com.google.android.apps.youtube.creator": "Google LLC",
         "com.google.android.apps.youtube.gaming": "Google LLC",
         "com.google.android.apps.youtube.kids": "Google LLC",
@@ -2602,12 +2193,9 @@
         "com.google.android.contacts": "Google LLC",
         "com.google.android.deskclock": "Google LLC",
         "com.google.android.dialer": "Google LLC",
-        "com.google.android.email": "Google LLC",
         "com.google.android.feedback": "Google LLC",
         "com.google.android.gm": "Google LLC",
         "com.google.android.gm.lite": "Google LLC",
-        "com.google.android.gms.location.history": "Google LLC",
-        "com.google.android.gms.policy_sidecar_aps": "Google LLC",
         "com.google.android.googlequicksearchbox": "Google LLC",
         "com.google.android.inputmethod.latin": "Google LLC",
         "com.google.android.instantapps.supervisor": "Google LLC",
@@ -2616,19 +2204,17 @@
         "com.google.android.marvin.talkback": "Google LLC",
         "com.google.android.music": "Google LLC",
         "com.google.android.onetimeinitializer": "Google LLC",
-        "com.google.android.partnersetup": "Google LLC",
-        "com.google.android.pixel.setupwizard": "Google LLC",
         "com.google.android.play.games": "Google LLC",
         "com.google.android.printservice.recommendation": "Google LLC",
         "com.google.android.projection.gearhead": "Google LLC",
         "com.google.android.setupwizard": "Google LLC",
         "com.google.android.setupwizard.a_overlay": "Google LLC",
+        "com.google.android.pixel.setupwizard": "Google LLC",
         "com.google.android.soundpicker": "Google LLC",
         "com.google.android.street": "Google LLC",
         "com.google.android.syncadapters.bookmarks": "Google LLC",
         "com.google.android.syncadapters.calendar": "Google LLC",
         "com.google.android.syncadapters.contacts": "Google LLC",
-        "com.google.android.tag": "Google LLC",
         "com.google.android.talk": "Google LLC",
         "com.google.android.tts": "Google LLC",
         "com.google.android.tv.remote": "Google LLC",
@@ -2641,7 +2227,6 @@
         "com.google.android.youtube": "Google LLC",
         "com.google.ar.core": "Google LLC",
         "com.google.ar.lens": "Google LLC",
-        "com.google.audio.hearing.visualization.accessibility.scribe": "Google LLC",
         "com.google.chromeremotedesktop": "Google LLC",
         "com.google.earth": "Google LLC",
         "com.google.marvin.talkback": "Google LLC",
@@ -2652,27 +2237,31 @@
         "com.google.vr.expeditions": "Google LLC",
         "com.google.vr.vrcore": "Google LLC",
         "com.google.zxing.client.android": "Google LLC",
+        "com.google.android.apps.work.oobconfig": "Google LLC",
+        "com.google.android.email": "Google LLC",
+        "com.google.android.tag": "Google LLC",
+        "com.google.android.gms.location.history": "Google LLC",
+        "com.google.android.gms.policy_sidecar_aps": "Google LLC",
+        "com.google.android.partnersetup": "Google LLC",
+        "com.google.audio.hearing.visualization.accessibility.scribe": "Google LLC",
+        "com.nest.android": "Google LLC",
+        "com.niksoftware.snapseed": "Google LLC",
+        "com.waze": "Google LLC",
+        "dev.firebase.appdistribution": "Google LLC",
+        "com.mapbox.mapboxandroiddemo": "Mapbox Inc.",
+        "com.mapbox.studio": "Mapbox Inc.",
+        "com.mapbox.locate": "Mapbox Inc.",
+        "com.mapbox.vision.teaser": "Mapbox Inc.",
+        "com.azure.authenticator": "Microsoft Corporation",
+        "com.gamepass": "Microsoft Corporation",
+        "com.gamepass.beta": "Microsoft Corporation",
         "com.groupme.android": "Microsoft Corporation",
-        "com.imdb.mobile": "Amazon Technologies, Inc.",
-        "com.imdb.pro.mobile.android": "Amazon Technologies, Inc.",
-        "com.imdbtv.livingroom": "Amazon Technologies, Inc.",
-        "com.instagram.android": "Facebook, Inc.",
-        "com.instagram.boomerang": "Facebook, Inc.",
-        "com.instagram.igtv": "Facebook, Inc.",
-        "com.instagram.layout": "Facebook, Inc.",
-        "com.instagram.threadsapp": "Facebook, Inc.",
-        "com.joelapenna.foursquared": "Foursquare Labs, Inc.",
-        "com.lemon.lvoverseas": "ByteDance Ltd.",
         "com.linkedin.android": "Microsoft Corporation",
         "com.linkedin.android.learning": "Microsoft Corporation",
         "com.linkedin.android.salesnavigator": "Microsoft Corporation",
         "com.linkedin.leap": "Microsoft Corporation",
         "com.linkedin.recruiter": "Microsoft Corporation",
         "com.lynda.android.root": "Microsoft Corporation",
-        "com.mapbox.locate": "Mapbox Inc.",
-        "com.mapbox.mapboxandroiddemo": "Mapbox Inc.",
-        "com.mapbox.studio": "Mapbox Inc.",
-        "com.mapbox.vision.teaser": "Mapbox Inc.",
         "com.microsoft.amp.apps.bingfinance": "Microsoft Corporation",
         "com.microsoft.amp.apps.bingnews": "Microsoft Corporation",
         "com.microsoft.android.smsorganizer": "Microsoft Corporation",
@@ -2694,8 +2283,8 @@
         "com.microsoft.msapps": "Microsoft Corporation",
         "com.microsoft.office.excel": "Microsoft Corporation",
         "com.microsoft.office.lync15": "Microsoft Corporation",
-        "com.microsoft.office.officehub": "Microsoft Corporation",
         "com.microsoft.office.officehubhl": "Microsoft Corporation",
+        "com.microsoft.office.officehub": "Microsoft Corporation",
         "com.microsoft.office.officehubrow": "Microsoft Corporation",
         "com.microsoft.office.officelens": "Microsoft Corporation",
         "com.microsoft.office.onenote": "Microsoft Corporation",
@@ -2721,47 +2310,41 @@
         "com.microsoft.xboxone.smartglass": "Microsoft Corporation",
         "com.microsoft.xboxone.smartglass.beta": "Microsoft Corporation",
         "com.microsoft.xcloud": "Microsoft Corporation",
-        "com.mobilemotion.dubsmash": "Reddit Inc.",
         "com.ms.office365admin": "Microsoft Corporation",
-        "com.nest.android": "Google LLC",
-        "com.newrelic.rpm": "New Relic",
-        "com.niksoftware.snapseed": "Google LLC",
-        "com.oath.MediaAnalytics": "Verizon Media",
-        "com.pinterest": "Pinterest, Inc.",
-        "com.pinterest.twa": "Pinterest, Inc.",
-        "com.reddit.frontpage": "Reddit Inc.",
-        "com.relateiq.android": "Salesforce.com, Inc.",
-        "com.ringapp": "Amazon Technologies, Inc.",
-        "com.roku.remote": "Roku, Inc.",
-        "com.salesforce.admin1": "Salesforce.com, Inc.",
-        "com.salesforce.authenticator": "Salesforce.com, Inc.",
-        "com.salesforce.chatter": "Salesforce.com, Inc.",
-        "com.salesforce.dreamoji": "Salesforce.com, Inc.",
-        "com.salesforce.fieldservice.app": "Salesforce.com, Inc.",
-        "com.salesforce.marketingcloud": "Salesforce.com, Inc.",
-        "com.salesforce.socialstudio": "Salesforce.com, Inc.",
-        "com.salesforce.trailheadgo.app": "Salesforce.com, Inc.",
-        "com.salesforce.wave": "Salesforce.com, Inc.",
-        "com.sewichi.client.panel": "Foursquare Labs, Inc.",
         "com.skype.insiders": "Microsoft Corporation",
         "com.skype.raider": "Microsoft Corporation",
-        "com.snapchat.android": "Snap Inc.",
-        "com.ss.android.ugc.trill": "ByteDance Ltd.",
-        "com.taboola.newsroomMobile": "Taboola, Inc.",
         "com.touchtype.swiftkey": "Microsoft Corporation",
         "com.touchtype.swiftkey.beta": "Microsoft Corporation",
+        "com.newrelic.rpm": "New Relic",
+        "com.pinterest": "Pinterest, Inc.",
+        "com.pinterest.twa": "Pinterest, Inc.",
+        "com.desk.android": "Salesforce.com, Inc.",
+        "com.salesforce.chatter": "Salesforce.com, Inc.",
+        "com.salesforce.authenticator": "Salesforce.com, Inc.",
+        "com.salesforce.trailheadgo.app": "Salesforce.com, Inc.",
+        "com.salesforce.fieldservice.app": "Salesforce.com, Inc.",
+        "com.salesforce.admin1": "Salesforce.com, Inc.",
+        "com.relateiq.android": "Salesforce.com, Inc.",
+        "com.salesforce.dreamoji": "Salesforce.com, Inc.",
+        "com.salesforce.wave": "Salesforce.com, Inc.",
+        "com.salesforce.marketingcloud": "Salesforce.com, Inc.",
+        "com.salesforce.socialstudio": "Salesforce.com, Inc.",
+        "org.salesforce.philanthropycloud": "Salesforce.com, Inc.",
+        "app.zenly.locator": "Snap Inc.",
+        "com.snapchat.android": "Snap Inc.",
+        "com.bitstrips.imoji": "Snap Inc.",
+        "com.taboola.newsroomMobile": "Taboola, Inc.",
         "com.twitter.android": "Twitter, Inc.",
+        "co.vine.android": "Twitter, Inc.",
+        "com.flurry.instantapp.test.app": "Verizon Media",
+        "com.aol.mobile.aolapp": "Verizon Media",
+        "com.aol.mobile.techcrunch": "Verizon Media",
+        "com.oath.MediaAnalytics": "Verizon Media",
         "com.verizonmedia.makers": "Verizon Media",
-        "com.waze": "Google LLC",
-        "com.whatsapp": "Facebook, Inc.",
-        "com.yahoo.apps.yahooapp": "Verizon Media",
-        "com.yahoo.flurry": "Verizon Media",
-        "com.yahoo.harmony": "Verizon Media",
-        "com.yahoo.infohub": "Verizon Media",
         "com.yahoo.mobile.client.android.ecshopping": "Verizon Media",
-        "com.yahoo.mobile.client.android.fantasyfootball": "Verizon Media",
         "com.yahoo.mobile.client.android.finance": "Verizon Media",
         "com.yahoo.mobile.client.android.finance.androidtv": "Verizon Media",
+        "com.yahoo.mobile.client.android.fantasyfootball": "Verizon Media",
         "com.yahoo.mobile.client.android.mail": "Verizon Media",
         "com.yahoo.mobile.client.android.mail.lite": "Verizon Media",
         "com.yahoo.mobile.client.android.nativemail": "Verizon Media",
@@ -2769,144 +2352,180 @@
         "com.yahoo.mobile.client.android.sportacular": "Verizon Media",
         "com.yahoo.mobile.client.android.weather": "Verizon Media",
         "com.yahoo.mobile.client.android.yahoo": "Verizon Media",
+        "com.yahoo.apps.yahooapp": "Verizon Media",
+        "com.yahoo.flurry": "Verizon Media",
+        "com.yahoo.harmony": "Verizon Media",
+        "com.yahoo.infohub": "Verizon Media",
         "com.yahoo.onesearch": "Verizon Media",
         "com.yahoo.otterdroid": "Verizon Media",
         "com.yahoo.wwww.twa": "Verizon Media",
-        "com.yandex.browser": "Yandex LLC",
-        "com.yandex.courier": "Yandex LLC",
-        "com.yandex.mobile.drive": "Yandex LLC",
-        "com.yandex.q": "Yandex LLC",
-        "com.yandex.qmobile": "Yandex LLC",
-        "com.yandex.yamb": "Yandex LLC",
-        "com.zhiliao.musically.livewallpaper": "ByteDance Ltd.",
-        "com.zhiliaoapp.musically": "ByteDance Ltd.",
-        "dev.firebase.appdistribution": "Google LLC",
-        "in.amazon.mShop.android.shopping": "Amazon Technologies, Inc.",
-        "io.branch.android.discovery": "Branch Metrics, Inc.",
-        "io.branch.branchster": "Branch Metrics, Inc.",
-        "io.branch.deviceid": "Branch Metrics, Inc.",
-        "io.branch.sample.hellobranch": "Branch Metrics, Inc.",
         "nexti.android.bustaichung": "Verizon Media",
         "nexti.android.bustaipei": "Verizon Media",
         "nexti.android.bustaiwan": "Verizon Media",
-        "org.salesforce.philanthropycloud": "Salesforce.com, Inc.",
+        "com.adultswim.videoapp.android": "WarnerMedia, LLC",
+        "com.cnn.mobile.android.phone": "WarnerMedia, LLC",
+        "com.cnn.mobile.android.tv": "WarnerMedia, LLC",
+        "com.hbo.android.app": "WarnerMedia, LLC",
+        "com.hbo.hbonow": "WarnerMedia, LLC",
+        "com.tcm.tcm": "WarnerMedia, LLC",
+        "com.turner.cnvideoapp": "WarnerMedia, LLC",
+        "com.turner.tbs.android.networkapp": "WarnerMedia, LLC",
+        "com.turner.tnt.android.networkapp": "WarnerMedia, LLC",
+        "com.turner.trutv": "WarnerMedia, LLC",
+        "com.turner.trutv.wheelofdoom": "WarnerMedia, LLC",
+        "com.warnermedia.wmce.ride": "WarnerMedia, LLC",
+        "com.wb.goog.mkx": "WarnerMedia, LLC",
+        "com.wb.goog.injustice.brawler2017": "WarnerMedia, LLC",
+        "com.wb.goog.dc.legends": "WarnerMedia, LLC",
+        "com.wb.goog.dcuniverse": "WarnerMedia, LLC",
+        "com.wb.goog.ellentube": "WarnerMedia, LLC",
+        "com.wb.goog.injustice": "WarnerMedia, LLC",
+        "com.wb.goog.got.conquest": "WarnerMedia, LLC",
+        "com.wb.goog.emojiexplojipaid": "WarnerMedia, LLC",
+        "com.wb.goog.phonelog": "WarnerMedia, LLC",
+        "com.wb.goog.scribblenauts3": "WarnerMedia, LLC",
+        "com.wb.goog.scribbleremix": "WarnerMedia, LLC",
+        "com.wb.goog.shoutrageous": "WarnerMedia, LLC",
+        "com.wb.headsup": "WarnerMedia, LLC",
+        "com.wb.map": "WarnerMedia, LLC",
+        "com.wb.wbtvdistribution": "WarnerMedia, LLC",
+        "com.wb.wbfyc": "WarnerMedia, LLC",
+        "com.rhythmnewmedia.tmz": "WarnerMedia, LLC",
+        "eu.hbogo.android": "WarnerMedia, LLC",
+        "com.yandex.browser": "Yandex LLC",
+        "ru.yandex.searchplugin": "Yandex LLC",
+        "ru.yandex.searchplugin.beta": "Yandex LLC",
+        "ru.yandex.taxi": "Yandex LLC",
+        "ru.yandex.yandexmaps": "Yandex LLC",
+        "ru.yandex.yandexnavi": "Yandex LLC",
+        "ru.yandex.disk": "Yandex LLC",
+        "ru.yandex.disk.beta": "Yandex LLC",
+        "ru.yandex.music": "Yandex LLC",
+        "ru.kinopoisk": "Yandex LLC",
+        "ru.kinopoisk.tv": "Yandex LLC",
+        "ru.yandex.mail": "Yandex LLC",
+        "ru.yandex.taximeter": "Yandex LLC",
+        "ru.yandex.taximeter.beta": "Yandex LLC",
         "ru.auto.ara": "Yandex LLC",
         "ru.foodfox.client": "Yandex LLC",
         "ru.foodfox.courier.debug.releaseserver": "Yandex LLC",
         "ru.foodfox.vendor": "Yandex LLC",
-        "ru.kinopoisk": "Yandex LLC",
-        "ru.kinopoisk.tv": "Yandex LLC",
-        "ru.theexpert.app": "Yandex LLC",
-        "ru.yandex.direct": "Yandex LLC",
-        "ru.yandex.disk": "Yandex LLC",
-        "ru.yandex.disk.beta": "Yandex LLC",
-        "ru.yandex.key": "Yandex LLC",
-        "ru.yandex.mail": "Yandex LLC",
-        "ru.yandex.market": "Yandex LLC",
-        "ru.yandex.market.partner": "Yandex LLC",
-        "ru.yandex.med": "Yandex LLC",
         "ru.yandex.metro": "Yandex LLC",
-        "ru.yandex.mobile.appmetrica": "Yandex LLC",
-        "ru.yandex.mobile.avia": "Yandex LLC",
-        "ru.yandex.mobile.gasstations": "Yandex LLC",
-        "ru.yandex.mobile.metrica": "Yandex LLC",
-        "ru.yandex.music": "Yandex LLC",
-        "ru.yandex.nokiasystemservice": "Yandex LLC",
-        "ru.yandex.rasp": "Yandex LLC",
-        "ru.yandex.searchplugin": "Yandex LLC",
-        "ru.yandex.searchplugin.beta": "Yandex LLC",
-        "ru.yandex.taxi": "Yandex LLC",
-        "ru.yandex.taximeter": "Yandex LLC",
-        "ru.yandex.taximeter.beta": "Yandex LLC",
-        "ru.yandex.telemed.doctor": "Yandex LLC",
-        "ru.yandex.telemost": "Yandex LLC",
         "ru.yandex.weatherplugin": "Yandex LLC",
-        "ru.yandex.yandexmaps": "Yandex LLC",
-        "ru.yandex.yandexnavi": "Yandex LLC",
-        "tv.twitch.android.app": "Amazon Technologies, Inc.",
-        "yandex.auto.mobile": "Yandex LLC"
+        "ru.yandex.telemost": "Yandex LLC",
+        "ru.yandex.key": "Yandex LLC",
+        "ru.yandex.rasp": "Yandex LLC",
+        "com.yandex.mobile.drive": "Yandex LLC",
+        "ru.yandex.mobile.avia": "Yandex LLC",
+        "com.yandex.yamb": "Yandex LLC",
+        "ru.yandex.market.partner": "Yandex LLC",
+        "ru.yandex.market": "Yandex LLC",
+        "ru.yandex.mobile.gasstations": "Yandex LLC",
+        "ru.yandex.direct": "Yandex LLC",
+        "yandex.auto.mobile": "Yandex LLC",
+        "ru.yandex.mobile.appmetrica": "Yandex LLC",
+        "ru.yandex.mobile.metrica": "Yandex LLC",
+        "com.yandex.courier": "Yandex LLC",
+        "ru.yandex.nokiasystemservice": "Yandex LLC",
+        "com.yandex.q": "Yandex LLC",
+        "com.yandex.qmobile": "Yandex LLC",
+        "ru.yandex.med": "Yandex LLC",
+        "ru.yandex.telemed.doctor": "Yandex LLC",
+        "ru.theexpert.app": "Yandex LLC"
     },
     "entities": {
-        "33Across, Inc.": {
-            "score": 590,
+        "Google LLC": {
+            "score": 97594,
             "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "A.Mob SAS": {
-            "score": 585,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_model",
-                "device_language",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "platform"
-            ]
-        },
-        "AcuityAds": {
-            "score": 702,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_model",
-                "app_version",
-                "device_language",
-                "device_make",
-                "os_version",
-                "app_name",
-                "country",
-                "platform"
-            ]
-        },
-        "Adform A/S": {
-            "score": 1680,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Adjust GmbH": {
-            "score": 18942,
-            "signals": [
-                "phone_number",
+                "gps_coordinates",
                 "email_address",
+                "first_name",
+                "last_name",
+                "device_name",
                 "postal_code",
-                "AAID",
+                "device_boot_time",
                 "city",
+                "AAID",
                 "unique_identifier",
+                "local_ip",
+                "gender",
+                "device_free_storage",
+                "state",
                 "cookies",
-                "cpu_data",
+                "device_battery_level",
+                "device_volume",
+                "device_total_memory",
+                "device_headphone_status",
                 "os_build_version",
                 "device_resolution",
                 "device_model",
                 "app_version",
                 "device_connectivity",
                 "device_language",
+                "cpu_data",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Facebook, Inc.": {
+            "score": 42596,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "gender",
+                "accelerometer_data",
+                "device_free_storage",
+                "rotation_data",
+                "state",
+                "device_free_memory",
+                "network_carrier",
+                "cookies",
+                "device_volume",
+                "device_total_memory",
+                "cpu_data",
+                "device_headphone_status",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "device_screen_density",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Branch Metrics, Inc.": {
+            "score": 13976,
+            "signals": [
+                "email_address",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "local_ip",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "install_date",
                 "app_name",
                 "device_make",
                 "os_version",
@@ -2915,126 +2534,30 @@
                 "platform"
             ]
         },
-        "Adkernel, LLC": {
-            "score": 530,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_connectivity",
-                "device_model",
-                "device_language",
-                "app_name",
-                "os_version",
-                "device_make",
-                "country",
-                "platform"
-            ]
-        },
-        "ADman Media": {
-            "score": 702,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_model",
-                "app_version",
-                "device_language",
-                "device_make",
-                "os_version",
-                "app_name",
-                "country",
-                "platform"
-            ]
-        },
-        "Adobe Inc.": {
-            "score": 20715,
+        "The Trade Desk Inc": {
+            "score": 12664,
             "signals": [
                 "gps_coordinates",
-                "email_address",
-                "neighborhood",
                 "postal_code",
                 "AAID",
-                "unique_identifier",
-                "network_carrier",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_model",
-                "install_date",
-                "device_language",
-                "device_connectivity",
-                "app_name",
-                "os_version",
-                "device_make",
-                "country",
-                "timezone",
-                "platform",
-                "device_orientation"
-            ]
-        },
-        "AdRoll, Inc.": {
-            "score": 1008,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_model",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Adscore Technologies DMCC": {
-            "score": 704,
-            "signals": [
                 "city",
                 "unique_identifier",
+                "state",
                 "cookies",
                 "os_build_version",
+                "device_model",
                 "app_version",
-                "device_model",
-                "device_language",
                 "app_name",
                 "device_make",
                 "os_version",
-                "country",
-                "timezone",
-                "platform"
-            ]
-        },
-        "AdTheorent Inc": {
-            "score": 585,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_model",
-                "device_language",
-                "device_make",
-                "os_version",
-                "app_name",
                 "country",
                 "platform"
             ]
         },
         "Amazon Technologies, Inc.": {
-            "score": 27934,
+            "score": 12477,
             "signals": [
-                "email_address",
-                "password",
-                "username",
                 "gps_coordinates",
-                "first_name",
-                "last_name",
-                "neighborhood",
                 "AAID",
                 "city",
                 "unique_identifier",
@@ -3047,94 +2570,277 @@
                 "device_resolution",
                 "device_model",
                 "app_version",
-                "device_language",
                 "device_connectivity",
-                "app_name",
+                "device_language",
                 "device_make",
                 "os_version",
+                "app_name",
                 "country",
-                "timezone",
                 "device_screen_density",
                 "platform",
                 "device_orientation"
             ]
         },
-        "Amobee, Inc": {
-            "score": 2260,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Amplitude": {
-            "score": 7196,
+        "Taboola, Inc.": {
+            "score": 12245,
             "signals": [
                 "gps_coordinates",
-                "username",
-                "first_name",
-                "birthday",
-                "neighborhood",
-                "postal_code",
                 "AAID",
-                "city",
-                "device_boot_time",
                 "unique_identifier",
                 "state",
-                "device_font_size",
-                "birth_year",
-                "network_carrier",
-                "device_headphone_status",
+                "cookies",
+                "device_total_memory",
                 "os_build_version",
                 "device_resolution",
                 "app_version",
+                "device_connectivity",
                 "device_language",
                 "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Integral Ad Science, Inc.": {
+            "score": 10518,
+            "signals": [
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "device_volume",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "device_screen_density",
+                "platform"
+            ]
+        },
+        "Verizon Media": {
+            "score": 10342,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "device_boot_time",
+                "city",
+                "unique_identifier",
+                "device_free_storage",
+                "state",
+                "device_free_memory",
+                "network_carrier",
+                "cookies",
+                "device_battery_level",
+                "device_total_storage",
+                "device_total_memory",
+                "device_headphone_status",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
                 "device_connectivity",
+                "device_language",
+                "app_name",
+                "device_charging_status",
                 "device_make",
                 "os_version",
                 "country",
+                "timezone",
+                "device_screen_density",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "WarnerMedia, LLC": {
+            "score": 9846,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "city",
+                "AAID",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
                 "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Adobe Inc.": {
+            "score": 9528,
+            "signals": [
+                "gps_coordinates",
+                "email_address",
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "network_carrier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_model",
+                "install_date",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "timezone",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Twitter, Inc.": {
+            "score": 8444,
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_language",
+                "device_connectivity",
+                "app_name",
+                "device_make",
+                "country",
+                "os_version",
                 "device_screen_density",
                 "timezone",
                 "platform"
             ]
         },
-        "AppLovin Corporation": {
-            "score": 26675,
+        "Oracle Corporation": {
+            "score": 6426,
             "signals": [
-                "gps_coordinates",
-                "neighborhood",
-                "postal_code",
                 "AAID",
-                "city",
                 "unique_identifier",
+                "network_carrier",
                 "cookies",
+                "device_total_memory",
                 "os_build_version",
                 "device_resolution",
                 "device_model",
                 "app_version",
                 "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "comScore, Inc": {
+            "score": 6342,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "city",
+                "AAID",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "device_total_memory",
+                "device_model",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "IPONWEB GmbH": {
+            "score": 6265,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
                 "device_connectivity",
                 "app_name",
                 "device_make",
-                "country",
                 "os_version",
-                "device_screen_density",
+                "country",
+                "platform"
+            ]
+        },
+        "Criteo SA": {
+            "score": 6006,
+            "signals": [
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_model",
+                "device_language",
+                "device_connectivity",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Braze, Inc.": {
+            "score": 5918,
+            "signals": [
+                "gps_coordinates",
+                "email_address",
+                "first_name",
+                "last_name",
+                "postal_code",
+                "city",
+                "AAID",
+                "unique_identifier",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "os_version",
                 "timezone",
                 "platform"
             ]
         },
         "AppsFlyer": {
-            "score": 15310,
+            "score": 5351,
             "signals": [
                 "device_magnetometer",
                 "AAID",
@@ -3160,13 +2866,55 @@
                 "platform"
             ]
         },
-        "Apptentive Inc.": {
-            "score": 1915,
+        "Tapad, Inc.": {
+            "score": 5313,
             "signals": [
-                "phone_number",
-                "birthday",
+                "postal_code",
+                "AAID",
+                "city",
                 "unique_identifier",
-                "network_carrier",
+                "state",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Salesforce.com, Inc.": {
+            "score": 5262,
+            "signals": [
+                "email_address",
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Adjust GmbH": {
+            "score": 5010,
+            "signals": [
+                "email_address",
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "cookies",
                 "cpu_data",
                 "os_build_version",
                 "device_model",
@@ -3177,124 +2925,539 @@
                 "device_make",
                 "os_version",
                 "country",
+                "device_screen_density",
                 "platform"
             ]
         },
-        "Avocet Systems Ltd.": {
-            "score": 625,
+        "PubMatic, Inc.": {
+            "score": 4926,
             "signals": [
+                "city",
+                "AAID",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_model",
+                "device_connectivity",
                 "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Kochava": {
+            "score": 4884,
+            "signals": [
+                "device_name",
+                "wifi_ssid",
+                "postal_code",
+                "AAID",
+                "device_boot_time",
+                "unique_identifier",
+                "network_carrier",
+                "screen_brightness",
+                "device_battery_level",
+                "device_volume",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Microsoft Corporation": {
+            "score": 4804,
+            "signals": [
+                "gps_coordinates",
+                "city",
+                "AAID",
+                "unique_identifier",
+                "state",
+                "network_carrier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Index Exchange, Inc.": {
+            "score": 4300,
+            "signals": [
+                "gps_coordinates",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
                 "device_model",
                 "app_version",
                 "device_make",
                 "os_version",
-                "country",
                 "app_name",
                 "platform"
             ]
         },
-        "Beeswax": {
-            "score": 3600,
+        "Amplitude": {
+            "score": 4265,
             "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "device_boot_time",
                 "unique_identifier",
-                "cookies",
+                "state",
+                "device_font_size",
+                "network_carrier",
+                "device_headphone_status",
                 "os_build_version",
+                "device_resolution",
+                "app_version",
                 "device_language",
                 "device_model",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Bidtellect, Inc": {
-            "score": 1365,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "app_version",
                 "device_connectivity",
                 "device_make",
                 "os_version",
                 "country",
                 "app_name",
+                "device_screen_density",
+                "timezone",
                 "platform"
             ]
         },
-        "Branch Metrics, Inc.": {
-            "score": 33342,
+        "DoubleVerify": {
+            "score": 3510,
             "signals": [
-                "email_address",
-                "username",
-                "phone_number",
-                "first_name",
+                "AAID",
+                "unique_identifier",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Smartadserver S.A.S": {
+            "score": 3334,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "platform"
+            ]
+        },
+        "The Nielsen Company": {
+            "score": 3306,
+            "signals": [
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "The Rubicon Project, Inc.": {
+            "score": 2982,
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "LiveRamp": {
+            "score": 2967,
+            "signals": [
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Segment.io, Inc.": {
+            "score": 2950,
+            "signals": [
+                "gps_coordinates",
                 "postal_code",
                 "AAID",
                 "city",
                 "unique_identifier",
                 "local_ip",
+                "state",
                 "network_carrier",
-                "cpu_data",
+                "device_model",
                 "os_build_version",
                 "device_resolution",
-                "app_version",
+                "device_connectivity",
                 "device_language",
-                "device_model",
-                "install_date",
+                "app_version",
                 "app_name",
                 "device_make",
                 "os_version",
                 "country",
-                "dialing_code",
                 "device_screen_density",
                 "timezone",
                 "platform"
             ]
         },
-        "Braze, Inc.": {
-            "score": 10584,
+        "Pixalate, Inc.": {
+            "score": 2654,
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Urban Airship, Inc.": {
+            "score": 2641,
             "signals": [
                 "gps_coordinates",
                 "email_address",
-                "first_name",
-                "last_name",
-                "postal_code",
-                "neighborhood",
                 "city",
-                "AAID",
                 "unique_identifier",
+                "network_carrier",
+                "app_version",
+                "device_model",
+                "app_name",
+                "os_version",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Functional Software, Inc.": {
+            "score": 2540,
+            "signals": [
+                "device_name",
+                "device_boot_time",
+                "unique_identifier",
+                "device_free_memory",
+                "device_battery_level",
+                "device_total_storage",
+                "cpu_data",
+                "device_total_memory",
                 "os_build_version",
                 "device_resolution",
                 "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Innovid Media": {
+            "score": 2538,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_name",
+                "os_version",
+                "platform"
+            ]
+        },
+        "MediaMath, Inc.": {
+            "score": 2472,
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_language",
+                "device_make",
+                "os_version",
+                "app_name",
+                "country",
+                "platform"
+            ]
+        },
+        "Xaxis": {
+            "score": 2176,
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "SpotX, Inc.": {
+            "score": 2163,
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform"
+            ]
+        },
+        "Liftoff Mobile, Inc.": {
+            "score": 2054,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "device_total_memory",
+                "os_build_version",
                 "device_language",
                 "device_model",
                 "app_name",
                 "os_version",
-                "device_make",
                 "country",
-                "timezone",
-                "device_screen_density",
                 "platform"
             ]
         },
-        "Bugsnag Inc.": {
-            "score": 2201,
+        "Smaato Inc.": {
+            "score": 1932,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "network_carrier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "device_connectivity",
+                "app_name",
+                "device_make",
+                "os_version",
+                "timezone",
+                "platform"
+            ]
+        },
+        "OpenX Technologies Inc": {
+            "score": 1905,
             "signals": [
                 "city",
                 "unique_identifier",
-                "device_free_storage",
-                "device_free_memory",
-                "device_battery_level",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Pinterest, Inc.": {
+            "score": 1896,
+            "signals": [
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "OneSignal": {
+            "score": 1855,
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_name",
+                "os_version",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Neustar, Inc.": {
+            "score": 1689,
+            "signals": [
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "cookies",
                 "device_total_memory",
-                "cpu_data",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Centro, Inc.": {
+            "score": 1496,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "TripleLift": {
+            "score": 1496,
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Sift Science, Inc.": {
+            "score": 1492,
+            "signals": [
+                "gps_coordinates",
+                "unique_identifier",
+                "local_ip",
+                "device_battery_level",
+                "device_model",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Unity Technologies ApS": {
+            "score": 1488,
+            "signals": [
+                "AAID",
+                "device_free_storage",
+                "external_free_storage",
+                "device_free_memory",
+                "screen_brightness",
+                "device_battery_level",
+                "device_total_storage",
+                "external_total_storage",
+                "device_volume",
+                "device_total_memory",
+                "device_headphone_status",
                 "os_build_version",
                 "device_resolution",
                 "app_version",
@@ -3306,106 +3469,84 @@
                 "device_make",
                 "os_version",
                 "device_screen_density",
+                "timezone",
                 "device_orientation",
                 "platform"
             ]
         },
-        "ByteDance Ltd.": {
-            "score": 1452,
+        "Snap Inc.": {
+            "score": 1480,
             "signals": [
                 "AAID",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
+                "device_resolution",
                 "app_version",
                 "device_model",
                 "device_language",
                 "app_name",
                 "device_make",
                 "os_version",
-                "country",
                 "platform"
             ]
         },
-        "Centro, Inc.": {
-            "score": 2400,
+        "Foursquare Labs, Inc.": {
+            "score": 1395,
             "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Collective Roll": {
-            "score": 2750,
-            "signals": [
-                "neighborhood",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_connectivity",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "comScore, Inc": {
-            "score": 14164,
-            "signals": [
-                "gps_coordinates",
                 "postal_code",
-                "city",
                 "AAID",
                 "unique_identifier",
-                "state",
                 "cookies",
                 "device_total_memory",
-                "cpu_data",
-                "device_model",
                 "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_language",
-                "device_connectivity",
+                "device_model",
                 "app_name",
                 "os_version",
-                "device_make",
-                "country",
                 "platform"
             ]
         },
-        "Criteo SA": {
-            "score": 10557,
+        "Amobee, Inc": {
+            "score": 1331,
             "signals": [
-                "AAID",
-                "city",
                 "unique_identifier",
-                "state",
                 "cookies",
                 "os_build_version",
-                "device_resolution",
-                "app_version",
                 "device_model",
-                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Instabug": {
+            "score": 1320,
+            "signals": [
+                "gps_coordinates",
+                "wifi_ssid",
+                "postal_code",
+                "city",
+                "unique_identifier",
+                "device_free_storage",
+                "state",
+                "device_free_memory",
+                "network_carrier",
+                "device_battery_level",
+                "device_total_storage",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
                 "device_connectivity",
                 "app_name",
-                "os_version",
+                "device_charging_status",
                 "device_make",
+                "os_version",
                 "country",
-                "platform",
-                "device_orientation"
+                "device_screen_density",
+                "device_orientation",
+                "platform"
             ]
         },
         "Datadog, Inc.": {
@@ -3428,236 +3569,55 @@
                 "platform"
             ]
         },
-        "DeepIntent Inc": {
-            "score": 625,
+        "Beeswax": {
+            "score": 1290,
             "signals": [
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
-                "device_language",
-                "device_model",
                 "app_version",
-                "device_make",
-                "os_version",
-                "country",
+                "device_model",
                 "app_name",
+                "os_version",
+                "device_make",
                 "platform"
             ]
         },
-        "Digital Turbine": {
-            "score": 6813,
+        "Pulsepoint, Inc.": {
+            "score": 1267,
             "signals": [
+                "city",
                 "AAID",
                 "unique_identifier",
-                "mac_address",
-                "device_free_memory",
-                "network_carrier",
                 "cookies",
-                "device_battery_level",
-                "cpu_data",
-                "device_headphone_status",
                 "os_build_version",
-                "device_resolution",
                 "app_version",
                 "device_connectivity",
-                "device_language",
                 "device_model",
                 "app_name",
-                "device_make",
                 "os_version",
-                "country",
-                "device_screen_density",
-                "timezone",
-                "device_orientation",
+                "device_make",
                 "platform"
             ]
         },
-        "Dotmetrics": {
-            "score": 1228,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "device_total_memory",
-                "cpu_data",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_language",
-                "device_model",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "timezone",
-                "platform"
-            ]
-        },
-        "DoubleVerify": {
-            "score": 9921,
-            "signals": [
-                "gps_coordinates",
-                "neighborhood",
-                "AAID",
-                "unique_identifier",
-                "device_total_memory",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Engine USA LLC": {
-            "score": 1524,
+        "RhythmOne": {
+            "score": 1232,
             "signals": [
                 "city",
-                "AAID",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
                 "app_version",
                 "device_model",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Exponential Interactive Inc.": {
-            "score": 726,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_model",
-                "app_version",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "eyeota Limited": {
-            "score": 1400,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Facebook, Inc.": {
-            "score": 119895,
-            "signals": [
-                "gps_coordinates",
-                "email_address",
-                "username",
-                "first_name",
-                "last_name",
-                "postal_code",
-                "birthday",
-                "neighborhood",
-                "AAID",
-                "city",
-                "unique_identifier",
-                "gender",
-                "accelerometer_data",
-                "device_free_storage",
-                "rotation_data",
-                "state",
-                "device_free_memory",
-                "network_carrier",
-                "cookies",
-                "device_volume",
-                "device_total_memory",
-                "device_headphone_status",
-                "os_build_version",
-                "device_resolution",
-                "device_model",
-                "app_version",
                 "device_connectivity",
-                "device_language",
-                "app_name",
-                "device_charging_status",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "device_screen_density",
-                "platform",
-                "device_orientation"
-            ]
-        },
-        "Fastly, Inc.": {
-            "score": 792,
-            "signals": [
-                "city",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_model",
-                "device_language",
                 "app_name",
                 "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Flashtalking Inc": {
-            "score": 2050,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "cpu_data",
-                "device_total_memory",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "app_version",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "platform",
-                "device_orientation"
-            ]
-        },
-        "Foursquare Labs, Inc.": {
-            "score": 1395,
-            "signals": [
-                "postal_code",
-                "AAID",
-                "unique_identifier",
-                "cookies",
-                "device_total_memory",
-                "os_build_version",
-                "device_model",
-                "app_name",
                 "os_version",
                 "platform"
             ]
         },
-        "FreeWheel": {
-            "score": 1896,
+        "Yandex LLC": {
+            "score": 1219,
             "signals": [
                 "gps_coordinates",
                 "AAID",
@@ -3666,169 +3626,21 @@
                 "os_build_version",
                 "device_resolution",
                 "device_model",
-                "app_version",
                 "device_language",
-                "app_name",
                 "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Functional Software, Inc.": {
-            "score": 6310,
-            "signals": [
-                "device_name",
-                "device_boot_time",
-                "unique_identifier",
-                "device_free_memory",
-                "device_battery_level",
-                "device_total_storage",
-                "cpu_data",
-                "device_total_memory",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_connectivity",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_charging_status",
-                "device_make",
-                "os_version",
-                "country",
-                "device_screen_density",
-                "timezone",
-                "device_orientation",
-                "platform"
-            ]
-        },
-        "GameAnalytics ApS": {
-            "score": 955,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "device_screen_density",
-                "platform"
-            ]
-        },
-        "Google LLC": {
-            "score": 326430,
-            "signals": [
-                "gps_coordinates",
-                "email_address",
-                "phone_number",
-                "username",
-                "password",
-                "first_name",
-                "last_name",
-                "neighborhood",
-                "device_name",
-                "postal_code",
-                "AAID",
-                "device_boot_time",
-                "city",
-                "unique_identifier",
-                "local_ip",
-                "gender",
-                "device_free_storage",
-                "state",
-                "network_carrier",
-                "cookies",
-                "device_battery_level",
-                "device_volume",
-                "device_total_memory",
-                "cpu_data",
-                "device_headphone_status",
-                "os_build_version",
-                "device_resolution",
-                "device_model",
-                "app_version",
-                "device_connectivity",
-                "device_language",
-                "install_date",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "device_charging_status",
-                "timezone",
-                "device_screen_density",
-                "platform",
-                "device_orientation"
-            ]
-        },
-        "Hexagon Data, S.A.P.I. de C.V.": {
-            "score": 774,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "cpu_data",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Human Security, Inc.": {
-            "score": 378,
-            "signals": [
-                "AAID",
-                "cookies",
-                "os_build_version",
-                "device_model",
                 "app_name",
                 "os_version",
                 "platform"
             ]
         },
-        "ID5 Technology Ltd": {
-            "score": 861,
+        "Zeotap GmbH": {
+            "score": 1176,
             "signals": [
-                "city",
                 "AAID",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
-                "device_resolution",
                 "device_model",
-                "app_version",
-                "device_connectivity",
-                "device_language",
-                "device_make",
-                "os_version",
-                "app_name",
-                "country",
-                "platform"
-            ]
-        },
-        "Index Exchange, Inc.": {
-            "score": 11308,
-            "signals": [
-                "gps_coordinates",
-                "city",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "app_version",
                 "app_name",
                 "device_make",
                 "os_version",
@@ -3837,7 +3649,7 @@
             ]
         },
         "Inmar, Inc.": {
-            "score": 2486,
+            "score": 1130,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -3846,326 +3658,47 @@
                 "os_build_version",
                 "app_version",
                 "device_model",
-                "device_language",
                 "app_name",
                 "device_make",
                 "os_version",
-                "country",
                 "platform"
             ]
         },
-        "InMobi Pte Ltd": {
-            "score": 800,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "device_volume",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_connectivity",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "device_screen_density",
-                "timezone",
-                "device_orientation",
-                "platform"
-            ]
-        },
-        "Innovid Media": {
-            "score": 3400,
-            "signals": [
-                "gps_coordinates",
-                "postal_code",
-                "neighborhood",
-                "AAID",
-                "city",
-                "unique_identifier",
-                "cookies",
-                "device_total_memory",
-                "os_build_version",
-                "device_resolution",
-                "device_model",
-                "device_language",
-                "app_name",
-                "os_version",
-                "device_make",
-                "country",
-                "platform"
-            ]
-        },
-        "Integral Ad Science, Inc.": {
-            "score": 18228,
+        "Media.net Advertising FZ-LLC": {
+            "score": 1114,
             "signals": [
                 "postal_code",
-                "AAID",
                 "city",
                 "unique_identifier",
-                "state",
-                "device_volume",
-                "device_total_memory",
-                "os_build_version",
-                "device_resolution",
-                "device_model",
-                "device_language",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "device_screen_density",
-                "platform"
-            ]
-        },
-        "Intuition Machines, Inc.": {
-            "score": 460,
-            "signals": [
-                "unique_identifier",
                 "cookies",
-                "cpu_data",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "app_version",
-                "app_name",
-                "os_version",
-                "device_make",
-                "platform"
-            ]
-        },
-        "IPONWEB GmbH": {
-            "score": 9445,
-            "signals": [
-                "gps_coordinates",
-                "postal_code",
-                "AAID",
-                "city",
-                "unique_identifier",
-                "state",
-                "cookies",
-                "os_build_version",
-                "device_model",
-                "device_language",
-                "app_version",
-                "device_connectivity",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "ironSource Ltd": {
-            "score": 29113,
-            "signals": [
-                "postal_code",
-                "neighborhood",
-                "AAID",
-                "city",
-                "unique_identifier",
-                "local_ip",
-                "device_free_storage",
-                "network_isp",
-                "network_carrier",
-                "device_free_memory",
-                "device_battery_level",
-                "os_build_version",
-                "device_resolution",
-                "device_connectivity",
-                "device_model",
-                "device_language",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "device_screen_density",
-                "timezone",
-                "device_orientation",
-                "platform"
-            ]
-        },
-        "iSpot.tv": {
-            "score": 670,
-            "signals": [
-                "city",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_model",
-                "device_language",
-                "app_name",
-                "os_version",
-                "device_make",
-                "country",
-                "platform"
-            ]
-        },
-        "Iterable, Inc.": {
-            "score": 1395,
-            "signals": [
-                "email_address",
-                "AAID",
-                "unique_identifier",
-                "os_build_version",
-                "device_model",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "platform"
-            ]
-        },
-        "Kantar Operations": {
-            "score": 1098,
-            "signals": [
-                "device_magnetometer",
-                "AAID",
-                "accelerometer_data",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Kochava": {
-            "score": 11696,
-            "signals": [
-                "gps_coordinates",
-                "wifi_ssid",
-                "device_name",
-                "postal_code",
-                "AAID",
-                "device_boot_time",
-                "unique_identifier",
-                "network_isp",
-                "network_carrier",
-                "screen_brightness",
-                "device_battery_level",
-                "device_volume",
-                "cpu_data",
                 "os_build_version",
                 "device_resolution",
                 "device_model",
                 "app_version",
-                "device_connectivity",
-                "device_language",
                 "app_name",
                 "device_make",
                 "os_version",
-                "country",
-                "device_charging_status",
-                "timezone",
-                "device_orientation",
                 "platform"
             ]
         },
-        "Liftoff Mobile, Inc.": {
-            "score": 7491,
-            "signals": [
-                "gps_coordinates",
-                "postal_code",
-                "AAID",
-                "city",
-                "unique_identifier",
-                "state",
-                "device_total_memory",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "app_name",
-                "os_version",
-                "country",
-                "device_make",
-                "platform"
-            ]
-        },
-        "LiveIntent Inc.": {
-            "score": 1044,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_model",
-                "device_language",
-                "app_name",
-                "os_version",
-                "device_make",
-                "country",
-                "platform"
-            ]
-        },
-        "LiveRamp Holdings, Inc.": {
-            "score": 6738,
-            "signals": [
-                "AAID",
-                "city",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Lotame Solutions, Inc.": {
-            "score": 2102,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Magnite, Inc.": {
-            "score": 8432,
+        "FreeWheel": {
+            "score": 1070,
             "signals": [
                 "gps_coordinates",
                 "AAID",
-                "city",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_connectivity",
                 "device_model",
-                "device_language",
+                "app_version",
                 "app_name",
                 "device_make",
                 "os_version",
-                "country",
-                "device_screen_density",
                 "platform"
             ]
         },
         "Mapbox Inc.": {
-            "score": 1662,
+            "score": 1040,
             "signals": [
                 "gps_coordinates",
                 "AAID",
@@ -4176,146 +3709,99 @@
                 "device_model",
                 "app_version",
                 "device_connectivity",
-                "device_language",
                 "app_name",
                 "os_version",
                 "device_make",
-                "country",
                 "platform",
                 "device_orientation"
             ]
         },
-        "Media.net Advertising FZ-LLC": {
-            "score": 530,
-            "signals": [
-                "city",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_model",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "MediaMath, Inc.": {
-            "score": 4429,
+        "Teads ( Luxenbourg ) SA": {
+            "score": 1022,
             "signals": [
                 "city",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
-                "device_language",
-                "device_model",
                 "app_version",
+                "device_model",
+                "app_name",
                 "device_make",
                 "os_version",
-                "country",
-                "app_name",
                 "platform"
             ]
         },
-        "Microsoft Corporation": {
-            "score": 37698,
+        "Lotame Solutions, Inc.": {
+            "score": 1011,
             "signals": [
-                "gps_coordinates",
-                "username",
-                "postal_code",
-                "birthday",
-                "city",
                 "AAID",
                 "unique_identifier",
-                "state",
-                "network_carrier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Sovrn Holdings": {
+            "score": 975,
+            "signals": [
+                "AAID",
+                "unique_identifier",
                 "cookies",
                 "os_build_version",
                 "device_resolution",
-                "app_version",
-                "device_connectivity",
-                "device_language",
                 "device_model",
-                "app_name",
-                "os_version",
-                "country",
+                "app_version",
                 "device_make",
-                "timezone",
+                "os_version",
+                "app_name",
                 "platform"
             ]
         },
-        "Mixpanel, Inc.": {
-            "score": 2984,
+        "LiveIntent Inc.": {
+            "score": 870,
             "signals": [
-                "email_address",
-                "phone_number",
-                "username",
-                "first_name",
                 "AAID",
-                "device_boot_time",
                 "unique_identifier",
-                "gender",
-                "network_carrier",
+                "cookies",
                 "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_connectivity",
-                "device_language",
                 "device_model",
                 "app_name",
-                "device_make",
                 "os_version",
-                "country",
+                "device_make",
                 "platform"
             ]
         },
-        "Mobiquity Inc.": {
-            "score": 702,
+        "Sharethrough, Inc.": {
+            "score": 868,
             "signals": [
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
                 "device_model",
-                "device_language",
-                "device_make",
-                "os_version",
-                "app_name",
-                "country",
-                "platform"
-            ]
-        },
-        "Moloco Inc.": {
-            "score": 1904,
-            "signals": [
-                "neighborhood",
-                "os_build_version",
                 "app_version",
-                "device_language",
-                "device_model",
                 "app_name",
                 "os_version",
-                "country",
                 "device_make",
                 "platform"
             ]
         },
-        "Neustar, Inc.": {
-            "score": 3528,
+        "Unruly Group Limited": {
+            "score": 830,
             "signals": [
-                "postal_code",
-                "AAID",
+                "city",
                 "unique_identifier",
                 "cookies",
-                "device_total_memory",
                 "os_build_version",
                 "app_version",
-                "device_language",
                 "device_model",
+                "device_connectivity",
                 "app_name",
                 "device_make",
                 "os_version",
-                "country",
                 "platform"
             ]
         },
@@ -4337,126 +3823,159 @@
                 "platform"
             ]
         },
-        "Ogury Limited": {
-            "score": 696,
-            "signals": [
-                "AAID",
-                "cpu_data",
-                "device_resolution",
-                "device_connectivity",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "platform"
-            ]
-        },
-        "OnAudience Ltd.": {
-            "score": 630,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "OneSignal": {
-            "score": 4452,
+        "Tappcelator Media S.L.": {
+            "score": 822,
             "signals": [
                 "gps_coordinates",
-                "first_name",
                 "AAID",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
                 "device_model",
-                "install_date",
                 "app_version",
                 "app_name",
-                "os_version",
-                "country",
                 "device_make",
-                "timezone",
+                "os_version",
                 "platform"
             ]
         },
-        "OpenX Technologies Inc": {
-            "score": 3391,
+        "Engine USA LLC": {
+            "score": 820,
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform"
+            ]
+        },
+        "Intent IQ, LLC": {
+            "score": 767,
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Bugsnag Inc.": {
+            "score": 760,
             "signals": [
                 "city",
                 "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_model",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Optimizely, Inc.": {
-            "score": 1790,
-            "signals": [
-                "unique_identifier",
-                "os_build_version",
-                "device_model",
-                "device_language",
-                "app_version",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "platform"
-            ]
-        },
-        "Oracle Corporation": {
-            "score": 8083,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "network_carrier",
-                "cookies",
+                "cpu_data",
                 "device_total_memory",
                 "os_build_version",
                 "device_resolution",
-                "device_model",
-                "device_language",
                 "app_version",
+                "device_language",
+                "device_model",
                 "app_name",
                 "device_make",
                 "os_version",
-                "country",
-                "device_screen_density",
-                "platform",
-                "device_orientation"
+                "platform"
             ]
         },
-        "Outbrain": {
-            "score": 1250,
+        "AdRoll, Inc.": {
+            "score": 756,
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "NinthDecimal, Inc": {
+            "score": 754,
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "os_build_version",
+                "device_model",
+                "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "platform"
+            ]
+        },
+        "eyeota Limited": {
+            "score": 744,
             "signals": [
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
-                "device_language",
+                "device_model",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform"
+            ]
+        },
+        "ID5 Technology Ltd": {
+            "score": 738,
+            "signals": [
+                "city",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
                 "device_model",
                 "app_version",
+                "device_connectivity",
                 "device_make",
                 "os_version",
-                "country",
                 "app_name",
+                "platform"
+            ]
+        },
+        "Riskified Ltd.": {
+            "score": 732,
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "network_carrier",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "os_version",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Simplifi Holdings Inc.": {
+            "score": 726,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
                 "platform"
             ]
         },
@@ -4477,320 +3996,28 @@
                 "platform"
             ]
         },
-        "Permutive, Inc.": {
-            "score": 2010,
+        "33Across, Inc.": {
+            "score": 684,
             "signals": [
-                "neighborhood",
-                "city",
                 "unique_identifier",
-                "state",
-                "network_isp",
                 "cookies",
                 "os_build_version",
-                "device_language",
                 "device_model",
-                "app_name",
+                "app_version",
                 "device_make",
                 "os_version",
-                "country",
+                "app_name",
                 "platform"
             ]
         },
-        "Pinterest, Inc.": {
-            "score": 3092,
+        "Vungle Inc": {
+            "score": 660,
             "signals": [
                 "AAID",
-                "city",
-                "unique_identifier",
-                "state",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_model",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Pixalate, Inc.": {
-            "score": 3330,
-            "signals": [
-                "gps_coordinates",
-                "AAID",
-                "cookies",
-                "device_total_memory",
-                "os_build_version",
-                "device_resolution",
-                "device_model",
-                "device_language",
-                "app_version",
-                "app_name",
-                "os_version",
-                "device_make",
-                "country",
-                "platform",
-                "device_orientation"
-            ]
-        },
-        "Prospect One": {
-            "score": 816,
-            "signals": [
-                "AAID",
-                "os_build_version",
-                "app_version",
-                "device_model",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "PubMatic, Inc.": {
-            "score": 17734,
-            "signals": [
-                "gps_coordinates",
-                "city",
-                "AAID",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "app_version",
-                "device_connectivity",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Pulsepoint, Inc.": {
-            "score": 1629,
-            "signals": [
-                "city",
-                "AAID",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_connectivity",
-                "device_model",
-                "device_language",
-                "app_name",
-                "os_version",
-                "device_make",
-                "country",
-                "platform"
-            ]
-        },
-        "Quantcast Corporation": {
-            "score": 1408,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "device_connectivity",
-                "device_model",
-                "device_language",
-                "app_version",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "platform"
-            ]
-        },
-        "Reddit Inc.": {
-            "score": 1038,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "RevenueCat": {
-            "score": 1773,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "os_build_version",
-                "app_version",
-                "device_language",
-                "device_model",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "RhythmOne": {
-            "score": 1584,
-            "signals": [
-                "city",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_model",
-                "device_language",
-                "device_connectivity",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Riskified Ltd.": {
-            "score": 1318,
-            "signals": [
-                "gps_coordinates",
-                "first_name",
-                "last_name",
-                "AAID",
-                "network_carrier",
-                "os_build_version",
-                "device_model",
-                "app_version",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "platform"
-            ]
-        },
-        "Roku, Inc.": {
-            "score": 1400,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "RTB House S.A.": {
-            "score": 575,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "platform"
-            ]
-        },
-        "Salesforce.com, Inc.": {
-            "score": 8391,
-            "signals": [
-                "email_address",
-                "postal_code",
-                "AAID",
-                "unique_identifier",
-                "state",
-                "cookies",
-                "device_total_memory",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "platform"
-            ]
-        },
-        "Segment.io, Inc.": {
-            "score": 4752,
-            "signals": [
-                "email_address",
-                "username",
-                "gps_coordinates",
-                "first_name",
-                "last_name",
-                "neighborhood",
-                "postal_code",
-                "AAID",
-                "city",
-                "unique_identifier",
-                "local_ip",
-                "state",
-                "network_carrier",
-                "device_model",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_connectivity",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "device_screen_density",
-                "timezone",
-                "platform"
-            ]
-        },
-        "Sharethrough, Inc.": {
-            "score": 2380,
-            "signals": [
-                "city",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "app_version",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "platform"
-            ]
-        },
-        "Sift Science, Inc.": {
-            "score": 2563,
-            "signals": [
-                "gps_coordinates",
-                "neighborhood",
-                "unique_identifier",
-                "local_ip",
+                "device_free_storage",
                 "network_carrier",
                 "device_battery_level",
                 "os_build_version",
-                "device_resolution",
                 "device_model",
                 "app_version",
                 "device_language",
@@ -4798,154 +4025,44 @@
                 "device_charging_status",
                 "device_make",
                 "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Simplifi Holdings Inc.": {
-            "score": 1375,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "app_version",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "platform"
-            ]
-        },
-        "Smaato Inc.": {
-            "score": 2760,
-            "signals": [
-                "gps_coordinates",
-                "postal_code",
-                "AAID",
-                "unique_identifier",
-                "network_carrier",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "device_connectivity",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
                 "timezone",
                 "platform"
             ]
         },
-        "Smartadserver S.A.S": {
-            "score": 3495,
+        "Collective Roll": {
+            "score": 660,
             "signals": [
-                "gps_coordinates",
-                "postal_code",
-                "AAID",
-                "city",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
-                "device_resolution",
-                "device_model",
-                "app_version",
-                "device_language",
-                "app_name",
-                "os_version",
-                "country",
-                "device_make",
-                "platform"
-            ]
-        },
-        "Snap Inc.": {
-            "score": 2702,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_model",
-                "device_language",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Sovrn Holdings": {
-            "score": 1625,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
                 "device_model",
                 "app_version",
                 "device_make",
                 "os_version",
-                "country",
                 "app_name",
                 "platform"
             ]
         },
-        "SpotX, Inc.": {
-            "score": 4326,
+        "DataXu": {
+            "score": 620,
             "signals": [
-                "gps_coordinates",
-                "AAID",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
-                "device_resolution",
-                "device_connectivity",
-                "device_language",
                 "device_model",
-                "app_version",
                 "app_name",
                 "os_version",
                 "device_make",
-                "country",
                 "platform"
             ]
         },
-        "Synacor, Inc.": {
-            "score": 1600,
+        "InMobi Pte Ltd": {
+            "score": 600,
             "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "device_connectivity",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Taboola, Inc.": {
-            "score": 14406,
-            "signals": [
-                "gps_coordinates",
-                "neighborhood",
                 "AAID",
                 "unique_identifier",
-                "state",
-                "cookies",
-                "device_total_memory",
+                "device_volume",
                 "os_build_version",
-                "device_resolution",
                 "app_version",
                 "device_connectivity",
                 "device_language",
@@ -4953,490 +4070,613 @@
                 "app_name",
                 "device_make",
                 "os_version",
-                "country",
-                "timezone",
-                "platform"
-            ]
-        },
-        "Take-Two Interactive Software, Inc.": {
-            "score": 858,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "network_carrier",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
                 "device_screen_density",
-                "timezone",
-                "platform"
-            ]
-        },
-        "Talent Game Box": {
-            "score": 2183,
-            "signals": [
-                "neighborhood",
-                "AAID",
-                "unique_identifier",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_connectivity",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
                 "timezone",
                 "device_orientation",
                 "platform"
             ]
         },
-        "Tapad, Inc.": {
-            "score": 7850,
+        "Bidtellect, Inc": {
+            "score": 585,
             "signals": [
-                "postal_code",
-                "AAID",
-                "city",
-                "unique_identifier",
-                "state",
-                "cookies",
-                "device_total_memory",
-                "os_build_version",
-                "device_model",
-                "device_language",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Tapjoy, Inc.": {
-            "score": 9396,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "mac_address",
-                "network_carrier",
-                "device_volume",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "device_screen_density",
-                "timezone",
-                "platform"
-            ]
-        },
-        "Tappcelator Media S.L.": {
-            "score": 822,
-            "signals": [
-                "gps_coordinates",
-                "AAID",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
                 "device_model",
                 "app_version",
-                "app_name",
+                "device_connectivity",
                 "device_make",
                 "os_version",
+                "app_name",
                 "platform"
             ]
         },
-        "Teads ( Luxenbourg ) SA": {
-            "score": 880,
+        "Outbrain": {
+            "score": 585,
             "signals": [
-                "city",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
-                "app_version",
                 "device_model",
-                "device_language",
-                "app_name",
                 "device_make",
                 "os_version",
-                "country",
+                "app_name",
                 "platform"
             ]
         },
         "Telaria": {
-            "score": 870,
+            "score": 522,
             "signals": [
                 "AAID",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
                 "device_model",
-                "app_version",
-                "device_language",
                 "app_name",
                 "os_version",
                 "device_make",
-                "country",
                 "platform"
             ]
         },
-        "The Nielsen Company": {
-            "score": 4327,
-            "signals": [
-                "AAID",
-                "city",
-                "unique_identifier",
-                "state",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "device_model",
-                "device_language",
-                "app_version",
-                "app_name",
-                "os_version",
-                "device_make",
-                "country",
-                "platform"
-            ]
-        },
-        "The Trade Desk Inc": {
-            "score": 18988,
-            "signals": [
-                "gps_coordinates",
-                "postal_code",
-                "AAID",
-                "city",
-                "unique_identifier",
-                "state",
-                "cookies",
-                "os_build_version",
-                "device_model",
-                "device_language",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "TripleLift": {
-            "score": 3543,
-            "signals": [
-                "city",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_resolution",
-                "device_language",
-                "device_model",
-                "app_version",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "platform"
-            ]
-        },
-        "TrustArc Inc.": {
-            "score": 1014,
+        "Hexagon Data, S.A.P.I. de C.V.": {
+            "score": 516,
             "signals": [
                 "AAID",
                 "unique_identifier",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "app_name",
-                "os_version",
-                "platform"
-            ]
-        },
-        "Twitter, Inc.": {
-            "score": 13507,
-            "signals": [
-                "email_address",
-                "password",
-                "username",
-                "AAID",
-                "city",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "app_version",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "platform"
-            ]
-        },
-        "Undertone Networks": {
-            "score": 740,
-            "signals": [
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "device_make",
-                "os_version",
-                "country",
-                "app_name",
-                "platform"
-            ]
-        },
-        "Unity Technologies ApS": {
-            "score": 27349,
-            "signals": [
-                "neighborhood",
-                "postal_code",
-                "device_name",
-                "AAID",
-                "device_boot_time",
-                "unique_identifier",
-                "device_free_storage",
-                "external_free_storage",
-                "accelerometer_data",
-                "device_free_memory",
-                "screen_brightness",
-                "device_battery_level",
-                "device_total_storage",
-                "external_total_storage",
-                "device_volume",
-                "device_total_memory",
-                "device_headphone_status",
-                "os_build_version",
-                "device_resolution",
-                "app_version",
-                "device_connectivity",
-                "device_language",
-                "device_model",
-                "app_name",
-                "device_charging_status",
-                "device_make",
-                "os_version",
-                "country",
-                "device_screen_density",
-                "timezone",
-                "device_orientation",
-                "platform"
-            ]
-        },
-        "Unruly Group Limited": {
-            "score": 1162,
-            "signals": [
-                "city",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "app_version",
-                "device_model",
-                "device_language",
-                "device_connectivity",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Upland Software Inc.": {
-            "score": 930,
-            "signals": [
-                "postal_code",
-                "city",
-                "AAID",
-                "unique_identifier",
-                "state",
-                "os_build_version",
-                "app_version",
-                "device_connectivity",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "device_orientation",
-                "platform"
-            ]
-        },
-        "Urban Airship, Inc.": {
-            "score": 4751,
-            "signals": [
-                "gps_coordinates",
-                "email_address",
-                "neighborhood",
-                "city",
-                "unique_identifier",
-                "network_carrier",
-                "app_version",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "device_screen_density",
-                "platform"
-            ]
-        },
-        "Verizon Media": {
-            "score": 18260,
-            "signals": [
-                "gps_coordinates",
-                "birthday",
-                "AAID",
-                "device_boot_time",
-                "city",
-                "unique_identifier",
-                "device_free_storage",
-                "external_free_storage",
-                "device_free_memory",
-                "network_carrier",
-                "cookies",
-                "device_battery_level",
-                "device_total_storage",
-                "external_total_storage",
                 "cpu_data",
-                "device_total_memory",
-                "device_headphone_status",
                 "os_build_version",
                 "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Quantcast Corporation": {
+            "score": 512,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_connectivity",
+                "device_model",
+                "app_version",
+                "device_language",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Synacor, Inc.": {
+            "score": 488,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_connectivity",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "ByteDance Ltd.": {
+            "score": 484,
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Fastly, Inc.": {
+            "score": 480,
+            "signals": [
+                "city",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Kantar Operations": {
+            "score": 470,
+            "signals": [
+                "AAID",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "app_name",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Beachfront Media LLC": {
+            "score": 468,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Adform A/S": {
+            "score": 468,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "AcuityAds": {
+            "score": 468,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "ADman Media": {
+            "score": 468,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Apptentive Inc.": {
+            "score": 440,
+            "signals": [
+                "unique_identifier",
+                "network_carrier",
+                "cpu_data",
+                "os_build_version",
                 "device_model",
                 "app_version",
                 "device_connectivity",
                 "device_language",
                 "app_name",
-                "device_charging_status",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "device_screen_density",
-                "platform",
-                "device_orientation"
-            ]
-        },
-        "Vungle Inc": {
-            "score": 6282,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "device_free_storage",
-                "network_carrier",
-                "device_battery_level",
-                "device_volume",
-                "os_build_version",
-                "device_resolution",
-                "device_model",
-                "app_version",
-                "device_language",
-                "app_name",
-                "device_charging_status",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "platform"
-            ]
-        },
-        "WPP plc": {
-            "score": 2992,
-            "signals": [
-                "AAID",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_model",
-                "app_version",
-                "device_language",
-                "app_name",
                 "device_make",
                 "os_version",
                 "country",
                 "platform"
             ]
         },
-        "Yandex LLC": {
-            "score": 1219,
+        "Reddit Inc.": {
+            "score": 438,
             "signals": [
-                "gps_coordinates",
+                "AAID",
+                "unique_identifier",
+                "platform"
+            ]
+        },
+        "Adkernel, LLC": {
+            "score": 424,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_connectivity",
+                "device_model",
+                "app_name",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Flashtalking Inc": {
+            "score": 423,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Data Plus Math": {
+            "score": 416,
+            "signals": [
+                "AAID",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform"
+            ]
+        },
+        "Prospect One": {
+            "score": 408,
+            "signals": [
+                "AAID",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "GumGum": {
+            "score": 384,
+            "signals": [
+                "city",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Human Security, Inc.": {
+            "score": 378,
+            "signals": [
+                "AAID",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_name",
+                "os_version",
+                "platform"
+            ]
+        },
+        "engageBDR": {
+            "score": 372,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform"
+            ]
+        },
+        "SSP Network Ltd": {
+            "score": 372,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform"
+            ]
+        },
+        "Exponential Interactive Inc.": {
+            "score": 363,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Cognitiv Corp.": {
+            "score": 363,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Optimizely, Inc.": {
+            "score": 356,
+            "signals": [
+                "unique_identifier",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform"
+            ]
+        },
+        "ZypMedia, Inc.": {
+            "score": 351,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Zeta Global": {
+            "score": 351,
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Merkle Inc": {
+            "score": 351,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Kargo Global, Inc.": {
+            "score": 351,
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Sonobi, Inc": {
+            "score": 351,
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "country",
+                "platform"
+            ]
+        },
+        "District M Inc.": {
+            "score": 351,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Connexity, Inc.": {
+            "score": 351,
+            "signals": [
                 "AAID",
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
+                "device_model",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Knorex Pte. Ltd.": {
+            "score": 351,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Avocet Systems Ltd.": {
+            "score": 351,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Mobiquity Inc.": {
+            "score": 351,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "AdTheorent Inc": {
+            "score": 351,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Intuition Machines, Inc.": {
+            "score": 336,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "cpu_data",
+                "os_build_version",
                 "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform"
+            ]
+        },
+        "Storygize": {
+            "score": 327,
+            "signals": [
+                "AAID",
+                "cookies",
+                "os_build_version",
+                "device_connectivity",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "platform"
+            ]
+        },
+        "RTB House S.A.": {
+            "score": 321,
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
                 "device_model",
                 "device_language",
                 "device_make",
+                "os_version",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Bazaarvoice, Inc.": {
+            "score": 321,
+            "signals": [
+                "AAID",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
                 "app_name",
                 "os_version",
                 "platform"
             ]
         },
         "YieldMo, Inc.": {
-            "score": 675,
+            "score": 321,
             "signals": [
                 "unique_identifier",
                 "cookies",
                 "os_build_version",
-                "device_language",
                 "device_model",
-                "app_name",
                 "device_make",
                 "os_version",
-                "country",
+                "app_name",
                 "platform"
             ]
         },
-        "Zeotap GmbH": {
-            "score": 1614,
+        "Treasure Data, Inc": {
+            "score": 312,
             "signals": [
                 "AAID",
-                "unique_identifier",
                 "cookies",
                 "os_build_version",
                 "device_model",
-                "device_language",
-                "app_version",
                 "app_name",
-                "device_make",
                 "os_version",
-                "country",
-                "platform"
-            ]
-        },
-        "Zeta Global": {
-            "score": 625,
-            "signals": [
-                "city",
-                "unique_identifier",
-                "cookies",
-                "os_build_version",
-                "device_language",
-                "device_model",
-                "app_version",
                 "device_make",
-                "os_version",
-                "country",
-                "app_name",
                 "platform"
             ]
         }

--- a/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
+++ b/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
@@ -1,6 +1,6 @@
 {
     "readme": "https://github.com/duckduckgo/tracker-blocklists",
-    "version": "1680299195572",
+    "version": 1680299195572,
     "trackers": {
         "15.taboola.com": {
             "owner": {

--- a/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
+++ b/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
@@ -1,5890 +1,5314 @@
 {
-  "version": 1639624032609,
-  "trackers": {
-    "api.instabug.com": {
-      "owner": {
-        "name": "Instabug",
-        "displayName": "Instabug"
-      },
-      "app": {
-        "score": 660,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "iad-01.braze.com": {
-      "owner": {
-        "name": "Braze, Inc.",
-        "displayName": "Braze"
-      },
-      "app": {
-        "score": 626,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api.segment.io": {
-      "owner": {
-        "name": "Segment.io, Inc.",
-        "displayName": "Segment.io"
-      },
-      "app": {
-        "score": 590,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "crashlyticsreports-pa.googleapis.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 576,
-        "prevalence": 0.293
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api2.branch.io": {
-      "owner": {
-        "name": "Branch Metrics, Inc.",
-        "displayName": "Branch Metrics"
-      },
-      "app": {
-        "score": 572,
-        "prevalence": 0.307
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "data.flurry.com": {
-      "owner": {
-        "name": "Verizon Media",
-        "displayName": "Verizon Media"
-      },
-      "app": {
-        "score": 566,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "aws.oath.cloud": {
-      "owner": {
-        "name": "Verizon Media",
-        "displayName": "Verizon Media"
-      },
-      "app": {
-        "score": 541,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.facebook.com": {
-      "owner": {
-        "name": "Facebook, Inc.",
-        "displayName": "Facebook"
-      },
-      "app": {
-        "score": 528,
-        "prevalence": 0.387
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "control.kochava.com": {
-      "owner": {
-        "name": "Kochava",
-        "displayName": "Kochava"
-      },
-      "app": {
-        "score": 524,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "use-tor.adsrvr.org": {
-      "owner": {
-        "name": "The Trade Desk Inc",
-        "displayName": "The Trade Desk"
-      },
-      "app": {
-        "score": 510,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api2.amplitude.com": {
-      "owner": {
-        "name": "Amplitude",
-        "displayName": "Amplitude"
-      },
-      "app": {
-        "score": 497,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "t.appsflyer.com": {
-      "owner": {
-        "name": "AppsFlyer",
-        "displayName": "AppsFlyer"
-      },
-      "app": {
-        "score": 477,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "adexp.liftoff.io": {
-      "owner": {
-        "name": "Liftoff Mobile, Inc.",
-        "displayName": "Liftoff"
-      },
-      "app": {
-        "score": 477,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ib.adnxs.com": {
-      "owner": {
-        "name": "WarnerMedia, LLC",
-        "displayName": "WarnerMedia"
-      },
-      "app": {
-        "score": 475,
-        "prevalence": 0.187
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "g.doubleclick.net": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 444,
-        "prevalence": 0.547
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "logs.datadoghq.com": {
-      "owner": {
-        "name": "Datadog, Inc.",
-        "displayName": "Datadog"
-      },
-      "app": {
-        "score": 435,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ads.mopub.com": {
-      "owner": {
-        "name": "Twitter, Inc.",
-        "displayName": "Twitter"
-      },
-      "app": {
-        "score": 433,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "gce-sc.bidswitch.net": {
-      "owner": {
-        "name": "IPONWEB GmbH",
-        "displayName": "IPONWEB"
-      },
-      "app": {
-        "score": 430,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sentry.io": {
-      "owner": {
-        "name": "Functional Software, Inc.",
-        "displayName": "Functional Software"
-      },
-      "app": {
-        "score": 426,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "s.innovid.com": {
-      "owner": {
-        "name": "Innovid Media",
-        "displayName": "Innovid Media"
-      },
-      "app": {
-        "score": 425,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ag.innovid.com": {
-      "owner": {
-        "name": "Innovid Media",
-        "displayName": "Innovid Media"
-      },
-      "app": {
-        "score": 425,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "s-static.innovid.com": {
-      "owner": {
-        "name": "Innovid Media",
-        "displayName": "Innovid Media"
-      },
-      "app": {
-        "score": 419,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ingest.sentry.io": {
-      "owner": {
-        "name": "Functional Software, Inc.",
-        "displayName": "Functional Software"
-      },
-      "app": {
-        "score": 418,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ny1-bid.adsrvr.org": {
-      "owner": {
-        "name": "The Trade Desk Inc",
-        "displayName": "The Trade Desk"
-      },
-      "app": {
-        "score": 415,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "us-east-1.amazonaws.com": {
-      "owner": {
-        "name": "Amazon Technologies, Inc.",
-        "displayName": "Amazon"
-      },
-      "app": {
-        "score": 409,
-        "prevalence": 0.053
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "tapestry.tapad.com": {
-      "owner": {
-        "name": "Tapad, Inc.",
-        "displayName": "Tapad"
-      },
-      "app": {
-        "score": 407,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "t.myvisualiq.net": {
-      "owner": {
-        "name": "The Nielsen Company",
-        "displayName": "The Nielsen Company"
-      },
-      "app": {
-        "score": 407,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "prg.smartadserver.com": {
-      "owner": {
-        "name": "Smartadserver S.A.S",
-        "displayName": "Smartadserver"
-      },
-      "app": {
-        "score": 402,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "web.facebook.com": {
-      "owner": {
-        "name": "Facebook, Inc.",
-        "displayName": "Facebook"
-      },
-      "app": {
-        "score": 397,
-        "prevalence": 0.12
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sc.omtrdc.net": {
-      "owner": {
-        "name": "Adobe Inc.",
-        "displayName": "Adobe"
-      },
-      "app": {
-        "score": 377,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "rtb.ninthdecimal.com": {
-      "owner": {
-        "name": "NinthDecimal, Inc",
-        "displayName": "NinthDecimal"
-      },
-      "app": {
-        "score": 377,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "unityads.unity3d.com": {
-      "owner": {
-        "name": "Unity Technologies ApS",
-        "displayName": "Unity"
-      },
-      "app": {
-        "score": 372,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api.onesignal.com": {
-      "owner": {
-        "name": "OneSignal",
-        "displayName": "OneSignal"
-      },
-      "app": {
-        "score": 371,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "fra-01.braze.eu": {
-      "owner": {
-        "name": "Braze, Inc.",
-        "displayName": "Braze"
-      },
-      "app": {
-        "score": 357,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api.amplitude.com": {
-      "owner": {
-        "name": "Amplitude",
-        "displayName": "Amplitude"
-      },
-      "app": {
-        "score": 353,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "hblg.media.net": {
-      "owner": {
-        "name": "Media.net Advertising FZ-LLC",
-        "displayName": "Media.net Advertising"
-      },
-      "app": {
-        "score": 345,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ad.doubleclick.net": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 339,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sb.scorecardresearch.com": {
-      "owner": {
-        "name": "comScore, Inc",
-        "displayName": "comScore"
-      },
-      "app": {
-        "score": 314,
-        "prevalence": 0.24
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "mobile.adsafeprotected.com": {
-      "owner": {
-        "name": "Integral Ad Science, Inc.",
-        "displayName": "Integral Ad Science"
-      },
-      "app": {
-        "score": 313,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "search.spotxchange.com": {
-      "owner": {
-        "name": "SpotX, Inc.",
-        "displayName": "SpotX"
-      },
-      "app": {
-        "score": 309,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pagead2.googlesyndication.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 308,
-        "prevalence": 0.253
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "dt.adsafeprotected.com": {
-      "owner": {
-        "name": "Integral Ad Science, Inc.",
-        "displayName": "Integral Ad Science"
-      },
-      "app": {
-        "score": 308,
-        "prevalence": 0.12
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "prebid.adnxs.com": {
-      "owner": {
-        "name": "WarnerMedia, LLC",
-        "displayName": "WarnerMedia"
-      },
-      "app": {
-        "score": 308,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "fw.adsafeprotected.com": {
-      "owner": {
-        "name": "Integral Ad Science, Inc.",
-        "displayName": "Integral Ad Science"
-      },
-      "app": {
-        "score": 308,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "events.appsflyer.com": {
-      "owner": {
-        "name": "AppsFlyer",
-        "displayName": "AppsFlyer"
-      },
-      "app": {
-        "score": 307,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "insight.adsrvr.org": {
-      "owner": {
-        "name": "The Trade Desk Inc",
-        "displayName": "The Trade Desk"
-      },
-      "app": {
-        "score": 305,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "tpc.googlesyndication.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 302,
-        "prevalence": 0.2
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "static.adsafeprotected.com": {
-      "owner": {
-        "name": "Integral Ad Science, Inc.",
-        "displayName": "Integral Ad Science"
-      },
-      "app": {
-        "score": 302,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "s0.2mdn.net": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 302,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "rtb-csync.smartadserver.com": {
-      "owner": {
-        "name": "Smartadserver S.A.S",
-        "displayName": "Smartadserver"
-      },
-      "app": {
-        "score": 297,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "app.adjust.com": {
-      "owner": {
-        "name": "Adjust GmbH",
-        "displayName": "Adjust"
-      },
-      "app": {
-        "score": 290,
-        "prevalence": 0.2
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "p.placed.com": {
-      "owner": {
-        "name": "Foursquare Labs, Inc.",
-        "displayName": "Foursquare Labs"
-      },
-      "app": {
-        "score": 279,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ad.smaato.net": {
-      "owner": {
-        "name": "Smaato Inc.",
-        "displayName": "Smaato"
-      },
-      "app": {
-        "score": 276,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api.tappx.com": {
-      "owner": {
-        "name": "Tappcelator Media S.L.",
-        "displayName": "Tappx"
-      },
-      "app": {
-        "score": 274,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "iad-03.braze.com": {
-      "owner": {
-        "name": "Braze, Inc.",
-        "displayName": "Braze"
-      },
-      "app": {
-        "score": 274,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "odr.mookie1.com": {
-      "owner": {
-        "name": "Xaxis",
-        "displayName": "Xaxis"
-      },
-      "app": {
-        "score": 272,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www9.smartadserver.com": {
-      "owner": {
-        "name": "Smartadserver S.A.S",
-        "displayName": "Smartadserver"
-      },
-      "app": {
-        "score": 269,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "trc.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 266,
-        "prevalence": 0.12
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.google-analytics.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 263,
-        "prevalence": 0.333
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ads-bidder-api.twitter.com": {
-      "owner": {
-        "name": "Twitter, Inc.",
-        "displayName": "Twitter"
-      },
-      "app": {
-        "score": 263,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "in.appcenter.ms": {
-      "owner": {
-        "name": "Microsoft Corporation",
-        "displayName": "Visual Studio App Center"
-      },
-      "app": {
-        "score": 258,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "tr.snapchat.com": {
-      "owner": {
-        "name": "Snap Inc.",
-        "displayName": "Snap"
-      },
-      "app": {
-        "score": 258,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "hexagon-analytics.com": {
-      "owner": {
-        "name": "Hexagon Data, S.A.P.I. de C.V.",
-        "displayName": "Hexagon Data"
-      },
-      "app": {
-        "score": 258,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.google.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 255,
-        "prevalence": 0.387
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "match.adsrvr.org": {
-      "owner": {
-        "name": "The Trade Desk Inc",
-        "displayName": "The Trade Desk"
-      },
-      "app": {
-        "score": 252,
-        "prevalence": 0.227
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "analytics.twitter.com": {
-      "owner": {
-        "name": "Twitter, Inc.",
-        "displayName": "Twitter"
-      },
-      "app": {
-        "score": 252,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "d.adroll.com": {
-      "owner": {
-        "name": "AdRoll, Inc.",
-        "displayName": "AdRoll"
-      },
-      "app": {
-        "score": 252,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "aax-us-east.amazon-adsystem.com": {
-      "owner": {
-        "name": "Amazon Technologies, Inc.",
-        "displayName": "Amazon"
-      },
-      "app": {
-        "score": 251,
-        "prevalence": 0.147
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.googleadservices.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 248,
-        "prevalence": 0.187
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ct.pinterest.com": {
-      "owner": {
-        "name": "Pinterest, Inc.",
-        "displayName": "Pinterest"
-      },
-      "app": {
-        "score": 248,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "graph.instagram.com": {
-      "owner": {
-        "name": "Facebook, Inc.",
-        "displayName": "Facebook"
-      },
-      "app": {
-        "score": 246,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.googletagservices.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 244,
-        "prevalence": 0.24
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "maps.googleapis.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 244,
-        "prevalence": 0.12
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "analytics.tiktok.com": {
-      "owner": {
-        "name": "ByteDance Ltd.",
-        "displayName": "ByteDance"
-      },
-      "app": {
-        "score": 242,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "gum.criteo.com": {
-      "owner": {
-        "name": "Criteo SA",
-        "displayName": "Criteo"
-      },
-      "app": {
-        "score": 241,
-        "prevalence": 0.187
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "combine.urbanairship.com": {
-      "owner": {
-        "name": "Urban Airship, Inc.",
-        "displayName": "Urban Airship"
-      },
-      "app": {
-        "score": 241,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pixel.parsely.com": {
-      "owner": {
-        "name": "Parsely, Inc.",
-        "displayName": "Parsely"
-      },
-      "app": {
-        "score": 240,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "trc-events.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 235,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "aax.amazon-adsystem.com": {
-      "owner": {
-        "name": "Amazon Technologies, Inc.",
-        "displayName": "Amazon"
-      },
-      "app": {
-        "score": 230,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "s.amazon-adsystem.com": {
-      "owner": {
-        "name": "Amazon Technologies, Inc.",
-        "displayName": "Amazon"
-      },
-      "app": {
-        "score": 229,
-        "prevalence": 0.213
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "px.owneriq.net": {
-      "owner": {
-        "name": "Inmar, Inc.",
-        "displayName": "Inmar"
-      },
-      "app": {
-        "score": 226,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api.vungle.com": {
-      "owner": {
-        "name": "Vungle Inc",
-        "displayName": "Vungle"
-      },
-      "app": {
-        "score": 220,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api.apptentive.com": {
-      "owner": {
-        "name": "Apptentive Inc.",
-        "displayName": "Apptentive"
-      },
-      "app": {
-        "score": 220,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pixel.advertising.com": {
-      "owner": {
-        "name": "Verizon Media",
-        "displayName": "Verizon Media"
-      },
-      "app": {
-        "score": 217,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "analytics.yahoo.com": {
-      "owner": {
-        "name": "Verizon Media",
-        "displayName": "Verizon Media"
-      },
-      "app": {
-        "score": 217,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "tt.omtrdc.net": {
-      "owner": {
-        "name": "Adobe Inc.",
-        "displayName": "Adobe"
-      },
-      "app": {
-        "score": 216,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "v.fwmrm.net": {
-      "owner": {
-        "name": "FreeWheel",
-        "displayName": "FreeWheel"
-      },
-      "app": {
-        "score": 214,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "secure.adnxs.com": {
-      "owner": {
-        "name": "WarnerMedia, LLC",
-        "displayName": "WarnerMedia"
-      },
-      "app": {
-        "score": 212,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "register.appsflyer.com": {
-      "owner": {
-        "name": "AppsFlyer",
-        "displayName": "AppsFlyer"
-      },
-      "app": {
-        "score": 207,
-        "prevalence": 0.027
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "dpm.demdex.net": {
-      "owner": {
-        "name": "Adobe Inc.",
-        "displayName": "Adobe"
-      },
-      "app": {
-        "score": 204,
-        "prevalence": 0.28
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "bidder.criteo.com": {
-      "owner": {
-        "name": "Criteo SA",
-        "displayName": "Criteo"
-      },
-      "app": {
-        "score": 204,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "tags.bluekai.com": {
-      "owner": {
-        "name": "Oracle Corporation",
-        "displayName": "Oracle"
-      },
-      "app": {
-        "score": 202,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "stags.bluekai.com": {
-      "owner": {
-        "name": "Oracle Corporation",
-        "displayName": "Oracle"
-      },
-      "app": {
-        "score": 200,
-        "prevalence": 0.12
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ads.inmobi.com": {
-      "owner": {
-        "name": "InMobi Pte Ltd",
-        "displayName": "InMobi"
-      },
-      "app": {
-        "score": 200,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "loadm.exelator.com": {
-      "owner": {
-        "name": "The Nielsen Company",
-        "displayName": "The Nielsen Company"
-      },
-      "app": {
-        "score": 199,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ads.linkedin.com": {
-      "owner": {
-        "name": "Microsoft Corporation",
-        "displayName": "LinkedIn"
-      },
-      "app": {
-        "score": 199,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "p.adsymptotic.com": {
-      "owner": {
-        "name": "Microsoft Corporation",
-        "displayName": "LinkedIn"
-      },
-      "app": {
-        "score": 199,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "tps.doubleverify.com": {
-      "owner": {
-        "name": "DoubleVerify",
-        "displayName": "DoubleVerify"
-      },
-      "app": {
-        "score": 198,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "device.marketingcloudapis.com": {
-      "owner": {
-        "name": "Salesforce.com, Inc.",
-        "displayName": "Salesforce.com"
-      },
-      "app": {
-        "score": 197,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "mpx.mopub.com": {
-      "owner": {
-        "name": "Twitter, Inc.",
-        "displayName": "Twitter"
-      },
-      "app": {
-        "score": 194,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sessions.bugsnag.com": {
-      "owner": {
-        "name": "Bugsnag Inc.",
-        "displayName": "Bugsnag"
-      },
-      "app": {
-        "score": 190,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "cds.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 189,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "cdn.doubleverify.com": {
-      "owner": {
-        "name": "DoubleVerify",
-        "displayName": "DoubleVerify"
-      },
-      "app": {
-        "score": 189,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "15.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 189,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ch-wf.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 189,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pixel.tapad.com": {
-      "owner": {
-        "name": "Tapad, Inc.",
-        "displayName": "Tapad"
-      },
-      "app": {
-        "score": 187,
-        "prevalence": 0.147
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pixel-sync.sitescout.com": {
-      "owner": {
-        "name": "Centro, Inc.",
-        "displayName": "Centro"
-      },
-      "app": {
-        "score": 187,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "fonts.googleapis.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 186,
-        "prevalence": 0.293
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "ads.nexage.com": {
-      "owner": {
-        "name": "Verizon Media",
-        "displayName": "Verizon Media"
-      },
-      "app": {
-        "score": 182,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "bh.contextweb.com": {
-      "owner": {
-        "name": "Pulsepoint, Inc.",
-        "displayName": "Pulsepoint"
-      },
-      "app": {
-        "score": 181,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "htlb.casalemedia.com": {
-      "owner": {
-        "name": "Index Exchange, Inc.",
-        "displayName": "Index Exchange"
-      },
-      "app": {
-        "score": 178,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync.mathtag.com": {
-      "owner": {
-        "name": "MediaMath, Inc.",
-        "displayName": "MediaMath"
-      },
-      "app": {
-        "score": 177,
-        "prevalence": 0.133
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "x.bidswitch.net": {
-      "owner": {
-        "name": "IPONWEB GmbH",
-        "displayName": "IPONWEB"
-      },
-      "app": {
-        "score": 176,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "us-u.openx.net": {
-      "owner": {
-        "name": "OpenX Technologies Inc",
-        "displayName": "OpenX"
-      },
-      "app": {
-        "score": 176,
-        "prevalence": 0.12
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ybp.yahoo.com": {
-      "owner": {
-        "name": "Verizon Media",
-        "displayName": "Verizon Media"
-      },
-      "app": {
-        "score": 176,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync.1rx.io": {
-      "owner": {
-        "name": "RhythmOne",
-        "displayName": "RhythmOne"
-      },
-      "app": {
-        "score": 176,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ssum-sec.casalemedia.com": {
-      "owner": {
-        "name": "Index Exchange, Inc.",
-        "displayName": "Index Exchange"
-      },
-      "app": {
-        "score": 176,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync.teads.tv": {
-      "owner": {
-        "name": "Teads ( Luxenbourg ) SA",
-        "displayName": "Teads"
-      },
-      "app": {
-        "score": 176,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ssp.yahoo.com": {
-      "owner": {
-        "name": "Verizon Media",
-        "displayName": "Verizon Media"
-      },
-      "app": {
-        "score": 175,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "beacon.krxd.net": {
-      "owner": {
-        "name": "Salesforce.com, Inc.",
-        "displayName": "Salesforce.com"
-      },
-      "app": {
-        "score": 174,
-        "prevalence": 0.147
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "d.agkn.com": {
-      "owner": {
-        "name": "Neustar, Inc.",
-        "displayName": "Neustar"
-      },
-      "app": {
-        "score": 174,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "i.liadm.com": {
-      "owner": {
-        "name": "LiveIntent Inc.",
-        "displayName": "LiveIntent"
-      },
-      "app": {
-        "score": 174,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ads.tremorhub.com": {
-      "owner": {
-        "name": "Telaria",
-        "displayName": "Telaria"
-      },
-      "app": {
-        "score": 174,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api.kochava.com": {
-      "owner": {
-        "name": "Kochava",
-        "displayName": "Kochava"
-      },
-      "app": {
-        "score": 173,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.youtube.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 172,
-        "prevalence": 0.04
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "ads.pubmatic.com": {
-      "owner": {
-        "name": "PubMatic, Inc.",
-        "displayName": "PubMatic"
-      },
-      "app": {
-        "score": 166,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "targeting.unrulymedia.com": {
-      "owner": {
-        "name": "Unruly Group Limited",
-        "displayName": "Unruly Group"
-      },
-      "app": {
-        "score": 166,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.instagram.com": {
-      "owner": {
-        "name": "Facebook, Inc.",
-        "displayName": "Facebook"
-      },
-      "app": {
-        "score": 165,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "px.moatads.com": {
-      "owner": {
-        "name": "Oracle Corporation",
-        "displayName": "Oracle"
-      },
-      "app": {
-        "score": 164,
-        "prevalence": 0.12
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "e1.emxdgt.com": {
-      "owner": {
-        "name": "Engine USA LLC",
-        "displayName": "Engine USA"
-      },
-      "app": {
-        "score": 164,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "impression.link": {
-      "owner": {
-        "name": "Branch Metrics, Inc.",
-        "displayName": "Branch Metrics"
-      },
-      "app": {
-        "score": 164,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "collect.igodigital.com": {
-      "owner": {
-        "name": "Salesforce.com, Inc.",
-        "displayName": "Salesforce.com"
-      },
-      "app": {
-        "score": 160,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "device-api.urbanairship.com": {
-      "owner": {
-        "name": "Urban Airship, Inc.",
-        "displayName": "Urban Airship"
-      },
-      "app": {
-        "score": 159,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ads.yahoo.com": {
-      "owner": {
-        "name": "Verizon Media",
-        "displayName": "Verizon Media"
-      },
-      "app": {
-        "score": 147,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.googletagmanager.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 146,
-        "prevalence": 0.24
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "d9.flashtalking.com": {
-      "owner": {
-        "name": "Flashtalking Inc",
-        "displayName": "Flashtalking"
-      },
-      "app": {
-        "score": 141,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "csi.gstatic.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 140,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "mobile-collector.newrelic.com": {
-      "owner": {
-        "name": "New Relic",
-        "displayName": "New Relic"
-      },
-      "app": {
-        "score": 138,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "impression.appsflyer.com": {
-      "owner": {
-        "name": "AppsFlyer",
-        "displayName": "AppsFlyer"
-      },
-      "app": {
-        "score": 135,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 134,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "cdn.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 134,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync-t1.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 134,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "mwzeom.zeotap.com": {
-      "owner": {
-        "name": "Zeotap GmbH",
-        "displayName": "Zeotap"
-      },
-      "app": {
-        "score": 132,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync.crwdcntrl.net": {
-      "owner": {
-        "name": "Lotame Solutions, Inc.",
-        "displayName": "Lotame Solutions"
-      },
-      "app": {
-        "score": 132,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "view.adjust.com": {
-      "owner": {
-        "name": "Adjust GmbH",
-        "displayName": "Adjust"
-      },
-      "app": {
-        "score": 132,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "srv.stackadapt.com": {
-      "owner": {
-        "name": "Collective Roll",
-        "displayName": "Collective Roll"
-      },
-      "app": {
-        "score": 132,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "prod.bidr.io": {
-      "owner": {
-        "name": "Beeswax",
-        "displayName": "Beeswax"
-      },
-      "app": {
-        "score": 129,
-        "prevalence": 0.133
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "cm.everesttech.net": {
-      "owner": {
-        "name": "Adobe Inc.",
-        "displayName": "Adobe"
-      },
-      "app": {
-        "score": 129,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "us.criteo.com": {
-      "owner": {
-        "name": "Criteo SA",
-        "displayName": "Criteo"
-      },
-      "app": {
-        "score": 129,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "aa.agkn.com": {
-      "owner": {
-        "name": "Neustar, Inc.",
-        "displayName": "Neustar"
-      },
-      "app": {
-        "score": 129,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pixel.quantserve.com": {
-      "owner": {
-        "name": "Quantcast Corporation",
-        "displayName": "Quantcast"
-      },
-      "app": {
-        "score": 128,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "dsum-sec.casalemedia.com": {
-      "owner": {
-        "name": "Index Exchange, Inc.",
-        "displayName": "Index Exchange"
-      },
-      "app": {
-        "score": 127,
-        "prevalence": 0.12
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "rtb.mfadsrvr.com": {
-      "owner": {
-        "name": "IPONWEB GmbH",
-        "displayName": "IPONWEB"
-      },
-      "app": {
-        "score": 127,
-        "prevalence": 0.12
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "dsum.casalemedia.com": {
-      "owner": {
-        "name": "Index Exchange, Inc.",
-        "displayName": "Index Exchange"
-      },
-      "app": {
-        "score": 127,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "fls.doubleclick.net": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 124,
-        "prevalence": 0.12
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync-tm.everesttech.net": {
-      "owner": {
-        "name": "Adobe Inc.",
-        "displayName": "Adobe"
-      },
-      "app": {
-        "score": 124,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "match.sharethrough.com": {
-      "owner": {
-        "name": "Sharethrough, Inc.",
-        "displayName": "Sharethrough"
-      },
-      "app": {
-        "score": 124,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ps.eyeota.net": {
-      "owner": {
-        "name": "eyeota Limited",
-        "displayName": "eyeota"
-      },
-      "app": {
-        "score": 124,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "image2.pubmatic.com": {
-      "owner": {
-        "name": "PubMatic, Inc.",
-        "displayName": "PubMatic"
-      },
-      "app": {
-        "score": 124,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pm.w55c.net": {
-      "owner": {
-        "name": "DataXu",
-        "displayName": "DataXu"
-      },
-      "app": {
-        "score": 124,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "image8.pubmatic.com": {
-      "owner": {
-        "name": "PubMatic, Inc.",
-        "displayName": "PubMatic"
-      },
-      "app": {
-        "score": 124,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "match.bnmla.com": {
-      "owner": {
-        "name": "engageBDR",
-        "displayName": "engageBDR"
-      },
-      "app": {
-        "score": 124,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ads.betweendigital.com": {
-      "owner": {
-        "name": "SSP Network Ltd",
-        "displayName": "SSP Network"
-      },
-      "app": {
-        "score": 124,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "id5-sync.com": {
-      "owner": {
-        "name": "ID5 Technology Ltd",
-        "displayName": "ID5"
-      },
-      "app": {
-        "score": 123,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ssum.casalemedia.com": {
-      "owner": {
-        "name": "Index Exchange, Inc.",
-        "displayName": "Index Exchange"
-      },
-      "app": {
-        "score": 123,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync.technoratimedia.com": {
-      "owner": {
-        "name": "Synacor, Inc.",
-        "displayName": "Synacor"
-      },
-      "app": {
-        "score": 122,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "simage2.pubmatic.com": {
-      "owner": {
-        "name": "PubMatic, Inc.",
-        "displayName": "PubMatic"
-      },
-      "app": {
-        "score": 121,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "d.turn.com": {
-      "owner": {
-        "name": "Amobee, Inc",
-        "displayName": "Amobee"
-      },
-      "app": {
-        "score": 121,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "dlx.addthis.com": {
-      "owner": {
-        "name": "Oracle Corporation",
-        "displayName": "Oracle"
-      },
-      "app": {
-        "score": 121,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "um.simpli.fi": {
-      "owner": {
-        "name": "Simplifi Holdings Inc.",
-        "displayName": "Simplifi Holdings"
-      },
-      "app": {
-        "score": 121,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ad.turn.com": {
-      "owner": {
-        "name": "Amobee, Inc",
-        "displayName": "Amobee"
-      },
-      "app": {
-        "score": 121,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "loadus.exelator.com": {
-      "owner": {
-        "name": "The Nielsen Company",
-        "displayName": "The Nielsen Company"
-      },
-      "app": {
-        "score": 121,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "a.tribalfusion.com": {
-      "owner": {
-        "name": "Exponential Interactive Inc.",
-        "displayName": "Exponential Interactive"
-      },
-      "app": {
-        "score": 121,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "lynx.cognitivlabs.com": {
-      "owner": {
-        "name": "Cognitiv Corp.",
-        "displayName": "Cognitiv"
-      },
-      "app": {
-        "score": 121,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "images.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 119,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "wf.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 119,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ch-vid-events.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 119,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "imprchmp.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 119,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "vidstat.taboola.com": {
-      "owner": {
-        "name": "Taboola, Inc.",
-        "displayName": "Taboola"
-      },
-      "app": {
-        "score": 119,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pixel.rubiconproject.com": {
-      "owner": {
-        "name": "The Rubicon Project, Inc.",
-        "displayName": "The Rubicon Project"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.147
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "eb2.3lift.com": {
-      "owner": {
-        "name": "TripleLift",
-        "displayName": "TripleLift"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pixel.mathtag.com": {
-      "owner": {
-        "name": "MediaMath, Inc.",
-        "displayName": "MediaMath"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "firebaselogging-pa.googleapis.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "bttrack.com": {
-      "owner": {
-        "name": "Bidtellect, Inc",
-        "displayName": "Bidtellect"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "b1sync.zemanta.com": {
-      "owner": {
-        "name": "Outbrain",
-        "displayName": "Outbrain"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pippio.com": {
-      "owner": {
-        "name": "LiveRamp",
-        "displayName": "LiveRamp"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "image4.pubmatic.com": {
-      "owner": {
-        "name": "PubMatic, Inc.",
-        "displayName": "PubMatic"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "image6.pubmatic.com": {
-      "owner": {
-        "name": "PubMatic, Inc.",
-        "displayName": "PubMatic"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync.bfmio.com": {
-      "owner": {
-        "name": "Beachfront Media LLC",
-        "displayName": "Beachfront Media"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "c1.adform.net": {
-      "owner": {
-        "name": "Adform A/S",
-        "displayName": "Adform"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ums.acuityplatform.com": {
-      "owner": {
-        "name": "AcuityAds",
-        "displayName": "AcuityAds"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "cs.admanmedia.com": {
-      "owner": {
-        "name": "ADman Media",
-        "displayName": "ADman Media"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync.extend.tv": {
-      "owner": {
-        "name": "ZypMedia, Inc.",
-        "displayName": "ZypMedia"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "p.rfihub.com": {
-      "owner": {
-        "name": "Zeta Global",
-        "displayName": "Zeta Global"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "mid.rkdms.com": {
-      "owner": {
-        "name": "Merkle Inc",
-        "displayName": "Merkle"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "id.rlcdn.com": {
-      "owner": {
-        "name": "LiveRamp",
-        "displayName": "LiveRamp"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pixel-us-east.rubiconproject.com": {
-      "owner": {
-        "name": "The Rubicon Project, Inc.",
-        "displayName": "The Rubicon Project"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ap.lijit.com": {
-      "owner": {
-        "name": "Sovrn Holdings",
-        "displayName": "Sovrn Holdings"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "krk.kargo.com": {
-      "owner": {
-        "name": "Kargo Global, Inc.",
-        "displayName": "Kargo"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync1.intentiq.com": {
-      "owner": {
-        "name": "Intent IQ, LLC",
-        "displayName": "Intent IQ"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "go.sonobi.com": {
-      "owner": {
-        "name": "Sonobi, Inc",
-        "displayName": "Sonobi"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "dmx.districtm.io": {
-      "owner": {
-        "name": "District M Inc.",
-        "displayName": "District M"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "bcp.crwdcntrl.net": {
-      "owner": {
-        "name": "Lotame Solutions, Inc.",
-        "displayName": "Lotame Solutions"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pxl.connexity.net": {
-      "owner": {
-        "name": "Connexity, Inc.",
-        "displayName": "Connexity"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "dmp.brand-display.com": {
-      "owner": {
-        "name": "Knorex Pte. Ltd.",
-        "displayName": "Knorex"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "de.tynt.com": {
-      "owner": {
-        "name": "33Across, Inc.",
-        "displayName": "33Across"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ads.avct.cloud": {
-      "owner": {
-        "name": "Avocet Systems Ltd.",
-        "displayName": "Avocet Systems"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "nep.advangelists.com": {
-      "owner": {
-        "name": "Mobiquity Inc.",
-        "displayName": "Mobiquity"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "rtb.adentifi.com": {
-      "owner": {
-        "name": "AdTheorent Inc",
-        "displayName": "AdTheorent"
-      },
-      "app": {
-        "score": 117,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "b.scorecardresearch.com": {
-      "owner": {
-        "name": "comScore, Inc",
-        "displayName": "comScore"
-      },
-      "app": {
-        "score": 115,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "fastlane.rubiconproject.com": {
-      "owner": {
-        "name": "The Rubicon Project, Inc.",
-        "displayName": "The Rubicon Project"
-      },
-      "app": {
-        "score": 112,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "tlx.3lift.com": {
-      "owner": {
-        "name": "TripleLift",
-        "displayName": "TripleLift"
-      },
-      "app": {
-        "score": 112,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sc-static.net": {
-      "owner": {
-        "name": "Snap Inc.",
-        "displayName": "Snap"
-      },
-      "app": {
-        "score": 112,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "apis.google.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 111,
-        "prevalence": 0.067
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "usermatch.krxd.net": {
-      "owner": {
-        "name": "Salesforce.com, Inc.",
-        "displayName": "Salesforce.com"
-      },
-      "app": {
-        "score": 111,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "cms-xch-chicago.33across.com": {
-      "owner": {
-        "name": "33Across, Inc.",
-        "displayName": "33Across"
-      },
-      "app": {
-        "score": 111,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "pixel.adsafeprotected.com": {
-      "owner": {
-        "name": "Integral Ad Science, Inc.",
-        "displayName": "Integral Ad Science"
-      },
-      "app": {
-        "score": 110,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.storygize.net": {
-      "owner": {
-        "name": "Storygize",
-        "displayName": "Storygize"
-      },
-      "app": {
-        "score": 109,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "connect.facebook.net": {
-      "owner": {
-        "name": "Facebook, Inc.",
-        "displayName": "Facebook"
-      },
-      "app": {
-        "score": 107,
-        "prevalence": 0.227
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "www.gstatic.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 107,
-        "prevalence": 0.147
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "events.mapbox.com": {
-      "owner": {
-        "name": "Mapbox Inc.",
-        "displayName": "Mapbox"
-      },
-      "app": {
-        "score": 107,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "hbopenbid.pubmatic.com": {
-      "owner": {
-        "name": "PubMatic, Inc.",
-        "displayName": "PubMatic"
-      },
-      "app": {
-        "score": 107,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "rtb.openx.net": {
-      "owner": {
-        "name": "OpenX Technologies Inc",
-        "displayName": "OpenX"
-      },
-      "app": {
-        "score": 107,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "creativecdn.com": {
-      "owner": {
-        "name": "RTB House S.A.",
-        "displayName": "RTB House"
-      },
-      "app": {
-        "score": 107,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "network.bazaarvoice.com": {
-      "owner": {
-        "name": "Bazaarvoice, Inc.",
-        "displayName": "Bazaarvoice"
-      },
-      "app": {
-        "score": 107,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ads.yieldmo.com": {
-      "owner": {
-        "name": "YieldMo, Inc.",
-        "displayName": "YieldMo"
-      },
-      "app": {
-        "score": 107,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "c.amazon-adsystem.com": {
-      "owner": {
-        "name": "Amazon Technologies, Inc.",
-        "displayName": "Amazon"
-      },
-      "app": {
-        "score": 106,
-        "prevalence": 0.173
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "contextual.media.net": {
-      "owner": {
-        "name": "Media.net Advertising FZ-LLC",
-        "displayName": "Media.net Advertising"
-      },
-      "app": {
-        "score": 106,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "dsp.adkernel.com": {
-      "owner": {
-        "name": "Adkernel, LLC",
-        "displayName": "Adkernel"
-      },
-      "app": {
-        "score": 106,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "a.teads.tv": {
-      "owner": {
-        "name": "Teads ( Luxenbourg ) SA",
-        "displayName": "Teads"
-      },
-      "app": {
-        "score": 106,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "hb.omtrdc.net": {
-      "owner": {
-        "name": "Adobe Inc.",
-        "displayName": "Adobe"
-      },
-      "app": {
-        "score": 105,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "idsync.rlcdn.com": {
-      "owner": {
-        "name": "LiveRamp",
-        "displayName": "LiveRamp"
-      },
-      "app": {
-        "score": 104,
-        "prevalence": 0.16
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ce.lijit.com": {
-      "owner": {
-        "name": "Sovrn Holdings",
-        "displayName": "Sovrn Holdings"
-      },
-      "app": {
-        "score": 104,
-        "prevalence": 0.08
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "sync.intentiq.com": {
-      "owner": {
-        "name": "Intent IQ, LLC",
-        "displayName": "Intent IQ"
-      },
-      "app": {
-        "score": 104,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "p.tvpixel.com": {
-      "owner": {
-        "name": "Data Plus Math",
-        "displayName": "Data Plus Math"
-      },
-      "app": {
-        "score": 104,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "secure-gl.imrworldwide.com": {
-      "owner": {
-        "name": "The Nielsen Company",
-        "displayName": "The Nielsen Company"
-      },
-      "app": {
-        "score": 104,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "in.treasuredata.com": {
-      "owner": {
-        "name": "Treasure Data, Inc",
-        "displayName": "Treasure Data"
-      },
-      "app": {
-        "score": 104,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "s3.amazonaws.com": {
-      "owner": {
-        "name": "Amazon Technologies, Inc.",
-        "displayName": "Amazon"
-      },
-      "app": {
-        "score": 102,
-        "prevalence": 0.2
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "api.mapbox.com": {
-      "owner": {
-        "name": "Mapbox Inc.",
-        "displayName": "Mapbox"
-      },
-      "app": {
-        "score": 102,
-        "prevalence": 0.08
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "js.adsrvr.org": {
-      "owner": {
-        "name": "The Trade Desk Inc",
-        "displayName": "The Trade Desk"
-      },
-      "app": {
-        "score": 102,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "static.ads-twitter.com": {
-      "owner": {
-        "name": "Twitter, Inc.",
-        "displayName": "Twitter"
-      },
-      "app": {
-        "score": 102,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "cdn.jsdelivr.net": {
-      "owner": {
-        "name": "Prospect One",
-        "displayName": "Prospect One"
-      },
-      "app": {
-        "score": 102,
-        "prevalence": 0.053
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "s.pinimg.com": {
-      "owner": {
-        "name": "Pinterest, Inc.",
-        "displayName": "Pinterest"
-      },
-      "app": {
-        "score": 102,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "di.rlcdn.com": {
-      "owner": {
-        "name": "LiveRamp",
-        "displayName": "LiveRamp"
-      },
-      "app": {
-        "score": 101,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "cdn.amplitude.com": {
-      "owner": {
-        "name": "Amplitude",
-        "displayName": "Amplitude"
-      },
-      "app": {
-        "score": 101,
-        "prevalence": 0.04
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "adservice.google.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 99,
-        "prevalence": 0.253
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "imasdk.googleapis.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.133
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "safeframe.googlesyndication.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.107
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "platform.twitter.com": {
-      "owner": {
-        "name": "Twitter, Inc.",
-        "displayName": "Twitter"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ajax.googleapis.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.093
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "storage.googleapis.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.093
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "eus.rubiconproject.com": {
-      "owner": {
-        "name": "The Rubicon Project, Inc.",
-        "displayName": "The Rubicon Project"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "ssl.fastly.net": {
-      "owner": {
-        "name": "Fastly, Inc.",
-        "displayName": "Fastly"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.067
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "graph.accountkit.com": {
-      "owner": {
-        "name": "Facebook, Inc.",
-        "displayName": "Facebook"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "acdn.adnxs.com": {
-      "owner": {
-        "name": "WarnerMedia, LLC",
-        "displayName": "WarnerMedia"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api.rlcdn.com": {
-      "owner": {
-        "name": "LiveRamp",
-        "displayName": "LiveRamp"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "js-sec.indexww.com": {
-      "owner": {
-        "name": "Index Exchange, Inc.",
-        "displayName": "Index Exchange"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "spl.zeotap.com": {
-      "owner": {
-        "name": "Zeotap GmbH",
-        "displayName": "Zeotap"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "as-sec.casalemedia.com": {
-      "owner": {
-        "name": "Index Exchange, Inc.",
-        "displayName": "Index Exchange"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "rtb.gumgum.com": {
-      "owner": {
-        "name": "GumGum",
-        "displayName": "GumGum"
-      },
-      "app": {
-        "score": 96,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "cdn.krxd.net": {
-      "owner": {
-        "name": "Salesforce.com, Inc.",
-        "displayName": "Salesforce.com"
-      },
-      "app": {
-        "score": 94,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "consumer.krxd.net": {
-      "owner": {
-        "name": "Salesforce.com, Inc.",
-        "displayName": "Salesforce.com"
-      },
-      "app": {
-        "score": 94,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "secure.insightexpressai.com": {
-      "owner": {
-        "name": "Kantar Operations",
-        "displayName": "Kantar Operations"
-      },
-      "app": {
-        "score": 94,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "syndication.twitter.com": {
-      "owner": {
-        "name": "Twitter, Inc.",
-        "displayName": "Twitter"
-      },
-      "app": {
-        "score": 91,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "gcdsdk.appsflyer.com": {
-      "owner": {
-        "name": "AppsFlyer",
-        "displayName": "AppsFlyer"
-      },
-      "app": {
-        "score": 89,
-        "prevalence": 0.133
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "impression-east.liftoff.io": {
-      "owner": {
-        "name": "Liftoff Mobile, Inc.",
-        "displayName": "Liftoff"
-      },
-      "app": {
-        "score": 89,
-        "prevalence": 0.093
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "api.appsflyer.com": {
-      "owner": {
-        "name": "AppsFlyer",
-        "displayName": "AppsFlyer"
-      },
-      "app": {
-        "score": 89,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "logx.optimizely.com": {
-      "owner": {
-        "name": "Optimizely, Inc.",
-        "displayName": "Optimizely"
-      },
-      "app": {
-        "score": 89,
-        "prevalence": 0.053
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "fonts.gstatic.com": {
-      "owner": {
-        "name": "Google LLC",
-        "displayName": "Google"
-      },
-      "app": {
-        "score": 87,
-        "prevalence": 0.24
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "dis.criteo.com": {
-      "owner": {
-        "name": "Criteo SA",
-        "displayName": "Criteo"
-      },
-      "app": {
-        "score": 86,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "com.fake.cdn.ignore": {
-      "owner": {
-        "name": "CDN",
-        "displayName": "CDN"
-      },
-      "app": {
-        "score": 86,
-        "prevalence": 0.067
-      },
-      "default": "ignore",
-      "CDN": true
-    },
-    "com.fake.tracker.block": {
-      "owner": {
-        "name": "CDN",
-        "displayName": "CDN"
-      },
-      "app": {
-        "score": 86,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": false
-    },
-    "com.fake.cdn.block": {
-      "owner": {
-        "name": "CDN",
-        "displayName": "CDN"
-      },
-      "app": {
-        "score": 86,
-        "prevalence": 0.067
-      },
-      "default": "block",
-      "CDN": true
+    "readme": "https://github.com/duckduckgo/tracker-blocklists",
+    "version": "1680299195572",
+    "trackers": {
+        "15.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "a.applovin.com": {
+            "owner": {
+                "name": "AppLovin Corporation",
+                "displayName": "AppLovin"
+            },
+            "default": "block"
+        },
+        "a.tribalfusion.com": {
+            "owner": {
+                "name": "Exponential Interactive Inc.",
+                "displayName": "Exponential Interactive"
+            },
+            "default": "block"
+        },
+        "aa.agkn.com": {
+            "owner": {
+                "name": "Neustar, Inc.",
+                "displayName": "Neustar"
+            },
+            "default": "block"
+        },
+        "aax-eu.amazon-adsystem.com": {
+            "owner": {
+                "name": "Amazon Technologies, Inc.",
+                "displayName": "Amazon.com"
+            },
+            "default": "block"
+        },
+        "aax-us-east.amazon-adsystem.com": {
+            "owner": {
+                "name": "Amazon Technologies, Inc.",
+                "displayName": "Amazon.com"
+            },
+            "default": "block"
+        },
+        "aax.amazon-adsystem.com": {
+            "owner": {
+                "name": "Amazon Technologies, Inc.",
+                "displayName": "Amazon.com"
+            },
+            "default": "block"
+        },
+        "accounts.google.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "acdn.adnxs.com": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "ad.doubleclick.net": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "ad.smaato.net": {
+            "owner": {
+                "name": "Smaato Inc.",
+                "displayName": "Smaato"
+            },
+            "default": "block"
+        },
+        "ad.turn.com": {
+            "owner": {
+                "name": "Amobee, Inc",
+                "displayName": "Amobee"
+            },
+            "default": "block"
+        },
+        "adc3-launch.adcolony.com": {
+            "owner": {
+                "name": "Digital Turbine",
+                "displayName": "AdColony"
+            },
+            "default": "block"
+        },
+        "adexp.liftoff.io": {
+            "owner": {
+                "name": "Liftoff Mobile, Inc.",
+                "displayName": "Liftoff"
+            },
+            "default": "block"
+        },
+        "adrta.com": {
+            "owner": {
+                "name": "Pixalate, Inc.",
+                "displayName": "Pixalate"
+            },
+            "default": "ignore"
+        },
+        "ads-bidder-api.twitter.com": {
+            "owner": {
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
+            },
+            "default": "block"
+        },
+        "ads.avct.cloud": {
+            "owner": {
+                "name": "Avocet Systems Ltd.",
+                "displayName": "Avocet Systems"
+            },
+            "default": "block"
+        },
+        "ads.inmobi.com": {
+            "owner": {
+                "name": "InMobi Pte Ltd",
+                "displayName": "InMobi"
+            },
+            "default": "block"
+        },
+        "ads.linkedin.com": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "ads.mopub.com": {
+            "owner": {
+                "name": "AppLovin Corporation",
+                "displayName": "AppLovin"
+            },
+            "default": "block"
+        },
+        "ads.nexage.com": {
+            "owner": {
+                "name": "Verizon Media",
+                "displayName": "Verizon Media"
+            },
+            "default": "block"
+        },
+        "ads.pubmatic.com": {
+            "owner": {
+                "name": "PubMatic, Inc.",
+                "displayName": "PubMatic"
+            },
+            "default": "block"
+        },
+        "ads.stickyadstv.com": {
+            "owner": {
+                "name": "FreeWheel",
+                "displayName": "FreeWheel"
+            },
+            "default": "block"
+        },
+        "ads.tremorhub.com": {
+            "owner": {
+                "name": "Telaria",
+                "displayName": "Telaria"
+            },
+            "default": "block"
+        },
+        "ads.undertone.com": {
+            "owner": {
+                "name": "Undertone Networks",
+                "displayName": "Undertone Networks"
+            },
+            "default": "block"
+        },
+        "ads.yahoo.com": {
+            "owner": {
+                "name": "Verizon Media",
+                "displayName": "Verizon Media"
+            },
+            "default": "block"
+        },
+        "ads.yieldmo.com": {
+            "owner": {
+                "name": "YieldMo, Inc.",
+                "displayName": "YieldMo"
+            },
+            "default": "block"
+        },
+        "adservice.google.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "ag.innovid.com": {
+            "owner": {
+                "name": "Innovid Media",
+                "displayName": "Innovid Media"
+            },
+            "default": "block"
+        },
+        "ajax.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "alb.reddit.com": {
+            "owner": {
+                "name": "Reddit Inc.",
+                "displayName": "Reddit"
+            },
+            "default": "block"
+        },
+        "analytics.google.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "analytics.localytics.com": {
+            "owner": {
+                "name": "Upland Software Inc.",
+                "displayName": "Upland Software"
+            },
+            "default": "block"
+        },
+        "analytics.rayjump.com": {
+            "owner": {
+                "name": "Talent Game Box",
+                "displayName": "Talent Game Box"
+            },
+            "default": "block"
+        },
+        "analytics.tiktok.com": {
+            "owner": {
+                "name": "ByteDance Ltd.",
+                "displayName": "ByteDance"
+            },
+            "default": "block"
+        },
+        "analytics.twitter.com": {
+            "owner": {
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
+            },
+            "default": "block"
+        },
+        "analytics.yahoo.com": {
+            "owner": {
+                "name": "Verizon Media",
+                "displayName": "Verizon Media"
+            },
+            "default": "block"
+        },
+        "androidads4-5.adcolony.com": {
+            "owner": {
+                "name": "Digital Turbine",
+                "displayName": "AdColony"
+            },
+            "default": "block"
+        },
+        "ap.lijit.com": {
+            "owner": {
+                "name": "Sovrn Holdings",
+                "displayName": "Sovrn Holdings"
+            },
+            "default": "block"
+        },
+        "api.amplitude.com": {
+            "owner": {
+                "name": "Amplitude",
+                "displayName": "Amplitude"
+            },
+            "default": "block"
+        },
+        "api.appsflyer.com": {
+            "owner": {
+                "name": "AppsFlyer",
+                "displayName": "AppsFlyer"
+            },
+            "default": "block"
+        },
+        "api.apptentive.com": {
+            "owner": {
+                "name": "Apptentive Inc.",
+                "displayName": "Apptentive"
+            },
+            "default": "block"
+        },
+        "api.branch.io": {
+            "owner": {
+                "name": "Branch Metrics, Inc.",
+                "displayName": "Branch Metrics"
+            },
+            "default": "block"
+        },
+        "api.gameanalytics.com": {
+            "owner": {
+                "name": "GameAnalytics ApS",
+                "displayName": "GameAnalytics"
+            },
+            "default": "block"
+        },
+        "api.iterable.com": {
+            "owner": {
+                "name": "Iterable, Inc.",
+                "displayName": "Iterable"
+            },
+            "default": "block"
+        },
+        "api.kochava.com": {
+            "owner": {
+                "name": "Kochava",
+                "displayName": "Kochava"
+            },
+            "default": "block"
+        },
+        "api.mapbox.com": {
+            "owner": {
+                "name": "Mapbox Inc.",
+                "displayName": "Mapbox"
+            },
+            "default": "ignore"
+        },
+        "api.mixpanel.com": {
+            "owner": {
+                "name": "Mixpanel, Inc.",
+                "displayName": "Mixpanel"
+            },
+            "default": "block"
+        },
+        "api.onesignal.com": {
+            "owner": {
+                "name": "OneSignal",
+                "displayName": "OneSignal"
+            },
+            "default": "block"
+        },
+        "api.permutive.com": {
+            "owner": {
+                "name": "Permutive, Inc.",
+                "displayName": "Permutive"
+            },
+            "default": "block"
+        },
+        "api.revenuecat.com": {
+            "owner": {
+                "name": "RevenueCat",
+                "displayName": "RevenueCat"
+            },
+            "default": "block"
+        },
+        "api.rlcdn.com": {
+            "owner": {
+                "name": "LiveRamp Holdings, Inc.",
+                "displayName": "LiveRamp"
+            },
+            "default": "block"
+        },
+        "api.segment.io": {
+            "owner": {
+                "name": "Segment.io, Inc.",
+                "displayName": "Segment.io"
+            },
+            "default": "block"
+        },
+        "api.tappx.com": {
+            "owner": {
+                "name": "Tappcelator Media S.L.",
+                "displayName": "Tappx"
+            },
+            "default": "block"
+        },
+        "api.twitter.com": {
+            "owner": {
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
+            },
+            "default": "block"
+        },
+        "api.vungle.com": {
+            "owner": {
+                "name": "Vungle Inc",
+                "displayName": "Vungle"
+            },
+            "default": "block"
+        },
+        "api2.amplitude.com": {
+            "owner": {
+                "name": "Amplitude",
+                "displayName": "Amplitude"
+            },
+            "default": "block"
+        },
+        "api2.branch.io": {
+            "owner": {
+                "name": "Branch Metrics, Inc.",
+                "displayName": "Branch Metrics"
+            },
+            "default": "block"
+        },
+        "api3.siftscience.com": {
+            "owner": {
+                "name": "Sift Science, Inc.",
+                "displayName": "Sift Science"
+            },
+            "default": "ignore"
+        },
+        "apis.google.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "app.adjust.com": {
+            "owner": {
+                "name": "Adjust GmbH",
+                "displayName": "Adjust"
+            },
+            "default": "block"
+        },
+        "app.appsflyer.com": {
+            "owner": {
+                "name": "AppsFlyer",
+                "displayName": "AppsFlyer"
+            },
+            "default": "block"
+        },
+        "appmetrica.yandex.net": {
+            "owner": {
+                "name": "Yandex LLC",
+                "displayName": "Yandex"
+            },
+            "default": "block"
+        },
+        "assets.hcaptcha.com": {
+            "owner": {
+                "name": "Intuition Machines, Inc.",
+                "displayName": "Intuition Machines"
+            },
+            "default": "ignore"
+        },
+        "aud.pubmatic.com": {
+            "owner": {
+                "name": "PubMatic, Inc.",
+                "displayName": "PubMatic"
+            },
+            "default": "block"
+        },
+        "b.scorecardresearch.com": {
+            "owner": {
+                "name": "comScore, Inc",
+                "displayName": "comScore"
+            },
+            "default": "block"
+        },
+        "b1sync.zemanta.com": {
+            "owner": {
+                "name": "Outbrain",
+                "displayName": "Outbrain"
+            },
+            "default": "block"
+        },
+        "bat.bing.com": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "bcp.crwdcntrl.net": {
+            "owner": {
+                "name": "Lotame Solutions, Inc.",
+                "displayName": "Lotame Solutions"
+            },
+            "default": "block"
+        },
+        "beacon.krxd.net": {
+            "owner": {
+                "name": "Salesforce.com, Inc.",
+                "displayName": "Salesforce.com"
+            },
+            "default": "block"
+        },
+        "beacon.riskified.com": {
+            "owner": {
+                "name": "Riskified Ltd.",
+                "displayName": "Riskified"
+            },
+            "default": "ignore"
+        },
+        "bh.contextweb.com": {
+            "owner": {
+                "name": "Pulsepoint, Inc.",
+                "displayName": "Pulsepoint"
+            },
+            "default": "block"
+        },
+        "bidder.criteo.com": {
+            "owner": {
+                "name": "Criteo SA",
+                "displayName": "Criteo"
+            },
+            "default": "block"
+        },
+        "btlr.sharethrough.com": {
+            "owner": {
+                "name": "Sharethrough, Inc.",
+                "displayName": "Sharethrough"
+            },
+            "default": "block"
+        },
+        "bttrack.com": {
+            "owner": {
+                "name": "Bidtellect, Inc",
+                "displayName": "Bidtellect"
+            },
+            "default": "block"
+        },
+        "c.amazon-adsystem.com": {
+            "owner": {
+                "name": "Amazon Technologies, Inc.",
+                "displayName": "Amazon.com"
+            },
+            "default": "block"
+        },
+        "c.bing.com": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "c.riskified.com": {
+            "owner": {
+                "name": "Riskified Ltd.",
+                "displayName": "Riskified"
+            },
+            "default": "ignore"
+        },
+        "c1.adform.net": {
+            "owner": {
+                "name": "Adform A/S",
+                "displayName": "Adform"
+            },
+            "default": "block"
+        },
+        "cb.mopub.com": {
+            "owner": {
+                "name": "AppLovin Corporation",
+                "displayName": "AppLovin"
+            },
+            "default": "block"
+        },
+        "cdn-f.adsmoloco.com": {
+            "owner": {
+                "name": "Moloco Inc.",
+                "displayName": "Moloco"
+            },
+            "default": "block"
+        },
+        "cdn-lb.vungle.com": {
+            "owner": {
+                "name": "Vungle Inc",
+                "displayName": "Vungle"
+            },
+            "default": "block"
+        },
+        "cdn.doubleverify.com": {
+            "owner": {
+                "name": "DoubleVerify",
+                "displayName": "DoubleVerify"
+            },
+            "default": "block"
+        },
+        "cdn.jsdelivr.net": {
+            "owner": {
+                "name": "Prospect One",
+                "displayName": "Prospect One"
+            },
+            "default": "ignore"
+        },
+        "cdn.krxd.net": {
+            "owner": {
+                "name": "Salesforce.com, Inc.",
+                "displayName": "Salesforce.com"
+            },
+            "default": "block"
+        },
+        "cdn.permutive.com": {
+            "owner": {
+                "name": "Permutive, Inc.",
+                "displayName": "Permutive"
+            },
+            "default": "block"
+        },
+        "cdn.siftscience.com": {
+            "owner": {
+                "name": "Sift Science, Inc.",
+                "displayName": "Sift Science"
+            },
+            "default": "ignore"
+        },
+        "cdn.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "cds.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "ce.lijit.com": {
+            "owner": {
+                "name": "Sovrn Holdings",
+                "displayName": "Sovrn Holdings"
+            },
+            "default": "block"
+        },
+        "ch-wf.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "choices.truste.com": {
+            "owner": {
+                "name": "TrustArc Inc.",
+                "displayName": "TrustArc"
+            },
+            "default": "block"
+        },
+        "click-haproxy.supersonicads.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "cloud.unity3d.com": {
+            "owner": {
+                "name": "Unity Technologies ApS",
+                "displayName": "Unity"
+            },
+            "default": "block"
+        },
+        "cm.everesttech.net": {
+            "owner": {
+                "name": "Adobe Inc.",
+                "displayName": "Adobe"
+            },
+            "default": "block"
+        },
+        "collect.igodigital.com": {
+            "owner": {
+                "name": "Salesforce.com, Inc.",
+                "displayName": "Salesforce.com"
+            },
+            "default": "block"
+        },
+        "combine.urbanairship.com": {
+            "owner": {
+                "name": "Urban Airship, Inc.",
+                "displayName": "Urban Airship"
+            },
+            "default": "block"
+        },
+        "configure.rayjump.com": {
+            "owner": {
+                "name": "Talent Game Box",
+                "displayName": "Talent Game Box"
+            },
+            "default": "block"
+        },
+        "connect.facebook.net": {
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook"
+            },
+            "default": "block"
+        },
+        "connect.tapjoy.com": {
+            "owner": {
+                "name": "Tapjoy, Inc.",
+                "displayName": "Tapjoy"
+            },
+            "default": "block"
+        },
+        "consumer.krxd.net": {
+            "owner": {
+                "name": "Salesforce.com, Inc.",
+                "displayName": "Salesforce.com"
+            },
+            "default": "block"
+        },
+        "contextual.media.net": {
+            "owner": {
+                "name": "Media.net Advertising FZ-LLC",
+                "displayName": "Media.net Advertising"
+            },
+            "default": "block"
+        },
+        "control.kochava.com": {
+            "owner": {
+                "name": "Kochava",
+                "displayName": "Kochava"
+            },
+            "default": "block"
+        },
+        "crashlyticsreports-pa.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "creativecdn.com": {
+            "owner": {
+                "name": "RTB House S.A.",
+                "displayName": "RTB House"
+            },
+            "default": "block"
+        },
+        "cs.admanmedia.com": {
+            "owner": {
+                "name": "ADman Media",
+                "displayName": "ADman Media"
+            },
+            "default": "block"
+        },
+        "cs.emxdgt.com": {
+            "owner": {
+                "name": "Engine USA LLC",
+                "displayName": "Engine USA"
+            },
+            "default": "block"
+        },
+        "csi.gstatic.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "ct.pinterest.com": {
+            "owner": {
+                "name": "Pinterest, Inc.",
+                "displayName": "Pinterest"
+            },
+            "default": "block"
+        },
+        "d.adroll.com": {
+            "owner": {
+                "name": "AdRoll, Inc.",
+                "displayName": "AdRoll"
+            },
+            "default": "block"
+        },
+        "d.agkn.com": {
+            "owner": {
+                "name": "Neustar, Inc.",
+                "displayName": "Neustar"
+            },
+            "default": "block"
+        },
+        "d.turn.com": {
+            "owner": {
+                "name": "Amobee, Inc",
+                "displayName": "Amobee"
+            },
+            "default": "block"
+        },
+        "d9.flashtalking.com": {
+            "owner": {
+                "name": "Flashtalking Inc",
+                "displayName": "Flashtalking"
+            },
+            "default": "block"
+        },
+        "data.ad-score.com": {
+            "owner": {
+                "name": "Adscore Technologies DMCC",
+                "displayName": "Adscore"
+            },
+            "default": "block"
+        },
+        "data.flurry.com": {
+            "owner": {
+                "name": "Verizon Media",
+                "displayName": "Verizon Media"
+            },
+            "default": "block"
+        },
+        "de.tynt.com": {
+            "owner": {
+                "name": "33Across, Inc.",
+                "displayName": "33Across"
+            },
+            "default": "block"
+        },
+        "device-api.urbanairship.com": {
+            "owner": {
+                "name": "Urban Airship, Inc.",
+                "displayName": "Urban Airship"
+            },
+            "default": "block"
+        },
+        "device.marketingcloudapis.com": {
+            "owner": {
+                "name": "Salesforce.com, Inc.",
+                "displayName": "Salesforce.com"
+            },
+            "default": "block"
+        },
+        "di.rlcdn.com": {
+            "owner": {
+                "name": "LiveRamp Holdings, Inc.",
+                "displayName": "LiveRamp"
+            },
+            "default": "block"
+        },
+        "dis.criteo.com": {
+            "owner": {
+                "name": "Criteo SA",
+                "displayName": "Criteo"
+            },
+            "default": "block"
+        },
+        "dlsdk.appsflyer.com": {
+            "owner": {
+                "name": "AppsFlyer",
+                "displayName": "AppsFlyer"
+            },
+            "default": "block"
+        },
+        "dlx.addthis.com": {
+            "owner": {
+                "name": "Oracle Corporation",
+                "displayName": "Oracle"
+            },
+            "default": "block"
+        },
+        "dpm.demdex.net": {
+            "owner": {
+                "name": "Adobe Inc.",
+                "displayName": "Adobe"
+            },
+            "default": "block"
+        },
+        "dsp.adkernel.com": {
+            "owner": {
+                "name": "Adkernel, LLC",
+                "displayName": "Adkernel"
+            },
+            "default": "block"
+        },
+        "dsum-sec.casalemedia.com": {
+            "owner": {
+                "name": "Index Exchange, Inc.",
+                "displayName": "Index Exchange"
+            },
+            "default": "block"
+        },
+        "dsum.casalemedia.com": {
+            "owner": {
+                "name": "Index Exchange, Inc.",
+                "displayName": "Index Exchange"
+            },
+            "default": "block"
+        },
+        "dt.adsafeprotected.com": {
+            "owner": {
+                "name": "Integral Ad Science, Inc.",
+                "displayName": "Integral Ad Science"
+            },
+            "default": "block"
+        },
+        "e1.emxdgt.com": {
+            "owner": {
+                "name": "Engine USA LLC",
+                "displayName": "Engine USA"
+            },
+            "default": "block"
+        },
+        "eb2.3lift.com": {
+            "owner": {
+                "name": "TripleLift",
+                "displayName": "TripleLift"
+            },
+            "default": "block"
+        },
+        "eus.rubiconproject.com": {
+            "owner": {
+                "name": "Magnite, Inc.",
+                "displayName": "Magnite"
+            },
+            "default": "block"
+        },
+        "events.appsflyer.com": {
+            "owner": {
+                "name": "AppsFlyer",
+                "displayName": "AppsFlyer"
+            },
+            "default": "block"
+        },
+        "events.mapbox.com": {
+            "owner": {
+                "name": "Mapbox Inc.",
+                "displayName": "Mapbox"
+            },
+            "default": "block"
+        },
+        "fastlane.rubiconproject.com": {
+            "owner": {
+                "name": "Magnite, Inc.",
+                "displayName": "Magnite"
+            },
+            "default": "block"
+        },
+        "firebaseinstallations.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "firebaselogging-pa.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "firebaseremoteconfig.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "fls.doubleclick.net": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "fonts.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "fonts.gstatic.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "fra-01.braze.eu": {
+            "owner": {
+                "name": "Braze, Inc.",
+                "displayName": "Braze"
+            },
+            "default": "block"
+        },
+        "fundingchoicesmessages.google.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "fw.adsafeprotected.com": {
+            "owner": {
+                "name": "Integral Ad Science, Inc.",
+                "displayName": "Integral Ad Science"
+            },
+            "default": "block"
+        },
+        "g.doubleclick.net": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "gcdsdk.appsflyer.com": {
+            "owner": {
+                "name": "AppsFlyer",
+                "displayName": "AppsFlyer"
+            },
+            "default": "block"
+        },
+        "gce-sc.bidswitch.net": {
+            "owner": {
+                "name": "IPONWEB GmbH",
+                "displayName": "IPONWEB"
+            },
+            "default": "block"
+        },
+        "gql.reddit.com": {
+            "owner": {
+                "name": "Reddit Inc.",
+                "displayName": "Reddit"
+            },
+            "default": "ignore"
+        },
+        "graph.facebook.com": {
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook"
+            },
+            "default": "ignore"
+        },
+        "gum.criteo.com": {
+            "owner": {
+                "name": "Criteo SA",
+                "displayName": "Criteo"
+            },
+            "default": "block"
+        },
+        "hb.omtrdc.net": {
+            "owner": {
+                "name": "Adobe Inc.",
+                "displayName": "Adobe"
+            },
+            "default": "block"
+        },
+        "hbopenbid.pubmatic.com": {
+            "owner": {
+                "name": "PubMatic, Inc.",
+                "displayName": "PubMatic"
+            },
+            "default": "block"
+        },
+        "hcaptcha.com": {
+            "owner": {
+                "name": "Intuition Machines, Inc.",
+                "displayName": "Intuition Machines"
+            },
+            "default": "ignore"
+        },
+        "hexagon-analytics.com": {
+            "owner": {
+                "name": "Hexagon Data, S.A.P.I. de C.V.",
+                "displayName": "Hexagon Data"
+            },
+            "default": "block"
+        },
+        "htlb.casalemedia.com": {
+            "owner": {
+                "name": "Index Exchange, Inc.",
+                "displayName": "Index Exchange"
+            },
+            "default": "block"
+        },
+        "i.liadm.com": {
+            "owner": {
+                "name": "LiveIntent Inc.",
+                "displayName": "LiveIntent"
+            },
+            "default": "block"
+        },
+        "iab-imp-gateway.supersonicads.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "iad-01.braze.com": {
+            "owner": {
+                "name": "Braze, Inc.",
+                "displayName": "Braze"
+            },
+            "default": "block"
+        },
+        "iad-03.braze.com": {
+            "owner": {
+                "name": "Braze, Inc.",
+                "displayName": "Braze"
+            },
+            "default": "block"
+        },
+        "ib.adnxs.com": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "id.rlcdn.com": {
+            "owner": {
+                "name": "LiveRamp Holdings, Inc.",
+                "displayName": "LiveRamp"
+            },
+            "default": "block"
+        },
+        "id5-sync.com": {
+            "owner": {
+                "name": "ID5 Technology Ltd",
+                "displayName": "ID5"
+            },
+            "default": "block"
+        },
+        "idsync.rlcdn.com": {
+            "owner": {
+                "name": "LiveRamp Holdings, Inc.",
+                "displayName": "LiveRamp"
+            },
+            "default": "block"
+        },
+        "image2.pubmatic.com": {
+            "owner": {
+                "name": "PubMatic, Inc.",
+                "displayName": "PubMatic"
+            },
+            "default": "block"
+        },
+        "image4.pubmatic.com": {
+            "owner": {
+                "name": "PubMatic, Inc.",
+                "displayName": "PubMatic"
+            },
+            "default": "block"
+        },
+        "image6.pubmatic.com": {
+            "owner": {
+                "name": "PubMatic, Inc.",
+                "displayName": "PubMatic"
+            },
+            "default": "block"
+        },
+        "image8.pubmatic.com": {
+            "owner": {
+                "name": "PubMatic, Inc.",
+                "displayName": "PubMatic"
+            },
+            "default": "block"
+        },
+        "images.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "imasdk.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "img.riskified.com": {
+            "owner": {
+                "name": "Riskified Ltd.",
+                "displayName": "Riskified"
+            },
+            "default": "ignore"
+        },
+        "imgs.hcaptcha.com": {
+            "owner": {
+                "name": "Intuition Machines, Inc.",
+                "displayName": "Intuition Machines"
+            },
+            "default": "ignore"
+        },
+        "impression-east.liftoff.io": {
+            "owner": {
+                "name": "Liftoff Mobile, Inc.",
+                "displayName": "Liftoff"
+            },
+            "default": "block"
+        },
+        "impression-europe.liftoff.io": {
+            "owner": {
+                "name": "Liftoff Mobile, Inc.",
+                "displayName": "Liftoff"
+            },
+            "default": "block"
+        },
+        "impression.appsflyer.com": {
+            "owner": {
+                "name": "AppsFlyer",
+                "displayName": "AppsFlyer"
+            },
+            "default": "block"
+        },
+        "impression.link": {
+            "owner": {
+                "name": "Branch Metrics, Inc.",
+                "displayName": "Branch Metrics"
+            },
+            "default": "block"
+        },
+        "in.appcenter.ms": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "ingest.sentry.io": {
+            "owner": {
+                "name": "Functional Software, Inc.",
+                "displayName": "Functional Software"
+            },
+            "default": "block"
+        },
+        "insight.adsrvr.org": {
+            "owner": {
+                "name": "The Trade Desk Inc",
+                "displayName": "The Trade Desk"
+            },
+            "default": "block"
+        },
+        "internal.unity3d.com": {
+            "owner": {
+                "name": "Unity Technologies ApS",
+                "displayName": "Unity"
+            },
+            "default": "block"
+        },
+        "ipds.adrta.com": {
+            "owner": {
+                "name": "Pixalate, Inc.",
+                "displayName": "Pixalate"
+            },
+            "default": "ignore"
+        },
+        "ipv6.adrta.com": {
+            "owner": {
+                "name": "Pixalate, Inc.",
+                "displayName": "Pixalate"
+            },
+            "default": "ignore"
+        },
+        "is-gateway.supersonicads.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "js-sec.indexww.com": {
+            "owner": {
+                "name": "Index Exchange, Inc.",
+                "displayName": "Index Exchange"
+            },
+            "default": "block"
+        },
+        "js.adsrvr.org": {
+            "owner": {
+                "name": "The Trade Desk Inc",
+                "displayName": "The Trade Desk"
+            },
+            "default": "block"
+        },
+        "lbs.yandex.net": {
+            "owner": {
+                "name": "Yandex LLC",
+                "displayName": "Yandex"
+            },
+            "default": "block"
+        },
+        "lh3.googleusercontent.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "live.chartboost.com": {
+            "owner": {
+                "name": "Take-Two Interactive Software, Inc.",
+                "displayName": "Take-Two Interactive Software"
+            },
+            "default": "block"
+        },
+        "load77.exelator.com": {
+            "owner": {
+                "name": "The Nielsen Company",
+                "displayName": "The Nielsen Company"
+            },
+            "default": "block"
+        },
+        "loadm.exelator.com": {
+            "owner": {
+                "name": "The Nielsen Company",
+                "displayName": "The Nielsen Company"
+            },
+            "default": "block"
+        },
+        "loadus.exelator.com": {
+            "owner": {
+                "name": "The Nielsen Company",
+                "displayName": "The Nielsen Company"
+            },
+            "default": "block"
+        },
+        "logs.datadoghq.com": {
+            "owner": {
+                "name": "Datadog, Inc.",
+                "displayName": "Datadog"
+            },
+            "default": "block"
+        },
+        "logs.ironsrc.mobi": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "logx.optimizely.com": {
+            "owner": {
+                "name": "Optimizely, Inc.",
+                "displayName": "Optimizely"
+            },
+            "default": "block"
+        },
+        "m.facebook.com": {
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook"
+            },
+            "default": "block"
+        },
+        "maps.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "match.adsrvr.org": {
+            "owner": {
+                "name": "The Trade Desk Inc",
+                "displayName": "The Trade Desk"
+            },
+            "default": "block"
+        },
+        "match.deepintent.com": {
+            "owner": {
+                "name": "DeepIntent Inc",
+                "displayName": "DeepIntent"
+            },
+            "default": "block"
+        },
+        "match.sharethrough.com": {
+            "owner": {
+                "name": "Sharethrough, Inc.",
+                "displayName": "Sharethrough"
+            },
+            "default": "block"
+        },
+        "mc.yandex.ru": {
+            "owner": {
+                "name": "Yandex LLC",
+                "displayName": "Yandex"
+            },
+            "default": "block"
+        },
+        "mobile-collector.newrelic.com": {
+            "owner": {
+                "name": "New Relic",
+                "displayName": "New Relic"
+            },
+            "default": "block"
+        },
+        "mobile.adsafeprotected.com": {
+            "owner": {
+                "name": "Integral Ad Science, Inc.",
+                "displayName": "Integral Ad Science"
+            },
+            "default": "block"
+        },
+        "mobile.webvisor.net": {
+            "owner": {
+                "name": "Yandex LLC",
+                "displayName": "Yandex"
+            },
+            "default": "block"
+        },
+        "mobile.yandex.net": {
+            "owner": {
+                "name": "Yandex LLC",
+                "displayName": "Yandex"
+            },
+            "default": "block"
+        },
+        "mpx.mopub.com": {
+            "owner": {
+                "name": "AppLovin Corporation",
+                "displayName": "AppLovin"
+            },
+            "default": "block"
+        },
+        "ms.applovin.com": {
+            "owner": {
+                "name": "AppLovin Corporation",
+                "displayName": "AppLovin"
+            },
+            "default": "block"
+        },
+        "mwzeom.zeotap.com": {
+            "owner": {
+                "name": "Zeotap GmbH",
+                "displayName": "Zeotap"
+            },
+            "default": "block"
+        },
+        "nep.advangelists.com": {
+            "owner": {
+                "name": "Mobiquity Inc.",
+                "displayName": "Mobiquity"
+            },
+            "default": "block"
+        },
+        "networksdk.ssacdn.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "notify.bugsnag.com": {
+            "owner": {
+                "name": "Bugsnag Inc.",
+                "displayName": "Bugsnag"
+            },
+            "default": "block"
+        },
+        "ny1-bid.adsrvr.org": {
+            "owner": {
+                "name": "The Trade Desk Inc",
+                "displayName": "The Trade Desk"
+            },
+            "default": "block"
+        },
+        "odr.mookie1.com": {
+            "owner": {
+                "name": "WPP plc",
+                "displayName": "WPP"
+            },
+            "default": "block"
+        },
+        "outcome-cdn.supersonicads.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "outcome-ssp.supersonicads.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "p.adsymptotic.com": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "p.placed.com": {
+            "owner": {
+                "name": "Foursquare Labs, Inc.",
+                "displayName": "Foursquare Labs"
+            },
+            "default": "block"
+        },
+        "p.rfihub.com": {
+            "owner": {
+                "name": "Zeta Global",
+                "displayName": "Zeta Global"
+            },
+            "default": "block"
+        },
+        "pad-v3.presage.io": {
+            "owner": {
+                "name": "Ogury Limited",
+                "displayName": "Ogury"
+            },
+            "default": "block"
+        },
+        "pagead2.googlesyndication.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "pippio.com": {
+            "owner": {
+                "name": "LiveRamp Holdings, Inc.",
+                "displayName": "LiveRamp"
+            },
+            "default": "block"
+        },
+        "pix.adrta.com": {
+            "owner": {
+                "name": "Pixalate, Inc.",
+                "displayName": "Pixalate"
+            },
+            "default": "ignore"
+        },
+        "pixel-sync.sitescout.com": {
+            "owner": {
+                "name": "Centro, Inc.",
+                "displayName": "Centro"
+            },
+            "default": "block"
+        },
+        "pixel-us-east.rubiconproject.com": {
+            "owner": {
+                "name": "Magnite, Inc.",
+                "displayName": "Magnite"
+            },
+            "default": "block"
+        },
+        "pixel.adsafeprotected.com": {
+            "owner": {
+                "name": "Integral Ad Science, Inc.",
+                "displayName": "Integral Ad Science"
+            },
+            "default": "block"
+        },
+        "pixel.advertising.com": {
+            "owner": {
+                "name": "Verizon Media",
+                "displayName": "Verizon Media"
+            },
+            "default": "block"
+        },
+        "pixel.mathtag.com": {
+            "owner": {
+                "name": "MediaMath, Inc.",
+                "displayName": "MediaMath"
+            },
+            "default": "block"
+        },
+        "pixel.onaudience.com": {
+            "owner": {
+                "name": "OnAudience Ltd.",
+                "displayName": "OnAudience"
+            },
+            "default": "block"
+        },
+        "pixel.parsely.com": {
+            "owner": {
+                "name": "Parsely, Inc.",
+                "displayName": "Parsely"
+            },
+            "default": "block"
+        },
+        "pixel.quantserve.com": {
+            "owner": {
+                "name": "Quantcast Corporation",
+                "displayName": "Quantcast"
+            },
+            "default": "block"
+        },
+        "pixel.rubiconproject.com": {
+            "owner": {
+                "name": "Magnite, Inc.",
+                "displayName": "Magnite"
+            },
+            "default": "block"
+        },
+        "pixel.tapad.com": {
+            "owner": {
+                "name": "Tapad, Inc.",
+                "displayName": "Tapad"
+            },
+            "default": "block"
+        },
+        "placements.tapjoy.com": {
+            "owner": {
+                "name": "Tapjoy, Inc.",
+                "displayName": "Tapjoy"
+            },
+            "default": "block"
+        },
+        "platform.ssacdn.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "platform.twitter.com": {
+            "owner": {
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
+            },
+            "default": "ignore"
+        },
+        "play.google.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "pm-gateway.supersonicads.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "pm.w55c.net": {
+            "owner": {
+                "name": "Roku, Inc.",
+                "displayName": "Roku"
+            },
+            "default": "block"
+        },
+        "prebid-server.rubiconproject.com": {
+            "owner": {
+                "name": "Magnite, Inc.",
+                "displayName": "Magnite"
+            },
+            "default": "block"
+        },
+        "prebid.adnxs.com": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "prg.smartadserver.com": {
+            "owner": {
+                "name": "Smartadserver S.A.S",
+                "displayName": "Smartadserver"
+            },
+            "default": "block"
+        },
+        "prod-a.applovin.com": {
+            "owner": {
+                "name": "AppLovin Corporation",
+                "displayName": "AppLovin"
+            },
+            "default": "block"
+        },
+        "prod-ms.applovin.com": {
+            "owner": {
+                "name": "AppLovin Corporation",
+                "displayName": "AppLovin"
+            },
+            "default": "block"
+        },
+        "prod.bidr.io": {
+            "owner": {
+                "name": "Beeswax",
+                "displayName": "Beeswax"
+            },
+            "default": "block"
+        },
+        "ps.eyeota.net": {
+            "owner": {
+                "name": "eyeota Limited",
+                "displayName": "eyeota"
+            },
+            "default": "block"
+        },
+        "pt.ispot.tv": {
+            "owner": {
+                "name": "iSpot.tv",
+                "displayName": "iSpot.tv"
+            },
+            "default": "block"
+        },
+        "px.moatads.com": {
+            "owner": {
+                "name": "Oracle Corporation",
+                "displayName": "Oracle"
+            },
+            "default": "block"
+        },
+        "px.owneriq.net": {
+            "owner": {
+                "name": "Inmar, Inc.",
+                "displayName": "Inmar"
+            },
+            "default": "block"
+        },
+        "q.adrta.com": {
+            "owner": {
+                "name": "Pixalate, Inc.",
+                "displayName": "Pixalate"
+            },
+            "default": "ignore"
+        },
+        "r.casalemedia.com": {
+            "owner": {
+                "name": "Index Exchange, Inc.",
+                "displayName": "Index Exchange"
+            },
+            "default": "block"
+        },
+        "register.appsflyer.com": {
+            "owner": {
+                "name": "AppsFlyer",
+                "displayName": "AppsFlyer"
+            },
+            "default": "block"
+        },
+        "rpc.tapjoy.com": {
+            "owner": {
+                "name": "Tapjoy, Inc.",
+                "displayName": "Tapjoy"
+            },
+            "default": "block"
+        },
+        "rt.applovin.com": {
+            "owner": {
+                "name": "AppLovin Corporation",
+                "displayName": "AppLovin"
+            },
+            "default": "block"
+        },
+        "rtb-csync.smartadserver.com": {
+            "owner": {
+                "name": "Smartadserver S.A.S",
+                "displayName": "Smartadserver"
+            },
+            "default": "block"
+        },
+        "rtb.adentifi.com": {
+            "owner": {
+                "name": "AdTheorent Inc",
+                "displayName": "AdTheorent"
+            },
+            "default": "block"
+        },
+        "rtb.mfadsrvr.com": {
+            "owner": {
+                "name": "IPONWEB GmbH",
+                "displayName": "IPONWEB"
+            },
+            "default": "block"
+        },
+        "rtb.openx.net": {
+            "owner": {
+                "name": "OpenX Technologies Inc",
+                "displayName": "OpenX"
+            },
+            "default": "block"
+        },
+        "rv-gateway.supersonicads.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "s.adsximg.com": {
+            "owner": {
+                "name": "Human Security, Inc.",
+                "displayName": "Human Security"
+            },
+            "default": "ignore"
+        },
+        "s.amazon-adsystem.com": {
+            "owner": {
+                "name": "Amazon Technologies, Inc.",
+                "displayName": "Amazon.com"
+            },
+            "default": "block"
+        },
+        "s.innovid.com": {
+            "owner": {
+                "name": "Innovid Media",
+                "displayName": "Innovid Media"
+            },
+            "default": "block"
+        },
+        "s.pinimg.com": {
+            "owner": {
+                "name": "Pinterest, Inc.",
+                "displayName": "Pinterest"
+            },
+            "default": "block"
+        },
+        "s0.2mdn.net": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "s2s.adjust.com": {
+            "owner": {
+                "name": "Adjust GmbH",
+                "displayName": "Adjust"
+            },
+            "default": "block"
+        },
+        "s3.amazonaws.com": {
+            "owner": {
+                "name": "Amazon Technologies, Inc.",
+                "displayName": "Amazon.com"
+            },
+            "default": "ignore"
+        },
+        "safeframe.googlesyndication.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "sb.scorecardresearch.com": {
+            "owner": {
+                "name": "comScore, Inc",
+                "displayName": "comScore"
+            },
+            "default": "block"
+        },
+        "sc-static.net": {
+            "owner": {
+                "name": "Snap Inc.",
+                "displayName": "Snap"
+            },
+            "default": "block"
+        },
+        "sc.omtrdc.net": {
+            "owner": {
+                "name": "Adobe Inc.",
+                "displayName": "Adobe"
+            },
+            "default": "block"
+        },
+        "sdk-events.inner-active.mobi": {
+            "owner": {
+                "name": "Digital Turbine",
+                "displayName": "AdColony"
+            },
+            "default": "block"
+        },
+        "search.spotxchange.com": {
+            "owner": {
+                "name": "SpotX, Inc.",
+                "displayName": "SpotX"
+            },
+            "default": "block"
+        },
+        "secure-dcr.imrworldwide.com": {
+            "owner": {
+                "name": "The Nielsen Company",
+                "displayName": "The Nielsen Company"
+            },
+            "default": "block"
+        },
+        "secure-gl.imrworldwide.com": {
+            "owner": {
+                "name": "The Nielsen Company",
+                "displayName": "The Nielsen Company"
+            },
+            "default": "block"
+        },
+        "secure.adnxs.com": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "secure.insightexpressai.com": {
+            "owner": {
+                "name": "Kantar Operations",
+                "displayName": "Kantar Operations"
+            },
+            "default": "block"
+        },
+        "sentry.io": {
+            "owner": {
+                "name": "Functional Software, Inc.",
+                "displayName": "Functional Software"
+            },
+            "default": "block"
+        },
+        "servedby.flashtalking.com": {
+            "owner": {
+                "name": "Flashtalking Inc",
+                "displayName": "Flashtalking"
+            },
+            "default": "block"
+        },
+        "servicebus.windows.net": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "ignore"
+        },
+        "sessions.bugsnag.com": {
+            "owner": {
+                "name": "Bugsnag Inc.",
+                "displayName": "Bugsnag"
+            },
+            "default": "block"
+        },
+        "simage2.pubmatic.com": {
+            "owner": {
+                "name": "PubMatic, Inc.",
+                "displayName": "PubMatic"
+            },
+            "default": "block"
+        },
+        "simage4.pubmatic.com": {
+            "owner": {
+                "name": "PubMatic, Inc.",
+                "displayName": "PubMatic"
+            },
+            "default": "block"
+        },
+        "sonic-us.supersonicads.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "spl.zeotap.com": {
+            "owner": {
+                "name": "Zeotap GmbH",
+                "displayName": "Zeotap"
+            },
+            "default": "block"
+        },
+        "srv.stackadapt.com": {
+            "owner": {
+                "name": "Collective Roll",
+                "displayName": "Collective Roll"
+            },
+            "default": "block"
+        },
+        "ssl.fastly.net": {
+            "owner": {
+                "name": "Fastly, Inc.",
+                "displayName": "Fastly"
+            },
+            "default": "ignore"
+        },
+        "ssp.yahoo.com": {
+            "owner": {
+                "name": "Verizon Media",
+                "displayName": "Verizon Media"
+            },
+            "default": "block"
+        },
+        "ssum-sec.casalemedia.com": {
+            "owner": {
+                "name": "Index Exchange, Inc.",
+                "displayName": "Index Exchange"
+            },
+            "default": "block"
+        },
+        "ssum.casalemedia.com": {
+            "owner": {
+                "name": "Index Exchange, Inc.",
+                "displayName": "Index Exchange"
+            },
+            "default": "block"
+        },
+        "stags.bluekai.com": {
+            "owner": {
+                "name": "Oracle Corporation",
+                "displayName": "Oracle"
+            },
+            "default": "block"
+        },
+        "static.ads-twitter.com": {
+            "owner": {
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
+            },
+            "default": "block"
+        },
+        "static.adsafeprotected.com": {
+            "owner": {
+                "name": "Integral Ad Science, Inc.",
+                "displayName": "Integral Ad Science"
+            },
+            "default": "block"
+        },
+        "storage.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "sync-t1.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "sync-tm.everesttech.net": {
+            "owner": {
+                "name": "Adobe Inc.",
+                "displayName": "Adobe"
+            },
+            "default": "block"
+        },
+        "sync.1rx.io": {
+            "owner": {
+                "name": "RhythmOne",
+                "displayName": "RhythmOne"
+            },
+            "default": "block"
+        },
+        "sync.adotmob.com": {
+            "owner": {
+                "name": "A.Mob SAS",
+                "displayName": "A.Mob"
+            },
+            "default": "block"
+        },
+        "sync.crwdcntrl.net": {
+            "owner": {
+                "name": "Lotame Solutions, Inc.",
+                "displayName": "Lotame Solutions"
+            },
+            "default": "block"
+        },
+        "sync.mathtag.com": {
+            "owner": {
+                "name": "MediaMath, Inc.",
+                "displayName": "MediaMath"
+            },
+            "default": "block"
+        },
+        "sync.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "sync.teads.tv": {
+            "owner": {
+                "name": "Teads ( Luxenbourg ) SA",
+                "displayName": "Teads"
+            },
+            "default": "block"
+        },
+        "sync.technoratimedia.com": {
+            "owner": {
+                "name": "Synacor, Inc.",
+                "displayName": "Synacor"
+            },
+            "default": "block"
+        },
+        "syndication.twitter.com": {
+            "owner": {
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
+            },
+            "default": "block"
+        },
+        "t.appsflyer.com": {
+            "owner": {
+                "name": "AppsFlyer",
+                "displayName": "AppsFlyer"
+            },
+            "default": "block"
+        },
+        "t.co": {
+            "owner": {
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
+            },
+            "default": "ignore"
+        },
+        "tags.bluekai.com": {
+            "owner": {
+                "name": "Oracle Corporation",
+                "displayName": "Oracle"
+            },
+            "default": "block"
+        },
+        "tapestry.tapad.com": {
+            "owner": {
+                "name": "Tapad, Inc.",
+                "displayName": "Tapad"
+            },
+            "default": "block"
+        },
+        "targeting.unrulymedia.com": {
+            "owner": {
+                "name": "Unruly Group Limited",
+                "displayName": "Unruly Group"
+            },
+            "default": "block"
+        },
+        "tlx.3lift.com": {
+            "owner": {
+                "name": "TripleLift",
+                "displayName": "TripleLift"
+            },
+            "default": "block"
+        },
+        "token.rubiconproject.com": {
+            "owner": {
+                "name": "Magnite, Inc.",
+                "displayName": "Magnite"
+            },
+            "default": "block"
+        },
+        "tpc.googlesyndication.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "tps.doubleverify.com": {
+            "owner": {
+                "name": "DoubleVerify",
+                "displayName": "DoubleVerify"
+            },
+            "default": "block"
+        },
+        "tr.snapchat.com": {
+            "owner": {
+                "name": "Snap Inc.",
+                "displayName": "Snap"
+            },
+            "default": "block"
+        },
+        "track.atom-data.io": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "trc-events.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "trc.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "tt.omtrdc.net": {
+            "owner": {
+                "name": "Adobe Inc.",
+                "displayName": "Adobe"
+            },
+            "default": "block"
+        },
+        "twitter.com": {
+            "owner": {
+                "name": "Twitter, Inc.",
+                "displayName": "Twitter"
+            },
+            "default": "block"
+        },
+        "uk-script.dotmetrics.net": {
+            "owner": {
+                "name": "Dotmetrics",
+                "displayName": "Dotmetrics"
+            },
+            "default": "block"
+        },
+        "um.simpli.fi": {
+            "owner": {
+                "name": "Simplifi Holdings Inc.",
+                "displayName": "Simplifi Holdings"
+            },
+            "default": "block"
+        },
+        "ums.acuityplatform.com": {
+            "owner": {
+                "name": "AcuityAds",
+                "displayName": "AcuityAds"
+            },
+            "default": "block"
+        },
+        "unityads.unity3d.com": {
+            "owner": {
+                "name": "Unity Technologies ApS",
+                "displayName": "Unity"
+            },
+            "default": "block"
+        },
+        "update.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "us-east-1.amazonaws.com": {
+            "owner": {
+                "name": "Amazon Technologies, Inc.",
+                "displayName": "Amazon.com"
+            },
+            "default": "ignore"
+        },
+        "us-u.openx.net": {
+            "owner": {
+                "name": "OpenX Technologies Inc",
+                "displayName": "OpenX"
+            },
+            "default": "block"
+        },
+        "us.criteo.com": {
+            "owner": {
+                "name": "Criteo SA",
+                "displayName": "Criteo"
+            },
+            "default": "block"
+        },
+        "use-tor.adsrvr.org": {
+            "owner": {
+                "name": "The Trade Desk Inc",
+                "displayName": "The Trade Desk"
+            },
+            "default": "block"
+        },
+        "usermatch.krxd.net": {
+            "owner": {
+                "name": "Salesforce.com, Inc.",
+                "displayName": "Salesforce.com"
+            },
+            "default": "block"
+        },
+        "v.fwmrm.net": {
+            "owner": {
+                "name": "FreeWheel",
+                "displayName": "FreeWheel"
+            },
+            "default": "block"
+        },
+        "vidstat.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "view.adjust.com": {
+            "owner": {
+                "name": "Adjust GmbH",
+                "displayName": "Adjust"
+            },
+            "default": "block"
+        },
+        "web.facebook.com": {
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook"
+            },
+            "default": "block"
+        },
+        "wf.taboola.com": {
+            "owner": {
+                "name": "Taboola, Inc.",
+                "displayName": "Taboola"
+            },
+            "default": "block"
+        },
+        "wins.isprog.com": {
+            "owner": {
+                "name": "ironSource Ltd",
+                "displayName": "ironSource"
+            },
+            "default": "block"
+        },
+        "ws.tapjoyads.com": {
+            "owner": {
+                "name": "Tapjoy, Inc.",
+                "displayName": "Tapjoy"
+            },
+            "default": "block"
+        },
+        "wv.inner-active.mobi": {
+            "owner": {
+                "name": "Digital Turbine",
+                "displayName": "AdColony"
+            },
+            "default": "block"
+        },
+        "www.facebook.com": {
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook"
+            },
+            "default": "block"
+        },
+        "www.google-analytics.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "www.google.co.uk": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "www.google.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "www.googleadservices.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "www.googleapis.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "www.googletagmanager.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "www.googletagservices.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "block"
+        },
+        "www.gstatic.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "www.instagram.com": {
+            "owner": {
+                "name": "Facebook, Inc.",
+                "displayName": "Facebook"
+            },
+            "default": "block"
+        },
+        "www.linkedin.com": {
+            "owner": {
+                "name": "Microsoft Corporation",
+                "displayName": "Microsoft"
+            },
+            "default": "block"
+        },
+        "www.youtube.com": {
+            "owner": {
+                "name": "Google LLC",
+                "displayName": "Google"
+            },
+            "default": "ignore"
+        },
+        "x.bidswitch.net": {
+            "owner": {
+                "name": "IPONWEB GmbH",
+                "displayName": "IPONWEB"
+            },
+            "default": "block"
+        },
+        "ybp.yahoo.com": {
+            "owner": {
+                "name": "Verizon Media",
+                "displayName": "Verizon Media"
+            },
+            "default": "block"
+        }
+    },
+    "packageNames": {
+        "air.com.adobe.connectpro": "Adobe Inc.",
+        "amazon.speech.sim": "Amazon Technologies, Inc.",
+        "app.zenly.locator": "Snap Inc.",
+        "co.vine.android": "Twitter, Inc.",
+        "com.adjust.insights": "Adjust GmbH",
+        "com.adobe.adobephotoshopfix": "Adobe Inc.",
+        "com.adobe.aem.forms": "Adobe Inc.",
+        "com.adobe.aero.android": "Adobe Inc.",
+        "com.adobe.analyticsdashboards": "Adobe Inc.",
+        "com.adobe.captivateprime": "Adobe Inc.",
+        "com.adobe.cc": "Adobe Inc.",
+        "com.adobe.comp": "Adobe Inc.",
+        "com.adobe.creativeapps.draw": "Adobe Inc.",
+        "com.adobe.creativeapps.gather": "Adobe Inc.",
+        "com.adobe.creativeapps.sketch": "Adobe Inc.",
+        "com.adobe.digitaleditions": "Adobe Inc.",
+        "com.adobe.echosign": "Adobe Inc.",
+        "com.adobe.fas": "Adobe Inc.",
+        "com.adobe.ims.accountaccess": "Adobe Inc.",
+        "com.adobe.ims.push.android": "Adobe Inc.",
+        "com.adobe.lens.android": "Adobe Inc.",
+        "com.adobe.lrmobile": "Adobe Inc.",
+        "com.adobe.monocle.companion": "Adobe Inc.",
+        "com.adobe.phonegap.app": "Adobe Inc.",
+        "com.adobe.photoshopmix": "Adobe Inc.",
+        "com.adobe.premiererush.videoeditor": "Adobe Inc.",
+        "com.adobe.psmobile": "Adobe Inc.",
+        "com.adobe.reader": "Adobe Inc.",
+        "com.adobe.scan.android": "Adobe Inc.",
+        "com.adobe.spark.post": "Adobe Inc.",
+        "com.adobe.sparklerandroid": "Adobe Inc.",
+        "com.amazon.aa": "Amazon Technologies, Inc.",
+        "com.amazon.aa.attribution": "Amazon Technologies, Inc.",
+        "com.amazon.amazonvideo.livingroom": "Amazon Technologies, Inc.",
+        "com.amazon.appmanager": "Amazon Technologies, Inc.",
+        "com.amazon.avod.thirdpartyclient": "Amazon Technologies, Inc.",
+        "com.amazon.aws.honeycode": "Amazon Technologies, Inc.",
+        "com.amazon.chime": "Amazon Technologies, Inc.",
+        "com.amazon.clouddrive.photos": "Amazon Technologies, Inc.",
+        "com.amazon.cosmos": "Amazon Technologies, Inc.",
+        "com.amazon.dee.app": "Amazon Technologies, Inc.",
+        "com.amazon.drive": "Amazon Technologies, Inc.",
+        "com.amazon.fv": "Amazon Technologies, Inc.",
+        "com.amazon.healthtech.malibu": "Amazon Technologies, Inc.",
+        "com.amazon.kindle": "Amazon Technologies, Inc.",
+        "com.amazon.mShop.android": "Amazon Technologies, Inc.",
+        "com.amazon.mShop.android.business.shopping": "Amazon Technologies, Inc.",
+        "com.amazon.mShop.android.shopping": "Amazon Technologies, Inc.",
+        "com.amazon.mShop.android.shopping.vpl": "Amazon Technologies, Inc.",
+        "com.amazon.mp3": "Amazon Technologies, Inc.",
+        "com.amazon.muse": "Amazon Technologies, Inc.",
+        "com.amazon.music.tv": "Amazon Technologies, Inc.",
+        "com.amazon.now": "Amazon Technologies, Inc.",
+        "com.amazon.phseven.prod": "Amazon Technologies, Inc.",
+        "com.amazon.relay": "Amazon Technologies, Inc.",
+        "com.amazon.sellermobile.android": "Amazon Technologies, Inc.",
+        "com.amazon.shopperpanel.android.mobile.app": "Amazon Technologies, Inc.",
+        "com.amazon.storm.lightning.client.aosp": "Amazon Technologies, Inc.",
+        "com.amazon.venezia": "Amazon Technologies, Inc.",
+        "com.amazon.widgets": "Amazon Technologies, Inc.",
+        "com.amazon.windowshop": "Amazon Technologies, Inc.",
+        "com.amazon.ziggy.android": "Amazon Technologies, Inc.",
+        "com.android.chrome": "Google LLC",
+        "com.android.hotwordenrollment.okgoogle": "Google LLC",
+        "com.android.hotwordenrollment.xgoogle": "Google LLC",
+        "com.android.partnerbrowsercustomizations.chromeHomepage": "Google LLC",
+        "com.android.vending": "Google LLC",
+        "com.aol.mobile.aolapp": "Verizon Media",
+        "com.aol.mobile.techcrunch": "Verizon Media",
+        "com.appsflyer.adNetworkTest": "AppsFlyer",
+        "com.appsflyer.afsupportapp": "AppsFlyer",
+        "com.appsflyer.analytics": "AppsFlyer",
+        "com.appsflyer.android.deviceid": "AppsFlyer",
+        "com.appsflyer.app.ezshop": "AppsFlyer",
+        "com.appsflyer.onelinksimulator": "AppsFlyer",
+        "com.azure.authenticator": "Microsoft Corporation",
+        "com.bitstrips.imoji": "Snap Inc.",
+        "com.chrome.beta": "Google LLC",
+        "com.chrome.canary": "Google LLC",
+        "com.chrome.dev": "Google LLC",
+        "com.desk.android": "Salesforce.com, Inc.",
+        "com.facebook.Origami": "Facebook, Inc.",
+        "com.facebook.adsmanager": "Facebook, Inc.",
+        "com.facebook.analytics": "Facebook, Inc.",
+        "com.facebook.appmanager": "Facebook, Inc.",
+        "com.facebook.arstudio.player": "Facebook, Inc.",
+        "com.facebook.bishop": "Facebook, Inc.",
+        "com.facebook.creatorstudio": "Facebook, Inc.",
+        "com.facebook.games": "Facebook, Inc.",
+        "com.facebook.katana": "Facebook, Inc.",
+        "com.facebook.lite": "Facebook, Inc.",
+        "com.facebook.mlite": "Facebook, Inc.",
+        "com.facebook.orca": "Facebook, Inc.",
+        "com.facebook.pages.app": "Facebook, Inc.",
+        "com.facebook.services": "Facebook, Inc.",
+        "com.facebook.study": "Facebook, Inc.",
+        "com.facebook.system": "Facebook, Inc.",
+        "com.facebook.talk": "Facebook, Inc.",
+        "com.facebook.viewpoints": "Facebook, Inc.",
+        "com.facebook.work": "Facebook, Inc.",
+        "com.facebook.workchat": "Facebook, Inc.",
+        "com.fitbit.FitbitMobile": "Google LLC",
+        "com.flurry.instantapp.test.app": "Verizon Media",
+        "com.foursquare.marsbot": "Foursquare Labs, Inc.",
+        "com.foursquare.pilgrimdemo": "Foursquare Labs, Inc.",
+        "com.foursquare.robin": "Foursquare Labs, Inc.",
+        "com.gamepass": "Microsoft Corporation",
+        "com.gamepass.beta": "Microsoft Corporation",
+        "com.google.android.apps.access.wifi.consumer": "Google LLC",
+        "com.google.android.apps.adm": "Google LLC",
+        "com.google.android.apps.ads.publisher": "Google LLC",
+        "com.google.android.apps.adwords": "Google LLC",
+        "com.google.android.apps.authenticator2": "Google LLC",
+        "com.google.android.apps.blogger": "Google LLC",
+        "com.google.android.apps.books": "Google LLC",
+        "com.google.android.apps.chromecast.app": "Google LLC",
+        "com.google.android.apps.cloudprint": "Google LLC",
+        "com.google.android.apps.cultural": "Google LLC",
+        "com.google.android.apps.currents": "Google LLC",
+        "com.google.android.apps.docs": "Google LLC",
+        "com.google.android.apps.docs.editors.docs": "Google LLC",
+        "com.google.android.apps.docs.editors.sheets": "Google LLC",
+        "com.google.android.apps.docs.editors.slides": "Google LLC",
+        "com.google.android.apps.dynamite": "Google LLC",
+        "com.google.android.apps.enterprise.cpanel": "Google LLC",
+        "com.google.android.apps.enterprise.dmagent": "Google LLC",
+        "com.google.android.apps.fireball": "Google LLC",
+        "com.google.android.apps.fitness": "Google LLC",
+        "com.google.android.apps.freighter": "Google LLC",
+        "com.google.android.apps.giant": "Google LLC",
+        "com.google.android.apps.googleassistant": "Google LLC",
+        "com.google.android.apps.googlevoice": "Google LLC",
+        "com.google.android.apps.handwriting.ime": "Google LLC",
+        "com.google.android.apps.hangoutsdialer": "Google LLC",
+        "com.google.android.apps.inbox": "Google LLC",
+        "com.google.android.apps.kids.familylink": "Google LLC",
+        "com.google.android.apps.kids.familylinkhelper": "Google LLC",
+        "com.google.android.apps.m4b": "Google LLC",
+        "com.google.android.apps.magazines": "Google LLC",
+        "com.google.android.apps.maps": "Google LLC",
+        "com.google.android.apps.mapslite": "Google LLC",
+        "com.google.android.apps.meetings": "Google LLC",
+        "com.google.android.apps.messaging": "Google LLC",
+        "com.google.android.apps.navlite": "Google LLC",
+        "com.google.android.apps.nbu.files": "Google LLC",
+        "com.google.android.apps.nbu.paisa.user": "Google LLC",
+        "com.google.android.apps.paidtasks": "Google LLC",
+        "com.google.android.apps.pdfviewer": "Google LLC",
+        "com.google.android.apps.photos": "Google LLC",
+        "com.google.android.apps.photos.scanner": "Google LLC",
+        "com.google.android.apps.photosgo": "Google LLC",
+        "com.google.android.apps.plus": "Google LLC",
+        "com.google.android.apps.podcasts": "Google LLC",
+        "com.google.android.apps.recorder": "Google LLC",
+        "com.google.android.apps.restore": "Google LLC",
+        "com.google.android.apps.santatracker": "Google LLC",
+        "com.google.android.apps.setupwizard.searchselector": "Google LLC",
+        "com.google.android.apps.subscriptions.red": "Google LLC",
+        "com.google.android.apps.tachyon": "Google LLC",
+        "com.google.android.apps.tasks": "Google LLC",
+        "com.google.android.apps.translate": "Google LLC",
+        "com.google.android.apps.travel.onthego": "Google LLC",
+        "com.google.android.apps.tycho": "Google LLC",
+        "com.google.android.apps.uploader": "Google LLC",
+        "com.google.android.apps.vega": "Google LLC",
+        "com.google.android.apps.walletnfcrel": "Google LLC",
+        "com.google.android.apps.wallpaper": "Google LLC",
+        "com.google.android.apps.wellbeing": "Google LLC",
+        "com.google.android.apps.work.oobconfig": "Google LLC",
+        "com.google.android.apps.youtube.creator": "Google LLC",
+        "com.google.android.apps.youtube.gaming": "Google LLC",
+        "com.google.android.apps.youtube.kids": "Google LLC",
+        "com.google.android.apps.youtube.music": "Google LLC",
+        "com.google.android.apps.youtube.unplugged": "Google LLC",
+        "com.google.android.apps.youtube.vr": "Google LLC",
+        "com.google.android.backup": "Google LLC",
+        "com.google.android.backuptransport": "Google LLC",
+        "com.google.android.calculator": "Google LLC",
+        "com.google.android.calendar": "Google LLC",
+        "com.google.android.configupdater": "Google LLC",
+        "com.google.android.contacts": "Google LLC",
+        "com.google.android.deskclock": "Google LLC",
+        "com.google.android.dialer": "Google LLC",
+        "com.google.android.email": "Google LLC",
+        "com.google.android.feedback": "Google LLC",
+        "com.google.android.gm": "Google LLC",
+        "com.google.android.gm.lite": "Google LLC",
+        "com.google.android.gms.location.history": "Google LLC",
+        "com.google.android.gms.policy_sidecar_aps": "Google LLC",
+        "com.google.android.googlequicksearchbox": "Google LLC",
+        "com.google.android.inputmethod.latin": "Google LLC",
+        "com.google.android.instantapps.supervisor": "Google LLC",
+        "com.google.android.keep": "Google LLC",
+        "com.google.android.markup": "Google LLC",
+        "com.google.android.marvin.talkback": "Google LLC",
+        "com.google.android.music": "Google LLC",
+        "com.google.android.onetimeinitializer": "Google LLC",
+        "com.google.android.partnersetup": "Google LLC",
+        "com.google.android.pixel.setupwizard": "Google LLC",
+        "com.google.android.play.games": "Google LLC",
+        "com.google.android.printservice.recommendation": "Google LLC",
+        "com.google.android.projection.gearhead": "Google LLC",
+        "com.google.android.setupwizard": "Google LLC",
+        "com.google.android.setupwizard.a_overlay": "Google LLC",
+        "com.google.android.soundpicker": "Google LLC",
+        "com.google.android.street": "Google LLC",
+        "com.google.android.syncadapters.bookmarks": "Google LLC",
+        "com.google.android.syncadapters.calendar": "Google LLC",
+        "com.google.android.syncadapters.contacts": "Google LLC",
+        "com.google.android.tag": "Google LLC",
+        "com.google.android.talk": "Google LLC",
+        "com.google.android.tts": "Google LLC",
+        "com.google.android.tv.remote": "Google LLC",
+        "com.google.android.videoeditor": "Google LLC",
+        "com.google.android.videos": "Google LLC",
+        "com.google.android.voicesearch": "Google LLC",
+        "com.google.android.vr.home": "Google LLC",
+        "com.google.android.vr.inputmethod": "Google LLC",
+        "com.google.android.wearable.app": "Google LLC",
+        "com.google.android.youtube": "Google LLC",
+        "com.google.ar.core": "Google LLC",
+        "com.google.ar.lens": "Google LLC",
+        "com.google.audio.hearing.visualization.accessibility.scribe": "Google LLC",
+        "com.google.chromeremotedesktop": "Google LLC",
+        "com.google.earth": "Google LLC",
+        "com.google.marvin.talkback": "Google LLC",
+        "com.google.samples.apps.cardboarddemo": "Google LLC",
+        "com.google.socratic": "Google LLC",
+        "com.google.tango.measure": "Google LLC",
+        "com.google.vr.cyclops": "Google LLC",
+        "com.google.vr.expeditions": "Google LLC",
+        "com.google.vr.vrcore": "Google LLC",
+        "com.google.zxing.client.android": "Google LLC",
+        "com.groupme.android": "Microsoft Corporation",
+        "com.imdb.mobile": "Amazon Technologies, Inc.",
+        "com.imdb.pro.mobile.android": "Amazon Technologies, Inc.",
+        "com.imdbtv.livingroom": "Amazon Technologies, Inc.",
+        "com.instagram.android": "Facebook, Inc.",
+        "com.instagram.boomerang": "Facebook, Inc.",
+        "com.instagram.igtv": "Facebook, Inc.",
+        "com.instagram.layout": "Facebook, Inc.",
+        "com.instagram.threadsapp": "Facebook, Inc.",
+        "com.joelapenna.foursquared": "Foursquare Labs, Inc.",
+        "com.lemon.lvoverseas": "ByteDance Ltd.",
+        "com.linkedin.android": "Microsoft Corporation",
+        "com.linkedin.android.learning": "Microsoft Corporation",
+        "com.linkedin.android.salesnavigator": "Microsoft Corporation",
+        "com.linkedin.leap": "Microsoft Corporation",
+        "com.linkedin.recruiter": "Microsoft Corporation",
+        "com.lynda.android.root": "Microsoft Corporation",
+        "com.mapbox.locate": "Mapbox Inc.",
+        "com.mapbox.mapboxandroiddemo": "Mapbox Inc.",
+        "com.mapbox.studio": "Mapbox Inc.",
+        "com.mapbox.vision.teaser": "Mapbox Inc.",
+        "com.microsoft.amp.apps.bingfinance": "Microsoft Corporation",
+        "com.microsoft.amp.apps.bingnews": "Microsoft Corporation",
+        "com.microsoft.android.smsorganizer": "Microsoft Corporation",
+        "com.microsoft.appmanager": "Microsoft Corporation",
+        "com.microsoft.azure": "Microsoft Corporation",
+        "com.microsoft.bing": "Microsoft Corporation",
+        "com.microsoft.emmx": "Microsoft Corporation",
+        "com.microsoft.emmx.canary": "Microsoft Corporation",
+        "com.microsoft.familysafety": "Microsoft Corporation",
+        "com.microsoft.gravity": "Microsoft Corporation",
+        "com.microsoft.hyperlapsemobile": "Microsoft Corporation",
+        "com.microsoft.intune": "Microsoft Corporation",
+        "com.microsoft.ipviewer": "Microsoft Corporation",
+        "com.microsoft.launcher": "Microsoft Corporation",
+        "com.microsoft.mahjong": "Microsoft Corporation",
+        "com.microsoft.math": "Microsoft Corporation",
+        "com.microsoft.microsoftsolitairecollection": "Microsoft Corporation",
+        "com.microsoft.mobile.polymer": "Microsoft Corporation",
+        "com.microsoft.msapps": "Microsoft Corporation",
+        "com.microsoft.office.excel": "Microsoft Corporation",
+        "com.microsoft.office.lync15": "Microsoft Corporation",
+        "com.microsoft.office.officehub": "Microsoft Corporation",
+        "com.microsoft.office.officehubhl": "Microsoft Corporation",
+        "com.microsoft.office.officehubrow": "Microsoft Corporation",
+        "com.microsoft.office.officelens": "Microsoft Corporation",
+        "com.microsoft.office.onenote": "Microsoft Corporation",
+        "com.microsoft.office.outlook": "Microsoft Corporation",
+        "com.microsoft.office.powerpoint": "Microsoft Corporation",
+        "com.microsoft.office.word": "Microsoft Corporation",
+        "com.microsoft.planner": "Microsoft Corporation",
+        "com.microsoft.powerbim": "Microsoft Corporation",
+        "com.microsoft.rdc.android": "Microsoft Corporation",
+        "com.microsoft.rdc.androidx": "Microsoft Corporation",
+        "com.microsoft.scmx": "Microsoft Corporation",
+        "com.microsoft.sharepoint": "Microsoft Corporation",
+        "com.microsoft.skydrive": "Microsoft Corporation",
+        "com.microsoft.stream": "Microsoft Corporation",
+        "com.microsoft.sudoku": "Microsoft Corporation",
+        "com.microsoft.teams": "Microsoft Corporation",
+        "com.microsoft.todos": "Microsoft Corporation",
+        "com.microsoft.translator": "Microsoft Corporation",
+        "com.microsoft.whiteboard.publicpreview": "Microsoft Corporation",
+        "com.microsoft.windowsintune.companyportal": "Microsoft Corporation",
+        "com.microsoft.wordament": "Microsoft Corporation",
+        "com.microsoft.xboxfamily": "Microsoft Corporation",
+        "com.microsoft.xboxone.smartglass": "Microsoft Corporation",
+        "com.microsoft.xboxone.smartglass.beta": "Microsoft Corporation",
+        "com.microsoft.xcloud": "Microsoft Corporation",
+        "com.mobilemotion.dubsmash": "Reddit Inc.",
+        "com.ms.office365admin": "Microsoft Corporation",
+        "com.nest.android": "Google LLC",
+        "com.newrelic.rpm": "New Relic",
+        "com.niksoftware.snapseed": "Google LLC",
+        "com.oath.MediaAnalytics": "Verizon Media",
+        "com.pinterest": "Pinterest, Inc.",
+        "com.pinterest.twa": "Pinterest, Inc.",
+        "com.reddit.frontpage": "Reddit Inc.",
+        "com.relateiq.android": "Salesforce.com, Inc.",
+        "com.ringapp": "Amazon Technologies, Inc.",
+        "com.roku.remote": "Roku, Inc.",
+        "com.salesforce.admin1": "Salesforce.com, Inc.",
+        "com.salesforce.authenticator": "Salesforce.com, Inc.",
+        "com.salesforce.chatter": "Salesforce.com, Inc.",
+        "com.salesforce.dreamoji": "Salesforce.com, Inc.",
+        "com.salesforce.fieldservice.app": "Salesforce.com, Inc.",
+        "com.salesforce.marketingcloud": "Salesforce.com, Inc.",
+        "com.salesforce.socialstudio": "Salesforce.com, Inc.",
+        "com.salesforce.trailheadgo.app": "Salesforce.com, Inc.",
+        "com.salesforce.wave": "Salesforce.com, Inc.",
+        "com.sewichi.client.panel": "Foursquare Labs, Inc.",
+        "com.skype.insiders": "Microsoft Corporation",
+        "com.skype.raider": "Microsoft Corporation",
+        "com.snapchat.android": "Snap Inc.",
+        "com.ss.android.ugc.trill": "ByteDance Ltd.",
+        "com.taboola.newsroomMobile": "Taboola, Inc.",
+        "com.touchtype.swiftkey": "Microsoft Corporation",
+        "com.touchtype.swiftkey.beta": "Microsoft Corporation",
+        "com.twitter.android": "Twitter, Inc.",
+        "com.verizonmedia.makers": "Verizon Media",
+        "com.waze": "Google LLC",
+        "com.whatsapp": "Facebook, Inc.",
+        "com.yahoo.apps.yahooapp": "Verizon Media",
+        "com.yahoo.flurry": "Verizon Media",
+        "com.yahoo.harmony": "Verizon Media",
+        "com.yahoo.infohub": "Verizon Media",
+        "com.yahoo.mobile.client.android.ecshopping": "Verizon Media",
+        "com.yahoo.mobile.client.android.fantasyfootball": "Verizon Media",
+        "com.yahoo.mobile.client.android.finance": "Verizon Media",
+        "com.yahoo.mobile.client.android.finance.androidtv": "Verizon Media",
+        "com.yahoo.mobile.client.android.mail": "Verizon Media",
+        "com.yahoo.mobile.client.android.mail.lite": "Verizon Media",
+        "com.yahoo.mobile.client.android.nativemail": "Verizon Media",
+        "com.yahoo.mobile.client.android.search": "Verizon Media",
+        "com.yahoo.mobile.client.android.sportacular": "Verizon Media",
+        "com.yahoo.mobile.client.android.weather": "Verizon Media",
+        "com.yahoo.mobile.client.android.yahoo": "Verizon Media",
+        "com.yahoo.onesearch": "Verizon Media",
+        "com.yahoo.otterdroid": "Verizon Media",
+        "com.yahoo.wwww.twa": "Verizon Media",
+        "com.yandex.browser": "Yandex LLC",
+        "com.yandex.courier": "Yandex LLC",
+        "com.yandex.mobile.drive": "Yandex LLC",
+        "com.yandex.q": "Yandex LLC",
+        "com.yandex.qmobile": "Yandex LLC",
+        "com.yandex.yamb": "Yandex LLC",
+        "com.zhiliao.musically.livewallpaper": "ByteDance Ltd.",
+        "com.zhiliaoapp.musically": "ByteDance Ltd.",
+        "dev.firebase.appdistribution": "Google LLC",
+        "in.amazon.mShop.android.shopping": "Amazon Technologies, Inc.",
+        "io.branch.android.discovery": "Branch Metrics, Inc.",
+        "io.branch.branchster": "Branch Metrics, Inc.",
+        "io.branch.deviceid": "Branch Metrics, Inc.",
+        "io.branch.sample.hellobranch": "Branch Metrics, Inc.",
+        "nexti.android.bustaichung": "Verizon Media",
+        "nexti.android.bustaipei": "Verizon Media",
+        "nexti.android.bustaiwan": "Verizon Media",
+        "org.salesforce.philanthropycloud": "Salesforce.com, Inc.",
+        "ru.auto.ara": "Yandex LLC",
+        "ru.foodfox.client": "Yandex LLC",
+        "ru.foodfox.courier.debug.releaseserver": "Yandex LLC",
+        "ru.foodfox.vendor": "Yandex LLC",
+        "ru.kinopoisk": "Yandex LLC",
+        "ru.kinopoisk.tv": "Yandex LLC",
+        "ru.theexpert.app": "Yandex LLC",
+        "ru.yandex.direct": "Yandex LLC",
+        "ru.yandex.disk": "Yandex LLC",
+        "ru.yandex.disk.beta": "Yandex LLC",
+        "ru.yandex.key": "Yandex LLC",
+        "ru.yandex.mail": "Yandex LLC",
+        "ru.yandex.market": "Yandex LLC",
+        "ru.yandex.market.partner": "Yandex LLC",
+        "ru.yandex.med": "Yandex LLC",
+        "ru.yandex.metro": "Yandex LLC",
+        "ru.yandex.mobile.appmetrica": "Yandex LLC",
+        "ru.yandex.mobile.avia": "Yandex LLC",
+        "ru.yandex.mobile.gasstations": "Yandex LLC",
+        "ru.yandex.mobile.metrica": "Yandex LLC",
+        "ru.yandex.music": "Yandex LLC",
+        "ru.yandex.nokiasystemservice": "Yandex LLC",
+        "ru.yandex.rasp": "Yandex LLC",
+        "ru.yandex.searchplugin": "Yandex LLC",
+        "ru.yandex.searchplugin.beta": "Yandex LLC",
+        "ru.yandex.taxi": "Yandex LLC",
+        "ru.yandex.taximeter": "Yandex LLC",
+        "ru.yandex.taximeter.beta": "Yandex LLC",
+        "ru.yandex.telemed.doctor": "Yandex LLC",
+        "ru.yandex.telemost": "Yandex LLC",
+        "ru.yandex.weatherplugin": "Yandex LLC",
+        "ru.yandex.yandexmaps": "Yandex LLC",
+        "ru.yandex.yandexnavi": "Yandex LLC",
+        "tv.twitch.android.app": "Amazon Technologies, Inc.",
+        "yandex.auto.mobile": "Yandex LLC"
+    },
+    "entities": {
+        "33Across, Inc.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "A.Mob SAS": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_language",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "AcuityAds": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_language",
+                "device_make",
+                "os_version",
+                "app_name",
+                "country",
+                "platform"
+            ]
+        },
+        "Adform A/S": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Adjust GmbH": {
+            "signals": [
+                "phone_number",
+                "email_address",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "platform"
+            ]
+        },
+        "Adkernel, LLC": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_connectivity",
+                "device_model",
+                "device_language",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "ADman Media": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_language",
+                "device_make",
+                "os_version",
+                "app_name",
+                "country",
+                "platform"
+            ]
+        },
+        "Adobe Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "email_address",
+                "neighborhood",
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "network_carrier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_model",
+                "install_date",
+                "device_language",
+                "device_connectivity",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "timezone",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "AdRoll, Inc.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Adscore Technologies DMCC": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "platform"
+            ]
+        },
+        "AdTheorent Inc": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_language",
+                "device_make",
+                "os_version",
+                "app_name",
+                "country",
+                "platform"
+            ]
+        },
+        "Amazon Technologies, Inc.": {
+            "signals": [
+                "email_address",
+                "password",
+                "username",
+                "gps_coordinates",
+                "first_name",
+                "last_name",
+                "neighborhood",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "accelerometer_data",
+                "state",
+                "network_carrier",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_language",
+                "device_connectivity",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "device_screen_density",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Amobee, Inc": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Amplitude": {
+            "signals": [
+                "gps_coordinates",
+                "username",
+                "first_name",
+                "birthday",
+                "neighborhood",
+                "postal_code",
+                "AAID",
+                "city",
+                "device_boot_time",
+                "unique_identifier",
+                "state",
+                "device_font_size",
+                "birth_year",
+                "network_carrier",
+                "device_headphone_status",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "device_connectivity",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "device_screen_density",
+                "timezone",
+                "platform"
+            ]
+        },
+        "AppLovin Corporation": {
+            "signals": [
+                "gps_coordinates",
+                "neighborhood",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_language",
+                "device_connectivity",
+                "app_name",
+                "device_make",
+                "country",
+                "os_version",
+                "device_screen_density",
+                "timezone",
+                "platform"
+            ]
+        },
+        "AppsFlyer": {
+            "signals": [
+                "device_magnetometer",
+                "AAID",
+                "unique_identifier",
+                "accelerometer_data",
+                "network_carrier",
+                "cookies",
+                "device_battery_level",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "first_launch_date",
+                "install_date",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "platform"
+            ]
+        },
+        "Apptentive Inc.": {
+            "signals": [
+                "phone_number",
+                "birthday",
+                "unique_identifier",
+                "network_carrier",
+                "cpu_data",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Avocet Systems Ltd.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Beeswax": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Bidtellect, Inc": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Branch Metrics, Inc.": {
+            "signals": [
+                "email_address",
+                "username",
+                "phone_number",
+                "first_name",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "local_ip",
+                "network_carrier",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "install_date",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "dialing_code",
+                "device_screen_density",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Braze, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "email_address",
+                "first_name",
+                "last_name",
+                "postal_code",
+                "neighborhood",
+                "city",
+                "AAID",
+                "unique_identifier",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "timezone",
+                "device_screen_density",
+                "platform"
+            ]
+        },
+        "Bugsnag Inc.": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "device_free_storage",
+                "device_free_memory",
+                "device_battery_level",
+                "device_total_memory",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "device_screen_density",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "ByteDance Ltd.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Centro, Inc.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Collective Roll": {
+            "signals": [
+                "neighborhood",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "comScore, Inc": {
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "city",
+                "AAID",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "device_total_memory",
+                "cpu_data",
+                "device_model",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_connectivity",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "Criteo SA": {
+            "signals": [
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_model",
+                "device_language",
+                "device_connectivity",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Datadog, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "city",
+                "unique_identifier",
+                "state",
+                "device_battery_level",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_model",
+                "app_name",
+                "os_version",
+                "device_screen_density",
+                "platform"
+            ]
+        },
+        "DeepIntent Inc": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Digital Turbine": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "mac_address",
+                "device_free_memory",
+                "network_carrier",
+                "cookies",
+                "device_battery_level",
+                "cpu_data",
+                "device_headphone_status",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Dotmetrics": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "device_total_memory",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "timezone",
+                "platform"
+            ]
+        },
+        "DoubleVerify": {
+            "signals": [
+                "gps_coordinates",
+                "neighborhood",
+                "AAID",
+                "unique_identifier",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Engine USA LLC": {
+            "signals": [
+                "city",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Exponential Interactive Inc.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "eyeota Limited": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Facebook, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "email_address",
+                "username",
+                "first_name",
+                "last_name",
+                "postal_code",
+                "birthday",
+                "neighborhood",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "gender",
+                "accelerometer_data",
+                "device_free_storage",
+                "rotation_data",
+                "state",
+                "device_free_memory",
+                "network_carrier",
+                "cookies",
+                "device_volume",
+                "device_total_memory",
+                "device_headphone_status",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "device_screen_density",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Fastly, Inc.": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Flashtalking Inc": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "cpu_data",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Foursquare Labs, Inc.": {
+            "signals": [
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_model",
+                "app_name",
+                "os_version",
+                "platform"
+            ]
+        },
+        "FreeWheel": {
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Functional Software, Inc.": {
+            "signals": [
+                "device_name",
+                "device_boot_time",
+                "unique_identifier",
+                "device_free_memory",
+                "device_battery_level",
+                "device_total_storage",
+                "cpu_data",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "GameAnalytics ApS": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "platform"
+            ]
+        },
+        "Google LLC": {
+            "signals": [
+                "gps_coordinates",
+                "email_address",
+                "phone_number",
+                "username",
+                "password",
+                "first_name",
+                "last_name",
+                "neighborhood",
+                "device_name",
+                "postal_code",
+                "AAID",
+                "device_boot_time",
+                "city",
+                "unique_identifier",
+                "local_ip",
+                "gender",
+                "device_free_storage",
+                "state",
+                "network_carrier",
+                "cookies",
+                "device_battery_level",
+                "device_volume",
+                "device_total_memory",
+                "cpu_data",
+                "device_headphone_status",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "install_date",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_charging_status",
+                "timezone",
+                "device_screen_density",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Hexagon Data, S.A.P.I. de C.V.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Human Security, Inc.": {
+            "signals": [
+                "AAID",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_name",
+                "os_version",
+                "platform"
+            ]
+        },
+        "ID5 Technology Ltd": {
+            "signals": [
+                "city",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_make",
+                "os_version",
+                "app_name",
+                "country",
+                "platform"
+            ]
+        },
+        "Index Exchange, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Inmar, Inc.": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "InMobi Pte Ltd": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "device_volume",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "device_screen_density",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Innovid Media": {
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "neighborhood",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "device_language",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "Integral Ad Science, Inc.": {
+            "signals": [
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "device_volume",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "device_language",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "platform"
+            ]
+        },
+        "Intuition Machines, Inc.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "platform"
+            ]
+        },
+        "IPONWEB GmbH": {
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_language",
+                "app_version",
+                "device_connectivity",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "ironSource Ltd": {
+            "signals": [
+                "postal_code",
+                "neighborhood",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "local_ip",
+                "device_free_storage",
+                "network_isp",
+                "network_carrier",
+                "device_free_memory",
+                "device_battery_level",
+                "os_build_version",
+                "device_resolution",
+                "device_connectivity",
+                "device_model",
+                "device_language",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "iSpot.tv": {
+            "signals": [
+                "city",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "Iterable, Inc.": {
+            "signals": [
+                "email_address",
+                "AAID",
+                "unique_identifier",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Kantar Operations": {
+            "signals": [
+                "device_magnetometer",
+                "AAID",
+                "accelerometer_data",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Kochava": {
+            "signals": [
+                "gps_coordinates",
+                "wifi_ssid",
+                "device_name",
+                "postal_code",
+                "AAID",
+                "device_boot_time",
+                "unique_identifier",
+                "network_isp",
+                "network_carrier",
+                "screen_brightness",
+                "device_battery_level",
+                "device_volume",
+                "cpu_data",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_charging_status",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Liftoff Mobile, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "platform"
+            ]
+        },
+        "LiveIntent Inc.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "LiveRamp Holdings, Inc.": {
+            "signals": [
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Lotame Solutions, Inc.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Magnite, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "platform"
+            ]
+        },
+        "Mapbox Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "network_carrier",
+                "device_battery_level",
+                "cpu_data",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Media.net Advertising FZ-LLC": {
+            "signals": [
+                "city",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "MediaMath, Inc.": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Microsoft Corporation": {
+            "signals": [
+                "gps_coordinates",
+                "username",
+                "postal_code",
+                "birthday",
+                "city",
+                "AAID",
+                "unique_identifier",
+                "state",
+                "network_carrier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Mixpanel, Inc.": {
+            "signals": [
+                "email_address",
+                "phone_number",
+                "username",
+                "first_name",
+                "AAID",
+                "device_boot_time",
+                "unique_identifier",
+                "gender",
+                "network_carrier",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Mobiquity Inc.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_language",
+                "device_make",
+                "os_version",
+                "app_name",
+                "country",
+                "platform"
+            ]
+        },
+        "Moloco Inc.": {
+            "signals": [
+                "neighborhood",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "platform"
+            ]
+        },
+        "Neustar, Inc.": {
+            "signals": [
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "New Relic": {
+            "signals": [
+                "unique_identifier",
+                "network_carrier",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "country",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Ogury Limited": {
+            "signals": [
+                "AAID",
+                "cpu_data",
+                "device_resolution",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "platform"
+            ]
+        },
+        "OnAudience Ltd.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "OneSignal": {
+            "signals": [
+                "gps_coordinates",
+                "first_name",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "install_date",
+                "app_version",
+                "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "timezone",
+                "platform"
+            ]
+        },
+        "OpenX Technologies Inc": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Optimizely, Inc.": {
+            "signals": [
+                "unique_identifier",
+                "os_build_version",
+                "device_model",
+                "device_language",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Oracle Corporation": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "network_carrier",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "device_language",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Outbrain": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Parsely, Inc.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "state",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Permutive, Inc.": {
+            "signals": [
+                "neighborhood",
+                "city",
+                "unique_identifier",
+                "state",
+                "network_isp",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Pinterest, Inc.": {
+            "signals": [
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Pixalate, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "device_language",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Prospect One": {
+            "signals": [
+                "AAID",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "PubMatic, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "city",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Pulsepoint, Inc.": {
+            "signals": [
+                "city",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_connectivity",
+                "device_model",
+                "device_language",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "Quantcast Corporation": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_connectivity",
+                "device_model",
+                "device_language",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Reddit Inc.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "RevenueCat": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "RhythmOne": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "device_connectivity",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Riskified Ltd.": {
+            "signals": [
+                "gps_coordinates",
+                "first_name",
+                "last_name",
+                "AAID",
+                "network_carrier",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Roku, Inc.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "RTB House S.A.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Salesforce.com, Inc.": {
+            "signals": [
+                "email_address",
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Segment.io, Inc.": {
+            "signals": [
+                "email_address",
+                "username",
+                "gps_coordinates",
+                "first_name",
+                "last_name",
+                "neighborhood",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "local_ip",
+                "state",
+                "network_carrier",
+                "device_model",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Sharethrough, Inc.": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Sift Science, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "neighborhood",
+                "unique_identifier",
+                "local_ip",
+                "network_carrier",
+                "device_battery_level",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Simplifi Holdings Inc.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Smaato Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "unique_identifier",
+                "network_carrier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "device_connectivity",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Smartadserver S.A.S": {
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "os_version",
+                "country",
+                "device_make",
+                "platform"
+            ]
+        },
+        "Snap Inc.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Sovrn Holdings": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "SpotX, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "Synacor, Inc.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "device_connectivity",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Taboola, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "neighborhood",
+                "AAID",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Take-Two Interactive Software, Inc.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "network_carrier",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Talent Game Box": {
+            "signals": [
+                "neighborhood",
+                "AAID",
+                "unique_identifier",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Tapad, Inc.": {
+            "signals": [
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "device_total_memory",
+                "os_build_version",
+                "device_model",
+                "device_language",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Tapjoy, Inc.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "mac_address",
+                "network_carrier",
+                "device_volume",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Tappcelator Media S.L.": {
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Teads ( Luxenbourg ) SA": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Telaria": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "The Nielsen Company": {
+            "signals": [
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "device_language",
+                "app_version",
+                "app_name",
+                "os_version",
+                "device_make",
+                "country",
+                "platform"
+            ]
+        },
+        "The Trade Desk Inc": {
+            "signals": [
+                "gps_coordinates",
+                "postal_code",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "state",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_language",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "TripleLift": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "TrustArc Inc.": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "os_version",
+                "platform"
+            ]
+        },
+        "Twitter, Inc.": {
+            "signals": [
+                "email_address",
+                "password",
+                "username",
+                "AAID",
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "platform"
+            ]
+        },
+        "Undertone Networks": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        },
+        "Unity Technologies ApS": {
+            "signals": [
+                "neighborhood",
+                "postal_code",
+                "device_name",
+                "AAID",
+                "device_boot_time",
+                "unique_identifier",
+                "device_free_storage",
+                "external_free_storage",
+                "accelerometer_data",
+                "device_free_memory",
+                "screen_brightness",
+                "device_battery_level",
+                "device_total_storage",
+                "external_total_storage",
+                "device_volume",
+                "device_total_memory",
+                "device_headphone_status",
+                "os_build_version",
+                "device_resolution",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "device_screen_density",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Unruly Group Limited": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "app_version",
+                "device_model",
+                "device_language",
+                "device_connectivity",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Upland Software Inc.": {
+            "signals": [
+                "postal_code",
+                "city",
+                "AAID",
+                "unique_identifier",
+                "state",
+                "os_build_version",
+                "app_version",
+                "device_connectivity",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "device_orientation",
+                "platform"
+            ]
+        },
+        "Urban Airship, Inc.": {
+            "signals": [
+                "gps_coordinates",
+                "email_address",
+                "neighborhood",
+                "city",
+                "unique_identifier",
+                "network_carrier",
+                "app_version",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "device_screen_density",
+                "platform"
+            ]
+        },
+        "Verizon Media": {
+            "signals": [
+                "gps_coordinates",
+                "birthday",
+                "AAID",
+                "device_boot_time",
+                "city",
+                "unique_identifier",
+                "device_free_storage",
+                "external_free_storage",
+                "device_free_memory",
+                "network_carrier",
+                "cookies",
+                "device_battery_level",
+                "device_total_storage",
+                "external_total_storage",
+                "cpu_data",
+                "device_total_memory",
+                "device_headphone_status",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_connectivity",
+                "device_language",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "device_screen_density",
+                "platform",
+                "device_orientation"
+            ]
+        },
+        "Vungle Inc": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "device_free_storage",
+                "network_carrier",
+                "device_battery_level",
+                "device_volume",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "device_charging_status",
+                "device_make",
+                "os_version",
+                "country",
+                "timezone",
+                "platform"
+            ]
+        },
+        "WPP plc": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "app_version",
+                "device_language",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Yandex LLC": {
+            "signals": [
+                "gps_coordinates",
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_resolution",
+                "device_model",
+                "device_language",
+                "device_make",
+                "app_name",
+                "os_version",
+                "platform"
+            ]
+        },
+        "YieldMo, Inc.": {
+            "signals": [
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Zeotap GmbH": {
+            "signals": [
+                "AAID",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_model",
+                "device_language",
+                "app_version",
+                "app_name",
+                "device_make",
+                "os_version",
+                "country",
+                "platform"
+            ]
+        },
+        "Zeta Global": {
+            "signals": [
+                "city",
+                "unique_identifier",
+                "cookies",
+                "os_build_version",
+                "device_language",
+                "device_model",
+                "app_version",
+                "device_make",
+                "os_version",
+                "country",
+                "app_name",
+                "platform"
+            ]
+        }
     }
-  },
-  "packageNames": {
-    "com.adjust.insights": "Adjust GmbH",
-    "air.com.adobe.connectpro": "Adobe Inc.",
-    "com.adobe.reader": "Adobe Inc.",
-    "com.adobe.lrmobile": "Adobe Inc.",
-    "com.adobe.scan.android": "Adobe Inc.",
-    "com.adobe.psmobile": "Adobe Inc.",
-    "com.adobe.fas": "Adobe Inc.",
-    "com.adobe.spark.post": "Adobe Inc.",
-    "com.adobe.creativeapps.sketch": "Adobe Inc.",
-    "com.adobe.creativeapps.draw": "Adobe Inc.",
-    "com.adobe.photoshopmix": "Adobe Inc.",
-    "com.adobe.cc": "Adobe Inc.",
-    "com.adobe.lens.android": "Adobe Inc.",
-    "com.adobe.premiererush.videoeditor": "Adobe Inc.",
-    "com.adobe.adobephotoshopfix": "Adobe Inc.",
-    "com.adobe.ims.accountaccess": "Adobe Inc.",
-    "com.adobe.ims.push.android": "Adobe Inc.",
-    "com.adobe.creativeapps.gather": "Adobe Inc.",
-    "com.adobe.digitaleditions": "Adobe Inc.",
-    "com.adobe.echosign": "Adobe Inc.",
-    "com.adobe.sparklerandroid": "Adobe Inc.",
-    "com.adobe.comp": "Adobe Inc.",
-    "com.adobe.captivateprime": "Adobe Inc.",
-    "com.adobe.aem.forms": "Adobe Inc.",
-    "com.adobe.phonegap.app": "Adobe Inc.",
-    "com.adobe.analyticsdashboards": "Adobe Inc.",
-    "com.adobe.monocle.companion": "Adobe Inc.",
-    "com.adobe.aero.android": "Adobe Inc.",
-    "amazon.speech.sim": "Amazon Technologies, Inc.",
-    "com.amazon.aa": "Amazon Technologies, Inc.",
-    "com.amazon.aa.attribution": "Amazon Technologies, Inc.",
-    "com.amazon.amazonvideo.livingroom": "Amazon Technologies, Inc.",
-    "com.amazon.appmanager": "Amazon Technologies, Inc.",
-    "com.amazon.avod.thirdpartyclient": "Amazon Technologies, Inc.",
-    "com.amazon.aws.honeycode": "Amazon Technologies, Inc.",
-    "com.amazon.chime": "Amazon Technologies, Inc.",
-    "com.amazon.clouddrive.photos": "Amazon Technologies, Inc.",
-    "com.amazon.cosmos": "Amazon Technologies, Inc.",
-    "com.amazon.dee.app": "Amazon Technologies, Inc.",
-    "com.amazon.drive": "Amazon Technologies, Inc.",
-    "com.amazon.fv": "Amazon Technologies, Inc.",
-    "com.amazon.healthtech.malibu": "Amazon Technologies, Inc.",
-    "com.amazon.kindle": "Amazon Technologies, Inc.",
-    "com.amazon.mShop.android": "Amazon Technologies, Inc.",
-    "com.amazon.mShop.android.business.shopping": "Amazon Technologies, Inc.",
-    "com.amazon.mShop.android.shopping": "Amazon Technologies, Inc.",
-    "com.amazon.mShop.android.shopping.vpl": "Amazon Technologies, Inc.",
-    "com.amazon.mp3": "Amazon Technologies, Inc.",
-    "com.amazon.muse": "Amazon Technologies, Inc.",
-    "com.amazon.music.tv": "Amazon Technologies, Inc.",
-    "com.amazon.now": "Amazon Technologies, Inc.",
-    "com.amazon.phseven.prod": "Amazon Technologies, Inc.",
-    "com.amazon.relay": "Amazon Technologies, Inc.",
-    "com.amazon.sellermobile.android": "Amazon Technologies, Inc.",
-    "com.amazon.shopperpanel.android.mobile.app": "Amazon Technologies, Inc.",
-    "com.amazon.storm.lightning.client.aosp": "Amazon Technologies, Inc.",
-    "com.amazon.widgets": "Amazon Technologies, Inc.",
-    "com.amazon.windowshop": "Amazon Technologies, Inc.",
-    "com.amazon.venezia": "Amazon Technologies, Inc.",
-    "com.amazon.ziggy.android": "Amazon Technologies, Inc.",
-    "com.imdb.mobile": "Amazon Technologies, Inc.",
-    "com.imdb.pro.mobile.android": "Amazon Technologies, Inc.",
-    "com.imdbtv.livingroom": "Amazon Technologies, Inc.",
-    "com.ringapp": "Amazon Technologies, Inc.",
-    "in.amazon.mShop.android.shopping": "Amazon Technologies, Inc.",
-    "tv.twitch.android.app": "Amazon Technologies, Inc.",
-    "com.appsflyer.analytics": "AppsFlyer",
-    "com.appsflyer.android.deviceid": "AppsFlyer",
-    "com.appsflyer.onelinksimulator": "AppsFlyer",
-    "com.appsflyer.app.ezshop": "AppsFlyer",
-    "com.appsflyer.afsupportapp": "AppsFlyer",
-    "com.appsflyer.adNetworkTest": "AppsFlyer",
-    "io.branch.deviceid": "Branch Metrics, Inc.",
-    "io.branch.android.discovery": "Branch Metrics, Inc.",
-    "io.branch.branchster": "Branch Metrics, Inc.",
-    "io.branch.sample.hellobranch": "Branch Metrics, Inc.",
-    "com.ss.android.ugc.trill": "ByteDance Ltd.",
-    "com.zhiliaoapp.musically": "ByteDance Ltd.",
-    "com.zhiliao.musically.livewallpaper": "ByteDance Ltd.",
-    "com.lemon.lvoverseas": "ByteDance Ltd.",
-    "com.facebook.adsmanager": "Facebook, Inc.",
-    "com.facebook.analytics": "Facebook, Inc.",
-    "com.facebook.appmanager": "Facebook, Inc.",
-    "com.facebook.arstudio.player": "Facebook, Inc.",
-    "com.facebook.bishop": "Facebook, Inc.",
-    "com.facebook.creatorstudio": "Facebook, Inc.",
-    "com.facebook.games": "Facebook, Inc.",
-    "com.facebook.katana": "Facebook, Inc.",
-    "com.facebook.lite": "Facebook, Inc.",
-    "com.facebook.mlite": "Facebook, Inc.",
-    "com.facebook.Origami": "Facebook, Inc.",
-    "com.facebook.orca": "Facebook, Inc.",
-    "com.facebook.pages.app": "Facebook, Inc.",
-    "com.facebook.services": "Facebook, Inc.",
-    "com.facebook.study": "Facebook, Inc.",
-    "com.facebook.system": "Facebook, Inc.",
-    "com.facebook.talk": "Facebook, Inc.",
-    "com.facebook.viewpoints": "Facebook, Inc.",
-    "com.facebook.work": "Facebook, Inc.",
-    "com.facebook.workchat": "Facebook, Inc.",
-    "com.instagram.android": "Facebook, Inc.",
-    "com.instagram.boomerang": "Facebook, Inc.",
-    "com.instagram.igtv": "Facebook, Inc.",
-    "com.instagram.layout": "Facebook, Inc.",
-    "com.instagram.threadsapp": "Facebook, Inc.",
-    "com.whatsapp": "Facebook, Inc.",
-    "com.joelapenna.foursquared": "Foursquare Labs, Inc.",
-    "com.sewichi.client.panel": "Foursquare Labs, Inc.",
-    "com.foursquare.robin": "Foursquare Labs, Inc.",
-    "com.foursquare.pilgrimdemo": "Foursquare Labs, Inc.",
-    "com.foursquare.marsbot": "Foursquare Labs, Inc.",
-    "com.android.hotwordenrollment.okgoogle": "Google LLC",
-    "com.android.hotwordenrollment.xgoogle": "Google LLC",
-    "com.android.partnerbrowsercustomizations.chromeHomepage": "Google LLC",
-    "com.android.chrome": "Google LLC",
-    "com.chrome.beta": "Google LLC",
-    "com.chrome.canary": "Google LLC",
-    "com.chrome.dev": "Google LLC",
-    "com.google.android.apps.access.wifi.consumer": "Google LLC",
-    "com.google.android.apps.adm": "Google LLC",
-    "com.google.android.apps.ads.publisher": "Google LLC",
-    "com.google.android.apps.adwords": "Google LLC",
-    "com.google.android.apps.authenticator2": "Google LLC",
-    "com.google.android.apps.blogger": "Google LLC",
-    "com.google.android.apps.books": "Google LLC",
-    "com.google.android.apps.chromecast.app": "Google LLC",
-    "com.google.android.apps.cloudprint": "Google LLC",
-    "com.google.android.apps.cultural": "Google LLC",
-    "com.google.android.apps.currents": "Google LLC",
-    "com.google.android.apps.docs": "Google LLC",
-    "com.google.android.apps.docs.editors.docs": "Google LLC",
-    "com.google.android.apps.docs.editors.sheets": "Google LLC",
-    "com.google.android.apps.docs.editors.slides": "Google LLC",
-    "com.google.android.apps.dynamite": "Google LLC",
-    "com.google.android.apps.enterprise.cpanel": "Google LLC",
-    "com.google.android.apps.enterprise.dmagent": "Google LLC",
-    "com.google.android.apps.fireball": "Google LLC",
-    "com.google.android.apps.fitness": "Google LLC",
-    "com.google.android.apps.freighter": "Google LLC",
-    "com.google.android.apps.giant": "Google LLC",
-    "com.google.android.apps.googleassistant": "Google LLC",
-    "com.google.android.apps.handwriting.ime": "Google LLC",
-    "com.google.android.apps.hangoutsdialer": "Google LLC",
-    "com.google.android.apps.inbox": "Google LLC",
-    "com.google.android.apps.kids.familylink": "Google LLC",
-    "com.google.android.apps.kids.familylinkhelper": "Google LLC",
-    "com.google.android.apps.m4b": "Google LLC",
-    "com.google.android.apps.magazines": "Google LLC",
-    "com.google.android.apps.mapslite": "Google LLC",
-    "com.google.android.apps.meetings": "Google LLC",
-    "com.google.android.apps.messaging": "Google LLC",
-    "com.google.android.apps.navlite": "Google LLC",
-    "com.google.android.apps.nbu.files": "Google LLC",
-    "com.google.android.apps.paidtasks": "Google LLC",
-    "com.google.android.apps.pdfviewer": "Google LLC",
-    "com.google.android.apps.photos": "Google LLC",
-    "com.google.android.apps.photos.scanner": "Google LLC",
-    "com.google.android.apps.plus": "Google LLC",
-    "com.google.android.apps.podcasts": "Google LLC",
-    "com.google.android.apps.restore": "Google LLC",
-    "com.google.android.apps.recorder": "Google LLC",
-    "com.google.android.apps.setupwizard.searchselector": "Google LLC",
-    "com.google.android.apps.santatracker": "Google LLC",
-    "com.google.android.apps.subscriptions.red": "Google LLC",
-    "com.google.android.apps.tachyon": "Google LLC",
-    "com.google.android.apps.tasks": "Google LLC",
-    "com.google.android.apps.translate": "Google LLC",
-    "com.google.android.apps.travel.onthego": "Google LLC",
-    "com.google.android.apps.uploader": "Google LLC",
-    "com.google.android.apps.vega": "Google LLC",
-    "com.google.android.apps.walletnfcrel": "Google LLC",
-    "com.google.android.apps.wallpaper": "Google LLC",
-    "com.google.android.apps.wellbeing": "Google LLC",
-    "com.google.android.apps.youtube.creator": "Google LLC",
-    "com.google.android.apps.youtube.gaming": "Google LLC",
-    "com.google.android.apps.youtube.kids": "Google LLC",
-    "com.google.android.apps.youtube.music": "Google LLC",
-    "com.google.android.apps.youtube.vr": "Google LLC",
-    "com.google.android.backup": "Google LLC",
-    "com.google.android.backuptransport": "Google LLC",
-    "com.google.android.calculator": "Google LLC",
-    "com.google.android.calendar": "Google LLC",
-    "com.google.android.configupdater": "Google LLC",
-    "com.google.android.feedback": "Google LLC",
-    "com.google.android.googlequicksearchbox": "Google LLC",
-    "com.google.android.instantapps.supervisor": "Google LLC",
-    "com.google.android.keep": "Google LLC",
-    "com.google.android.markup": "Google LLC",
-    "com.google.android.marvin.talkback": "Google LLC",
-    "com.google.android.music": "Google LLC",
-    "com.google.android.onetimeinitializer": "Google LLC",
-    "com.google.android.play.games": "Google LLC",
-    "com.google.android.printservice.recommendation": "Google LLC",
-    "com.google.android.projection.gearhead": "Google LLC",
-    "com.google.android.setupwizard": "Google LLC",
-    "com.google.android.setupwizard.a_overlay": "Google LLC",
-    "com.google.android.pixel.setupwizard": "Google LLC",
-    "com.google.android.soundpicker": "Google LLC",
-    "com.google.android.street": "Google LLC",
-    "com.google.android.syncadapters.bookmarks": "Google LLC",
-    "com.google.android.syncadapters.calendar": "Google LLC",
-    "com.google.android.syncadapters.contacts": "Google LLC",
-    "com.google.android.talk": "Google LLC",
-    "com.google.android.tts": "Google LLC",
-    "com.google.android.tv.remote": "Google LLC",
-    "com.google.android.videoeditor": "Google LLC",
-    "com.google.android.videos": "Google LLC",
-    "com.google.android.voicesearch": "Google LLC",
-    "com.google.android.vr.home": "Google LLC",
-    "com.google.android.vr.inputmethod": "Google LLC",
-    "com.google.android.wearable.app": "Google LLC",
-    "com.google.android.youtube": "Google LLC",
-    "com.google.ar.core": "Google LLC",
-    "com.google.ar.lens": "Google LLC",
-    "com.google.chromeremotedesktop": "Google LLC",
-    "com.google.earth": "Google LLC",
-    "com.google.marvin.talkback": "Google LLC",
-    "com.google.samples.apps.cardboarddemo": "Google LLC",
-    "com.google.tango.measure": "Google LLC",
-    "com.google.vr.cyclops": "Google LLC",
-    "com.google.vr.expeditions": "Google LLC",
-    "com.google.vr.vrcore": "Google LLC",
-    "com.google.zxing.client.android": "Google LLC",
-    "com.google.android.apps.work.oobconfig": "Google LLC",
-    "com.google.android.email": "Google LLC",
-    "com.google.android.tag": "Google LLC",
-    "com.google.android.gms.location.history": "Google LLC",
-    "com.google.android.gms.policy_sidecar_aps": "Google LLC",
-    "com.google.android.partnersetup": "Google LLC",
-    "com.google.audio.hearing.visualization.accessibility.scribe": "Google LLC",
-    "com.waze": "Google LLC",
-    "dev.firebase.appdistribution": "Google LLC",
-    "com.mapbox.mapboxandroiddemo": "Mapbox Inc.",
-    "com.mapbox.studio": "Mapbox Inc.",
-    "com.mapbox.locate": "Mapbox Inc.",
-    "com.mapbox.vision.teaser": "Mapbox Inc.",
-    "com.azure.authenticator": "Microsoft Corporation",
-    "com.gamepass": "Microsoft Corporation",
-    "com.gamepass.beta": "Microsoft Corporation",
-    "com.groupme.android": "Microsoft Corporation",
-    "com.linkedin.android": "Microsoft Corporation",
-    "com.linkedin.android.learning": "Microsoft Corporation",
-    "com.linkedin.android.salesnavigator": "Microsoft Corporation",
-    "com.linkedin.leap": "Microsoft Corporation",
-    "com.linkedin.recruiter": "Microsoft Corporation",
-    "com.lynda.android.root": "Microsoft Corporation",
-    "com.microsoft.amp.apps.bingfinance": "Microsoft Corporation",
-    "com.microsoft.amp.apps.bingnews": "Microsoft Corporation",
-    "com.microsoft.android.smsorganizer": "Microsoft Corporation",
-    "com.microsoft.appmanager": "Microsoft Corporation",
-    "com.microsoft.azure": "Microsoft Corporation",
-    "com.microsoft.bing": "Microsoft Corporation",
-    "com.microsoft.emmx": "Microsoft Corporation",
-    "com.microsoft.emmx.canary": "Microsoft Corporation",
-    "com.microsoft.familysafety": "Microsoft Corporation",
-    "com.microsoft.gravity": "Microsoft Corporation",
-    "com.microsoft.hyperlapsemobile": "Microsoft Corporation",
-    "com.microsoft.intune": "Microsoft Corporation",
-    "com.microsoft.ipviewer": "Microsoft Corporation",
-    "com.microsoft.launcher": "Microsoft Corporation",
-    "com.microsoft.mahjong": "Microsoft Corporation",
-    "com.microsoft.math": "Microsoft Corporation",
-    "com.microsoft.microsoftsolitairecollection": "Microsoft Corporation",
-    "com.microsoft.mobile.polymer": "Microsoft Corporation",
-    "com.microsoft.msapps": "Microsoft Corporation",
-    "com.microsoft.office.excel": "Microsoft Corporation",
-    "com.microsoft.office.lync15": "Microsoft Corporation",
-    "com.microsoft.office.officehubhl": "Microsoft Corporation",
-    "com.microsoft.office.officehub": "Microsoft Corporation",
-    "com.microsoft.office.officehubrow": "Microsoft Corporation",
-    "com.microsoft.office.officelens": "Microsoft Corporation",
-    "com.microsoft.office.onenote": "Microsoft Corporation",
-    "com.microsoft.office.outlook": "Microsoft Corporation",
-    "com.microsoft.office.powerpoint": "Microsoft Corporation",
-    "com.microsoft.office.word": "Microsoft Corporation",
-    "com.microsoft.planner": "Microsoft Corporation",
-    "com.microsoft.powerbim": "Microsoft Corporation",
-    "com.microsoft.rdc.android": "Microsoft Corporation",
-    "com.microsoft.rdc.androidx": "Microsoft Corporation",
-    "com.microsoft.scmx": "Microsoft Corporation",
-    "com.microsoft.sharepoint": "Microsoft Corporation",
-    "com.microsoft.skydrive": "Microsoft Corporation",
-    "com.microsoft.stream": "Microsoft Corporation",
-    "com.microsoft.sudoku": "Microsoft Corporation",
-    "com.microsoft.teams": "Microsoft Corporation",
-    "com.microsoft.todos": "Microsoft Corporation",
-    "com.microsoft.translator": "Microsoft Corporation",
-    "com.microsoft.whiteboard.publicpreview": "Microsoft Corporation",
-    "com.microsoft.windowsintune.companyportal": "Microsoft Corporation",
-    "com.microsoft.wordament": "Microsoft Corporation",
-    "com.microsoft.xboxfamily": "Microsoft Corporation",
-    "com.microsoft.xboxone.smartglass": "Microsoft Corporation",
-    "com.microsoft.xboxone.smartglass.beta": "Microsoft Corporation",
-    "com.microsoft.xcloud": "Microsoft Corporation",
-    "com.ms.office365admin": "Microsoft Corporation",
-    "com.skype.insiders": "Microsoft Corporation",
-    "com.skype.raider": "Microsoft Corporation",
-    "com.touchtype.swiftkey": "Microsoft Corporation",
-    "com.touchtype.swiftkey.beta": "Microsoft Corporation",
-    "com.newrelic.rpm": "New Relic",
-    "com.pinterest": "Pinterest, Inc.",
-    "com.pinterest.twa": "Pinterest, Inc.",
-    "com.desk.android": "Salesforce.com, Inc.",
-    "com.salesforce.chatter": "Salesforce.com, Inc.",
-    "com.salesforce.authenticator": "Salesforce.com, Inc.",
-    "com.salesforce.trailheadgo.app": "Salesforce.com, Inc.",
-    "com.salesforce.fieldservice.app": "Salesforce.com, Inc.",
-    "com.salesforce.admin1": "Salesforce.com, Inc.",
-    "com.relateiq.android": "Salesforce.com, Inc.",
-    "com.salesforce.dreamoji": "Salesforce.com, Inc.",
-    "com.salesforce.wave": "Salesforce.com, Inc.",
-    "com.salesforce.marketingcloud": "Salesforce.com, Inc.",
-    "com.salesforce.socialstudio": "Salesforce.com, Inc.",
-    "org.salesforce.philanthropycloud": "Salesforce.com, Inc.",
-    "app.zenly.locator": "Snap Inc.",
-    "com.snapchat.android": "Snap Inc.",
-    "com.bitstrips.imoji": "Snap Inc.",
-    "com.taboola.newsroomMobile": "Taboola, Inc.",
-    "com.twitter.android": "Twitter, Inc.",
-    "co.vine.android": "Twitter, Inc.",
-    "com.flurry.instantapp.test.app": "Verizon Media",
-    "com.aol.mobile.aolapp": "Verizon Media",
-    "com.aol.mobile.techcrunch": "Verizon Media",
-    "com.oath.MediaAnalytics": "Verizon Media",
-    "com.verizonmedia.makers": "Verizon Media",
-    "com.yahoo.mobile.client.android.ecshopping": "Verizon Media",
-    "com.yahoo.mobile.client.android.finance": "Verizon Media",
-    "com.yahoo.mobile.client.android.finance.androidtv": "Verizon Media",
-    "com.yahoo.mobile.client.android.fantasyfootball": "Verizon Media",
-    "com.yahoo.mobile.client.android.mail": "Verizon Media",
-    "com.yahoo.mobile.client.android.mail.lite": "Verizon Media",
-    "com.yahoo.mobile.client.android.nativemail": "Verizon Media",
-    "com.yahoo.mobile.client.android.search": "Verizon Media",
-    "com.yahoo.mobile.client.android.sportacular": "Verizon Media",
-    "com.yahoo.mobile.client.android.weather": "Verizon Media",
-    "com.yahoo.mobile.client.android.yahoo": "Verizon Media",
-    "com.yahoo.apps.yahooapp": "Verizon Media",
-    "com.yahoo.flurry": "Verizon Media",
-    "com.yahoo.harmony": "Verizon Media",
-    "com.yahoo.infohub": "Verizon Media",
-    "com.yahoo.onesearch": "Verizon Media",
-    "com.yahoo.otterdroid": "Verizon Media",
-    "com.yahoo.wwww.twa": "Verizon Media",
-    "nexti.android.bustaichung": "Verizon Media",
-    "nexti.android.bustaipei": "Verizon Media",
-    "nexti.android.bustaiwan": "Verizon Media",
-    "com.adultswim.videoapp.android": "WarnerMedia, LLC",
-    "com.cnn.mobile.android.phone": "WarnerMedia, LLC",
-    "com.cnn.mobile.android.tv": "WarnerMedia, LLC",
-    "com.hbo.android.app": "WarnerMedia, LLC",
-    "com.hbo.hbonow": "WarnerMedia, LLC",
-    "com.tcm.tcm": "WarnerMedia, LLC",
-    "com.turner.cnvideoapp": "WarnerMedia, LLC",
-    "com.turner.tbs.android.networkapp": "WarnerMedia, LLC",
-    "com.turner.tnt.android.networkapp": "WarnerMedia, LLC",
-    "com.turner.trutv": "WarnerMedia, LLC",
-    "com.turner.trutv.wheelofdoom": "WarnerMedia, LLC",
-    "com.warnermedia.wmce.ride": "WarnerMedia, LLC",
-    "com.wb.goog.mkx": "WarnerMedia, LLC",
-    "com.wb.goog.injustice.brawler2017": "WarnerMedia, LLC",
-    "com.wb.goog.dc.legends": "WarnerMedia, LLC",
-    "com.wb.goog.dcuniverse": "WarnerMedia, LLC",
-    "com.wb.goog.ellentube": "WarnerMedia, LLC",
-    "com.wb.goog.injustice": "WarnerMedia, LLC",
-    "com.wb.goog.got.conquest": "WarnerMedia, LLC",
-    "com.wb.goog.emojiexplojipaid": "WarnerMedia, LLC",
-    "com.wb.goog.phonelog": "WarnerMedia, LLC",
-    "com.wb.goog.scribblenauts3": "WarnerMedia, LLC",
-    "com.wb.goog.scribbleremix": "WarnerMedia, LLC",
-    "com.wb.goog.shoutrageous": "WarnerMedia, LLC",
-    "com.wb.headsup": "WarnerMedia, LLC",
-    "com.wb.map": "WarnerMedia, LLC",
-    "com.wb.wbtvdistribution": "WarnerMedia, LLC",
-    "com.wb.wbfyc": "WarnerMedia, LLC",
-    "com.rhythmnewmedia.tmz": "WarnerMedia, LLC",
-    "eu.hbogo.android": "WarnerMedia, LLC"
-  },
-  "entities": {
-    "Google LLC": {
-      "score": 97594,
-      "signals": [
-        "gps_coordinates",
-        "email_address",
-        "first_name",
-        "last_name",
-        "device_name",
-        "postal_code",
-        "device_boot_time",
-        "city",
-        "AAID",
-        "unique_identifier",
-        "local_ip",
-        "gender",
-        "device_free_storage",
-        "state",
-        "cookies",
-        "device_battery_level",
-        "device_volume",
-        "device_total_memory",
-        "device_headphone_status",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "cpu_data",
-        "app_name",
-        "device_charging_status",
-        "device_make",
-        "os_version",
-        "country",
-        "device_screen_density",
-        "timezone",
-        "device_orientation",
-        "platform"
-      ]
-    },
-    "Facebook, Inc.": {
-      "score": 42596,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "gender",
-        "accelerometer_data",
-        "device_free_storage",
-        "rotation_data",
-        "state",
-        "device_free_memory",
-        "network_carrier",
-        "cookies",
-        "device_volume",
-        "device_total_memory",
-        "cpu_data",
-        "device_headphone_status",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "app_name",
-        "device_charging_status",
-        "device_make",
-        "os_version",
-        "country",
-        "timezone",
-        "device_screen_density",
-        "platform",
-        "device_orientation"
-      ]
-    },
-    "Branch Metrics, Inc.": {
-      "score": 13976,
-      "signals": [
-        "email_address",
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "local_ip",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_language",
-        "device_model",
-        "install_date",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "device_screen_density",
-        "platform"
-      ]
-    },
-    "The Trade Desk Inc": {
-      "score": 12664,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "platform"
-      ]
-    },
-    "Amazon Technologies, Inc.": {
-      "score": 12477,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "accelerometer_data",
-        "state",
-        "network_carrier",
-        "cookies",
-        "device_total_memory",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "device_make",
-        "os_version",
-        "app_name",
-        "country",
-        "device_screen_density",
-        "platform",
-        "device_orientation"
-      ]
-    },
-    "Taboola, Inc.": {
-      "score": 12245,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "device_total_memory",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Integral Ad Science, Inc.": {
-      "score": 10518,
-      "signals": [
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "state",
-        "device_volume",
-        "device_total_memory",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "device_screen_density",
-        "platform"
-      ]
-    },
-    "Verizon Media": {
-      "score": 10342,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "device_boot_time",
-        "city",
-        "unique_identifier",
-        "device_free_storage",
-        "state",
-        "device_free_memory",
-        "network_carrier",
-        "cookies",
-        "device_battery_level",
-        "device_total_storage",
-        "device_total_memory",
-        "device_headphone_status",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "app_name",
-        "device_charging_status",
-        "device_make",
-        "os_version",
-        "country",
-        "timezone",
-        "device_screen_density",
-        "device_orientation",
-        "platform"
-      ]
-    },
-    "WarnerMedia, LLC": {
-      "score": 9846,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "city",
-        "AAID",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "device_model",
-        "app_name",
-        "os_version",
-        "country",
-        "device_make",
-        "timezone",
-        "platform"
-      ]
-    },
-    "Adobe Inc.": {
-      "score": 9528,
-      "signals": [
-        "gps_coordinates",
-        "email_address",
-        "postal_code",
-        "AAID",
-        "unique_identifier",
-        "network_carrier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_model",
-        "install_date",
-        "device_connectivity",
-        "device_language",
-        "app_name",
-        "os_version",
-        "country",
-        "device_make",
-        "timezone",
-        "platform",
-        "device_orientation"
-      ]
-    },
-    "Twitter, Inc.": {
-      "score": 8444,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_language",
-        "device_connectivity",
-        "app_name",
-        "device_make",
-        "country",
-        "os_version",
-        "device_screen_density",
-        "timezone",
-        "platform"
-      ]
-    },
-    "Oracle Corporation": {
-      "score": 6426,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "network_carrier",
-        "cookies",
-        "device_total_memory",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_language",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "device_screen_density",
-        "platform",
-        "device_orientation"
-      ]
-    },
-    "comScore, Inc": {
-      "score": 6342,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "city",
-        "AAID",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "device_total_memory",
-        "device_model",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_make",
-        "country",
-        "platform"
-      ]
-    },
-    "IPONWEB GmbH": {
-      "score": 6265,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "platform"
-      ]
-    },
-    "Criteo SA": {
-      "score": 6006,
-      "signals": [
-        "AAID",
-        "city",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_model",
-        "device_language",
-        "device_connectivity",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform",
-        "device_orientation"
-      ]
-    },
-    "Braze, Inc.": {
-      "score": 5918,
-      "signals": [
-        "gps_coordinates",
-        "email_address",
-        "first_name",
-        "last_name",
-        "postal_code",
-        "city",
-        "AAID",
-        "unique_identifier",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_language",
-        "device_model",
-        "app_name",
-        "os_version",
-        "timezone",
-        "platform"
-      ]
-    },
-    "AppsFlyer": {
-      "score": 5351,
-      "signals": [
-        "device_magnetometer",
-        "AAID",
-        "unique_identifier",
-        "accelerometer_data",
-        "network_carrier",
-        "cookies",
-        "device_battery_level",
-        "cpu_data",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "first_launch_date",
-        "install_date",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "device_screen_density",
-        "platform"
-      ]
-    },
-    "Tapad, Inc.": {
-      "score": 5313,
-      "signals": [
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "device_total_memory",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Salesforce.com, Inc.": {
-      "score": 5262,
-      "signals": [
-        "email_address",
-        "postal_code",
-        "AAID",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "device_total_memory",
-        "os_build_version",
-        "app_version",
-        "device_language",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "timezone",
-        "platform"
-      ]
-    },
-    "Adjust GmbH": {
-      "score": 5010,
-      "signals": [
-        "email_address",
-        "postal_code",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "cpu_data",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "device_screen_density",
-        "platform"
-      ]
-    },
-    "PubMatic, Inc.": {
-      "score": 4926,
-      "signals": [
-        "city",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_model",
-        "device_connectivity",
-        "device_language",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Kochava": {
-      "score": 4884,
-      "signals": [
-        "device_name",
-        "wifi_ssid",
-        "postal_code",
-        "AAID",
-        "device_boot_time",
-        "unique_identifier",
-        "network_carrier",
-        "screen_brightness",
-        "device_battery_level",
-        "device_volume",
-        "cpu_data",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "app_name",
-        "device_charging_status",
-        "device_make",
-        "os_version",
-        "timezone",
-        "device_orientation",
-        "platform"
-      ]
-    },
-    "Microsoft Corporation": {
-      "score": 4804,
-      "signals": [
-        "gps_coordinates",
-        "city",
-        "AAID",
-        "unique_identifier",
-        "state",
-        "network_carrier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_language",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "country",
-        "device_make",
-        "timezone",
-        "platform"
-      ]
-    },
-    "Index Exchange, Inc.": {
-      "score": 4300,
-      "signals": [
-        "gps_coordinates",
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Amplitude": {
-      "score": 4265,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "city",
-        "device_boot_time",
-        "unique_identifier",
-        "state",
-        "device_font_size",
-        "network_carrier",
-        "device_headphone_status",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_language",
-        "device_model",
-        "device_connectivity",
-        "device_make",
-        "os_version",
-        "country",
-        "app_name",
-        "device_screen_density",
-        "timezone",
-        "platform"
-      ]
-    },
-    "DoubleVerify": {
-      "score": 3510,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "device_total_memory",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Smartadserver S.A.S": {
-      "score": 3334,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "country",
-        "device_make",
-        "platform"
-      ]
-    },
-    "The Nielsen Company": {
-      "score": 3306,
-      "signals": [
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_language",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "The Rubicon Project, Inc.": {
-      "score": 2982,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "LiveRamp": {
-      "score": 2967,
-      "signals": [
-        "AAID",
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Segment.io, Inc.": {
-      "score": 2950,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "local_ip",
-        "state",
-        "network_carrier",
-        "device_model",
-        "os_build_version",
-        "device_resolution",
-        "device_connectivity",
-        "device_language",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "device_screen_density",
-        "timezone",
-        "platform"
-      ]
-    },
-    "Pixalate, Inc.": {
-      "score": 2654,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "cookies",
-        "device_total_memory",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform",
-        "device_orientation"
-      ]
-    },
-    "Urban Airship, Inc.": {
-      "score": 2641,
-      "signals": [
-        "gps_coordinates",
-        "email_address",
-        "city",
-        "unique_identifier",
-        "network_carrier",
-        "app_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "timezone",
-        "platform"
-      ]
-    },
-    "Functional Software, Inc.": {
-      "score": 2540,
-      "signals": [
-        "device_name",
-        "device_boot_time",
-        "unique_identifier",
-        "device_free_memory",
-        "device_battery_level",
-        "device_total_storage",
-        "cpu_data",
-        "device_total_memory",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "device_model",
-        "app_name",
-        "device_charging_status",
-        "device_make",
-        "os_version",
-        "country",
-        "device_screen_density",
-        "timezone",
-        "device_orientation",
-        "platform"
-      ]
-    },
-    "Innovid Media": {
-      "score": 2538,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "device_total_memory",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_name",
-        "os_version",
-        "platform"
-      ]
-    },
-    "MediaMath, Inc.": {
-      "score": 2472,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_language",
-        "device_make",
-        "os_version",
-        "app_name",
-        "country",
-        "platform"
-      ]
-    },
-    "Xaxis": {
-      "score": 2176,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "SpotX, Inc.": {
-      "score": 2163,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_connectivity",
-        "device_language",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "Liftoff Mobile, Inc.": {
-      "score": 2054,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "state",
-        "device_total_memory",
-        "os_build_version",
-        "device_language",
-        "device_model",
-        "app_name",
-        "os_version",
-        "country",
-        "platform"
-      ]
-    },
-    "Smaato Inc.": {
-      "score": 1932,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "unique_identifier",
-        "network_carrier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_language",
-        "device_model",
-        "device_connectivity",
-        "app_name",
-        "device_make",
-        "os_version",
-        "timezone",
-        "platform"
-      ]
-    },
-    "OpenX Technologies Inc": {
-      "score": 1905,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Pinterest, Inc.": {
-      "score": 1896,
-      "signals": [
-        "AAID",
-        "city",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_model",
-        "device_language",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "platform"
-      ]
-    },
-    "OneSignal": {
-      "score": 1855,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "timezone",
-        "platform"
-      ]
-    },
-    "Neustar, Inc.": {
-      "score": 1689,
-      "signals": [
-        "postal_code",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "device_total_memory",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "platform"
-      ]
-    },
-    "Centro, Inc.": {
-      "score": 1496,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "TripleLift": {
-      "score": 1496,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Sift Science, Inc.": {
-      "score": 1492,
-      "signals": [
-        "gps_coordinates",
-        "unique_identifier",
-        "local_ip",
-        "device_battery_level",
-        "device_model",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "app_name",
-        "device_charging_status",
-        "device_make",
-        "os_version",
-        "country",
-        "platform"
-      ]
-    },
-    "Unity Technologies ApS": {
-      "score": 1488,
-      "signals": [
-        "AAID",
-        "device_free_storage",
-        "external_free_storage",
-        "device_free_memory",
-        "screen_brightness",
-        "device_battery_level",
-        "device_total_storage",
-        "external_total_storage",
-        "device_volume",
-        "device_total_memory",
-        "device_headphone_status",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "device_model",
-        "app_name",
-        "device_charging_status",
-        "device_make",
-        "os_version",
-        "device_screen_density",
-        "timezone",
-        "device_orientation",
-        "platform"
-      ]
-    },
-    "Snap Inc.": {
-      "score": 1480,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_model",
-        "device_language",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Foursquare Labs, Inc.": {
-      "score": 1395,
-      "signals": [
-        "postal_code",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "device_total_memory",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Amobee, Inc": {
-      "score": 1331,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Instabug": {
-      "score": 1320,
-      "signals": [
-        "gps_coordinates",
-        "wifi_ssid",
-        "postal_code",
-        "city",
-        "unique_identifier",
-        "device_free_storage",
-        "state",
-        "device_free_memory",
-        "network_carrier",
-        "device_battery_level",
-        "device_total_storage",
-        "cpu_data",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "app_name",
-        "device_charging_status",
-        "device_make",
-        "os_version",
-        "country",
-        "device_screen_density",
-        "device_orientation",
-        "platform"
-      ]
-    },
-    "Datadog, Inc.": {
-      "score": 1305,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "city",
-        "unique_identifier",
-        "state",
-        "device_battery_level",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_connectivity",
-        "device_model",
-        "app_name",
-        "os_version",
-        "device_screen_density",
-        "platform"
-      ]
-    },
-    "Beeswax": {
-      "score": 1290,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "Pulsepoint, Inc.": {
-      "score": 1267,
-      "signals": [
-        "city",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_connectivity",
-        "device_model",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "RhythmOne": {
-      "score": 1232,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "device_connectivity",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Zeotap GmbH": {
-      "score": 1176,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "platform"
-      ]
-    },
-    "Inmar, Inc.": {
-      "score": 1130,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "state",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Media.net Advertising FZ-LLC": {
-      "score": 1114,
-      "signals": [
-        "postal_code",
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "FreeWheel": {
-      "score": 1070,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Mapbox Inc.": {
-      "score": 1040,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "network_carrier",
-        "device_battery_level",
-        "cpu_data",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform",
-        "device_orientation"
-      ]
-    },
-    "Teads ( Luxenbourg ) SA": {
-      "score": 1022,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Lotame Solutions, Inc.": {
-      "score": 1011,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Sovrn Holdings": {
-      "score": 975,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "LiveIntent Inc.": {
-      "score": 870,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "Sharethrough, Inc.": {
-      "score": 868,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "Unruly Group Limited": {
-      "score": 830,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "device_connectivity",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "New Relic": {
-      "score": 828,
-      "signals": [
-        "unique_identifier",
-        "network_carrier",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "device_model",
-        "app_name",
-        "device_make",
-        "country",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Tappcelator Media S.L.": {
-      "score": 822,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Engine USA LLC": {
-      "score": 820,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "Intent IQ, LLC": {
-      "score": 767,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Bugsnag Inc.": {
-      "score": 760,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cpu_data",
-        "device_total_memory",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_language",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "AdRoll, Inc.": {
-      "score": 756,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "NinthDecimal, Inc": {
-      "score": 754,
-      "signals": [
-        "gps_coordinates",
-        "postal_code",
-        "AAID",
-        "city",
-        "unique_identifier",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "country",
-        "device_make",
-        "platform"
-      ]
-    },
-    "eyeota Limited": {
-      "score": 744,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "ID5 Technology Ltd": {
-      "score": 738,
-      "signals": [
-        "city",
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Riskified Ltd.": {
-      "score": 732,
-      "signals": [
-        "gps_coordinates",
-        "AAID",
-        "network_carrier",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_language",
-        "app_name",
-        "os_version",
-        "timezone",
-        "platform"
-      ]
-    },
-    "Simplifi Holdings Inc.": {
-      "score": 726,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Parsely, Inc.": {
-      "score": 720,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "state",
-        "os_build_version",
-        "device_resolution",
-        "device_model",
-        "app_version",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "platform"
-      ]
-    },
-    "33Across, Inc.": {
-      "score": 684,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Vungle Inc": {
-      "score": 660,
-      "signals": [
-        "AAID",
-        "device_free_storage",
-        "network_carrier",
-        "device_battery_level",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_language",
-        "app_name",
-        "device_charging_status",
-        "device_make",
-        "os_version",
-        "timezone",
-        "platform"
-      ]
-    },
-    "Collective Roll": {
-      "score": 660,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "DataXu": {
-      "score": 620,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "InMobi Pte Ltd": {
-      "score": 600,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "device_volume",
-        "os_build_version",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "device_screen_density",
-        "timezone",
-        "device_orientation",
-        "platform"
-      ]
-    },
-    "Bidtellect, Inc": {
-      "score": 585,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Outbrain": {
-      "score": 585,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Telaria": {
-      "score": 522,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "Hexagon Data, S.A.P.I. de C.V.": {
-      "score": 516,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cpu_data",
-        "os_build_version",
-        "device_resolution",
-        "app_version",
-        "device_language",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Quantcast Corporation": {
-      "score": 512,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_resolution",
-        "device_connectivity",
-        "device_model",
-        "app_version",
-        "device_language",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Synacor, Inc.": {
-      "score": 488,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_connectivity",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "ByteDance Ltd.": {
-      "score": 484,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Fastly, Inc.": {
-      "score": 480,
-      "signals": [
-        "city",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Kantar Operations": {
-      "score": 470,
-      "signals": [
-        "AAID",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Beachfront Media LLC": {
-      "score": 468,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Adform A/S": {
-      "score": 468,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "AcuityAds": {
-      "score": 468,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "ADman Media": {
-      "score": 468,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Apptentive Inc.": {
-      "score": 440,
-      "signals": [
-        "unique_identifier",
-        "network_carrier",
-        "cpu_data",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "app_name",
-        "device_make",
-        "os_version",
-        "country",
-        "platform"
-      ]
-    },
-    "Reddit Inc.": {
-      "score": 438,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "platform"
-      ]
-    },
-    "Adkernel, LLC": {
-      "score": 424,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_connectivity",
-        "device_model",
-        "app_name",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Flashtalking Inc": {
-      "score": 423,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "cpu_data",
-        "os_build_version",
-        "device_resolution",
-        "device_language",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_orientation",
-        "platform"
-      ]
-    },
-    "Data Plus Math": {
-      "score": 416,
-      "signals": [
-        "AAID",
-        "cookies",
-        "device_total_memory",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "Prospect One": {
-      "score": 408,
-      "signals": [
-        "AAID",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "GumGum": {
-      "score": 384,
-      "signals": [
-        "city",
-        "cookies",
-        "os_build_version",
-        "app_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Human Security, Inc.": {
-      "score": 378,
-      "signals": [
-        "AAID",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "platform"
-      ]
-    },
-    "engageBDR": {
-      "score": 372,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "SSP Network Ltd": {
-      "score": 372,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "Exponential Interactive Inc.": {
-      "score": 363,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Cognitiv Corp.": {
-      "score": 363,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "device_make",
-        "os_version",
-        "platform"
-      ]
-    },
-    "Optimizely, Inc.": {
-      "score": 356,
-      "signals": [
-        "unique_identifier",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "ZypMedia, Inc.": {
-      "score": 351,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Zeta Global": {
-      "score": 351,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Merkle Inc": {
-      "score": 351,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Kargo Global, Inc.": {
-      "score": 351,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Sonobi, Inc": {
-      "score": 351,
-      "signals": [
-        "city",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "country",
-        "platform"
-      ]
-    },
-    "District M Inc.": {
-      "score": 351,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Connexity, Inc.": {
-      "score": 351,
-      "signals": [
-        "AAID",
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Knorex Pte. Ltd.": {
-      "score": 351,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Avocet Systems Ltd.": {
-      "score": 351,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Mobiquity Inc.": {
-      "score": 351,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "AdTheorent Inc": {
-      "score": 351,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Intuition Machines, Inc.": {
-      "score": 336,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "cpu_data",
-        "os_build_version",
-        "device_resolution",
-        "device_language",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    },
-    "Storygize": {
-      "score": 327,
-      "signals": [
-        "AAID",
-        "cookies",
-        "os_build_version",
-        "device_connectivity",
-        "device_model",
-        "app_version",
-        "app_name",
-        "os_version",
-        "platform"
-      ]
-    },
-    "RTB House S.A.": {
-      "score": 321,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_language",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Bazaarvoice, Inc.": {
-      "score": 321,
-      "signals": [
-        "AAID",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_version",
-        "device_connectivity",
-        "device_language",
-        "app_name",
-        "os_version",
-        "platform"
-      ]
-    },
-    "YieldMo, Inc.": {
-      "score": 321,
-      "signals": [
-        "unique_identifier",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "device_make",
-        "os_version",
-        "app_name",
-        "platform"
-      ]
-    },
-    "Treasure Data, Inc": {
-      "score": 312,
-      "signals": [
-        "AAID",
-        "cookies",
-        "os_build_version",
-        "device_model",
-        "app_name",
-        "os_version",
-        "device_make",
-        "platform"
-      ]
-    }
-  }
 }

--- a/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
+++ b/app-tracking-protection/vpn-store/src/test/resources/full_app_trackers_blocklist.json
@@ -2828,6 +2828,7 @@
     },
     "entities": {
         "33Across, Inc.": {
+            "score": 590,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -2843,6 +2844,7 @@
             ]
         },
         "A.Mob SAS": {
+            "score": 585,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -2857,6 +2859,7 @@
             ]
         },
         "AcuityAds": {
+            "score": 702,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -2872,6 +2875,7 @@
             ]
         },
         "Adform A/S": {
+            "score": 1680,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -2887,6 +2891,7 @@
             ]
         },
         "Adjust GmbH": {
+            "score": 18942,
             "signals": [
                 "phone_number",
                 "email_address",
@@ -2911,6 +2916,7 @@
             ]
         },
         "Adkernel, LLC": {
+            "score": 530,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -2927,6 +2933,7 @@
             ]
         },
         "ADman Media": {
+            "score": 702,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -2942,6 +2949,7 @@
             ]
         },
         "Adobe Inc.": {
+            "score": 20715,
             "signals": [
                 "gps_coordinates",
                 "email_address",
@@ -2968,6 +2976,7 @@
             ]
         },
         "AdRoll, Inc.": {
+            "score": 1008,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -2984,6 +2993,7 @@
             ]
         },
         "Adscore Technologies DMCC": {
+            "score": 704,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -3001,6 +3011,7 @@
             ]
         },
         "AdTheorent Inc": {
+            "score": 585,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3015,6 +3026,7 @@
             ]
         },
         "Amazon Technologies, Inc.": {
+            "score": 27934,
             "signals": [
                 "email_address",
                 "password",
@@ -3048,6 +3060,7 @@
             ]
         },
         "Amobee, Inc": {
+            "score": 2260,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3063,6 +3076,7 @@
             ]
         },
         "Amplitude": {
+            "score": 7196,
             "signals": [
                 "gps_coordinates",
                 "username",
@@ -3095,6 +3109,7 @@
             ]
         },
         "AppLovin Corporation": {
+            "score": 26675,
             "signals": [
                 "gps_coordinates",
                 "neighborhood",
@@ -3119,6 +3134,7 @@
             ]
         },
         "AppsFlyer": {
+            "score": 15310,
             "signals": [
                 "device_magnetometer",
                 "AAID",
@@ -3145,6 +3161,7 @@
             ]
         },
         "Apptentive Inc.": {
+            "score": 1915,
             "signals": [
                 "phone_number",
                 "birthday",
@@ -3164,6 +3181,7 @@
             ]
         },
         "Avocet Systems Ltd.": {
+            "score": 625,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3179,6 +3197,7 @@
             ]
         },
         "Beeswax": {
+            "score": 3600,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3194,6 +3213,7 @@
             ]
         },
         "Bidtellect, Inc": {
+            "score": 1365,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3210,6 +3230,7 @@
             ]
         },
         "Branch Metrics, Inc.": {
+            "score": 33342,
             "signals": [
                 "email_address",
                 "username",
@@ -3239,6 +3260,7 @@
             ]
         },
         "Braze, Inc.": {
+            "score": 10584,
             "signals": [
                 "gps_coordinates",
                 "email_address",
@@ -3264,6 +3286,7 @@
             ]
         },
         "Bugsnag Inc.": {
+            "score": 2201,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -3288,6 +3311,7 @@
             ]
         },
         "ByteDance Ltd.": {
+            "score": 1452,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -3304,6 +3328,7 @@
             ]
         },
         "Centro, Inc.": {
+            "score": 2400,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3319,6 +3344,7 @@
             ]
         },
         "Collective Roll": {
+            "score": 2750,
             "signals": [
                 "neighborhood",
                 "unique_identifier",
@@ -3336,6 +3362,7 @@
             ]
         },
         "comScore, Inc": {
+            "score": 14164,
             "signals": [
                 "gps_coordinates",
                 "postal_code",
@@ -3360,6 +3387,7 @@
             ]
         },
         "Criteo SA": {
+            "score": 10557,
             "signals": [
                 "AAID",
                 "city",
@@ -3381,6 +3409,7 @@
             ]
         },
         "Datadog, Inc.": {
+            "score": 1305,
             "signals": [
                 "gps_coordinates",
                 "postal_code",
@@ -3400,6 +3429,7 @@
             ]
         },
         "DeepIntent Inc": {
+            "score": 625,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3415,6 +3445,7 @@
             ]
         },
         "Digital Turbine": {
+            "score": 6813,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -3442,6 +3473,7 @@
             ]
         },
         "Dotmetrics": {
+            "score": 1228,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3461,6 +3493,7 @@
             ]
         },
         "DoubleVerify": {
+            "score": 9921,
             "signals": [
                 "gps_coordinates",
                 "neighborhood",
@@ -3480,6 +3513,7 @@
             ]
         },
         "Engine USA LLC": {
+            "score": 1524,
             "signals": [
                 "city",
                 "AAID",
@@ -3497,6 +3531,7 @@
             ]
         },
         "Exponential Interactive Inc.": {
+            "score": 726,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3512,6 +3547,7 @@
             ]
         },
         "eyeota Limited": {
+            "score": 1400,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3527,6 +3563,7 @@
             ]
         },
         "Facebook, Inc.": {
+            "score": 119895,
             "signals": [
                 "gps_coordinates",
                 "email_address",
@@ -3568,6 +3605,7 @@
             ]
         },
         "Fastly, Inc.": {
+            "score": 792,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -3584,6 +3622,7 @@
             ]
         },
         "Flashtalking Inc": {
+            "score": 2050,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3603,6 +3642,7 @@
             ]
         },
         "Foursquare Labs, Inc.": {
+            "score": 1395,
             "signals": [
                 "postal_code",
                 "AAID",
@@ -3617,6 +3657,7 @@
             ]
         },
         "FreeWheel": {
+            "score": 1896,
             "signals": [
                 "gps_coordinates",
                 "AAID",
@@ -3635,6 +3676,7 @@
             ]
         },
         "Functional Software, Inc.": {
+            "score": 6310,
             "signals": [
                 "device_name",
                 "device_boot_time",
@@ -3662,6 +3704,7 @@
             ]
         },
         "GameAnalytics ApS": {
+            "score": 955,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -3679,6 +3722,7 @@
             ]
         },
         "Google LLC": {
+            "score": 326430,
             "signals": [
                 "gps_coordinates",
                 "email_address",
@@ -3724,6 +3768,7 @@
             ]
         },
         "Hexagon Data, S.A.P.I. de C.V.": {
+            "score": 774,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -3741,6 +3786,7 @@
             ]
         },
         "Human Security, Inc.": {
+            "score": 378,
             "signals": [
                 "AAID",
                 "cookies",
@@ -3752,6 +3798,7 @@
             ]
         },
         "ID5 Technology Ltd": {
+            "score": 861,
             "signals": [
                 "city",
                 "AAID",
@@ -3771,6 +3818,7 @@
             ]
         },
         "Index Exchange, Inc.": {
+            "score": 11308,
             "signals": [
                 "gps_coordinates",
                 "city",
@@ -3789,6 +3837,7 @@
             ]
         },
         "Inmar, Inc.": {
+            "score": 2486,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -3806,6 +3855,7 @@
             ]
         },
         "InMobi Pte Ltd": {
+            "score": 800,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -3826,6 +3876,7 @@
             ]
         },
         "Innovid Media": {
+            "score": 3400,
             "signals": [
                 "gps_coordinates",
                 "postal_code",
@@ -3847,6 +3898,7 @@
             ]
         },
         "Integral Ad Science, Inc.": {
+            "score": 18228,
             "signals": [
                 "postal_code",
                 "AAID",
@@ -3869,6 +3921,7 @@
             ]
         },
         "Intuition Machines, Inc.": {
+            "score": 460,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -3885,6 +3938,7 @@
             ]
         },
         "IPONWEB GmbH": {
+            "score": 9445,
             "signals": [
                 "gps_coordinates",
                 "postal_code",
@@ -3906,6 +3960,7 @@
             ]
         },
         "ironSource Ltd": {
+            "score": 29113,
             "signals": [
                 "postal_code",
                 "neighborhood",
@@ -3935,6 +3990,7 @@
             ]
         },
         "iSpot.tv": {
+            "score": 670,
             "signals": [
                 "city",
                 "cookies",
@@ -3950,6 +4006,7 @@
             ]
         },
         "Iterable, Inc.": {
+            "score": 1395,
             "signals": [
                 "email_address",
                 "AAID",
@@ -3964,6 +4021,7 @@
             ]
         },
         "Kantar Operations": {
+            "score": 1098,
             "signals": [
                 "device_magnetometer",
                 "AAID",
@@ -3981,6 +4039,7 @@
             ]
         },
         "Kochava": {
+            "score": 11696,
             "signals": [
                 "gps_coordinates",
                 "wifi_ssid",
@@ -4012,6 +4071,7 @@
             ]
         },
         "Liftoff Mobile, Inc.": {
+            "score": 7491,
             "signals": [
                 "gps_coordinates",
                 "postal_code",
@@ -4032,6 +4092,7 @@
             ]
         },
         "LiveIntent Inc.": {
+            "score": 1044,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4047,6 +4108,7 @@
             ]
         },
         "LiveRamp Holdings, Inc.": {
+            "score": 6738,
             "signals": [
                 "AAID",
                 "city",
@@ -4064,6 +4126,7 @@
             ]
         },
         "Lotame Solutions, Inc.": {
+            "score": 2102,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4080,6 +4143,7 @@
             ]
         },
         "Magnite, Inc.": {
+            "score": 8432,
             "signals": [
                 "gps_coordinates",
                 "AAID",
@@ -4101,6 +4165,7 @@
             ]
         },
         "Mapbox Inc.": {
+            "score": 1662,
             "signals": [
                 "gps_coordinates",
                 "AAID",
@@ -4121,6 +4186,7 @@
             ]
         },
         "Media.net Advertising FZ-LLC": {
+            "score": 530,
             "signals": [
                 "city",
                 "cookies",
@@ -4136,6 +4202,7 @@
             ]
         },
         "MediaMath, Inc.": {
+            "score": 4429,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -4152,6 +4219,7 @@
             ]
         },
         "Microsoft Corporation": {
+            "score": 37698,
             "signals": [
                 "gps_coordinates",
                 "username",
@@ -4178,6 +4246,7 @@
             ]
         },
         "Mixpanel, Inc.": {
+            "score": 2984,
             "signals": [
                 "email_address",
                 "phone_number",
@@ -4202,6 +4271,7 @@
             ]
         },
         "Mobiquity Inc.": {
+            "score": 702,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -4216,6 +4286,7 @@
             ]
         },
         "Moloco Inc.": {
+            "score": 1904,
             "signals": [
                 "neighborhood",
                 "os_build_version",
@@ -4230,6 +4301,7 @@
             ]
         },
         "Neustar, Inc.": {
+            "score": 3528,
             "signals": [
                 "postal_code",
                 "AAID",
@@ -4248,6 +4320,7 @@
             ]
         },
         "New Relic": {
+            "score": 828,
             "signals": [
                 "unique_identifier",
                 "network_carrier",
@@ -4265,6 +4338,7 @@
             ]
         },
         "Ogury Limited": {
+            "score": 696,
             "signals": [
                 "AAID",
                 "cpu_data",
@@ -4281,6 +4355,7 @@
             ]
         },
         "OnAudience Ltd.": {
+            "score": 630,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -4296,6 +4371,7 @@
             ]
         },
         "OneSignal": {
+            "score": 4452,
             "signals": [
                 "gps_coordinates",
                 "first_name",
@@ -4315,6 +4391,7 @@
             ]
         },
         "OpenX Technologies Inc": {
+            "score": 3391,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -4331,6 +4408,7 @@
             ]
         },
         "Optimizely, Inc.": {
+            "score": 1790,
             "signals": [
                 "unique_identifier",
                 "os_build_version",
@@ -4345,6 +4423,7 @@
             ]
         },
         "Oracle Corporation": {
+            "score": 8083,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4366,6 +4445,7 @@
             ]
         },
         "Outbrain": {
+            "score": 1250,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -4381,6 +4461,7 @@
             ]
         },
         "Parsely, Inc.": {
+            "score": 720,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4397,6 +4478,7 @@
             ]
         },
         "Permutive, Inc.": {
+            "score": 2010,
             "signals": [
                 "neighborhood",
                 "city",
@@ -4415,6 +4497,7 @@
             ]
         },
         "Pinterest, Inc.": {
+            "score": 3092,
             "signals": [
                 "AAID",
                 "city",
@@ -4434,6 +4517,7 @@
             ]
         },
         "Pixalate, Inc.": {
+            "score": 3330,
             "signals": [
                 "gps_coordinates",
                 "AAID",
@@ -4453,6 +4537,7 @@
             ]
         },
         "Prospect One": {
+            "score": 816,
             "signals": [
                 "AAID",
                 "os_build_version",
@@ -4467,6 +4552,7 @@
             ]
         },
         "PubMatic, Inc.": {
+            "score": 17734,
             "signals": [
                 "gps_coordinates",
                 "city",
@@ -4487,6 +4573,7 @@
             ]
         },
         "Pulsepoint, Inc.": {
+            "score": 1629,
             "signals": [
                 "city",
                 "AAID",
@@ -4505,6 +4592,7 @@
             ]
         },
         "Quantcast Corporation": {
+            "score": 1408,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -4522,6 +4610,7 @@
             ]
         },
         "Reddit Inc.": {
+            "score": 1038,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4537,6 +4626,7 @@
             ]
         },
         "RevenueCat": {
+            "score": 1773,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4551,6 +4641,7 @@
             ]
         },
         "RhythmOne": {
+            "score": 1584,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -4568,6 +4659,7 @@
             ]
         },
         "Riskified Ltd.": {
+            "score": 1318,
             "signals": [
                 "gps_coordinates",
                 "first_name",
@@ -4587,6 +4679,7 @@
             ]
         },
         "Roku, Inc.": {
+            "score": 1400,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -4602,6 +4695,7 @@
             ]
         },
         "RTB House S.A.": {
+            "score": 575,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -4616,6 +4710,7 @@
             ]
         },
         "Salesforce.com, Inc.": {
+            "score": 8391,
             "signals": [
                 "email_address",
                 "postal_code",
@@ -4637,6 +4732,7 @@
             ]
         },
         "Segment.io, Inc.": {
+            "score": 4752,
             "signals": [
                 "email_address",
                 "username",
@@ -4667,6 +4763,7 @@
             ]
         },
         "Sharethrough, Inc.": {
+            "score": 2380,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -4684,6 +4781,7 @@
             ]
         },
         "Sift Science, Inc.": {
+            "score": 2563,
             "signals": [
                 "gps_coordinates",
                 "neighborhood",
@@ -4705,6 +4803,7 @@
             ]
         },
         "Simplifi Holdings Inc.": {
+            "score": 1375,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -4720,6 +4819,7 @@
             ]
         },
         "Smaato Inc.": {
+            "score": 2760,
             "signals": [
                 "gps_coordinates",
                 "postal_code",
@@ -4741,6 +4841,7 @@
             ]
         },
         "Smartadserver S.A.S": {
+            "score": 3495,
             "signals": [
                 "gps_coordinates",
                 "postal_code",
@@ -4761,6 +4862,7 @@
             ]
         },
         "Snap Inc.": {
+            "score": 2702,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4778,6 +4880,7 @@
             ]
         },
         "Sovrn Holdings": {
+            "score": 1625,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4795,6 +4898,7 @@
             ]
         },
         "SpotX, Inc.": {
+            "score": 4326,
             "signals": [
                 "gps_coordinates",
                 "AAID",
@@ -4814,6 +4918,7 @@
             ]
         },
         "Synacor, Inc.": {
+            "score": 1600,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -4830,6 +4935,7 @@
             ]
         },
         "Taboola, Inc.": {
+            "score": 14406,
             "signals": [
                 "gps_coordinates",
                 "neighborhood",
@@ -4853,6 +4959,7 @@
             ]
         },
         "Take-Two Interactive Software, Inc.": {
+            "score": 858,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4872,6 +4979,7 @@
             ]
         },
         "Talent Game Box": {
+            "score": 2183,
             "signals": [
                 "neighborhood",
                 "AAID",
@@ -4892,6 +5000,7 @@
             ]
         },
         "Tapad, Inc.": {
+            "score": 7850,
             "signals": [
                 "postal_code",
                 "AAID",
@@ -4912,6 +5021,7 @@
             ]
         },
         "Tapjoy, Inc.": {
+            "score": 9396,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4933,6 +5043,7 @@
             ]
         },
         "Tappcelator Media S.L.": {
+            "score": 822,
             "signals": [
                 "gps_coordinates",
                 "AAID",
@@ -4948,6 +5059,7 @@
             ]
         },
         "Teads ( Luxenbourg ) SA": {
+            "score": 880,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -4964,6 +5076,7 @@
             ]
         },
         "Telaria": {
+            "score": 870,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -4980,6 +5093,7 @@
             ]
         },
         "The Nielsen Company": {
+            "score": 4327,
             "signals": [
                 "AAID",
                 "city",
@@ -4999,6 +5113,7 @@
             ]
         },
         "The Trade Desk Inc": {
+            "score": 18988,
             "signals": [
                 "gps_coordinates",
                 "postal_code",
@@ -5019,6 +5134,7 @@
             ]
         },
         "TripleLift": {
+            "score": 3543,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -5036,6 +5152,7 @@
             ]
         },
         "TrustArc Inc.": {
+            "score": 1014,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -5048,6 +5165,7 @@
             ]
         },
         "Twitter, Inc.": {
+            "score": 13507,
             "signals": [
                 "email_address",
                 "password",
@@ -5069,6 +5187,7 @@
             ]
         },
         "Undertone Networks": {
+            "score": 740,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -5083,6 +5202,7 @@
             ]
         },
         "Unity Technologies ApS": {
+            "score": 27349,
             "signals": [
                 "neighborhood",
                 "postal_code",
@@ -5119,6 +5239,7 @@
             ]
         },
         "Unruly Group Limited": {
+            "score": 1162,
             "signals": [
                 "city",
                 "unique_identifier",
@@ -5136,6 +5257,7 @@
             ]
         },
         "Upland Software Inc.": {
+            "score": 930,
             "signals": [
                 "postal_code",
                 "city",
@@ -5156,6 +5278,7 @@
             ]
         },
         "Urban Airship, Inc.": {
+            "score": 4751,
             "signals": [
                 "gps_coordinates",
                 "email_address",
@@ -5175,6 +5298,7 @@
             ]
         },
         "Verizon Media": {
+            "score": 18260,
             "signals": [
                 "gps_coordinates",
                 "birthday",
@@ -5211,6 +5335,7 @@
             ]
         },
         "Vungle Inc": {
+            "score": 6282,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -5233,6 +5358,7 @@
             ]
         },
         "WPP plc": {
+            "score": 2992,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -5249,6 +5375,7 @@
             ]
         },
         "Yandex LLC": {
+            "score": 1219,
             "signals": [
                 "gps_coordinates",
                 "AAID",
@@ -5265,6 +5392,7 @@
             ]
         },
         "YieldMo, Inc.": {
+            "score": 675,
             "signals": [
                 "unique_identifier",
                 "cookies",
@@ -5279,6 +5407,7 @@
             ]
         },
         "Zeotap GmbH": {
+            "score": 1614,
             "signals": [
                 "AAID",
                 "unique_identifier",
@@ -5295,6 +5424,7 @@
             ]
         },
         "Zeta Global": {
+            "score": 625,
             "signals": [
                 "city",
                 "unique_identifier",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204239971719179/f

### Description
Now that we're using the cumulative blocklist for AppTP, we've decided to use a new endpoint to support the new list format and any future updates. We'll maintain the old endpoint, without updates, for users on earlier versions.

### Steps to test this PR
The endpoint is up & running with the old (current) list, but in the new format (which I'll alter today to include entity scores).

To test:
Install app from `develop`, enable AppTP & let block some trackers
Update app from this branch, verify that database transitions smoothly without trying to migrate to a new version

