### PR TITLE
Change autofill subfeature names in prep for releasing

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -30,23 +30,23 @@ interface AutofillFeature {
     fun self(): Toggle
 
     /**
-     * @return `true` when the remote config has the global "injectCredentials" autofill sub-feature flag enabled
+     * @return `true` when the remote config has the global "canInjectCredentials" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
     @Toggle.DefaultValue(false)
-    fun injectCredentials(): Toggle
+    fun canInjectCredentials(): Toggle
 
     /**
-     * @return `true` when the remote config has the global "saveCredentials" autofill sub-feature flag enabled
+     * @return `true` when the remote config has the global "canSaveCredentials" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
     @Toggle.DefaultValue(false)
-    fun saveCredentials(): Toggle
+    fun canSaveCredentials(): Toggle
 
     /**
-     * @return `true` when the remote config has the global "accessCredentialManagement" autofill sub-feature flag enabled
+     * @return `true` when the remote config has the global "canAccessCredentialManagement" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
     @Toggle.DefaultValue(false)
-    fun accessCredentialManagement(): Toggle
+    fun canAccessCredentialManagement(): Toggle
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillCapabilityCheckerImpl.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillCapabilityCheckerImpl.kt
@@ -40,7 +40,7 @@ class AutofillCapabilityCheckerImpl @Inject constructor(
 
         if (isInternalTester()) return@withContext true
 
-        return@withContext autofillFeature.injectCredentials().isEnabled()
+        return@withContext autofillFeature.canInjectCredentials().isEnabled()
     }
 
     override suspend fun canSaveCredentialsFromWebView(url: String): Boolean = withContext(dispatcherProvider.io()) {
@@ -50,7 +50,7 @@ class AutofillCapabilityCheckerImpl @Inject constructor(
 
         if (isInternalTester()) return@withContext true
 
-        return@withContext autofillFeature.saveCredentials().isEnabled()
+        return@withContext autofillFeature.canSaveCredentials().isEnabled()
     }
 
     /**
@@ -62,7 +62,7 @@ class AutofillCapabilityCheckerImpl @Inject constructor(
     override suspend fun canAccessCredentialManagementScreen(): Boolean = withContext(dispatcherProvider.io()) {
         if (isInternalTester()) return@withContext true
         if (!isGlobalFeatureEnabled()) return@withContext false
-        return@withContext autofillFeature.accessCredentialManagement().isEnabled()
+        return@withContext autofillFeature.canAccessCredentialManagement().isEnabled()
     }
 
     private suspend fun isInternalTester(): Boolean {

--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -97,7 +97,8 @@
                     "reason": "site breakage"
                 }
             ],
-            "state": "enabled"
+            "state": "enabled",
+            "hash": "0"
         },
         "clickToPlay": {
             "exceptions": [],

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
@@ -38,7 +38,7 @@ import com.duckduckgo.privacy.config.store.features.useragent.UserAgentDao
 )
 @Database(
     exportSchema = true,
-    version = 11,
+    version = 12,
     entities = [
         TrackerAllowlistEntity::class,
         UnprotectedTemporaryEntity::class,
@@ -92,4 +92,10 @@ val MIGRATION_10_11 = object : Migration(10, 11) {
     }
 }
 
-val ALL_MIGRATIONS = arrayOf(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_10_11)
+val MIGRATION_11_12 = object : Migration(11, 12) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("DELETE FROM privacy_config")
+    }
+}
+
+val ALL_MIGRATIONS = arrayOf(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_10_11, MIGRATION_11_12)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204370666975082/f

### Description
Renames the autofill subfeatures, as is required to prepare for the autofill release.

### Steps to test this PR

**Start with develop branch.**
- [x] Checkout `develop`
- [x] Build using `play` variant, and do a clean install. 
- [x] Give the app a few seconds after launching to fetch the remote config.
- [x] Verify that autofill is NOT visible (e.g., you cannot access the credential management screen)

**Use new remote config**
Change URL we use for the remote config (it's defined in `PrivacyFeatureName.PRIVACY_REMOTE_CONFIG_URL`)
- [x] change it to https://jsonblob.com/api/1095045267291652096 
- [x] Make the above change to the URL in `develop`
- [x] Build using`play` variant again, and install the app. 
- [x] Give the app a few seconds after launching to fetch the remote config.
- [x] Verify that autofill is still NOT visible (e.g., you cannot access the credential management screen)

**Checkout the branch from this PR**
- [x] Checkout the branch from this PR, and apply the URL change as above so it's getting the new remote config type
- [x] Install using `play` variant again.
- [x] Give the app a few seconds after launching to fetch the remote config.
- [x] Verify that autofill IS visible (e.g., you can access the credential management screen - you might need to launch a new tab to see it picked up in the overflow if you were already viewing a tab)
- [x] Verify that autofill is DISABLED by default ⚠️ 