### PR TITLE
Add cookie feature to content scope scripts

### DIFF
--- a/cookies/cookies-impl/build.gradle
+++ b/cookies/cookies-impl/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation project(':cookies-store')
     implementation project(':browser-api')
     implementation project(':statistics')
+    implementation project(':content-scope-scripts-api')
 
     implementation Kotlin.stdlib.jdk7
     implementation JakeWharton.timber

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/CookiesContentScopeConfigPlugin.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/CookiesContentScopeConfigPlugin.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.cookies.impl
+
+import com.duckduckgo.contentscopescripts.api.ContentScopeConfigPlugin
+import com.duckduckgo.cookies.api.CookiesFeatureName
+import com.duckduckgo.cookies.store.contentscopescripts.ContentScopeScriptsCookieRepository
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class CookiesContentScopeConfigPlugin @Inject constructor(
+    private val cookiesRepository: ContentScopeScriptsCookieRepository,
+) : ContentScopeConfigPlugin {
+
+    override fun config(): String {
+        val featureName = CookiesFeatureName.Cookie.value
+        val config = cookiesRepository.getCookieEntity().json
+        return "\"$featureName\":$config"
+    }
+
+    override fun preferences(): String? {
+        return null
+    }
+}

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/di/CookiesModule.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/di/CookiesModule.kt
@@ -28,6 +28,8 @@ import com.duckduckgo.cookies.store.CookiesRepository
 import com.duckduckgo.cookies.store.RealCookieRepository
 import com.duckduckgo.cookies.store.RealCookiesFeatureToggleRepository
 import com.duckduckgo.cookies.store.RealCookiesFeatureToggleStore
+import com.duckduckgo.cookies.store.contentscopescripts.ContentScopeScriptsCookieRepository
+import com.duckduckgo.cookies.store.contentscopescripts.RealContentScopeScriptsCookieRepository
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -68,5 +70,15 @@ object CookiesModule {
     @Provides
     fun provideCookiesFeatureToggleStore(context: Context): CookiesFeatureToggleStore {
         return RealCookiesFeatureToggleStore(context)
+    }
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideContentScopeScriptsCookieRepository(
+        database: CookiesDatabase,
+        @AppCoroutineScope coroutineScope: CoroutineScope,
+        dispatcherProvider: DispatcherProvider,
+    ): ContentScopeScriptsCookieRepository {
+        return RealContentScopeScriptsCookieRepository(database, coroutineScope, dispatcherProvider)
     }
 }

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeaturePlugin.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeaturePlugin.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.cookies.impl.features
 
 import com.duckduckgo.cookies.api.CookiesFeatureName
 import com.duckduckgo.cookies.impl.cookiesFeatureValueOf
+import com.duckduckgo.cookies.store.CookieEntity
 import com.duckduckgo.cookies.store.CookieExceptionEntity
 import com.duckduckgo.cookies.store.CookiesFeatureToggleRepository
 import com.duckduckgo.cookies.store.CookiesFeatureToggles
@@ -25,6 +26,7 @@ import com.duckduckgo.cookies.store.CookiesRepository
 import com.duckduckgo.cookies.store.FirstPartyCookiePolicyEntity
 import com.duckduckgo.cookies.store.RealCookieRepository.Companion.DEFAULT_MAX_AGE
 import com.duckduckgo.cookies.store.RealCookieRepository.Companion.DEFAULT_THRESHOLD
