### PR TITLE
Update content scope scripts to latest version

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -86,7 +86,7 @@
      * Best guess effort if the document is third party
      * @returns {boolean} if we infer the document is third party
      */
-    function isThirdParty () {
+    function isThirdPartyFrame () {
         if (!isBeingFramed()) {
             return false
         }
@@ -288,7 +288,7 @@
     /**
      * Handles the processing of a config setting.
      * @param {*} configSetting
-     * @param {*} defaultValue
+     * @param {*} [defaultValue]
      * @returns
      */
     function processAttr (configSetting, defaultValue) {
@@ -450,6 +450,16 @@
      */
 
     /**
+     * Used to inialize extension code in the load phase
+     */
+    function computeLimitedSiteObject () {
+        const topLevelHostname = getTabHostname();
+        return {
+            domain: topLevelHostname
+        }
+    }
+
+    /**
      * Expansion point to add platform specific versioning logic
      * @param {UserPreferences} preferences
      * @returns {string | number | undefined}
@@ -506,16 +516,23 @@
     }
 
     /**
-     * @param {{ features: Record<string, { state: string; settings: any; exceptions: string[], minSupportedVersion?: string|number }>; unprotectedTemporary: string[]; }} data
+     * @typedef RemoteConfig
+     * @property {Record<string, { state: string; settings: any; exceptions: { domain: string }[], minSupportedVersion?: string|number }>} features
+     * @property {string[]} unprotectedTemporary
+     */
+
+    /**
+     * @param {RemoteConfig} data
      * @param {string[]} userList
      * @param {UserPreferences} preferences
      * @param {string[]} platformSpecificFeatures
      */
     function processConfig (data, userList, preferences, platformSpecificFeatures = []) {
         const topLevelHostname = getTabHostname();
+        const site = computeLimitedSiteObject();
         const allowlisted = userList.filter(domain => domain === topLevelHostname).length > 0;
         const remoteFeatureNames = Object.keys(data.features);
-        const platformSpecificFeaturesNotInRemoteConfig = platformSpecificFeatures.filter((featureName) => !remoteFeatureNames.includes(featureName));
+        platformSpecificFeatures.filter((featureName) => !remoteFeatureNames.includes(featureName));
         /** @type {Record<string, any>} */
         const output = { ...preferences };
         if (output.platform) {
@@ -524,37 +541,65 @@
                 output.platform.version = version;
             }
         }
+        const enabledFeatures = computeEnabledFeatures(data, topLevelHostname, preferences.platform?.version, platformSpecificFeatures);
+        const isBroken = isUnprotectedDomain(topLevelHostname, data.unprotectedTemporary);
+        output.site = Object.assign(site, {
+            isBroken,
+            allowlisted,
+            enabledFeatures
+        });
+        // TODO
+        output.cookie = {};
+
+        // Copy feature settings from remote config to preferences object
+        output.featureSettings = parseFeatureSettings(data, enabledFeatures);
+        output.trackerLookup = {"org":{"cdn77":{"rsc":{"1666210260":1}},"adsrvr":1,"ampproject":1,"browser-update":1,"flowplayer":1,"privacy-center":1,"webvisor":1,"framasoft":1,"do-not-tracker":1,"trackersimulator":1},"io":{"1dmp":1,"1rx":1,"4dex":1,"adnami":1,"aidata":1,"arcspire":1,"bidr":1,"branch":1,"center":1,"concert":1,"connectad":1,"cordial":1,"dcmn":1,"extole":1,"getblue":1,"hbrd":1,"imbox":1,"instana":1,"karte":1,"lytics":1,"marchex":1,"mediago":1,"mrf":1,"myfidevs":1,"narrative":1,"ntv":1,"optad360":1,"oracleinfinity":1,"oribi":1,"p-n":1,"personalizer":1,"pghub":1,"piano":1,"powr":1,"pzz":1,"searchspring":1,"segment":1,"siteimproveanalytics":1,"sjv":1,"sspinc":1,"t13":1,"webgains":1,"wovn":1,"yellowblue":1,"zprk":1,"reviews":1,"appconsent":1,"leadsmonitor":1},"com":{"2020mustang":1,"33across":1,"360yield":1,"3lift":1,"4dsply":1,"4jnzhl0d0":1,"4strokemedia":1,"5d2d04464c":1,"a-mx":1,"a2z":1,"aamsitecertifier":1,"absorbingband":1,"abstractedauthority":1,"abtasty":1,"acexedge":1,"acidpigs":1,"acsbapp":1,"acuityplatform":1,"ad-score":1,"ad-stir":1,"adalyser":1,"adapf":1,"adara":1,"adblade":1,"addthis":1,"addtoany":1,"adelixir":1,"adentifi":1,"adextrem":1,"adgrx":1,"adhese":1,"adition":1,"adkernel":1,"adlightning":1,"adlooxtracking":1,"admanmedia":1,"admedo":1,"adnium":1,"adnxs":1,"adobedtm":1,"adotmob":1,"adpone":1,"adpushup":1,"adroll":1,"adrta":1,"ads-twitter":1,"ads3-adnow":1,"adsafeprotected":1,"adstanding":1,"adswizz":1,"adsymptotic":1,"adtdp":1,"adtechus":1,"adtelligent":1,"adthrive":1,"adtlgc":1,"adtng":1,"adultfriendfinder":1,"advangelists":1,"adventive":1,"advertising":1,"aegpresents":1,"affinity":1,"affirm":1,"agilone":1,"agkn":1,"aimbase":1,"albacross":1,"alcmpn":1,"alexametrics":1,"alicdn":1,"alikeaddition":1,"aliveachiever":1,"aliyuncs":1,"alluringbucket":1,"aloofvest":1,"amazon-adsystem":1,"amazon":1,"amplitude":1,"analytics-egain":1,"aniview":1,"anymind360":1,"amazonaws":{"ap-southeast-2":1,"elb":{"eu-west-2":{"collect-prd-alb-539115803":1},"us-east-1":{"data-allstate-com-715826933":1,"prod-lb-8-1772099769":1,"proxy-mycigna-prod-678433465":1,"www-u45-pnc-com-902993410":1,"www-u46-pnc-com-13593657":1},"eu-west-1":{"devservicesalb-471015105":1,"petfre-content-1201188928":1},"us-east-2":{"elbpiwik-public-1781721271":1},"eu-central-1":{"prod-lb-6-388533732":1,"prod-lb-7-718125029":1,"prod-pub-alb-654989386":1}},"us-east-2":{"s3":{"hb-gretsch-talk":1,"hb-jetpunk":1,"hb-obv2":1}},"eu-central-1":{"s3":{"headless-ssr-prod-bucket":1}}},"app-us1":1,"appboycdn":1,"appdynamics":1,"aralego":1,"arkoselabs":1,"aswpsdkus":1,"atemda":1,"att":1,"attentivemobile":1,"attractionbanana":1,"audioeye":1,"audrte":1,"automaticside":1,"avanser":1,"avmws":1,"aweber":1,"aweprt":1,"azure":1,"b0e8":1,"bagbeam":1,"bandborder":1,"batch":1,"bawdybalance":1,"bc0a":1,"bdstatic":1,"bedsberry":1,"beginnerpancake":1,"benchmarkemail":1,"betweendigital":1,"bfmio":1,"bidderstack":1,"bidtheatre":1,"bimbolive":1,"bing":1,"bizographics":1,"bizrate":1,"bkrtx":1,"blismedia":1,"blogherads":1,"bluecava":1,"bluekai":1,"boatwizard":1,"boilingcredit":1,"boldchat":1,"booking":1,"borderfree":1,"bounceexchange":1,"brainlyads":1,"brand-display":1,"brandmetrics":1,"brealtime":1,"breinify":1,"brightedge":1,"brightfunnel":1,"brightspotcdn":1,"btloader":1,"btstatic":1,"bttrack":1,"btttag":1,"butterbulb":1,"buzzoola":1,"byside":1,"cabnnr":1,"calculatorstatement":1,"callrail":1,"calltracks":1,"capablecup":1,"captcha-delivery":1,"carpentercomparison":1,"cartstack":1,"carvecakes":1,"casalemedia":1,"cdn-btsg":1,"cdnwidget":1,"channeladvisor":1,"chartbeat":1,"chatango":1,"chaturbate":1,"cheqzone":1,"cherriescare":1,"chickensstation":1,"childlikecrowd":1,"childlikeform":1,"cintnetworks":1,"circlelevel":1,"civiccomputing":1,"ck-ie":1,"clcktrax":1,"clearbit":1,"clearbitjs":1,"clickagy":1,"clickcease":1,"clickcertain":1,"clicktripz":1,"clientgear":1,"clksite":1,"cloudflare":1,"cloudflareinsights":1,"cloudflarestream":1,"cloudmaestro":1,"cobaltgroup":1,"cobrowser":1,"cognitivlabs":1,"colossusssp":1,"comm100":1,"googleapis":{"commondatastorage":1,"storage":1},"company-target":1,"condenastdigital":1,"confusedcart":1,"connatix":1,"consentframework":1,"contextweb":1,"conversionruler":1,"convertkit":1,"convertlanguage":1,"cookieinformation":1,"cookiepro":1,"coveo":1,"cpmstar":1,"cquotient":1,"crabbychin":1,"crazyegg":1,"creative-serving":1,"creativecdn":1,"criteo":1,"crowdedmass":1,"crowdriff":1,"crownpeak":1,"crsspxl":1,"ctnsnet":1,"cubchannel":1,"cudasvc":1,"cuddlethehyena":1,"cumbersomecarpenter":1,"curalate":1,"curvedhoney":1,"cutechin":1,"cxense":1,"dailymotion":1,"damdoor":1,"dampdock":1,"dapperfloor":1,"datadoghq-browser-agent":1,"decisivebase":1,"deepintent":1,"defybrick":1,"delivra":1,"demandbase":1,"detectdiscovery":1,"devilishdinner":1,"dimelochat":1,"discreetfield":1,"disqus":1,"dmpxs":1,"dockdigestion":1,"dollardelta":1,"dotomi":1,"doubleverify":1,"drainpaste":1,"dramaticdirection":1,"driftt":1,"dtscdn":1,"dtscout":1,"dwin1":1,"dynamics":1,"dynamicyield":1,"dynatrace":1,"dyntrk":1,"ebaystatic":1,"ecal":1,"eccmp":1,"elasticchange":1,"elfsight":1,"elitrack":1,"eloqua":1,"en25":1,"encouragingthread":1,"ensighten":1,"enviousshape":1,"eqads":1,"ero-advertising":1,"esputnik":1,"evergage":1,"evgnet":1,"exdynsrv":1,"exelator":1,"exoclick":1,"exosrv":1,"expansioneggnog":1,"expertrec":1,"exponea":1,"exponential":1,"extole":1,"ezodn":1,"ezoic":1,"ezoiccdn":1,"facebook":1,"fadewaves":1,"fallaciousfifth":1,"farmergoldfish":1,"fastly-insights":1,"fearlessfaucet":1,"fiftyt":1,"financefear":1,"fitanalytics":1,"five9":1,"fksnk":1,"flashtalking":1,"flipp":1,"floweryflavor":1,"flutteringfireman":1,"flux-cdn":1,"fomo":1,"foresee":1,"forter":1,"fortunatemark":1,"fouanalytics":1,"fox":1,"fqtag":1,"frailfruit":1,"freezingbuilding":1,"fronttoad":1,"fullstory":1,"functionalfeather":1,"fuzzybasketball":1,"gammamaximum":1,"gbqofs":1,"geetest":1,"geistm":1,"geniusmonkey":1,"geoip-js":1,"getbread":1,"getcandid":1,"getclicky":1,"getdrip":1,"getelevar":1,"getpublica":1,"getrockerbox":1,"getshogun":1,"getsitecontrol":1,"glassdoor":1,"gloriousbeef":1,"godpvqnszo":1,"gondolagnome":1,"google-analytics":1,"google":1,"googleadservices":1,"googlehosted":1,"googleoptimize":1,"googlesyndication":1,"googletagmanager":1,"googletagservices":1,"govx":1,"greylabeldelivery":1,"groovehq":1,"gstatic":1,"guarantee-cdn":1,"guiltlessbasketball":1,"gumgum":1,"haltingbadge":1,"hammerhearing":1,"handsomelyhealth":1,"hawksearch":1,"heapanalytics":1,"hellobar":1,"hiconversion":1,"highwebmedia":1,"histats":1,"hlserve":1,"hocgeese":1,"hollowafterthought":1,"honorableland":1,"hotjar":1,"hp":1,"hs-banner":1,"htlbid":1,"htplayground":1,"hubspot":1,"iadvize":1,"ib-ibi":1,"id5-sync":1,"iesnare":1,"igodigital":1,"iheart":1,"iljmp":1,"illiweb":1,"impactcdn":1,"impactradius-event":1,"impactradius-go":1,"impossibleexpansion":1,"impressionmonster":1,"improvedcontactform":1,"improvedigital":1,"imrworldwide":1,"indexww":1,"infolinks":1,"infusionsoft":1,"inmobi":1,"inmoment":1,"inq":1,"inside-graph":1,"instagram":1,"intentiq":1,"intergient":1,"investingchannel":1,"invocacdn":1,"iplsc":1,"ipredictive":1,"iteratehq":1,"ivitrack":1,"j93557g":1,"jaavnacsdw":1,"jimstatic":1,"journity":1,"js7k":1,"juicyads":1,"justanswer":1,"justpremium":1,"kakao":1,"kampyle":1,"kargo":1,"kissmetrics":1,"klarnaservices":1,"klaviyo":1,"knottyswing":1,"kount":1,"krushmedia":1,"ktkjmp":1,"kxcdn":1,"ladesk":1,"ladsp":1,"laughablelizards":1,"leadsrx":1,"lendingtree":1,"levexis":1,"liadm":1,"licdn":1,"lightboxcdn":1,"lijit":1,"linkedin":1,"linksynergy":1,"list-manage":1,"listrakbi":1,"livechatinc":1,"livejasmin":1,"localytics":1,"loggly":1,"loop11":1,"lovelydrum":1,"luckyorange":1,"lunchroomlock":1,"maddeningpowder":1,"mailchimp":1,"mailchimpapp":1,"mailerlite":1,"maillist-manage":1,"marinsm":1,"marketiq":1,"marketo":1,"marriedbelief":1,"matheranalytics":1,"mathtag":1,"maxmind":1,"mczbf":1,"measlymiddle":1,"medallia":1,"media6degrees":1,"mediacategory":1,"mediavine":1,"mediawallahscript":1,"medtargetsystem":1,"megpxs":1,"metricode":1,"metricswpsh":1,"mfadsrvr":1,"mgid":1,"micpn":1,"microadinc":1,"minutemedia-prebid":1,"minutemediaservices":1,"mixpo":1,"mktoresp":1,"mktoweb":1,"ml314":1,"moatads":1,"mobtrakk":1,"monsido":1,"mookie1":1,"mountain":1,"mouseflow":1,"mpeasylink":1,"mql5":1,"mrtnsvr":1,"murdoog":1,"mxpnl":1,"mybestpro":1,"myfinance":1,"myregistry":1,"nappyattack":1,"navistechnologies":1,"neodatagroup":1,"nervoussummer":1,"newrelic":1,"newscgp":1,"nextdoor":1,"ninthdecimal":1,"nitrocdn":1,"noibu":1,"nondescriptnote":1,"nosto":1,"npttech":1,"nuance":1,"nxsttv":1,"omappapi":1,"omnisnippet1":1,"omnisrc":1,"omnitagjs":1,"oneall":1,"onesignal":1,"onetag-sys":1,"oo-syringe":1,"ooyala":1,"opecloud":1,"opentext":1,"opera":1,"opmnstr":1,"optimicdn":1,"optinmonster":1,"optmnstr":1,"optmstr":1,"optnmnstr":1,"optnmstr":1,"oraclecloud":1,"osano":1,"otm-r":1,"outbrain":1,"overconfidentfood":1,"ownlocal":1,"pamelarandom":1,"panickypancake":1,"panoramicplane":1,"parastorage":1,"pardot":1,"parsely":1,"partplanes":1,"patreon":1,"paypal":1,"pbstck":1,"pcmag":1,"peerius":1,"perfdrive":1,"perfectmarket":1,"permutive":1,"picreel":1,"pinimg":1,"pippio":1,"piwikpro":1,"pixlee":1,"pleasantpump":1,"plotrabbit":1,"pluckypocket":1,"pocketfaucet":1,"possibleboats":1,"postaffiliatepro":1,"postrelease":1,"potatoinvention":1,"prepareplanes":1,"pricespider":1,"pricklydebt":1,"profusesupport":1,"proofpoint":1,"protoawe":1,"providesupport":1,"pswec":1,"psyma":1,"ptengine":1,"publir":1,"pubmatic":1,"pubmine":1,"pubnation":1,"puffypurpose":1,"qualaroo":1,"qualtrics":1,"quantcast":1,"quantserve":1,"quantummetric":1,"quietknowledge":1,"quizzicalzephyr":1,"quora":1,"r42tag":1,"railwayreason":1,"rakuten":1,"rambunctiousflock":1,"rangeplayground":1,"realsrv":1,"rebelswing":1,"reconditerake":1,"reconditerespect":1,"recruitics":1,"reddit":1,"redditstatic":1,"rehabilitatereason":1,"reson8":1,"resonantrock":1,"responsiveads":1,"restrainstorm":1,"retargetly":1,"revcontent":1,"rezync":1,"rfihub":1,"rhetoricalloss":1,"richaudience":1,"righteouscrayon":1,"rightfulfall":1,"riotgames":1,"rkdms":1,"rlcdn":1,"rmtag":1,"rncdn5":1,"rnengage":1,"rogersmedia":1,"rokt":1,"route":1,"rubiconproject":1,"s-onetag":1,"saambaa":1,"sablesong":1,"sail-horizon":1,"salesforceliveagent":1,"samestretch":1,"satisfycork":1,"savoryorange":1,"scarabresearch":1,"scaredsnakes":1,"scarfsmash":1,"scatteredstream":1,"scene7":1,"scholarlyiq":1,"scintillatingsilver":1,"scorecardresearch":1,"screechingstove":1,"screenpopper":1,"sddan":1,"sdiapi":1,"seatsmoke":1,"securedvisit":1,"seedtag":1,"sefsdvc":1,"segment":1,"sekindo":1,"selectivesummer":1,"selfishsnake":1,"servebom":1,"servedbyadbutler":1,"servenobid":1,"serverbid":1,"serving-sys":1,"shakegoldfish":1,"shappify":1,"shareaholic":1,"sharethis":1,"sharethrough":1,"shopifyapps":1,"shopperapproved":1,"shrillspoon":1,"sibautomation":1,"sicksmash":1,"sift":1,"siftscience":1,"signifyd":1,"siteimprove":1,"siteimproveanalytics":1,"sitescout":1,"skillfuldrop":1,"sli-spark":1,"slickstream":1,"slopesoap":1,"smadex":1,"smartadserver":1,"smashquartz":1,"smashsurprise":1,"smg":1,"smilewanted":1,"smoggysnakes":1,"snapchat":1,"snapkit":1,"snigelweb":1,"socdm":1,"sojern":1,"songsterritory":1,"sonobi":1,"speedcurve":1,"sphereup":1,"spiceworks":1,"spookyexchange":1,"spookyskate":1,"spookysleet":1,"sportradar":1,"sportradarserving":1,"sportslocalmedia":1,"spotxchange":1,"springserve":1,"srvmath":1,"stackadapt":1,"stakingsmile":1,"statcounter":1,"steadfastseat":1,"steadfastsound":1,"steadfastsystem":1,"steelhousemedia":1,"steepsquirrel":1,"stereoproxy":1,"stereotypedsugar":1,"stickyadstv":1,"stiffgame":1,"straightnest":1,"stripchat":1,"stupendoussleet":1,"stupendoussnow":1,"stupidscene":1,"sulkycook":1,"sumo":1,"sumologic":1,"sundaysky":1,"superficialeyes":1,"superficialsquare":1,"survicate":1,"svonm":1,"symantec":1,"taboola":1,"tagcommander":1,"tailtarget":1,"talkable":1,"taobao":1,"tapad":1,"taptapnetworks":1,"taskanalytics":1,"tealiumiq":1,"technoratimedia":1,"techtarget":1,"tediousticket":1,"teenytinyshirt":1,"tendertest":1,"the-ozone-project":1,"theadex":1,"themoneytizer":1,"theplatform":1,"thestar":1,"thomastorch":1,"threetruck":1,"thrtle":1,"tidaltv":1,"tidiochat":1,"tiktok":1,"tinypass":1,"tiqcdn":1,"tiresomethunder":1,"trackjs":1,"trafficjunky":1,"travelaudience":1,"treasuredata":1,"tremorhub":1,"trendemon":1,"tribalfusion":1,"trovit":1,"trueleadid":1,"truoptik":1,"truste":1,"trustedsite":1,"trustpilot":1,"tsyndicate":1,"tubemogul":1,"turn":1,"tvpixel":1,"tvsquared":1,"tweakwise":1,"twitter":1,"tynt":1,"typicalteeth":1,"u5e":1,"ubembed":1,"uidapi":1,"ultraoranges":1,"unbecominglamp":1,"unbxdapi":1,"undertone":1,"uninterestedquarter":1,"unpkg":1,"unrulymedia":1,"unwieldyhealth":1,"unwieldyplastic":1,"upsellit":1,"urbanairship":1,"usabilla":1,"usbrowserspeed":1,"usemessages":1,"userreport":1,"uservoice":1,"valuecommerce":1,"vengefulgrass":1,"vidazoo":1,"videoplayerhub":1,"vidoomy":1,"viglink":1,"visualwebsiteoptimizer":1,"vivaclix":1,"vk":1,"vlitag":1,"vocento":1,"voicefive":1,"volatilevessel":1,"voraciousgrip":1,"voxmedia":1,"vrtcal":1,"w3counter":1,"walkme":1,"warmafterthought":1,"warmquiver":1,"webcontentassessor":1,"webengage":1,"webeyez":1,"webflow":1,"webtraxs":1,"webtrends-optimize":1,"webtrends":1,"wgplayer":1,"wisepops":1,"worldoftulo":1,"wpadmngr":1,"wpshsdk":1,"wpushsdk":1,"wsod":1,"wt-safetag":1,"wysistat":1,"xg4ken":1,"xiti":1,"xlirdr":1,"xlivrdr":1,"xnxx-cdn":1,"y-track":1,"yahoo":1,"yandex":1,"yieldmo":1,"yieldoptimizer":1,"yimg":1,"yotpo":1,"yottaa":1,"youtube-nocookie":1,"youtube":1,"zatnoh":1,"zemanta":1,"zendesk":1,"zeotap":1,"zeronaught":1,"zestycrime":1,"zonos":1,"zoominfo":1,"zopim":1,"adnxs-simple":1,"createsend1":1,"adventori":1,"facil-iti":1,"provenexpert":1,"veoxa":1,"getflowbox":1,"parchedsofa":1,"adtraction":1,"bannerflow":1,"aboardamusement":1,"absorbingcorn":1,"abstractedamount":1,"actoramusement":1,"actuallysnake":1,"adorableanger":1,"agreeabletouch":1,"aheadday":1,"ancientact":1,"annoyedairport":1,"annoyingacoustics":1,"aquaticowl":1,"aspiringattempt":1,"audioarctic":1,"awarealley":1,"awesomeagreement":1,"awzbijw":1,"basketballbelieve":1,"begintrain":1,"bestboundary":1,"blushingbeast":1,"boredcrown":1,"breadbalance":1,"breakfastboat":1,"bulbbait":1,"burnbubble":1,"bustlingbath":1,"callousbrake":1,"calmcactus":1,"capriciouscorn":1,"caringcast":1,"catschickens":1,"causecherry":1,"chunkycactus":1,"cloisteredcord":1,"closedcows":1,"colossalclouds":1,"colossalcoat":1,"comfortablecheese":1,"conditioncrush":1,"consciouscheese":1,"consciousdirt":1,"coverapparatus":1,"cratecamera":1,"critictruck":1,"curvycry":1,"cushionpig":1,"damageddistance":1,"debonairdust":1,"decisivedrawer":1,"decisiveducks":1,"detailedkitten":1,"diplomahawaii":1,"dk4ywix":1,"dq95d35":1,"energeticladybug":1,"enormousearth":1,"evanescentedge":1,"fadedsnow":1,"fancyactivity":1,"farshake":1,"fastenfather":1,"fatcoil":1,"faultycanvas":1,"firstfrogs":1,"flimsycircle":1,"flimsythought":1,"friendwool":1,"fumblingform":1,"futuristicfifth":1,"giddycoat":1,"giraffepiano":1,"glisteningguide":1,"grayreceipt":1,"greasysquare":1,"grouchypush":1,"haltinggold":1,"handyfield":1,"handyfireman":1,"hearthorn":1,"historicalbeam":1,"horsenectar":1,"hystericalcloth":1,"impulsejewel":1,"incompetentjoke":1,"internalsink":1,"lameletters":1,"livelumber":1,"livelylaugh":1,"lorenzourban":1,"lumpylumber":1,"maliciousmusic":1,"meatydime":1,"memorizeneck":1,"mightyspiders":1,"mixedreading":1,"modularmental":1,"motionlessbag":1,"movemeal":1,"nondescriptcrowd":1,"nostalgicneed":1,"nuttyorganization":1,"optimallimit":1,"outstandingincome":1,"outstandingsnails":1,"panickycurtain":1,"petiteumbrella":1,"placidperson":1,"plantdigestion":1,"punyplant":1,"rabbitbreath":1,"rabbitrifle":1,"raintwig":1,"rainyhand":1,"rainyrule":1,"rangecake":1,"raresummer":1,"readymoon":1,"rebelsubway":1,"receptivereaction":1,"regularplants":1,"repeatsweater":1,"replaceroute":1,"resonantbrush":1,"respectrain":1,"richstring":1,"roofrelation":1,"rusticprice":1,"scaredcomfort":1,"scaredsnake":1,"scientificshirt":1,"scintillatingscissors":1,"screechingfurniture":1,"seashoresociety":1,"secretturtle":1,"shakysurprise":1,"shallowblade":1,"shesubscriptions":1,"shockingship":1,"sillyscrew":1,"sincerebuffalo":1,"sinceresubstance":1,"singroot":1,"sixscissors":1,"soggysponge":1,"somberscarecrow":1,"sordidsmile":1,"sortsail":1,"sortsummer":1,"spellsalsa":1,"spotlessstamp":1,"spottednoise":1,"stalesummer":1,"steadycopper":1,"stepplane":1,"strangesink":1,"stretchsister":1,"strivesidewalk":1,"superficialspring":1,"swellstocking":1,"synonymousrule":1,"tangyamount":1,"tastelesstrees":1,"teenytinycellar":1,"teenytinytongue":1,"terriblethumb":1,"terrifictooth":1,"thirdrespect":1,"ticketaunt":1,"tremendousplastic":1,"troubledtail":1,"typicalairplane":1,"ubiquitousyard":1,"unbecominghall":1,"uncoveredexpert":1,"unequalbrake":1,"unknowncrate":1,"untidyrice":1,"unusedstone":1,"venusgloria":1,"verdantanswer":1,"verseballs":1,"wearbasin":1,"cautiouscredit":1,"confesschairs":1,"chinsnakes":1,"wellgroomedhydrant":1,"heavyplayground":1,"bravecalculator":1,"workoperation":1,"secondhandfall":1,"unablehope":1,"tastelesstrucks":1,"losslace":1,"barbarousbase":1,"supportwaves":1,"protestcopy":1,"automaticturkey":1,"stretchsquirrel":1,"equablekettle":1,"discreetquarter":1,"peacefullimit":1,"gulliblegrip":1,"swelteringsleep":1,"muteknife":1,"aliasanvil":1,"operationchicken":1,"courageousbaby":1,"flowerstreatment":1,"scissorsstatement":1,"furryfork":1,"synonymoussticks":1,"deerbeginner":1,"rhetoricalveil":1,"farsnails":1,"kaputquill":1,"digestiondrawer":1,"meltmilk":1,"endurablebulb":1,"sugarfriction":1,"combcompetition":1,"stakingshock":1,"stretchsneeze":1,"sinkbooks":1,"brotherslocket":1,"cautiouscamera":1,"materialparcel":1,"inputicicle":1,"chargecracker":1,"fewjuice":1,"tumbleicicle":1,"serpentshampoo":1,"nutritiousbean":1,"scrapesleep":1,"bleachbubble":1,"longingtrees":1,"leftliquid":1,"handsomehose":1,"powerfulcopper":1,"painstakingpickle":1,"swankysquare":1,"soundstocking":1,"disagreeabledrop":1,"cushiondrum":1,"ruralrobin":1,"gorgeousedge":1,"strivesquirrel":1,"currentcollar":1,"combativecar":1,"ambiguousafternoon":1,"harborcaption":1,"blushingbread":1,"suggestionbridge":1,"spectacularstamp":1,"skisofa":1,"predictplate":1,"shakyseat":1,"priceypies":1,"livelyreward":1,"stealsteel":1,"shiveringspot":1,"memorizematch":1,"knitstamp":1,"bushesbag":1,"mundanenail":1,"coldbalance":1,"shapecomb":1,"shiverscissors":1,"broadborder":1,"quirkysugar":1,"stingyspoon":1,"billowybelief":1,"crookedcreature":1,"acceptableauthority":1,"sadloaf":1,"separatesort":1,"pailpatch":1,"scribblestring":1,"exhibitsneeze":1,"largebrass":1,"combcattle":1,"materialisticmoon":1,"fixedfold":1,"restructureinvention":1,"scaredstomach":1,"cautiouscherries":1,"tritebadge":1,"motionflowers":1,"ballsbanana":1,"meddleplant":1,"simulateswing":1,"marketspiders":1,"grumpydime":1,"neatshade":1,"samplesamba":1,"samesticks":1,"buttonladybug":1,"mentorsticks":1,"scaredsong":1,"annoyingclover":1,"grainmass":1,"tempertrick":1,"quizzicalpartner":1,"franticroof":1,"cattlecommittee":1,"tangycover":1,"looseloaf":1,"psychedelicarithmetic":1,"radiateprose":1,"shamerain":1,"cleanhaircut":1,"badgevolcano":1,"laboredlocket":1,"zipperxray":1,"stingycrush":1,"sixauthority":1,"thinkitten":1,"strokesystem":1,"hatefulrequest":1},"net":{"2mdn":1,"2o7":1,"incapdns":{"x":{"3exvfbh":1,"5t48cjc":1,"7xjpy4d":1,"dzm868l":1,"ttk8bbo":1}},"3gl":1,"a-mo":1,"acint":1,"adform":1,"adhigh":1,"admixer":1,"adobedc":1,"adspeed":1,"azureedge":{"adv-cloudfilse":1,"afw-static":1,"bayleys-pri-cdn-endpoint":1,"cdne-nxtevo-prd01-ms":1,"discountcodeexpress":1,"fp-cdn":1,"lefigaro":1,"ocpd-content":1,"sdtagging":1,"trenord-europe-trenord-endpoint-prd":1},"adverticum":1,"edgekey":{"akamai-111035":1,"com":{"alicdn":1,"ebay":1,"mtvnservices":1,"nbcuni":1,"nintendo":1,"oneindia":1,"scene7":1,"turner":1,"ziffdavis":1,"ziffdavisinternational":1},"ame":1,"au":1,"br":1,"ca":1,"com-v1":1,"com-v2":1,"gov":1,"in":1,"io":1,"it":1,"net":1,"org":1,"ppll":1,"rakuten":1,"uk":1},"apicit":1,"appier":1,"akamaized":{"assets-momentum":1,"com":{"media-rockstargames-":1,"ntd":1,"vocento":1}},"aticdn":1,"azure":1,"azurefd":1,"bannerflow":1,"bf-tools":1,"bidswitch":1,"bitsngo":1,"blueconic":1,"boldapps":1,"buysellads":1,"cedexis":1,"certona":1,"fastly":{"map":{"cidgroup":1,"condenast":1,"ihrinferno":1,"prisa-us-eu":1,"scribd":1,"target-opus":1,"thriftbooks":1,"ticketmaster4":1,"twitch":1,"vox":1,"appnexus":1},"global":{"shared":{"d2":1,"s2":1},"sni":{"j":1}},"ssl":{"global":{"igao-prod-herokuapp-com":1,"mslc-prod-herokuapp-com":1}}},"confiant-integrations":1,"consentmanager":1,"contentsquare":1,"criteo":1,"crwdcntrl":1,"cloudfront":{"d16jny3kjm2a1j":1,"d16kgn4efacaad":1,"d19l6uotjzm32g":1,"d1af033869koo7":1,"d1bxz6tua5hq87":1,"d1cr9zxt7u0sgu":1,"d1egjda7ggd2ew":1,"d1eh9yux7w8iql":1,"d1gwclp1pmzk26":1,"d1nhstnts0iwzs":1,"d1p5cqqchvbqmy":1,"d1pq45hly7zfel":1,"d1rhs7mhgydok3":1,"d1rw50yn65615p":1,"d1s87id6169zda":1,"d1snv67wdds0p2":1,"d1tprjo2w7krrh":1,"d1vg5xiq7qffdj":1,"d1vo8zfysxy97v":1,"d1y068gyog18cq":1,"d214hhm15p4t1d":1,"d21gpk1vhmjuf5":1,"d244lyzgucnepm":1,"d27cwqlgojh9yd":1,"d2aioe7l2jay46":1,"d2bj4wnxqmm2tk":1,"d2droglu4qf8st":1,"d2eanzqpmoo3ec":1,"d2f4zoo8hyailp":1,"d2hs2r19gv871k":1,"d2j6syf6c0cltf":1,"d2jpq2u2vrjftk":1,"d2qlgd5odkppg5":1,"d2qrdklrsxowl2":1,"d2s6j0ghajv79z":1,"d2tyltutevw8th":1,"d2wo2i8fdcw8of":1,"d2xbocf5uqnw0w":1,"d2y7rifa1cwopa":1,"d2zah9y47r7bi2":1,"d30jydkdo8eo9b":1,"d355prp56x5ntt":1,"d35mt2i8wrf9y1":1,"d38aqfmkl3ge26":1,"d38xvr37kwwhcm":1,"d3fv2pqyjay52z":1,"d3gxe0jmvtuxbc":1,"d3i4yxtzktqr9n":1,"d3jruqy3qmm3fd":1,"d3nn82uaxijpm6":1,"d3o8vwpyaorolj":1,"d3ochae1kou2ub":1,"d3odp2r1osuwn0":1,"d3owq2fdwtdp2j":1,"d3txh7prdum3s8":1,"d3v7mj6iyaqfac":1,"d4egga2bwam6h":1,"d5yoctgpv4cpx":1,"d6tizftlrpuof":1,"d9k0w0y3delq8":1,"dbukjj6eu5tsf":1,"de2pmm85odupd":1,"de7iszmjjjuya":1,"dfx0d9twj2ai":1,"dj28g4s0yd4ph":1,"dn0qt3r0xannq":1,"dokumfe7mps0i":1,"dowpznhhyvkm4":1,"dsh7ky7308k4b":1,"dsx863kqtdxrt":1,"dtpw88eywzb7u":1,"duube1y6ojsji":1,"dzlkq6toxiazj":1,"dzz1zjxa9ulpk":1,"d2638j3z8ek976":1},"akadns":{"com":{"dellcdn":1,"febsec-fidelity":1},"line-zero":1},"demdex":1,"dotmetrics":1,"doubleclick":1,"durationmedia":1,"e-planning":1,"edgecastcdn":1,"emsecure":1,"episerver":1,"esm1":1,"eulerian":1,"everestjs":1,"everesttech":1,"eyeota":1,"ezoic":1,"facebook":1,"fastclick":1,"fbcdn":1,"fonts":1,"edgesuite":{"com":{"fox":1,"iq":1,"tiktokcdn-us":1,"vidio":1,"sky":1},"linkedin":1,"stls":1},"fuseplatform":1,"fwmrm":1,"go-mpulse":1,"hadronid":1,"hs-analytics":1,"hsleadflows":1,"im-apps":1,"impervadns":1,"iocnt":1,"iprom":1,"jsdelivr":1,"kanade-ad":1,"azurewebsites":{"keha-matomo-te-palvelut-prod":1,"neuterbot-client":1,"app-ch-sgtm-prod":1,"app-fnsp-matomo-analytics-prod":1},"krxd":1,"line-scdn":1,"listhub":1,"livecom":1,"livedoor":1,"liveperson":1,"lkqd":1,"llnwd":1,"lpsnmedia":1,"magnetmail":1,"marketo":1,"maxymiser":1,"media":1,"microad":1,"monetate":1,"mxptint":1,"myfonts":1,"myvisualiq":1,"naver":1,"b-cdn":{"nnwwwlive":1,"speedy":1},"nr-data":1,"omtrdc":1,"onecount":1,"online-metrix":1,"openx":1,"opta":1,"owneriq":1,"pages02":1,"pages03":1,"pages04":1,"pages05":1,"pages06":1,"pages08":1,"perimeterx":1,"pingdom":1,"pmdstatic":1,"popads":1,"popcash":1,"primecaster":1,"pro-market":1,"px-cloud":1,"akamaihd":{"pxlclnmdecom-a":1},"r9cdn":1,"rfihub":1,"sancdn":1,"sc-static":1,"semasio":1,"sensic":1,"trafficmanager":{"serviceschipotlecom":1},"sexad":1,"smaato":1,"spreadshirts":1,"storygize":1,"tfaforms":1,"trackcmp":1,"trackedlink":1,"truste-svc":1,"uuidksinc":1,"viafoura":1,"visilabs":1,"visx":1,"w55c":1,"wdsvc":1,"witglobal":1,"yandex":1,"yastatic":1,"yieldlab":1,"ywxi":1,"zdbb":1,"zencdn":1,"zucks":1,"eviltracker":1},"co":{"6sc":1,"ayads":1,"datadome":1,"idio":1,"increasingly":1,"jads":1,"nanorep":1,"nc0":1,"pcdn":1,"prmutv":1,"resetdigital":1,"t":1,"tctm":1,"zip":1},"de":{"71i":1,"adscale":1,"auswaertiges-amt":1,"fiduciagad":1,"ioam":1,"itzbund":1,"werk21system":1},"gt":{"ad":1},"jp":{"adingo":1,"admatrix":1,"auone":1,"co":{"dmm":1,"google":1,"rakuten":1,"yahoo":1},"fout":1,"gmossp-sp":1,"gssprt":1,"ne":{"hatena":1},"impact-ad":1,"microad":1,"nakanohito":1,"ptengine":1,"r10s":1,"reemo-ad":1,"rtoaster":1,"shinobi":1,"team-rec":1,"uncn":1,"yimg":1,"yjtag":1},"pl":{"adocean":1,"dreamlab":1,"gemius":1,"nsaudience":1,"onet":1,"salesmanago":1,"wp":1},"pro":{"adpartner":1,"piwik":1,"usocial":1},"ru":{"adriver":1,"digitaltarget":1,"mail":1,"mindbox":1,"rambler":1,"sape":1,"smi2":1,"tns-counter":1,"top100":1,"ulogin":1,"yandex":1},"re":{"adsco":1},"info":{"adxbid":1,"bitrix":1,"navistechnologies":1,"usergram":1,"webantenna":1},"tv":{"affec":1,"attn":1,"iris":1,"ispot":1,"samba":1,"teads":1,"twitch":1},"dev":{"amazon":1},"us":{"amung":1,"samplicio":1,"slgnt":1,"trkn":1},"media":{"andbeyond":1,"nextday":1,"townsquare":1,"underdog":1},"link":{"app":1},"cloud":{"avct":1,"coremedia":1,"egain":1,"matomo":1},"delivery":{"ay":1,"monu":1},"br":{"com":{"btg360":1,"clearsale":1,"jsuol":1,"shopconvert":1,"shoptarget":1,"soclminer":1},"org":{"ivcbrasil":1}},"ch":{"ch":1,"da-services":1,"google":1},"ms":{"clarity":1},"my":{"cnt":1},"se":{"codigo":1},"me":{"contentexchange":1,"grow":1,"line":1,"loopme":1,"t":1,"channel":1},"to":{"cpx":1,"tawk":1},"chat":{"crisp":1,"gorgias":1},"fr":{"d-bi":1,"open-system":1,"weborama":1},"uk":{"co":{"dailymail":1,"hsbc":1}},"id":{"net":{"detik":1}},"ai":{"e-volution":1,"m2":1,"nrich":1,"wknd":1},"be":{"geoedge":1},"au":{"com":{"google":1,"news":1,"nine":1,"realestate":1,"zipmoney":1,"telstra":1}},"stream":{"ibclick":1},"cz":{"imedia":1,"seznam":1,"trackad":1},"app":{"infusionsoft":1,"permutive":1,"shop":1},"tech":{"ingage":1,"primis":1},"eu":{"kameleoon":1,"medallia":1,"media01":1,"ocdn":1,"rqtrk":1,"slgnt":1,"usercentrics":1},"fi":{"kesko":1,"simpli":1},"live":{"lura":1},"services":{"marketingautomation":1},"sg":{"mediacorp":1},"bi":{"newsroom":1},"fm":{"pdst":1},"ad":{"pixel":1},"xyz":{"playground":1},"it":{"plug":1,"repstatic":1,"stbm":1},"cc":{"popin":1},"network":{"pub":1},"nl":{"rijksoverheid":1,"google":1},"fyi":{"sda":1},"pe":{"shop":1},"es":{"socy":1},"im":{"spot":1},"market":{"spotim":1},"am":{"tru":1},"at":{"waust":1},"gov":{"weather":1},"in":{"zoho":1},"ca":{"bc":{"gov":1}},"no":{"acdn":1,"uio":1},"example":{"ad-company":1},"site":{"ad-company":1,"third-party":{"bad":1,"broken":1}},"pw":{"zlp6s":1}};
+
+        return output
+    }
+
+    /**
+     * Retutns a list of enabled features
+     * @param {RemoteConfig} data
+     * @param {string | null} topLevelHostname
+     * @param {Platform['version']} platformVersion
+     * @param {string[]} platformSpecificFeatures
+     * @returns {string[]}
+     */
+    function computeEnabledFeatures (data, topLevelHostname, platformVersion, platformSpecificFeatures = []) {
+        const remoteFeatureNames = Object.keys(data.features);
+        const platformSpecificFeaturesNotInRemoteConfig = platformSpecificFeatures.filter((featureName) => !remoteFeatureNames.includes(featureName));
         const enabledFeatures = remoteFeatureNames.filter((featureName) => {
             const feature = data.features[featureName];
             // Check that the platform supports minSupportedVersion checks and that the feature has a minSupportedVersion
-            if (feature.minSupportedVersion && preferences.platform?.version) {
-                if (!isSupportedVersion(feature.minSupportedVersion, preferences.platform.version)) {
+            if (feature.minSupportedVersion && platformVersion) {
+                if (!isSupportedVersion(feature.minSupportedVersion, platformVersion)) {
                     return false
                 }
             }
             return feature.state === 'enabled' && !isUnprotectedDomain(topLevelHostname, feature.exceptions)
         }).concat(platformSpecificFeaturesNotInRemoteConfig); // only disable platform specific features if it's explicitly disabled in remote config
-        const isBroken = isUnprotectedDomain(topLevelHostname, data.unprotectedTemporary);
-        output.site = {
-            domain: topLevelHostname,
-            isBroken,
-            allowlisted,
-            enabledFeatures
-        };
-        // TODO
-        output.cookie = {};
+        return enabledFeatures
+    }
 
-        // Copy feature settings from remote config to preferences object
-        output.featureSettings = {};
+    /**
+     * Returns the relevant feature settings for the enabled features
+     * @param {RemoteConfig} data
+     * @param {string[]} enabledFeatures
+     * @returns {Record<string, unknown>}
+     */
+    function parseFeatureSettings (data, enabledFeatures) {
+        /** @type {Record<string, unknown>} */
+        const featureSettings = {};
+        const remoteFeatureNames = Object.keys(data.features);
         remoteFeatureNames.forEach((featureName) => {
             if (!enabledFeatures.includes(featureName)) {
                 return
             }
 
-            output.featureSettings[featureName] = data.features[featureName].settings;
+            featureSettings[featureName] = data.features[featureName].settings;
         });
-
-        return output
+        return featureSettings
     }
 
     function isGloballyDisabled (args) {
@@ -1136,11 +1181,41 @@
       return parseJSONPointer(fromPointer);
     }
 
+    /**
+     * @typedef {object} AssetConfig
+     * @property {string} regularFontUrl
+     * @property {string} boldFontUrl
+     */
+
+    /**
+     * @typedef {object} Site
+     * @property {string} domain
+     * @property {boolean} isBroken
+     * @property {boolean} allowlisted
+     * @property {string[]} enabledFeatures
+     */
+
     class ContentFeature {
+        /** @type {import('./utils.js').RemoteConfig | undefined} */
+        #bundledConfig
+        /** @type {object | undefined} */
+        #trackerLookup
+        /** @type {boolean | undefined} */
+        #documentOriginIsTracker
+        /** @type {Record<string, unknown> | undefined} */
+        #bundledfeatureSettings
+
+        /** @type {{ debug: boolean, featureSettings: Record<string, unknown>, assets: AssetConfig | undefined, site: Site  } | null} */
+        #args
+
         constructor (featureName) {
             this.name = featureName;
-            this._args = null;
+            this.#args = null;
             this.monitor = new PerformanceMonitor();
+        }
+
+        get isDebug () {
+            return this.#args?.debug || false
         }
 
         /**
@@ -1153,6 +1228,34 @@
         get platform () {
             // @ts-expect-error - Type 'Platform | undefined' is not assignable to type 'Platform'
             return this._platform
+        }
+
+        /**
+         * @type {AssetConfig | undefined}
+         */
+        get assetConfig () {
+            return this.#args?.assets
+        }
+
+        /**
+         * @returns {boolean}
+         */
+        get documentOriginIsTracker () {
+            return !!this.#documentOriginIsTracker
+        }
+
+        /**
+         * @returns {object}
+         **/
+        get trackerLookup () {
+            return this.#trackerLookup || {}
+        }
+
+        /**
+         * @returns {import('./utils.js').RemoteConfig | undefined}
+         **/
+        get bundledConfig () {
+            return this.#bundledConfig
         }
 
         /**
@@ -1171,10 +1274,11 @@
 
         /**
          * @param {string} featureKeyName
+         * @param {string} [featureName]
          * @returns {any}
          */
-        getFeatureSetting (featureKeyName) {
-            let result = this._getFeatureSetting();
+        getFeatureSetting (featureKeyName, featureName) {
+            let result = this._getFeatureSetting(featureName);
             if (featureKeyName === 'domains') {
                 throw new Error('domains is a reserved feature setting key name')
             }
@@ -1194,17 +1298,22 @@
             return result?.[featureKeyName]
         }
 
-        _getFeatureSetting () {
-            const camelFeatureName = camelcase(this.name);
-            return this._args.featureSettings?.[camelFeatureName]
+        /**
+         * @param {string} [featureName] - The name of the feature to get the settings for; defaults to the name of the feature
+         * @returns {any}
+         */
+        _getFeatureSetting (featureName) {
+            const camelFeatureName = featureName || camelcase(this.name);
+            return this.#args?.featureSettings?.[camelFeatureName]
         }
 
         /**
          * @param {string} featureKeyName
+         * @param {string} [featureName]
          * @returns {boolean}
          */
-        getFeatureSettingEnabled (featureKeyName) {
-            const result = this.getFeatureSetting(featureKeyName);
+        getFeatureSettingEnabled (featureKeyName, featureName) {
+            const result = this.getFeatureSetting(featureKeyName, featureName);
             return result === 'enabled'
         }
 
@@ -1213,9 +1322,11 @@
          * @return {any[]}
          */
         matchDomainFeatureSetting (featureKeyName) {
+            const domain = this.#args?.site.domain;
+            if (!domain) return []
             const domains = this._getFeatureSetting()?.[featureKeyName] || [];
             return domains.filter((rule) => {
-                return matchHostname(this._args.site.domain, rule.domain)
+                return matchHostname(domain, rule.domain)
             })
         }
 
@@ -1225,7 +1336,7 @@
 
         callInit (args) {
             const mark = this.monitor.mark(this.name + 'CallInit');
-            this._args = args;
+            this.#args = args;
             this.platform = args.platform;
             this.init(args);
             mark.end();
@@ -1238,14 +1349,23 @@
 
         callLoad (args) {
             const mark = this.monitor.mark(this.name + 'CallLoad');
-            this._args = args;
+            this.#args = args;
             this.platform = args.platform;
+            this.#bundledConfig = args.bundledConfig;
+            // If we have a bundled config, treat it as a regular config
+            // This will be overriden by the remote config if it is available
+            if (this.#bundledConfig && this.#args) {
+                const enabledFeatures = computeEnabledFeatures(args.bundledConfig, getTabHostname(), this.platform.version);
+                this.#args.featureSettings = parseFeatureSettings(args.bundledConfig, enabledFeatures);
+            }
+            this.#trackerLookup = args.trackerLookup;
+            this.#documentOriginIsTracker = args.documentOriginIsTracker;
             this.load(args);
             mark.end();
         }
 
         measure () {
-            if (this._args.debug) {
+            if (this.#args?.debug) {
                 this.monitor.measureAll();
             }
         }
@@ -1317,15 +1437,17 @@
         return new Proxy(scope, {
             get (target, property, receiver) {
                 const targetObj = target[property];
+                let targetOut = target;
+                if (typeof property === 'string' && property in outputs) {
+                    targetOut = outputs;
+                }
+                // Reflects functions with the correct 'this' scope
                 if (typeof targetObj === 'function') {
                     return (...args) => {
-                        return Reflect.apply(target[property], target, args)
+                        return Reflect.apply(targetOut[property], target, args)
                     }
                 } else {
-                    if (typeof property === 'string' && property in outputs) {
-                        return Reflect.get(outputs, property, receiver)
-                    }
-                    return Reflect.get(target, property, receiver)
+                    return Reflect.get(targetOut, property, receiver)
                 }
             }
         })
@@ -1382,7 +1504,6 @@
     function wrapScriptCodeOverload (code, config) {
         const processedConfig = {};
         for (const [key, value] of Object.entries(config)) {
-            // @ts-expect-error - Expected 2 arguments, but got 1
             processedConfig[key] = processAttr(value);
         }
         // Don't do anything if the config is empty
@@ -1464,7 +1585,9 @@
     // Store the original methods so we can call them without any side effects
     const defaultElementMethods = {
         setAttribute: HTMLElement.prototype.setAttribute,
+        setAttributeNS: HTMLElement.prototype.setAttributeNS,
         getAttribute: HTMLElement.prototype.getAttribute,
+        getAttributeNS: HTMLElement.prototype.getAttributeNS,
         removeAttribute: HTMLElement.prototype.removeAttribute,
         remove: HTMLElement.prototype.remove,
         removeChild: HTMLElement.prototype.removeChild
@@ -1688,6 +1811,13 @@
             return this._callMethod('getAttribute', name, value)
         }
 
+        getAttributeNS (namespace, name, value) {
+            if (namespace) {
+                return this._callMethod('getAttributeNS', namespace, name, value)
+            }
+            return Reflect.apply(DDGRuntimeChecks.prototype.getAttribute, this, [name, value])
+        }
+
         setAttribute (name, value) {
             if (shouldFilterKey(this.#tagName, 'attribute', name)) return
             if (supportedSinks.includes(name)) {
@@ -1695,6 +1825,13 @@
                 return Reflect.set(DDGRuntimeChecks.prototype, name, value, this)
             }
             return this._callMethod('setAttribute', name, value)
+        }
+
+        setAttributeNS (namespace, name, value) {
+            if (namespace) {
+                return this._callMethod('setAttributeNS', namespace, name, value)
+            }
+            return Reflect.apply(DDGRuntimeChecks.prototype.setAttribute, this, [name, value])
         }
 
         removeAttribute (name) {
@@ -4104,6 +4241,34 @@
         }
     }
 
+    /**
+     * Check if the current document origin is on the tracker list, using the provided lookup trie.
+     * @param {object} trackerLookup Trie lookup of tracker domains
+     * @returns {boolean} True iff the origin is a tracker.
+     */
+    function isTrackerOrigin (trackerLookup, originHostname = document.location.hostname) {
+        const parts = originHostname.split('.').reverse();
+        let node = trackerLookup;
+        for (const sub of parts) {
+            if (node[sub] === 1) {
+                return true
+            } else if (node[sub]) {
+                node = node[sub];
+            } else {
+                return false
+            }
+        }
+        return false
+    }
+
+    /**
+     * @typedef ExtensionCookiePolicy
+     * @property {boolean} isFrame
+     * @property {boolean} isTracker
+     * @property {boolean} shouldBlock
+     * @property {boolean} isThirdPartyFrame
+     */
+
     // Initial cookie policy pre init
     let cookiePolicy = {
         debug: false,
@@ -4112,12 +4277,18 @@
         shouldBlock: true,
         shouldBlockTrackerCookie: true,
         shouldBlockNonTrackerCookie: false,
-        isThirdParty: isThirdParty(),
+        isThirdPartyFrame: isThirdPartyFrame(),
         policy: {
             threshold: 604800, // 7 days
             maxAge: 604800 // 7 days
-        }
+        },
+        trackerPolicy: {
+            threshold: 86400, // 1 day
+            maxAge: 86400 // 1 day
+        },
+        allowlist: /** @type {{ host: string }[]} */([])
     };
+    let trackerLookup = {};
 
     let loadedPolicyResolve;
 
@@ -4137,6 +4308,9 @@
         });
     }
 
+    /**
+     * @returns {boolean}
+     */
     function shouldBlockTrackingCookie () {
         return cookiePolicy.shouldBlock && cookiePolicy.shouldBlockTrackerCookie && isTrackingCookie()
     }
@@ -4145,26 +4319,45 @@
         return cookiePolicy.shouldBlock && cookiePolicy.shouldBlockNonTrackerCookie && isNonTrackingCookie()
     }
 
+    /**
+     * @param {Set<string>} scriptOrigins
+     * @returns {boolean}
+     */
+    function isFirstPartyTrackerScript (scriptOrigins) {
+        let matched = false;
+        for (const scriptOrigin of scriptOrigins) {
+            if (cookiePolicy.allowlist.find((allowlistOrigin) => matchHostname(allowlistOrigin.host, scriptOrigin))) {
+                return false
+            }
+            if (isTrackerOrigin(trackerLookup, scriptOrigin)) {
+                matched = true;
+            }
+        }
+        return matched
+    }
+
+    /**
+     * @returns {boolean}
+     */
     function isTrackingCookie () {
-        return cookiePolicy.isFrame && cookiePolicy.isTracker && cookiePolicy.isThirdParty
+        return cookiePolicy.isFrame && cookiePolicy.isTracker && cookiePolicy.isThirdPartyFrame
     }
 
     function isNonTrackingCookie () {
-        return cookiePolicy.isFrame && !cookiePolicy.isTracker && cookiePolicy.isThirdParty
+        return cookiePolicy.isFrame && !cookiePolicy.isTracker && cookiePolicy.isThirdPartyFrame
     }
 
     class CookieFeature extends ContentFeature {
-        load (args) {
-            // Feature is only relevant to the extension and windows, we should skip for other platforms for now as the config testing is broken.
-            if (this.platform.name !== 'extension' && this.platform.name !== 'windows') {
-                return
-            }
-            if (args.documentOriginIsTracker) {
+        load () {
+            if (this.documentOriginIsTracker) {
                 cookiePolicy.isTracker = true;
             }
-            if (args.bundledConfig) {
+            if (this.trackerLookup) {
+                trackerLookup = this.trackerLookup;
+            }
+            if (this.bundledConfig) {
                 // use the bundled config to get a best-effort at the policy, before the background sends the real one
-                const { exceptions, settings } = args.bundledConfig.features.cookie;
+                const { exceptions, settings } = this.bundledConfig.features.cookie;
                 const tabHostname = getTabHostname();
                 let tabExempted = true;
 
@@ -4178,6 +4371,10 @@
                 });
                 cookiePolicy.shouldBlock = !frameExempted && !tabExempted;
                 cookiePolicy.policy = settings.firstPartyCookiePolicy;
+                cookiePolicy.trackerPolicy = settings.firstPartyTrackerCookiePolicy;
+                // Allows for ad click conversion detection as described by https://help.duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/.
+                // This only applies when the resources that would set these cookies are unblocked.
+                cookiePolicy.allowlist = this.getFeatureSetting('allowlist', 'adClickAttribution') || [];
             }
 
             // The cookie policy is injected into every frame immediately so that no cookie will
@@ -4238,20 +4435,20 @@
                 try {
                     // wait for config before doing same-site tests
                     loadPolicyThen(() => {
-                        const { shouldBlock, policy } = cookiePolicy;
+                        const { shouldBlock, policy, trackerPolicy } = cookiePolicy;
 
+                        const chosenPolicy = isFirstPartyTrackerScript(scriptOrigins) ? trackerPolicy : policy;
                         if (!shouldBlock) {
                             debugHelper('ignore', 'disabled', setCookieContext);
                             return
                         }
-
                         // extract cookie expiry from cookie string
                         const cookie = new Cookie(value);
                         // apply cookie policy
-                        if (cookie.getExpiry() > policy.threshold) {
+                        if (cookie.getExpiry() > chosenPolicy.threshold) {
                             // check if the cookie still exists
                             if (document.cookie.split(';').findIndex(kv => kv.trim().startsWith(cookie.parts[0].trim())) !== -1) {
-                                cookie.maxAge = policy.maxAge;
+                                cookie.maxAge = chosenPolicy.maxAge;
 
                                 debugHelper('restrict', 'expiry', setCookieContext);
 
@@ -4279,19 +4476,23 @@
         }
 
         init (args) {
+            const restOfPolicy = {
+                debug: this.isDebug,
+                shouldBlockTrackerCookie: this.getFeatureSettingEnabled('trackerCookie'),
+                shouldBlockNonTrackerCookie: this.getFeatureSettingEnabled('nonTrackerCookie'),
+                allowlist: this.getFeatureSetting('allowlist', 'adClickAttribution') || [],
+                policy: this.getFeatureSetting('firstPartyCookiePolicy'),
+                trackerPolicy: this.getFeatureSetting('firstPartyTrackerCookiePolicy')
+            };
+            // The extension provides some additional info about the cookie policy, let's use that over our guesses
             if (args.cookie) {
-                cookiePolicy = args.cookie;
-                args.cookie.debug = args.debug;
-
-                cookiePolicy.shouldBlockTrackerCookie = this.getFeatureSettingEnabled('trackerCookie');
-                cookiePolicy.shouldBlockNonTrackerCookie = this.getFeatureSettingEnabled('nonTrackerCookie');
-                const policy = this.getFeatureSetting('firstPartyCookiePolicy');
-                if (policy) {
-                    cookiePolicy.policy = policy;
-                }
+                const extensionCookiePolicy = /** @type {ExtensionCookiePolicy} */(args.cookie);
+                cookiePolicy = {
+                    ...extensionCookiePolicy,
+                    ...restOfPolicy
+                };
             } else {
-                // no cookie information - disable protections
-                cookiePolicy.shouldBlock = false;
+                cookiePolicy = Object.assign(cookiePolicy, restOfPolicy);
             }
 
             loadedPolicyResolve();
@@ -4573,30 +4774,40 @@
         }
     }
 
-    class NavigatorInterface extends ContentFeature {
-        init (args) {
-            try {
-                // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
-                if (navigator.duckduckgo) {
-                    return
-                }
-                if (!args.platform || !args.platform.name) {
-                    return
-                }
-                defineProperty(Navigator.prototype, 'duckduckgo', {
-                    value: {
-                        platform: args.platform.name,
-                        isDuckDuckGo () {
-                            return DDGPromise.resolve(true)
-                        }
-                    },
-                    enumerable: true,
-                    configurable: false,
-                    writable: false
-                });
-            } catch {
-                // todo: Just ignore this exception?
+    function injectNavigatorInterface (args) {
+        try {
+            // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
+            if (navigator.duckduckgo) {
+                return
             }
+            if (!args.platform || !args.platform.name) {
+                return
+            }
+            defineProperty(Navigator.prototype, 'duckduckgo', {
+                value: {
+                    platform: args.platform.name,
+                    isDuckDuckGo () {
+                        return DDGPromise.resolve(true)
+                    }
+                },
+                enumerable: true,
+                configurable: false,
+                writable: false
+            });
+        } catch {
+            // todo: Just ignore this exception?
+        }
+    }
+
+    class NavigatorInterface extends ContentFeature {
+        load (args) {
+            if (this.matchDomainFeatureSetting('privilegedDomains').length) {
+                injectNavigatorInterface(args);
+            }
+        }
+
+        init (args) {
+            injectNavigatorInterface(args);
         }
     }
 
@@ -4988,12 +5199,14 @@
 
     /**
      * @typedef {object} LoadArgs
+     * @property {object} site
      * @property {object} platform
      * @property {string} platform.name
      * @property {string} [platform.version]
-     * @property {boolean} [documentOriginIsTracker]
+     * @property {boolean} documentOriginIsTracker
      * @property {object} [bundledConfig]
      * @property {string} [injectName]
+     * @property {object} trackerLookup - provided currently only by the extension
      */
 
     /**
@@ -5088,7 +5301,10 @@
         }
 
         load({
-            platform: processedConfig.platform
+            platform: processedConfig.platform,
+            trackerLookup: processedConfig.trackerLookup,
+            documentOriginIsTracker: isTrackerOrigin(processedConfig.trackerLookup),
+            site: processedConfig.site
         });
 
         const messageSecret = processedConfig.messageSecret;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.1.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.12.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.13.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1682070153"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#bfc93515d3164c2ec04a9be00a61dd294ed44630",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9a07d092c4d8dcad08d61aecb66607a0abc83654",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -272,9 +272,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
-      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==",
+      "version": "18.16.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
+      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==",
       "dev": true
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.1.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.12.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.13.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1682070153"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass