### PR TITLE
Updated logic when VPN is restarted to avoid starting it twice.

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/heartbeat/VpnServiceHeartbeat.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/heartbeat/VpnServiceHeartbeat.kt
@@ -75,9 +75,8 @@ class VpnServiceHeartbeat @Inject constructor(
         logcat { "onVpnStopped called" }
         when (vpnStopReason) {
             ERROR -> logcat { "HB monitor: sudden vpn stopped $vpnStopReason" }
-            RESTART -> logcat { "HB monitor: restarting vpn $vpnStopReason" }
-            SELF_STOP, REVOKED, UNKNOWN -> {
-                logcat { "HB monitor: self stopped or revoked: $vpnStopReason" }
+            SELF_STOP, REVOKED, RESTART, UNKNOWN -> {
+                logcat { "HB monitor: self stopped or revoked or restart: $vpnStopReason" }
                 coroutineScope.launch { storeHeartbeat(VpnServiceHeartbeatMonitor.DATA_HEART_BEAT_TYPE_STOPPED) }
             }
         }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -188,6 +188,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope() {
 
         if (restartRequested) {
             restartRequested = false
+            logcat { "VPN log start from onDestroy" }
             startService(this)
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202279501986195/1204415151858394/f

### Description
Updated logic when VPN is restarted to avoid starting it twice.

### Steps to test this PR

- [ ] Install from this branch.
- [ ] Enable AppTP and wait until you see some trackers.
- [ ] On `App Tracking Protection` screen tap on one of the tracking attempts which will send you to "company details" screen.
- [ ] Disable / enable tracking from the toggle at the top. Check that the VPN restarts without issues. Check that you see in logcat `VPN log start from onDestroy` from `TrackerBlockingVpnService` and `No need to restart the VPN` from `VpnStateMonitorService`. Note that every state change is triggering a restart. E.g if you do `disable` you see each of the logs mentioned once.
 
### NO UI changes
