### PR TITLE
Check if table exists before executing query

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
@@ -91,6 +91,7 @@ class FireproofingReferenceTest(private val testCase: TestCase) {
             webViewDatabaseLocator,
             fireproofWebsiteRepositoryImpl,
             mock(),
+            mock(),
             DefaultDispatcherProvider(),
         )
 

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/CookiesPixelName.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/CookiesPixelName.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.cookies.impl
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class CookiesPixelName(override val pixelName: String) : Pixel.PixelName {
+    COOKIE_DB_OPEN_ERROR("m_cookie_db_open_error"),
+}

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifier.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/firstparty/FirstPartyCookiesModifier.kt
@@ -102,7 +102,7 @@ class RealFirstPartyCookiesModifier @Inject constructor(
                 // check table and column exist before executing query
                 // old WebView versions use httponly, newer use is_httponly
                 val columnExists =
-                    rawQuery("PRAGMA table_info('cookies')", null).use {
+                    rawQuery("PRAGMA table_info('${SQLCookieRemover.COOKIES_TABLE_NAME}')", null).use {
                         while (it.moveToNext()) {
                             val index = it.getColumnIndex("name")
                             if (it.getString(index).equals("is_httponly")) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204439154734764/f 

### Description
This PR checks it the cookies table exists prior trying to execute the delete query.

### Steps to test this PR

- [x] In `SQLCookieRemover` change the line 93 so it tries to get the table info from a table that doesn't exist i.e. 'myfaketable`
- [x] Launch the app and open a website with cookies, i.e. cnn.com
- [x] Use the fire button
- [x] The code to delete cookies should not be executed, i.e. the code below line 97 does not happen. You can add a log statement to double check. 

