### PR TITLE
Monitor webview pixels when renderer crashes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -401,6 +401,6 @@ class BrowserWebViewClient @Inject constructor(
 }
 
 enum class WebViewPixelName(override val pixelName: String) : Pixel.PixelName {
-    WEB_RENDERER_GONE_CRASH("m_d_wrg_c"),
-    WEB_RENDERER_GONE_KILLED("m_d_wrg_k"),
+    WEB_RENDERER_GONE_CRASH("m_web_view_renderer_gone_crash"),
+    WEB_RENDERER_GONE_KILLED("m_web_view_renderer_gone_killed"),
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204513195956995/f 

### Description
Monitor if the webview renderer is killed or gone. 

### Steps to test this PR

_Feature 1_
- [x] Apply patch attached in Asana task
- [x] Visit a website
- [x] it should trigger the pixel

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
