### PR TITLE
Support changes in the tracker entities

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ManageAppsProtectionViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ManageAppsProtectionViewModel.kt
@@ -27,8 +27,8 @@ import com.duckduckgo.mobile.android.vpn.apps.AppsProtectionType.FilterType
 import com.duckduckgo.mobile.android.vpn.apps.AppsProtectionType.InfoPanelType
 import com.duckduckgo.mobile.android.vpn.apps.ui.TrackingProtectionExclusionListActivity.Companion.AppsFilter
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageScreen
-import com.duckduckgo.mobile.android.vpn.model.BucketizedVpnTracker
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
+import com.duckduckgo.mobile.android.vpn.model.VpnTrackerWithEntity
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository.TimeWindow
@@ -135,19 +135,19 @@ class ManageAppsProtectionViewModel @Inject constructor(
             .flowOn(dispatcherProvider.io())
 
     private suspend fun aggregateDataPerApp(
-        trackerData: List<BucketizedVpnTracker>,
+        trackerData: List<VpnTrackerWithEntity>,
     ): List<TrackingApp> {
         val sourceData = mutableListOf<TrackingApp>()
-        val perSessionData = trackerData.groupBy { it.trackerCompanySignal.tracker.bucket }
+        val perSessionData = trackerData.groupBy { it.tracker.bucket }
 
         perSessionData.values.forEach { sessionTrackers ->
             coroutineContext.ensureActive()
 
-            val perAppData = sessionTrackers.groupBy { it.trackerCompanySignal.tracker.trackingApp.packageId }
+            val perAppData = sessionTrackers.groupBy { it.tracker.trackingApp.packageId }
 
             perAppData.values.forEach { appTrackers ->
-                val item = appTrackers.sortedByDescending { it.trackerCompanySignal.tracker.timestamp }.first()
-                sourceData.add(item.trackerCompanySignal.tracker.trackingApp)
+                val item = appTrackers.sortedByDescending { it.tracker.timestamp }.first()
+                sourceData.add(item.tracker.trackingApp)
             }
         }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnLastTrackersBlockedCollector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnLastTrackersBlockedCollector.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.app.global.formatters.time.model.dateOfLastDay
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.state.VpnStateCollectorPlugin
-import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
+import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -32,7 +32,7 @@ import org.threeten.bp.LocalDateTime
 
 @ContributesMultibinding(VpnScope::class)
 class VpnLastTrackersBlockedCollector @Inject constructor(
-    private val vpnDatabase: VpnDatabase,
+    private val appTrackerBlockingRepository: AppTrackerBlockingStatsRepository,
     private val dispatcherProvider: DispatcherProvider,
     private val moshi: Moshi,
 ) : VpnStateCollectorPlugin {
@@ -43,7 +43,7 @@ class VpnLastTrackersBlockedCollector @Inject constructor(
     override suspend fun collectVpnRelatedState(appPackageId: String?): JSONObject {
         return withContext(dispatcherProvider.io()) {
             val result = mutableMapOf<String, List<String>>()
-            vpnDatabase.vpnTrackerDao().getTrackersBetweenSync(dateOfLastDay(), noEndDate())
+            appTrackerBlockingRepository.getVpnTrackersSync({ dateOfLastDay() }, noEndDate())
                 .filter { tracker -> appPackageId?.let { tracker.trackingApp.packageId == it } ?: true }
                 .groupBy { it.trackingApp.packageId }
                 .mapValues { entry -> entry.value.map { it.domain } }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
@@ -28,7 +28,7 @@ import com.duckduckgo.mobile.android.vpn.model.TrackingApp
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
-import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
+import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
@@ -54,7 +54,7 @@ import org.threeten.bp.LocalDateTime
 class SendTrackerDebugReceiver @Inject constructor(
     private val context: Context,
     private val appBuildConfig: AppBuildConfig,
-    private val vpnDatabase: VpnDatabase,
+    private val appTrackerBlockingRepository: AppTrackerBlockingStatsRepository,
     private val dispatchers: DispatcherProvider,
 ) : BroadcastReceiver(), VpnServiceCallbacks {
 
@@ -89,7 +89,7 @@ class SendTrackerDebugReceiver @Inject constructor(
                     ),
                 )
             }
-            vpnDatabase.vpnTrackerDao().insert(insertionList)
+            appTrackerBlockingRepository.insert(insertionList)
         }
     }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
@@ -20,12 +20,15 @@ import android.content.Context
 import android.content.res.Resources
 import android.net.ConnectivityManager
 import androidx.room.Room
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistryImpl
 import com.duckduckgo.mobile.android.vpn.VpnServiceWrapper
 import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.remote_config.*
+import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
+import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.store.*
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerRepository
 import com.duckduckgo.mobile.android.vpn.trackers.RealAppTrackerRepository
@@ -98,5 +101,13 @@ object VpnAppModule {
         sharedPreferencesProvider: VpnSharedPreferencesProvider,
     ): VpnFeaturesRegistry {
         return VpnFeaturesRegistryImpl(VpnServiceWrapper(context), sharedPreferencesProvider)
+    }
+
+    @Provides
+    fun provideAppTrackerBlockingStatsRepository(
+        vpnDatabase: VpnDatabase,
+        dispatchers: DispatcherProvider,
+    ): AppTrackerBlockingStatsRepository {
+        return RealAppTrackerBlockingStatsRepository(vpnDatabase, dispatchers)
     }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/removal/VpnFeatureRemover.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/removal/VpnFeatureRemover.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.dao.VpnFeatureRemoverState
 import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import com.duckduckgo.mobile.android.vpn.service.VpnReminderNotificationWorker
+import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.ui.notification.AndroidDeviceShieldAlertNotificationBuilder
 import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldNotificationScheduler.Companion.VPN_DAILY_NOTIFICATION_ID
@@ -46,6 +47,7 @@ class DefaultVpnFeatureRemover @Inject constructor(
     private val vpnStore: VpnStore,
     private val notificationManager: NotificationManagerCompat,
     private val vpnDatabase: VpnDatabase,
+    private val appTrackerBlockingRepository: AppTrackerBlockingStatsRepository,
     // we use the Provider to avoid a cycle dependency
     private val workManagerProvider: Provider<WorkManager>,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
@@ -92,7 +94,7 @@ class DefaultVpnFeatureRemover @Inject constructor(
     }
 
     private fun deleteAllVpnTrackers() {
-        vpnDatabase.vpnTrackerDao().deleteAllTrackers()
+        appTrackerBlockingRepository.deleteAllTrackers()
     }
 
     private suspend fun removeVpnFeature() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.formatters.time.TimeDiffFormatter
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.apps.TrackingProtectionAppsRepository
-import com.duckduckgo.mobile.android.vpn.model.VpnTrackerCompanySignal
+import com.duckduckgo.mobile.android.vpn.model.VpnTrackerWithEntity
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackingSignal
@@ -72,7 +72,7 @@ constructor(
     }
 
     private suspend fun aggregateDataPerApp(
-        trackerData: List<VpnTrackerCompanySignal>,
+        trackerData: List<VpnTrackerWithEntity>,
         packageName: String,
     ): ViewState {
         val sourceData = mutableListOf<CompanyTrackingDetails>()

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/apps/ManageAppsProtectionViewModelTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/apps/ManageAppsProtectionViewModelTest.kt
@@ -27,7 +27,6 @@ import com.duckduckgo.mobile.android.vpn.apps.BannerContent.ALL_OR_PROTECTED_APP
 import com.duckduckgo.mobile.android.vpn.apps.BannerContent.CUSTOMISED_PROTECTION
 import com.duckduckgo.mobile.android.vpn.apps.BannerContent.UNPROTECTED_APPS
 import com.duckduckgo.mobile.android.vpn.apps.ui.TrackingProtectionExclusionListActivity
-import com.duckduckgo.mobile.android.vpn.apps.ui.TrackingProtectionExclusionListActivity.Companion.AppsFilter.PROTECTED_ONLY
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageScreen
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldWeeklyNotificationFactoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldWeeklyNotificationFactoryTest.kt
@@ -21,12 +21,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
-import com.duckduckgo.mobile.android.vpn.dao.VpnTrackerDao
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
+import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerEntity
 import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldNotificationFactory.DeviceShieldNotification
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -46,7 +46,6 @@ class DeviceShieldWeeklyNotificationFactoryTest {
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private lateinit var db: VpnDatabase
-    private lateinit var vpnTrackerDao: VpnTrackerDao
     private lateinit var appTrackerBlockingStatsRepository: AppTrackerBlockingStatsRepository
 
     private lateinit var factory: DeviceShieldNotificationFactory
@@ -56,7 +55,6 @@ class DeviceShieldWeeklyNotificationFactoryTest {
         db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, VpnDatabase::class.java)
             .allowMainThreadQueries()
             .build()
-        vpnTrackerDao = db.vpnTrackerDao()
         appTrackerBlockingStatsRepository = RealAppTrackerBlockingStatsRepository(db, coroutineTestRule.testDispatcherProvider)
 
         factory =
@@ -188,7 +186,18 @@ class DeviceShieldWeeklyNotificationFactoryTest {
             companyDisplayName = company,
             trackingApp = appContainingTracker,
         )
-        vpnTrackerDao.insert(tracker)
+        val trackers = listOf(tracker)
+        appTrackerBlockingStatsRepository.insert(trackers)
+        db.vpnAppTrackerBlockingDao().insertTrackerEntities(trackers.map { it.asEntity() })
+    }
+
+    private fun VpnTracker.asEntity(): AppTrackerEntity {
+        return AppTrackerEntity(
+            trackerCompanyId = this.trackerCompanyId,
+            entityName = "name",
+            score = 0,
+            signals = emptyList(),
+        )
     }
 
     private fun defaultApp() = TrackingApp("app.foo.com", "Foo App")

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModelTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModelTest.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.app.global.formatters.time.TimeDiffFormatter
 import com.duckduckgo.mobile.android.vpn.apps.TrackingProtectionAppsRepository
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
-import com.duckduckgo.mobile.android.vpn.model.VpnTrackerCompanySignal
+import com.duckduckgo.mobile.android.vpn.model.VpnTrackerWithEntity
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerEntity
@@ -78,20 +78,20 @@ class AppTPCompanyTrackersViewModelTest {
         viewModel.loadData(date, packageName)
     }
 
-    private fun getTrackersFlow(trackers: List<VpnTrackerCompanySignal>): Flow<List<VpnTrackerCompanySignal>> = flow {
+    private fun getTrackersFlow(trackers: List<VpnTrackerWithEntity>): Flow<List<VpnTrackerWithEntity>> = flow {
         while (true) {
             emit(trackers)
         }
     }
 
-    private fun someTrackers(): List<VpnTrackerCompanySignal> {
+    private fun someTrackers(): List<VpnTrackerWithEntity> {
         val defaultTrackingApp = TrackingApp("app.foo.com", "Foo App")
         val domain = "example.com"
         val trackerCompanyId: Int = -1
         val timestamp: String = DatabaseDateFormatter.bucketByHour()
 
         return listOf(
-            VpnTrackerCompanySignal(
+            VpnTrackerWithEntity(
                 VpnTracker(
                     trackerCompanyId = trackerCompanyId,
                     domain = domain,

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugActivity.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugActivity.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerExceptionRule
 import com.duckduckgo.vpn.internal.databinding.ActivityExceptionRulesDebugBinding
@@ -43,6 +44,9 @@ import logcat.logcat
 
 @InjectWith(ActivityScope::class)
 class ExceptionRulesDebugActivity : DuckDuckGoActivity(), RuleTrackerView.RuleTrackerListener {
+
+    @Inject
+    lateinit var appTrackerBlockingRepository: AppTrackerBlockingStatsRepository
 
     @Inject
     lateinit var vpnDatabase: VpnDatabase
@@ -113,7 +117,7 @@ class ExceptionRulesDebugActivity : DuckDuckGoActivity(), RuleTrackerView.RuleTr
             .asSequence()
             .map { InstalledApp(it.packageName, packageManager.getApplicationLabel(it).toString()) }
             .map {
-                val blockedTrackers = vpnDatabase.vpnTrackerDao().getTrackersForApp(it.packageName)
+                val blockedTrackers = appTrackerBlockingRepository.getTrackersForApp(it.packageName)
                     .map { tracker -> tracker.domain }
                     .toSortedSet() // dedup
                 InstalledAppTrackers(it.packageName, it.name, blockedTrackers)

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/trackers/DeleteTrackersDebugReceiver.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/trackers/DeleteTrackersDebugReceiver.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
-import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
+import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.vpn.internal.feature.InternalFeatureReceiver
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
@@ -53,7 +53,7 @@ class DeleteTrackersDebugReceiver(
 @ContributesMultibinding(VpnScope::class)
 class DeleteTrackersDebugReceiverRegister @Inject constructor(
     private val context: Context,
-    private val vpnDatabase: VpnDatabase,
+    private val appTrackerBlockingRepository: AppTrackerBlockingStatsRepository,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : VpnServiceCallbacks {
     private val className: String
@@ -68,7 +68,7 @@ class DeleteTrackersDebugReceiverRegister @Inject constructor(
 
         receiver = DeleteTrackersDebugReceiver(context) {
             appCoroutineScope.launch {
-                vpnDatabase.vpnTrackerDao().deleteAllTrackers()
+                appTrackerBlockingRepository.deleteAllTrackers()
             }
         }.apply { register() }
     }

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnTrackerDao.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnTrackerDao.kt
@@ -17,13 +17,12 @@
 package com.duckduckgo.mobile.android.vpn.dao
 
 import androidx.room.*
-import com.duckduckgo.mobile.android.vpn.model.BucketizedVpnTracker
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
 import com.duckduckgo.mobile.android.vpn.model.VpnTrackerCompanySignal
 import kotlinx.coroutines.flow.Flow
 
 @Dao
-interface VpnTrackerDao {
+internal interface VpnTrackerDao {
 
     @Transaction
     fun insert(tracker: VpnTracker) {
@@ -50,7 +49,7 @@ interface VpnTrackerDao {
     fun deleteAllTrackers()
 
     @Query("SELECT * FROM vpn_tracker ORDER BY timestamp DESC LIMIT 1")
-    fun getLatestTracker(): Flow<VpnTracker?>
+    fun getLatestTracker(): Flow<VpnTrackerCompanySignal?>
 
     @Query(
         "SELECT * FROM vpn_tracker " +
@@ -59,7 +58,7 @@ interface VpnTrackerDao {
     fun getTrackersBetween(
         startTime: String,
         endTime: String,
-    ): Flow<List<VpnTracker>>
+    ): Flow<List<VpnTrackerCompanySignal>>
 
     @Query(
         "SELECT * FROM vpn_tracker " +
@@ -68,18 +67,32 @@ interface VpnTrackerDao {
     fun getTrackersBetweenSync(
         startTime: String,
         endTime: String,
-    ): List<VpnTracker>
+    ): List<VpnTrackerCompanySignal>
 
     @Query("DELETE FROM vpn_tracker WHERE timestamp < :startTime")
     fun deleteOldDataUntil(startTime: String)
 
-    @Query("SELECT COALESCE(sum(count), 0) FROM vpn_tracker WHERE timestamp >= :startTime AND timestamp < :endTime")
+    @Query(
+        """
+            SELECT COALESCE(sum(count), 0) 
+            FROM vpn_tracker 
+            JOIN vpn_app_tracker_entities ON vpn_tracker.trackerCompanyId = vpn_app_tracker_entities.trackerCompanyId 
+            WHERE timestamp >= :startTime AND timestamp < :endTime
+        """,
+    )
     fun getTrackersCountBetween(
         startTime: String,
         endTime: String,
     ): Flow<Int>
 
-    @Query("SELECT COUNT(DISTINCT packageId) FROM vpn_tracker WHERE timestamp >= :startTime AND timestamp < :endTime")
+    @Query(
+        """
+            SELECT COUNT(DISTINCT packageId) 
+            FROM vpn_tracker 
+            JOIN vpn_app_tracker_entities ON vpn_tracker.trackerCompanyId = vpn_app_tracker_entities.trackerCompanyId 
+            WHERE timestamp >= :startTime AND timestamp < :endTime
+        """,
+    )
     fun getTrackingAppsCountBetween(
         startTime: String,
         endTime: String,
@@ -89,7 +102,7 @@ interface VpnTrackerDao {
         "SELECT * FROM vpn_tracker " +
             "WHERE timestamp >= :startTime order by timestamp DESC limit $MAX_NUMBER_OF_TRACKERS_IN_QUERY_RESULTS",
     )
-    fun getPagedTrackersSince(startTime: String): Flow<List<BucketizedVpnTracker>>
+    fun getPagedTrackersSince(startTime: String): Flow<List<VpnTrackerCompanySignal>>
 
     @Transaction
     @Query(
@@ -104,7 +117,7 @@ interface VpnTrackerDao {
     ): Flow<List<VpnTrackerCompanySignal>>
 
     @Query("SELECT * from vpn_tracker WHERE packageId = :appPackage")
-    fun getTrackersForApp(appPackage: String): List<VpnTracker>
+    fun getTrackersForApp(appPackage: String): List<VpnTrackerCompanySignal>
 
     @Query("select count(1) > 0 from vpn_tracker LIMIT 1")
     fun tableIsNotEmpty(): Boolean

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/VpnDatabaseModels.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/model/VpnDatabaseModels.kt
@@ -39,10 +39,6 @@ data class VpnTracker(
     val count: Int = 1,
 )
 
-data class BucketizedVpnTracker(
-    @Embedded val trackerCompanySignal: VpnTrackerCompanySignal,
-)
-
 enum class VpnServiceState {
     ENABLING,
     ENABLED,
@@ -81,11 +77,24 @@ data class TrackingApp(
     override fun toString(): String = "package=$packageId ($appDisplayName)"
 }
 
-data class VpnTrackerCompanySignal(
+internal data class VpnTrackerCompanySignal(
     @Embedded val tracker: VpnTracker,
     @Relation(
         parentColumn = "trackerCompanyId",
         entityColumn = "trackerCompanyId",
     )
+    val trackerEntity: AppTrackerEntity?,
+)
+
+internal fun List<VpnTrackerCompanySignal>.asListOfVpnTrackerWithEntity(): List<VpnTrackerWithEntity> {
+    return this.filter { it.trackerEntity != null }.map { VpnTrackerWithEntity(it.tracker, it.trackerEntity!!) }
+}
+
+internal fun List<VpnTrackerCompanySignal>.asListOfVpnTracker(): List<VpnTracker> {
+    return this.filter { it.trackerEntity != null }.map { it.tracker }
+}
+
+data class VpnTrackerWithEntity(
+    val tracker: VpnTracker,
     val trackerEntity: AppTrackerEntity,
 )

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabase.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabase.kt
@@ -54,7 +54,7 @@ import org.threeten.bp.format.DateTimeFormatter
 @TypeConverters(VpnTypeConverters::class)
 abstract class VpnDatabase : RoomDatabase() {
 
-    abstract fun vpnTrackerDao(): VpnTrackerDao
+    internal abstract fun vpnTrackerDao(): VpnTrackerDao
     abstract fun vpnHeartBeatDao(): VpnHeartBeatDao
     abstract fun vpnNotificationsDao(): VpnNotificationsDao
     abstract fun vpnAppTrackerBlockingDao(): VpnAppTrackerBlockingDao

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepositoryTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepositoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2023 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204479514332481/f

### Description
See the [asana task](https://app.asana.com/0/488551667048375/1204479514332481/f) for more context but in a nutshel:
* This PR adds support for changes in tracker entities
* It moves the `AppTrackerBlockingStatsRepository` repository to the `store` module and makes the vpn tracker DAO private so that all consumers have to go through the repository
  * This way we sealed the UI from any meaningful change

### Steps to test this PR

_Test entity changes_
- [x] install from this branch
- [x] launch app and enable AppTP
- [x] launch some apps that contain trackers (speed test for instance)
- [x] In the `vpn_app_tracker_entities` db table, modify the `trackerCompanyId` for one of the blocked trackers to be eg. `-1`
- [x] go to AppTP activity screen
- [x] verify the associated trackers no longer appear in any of the counts/UI that show trackers blocked
- [x] In the `vpn_app_tracker_blocking_list_metadata` db table, change the eTag to be eg. `1`
- [x] Go to in-app settings -> AppTP dev settings and force update the blocklist
- [x] Go to AppTP activity screen
- [x] verify previously gone trackers now appear as normal

