### PR TITLE
Handle being remotely signed out

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountObserver.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountObserver.kt
@@ -26,7 +26,7 @@ import dagger.SingleInstanceIn
 import javax.inject.*
 import kotlinx.coroutines.launch
 
-//This class can be removed when we have real sync observer for data
+// This class can be removed when we have real sync observer for data
 @ContributesMultibinding(
     scope = AppScope::class,
     boundType = MainProcessLifecycleObserver::class,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountObserver.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountObserver.kt
@@ -26,6 +26,7 @@ import dagger.SingleInstanceIn
 import javax.inject.*
 import kotlinx.coroutines.launch
 
+//This class can be removed when we have real sync observer for data
 @ContributesMultibinding(
     scope = AppScope::class,
     boundType = MainProcessLifecycleObserver::class,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountObserver.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountObserver.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.launch
+import javax.inject.*
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+@SingleInstanceIn(AppScope::class)
+class AccountObserver @Inject constructor(
+    val syncRepository: SyncRepository,
+    val dispatcherProvider: DispatcherProvider,
+) : MainProcessLifecycleObserver {
+    override fun onStart(owner: LifecycleOwner) {
+        owner.lifecycleScope.launch(dispatcherProvider.io()) {
+            syncRepository.getConnectedDevices()
+        }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountObserver.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountObserver.kt
@@ -23,8 +23,8 @@ import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
-import kotlinx.coroutines.launch
 import javax.inject.*
+import kotlinx.coroutines.launch
 
 @ContributesMultibinding(
     scope = AppScope::class,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
@@ -37,7 +37,7 @@ import timber.log.Timber
 
 interface SyncRepository {
 
-    fun signedIn(): Flow<Boolean>
+    fun isSignedInFlow(): Flow<Boolean>
     fun createAccount(): Result<Boolean>
     fun isSignedIn(): Boolean
 
@@ -73,7 +73,7 @@ class AppSyncRepository @Inject constructor(
     private val syncStore: SyncStore,
     private val syncCrypter: SyncCrypter,
 ) : SyncRepository {
-    override fun signedIn(): Flow<Boolean> = syncStore.isSignedInFlow()
+    override fun isSignedInFlow(): Flow<Boolean> = syncStore.isSignedInFlow()
 
     override fun createAccount(): Result<Boolean> {
         val userId = syncDeviceIds.userId()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
@@ -395,11 +395,10 @@ class AppSyncRepository @Inject constructor(
         }
     }
 
-    private fun Error.removeKeysIfInvalid(): Error {
+    private fun Error.removeKeysIfInvalid() {
         if (code == INVALID_LOGIN_CREDENTIALS.code) {
             syncStore.clearAll()
         }
-        return this
     }
 
     private class Adapters {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncRepository.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.crypto.AccountKeys
 import com.duckduckgo.sync.crypto.LoginKeys
 import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.API_CODE.INVALID_LOGIN_CREDENTIALS
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.parser.SyncCrypter
 import com.duckduckgo.sync.impl.parser.SyncDataRequest
@@ -395,7 +396,7 @@ class AppSyncRepository @Inject constructor(
     }
 
     private fun Error.removeKeysIfInvalid(): Error {
-        if (code == 401) {
+        if (code == INVALID_LOGIN_CREDENTIALS.code) {
             syncStore.clearAll()
         }
         return this

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -169,3 +169,7 @@ data class DataResponse(
     val settings: SettingsResponse,
     val devices: DeviceDataResponse,
 )
+
+enum class API_CODE(val code: Int) {
+    INVALID_LOGIN_CREDENTIALS(401),
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl.di
 
 import android.content.Context
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.sync.crypto.SyncLib
@@ -34,6 +35,7 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
 
 @Module
 @ContributesTo(AppScope::class)
@@ -41,8 +43,11 @@ object SyncStoreModule {
 
     @Provides
     @SingleInstanceIn(AppScope::class)
-    fun providesSyncStore(sharedPrefsProvider: SharedPrefsProvider): SyncStore {
-        return SyncSharedPrefsStore(sharedPrefsProvider)
+    fun providesSyncStore(
+        sharedPrefsProvider: SharedPrefsProvider,
+        @AppCoroutineScope appCoroutineScope: CoroutineScope,
+    ): SyncStore {
+        return SyncSharedPrefsStore(sharedPrefsProvider, appCoroutineScope)
     }
 
     @Provides

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -120,11 +120,6 @@ class SyncActivity : DuckDuckGoActivity() {
         }
     }
 
-    override fun onStart() {
-        super.onStart()
-        // viewModel.getSyncState()
-    }
-
     private fun observeUiEvents() {
         viewModel.viewState()
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -229,7 +229,6 @@ class SyncActivity : DuckDuckGoActivity() {
     }
 
     private fun renderViewState(viewState: ViewState) {
-        Timber.i("CRIS: rendering view state: $viewState")
         binding.deviceSyncStatusToggle.quietlySetIsChecked(viewState.syncToggleState, deviceSyncStatusToggleListener)
         binding.viewSwitcher.displayedChild = if (viewState.showAccount) 1 else 0
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -56,6 +56,7 @@ import com.google.android.material.snackbar.Snackbar
 import javax.inject.*
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(SyncActivityWithEmptyParams::class)
@@ -121,7 +122,7 @@ class SyncActivity : DuckDuckGoActivity() {
 
     override fun onStart() {
         super.onStart()
-        viewModel.getSyncState()
+        // viewModel.getSyncState()
     }
 
     private fun observeUiEvents() {
@@ -233,6 +234,7 @@ class SyncActivity : DuckDuckGoActivity() {
     }
 
     private fun renderViewState(viewState: ViewState) {
+        Timber.i("CRIS: rendering view state: $viewState")
         binding.deviceSyncStatusToggle.quietlySetIsChecked(viewState.syncToggleState, deviceSyncStatusToggleListener)
         binding.viewSwitcher.displayedChild = if (viewState.showAccount) 1 else 0
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -127,7 +127,7 @@ class SyncActivity : DuckDuckGoActivity() {
 
     private fun observeUiEvents() {
         viewModel.viewState()
-            .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { viewState -> renderViewState(viewState) }
             .launchIn(lifecycleScope)
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -56,7 +56,6 @@ import com.google.android.material.snackbar.Snackbar
 import javax.inject.*
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(SyncActivityWithEmptyParams::class)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -74,7 +74,7 @@ class SyncActivityViewModel @Inject constructor(
     }.flowOn(dispatchers.io())
 
     private fun observerSignedInState() {
-        syncRepository.signedIn().onEach { signedIn ->
+        syncRepository.isSignedInFlow().onEach { signedIn ->
             when (signedIn) {
                 true -> {
                     if (!viewState.value.isSignedInState()) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -70,7 +70,7 @@ class SyncActivityViewModel @Inject constructor(
             signedOutState()
         } else if (viewState.loginQRCode == null) {
             Timber.i("CRIS: viewState.combine: loginQRNULL")
-            initViewStateThisDevice()
+            initViewStateThisDeviceState()
         } else {
             viewState
         }
@@ -79,7 +79,7 @@ class SyncActivityViewModel @Inject constructor(
         fetchRemoteDevices()
     }.flowOn(dispatchers.io())
 
-    private suspend fun initViewStateThisDevice(): ViewState {
+    private suspend fun initViewStateThisDeviceState(): ViewState {
         if (!syncRepository.isSignedIn()) {
             return signedOutState()
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SaveRecoveryCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SaveRecoveryCodeViewModel.kt
@@ -37,7 +37,6 @@ import com.duckduckgo.sync.impl.ui.setup.SaveRecoveryCodeViewModel.ViewMode.Crea
 import com.duckduckgo.sync.impl.ui.setup.SaveRecoveryCodeViewModel.ViewMode.SignedIn
 import java.io.File
 import javax.inject.*
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -59,7 +58,7 @@ class SaveRecoveryCodeViewModel @Inject constructor(
     private val viewState = MutableStateFlow(ViewState())
     fun viewState(): Flow<ViewState> = viewState.onStart { createAccount() }
 
-    private fun createAccount() = viewModelScope.launch(dispatchers.io() + NonCancellable) {
+    private fun createAccount() = viewModelScope.launch(dispatchers.io()) {
         if (syncRepository.isSignedIn()) {
             syncRepository.getRecoveryCode()?.let {
                 val bitmap = qrEncoder.encodeAsBitmap(it, R.dimen.qrSizeSmall, R.dimen.qrSizeSmall)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SaveRecoveryCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SaveRecoveryCodeViewModel.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.sync.impl.ui.setup.SaveRecoveryCodeViewModel.ViewMode.Crea
 import com.duckduckgo.sync.impl.ui.setup.SaveRecoveryCodeViewModel.ViewMode.SignedIn
 import java.io.File
 import javax.inject.*
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -58,7 +59,7 @@ class SaveRecoveryCodeViewModel @Inject constructor(
     private val viewState = MutableStateFlow(ViewState())
     fun viewState(): Flow<ViewState> = viewState.onStart { createAccount() }
 
-    private fun createAccount() = viewModelScope.launch(dispatchers.io()) {
+    private fun createAccount() = viewModelScope.launch(dispatchers.io() + NonCancellable) {
         if (syncRepository.isSignedIn()) {
             syncRepository.getRecoveryCode()?.let {
                 val bitmap = qrEncoder.encodeAsBitmap(it, R.dimen.qrSizeSmall, R.dimen.qrSizeSmall)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.global.device.DeviceInfo
 import com.duckduckgo.sync.impl.AppSyncDeviceIds
 import com.duckduckgo.sync.impl.Type
 import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.flow.emptyFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -109,6 +110,21 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = "secretKey"
             override var recoveryCode: String? = "recoveryCode"
 
+            override fun isSignedInFlow() = emptyFlow<Boolean>()
+
+            override fun isSignedIn(): Boolean = primaryKey != null
+
+            override fun storeCredentials(
+                userId: String,
+                deviceId: String,
+                deviceName: String,
+                primaryKey: String,
+                secretKey: String,
+                token: String,
+            ) {
+                /* no-op */
+            }
+
             override fun clearAll(keepRecoveryCode: Boolean) {
                 /* no-op */
             }
@@ -124,6 +140,20 @@ class AppSyncDeviceIdsTest {
             override var primaryKey: String? = null
             override var secretKey: String? = null
             override var recoveryCode: String? = null
+            override fun isSignedInFlow() = emptyFlow<Boolean>()
+
+            override fun isSignedIn(): Boolean = false
+
+            override fun storeCredentials(
+                userId: String,
+                deviceId: String,
+                deviceName: String,
+                primaryKey: String,
+                secretKey: String,
+                token: String,
+            ) {
+                /* no-op */
+            }
 
             override fun clearAll(keepRecoveryCode: Boolean) {
                 /* no-op */

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncRepositoryTest.kt
@@ -102,12 +102,14 @@ class AppSyncRepositoryTest {
         val result = syncRepo.createAccount()
 
         assertEquals(Result.Success(true), result)
-        verify(syncStore).userId = userId
-        verify(syncStore).deviceId = deviceId
-        verify(syncStore).deviceName = deviceName
-        verify(syncStore).token = token
-        verify(syncStore).primaryKey = primaryKey
-        verify(syncStore).secretKey = secretKey
+        verify(syncStore).storeCredentials(
+            userId = userId,
+            deviceId = deviceId,
+            deviceName = deviceName,
+            primaryKey = primaryKey,
+            secretKey = secretKey,
+            token = token,
+        )
     }
 
     @Test
@@ -174,14 +176,14 @@ class AppSyncRepositoryTest {
     }
 
     @Test
-    fun whenLogoutFailsThenReturnError() {
+    fun whenLogoutFailsWithInvalidLoginCredentialsThenReturnErrorAndClearData() {
         givenAuthenticatedDevice()
         whenever(syncApi.logout(token, deviceId)).thenReturn(logoutInvalid)
 
         val result = syncRepo.logout(deviceId)
 
         assertTrue(result is Result.Error)
-        verify(syncStore, times(0)).clearAll()
+        verify(syncStore).clearAll()
     }
 
     @Test
@@ -208,14 +210,14 @@ class AppSyncRepositoryTest {
     }
 
     @Test
-    fun whenDeleteAccountFailsThenReturnError() {
+    fun whenDeleteAccountFailsWithInvalidLoginCredentialsThenReturnErrorAndClearData() {
         givenAuthenticatedDevice()
         whenever(syncApi.deleteAccount(token)).thenReturn(deleteAccountInvalid)
 
         val result = syncRepo.deleteAccount()
 
         assertTrue(result is Result.Error)
-        verify(syncStore, times(0)).clearAll()
+        verify(syncStore).clearAll()
     }
 
     @Test
@@ -226,12 +228,14 @@ class AppSyncRepositoryTest {
         val result = syncRepo.login()
 
         assertEquals(Result.Success(true), result)
-        verify(syncStore).userId = userId
-        verify(syncStore).deviceId = deviceId
-        verify(syncStore).deviceName = deviceName
-        verify(syncStore).token = token
-        verify(syncStore).primaryKey = primaryKey
-        verify(syncStore).secretKey = secretKey
+        verify(syncStore).storeCredentials(
+            userId = userId,
+            deviceId = deviceId,
+            deviceName = deviceName,
+            primaryKey = primaryKey,
+            secretKey = secretKey,
+            token = token,
+        )
     }
 
     @Test
@@ -241,12 +245,14 @@ class AppSyncRepositoryTest {
         val result = syncRepo.login(jsonRecoveryKeyEncoded)
 
         assertEquals(Result.Success(true), result)
-        verify(syncStore).userId = userId
-        verify(syncStore).deviceId = deviceId
-        verify(syncStore).deviceName = deviceName
-        verify(syncStore).token = token
-        verify(syncStore).primaryKey = primaryKey
-        verify(syncStore).secretKey = secretKey
+        verify(syncStore).storeCredentials(
+            userId = userId,
+            deviceId = deviceId,
+            deviceName = deviceName,
+            primaryKey = primaryKey,
+            secretKey = secretKey,
+            token = token,
+        )
     }
 
     @Test
@@ -420,7 +426,8 @@ class AppSyncRepositoryTest {
 
     @Test
     fun whenConnectingUsingQRFromUnauthenticatedDeviceThenAccountCreatedAndConnects() {
-        whenever(syncStore.primaryKey).thenReturn(null).thenReturn(primaryKey)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.isSignedIn()).thenReturn(false).thenReturn(true)
         whenever(syncStore.userId).thenReturn(userId)
         whenever(syncStore.deviceId).thenReturn(deviceId)
         whenever(syncStore.token).thenReturn(token)
@@ -514,6 +521,7 @@ class AppSyncRepositoryTest {
         whenever(syncStore.primaryKey).thenReturn(primaryKey)
         whenever(syncStore.secretKey).thenReturn(secretKey)
         whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.isSignedIn()).thenReturn(true)
     }
 
     private fun prepareToProvideDeviceIds() {

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
@@ -2,6 +2,10 @@ package com.duckduckgo.sync.store
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 interface SyncStore {
     var userId: String?
@@ -11,15 +15,28 @@ interface SyncStore {
     var primaryKey: String?
     var secretKey: String?
     var recoveryCode: String?
+    fun isSignedInFlow(): Flow<Boolean>
+    fun isSignedIn(): Boolean
+    fun storeCredentials(
+        userId: String,
+        deviceId: String,
+        deviceName: String,
+        primaryKey: String,
+        secretKey: String,
+        token: String,
+    )
     fun clearAll(keepRecoveryCode: Boolean = true)
 }
 
 class SyncSharedPrefsStore
 constructor(
     private val sharedPrefsProv: SharedPrefsProvider,
+    private val appCoroutineScope: CoroutineScope,
 ) : SyncStore {
 
     private val encryptedPreferences: SharedPreferences? by lazy { encryptedPreferences() }
+
+    private val isSignedInStateFlow = MutableStateFlow(isSignedIn())
 
     @Synchronized
     private fun encryptedPreferences(): SharedPreferences? {
@@ -109,11 +126,37 @@ constructor(
             }
         }
 
+    override fun isSignedInFlow(): Flow<Boolean> = isSignedInStateFlow
+
+    override fun isSignedIn() = !primaryKey.isNullOrEmpty() && !userId.isNullOrEmpty()
+
+    override fun storeCredentials(
+        userId: String,
+        deviceId: String,
+        deviceName: String,
+        primaryKey: String,
+        secretKey: String,
+        token: String,
+    ) {
+        this.userId = userId
+        this.deviceId = deviceId
+        this.deviceName = deviceName
+        this.token = token
+        this.primaryKey = primaryKey
+        this.secretKey = secretKey
+
+        appCoroutineScope.launch {
+            isSignedInStateFlow.emit(true)
+        }
+    }
     override fun clearAll(keepRecoveryCode: Boolean) {
         val recoveryCodeBackup = recoveryCode
         encryptedPreferences?.edit(commit = true) { clear() }
         if (keepRecoveryCode) {
             recoveryCode = recoveryCodeBackup
+        }
+        appCoroutineScope.launch {
+            isSignedInStateFlow.emit(false)
         }
     }
 

--- a/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
+++ b/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
@@ -18,12 +18,16 @@ package com.duckduckgo.sync.store
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class SyncSharedPrefsStoreTest {
     private lateinit var store: SyncSharedPrefsStore
@@ -32,7 +36,7 @@ class SyncSharedPrefsStoreTest {
 
     @Before
     fun setUp() {
-        store = SyncSharedPrefsStore(sharedPrefsProvider)
+        store = SyncSharedPrefsStore(sharedPrefsProvider, TestScope())
     }
 
     @Test
@@ -60,5 +64,49 @@ class SyncSharedPrefsStoreTest {
         assertEquals("test_device_id", store.deviceId)
         store.deviceId = null
         assertNull(store.deviceId)
+    }
+
+    @Test
+    fun whenStoreCredentialsThenValuesUpdatedInPrefsStore() {
+        assertNull(store.userId)
+        assertNull(store.deviceName)
+        assertNull(store.deviceId)
+        assertNull(store.primaryKey)
+        assertNull(store.secretKey)
+        assertNull(store.token)
+        store.storeCredentials("userId", "deviceId", "deviceName", "primaryKey", "secretKey", "token")
+        assertEquals("userId", store.userId)
+        assertEquals("deviceName", store.deviceName)
+        assertEquals("deviceId", store.deviceId)
+        assertEquals("primaryKey", store.primaryKey)
+        assertEquals("secretKey", store.secretKey)
+        assertEquals("token", store.token)
+    }
+
+    @Test
+    fun whenIsSignedInThenReturnTrueIfUserHasAuthKeys() {
+        store.storeCredentials("userId", "deviceId", "deviceName", "primaryKey", "secretKey", "token")
+
+        assertTrue(store.isSignedIn())
+    }
+
+    @Test
+    fun whenClearAllThenReturnRemoveAllKeys() {
+        store.storeCredentials("userId", "deviceId", "deviceName", "primaryKey", "secretKey", "token")
+        assertEquals("userId", store.userId)
+        assertEquals("deviceName", store.deviceName)
+        assertEquals("deviceId", store.deviceId)
+        assertEquals("primaryKey", store.primaryKey)
+        assertEquals("secretKey", store.secretKey)
+        assertEquals("token", store.token)
+
+        store.clearAll()
+
+        assertNull(store.userId)
+        assertNull(store.deviceName)
+        assertNull(store.deviceId)
+        assertNull(store.primaryKey)
+        assertNull(store.secretKey)
+        assertNull(store.token)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204341643230613/f 

### Description
Ensures if device has been signed out remotely, we remove keys when any request/authentication fails with invalid_code credentials.

### Steps to test this PR

_Feature 1_
- [ ] having 2 connected devices on the same account
- [ ] remove one device from another device
- [ ] When you open the app on the device you have just removed
- [ ] going to settings should reflect sync state as off
- [ ] Connect the device again
- [ ] now, repeat the process, but having the device you are going to disconnect in foreground on the sync settings main screen
- [ ] after removing the device, any action that triggers a request to the backend, should trigger a signout state on the UI (because keys has been removed from store)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
