### PR TITLE
Update content scope scripts to latest version

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -548,8 +548,6 @@
             allowlisted,
             enabledFeatures
         });
-        // TODO
-        output.cookie = {};
 
         // Copy feature settings from remote config to preferences object
         output.featureSettings = parseFeatureSettings(data, enabledFeatures);
@@ -1755,7 +1753,9 @@
 
             // Delay removal of the custom element so if the script calls removeChild it will still be in the DOM and not throw.
             setTimeout(() => {
-                this.remove();
+                try {
+                    super.remove();
+                } catch {}
             }, elementRemovalTimeout);
         }
 
@@ -1877,7 +1877,12 @@
         }
 
         remove () {
-            return this._callMethod('remove')
+            let returnVal;
+            try {
+                returnVal = this._callMethod('remove');
+                super.remove();
+            } catch {}
+            return returnVal
         }
 
         // @ts-expect-error TS node return here

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.1.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.13.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.16.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1682070153"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9a07d092c4d8dcad08d61aecb66607a0abc83654",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0340bae380ad480f420cce2b666da5e37f6b83d6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -272,9 +272,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
-      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==",
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
       "dev": true
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.1.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#6.4.3",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.13.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.16.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1682070153"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass