### PR TITLE
Use plugins to map remote message actions

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/AppTPRemoteMessageNavigationAction.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/AppTPRemoteMessageNavigationAction.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Action.AppNavigation
 import com.duckduckgo.remote.messaging.api.JsonActionType.APP_NAVIGATION
+import com.duckduckgo.remote.messaging.api.JsonActionType.APP_TP_ONBOARDING
 import com.duckduckgo.remote.messaging.api.JsonMessageAction
 import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -38,7 +39,11 @@ class AppTPRemoteMessageNavigationAction @Inject constructor(
 ) : MessageActionMapperPlugin {
 
     override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
-        return if (jsonMessageAction.type == APP_NAVIGATION.jsonValue && jsonMessageAction.value == "AppTP") {
+        val isAppTPOnboarding = jsonMessageAction.type == APP_TP_ONBOARDING.jsonValue
+        val isNavigateToAppTP = jsonMessageAction.type == APP_NAVIGATION.jsonValue && jsonMessageAction.value == "AppTP"
+        return if (isAppTPOnboarding) {
+            Action.AppTpOnboarding
+        } else if (isNavigateToAppTP) {
             val intent = globalActivityStarter.startIntent(context, AppTrackerOnboardingActivityWithEmptyParamsParams) ?: return null
             AppNavigation(intent, jsonMessageAction.value)
         } else {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/AppTPRemoteMessageNavigationAction.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/AppTPRemoteMessageNavigationAction.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.ui.onboarding
+
+import android.content.Context
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackerOnboardingActivityWithEmptyParamsParams
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.remote.messaging.api.Action
+import com.duckduckgo.remote.messaging.api.Action.AppNavigation
+import com.duckduckgo.remote.messaging.api.JsonActionType.APP_NAVIGATION
+import com.duckduckgo.remote.messaging.api.JsonMessageAction
+import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.*
+
+@ContributesMultibinding(
+    AppScope::class,
+    boundType = MessageActionMapperPlugin::class,
+)
+class AppTPRemoteMessageNavigationAction @Inject constructor(
+    private val context: Context,
+    private val globalActivityStarter: GlobalActivityStarter,
+) : MessageActionMapperPlugin {
+
+    override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
+        return if (jsonMessageAction.type == APP_NAVIGATION.jsonValue && jsonMessageAction.value == "AppTP") {
+            val intent = globalActivityStarter.startIntent(context, AppTrackerOnboardingActivityWithEmptyParamsParams) ?: return null
+            AppNavigation(intent, jsonMessageAction.value)
+        } else {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -203,6 +203,7 @@ import com.duckduckgo.mobile.android.ui.view.dialog.CustomAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.view.dialog.DaxAlertDialog
 import com.duckduckgo.mobile.android.ui.view.dialog.StackedAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnOnboardingActivity
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.remote.messaging.api.RemoteMessage
@@ -2510,10 +2511,6 @@ class BrowserTabFragment :
         if (appBuildConfig.sdkInt >= Build.VERSION_CODES.N) {
             requireActivity().launchDefaultAppActivity()
         }
-    }
-
-    private fun launchAppTPOnboardingScreen() {
-        globalActivityStarter.start(requireContext(), AppTrackerOnboardingActivityWithEmptyParamsParams)
     }
 
     private fun launchSurvey(survey: Survey) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1049,6 +1049,7 @@ class BrowserTabFragment :
             is Command.SubmitUrl -> submitQuery(it.url)
             is Command.LaunchAddWidget -> addWidgetLauncher.launchAddWidget(activity)
             is Command.LaunchDefaultBrowser -> launchDefaultBrowser()
+            is Command.LaunchAppTPOnboarding -> launchAppTPOnboardingScreen()
             is Command.NavigateToScreen -> navigateToScreen(it.intent)
             is Command.RequiresAuthentication -> showAuthenticationDialog(it.request)
             is Command.SaveCredentials -> saveBasicAuthCredentials(it.request, it.credentials)
@@ -2511,6 +2512,10 @@ class BrowserTabFragment :
         if (appBuildConfig.sdkInt >= Build.VERSION_CODES.N) {
             requireActivity().launchDefaultAppActivity()
         }
+    }
+
+    private fun launchAppTPOnboardingScreen() {
+        globalActivityStarter.start(requireContext(), AppTrackerOnboardingActivityWithEmptyParamsParams)
     }
 
     private fun navigateToScreen(intent: Intent) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -203,7 +203,6 @@ import com.duckduckgo.mobile.android.ui.view.dialog.CustomAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.view.dialog.DaxAlertDialog
 import com.duckduckgo.mobile.android.ui.view.dialog.StackedAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder
-import com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnOnboardingActivity
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.remote.messaging.api.RemoteMessage

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1049,7 +1049,7 @@ class BrowserTabFragment :
             is Command.SubmitUrl -> submitQuery(it.url)
             is Command.LaunchAddWidget -> addWidgetLauncher.launchAddWidget(activity)
             is Command.LaunchDefaultBrowser -> launchDefaultBrowser()
-            is Command.LaunchAppTPOnboarding -> launchAppTPOnboardingScreen()
+            is Command.NavigateToScreen -> navigateToScreen(it.intent)
             is Command.RequiresAuthentication -> showAuthenticationDialog(it.request)
             is Command.SaveCredentials -> saveBasicAuthCredentials(it.request, it.credentials)
             is Command.GenerateWebViewPreviewImage -> generateWebViewPreviewImage()
@@ -2511,6 +2511,10 @@ class BrowserTabFragment :
         if (appBuildConfig.sdkInt >= Build.VERSION_CODES.N) {
             requireActivity().launchDefaultAppActivity()
         }
+    }
+
+    private fun navigateToScreen(intent: Intent) {
+        startActivity(intent)
     }
 
     private fun launchSurvey(survey: Survey) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -379,6 +379,7 @@ class BrowserTabViewModel @Inject constructor(
         class LaunchPlayStore(val appPackage: String) : Command()
         class LaunchSurvey(val survey: Survey) : Command()
         object LaunchDefaultBrowser : Command()
+        object LaunchAppTPOnboarding : Command()
         class NavigateToScreen(val intent: Intent) : Command()
         object LaunchAddWidget : Command()
         class RequiresAuthentication(val request: BasicAuthenticationRequest) : Command()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
 import android.net.http.SslCertificate
@@ -378,7 +379,7 @@ class BrowserTabViewModel @Inject constructor(
         class LaunchPlayStore(val appPackage: String) : Command()
         class LaunchSurvey(val survey: Survey) : Command()
         object LaunchDefaultBrowser : Command()
-        object LaunchAppTPOnboarding : Command()
+        class NavigateToScreen(val intent: Intent) : Command()
         object LaunchAddWidget : Command()
         class RequiresAuthentication(val request: BasicAuthenticationRequest) : Command()
         class SaveCredentials(

--- a/app/src/main/java/com/duckduckgo/app/browser/remotemessage/CommandActionMapper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/remotemessage/CommandActionMapper.kt
@@ -29,6 +29,6 @@ fun Action.asBrowserTabCommand(): Command? {
         is PlayStore -> LaunchPlayStore(this.value)
         is Url -> SubmitUrl(this.value)
         is DefaultBrowser -> LaunchDefaultBrowser
-        is AppTpOnboarding -> LaunchAppTPOnboarding
+        is AppNavigation -> NavigateToScreen(this.intent)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/remotemessage/CommandActionMapper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/remotemessage/CommandActionMapper.kt
@@ -30,5 +30,6 @@ fun Action.asBrowserTabCommand(): Command? {
         is Url -> SubmitUrl(this.value)
         is DefaultBrowser -> LaunchDefaultBrowser
         is AppNavigation -> NavigateToScreen(this.intent)
+        is AppTpOnboarding -> LaunchAppTPOnboarding
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -51,6 +51,8 @@ import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnState
 import com.duckduckgo.networkprotection.impl.NetPVpnFeature
 import com.duckduckgo.networkprotection.impl.waitlist.NetPWaitlistState
 import com.duckduckgo.networkprotection.impl.waitlist.store.NetPWaitlistRepository
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.sync.api.DeviceSyncState

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -51,8 +51,6 @@ import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnState
 import com.duckduckgo.networkprotection.impl.NetPVpnFeature
 import com.duckduckgo.networkprotection.impl.waitlist.NetPWaitlistState
 import com.duckduckgo.networkprotection.impl.waitlist.store.NetPWaitlistRepository
-import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
-import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.sync.api.DeviceSyncState

--- a/remote-messaging/remote-messaging-api/build.gradle
+++ b/remote-messaging/remote-messaging-api/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 DuckDuckGo
+ * Copyright (c) 2022 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,17 @@
  */
 
 plugins {
-    id 'java-library'
-    id 'kotlin'
+    id 'com.android.library'
+    id 'kotlin-android'
 }
 
-apply from: "$rootProject.projectDir/code-formatting.gradle"
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation Kotlin.stdlib.jdk7
     implementation KotlinX.coroutines.core
+}
+
+android {
+    namespace 'com.duckduckgo.remote.messaging.api'
 }

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/MessageActionMapperPlugin.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/MessageActionMapperPlugin.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.api
+
+interface MessageActionMapperPlugin {
+    fun evaluate(jsonMessageAction: JsonMessageAction): Action?
+}
+
+data class JsonMessageAction(
+    val type: String,
+    val value: String,
+)
+
+sealed class JsonActionType(val jsonValue: String) {
+    object URL : JsonActionType("url")
+    object PLAYSTORE : JsonActionType("playstore")
+    object DEFAULT_BROWSER : JsonActionType("defaultBrowser")
+    object DISMISS : JsonActionType("dismiss")
+    object APP_TP_ONBOARDING : JsonActionType("atpOnboarding")
+}

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/MessageActionMapperPlugin.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/MessageActionMapperPlugin.kt
@@ -30,5 +30,5 @@ sealed class JsonActionType(val jsonValue: String) {
     object PLAYSTORE : JsonActionType("playstore")
     object DEFAULT_BROWSER : JsonActionType("defaultBrowser")
     object DISMISS : JsonActionType("dismiss")
-    object APP_TP_ONBOARDING : JsonActionType("atpOnboarding")
+    object APP_NAVIGATION : JsonActionType("appNavigation")
 }

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
@@ -20,6 +20,7 @@ package com.duckduckgo.remote.messaging.api
 
 import android.content.Intent
 import com.duckduckgo.remote.messaging.api.Action.ActionType.APP_NAVIGATION
+import com.duckduckgo.remote.messaging.api.Action.ActionType.APP_TP_ONBOARDING
 import com.duckduckgo.remote.messaging.api.Action.ActionType.DEFAULT_BROWSER
 import com.duckduckgo.remote.messaging.api.Action.ActionType.DISMISS
 import com.duckduckgo.remote.messaging.api.Action.ActionType.PLAYSTORE
@@ -87,6 +88,7 @@ sealed class Action(val actionType: ActionType) {
     data class DefaultBrowser(val value: String = "") : Action(DEFAULT_BROWSER)
     data class Dismiss(val value: String = "") : Action(DISMISS)
     data class AppNavigation(val intent: Intent) : Action(APP_NAVIGATION)
+    data class AppTpOnboarding(val value: String = "") : Action(APP_TP_ONBOARDING)
 
     enum class ActionType {
         URL,
@@ -94,5 +96,6 @@ sealed class Action(val actionType: ActionType) {
         DEFAULT_BROWSER,
         DISMISS,
         APP_NAVIGATION,
+        APP_TP_ONBOARDING,
     }
 }

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
@@ -18,7 +18,8 @@
 
 package com.duckduckgo.remote.messaging.api
 
-import com.duckduckgo.remote.messaging.api.Action.ActionType.APP_TP_ONBOARDING
+import android.content.Intent
+import com.duckduckgo.remote.messaging.api.Action.ActionType.APP_NAVIGATION
 import com.duckduckgo.remote.messaging.api.Action.ActionType.DEFAULT_BROWSER
 import com.duckduckgo.remote.messaging.api.Action.ActionType.DISMISS
 import com.duckduckgo.remote.messaging.api.Action.ActionType.PLAYSTORE
@@ -85,13 +86,13 @@ sealed class Action(val actionType: ActionType) {
     // Using data class instead of Object. Object can't be serialized
     data class DefaultBrowser(val value: String = "") : Action(DEFAULT_BROWSER)
     data class Dismiss(val value: String = "") : Action(DISMISS)
-    data class AppTpOnboarding(val value: String = "") : Action(APP_TP_ONBOARDING)
+    data class AppNavigation(val intent: Intent) : Action(APP_NAVIGATION)
 
     enum class ActionType {
         URL,
         PLAYSTORE,
         DEFAULT_BROWSER,
         DISMISS,
-        APP_TP_ONBOARDING,
+        APP_NAVIGATION,
     }
 }

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
@@ -19,16 +19,16 @@
 package com.duckduckgo.remote.messaging.api
 
 import android.content.Intent
-import com.duckduckgo.remote.messaging.api.Action.ActionType.APP_NAVIGATION
-import com.duckduckgo.remote.messaging.api.Action.ActionType.APP_TP_ONBOARDING
-import com.duckduckgo.remote.messaging.api.Action.ActionType.DEFAULT_BROWSER
-import com.duckduckgo.remote.messaging.api.Action.ActionType.DISMISS
-import com.duckduckgo.remote.messaging.api.Action.ActionType.PLAYSTORE
-import com.duckduckgo.remote.messaging.api.Action.ActionType.URL
 import com.duckduckgo.remote.messaging.api.Content.MessageType.BIG_SINGLE_ACTION
 import com.duckduckgo.remote.messaging.api.Content.MessageType.BIG_TWO_ACTION
 import com.duckduckgo.remote.messaging.api.Content.MessageType.MEDIUM
 import com.duckduckgo.remote.messaging.api.Content.MessageType.SMALL
+import com.duckduckgo.remote.messaging.api.JsonActionType.APP_NAVIGATION
+import com.duckduckgo.remote.messaging.api.JsonActionType.APP_TP_ONBOARDING
+import com.duckduckgo.remote.messaging.api.JsonActionType.DEFAULT_BROWSER
+import com.duckduckgo.remote.messaging.api.JsonActionType.DISMISS
+import com.duckduckgo.remote.messaging.api.JsonActionType.PLAYSTORE
+import com.duckduckgo.remote.messaging.api.JsonActionType.URL
 
 data class RemoteMessage(
     val id: String,
@@ -80,22 +80,11 @@ sealed class Content(val messageType: MessageType) {
     }
 }
 
-sealed class Action(val actionType: ActionType) {
-    data class Url(val value: String) : Action(URL)
-    data class PlayStore(val value: String) : Action(PLAYSTORE)
-
-    // Using data class instead of Object. Object can't be serialized
-    data class DefaultBrowser(val value: String = "") : Action(DEFAULT_BROWSER)
-    data class Dismiss(val value: String = "") : Action(DISMISS)
-    data class AppNavigation(val intent: Intent) : Action(APP_NAVIGATION)
-    data class AppTpOnboarding(val value: String = "") : Action(APP_TP_ONBOARDING)
-
-    enum class ActionType {
-        URL,
-        PLAYSTORE,
-        DEFAULT_BROWSER,
-        DISMISS,
-        APP_NAVIGATION,
-        APP_TP_ONBOARDING,
-    }
+sealed class Action(val actionType: String, open val value: String) {
+    data class Url(override val value: String) : Action(URL.jsonValue, value)
+    data class PlayStore(override val value: String) : Action(PLAYSTORE.jsonValue, value)
+    object DefaultBrowser : Action(DEFAULT_BROWSER.jsonValue, "")
+    object Dismiss : Action(DISMISS.jsonValue, "")
+    data class AppNavigation(val intent: Intent, override val value: String) : Action(APP_NAVIGATION.jsonValue, value)
+    object AppTpOnboarding : Action(APP_TP_ONBOARDING.jsonValue, "")
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.remote.messaging.impl
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Action.ActionType
-import com.duckduckgo.remote.messaging.api.Action.AppTpOnboarding
+import com.duckduckgo.remote.messaging.api.Action.AppNavigation
 import com.duckduckgo.remote.messaging.api.Action.DefaultBrowser
 import com.duckduckgo.remote.messaging.api.Action.Dismiss
 import com.duckduckgo.remote.messaging.api.Action.PlayStore
@@ -122,7 +122,7 @@ class AppRemoteMessagingRepository(
                         .withSubtype(Url::class.java, ActionType.URL.name)
                         .withSubtype(Dismiss::class.java, ActionType.DISMISS.name)
                         .withSubtype(DefaultBrowser::class.java, ActionType.DEFAULT_BROWSER.name)
-                        .withSubtype(AppTpOnboarding::class.java, ActionType.APP_TP_ONBOARDING.name),
+                        .withSubtype(AppNavigation::class.java, ActionType.APP_NAVIGATION.name),
                 )
                 .add(KotlinJsonAdapterFactory())
                 .build()

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -17,30 +17,14 @@
 package com.duckduckgo.remote.messaging.impl
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.remote.messaging.api.Action
-import com.duckduckgo.remote.messaging.api.Action.ActionType
-import com.duckduckgo.remote.messaging.api.Action.AppNavigation
-import com.duckduckgo.remote.messaging.api.Action.DefaultBrowser
-import com.duckduckgo.remote.messaging.api.Action.Dismiss
-import com.duckduckgo.remote.messaging.api.Action.PlayStore
-import com.duckduckgo.remote.messaging.api.Action.Url
-import com.duckduckgo.remote.messaging.api.Content
-import com.duckduckgo.remote.messaging.api.Content.BigSingleAction
-import com.duckduckgo.remote.messaging.api.Content.BigTwoActions
-import com.duckduckgo.remote.messaging.api.Content.Medium
-import com.duckduckgo.remote.messaging.api.Content.MessageType
-import com.duckduckgo.remote.messaging.api.Content.Small
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessagingRepository
+import com.duckduckgo.remote.messaging.impl.mappers.MessageMapper
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity.Status
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity.Status.SCHEDULED
 import com.duckduckgo.remote.messaging.store.RemoteMessagesDao
 import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -50,9 +34,8 @@ class AppRemoteMessagingRepository(
     private val remoteMessagingConfigRepository: RemoteMessagingConfigRepository,
     private val remoteMessagesDao: RemoteMessagesDao,
     private val dispatchers: DispatcherProvider,
+    private val messageMapper: MessageMapper,
 ) : RemoteMessagingRepository {
-
-    private val messageMapper = MessageMapper()
 
     override fun activeMessage(message: RemoteMessage?) {
         if (message == null) {
@@ -93,40 +76,5 @@ class AppRemoteMessagingRepository(
 
     override fun dismissedMessages(): List<String> {
         return remoteMessagesDao.dismissedMessages().map { it.id }.toList()
-    }
-
-    private class MessageMapper {
-
-        fun toString(sitePayload: RemoteMessage): String {
-            return messageAdapter.toJson(sitePayload)
-        }
-
-        fun fromMessage(payload: String): RemoteMessage? {
-            return runCatching {
-                messageAdapter.fromJson(payload)
-            }.getOrNull()
-        }
-
-        companion object {
-            private val moshi = Moshi.Builder()
-                .add(
-                    PolymorphicJsonAdapterFactory.of(Content::class.java, "messageType")
-                        .withSubtype(Small::class.java, MessageType.SMALL.name)
-                        .withSubtype(Medium::class.java, MessageType.MEDIUM.name)
-                        .withSubtype(BigSingleAction::class.java, MessageType.BIG_SINGLE_ACTION.name)
-                        .withSubtype(BigTwoActions::class.java, MessageType.BIG_TWO_ACTION.name),
-                )
-                .add(
-                    PolymorphicJsonAdapterFactory.of(Action::class.java, "actionType")
-                        .withSubtype(PlayStore::class.java, ActionType.PLAYSTORE.name)
-                        .withSubtype(Url::class.java, ActionType.URL.name)
-                        .withSubtype(Dismiss::class.java, ActionType.DISMISS.name)
-                        .withSubtype(DefaultBrowser::class.java, ActionType.DEFAULT_BROWSER.name)
-                        .withSubtype(AppNavigation::class.java, ActionType.APP_NAVIGATION.name),
-                )
-                .add(KotlinJsonAdapterFactory())
-                .build()
-            val messageAdapter: JsonAdapter<RemoteMessage> = moshi.adapter(RemoteMessage::class.java)
-        }
     }
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RMFMapperModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RMFMapperModule.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.impl.di
+
+import com.duckduckgo.di.DaggerSet
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.remote.messaging.api.Content
+import com.duckduckgo.remote.messaging.api.Content.BigSingleAction
+import com.duckduckgo.remote.messaging.api.Content.BigTwoActions
+import com.duckduckgo.remote.messaging.api.Content.Medium
+import com.duckduckgo.remote.messaging.api.Content.MessageType
+import com.duckduckgo.remote.messaging.api.Content.Small
+import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
+import com.duckduckgo.remote.messaging.api.RemoteMessage
+import com.duckduckgo.remote.messaging.impl.mappers.ActionAdapter
+import com.duckduckgo.remote.messaging.impl.mappers.MessageMapper
+import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+
+@Module
+@ContributesTo(AppScope::class)
+object RMFMapperModule {
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun providesMessageMapper(
+        messageAdapter: JsonAdapter<RemoteMessage>,
+    ): MessageMapper {
+        return MessageMapper(messageAdapter)
+    }
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun provideMoshiAdapter(
+        actionMappers: DaggerSet<MessageActionMapperPlugin>,
+    ): JsonAdapter<RemoteMessage> {
+        val moshi = Moshi.Builder()
+            .add(
+                PolymorphicJsonAdapterFactory.of(Content::class.java, "messageType")
+                    .withSubtype(Small::class.java, MessageType.SMALL.name)
+                    .withSubtype(Medium::class.java, MessageType.MEDIUM.name)
+                    .withSubtype(BigSingleAction::class.java, MessageType.BIG_SINGLE_ACTION.name)
+                    .withSubtype(BigTwoActions::class.java, MessageType.BIG_TWO_ACTION.name),
+            )
+            .add(ActionAdapter(actionMappers))
+            .add(KotlinJsonAdapterFactory())
+            .build()
+        return moshi.adapter(RemoteMessage::class.java)
+    }
+}

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.di.DaggerSet
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
+import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
 import com.duckduckgo.remote.messaging.api.RemoteMessagingRepository
 import com.duckduckgo.remote.messaging.impl.*
 import com.duckduckgo.remote.messaging.impl.RealRemoteMessagingConfigDownloader
@@ -98,9 +99,10 @@ object DataSourceModule {
     @Provides
     @SingleInstanceIn(AppScope::class)
     fun providesRemoteMessagingConfigJsonMapper(
+        actionMappers: DaggerSet<MessageActionMapperPlugin>,
         appBuildConfig: AppBuildConfig,
     ): RemoteMessagingConfigJsonMapper {
-        return RemoteMessagingConfigJsonMapper(appBuildConfig)
+        return RemoteMessagingConfigJsonMapper(appBuildConfig, actionMappers)
     }
 
     @Provides

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.remote.messaging.api.RemoteMessagingRepository
 import com.duckduckgo.remote.messaging.impl.*
 import com.duckduckgo.remote.messaging.impl.RealRemoteMessagingConfigDownloader
 import com.duckduckgo.remote.messaging.impl.RemoteMessagingConfigDownloader
+import com.duckduckgo.remote.messaging.impl.mappers.MessageMapper
 import com.duckduckgo.remote.messaging.impl.mappers.RemoteMessagingConfigJsonMapper
 import com.duckduckgo.remote.messaging.impl.matchers.AndroidAppAttributeMatcher
 import com.duckduckgo.remote.messaging.impl.matchers.DeviceAttributeMatcher
@@ -84,8 +85,9 @@ object DataSourceModule {
         remoteMessagingConfigRepository: RemoteMessagingConfigRepository,
         remoteMessagesDao: RemoteMessagesDao,
         dispatchers: DispatcherProvider,
+        messageMapper: MessageMapper,
     ): RemoteMessagingRepository {
-        return AppRemoteMessagingRepository(remoteMessagingConfigRepository, remoteMessagesDao, dispatchers)
+        return AppRemoteMessagingRepository(remoteMessagingConfigRepository, remoteMessagesDao, dispatchers, messageMapper)
     }
 
     @Provides

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/ActionAdapter.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/ActionAdapter.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.impl.mappers
+
+import com.duckduckgo.remote.messaging.api.Action
+import com.duckduckgo.remote.messaging.api.JsonMessageAction
+import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.lang.IllegalStateException
+
+class ActionAdapter constructor(
+    private val actionMappers: Set<MessageActionMapperPlugin>,
+) {
+    @ToJson fun userProfileToJson(model: Action): ActionJson {
+        return ActionJson(model.actionType, model.value)
+    }
+
+    @FromJson fun userProfileFromJson(json: ActionJson): Action {
+        val jsonAction = JsonMessageAction(json.actionType, json.value)
+        actionMappers.forEach {
+            val action = it.evaluate(jsonAction)
+            if (action != null) return action
+        }
+        throw IllegalStateException("No mapper found for action type ${json.actionType}")
+    }
+
+    class ActionJson(val actionType: String, val value: String)
+}
+

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonActionMappers.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonActionMappers.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.impl.mappers
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.remote.messaging.api.Action
+import com.duckduckgo.remote.messaging.api.JsonActionType.APP_TP_ONBOARDING
+import com.duckduckgo.remote.messaging.api.JsonActionType.DEFAULT_BROWSER
+import com.duckduckgo.remote.messaging.api.JsonActionType.DISMISS
+import com.duckduckgo.remote.messaging.api.JsonActionType.PLAYSTORE
+import com.duckduckgo.remote.messaging.api.JsonActionType.URL
+import com.duckduckgo.remote.messaging.api.JsonMessageAction
+import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.*
+
+@ContributesMultibinding(
+    AppScope::class,
+)
+class UrlActionMapper @Inject constructor() : MessageActionMapperPlugin {
+    override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
+        return if (jsonMessageAction.type == URL.jsonValue) {
+            Action.Url(jsonMessageAction.value)
+        } else {
+            null
+        }
+    }
+}
+
+@ContributesMultibinding(
+    AppScope::class,
+)
+class DismissActionMapper @Inject constructor() : MessageActionMapperPlugin {
+    override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
+        return if (jsonMessageAction.type == DISMISS.jsonValue) {
+            Action.Dismiss()
+        } else {
+            null
+        }
+    }
+}
+
+@ContributesMultibinding(
+    AppScope::class,
+)
+class PlayStoreActionMapper @Inject constructor() : MessageActionMapperPlugin {
+    override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
+        return if (jsonMessageAction.type == PLAYSTORE.jsonValue) {
+            Action.PlayStore(jsonMessageAction.value)
+        } else {
+            null
+        }
+    }
+}
+
+@ContributesMultibinding(
+    AppScope::class,
+)
+class DefaultBrowserActionMapper @Inject constructor() : MessageActionMapperPlugin {
+    override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
+        return if (jsonMessageAction.type == DEFAULT_BROWSER.jsonValue) {
+            Action.DefaultBrowser()
+        } else {
+            null
+        }
+    }
+}
+
+@ContributesMultibinding(
+    AppScope::class,
+)
+class AppTPActionMapper @Inject constructor() : MessageActionMapperPlugin {
+    override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
+        return if (jsonMessageAction.type == APP_TP_ONBOARDING.jsonValue) {
+            Action.AppTpOnboarding()
+        } else {
+            null
+        }
+    }
+}

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonActionMappers.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonActionMappers.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.remote.messaging.impl.mappers
 
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.remote.messaging.api.Action
-import com.duckduckgo.remote.messaging.api.JsonActionType.APP_TP_ONBOARDING
+import com.duckduckgo.remote.messaging.api.JsonActionType.APP_NAVIGATION
 import com.duckduckgo.remote.messaging.api.JsonActionType.DEFAULT_BROWSER
 import com.duckduckgo.remote.messaging.api.JsonActionType.DISMISS
 import com.duckduckgo.remote.messaging.api.JsonActionType.PLAYSTORE
@@ -74,19 +74,6 @@ class DefaultBrowserActionMapper @Inject constructor() : MessageActionMapperPlug
     override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
         return if (jsonMessageAction.type == DEFAULT_BROWSER.jsonValue) {
             Action.DefaultBrowser()
-        } else {
-            null
-        }
-    }
-}
-
-@ContributesMultibinding(
-    AppScope::class,
-)
-class AppTPActionMapper @Inject constructor() : MessageActionMapperPlugin {
-    override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
-        return if (jsonMessageAction.type == APP_TP_ONBOARDING.jsonValue) {
-            Action.AppTpOnboarding()
         } else {
             null
         }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonActionMappers.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonActionMappers.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.remote.messaging.impl.mappers
 
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.remote.messaging.api.Action
-import com.duckduckgo.remote.messaging.api.JsonActionType.APP_NAVIGATION
 import com.duckduckgo.remote.messaging.api.JsonActionType.DEFAULT_BROWSER
 import com.duckduckgo.remote.messaging.api.JsonActionType.DISMISS
 import com.duckduckgo.remote.messaging.api.JsonActionType.PLAYSTORE
@@ -47,7 +46,7 @@ class UrlActionMapper @Inject constructor() : MessageActionMapperPlugin {
 class DismissActionMapper @Inject constructor() : MessageActionMapperPlugin {
     override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
         return if (jsonMessageAction.type == DISMISS.jsonValue) {
-            Action.Dismiss()
+            Action.Dismiss
         } else {
             null
         }
@@ -73,7 +72,7 @@ class PlayStoreActionMapper @Inject constructor() : MessageActionMapperPlugin {
 class DefaultBrowserActionMapper @Inject constructor() : MessageActionMapperPlugin {
     override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
         return if (jsonMessageAction.type == DEFAULT_BROWSER.jsonValue) {
-            Action.DefaultBrowser()
+            Action.DefaultBrowser
         } else {
             null
         }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/MessageMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/MessageMapper.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.impl.mappers
+
+import com.duckduckgo.remote.messaging.api.RemoteMessage
+import com.squareup.moshi.JsonAdapter
+
+class MessageMapper(
+    private val messageAdapter: JsonAdapter<RemoteMessage>,
+) {
+
+    fun toString(sitePayload: RemoteMessage): String {
+        return messageAdapter.toJson(sitePayload)
+    }
+
+    fun fromMessage(payload: String): RemoteMessage? {
+        return runCatching {
+            messageAdapter.fromJson(payload)
+        }.getOrNull()
+    }
+}

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/RemoteMessagingConfigJsonMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/RemoteMessagingConfigJsonMapper.kt
@@ -17,13 +17,29 @@
 package com.duckduckgo.remote.messaging.impl.mappers
 
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.remote.messaging.api.Action
+import com.duckduckgo.remote.messaging.impl.models.JsonActionType.APP_TP_ONBOARDING
+import com.duckduckgo.remote.messaging.impl.models.JsonActionType.DEFAULT_BROWSER
+import com.duckduckgo.remote.messaging.impl.models.JsonActionType.DISMISS
+import com.duckduckgo.remote.messaging.impl.models.JsonActionType.PLAYSTORE
+import com.duckduckgo.remote.messaging.impl.models.JsonActionType.URL
+import com.duckduckgo.remote.messaging.impl.models.JsonMessageAction
 import com.duckduckgo.remote.messaging.impl.models.JsonRemoteMessagingConfig
 import com.duckduckgo.remote.messaging.impl.models.RemoteConfig
 import timber.log.Timber
 
-class RemoteMessagingConfigJsonMapper(private val appBuildConfig: AppBuildConfig) {
+class RemoteMessagingConfigJsonMapper(
+    private val appBuildConfig: AppBuildConfig
+) {
     fun map(jsonRemoteMessagingConfig: JsonRemoteMessagingConfig): RemoteConfig {
-        val messages = jsonRemoteMessagingConfig.messages.mapToRemoteMessage(appBuildConfig.deviceLocale)
+
+        val actionMappers = listOf<ActionMapper>(
+            ActionMapper(urlActionMapper),
+            ActionMapper(dismissActionMapper),
+            ActionMapper(playStoreActionMapper),
+            ActionMapper(appTpOnboardingActionMapper),
+        )
+        val messages = jsonRemoteMessagingConfig.messages.mapToRemoteMessage(appBuildConfig.deviceLocale, actionMappers)
         Timber.i("RMF: messages parsed $messages")
         val rules = jsonRemoteMessagingConfig.rules.mapToMatchingRules()
         return RemoteConfig(
@@ -32,3 +48,47 @@ class RemoteMessagingConfigJsonMapper(private val appBuildConfig: AppBuildConfig
         )
     }
 }
+
+private val urlActionMapper: (JsonMessageAction) -> Action? = {
+    if (it.type == URL.jsonValue) {
+        Action.Url(it.value)
+    } else {
+        null
+    }
+}
+
+private val dismissActionMapper: (JsonMessageAction) -> Action? = {
+    if (it.type == DISMISS.jsonValue) {
+        Action.Dismiss()
+    } else {
+        null
+    }
+}
+
+private val playStoreActionMapper: (JsonMessageAction) -> Action? = {
+    if (it.type == PLAYSTORE.jsonValue) {
+        Action.PlayStore(it.value)
+    } else {
+        null
+    }
+}
+
+private val defaultBrowserActionMapper: (JsonMessageAction) -> Action? = {
+    if (it.type == DEFAULT_BROWSER.jsonValue) {
+        Action.DefaultBrowser()
+    } else {
+        null
+    }
+}
+
+private val appTpOnboardingActionMapper: (JsonMessageAction) -> Action? = {
+    if (it.type == APP_TP_ONBOARDING.jsonValue) {
+        Action.AppTpOnboarding()
+    } else {
+        null
+    }
+}
+
+data class ActionMapper(
+    val mapper: (JsonMessageAction) -> Action?
+)

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/RemoteMessagingConfigJsonMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/RemoteMessagingConfigJsonMapper.kt
@@ -17,28 +17,16 @@
 package com.duckduckgo.remote.messaging.impl.mappers
 
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.remote.messaging.api.Action
-import com.duckduckgo.remote.messaging.impl.models.JsonActionType.APP_TP_ONBOARDING
-import com.duckduckgo.remote.messaging.impl.models.JsonActionType.DEFAULT_BROWSER
-import com.duckduckgo.remote.messaging.impl.models.JsonActionType.DISMISS
-import com.duckduckgo.remote.messaging.impl.models.JsonActionType.PLAYSTORE
-import com.duckduckgo.remote.messaging.impl.models.JsonActionType.URL
-import com.duckduckgo.remote.messaging.impl.models.JsonMessageAction
+import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
 import com.duckduckgo.remote.messaging.impl.models.JsonRemoteMessagingConfig
 import com.duckduckgo.remote.messaging.impl.models.RemoteConfig
 import timber.log.Timber
 
 class RemoteMessagingConfigJsonMapper(
-    private val appBuildConfig: AppBuildConfig
+    private val appBuildConfig: AppBuildConfig,
+    private val actionMappers: Set<MessageActionMapperPlugin>,
 ) {
     fun map(jsonRemoteMessagingConfig: JsonRemoteMessagingConfig): RemoteConfig {
-
-        val actionMappers = listOf<ActionMapper>(
-            ActionMapper(urlActionMapper),
-            ActionMapper(dismissActionMapper),
-            ActionMapper(playStoreActionMapper),
-            ActionMapper(appTpOnboardingActionMapper),
-        )
         val messages = jsonRemoteMessagingConfig.messages.mapToRemoteMessage(appBuildConfig.deviceLocale, actionMappers)
         Timber.i("RMF: messages parsed $messages")
         val rules = jsonRemoteMessagingConfig.rules.mapToMatchingRules()
@@ -48,47 +36,3 @@ class RemoteMessagingConfigJsonMapper(
         )
     }
 }
-
-private val urlActionMapper: (JsonMessageAction) -> Action? = {
-    if (it.type == URL.jsonValue) {
-        Action.Url(it.value)
-    } else {
-        null
-    }
-}
-
-private val dismissActionMapper: (JsonMessageAction) -> Action? = {
-    if (it.type == DISMISS.jsonValue) {
-        Action.Dismiss()
-    } else {
-        null
-    }
-}
-
-private val playStoreActionMapper: (JsonMessageAction) -> Action? = {
-    if (it.type == PLAYSTORE.jsonValue) {
-        Action.PlayStore(it.value)
-    } else {
-        null
-    }
-}
-
-private val defaultBrowserActionMapper: (JsonMessageAction) -> Action? = {
-    if (it.type == DEFAULT_BROWSER.jsonValue) {
-        Action.DefaultBrowser()
-    } else {
-        null
-    }
-}
-
-private val appTpOnboardingActionMapper: (JsonMessageAction) -> Action? = {
-    if (it.type == APP_TP_ONBOARDING.jsonValue) {
-        Action.AppTpOnboarding()
-    } else {
-        null
-    }
-}
-
-data class ActionMapper(
-    val mapper: (JsonMessageAction) -> Action?
-)

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/UnusedRemoteMessageNavigationActionPluginPoint.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/UnusedRemoteMessageNavigationActionPluginPoint.kt
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.remote.messaging.api
+package com.duckduckgo.remote.messaging.impl.mappers
 
-interface MessageActionMapperPlugin {
-    fun evaluate(jsonMessageAction: JsonMessageAction): Action?
-}
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
 
-data class JsonMessageAction(
-    val type: String,
-    val value: String,
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = MessageActionMapperPlugin::class,
 )
-
-sealed class JsonActionType(val jsonValue: String) {
-    object URL : JsonActionType("url")
-    object PLAYSTORE : JsonActionType("playstore")
-    object DEFAULT_BROWSER : JsonActionType("defaultBrowser")
-    object DISMISS : JsonActionType("dismiss")
-    object APP_NAVIGATION : JsonActionType("appNavigation")
-    object APP_TP_ONBOARDING : JsonActionType("atpOnboarding")
-}
+@Suppress("unused")
+interface UnusedRemoteMessageNavigationActionPluginPoint

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.remote.messaging.impl.models
 
+import com.duckduckgo.remote.messaging.api.JsonMessageAction
+
 data class JsonRemoteMessagingConfig(
     val version: Long,
     val messages: List<JsonRemoteMessage>,
@@ -61,19 +63,6 @@ data class JsonMatchingAttribute(
     val since: Any? = null,
     val fallback: Boolean? = null,
 )
-
-data class JsonMessageAction(
-    val type: String,
-    val value: String,
-)
-
-sealed class JsonActionType(val jsonValue: String) {
-    object URL : JsonActionType("url")
-    object PLAYSTORE : JsonActionType("playstore")
-    object DEFAULT_BROWSER : JsonActionType("defaultBrowser")
-    object DISMISS : JsonActionType("dismiss")
-    object APP_TP_ONBOARDING : JsonActionType("atpOnboarding")
-}
 
 sealed class JsonMessageType(val jsonValue: String) {
     object SMALL : JsonMessageType("small")

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,6 +23,6 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    @GET("https://jsonblob.com/api/jsonBlob/1085310672866394112")
+    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
     suspend fun config(): JsonRemoteMessagingConfig
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,6 +23,6 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    @GET("https://jsonblob.com/api/jsonBlob/1085310672866394112")
     suspend fun config(): JsonRemoteMessagingConfig
 }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/FakeActionPlugins.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/FakeActionPlugins.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.fixtures
+
+import android.content.Intent
+import com.duckduckgo.remote.messaging.api.Action
+import com.duckduckgo.remote.messaging.api.JsonMessageAction
+import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
+import com.duckduckgo.remote.messaging.impl.mappers.DefaultBrowserActionMapper
+import com.duckduckgo.remote.messaging.impl.mappers.DismissActionMapper
+import com.duckduckgo.remote.messaging.impl.mappers.PlayStoreActionMapper
+import com.duckduckgo.remote.messaging.impl.mappers.UrlActionMapper
+
+val messageActionPlugins = listOf(
+    FakeAppNavigationMapper(),
+    UrlActionMapper(),
+    DismissActionMapper(),
+    PlayStoreActionMapper(),
+    DefaultBrowserActionMapper(),
+).toSet()
+
+class FakeAppNavigationMapper : MessageActionMapperPlugin {
+    override fun evaluate(jsonMessageAction: JsonMessageAction): Action? {
+        if (jsonMessageAction.type != "appNavigation") return null
+        return Action.AppNavigation(Intent(), jsonMessageAction.value)
+    }
+}

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/JsonRemoteMessageOM.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/JsonRemoteMessageOM.kt
@@ -16,10 +16,10 @@
 
 package com.duckduckgo.remote.messaging.fixtures
 
+import com.duckduckgo.remote.messaging.api.JsonMessageAction
 import com.duckduckgo.remote.messaging.impl.models.JsonContent
 import com.duckduckgo.remote.messaging.impl.models.JsonContentTranslations
 import com.duckduckgo.remote.messaging.impl.models.JsonMatchingRule
-import com.duckduckgo.remote.messaging.impl.models.JsonMessageAction
 import com.duckduckgo.remote.messaging.impl.models.JsonRemoteMessage
 import com.duckduckgo.remote.messaging.impl.models.JsonRemoteMessagingConfig
 

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/TestMessageMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/TestMessageMapper.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.fixtures
+
+import com.duckduckgo.remote.messaging.impl.di.RMFMapperModule
+import com.duckduckgo.remote.messaging.impl.mappers.MessageMapper
+
+fun getMessageMapper() = MessageMapper(RMFMapperModule.provideMoshiAdapter(messageActionPlugins))

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.remote.messaging.api.Content.Medium
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.ANNOUNCE
 import com.duckduckgo.remote.messaging.api.Content.Small
 import com.duckduckgo.remote.messaging.api.RemoteMessage
+import com.duckduckgo.remote.messaging.fixtures.getMessageMapper
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity.Status
 import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
@@ -62,7 +63,7 @@ class AppRemoteMessagingRepositoryTest {
 
     private val remoteMessagingConfigRepository: RemoteMessagingConfigRepository = mock()
 
-    private val testee = AppRemoteMessagingRepository(remoteMessagingConfigRepository, dao, coroutineRule.testDispatcherProvider)
+    private val testee = AppRemoteMessagingRepository(remoteMessagingConfigRepository, dao, coroutineRule.testDispatcherProvider, getMessageMapper())
 
     @After
     fun after() {
@@ -188,7 +189,7 @@ class AppRemoteMessagingRepositoryTest {
                     primaryAction = Action.PlayStore(value = "com.duckduckgo.com"),
                     primaryActionText = "actionText",
                     secondaryActionText = "actionText",
-                    secondaryAction = Action.Dismiss(),
+                    secondaryAction = Action.Dismiss,
                 ),
                 matchingRules = emptyList(),
                 exclusionRules = emptyList(),
@@ -208,7 +209,7 @@ class AppRemoteMessagingRepositoryTest {
                         primaryAction = Action.PlayStore(value = "com.duckduckgo.com"),
                         primaryActionText = "actionText",
                         secondaryActionText = "actionText",
-                        secondaryAction = Action.Dismiss(),
+                        secondaryAction = Action.Dismiss,
                     ),
                     matchingRules = emptyList(),
                     exclusionRules = emptyList(),
@@ -231,7 +232,7 @@ class AppRemoteMessagingRepositoryTest {
                     primaryAction = Action.PlayStore(value = "com.duckduckgo.com"),
                     primaryActionText = "actionText",
                     secondaryActionText = "actionText",
-                    secondaryAction = Action.Dismiss(),
+                    secondaryAction = Action.Dismiss,
                 ),
                 matchingRules = emptyList(),
                 exclusionRules = emptyList(),
@@ -260,7 +261,7 @@ class AppRemoteMessagingRepositoryTest {
                     primaryAction = Action.PlayStore(value = "com.duckduckgo.com"),
                     primaryActionText = "actionText",
                     secondaryActionText = "actionText",
-                    secondaryAction = Action.Dismiss(),
+                    secondaryAction = Action.Dismiss,
                 ),
                 matchingRules = emptyList(),
                 exclusionRules = emptyList(),
@@ -293,7 +294,7 @@ class AppRemoteMessagingRepositoryTest {
                     primaryAction = Action.PlayStore(value = "com.duckduckgo.com"),
                     primaryActionText = "actionText",
                     secondaryActionText = "actionText",
-                    secondaryAction = Action.Dismiss(),
+                    secondaryAction = Action.Dismiss,
                 ),
                 matchingRules = emptyList(),
                 exclusionRules = emptyList(),

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageMapperTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageMapperTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.remote.messaging.fixtures.RemoteMessageOM.bigSingleActionC
 import com.duckduckgo.remote.messaging.fixtures.RemoteMessageOM.bigTwoActionsContent
 import com.duckduckgo.remote.messaging.fixtures.RemoteMessageOM.mediumContent
 import com.duckduckgo.remote.messaging.fixtures.RemoteMessageOM.smallContent
+import com.duckduckgo.remote.messaging.fixtures.messageActionPlugins
 import com.duckduckgo.remote.messaging.impl.mappers.mapToRemoteMessage
 import com.duckduckgo.remote.messaging.impl.models.JsonContentTranslations
 import com.duckduckgo.remote.messaging.impl.models.JsonRemoteMessage
@@ -45,7 +46,7 @@ class JsonRemoteMessageMapperTest(private val testCase: TestCase) {
 
     @Test
     fun whenJsonMessageThenReturnMessage() {
-        val remoteMessages = testCase.jsonRemoteMessages.mapToRemoteMessage(Locale.FRANCE, actionMappers)
+        val remoteMessages = testCase.jsonRemoteMessages.mapToRemoteMessage(Locale.FRANCE, messageActionPlugins)
 
         assertEquals(testCase.expectedMessages, remoteMessages)
     }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageMapperTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageMapperTest.kt
@@ -45,7 +45,7 @@ class JsonRemoteMessageMapperTest(private val testCase: TestCase) {
 
     @Test
     fun whenJsonMessageThenReturnMessage() {
-        val remoteMessages = testCase.jsonRemoteMessages.mapToRemoteMessage(Locale.FRANCE)
+        val remoteMessages = testCase.jsonRemoteMessages.mapToRemoteMessage(Locale.FRANCE, actionMappers)
 
         assertEquals(testCase.expectedMessages, remoteMessages)
     }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessagingConfigProcessorTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessagingConfigProcessorTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.remote.messaging.api.RemoteMessagingRepository
 import com.duckduckgo.remote.messaging.fixtures.JsonRemoteMessageOM.aJsonRemoteMessagingConfig
 import com.duckduckgo.remote.messaging.fixtures.RemoteMessagingConfigOM.aRemoteMessagingConfig
+import com.duckduckgo.remote.messaging.fixtures.messageActionPlugins
 import com.duckduckgo.remote.messaging.impl.mappers.RemoteMessagingConfigJsonMapper
 import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
 import java.util.*
@@ -43,7 +44,7 @@ class RealRemoteMessagingConfigProcessorTest {
     @get:Rule var coroutineRule = CoroutineTestRule()
 
     private val appBuildConfig: AppBuildConfig = mock()
-    private val remoteMessagingConfigJsonMapper = RemoteMessagingConfigJsonMapper(appBuildConfig)
+    private val remoteMessagingConfigJsonMapper = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
     private val remoteMessagingConfigRepository = mock<RemoteMessagingConfigRepository>()
     private val remoteMessagingRepository = mock<RemoteMessagingRepository>()
     private val remoteMessagingConfigMatcher = RemoteMessagingConfigMatcher(setOf(mock(), mock(), mock()), mock())

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigJsonMapperTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigJsonMapperTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.remote.messaging.api.Content.Placeholder.ANNOUNCE
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.APP_UPDATE
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.CRITICAL_UPDATE
 import com.duckduckgo.remote.messaging.api.RemoteMessage
+import com.duckduckgo.remote.messaging.fixtures.messageActionPlugins
 import com.duckduckgo.remote.messaging.impl.mappers.RemoteMessagingConfigJsonMapper
 import com.duckduckgo.remote.messaging.impl.models.*
 import com.duckduckgo.remote.messaging.impl.models.JsonRemoteMessagingConfig
@@ -53,7 +54,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenValidJsonParsedThenMessagesMappedIntoRemoteConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -108,7 +109,7 @@ class RemoteMessagingConfigJsonMapperTest {
                     value = "com.duckduckgo.mobile.android",
                 ),
                 secondaryActionText = "Cancel",
-                secondaryAction = Action.Dismiss(),
+                secondaryAction = Action.Dismiss,
             ),
             matchingRules = emptyList(),
             exclusionRules = emptyList(),
@@ -120,7 +121,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenValidJsonParsedThenRulesMappedIntoRemoteConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -144,7 +145,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenJsonMessagesHaveUnknownTypesThenMessagesNotMappedIntoConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_unsupported_items.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -155,7 +156,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenJsonMessagesHaveUnknownTypesThenRulesMappedIntoConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_unsupported_items.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -172,7 +173,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenJsonMessagesMalformedOrMissingInformationThenMessagesNotParsedIntoConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_malformed.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -193,7 +194,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenJsonMatchingAttributesMalformedThenParsedAsUnknownIntoConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_malformed.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -208,7 +209,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenUnknownMatchingAttributeDoesNotProvideFallbackThenFallbackIsNull() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_malformed.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
 
         val config = testee.map(result)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204530964544587/f 

### Description
Introduces plugins to allow features from other modules to provide Action for Remote messages.

We also introduce a new action that we can use next time we want to navigate to an specific screen within the app.

### Steps to test this PR

_Feature 1_
- [ ] Update endpoint to consume https://jsonblob.com/api/jsonBlob/1103286320440295424 (`RemoteMessagingService`)
- [ ] Open the app, skip onboarding
- [ ] You should see a message
- [ ] Clicking on the primary action, should take you to apptp onboaring
- [ ] Now go to https://www.jsonblob.com/1103286320440295424, increase the version number and save
- [ ] Press fire button in the app
- [ ] You should see a new message
- [ ] Clicking on the primary action, should take you to apptp onboaring


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