+import com.duckduckgo.cookies.store.contentscopescripts.ContentScopeScriptsCookieRepository
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -35,6 +37,7 @@ import javax.inject.Inject
 @ContributesMultibinding(AppScope::class)
 class CookiesFeaturePlugin @Inject constructor(
     private val cookiesRepository: CookiesRepository,
+    private val contentScopeScriptsCookieRepository: ContentScopeScriptsCookieRepository,
     private val cookiesFeatureToggleRepository: CookiesFeatureToggleRepository,
 ) : PrivacyFeaturePlugin {
 
@@ -60,6 +63,8 @@ class CookiesFeaturePlugin @Inject constructor(
             cookiesFeatureToggleRepository.insert(
                 CookiesFeatureToggles(cookiesFeatureName, isEnabled, cookiesFeature?.minSupportedVersion),
             )
+            val entity = CookieEntity(json = jsonString)
+            contentScopeScriptsCookieRepository.updateAll(cookieEntity = entity)
             return true
         }
         return false

--- a/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/CookiesContentScopeConfigPluginTest.kt
+++ b/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/CookiesContentScopeConfigPluginTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.cookies.impl
+
+import com.duckduckgo.cookies.store.CookieEntity
+import com.duckduckgo.cookies.store.contentscopescripts.ContentScopeScriptsCookieRepository
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class CookiesContentScopeConfigPluginTest {
+
+    lateinit var testee: CookiesContentScopeConfigPlugin
+
+    private val mockContentScopeScriptsCookieRepository: ContentScopeScriptsCookieRepository = mock()
+
+    @Before
+    fun before() {
+        testee = CookiesContentScopeConfigPlugin(mockContentScopeScriptsCookieRepository)
+    }
+
+    @Test
+    fun whenGetConfigThenReturnCorrectlyFormattedJson() {
+        whenever(mockContentScopeScriptsCookieRepository.getCookieEntity()).thenReturn(CookieEntity(json = config))
+        assertEquals("\"cookie\":$config", testee.config())
+    }
+
+    @Test
+    fun whenGetPreferencesThenReturnNull() {
+        assertNull(testee.preferences())
+    }
+
+    companion object {
+        const val config = "{\"key\":\"value\"}"
+    }
+}

--- a/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/features/CookiesFeaturePluginTest.kt
+++ b/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/features/CookiesFeaturePluginTest.kt
@@ -18,11 +18,13 @@ package com.duckduckgo.cookies.impl.features
 
 import com.duckduckgo.app.FileUtilities
 import com.duckduckgo.cookies.api.CookiesFeatureName
+import com.duckduckgo.cookies.store.CookieEntity
 import com.duckduckgo.cookies.store.CookieExceptionEntity
 import com.duckduckgo.cookies.store.CookiesFeatureToggleRepository
 import com.duckduckgo.cookies.store.CookiesFeatureToggles
 import com.duckduckgo.cookies.store.CookiesRepository
 import com.duckduckgo.cookies.store.FirstPartyCookiePolicyEntity
+import com.duckduckgo.cookies.store.contentscopescripts.ContentScopeScriptsCookieRepository
 import junit.framework.TestCase
 import org.junit.Assert.*
 import org.junit.Before
@@ -36,10 +38,11 @@ class CookiesFeaturePluginTest {
 
     private val mockFeatureTogglesRepository: CookiesFeatureToggleRepository = mock()
     private val mockCookiesRepository: CookiesRepository = mock()
+    private val mockContentScopeCookieRepository: ContentScopeScriptsCookieRepository = mock()
 
     @Before
     fun before() {
-        testee = CookiesFeaturePlugin(mockCookiesRepository, mockFeatureTogglesRepository)
+        testee = CookiesFeaturePlugin(mockCookiesRepository, mockContentScopeCookieRepository, mockFeatureTogglesRepository)
     }
 
     @Test
@@ -108,6 +111,16 @@ class CookiesFeaturePluginTest {
 
         assertEquals(1, cookiePolicyEntity.threshold)
         assertEquals(2, cookiePolicyEntity.maxAge)
+
+        val cookieCaptor = argumentCaptor<CookieEntity>()
+
+        verify(mockContentScopeCookieRepository).updateAll(
+            cookieCaptor.capture(),
+        )
+
+        val cookieEntity = cookieCaptor.firstValue
+
+        assertEquals(jsonString, cookieEntity.json)
     }
 
     companion object {

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesDatabase.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesDatabase.kt
@@ -19,17 +19,20 @@ package com.duckduckgo.cookies.store
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
+import com.duckduckgo.cookies.store.contentscopescripts.ContentScopeScriptsCookieDao
 
 @Database(
     exportSchema = true,
-    version = 1,
+    version = 2,
     entities = [
         FirstPartyCookiePolicyEntity::class,
         CookieExceptionEntity::class,
+        CookieEntity::class,
     ],
 )
 abstract class CookiesDatabase : RoomDatabase() {
     abstract fun cookiesDao(): CookiesDao
+    abstract fun contentScopeScriptsCookieDao(): ContentScopeScriptsCookieDao
 }
 
 val ALL_MIGRATIONS = emptyArray<Migration>()

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesDatabaseModels.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesDatabaseModels.kt
@@ -33,6 +33,12 @@ data class CookieExceptionEntity(
     val reason: String,
 )
 
+@Entity(tableName = "cookie")
+data class CookieEntity(
+    @PrimaryKey val id: Int = 1,
+    val json: String,
+)
+
 fun CookieExceptionEntity.toCookieException(): CookieException {
     return CookieException(domain = this.domain, reason = this.reason)
 }

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/contentscopescripts/ContentScopeScriptsCookieDao.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/contentscopescripts/ContentScopeScriptsCookieDao.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.cookies.store.contentscopescripts
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.cookies.store.CookieEntity
+
+@Dao
+interface ContentScopeScriptsCookieDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(cookieEntity: CookieEntity)
+
+    @Transaction
+    fun updateAll(
+        cookieEntity: CookieEntity,
+    ) {
+        delete()
+        insert(cookieEntity)
+    }
+
+    @Query("select * from cookie")
+    fun get(): CookieEntity?
+
+    @Query("delete from cookie")
+    fun delete()
+}

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/contentscopescripts/ContentScopeScriptsCookieRepository.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/contentscopescripts/ContentScopeScriptsCookieRepository.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.cookies.store.contentscopescripts
+
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.cookies.store.CookieEntity
+import com.duckduckgo.cookies.store.CookiesDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+interface ContentScopeScriptsCookieRepository {
+    fun updateAll(
+        cookieEntity: CookieEntity,
+    )
+    fun getCookieEntity(): CookieEntity
+}
+
+class RealContentScopeScriptsCookieRepository constructor(
+    private val database: CookiesDatabase,
+    coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : ContentScopeScriptsCookieRepository {
+
+    private val contentScopeScriptsCookieDao: ContentScopeScriptsCookieDao = database.contentScopeScriptsCookieDao()
+    private var cookieEntity = CookieEntity(json = EMPTY_JSON)
+
+    init {
+        coroutineScope.launch(dispatcherProvider.io()) {
+            loadToMemory()
+        }
+    }
+
+    override fun updateAll(cookieEntity: CookieEntity) {
+        contentScopeScriptsCookieDao.updateAll(cookieEntity)
+        loadToMemory()
+    }
+
+    override fun getCookieEntity(): CookieEntity {
+        return cookieEntity
+    }
+
+    private fun loadToMemory() {
+        cookieEntity =
+            contentScopeScriptsCookieDao.get() ?: CookieEntity(json = EMPTY_JSON)
+    }
+
+    companion object {
+        const val EMPTY_JSON = "{}"
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/0/1204498721431853/f

### Description
Implements Android cookie parsing for 'cookie' for ContentScopeScripts to consume.

### Steps to test this PR

- [x] Navigate to: https://good.third-party.site/privacy-protections/storage-blocking/
- [x] Click store data
- [x] Click retrieve data
- [x] Verify that JS cookie (3rd party tracking script) - "x" (expires in 1.00 days)
- [x] Verify that JS cookie (3rd party safe script) - "x" (expires in 7.00 days)

(x is a random value)
