### PR TITLE
Make sure default variant is always used in CI end-2-end tests

### DIFF
--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Assemble release APK
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assembleInternalRelease
+          arguments: assembleInternalRelease -Pforce-default-variant
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assembleInternalDebug
+          arguments: assembleInternalDebug -Pforce-default-variant
 
       - name: Obtain debug apk
         if: always()

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Assemble release APK
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assemblePlayRelease
+          arguments: assemblePlayRelease -Pforce-default-variant
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Assemble release APK
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assemblePlayRelease
+          arguments: assemblePlayRelease -Pforce-default-variant
 
       - name: Move APK to new folder
         if: always()

--- a/app-build-config/app-build-config-api/src/main/java/com/duckduckgo/appbuildconfig/api/AppBuildConfig.kt
+++ b/app-build-config/app-build-config-api/src/main/java/com/duckduckgo/appbuildconfig/api/AppBuildConfig.kt
@@ -31,6 +31,7 @@ interface AppBuildConfig {
     val manufacturer: String
     val model: String
     val deviceLocale: Locale
+    val isDefaultVariantForced: Boolean
 }
 
 enum class BuildFlavor {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,11 @@ android {
         } else {
             buildConfigField "boolean", "IS_PERFORMANCE_TEST", "false"
         }
+        if (project.hasProperty('force-default-variant')) {
+            buildConfigField "boolean", "FORCE_DEFAULT_VARIANT", "true"
+        } else {
+            buildConfigField "boolean", "FORCE_DEFAULT_VARIANT", "false"
+        }
     }
     buildFeatures {
         viewBinding = true

--- a/app/src/main/java/com/duckduckgo/app/buildconfig/RealAppBuildConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/buildconfig/RealAppBuildConfig.kt
@@ -52,6 +52,8 @@ class RealAppBuildConfig @Inject constructor() : AppBuildConfig {
         }
     }
     override val isPerformanceTest: Boolean = BuildConfig.IS_PERFORMANCE_TEST
+
+    override val isDefaultVariantForced: Boolean = BuildConfig.FORCE_DEFAULT_VARIANT
     override val deviceLocale: Locale
         get() = Locale.getDefault()
 }

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -208,7 +208,7 @@ class ExperimentationVariantManager(
         var newVariant = generateVariant(activeVariants)
         val compliesWithFilters = newVariant.filterBy(appBuildConfig)
 
-        if (!compliesWithFilters) {
+        if (!compliesWithFilters || appBuildConfig.isDefaultVariantForced) {
             newVariant = DEFAULT_VARIANT
         }
         Timber.i("Current variant is null; allocating new one $newVariant")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204340991927492/f

### Description
This PR makes sure the default variant is always used when running end to end tests on CI

### Steps to test this PR

- [x] Build the app normally and a variant should be allocated to your
- [x] Build the app using `-Pforce-default-variant`, for example `./gradlew installInternalDebug -Pforce-default-variant` and make sure you are always assigned the default variant.
- [x] All CI tests should also pass in this PR
- [x] All tests in https://github.com/duckduckgo/Android/actions/runs/4637681307 should pass and if they are not is not because the onboarding cannot be finished

