### PR TITLE
Disable Kotlin synthetics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.squareup.anvil'
 apply from: '../versioning.gradle'

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -41,7 +41,6 @@ import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import javax.inject.Inject
-import kotlinx.android.synthetic.main.include_dax_multiselect_dialog_cta.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.flow.*
@@ -126,12 +125,12 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
         binding.daxDialogCta.root.gone()
         binding.daxDialogMultiselectCta.apply {
             root.show()
-            root.dialogTextCta.startTypingAnimation(ctaText)
+            binding.daxDialogMultiselectCta.dialogTextCta.startTypingAnimation(ctaText)
             ViewCompat.animate(root)
                 .alpha(MAX_ALPHA)
                 .setDuration(ANIMATION_DURATION)
                 .withEndAction {
-                    ViewCompat.animate(root.featureOptionsContainer)
+                    ViewCompat.animate(binding.daxDialogMultiselectCta.featureOptionsContainer)
                         .alpha(MAX_ALPHA)
                         .setDuration(ANIMATION_DURATION)
                         .setStartDelay(ANIMATION_DURATION)

--- a/build.gradle
+++ b/build.gradle
@@ -48,14 +48,6 @@ allprojects {
 
 subprojects {
 
-    // Break build when using deprecated plugins
-    String[] allowDeprecatedModuleIn = ["app", "vpn-impl"]
-    project.plugins.withId('kotlin-android-extensions') {
-        if (!allowDeprecatedModuleIn.contains(project.name)) {
-            throw new GradleException("kotlin-android-extensions plugin is deprecated, DO NOT USE!")
-        }
-    }
-
     String[] allowAndroidTestsIn = ["app", "sync-lib"]
     if (!allowAndroidTestsIn.contains(project.name)) {
         project.projectDir.eachFile(groovy.io.FileType.DIRECTORIES) { File parent ->


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204458968322711/f

### Description
Removes the last usages of synthetics in `WelcomeFragment` and removes the `kotlin-android-extensions` plugin.

### Steps to test this PR
- [x] Set the experimental variant to `mj`.
- [x] Verify that the experiment displays correctly.