### PR TITLE
Add external reference test workflow

### DIFF
--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -1,0 +1,108 @@
+name: External Reference Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branchName:
+        description: 'Branch pull reference tests from the reference tests repo'
+        type: string
+        required: true
+        default: 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit_tests:
+    name: External reference tests unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install copy-files-from-to
+        run: npm install -g copy-files-from-to
+
+      - name: Install package
+        run: npm install "https://github.com/duckduckgo/privacy-reference-tests#${{ inputs.branchName }}" --save
+
+      - name: Copy files
+        run: copy-files-from-to
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: JVM tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: jvm_tests
+
+      - name: Bundle the JVM checks report
+        if: always()
+        run: find . -type d -name 'reports' | zip -@ -r unit-tests-report.zip
+
+      - name: Upload the JVM checks report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-tests-report
+          path: unit-tests-report.zip
+
+  android_tests:
+    runs-on: ubuntu-latest
+    name: External reference tests android tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install copy-files-from-to
+        run: npm install -g copy-files-from-to
+
+      - name: Install package
+        run: npm install "https://github.com/duckduckgo/privacy-reference-tests#${{ inputs.branchName }}" --save
+
+      - name: Copy files
+        run: copy-files-from-to
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Decode secret
+        env:
+          FLANK: ${{ secrets.FLANK }}
+        run: echo $FLANK > flank.json
+
+      - name: Build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: androidTestsBuild
+
+      - name: Run Android Tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: runFlankAndroidTests
+
+      - name: Bundle the Android CI tests report
+        if: always()
+        run: find . -type d -name 'fladleResults' | zip -@ -r android-tests-report.zip
+
+      - name: Upload the Android CI tests report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: android-tests-report
+          path: android-tests-report.zip
+


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204422679933921/f 

### Description
This PR adds a new GH workflow for the privacy team so they can run it before releasing new reference tests

### Steps to test this PR
[This](https://github.com/duckduckgo/Android/actions/runs/4746189594/jobs/8441926133) workflow should be red. It pulls from a testing branch in the reference tests repo that I created to explicitly make one test fail and prove that our workflow pulls from the branch, copy the files and execute the new tests.

