### PR TITLE
Update reference tests to latest version

### DIFF
--- a/app/src/androidTest/resources/reference_tests/domain_matching_tests.json
+++ b/app/src/androidTest/resources/reference_tests/domain_matching_tests.json
@@ -270,7 +270,11 @@
                 "siteURL": "https://ok-subdomain.also-site-that-tracks.com",
                 "requestURL": "https://sometimes-bad.third-party.site/option-blocking-only",
                 "requestType": "image",
-                "expectAction": "ignore"
+                "expectAction": "ignore",
+                "exceptPlatforms": [
+                    "web-extension",
+                    "web-extension-mv3"
+                ]
             },
             {
                 "name": "don't block tracker with site matching options domains but not types",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.11.2",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1680705748"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1681420141"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -89,7 +89,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#8a1e44b245d3002d906f6049d169bc8f4d632f58",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#7623f0b3e8d1dcfde3365ed035c7484a82b01043",
       "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.11.2",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1680705748"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1681420141"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [ ] All tests must pass