### PR TITLE
Replace all intents as the way activities are started has changed in develop

### DIFF
--- a/app-tracking-protection/app-tracking-api/src/main/java/com/duckduckgo/mobile/android/app/tracking/ui/AppTrackingProtectionScreens.kt
+++ b/app-tracking-protection/app-tracking-api/src/main/java/com/duckduckgo/mobile/android/app/tracking/ui/AppTrackingProtectionScreens.kt
@@ -33,3 +33,13 @@ object AppTrackerActivityWithEmptyParams : GlobalActivityStarter.ActivityParams
  * ```
  */
 object AppTrackerOnboardingActivityWithEmptyParamsParams : GlobalActivityStarter.ActivityParams
+
+/**
+ * Use this class to launch the AppTP onboarding screen from the notification
+ * ```kotlin
+ * globalActivityStarter.start(context, AppTrackerOnboardingActivityWithNotificationParams)
+ * ```
+ */
+data class AppTrackerOnboardingActivityWithNotificationParams(
+    val pixelName: String,
+) : GlobalActivityStarter.ActivityParams

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingActivity.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.mobile.android.vpn.ui.onboarding
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.content.Intent
 import android.net.VpnService
 import android.os.Build
@@ -33,6 +32,7 @@ import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackerOnboardingActivityWithEmptyParamsParams
+import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackerOnboardingActivityWithNotificationParams
 import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.view.getColorFromAttr
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
@@ -47,12 +47,14 @@ import com.duckduckgo.mobile.android.vpn.ui.onboarding.Command.RequestVPNPermiss
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.Command.ShowVpnAlwaysOnConflictDialog
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.Command.ShowVpnConflictDialog
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldTrackerActivity
+import com.duckduckgo.navigation.api.getActivityParams
 import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(AppTrackerOnboardingActivityWithEmptyParamsParams::class)
+@ContributeToActivityStarter(AppTrackerOnboardingActivityWithNotificationParams::class)
 class VpnOnboardingActivity : DuckDuckGoActivity() {
 
     @Inject
@@ -74,8 +76,8 @@ class VpnOnboardingActivity : DuckDuckGoActivity() {
         configureUI()
         observeViewModel()
 
-        intent?.getStringExtra(LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
-            viewModel.onLaunchedFromNotification(it)
+        intent?.getActivityParams(AppTrackerOnboardingActivityWithNotificationParams::class.java)?.let {
+            viewModel.onLaunchedFromNotification(it.pixelName)
         }
     }
 
@@ -306,12 +308,5 @@ class VpnOnboardingActivity : DuckDuckGoActivity() {
 
     companion object {
         private const val REQUEST_ASK_VPN_PERMISSION = 101
-
-        const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
-
-        // TODO: ANA remove this.
-        fun intent(context: Context): Intent {
-            return Intent(context, VpnOnboardingActivity::class.java)
-        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/model/EnableAppTpNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/EnableAppTpNotification.kt
@@ -30,9 +30,10 @@ import com.duckduckgo.app.statistics.isNextLevelPrivacyNotificationEnabled
 import com.duckduckgo.app.statistics.isOneEasyStepForPrivacyNotificationEnabled
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackerOnboardingActivityWithNotificationParams
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
-import com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnOnboardingActivity
+import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -113,6 +114,7 @@ class EnableAppTpNotificationPlugin @Inject constructor(
     private val pixel: Pixel,
     private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
+    private val globalActivityStarter: GlobalActivityStarter,
 ) : SchedulableNotificationPlugin {
 
     override fun getSchedulableNotification(): SchedulableNotification {
@@ -137,9 +139,10 @@ class EnableAppTpNotificationPlugin @Inject constructor(
     }
 
     override fun getLaunchIntent(): PendingIntent? {
-        val intent = VpnOnboardingActivity.intent(context).apply {
-            putExtra(VpnOnboardingActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME, pixelName(AppPixelName.NOTIFICATION_LAUNCHED.pixelName))
-        }
+        val intent = globalActivityStarter.startIntent(
+            context,
+            AppTrackerOnboardingActivityWithNotificationParams(pixelName = pixelName(AppPixelName.NOTIFICATION_LAUNCHED.pixelName)),
+        )
         val pendingIntent: PendingIntent? = taskStackBuilderFactory.createTaskBuilder().run {
             addNextIntentWithParentStack(intent)
             getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204411036946047/f

### Description
Used the new navlib to open AppTP onboarding from the notification.

### Steps to test this PR

- [ ] Install from this branch.
- [ ] Modify the `enableAppTpNotification` in `NotificationScheduler` to run every minute. Modify the `VariantManager` to have only variants `zm` or `zn` enabled.
- [ ] When the notification is displayed, make sure you have the app closed and tap on the notification. Check it opens the AppTP onboarding.
- [ ] Check the logcat to see the pixel was sent. The line is `Pixel sent: mnot_l_OneEasyStepForPrivacy with params: {} {}` for `zm` and `Pixel sent: mnot_l_NextLevelPrivacy with params: {} {}` for `zn`.

### NO UI changes
