### PR TITLE
Check table and column exist before executing query

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
@@ -27,7 +27,6 @@ import com.duckduckgo.app.fire.FireproofRepository
 import com.duckduckgo.app.fire.WebViewDatabaseLocator
 import com.duckduckgo.app.global.DefaultDispatcherProvider
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.cookies.api.CookieException
 import com.duckduckgo.cookies.impl.DefaultCookieManagerProvider
 import com.duckduckgo.cookies.impl.SQLCookieRemover
@@ -73,7 +72,6 @@ class FirstPartyCookiesReferenceTest(private val testCase: TestCase) {
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
     private val cookieManagerProvider = DefaultCookieManagerProvider()
     private val cookieManager = cookieManagerProvider.get()
-    private val mockPixel = mock<Pixel>()
     private val cookiesRepository = mock<CookiesRepository>()
     private val unprotectedTemporary = mock<UnprotectedTemporary>()
     private val userAllowListRepository = mock<UserAllowListRepository>()

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifier.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifier.kt
@@ -32,10 +32,9 @@ import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
 interface FirstPartyCookiesModifier {
-    suspend fun expireFirstPartyCookies(): Boolean
+    suspend fun expireFirstPartyCookies()
 }
 
 @ContributesBinding(AppScope::class)
@@ -49,13 +48,12 @@ class RealFirstPartyCookiesModifier @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) : FirstPartyCookiesModifier {
 
-    override suspend fun expireFirstPartyCookies(): Boolean {
-        return withContext(dispatcherProvider.io()) {
+    override suspend fun expireFirstPartyCookies() {
+        withContext(dispatcherProvider.io()) {
             val databasePath: String = webViewDatabaseLocator.getDatabasePath()
             if (databasePath.isNotEmpty()) {
-                return@withContext expireFirstPartyCookies(databasePath)
+                expireFirstPartyCookies(databasePath)
             }
-            return@withContext false
         }
     }
 
@@ -73,16 +71,17 @@ class RealFirstPartyCookiesModifier @Inject constructor(
             fireproofRepository.fireproofWebsites() +
             DDG_COOKIE_DOMAINS.map { it.toUri().host!! }
 
-    private fun buildSQLWhereClause(timestampThreshold: Long): String {
+    private fun buildSQLWhereClause(timestampThreshold: Long, isOldDb: Boolean): String {
+        val httpOnly = if (isOldDb) "httponly" else "is_httponly"
         val excludedSites: List<String> = excludedSites()
         if (excludedSites.isEmpty()) {
-            return "expires_utc > $timestampThreshold AND is_httponly = 0"
+            return "expires_utc > $timestampThreshold AND $httpOnly = 0"
         }
         return excludedSites.foldIndexed(
             "",
         ) { pos, acc, site ->
             if (pos == 0) {
-                "expires_utc > $timestampThreshold AND is_httponly = 0 AND host_key != '$site' AND host_key NOT LIKE '%.$site'"
+                "expires_utc > $timestampThreshold AND $httpOnly = 0 AND host_key != '$site' AND host_key NOT LIKE '%.$site'"
             } else {
                 "$acc AND host_key != '$site' AND host_key NOT LIKE '%.$site'"
             }
@@ -90,8 +89,7 @@ class RealFirstPartyCookiesModifier @Inject constructor(
     }
     private fun expireFirstPartyCookies(
         databasePath: String,
-    ): Boolean {
-        var updateExecuted = false
+    ) {
         openReadableDatabase(databasePath)?.apply {
             try {
                 val maxAge = cookiesRepository.firstPartyCookiePolicy.maxAge // in seconds
@@ -101,22 +99,38 @@ class RealFirstPartyCookiesModifier @Inject constructor(
                 val timestampThreshold = (System.currentTimeMillis() + TIME_1601_IN_MICRO + (threshold * MULTIPLIER)) * MULTIPLIER
                 val timestampMaxAge = (System.currentTimeMillis() + TIME_1601_IN_MICRO + (maxAge * MULTIPLIER)) * MULTIPLIER
 
-                execSQL(
-                    """
+                // check table and column exist before executing query
+                // old WebView versions use httponly, newer use is_httponly
+                val columnExists =
+                    rawQuery("PRAGMA table_info('cookies')", null).use {
+                        while (it.moveToNext()) {
+                            val index = it.getColumnIndex("name")
+                            if (it.getString(index).equals("is_httponly")) {
+                                return@use 1
+                            }
+                            if (it.getString(index).equals("httponly")) {
+                                return@use 2
+                            }
+                        }
+                        return@use 0
+                    }
+
+                if (columnExists > 0) {
+                    val isOldDb = (columnExists == 2)
+                    execSQL(
+                        """
                      UPDATE ${SQLCookieRemover.COOKIES_TABLE_NAME}
                      SET expires_utc=$timestampMaxAge
-                     WHERE ${buildSQLWhereClause(timestampThreshold)}
-                    """.trimIndent(),
-                )
-                updateExecuted = true
+                     WHERE ${buildSQLWhereClause(timestampThreshold, isOldDb)}
+                        """.trimIndent(),
+                    )
+                }
             } catch (exception: Exception) {
-                Timber.e(exception)
                 crashLogger.logCrash(CrashLogger.Crash(shortName = "m_cookie_db_expire_error", t = exception))
             } finally {
                 close()
             }
         }
-        return updateExecuted
     }
 
     private fun openReadableDatabase(databasePath: String): SQLiteDatabase? {

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifierWorker.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifierWorker.kt
@@ -50,12 +50,8 @@ class FirstPartyCookiesModifierWorker(
 
     override suspend fun doWork(): Result {
         return withContext(dispatcherProvider.io()) {
-            val result = firstPartyCookiesModifier.expireFirstPartyCookies()
-            return@withContext if (result) {
-                Result.success()
-            } else {
-                Result.retry()
-            }
+            firstPartyCookiesModifier.expireFirstPartyCookies()
+            Result.success()
         }
     }
 }
@@ -78,12 +74,16 @@ class FirstPartyCookiesModifierWorkerScheduler @Inject constructor(
     override fun onStop(owner: LifecycleOwner) {
         if (isFeatureEnabled()) {
             workManager.enqueueUniquePeriodicWork(FIRST_PARTY_COOKIES_EXPIRE_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, workerRequest)
+        } else {
+            workManager.cancelAllWorkByTag(FIRST_PARTY_COOKIES_EXPIRE_WORKER_TAG)
         }
     }
 
     override fun onStart(owner: LifecycleOwner) {
         if (isFeatureEnabled()) {
             workManager.enqueueUniquePeriodicWork(FIRST_PARTY_COOKIES_EXPIRE_WORKER_TAG, ExistingPeriodicWorkPolicy.KEEP, workerRequest)
+        } else {
+            workManager.cancelAllWorkByTag(FIRST_PARTY_COOKIES_EXPIRE_WORKER_TAG)
         }
     }
 

--- a/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifierWorkerSchedulerTest.kt
+++ b/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifierWorkerSchedulerTest.kt
@@ -27,7 +27,6 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -54,12 +53,12 @@ class FirstPartyCookiesModifierWorkerSchedulerTest {
     }
 
     @Test
-    fun whenOnStopIfFeatureNotEnabledThenDoNothing() {
+    fun whenOnStopIfFeatureNotEnabledThenDeleteTag() {
         whenever(mockToggle.isFeatureEnabled(CookiesFeatureName.Cookie.value)).thenReturn(false)
 
         firstPartyCookiesModifierWorkerScheduler.onStop(mockOwner)
 
-        verify(mockWorkManager, never()).enqueueUniquePeriodicWork(any(), any(), any())
+        verify(mockWorkManager).cancelAllWorkByTag(any())
     }
 
     @Test
@@ -72,11 +71,11 @@ class FirstPartyCookiesModifierWorkerSchedulerTest {
     }
 
     @Test
-    fun whenOnStartIfFeatureNotEnabledThenDoNothing() {
+    fun whenOnStartIfFeatureNotEnabledThenDeleteTag() {
         whenever(mockToggle.isFeatureEnabled(CookiesFeatureName.Cookie.value)).thenReturn(false)
 
         firstPartyCookiesModifierWorkerScheduler.onStart(mockOwner)
 
-        verify(mockWorkManager, never()).enqueueUniquePeriodicWork(any(), any(), any())
+        verify(mockWorkManager).cancelAllWorkByTag(any())
     }
 }

--- a/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifierWorkerTest.kt
+++ b/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifierWorkerTest.kt
@@ -27,7 +27,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 class FirstPartyCookiesModifierWorkerTest {
     @get:Rule var coroutineRule = CoroutineTestRule()
@@ -41,9 +40,7 @@ class FirstPartyCookiesModifierWorkerTest {
     }
 
     @Test
-    fun whenDoWorkIfExpireFirstPartyCookiesReturnsTrueThenReturnSuccess() = runTest {
-        whenever(mockFirstPartyCookiesModifier.expireFirstPartyCookies()).thenReturn(true)
-
+    fun whenDoWorkThenReturnSuccess() = runTest {
         val worker = TestListenableWorkerBuilder<FirstPartyCookiesModifierWorker>(context = context).build()
 
         worker.firstPartyCookiesModifier = mockFirstPartyCookiesModifier
@@ -51,18 +48,5 @@ class FirstPartyCookiesModifierWorkerTest {
 
         val result = worker.doWork()
         assertThat(result, `is`(Result.success()))
-    }
-
-    @Test
-    fun whenDoWorkIfExpireFirstPartyCookiesReturnsFalseThenReturnRetry() = runTest {
-        whenever(mockFirstPartyCookiesModifier.expireFirstPartyCookies()).thenReturn(false)
-
-        val worker = TestListenableWorkerBuilder<FirstPartyCookiesModifierWorker>(context = context).build()
-
-        worker.firstPartyCookiesModifier = mockFirstPartyCookiesModifier
-        worker.dispatcherProvider = coroutineRule.testDispatcherProvider
-
-        val result = worker.doWork()
-        assertThat(result, `is`(Result.retry()))
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204397066248837/f 

### Description
This PR checks if the cookies table and is_httponly column exist before executing the query.

### Steps to test this PR

- [x] Install in emulator with API 23 which will use an old webview version and won't have the is_httponly column
- [x] Launch the app and go to any website
- [x] Send the app to the background
- [x] App should not register a crash pixel
- [x] All tests should pass

