### PR TITLE
Fix -> showOverFlowMenu by clicking on the iconButton not the whole h…

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/sitepermissions/SitePermissionsAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/sitepermissions/SitePermissionsAdapter.kt
@@ -154,7 +154,7 @@ class SitePermissionsAdapter(
                 R.string.sitePermissionsSettingsAllowedSitesTitle -> {
                     binding.sitePermissionsSectionHeader.apply {
                         showOverflowMenuIcon(true)
-                        setOnClickListener { showOverflowMenu(isListEmpty) }
+                        setOverflowMenuClickListener { showOverflowMenu(isListEmpty) }
                     }
                 }
                 else -> binding.sitePermissionsSectionHeader.showOverflowMenuIcon(false)


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL:  https://github.com/duckduckgo/Android/issues/3139

### Description : 
This PR resolves the issue of clicking at any point of the Manage sites header in Site Permissions screen to show over flow menu.

### Steps to test this PR

1. go to settings 
2. go site permissions
3. click at any point of mange sites header and click on icon button to make sure that 
the over flow menu is only shown if the icon button is clicked 

### UI changes
| Before  | After |
| ------ | ----- |

https://user-images.githubusercontent.com/92212925/236549424-39b81984-ee6e-476e-8c74-9d21010542e4.mp4

