### PR TITLE
Ensure we catch ActivityNotFoundExceptions when opening external app links

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1375,16 +1375,24 @@ class BrowserTabFragment :
         if (appLink.appIntent != null) {
             appLink.appIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             try {
-                startActivity(appLink.appIntent)
+                startActivityOrQuietlyFail(appLink.appIntent)
             } catch (e: SecurityException) {
                 showToast(R.string.unableToOpenLink)
             }
         } else if (appLink.excludedComponents != null && appBuildConfig.sdkInt >= Build.VERSION_CODES.N) {
             val title = getString(R.string.appLinkIntentChooserTitle)
             val chooserIntent = getChooserIntent(appLink.uriString, title, appLink.excludedComponents)
-            startActivity(chooserIntent)
+            startActivityOrQuietlyFail(chooserIntent)
         }
         viewModel.clearPreviousUrl()
+    }
+
+    private fun startActivityOrQuietlyFail(intent: Intent) {
+        try {
+            startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Timber.w(e, "Activity not found")
+        }
     }
 
     private fun dismissAppLinkSnackBar() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204454121220459/f

### Description
When we detect users are navigating to a URL that could be consumed by a native app, we offer a snackbar with an option to launch that app. However, since we don't control the intent that will be used, there is a possibility our app will crash when we use that intent with `startActivity` due to an `ActivityNotFoundException` (which is happening according to our crash data)

### Steps to test this PR

- [x] Search for `uber play store`
- [x] Click on the Play Store result from the SERP
- [x] Click on the SnackBar action item; verify it launches ok
- [x] To really test it, use a fake intent in the `BrowserTabFragment.openAppLink()` function like this, `Intent("com.example.foo/com.bar.ActivityThatDoesNotExist")` and make sure the app doesn't crash when you click on the snackbar action button