### PR TITLE
Implement Dax dialog in the last step of onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -134,8 +134,8 @@ import com.duckduckgo.app.browser.webview.enableDarkMode
 import com.duckduckgo.app.browser.webview.enableLightMode
 import com.duckduckgo.app.cta.onboarding_experiment.DaxDialogExperimentListener
 import com.duckduckgo.app.cta.ui.*
-import com.duckduckgo.app.cta.ui.DaxDialogCta.DaxAutoconsentCta
-import com.duckduckgo.app.cta.ui.DaxDialogCta.DaxTrackersBlockedCta
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxEndEnableAppTpCta
+import com.duckduckgo.app.cta.ui.DaxDialogCta.*
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.downloads.DownloadsFileActions
 import com.duckduckgo.app.email.EmailAutofillTooltipFragment
@@ -3128,6 +3128,7 @@ class BrowserTabFragment :
         ) {
             when (configuration) {
                 is HomePanelCta -> showHomeCta(configuration, favorites)
+                is DaxEndEnableAppTpCta -> showDaxEndEnableAppTpCta(configuration)
                 is DaxBubbleCta -> showDaxCta(configuration)
                 is BubbleCta -> showBubbleCta(configuration)
                 is DialogCta -> showDaxDialogCta(configuration)
@@ -3206,6 +3207,24 @@ class BrowserTabFragment :
             hideHomeBackground()
             hideHomeCta()
             configuration.showCta(daxDialogCta.daxCtaContainer)
+            newBrowserTab.newTabLayout.setOnClickListener { daxDialogCta.dialogTextCta.finishAnimation() }
+
+            viewModel.onCtaShown()
+        }
+
+        private fun showDaxEndEnableAppTpCta(configuration: DaxEndEnableAppTpCta) {
+            hideHomeBackground()
+            hideHomeCta()
+            configuration.showCta(daxDialogCta.daxCtaContainer)
+
+            daxDialogCta.daxCtaContainer.findViewById<View>(R.id.primaryCtaVariant).setOnClickListener {
+                viewModel.onUserClickCtaOkButton()
+            }
+
+            daxDialogCta.daxCtaContainer.findViewById<View>(R.id.secondaryCtaVariant).setOnClickListener {
+                viewModel.onUserDismissedCta()
+            }
+
             newBrowserTab.newTabLayout.setOnClickListener { daxDialogCta.dialogTextCta.finishAnimation() }
 
             viewModel.onCtaShown()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2376,6 +2376,7 @@ class BrowserTabViewModel @Inject constructor(
         command.value = when (cta) {
             is HomePanelCta.Survey -> LaunchSurvey(cta.survey)
             is HomePanelCta.AddWidgetAuto, is HomePanelCta.AddWidgetInstructions -> LaunchAddWidget
+            is DaxBubbleCta.DaxEndEnableAppTpCta -> LaunchAppTPOnboarding
             else -> return
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -374,6 +374,31 @@ sealed class DaxBubbleCta(
         onboardingStore,
         appInstallStore,
     )
+
+    class DaxEndEnableAppTpCta(
+        override val onboardingStore: OnboardingStore,
+        override val appInstallStore: AppInstallStore,
+    ) : DaxBubbleCta(
+        ctaId = CtaId.DAX_END,
+        shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        cancelPixel = AppPixelName.ONBOARDING_DAX_CTA_CANCEL_BUTTON,
+        ctaPixelParam = Pixel.PixelValues.DAX_APPTP_CTA,
+        description = R.string.daxDialogAppTpRetentionText,
+        onboardingStore = onboardingStore,
+        appInstallStore = appInstallStore,
+    ) {
+        override fun showCta(view: View) {
+            val daxText = view.context.getString(description)
+            view.show()
+            view.alpha = 1f
+            view.findViewById<TextView>(R.id.hiddenTextCta).text = daxText.html(view.context)
+            view.findViewById<View>(R.id.primaryCta).hide()
+            view.findViewById<View>(R.id.primaryCtaVariant).show()
+            view.findViewById<View>(R.id.secondaryCtaVariant).show()
+            view.findViewById<TypeAnimationTextView>(R.id.dialogTextCta).startTypingAnimation(daxText, true)
+        }
+    }
 }
 
 sealed class BubbleCta(

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -38,6 +38,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     ONBOARDING_DAX_CTA_SHOWN("m_odc_s"),
     ONBOARDING_DAX_ALL_CTA_HIDDEN("m_odc_h"),
     ONBOARDING_DAX_CTA_OK_BUTTON("m_odc_ok"),
+    ONBOARDING_DAX_CTA_CANCEL_BUTTON("m_onboarding_dax_cta_cancel"),
     ONBOARDING_PRIVACY_SHIELD_BUTTON("m_onboarding_privacy_shield_button"),
 
     ONBOARDING_OPTION_PRIVATE_SEARCH_SELECTED("m_onboarding_option_private_search_selected"),

--- a/app/src/main/res/layout/include_dax_dialog_cta.xml
+++ b/app/src/main/res/layout/include_dax_dialog_cta.xml
@@ -41,32 +41,57 @@
         app:layout_constraintTop_toBottomOf="@id/logo"
         app:layout_constraintWidth_max="600dp">
 
-        <FrameLayout
+        <LinearLayout
             android:id="@+id/cardContainer"
             style="@style/Widget.DuckDuckGo.DaxDialog.Content"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-            <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
-                android:id="@+id/hiddenTextCta"
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+                    android:id="@+id/hiddenTextCta"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingBottom="@dimen/keyline_1"
+                    android:visibility="invisible"
+                    app:typography="body1"
+                    tools:text="@string/onboardingDaxText"
+                    tools:visibility="visible" />
+
+                <com.duckduckgo.mobile.android.ui.view.TypeAnimationTextView
+                    android:id="@+id/dialogTextCta"
+                    style="@style/Typography.DuckDuckGo.Body1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:textColor="?attr/daxColorPrimaryText" />
+
+            </FrameLayout>
+
+            <com.duckduckgo.mobile.android.ui.view.button.DaxButtonPrimary
+                android:id="@+id/primaryCtaVariant"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="@dimen/keyline_1"
-                android:visibility="invisible"
-                app:typography="body1"
-                tools:text="@string/onboardingDaxText"
-                tools:visibility="visible" />
+                app:buttonSize="large"
+                android:visibility="gone"
+                android:text="@string/daxDialogAppTpRetentionPrimaryButtonText"
+                android:layout_marginTop="@dimen/daxDialogButtonSpacing"/>
 
-            <com.duckduckgo.mobile.android.ui.view.TypeAnimationTextView
-                android:id="@+id/dialogTextCta"
-                style="@style/Typography.DuckDuckGo.Body1"
+            <com.duckduckgo.mobile.android.ui.view.button.DaxButtonGhost
+                android:id="@+id/secondaryCtaVariant"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:clickable="true"
-                android:focusable="true"
-                android:textColor="?attr/daxColorPrimaryText" />
+                app:buttonSize="large"
+                android:visibility="gone"
+                android:text="@string/daxDialogAppTpRetentionSecondaryButtonText"
+                android:layout_marginTop="@dimen/keyline_1"/>
 
-        </FrameLayout>
+        </LinearLayout>
     </com.duckduckgo.mobile.android.ui.view.shape.DaxBubbleCardView>
 
     <com.duckduckgo.mobile.android.ui.view.button.DaxButtonPrimary

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -96,13 +96,12 @@ interface Pixel {
         const val DAX_NO_TRACKERS_CTA = "nt"
         const val DAX_FIRE_DIALOG_CTA = "fd"
         const val DAX_AUTOCONSENT_CTA = "autoconsent"
+        const val DAX_APPTP_CTA = "apptp"
 
         const val FIRE_ANIMATION_INFERNO = "fai"
         const val FIRE_ANIMATION_AIRSTREAM = "faas"
         const val FIRE_ANIMATION_WHIRLPOOL = "fawp"
         const val FIRE_ANIMATION_NONE = "fann"
-
-        const val NOTIFY_ME_DOWNLOADS_SCREEN = "downloads"
     }
 
     fun fire(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204241239463177/f

### Description
Added a variation for the last Dax dialog.

### Steps to test this PR


_Variant zo_ 
- [x] Checkout from this branch.
- [x] Go to this line https://github.com/duckduckgo/Android/blob/feature/ana/implement_dax_dialog_in_the_last_step_of_onboarding_variant/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt#L86 and change the `weight` of the variant (`zo`) to `1.0`. Change all other weights to `0.0` in this file to make sure you'll land on `zo`.
- [x] Fresh install on a device from this branch.
- [x] Open the app and search for something. Notice a Dax dialog and tap on the blue button (don't hide all).
- [x] Open a new tab.
- [x] Notice the new Dax dialog with the text `You're now blocking trackers across the web 🎉 I can also block trackers hiding in your other apps, even when you aren't using your phone.` and 2 buttons: `Enable App Tracking Protection` and `Not Now`.
- [x] Open logcat and filter for `Pixel sent: m_odc_s with params: {cta=i:0-s:0-apptp:0} {}` to check the correct pixel was sent when the Dax message appeared.
- [x] Tap on `Not Now`.
- [x] Open logcat and filter for `Pixel sent: m_onboarding_dax_cta_cancel with params: {cta=apptp} {}`
- [x] Notice the Dax dialog disappeared and you see the pixel in logcat.
- [x] Clear app storage.
- [x] Open the app and search for something. Notice a Dax dialog and tap on the blue button (don't hide all).
- [x] Open a new tab.
- [x] Notice the new Dax dialog with the text `You're now blocking trackers across the web 🎉 I can also block trackers hiding in your other apps, even when you aren't using your phone.` and 2 buttons: `Enable App Tracking Protection` and `Not Now`.
- [x] Tap on `Enable App Tracking Protection`.
- [x] Open logcat and filter for `Pixel sent: m_odc_ok with params: {cta=apptp} {}`
- [x] Notice you see the pixel in logcat and you started the AppTP onboarding.
- [x] Clear app storage.
- [x] Open the app and enable AppTP.
- [x] Go back to the browser and search for something. Notice a Dax dialog and tap on the blue button (don't hide all).
- [x] Open a new tab. Notice the Dax dialog displayed has the text `You've got this! Remember: Every time you browse with me, a creepy ad loses its wings. 👍`

### UI changes
| Before  | After |
| ------ | ----- |
|![dax_dialog_original](https://user-images.githubusercontent.com/7963079/231439651-38d7e285-d027-4f9a-8854-039b64f248fc.png)|![dax_dialog_variant](https://user-images.githubusercontent.com/7963079/231439660-1872a15b-3748-4b91-8021-7f1f0af32b67.png)|


