### PR TITLE
Replace cookie crashes with regular pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
@@ -91,7 +91,6 @@ class FireproofingReferenceTest(private val testCase: TestCase) {
             webViewDatabaseLocator,
             fireproofWebsiteRepositoryImpl,
             mock(),
-            mock(),
             DefaultDispatcherProvider(),
         )
 

--- a/app/src/androidTest/java/com/duckduckgo/cookies/impl/SQLCookieRemoverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/cookies/impl/SQLCookieRemoverTest.kt
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint
 import android.webkit.CookieManager
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
-import com.duckduckgo.anrs.api.CrashLogger
 import com.duckduckgo.app.fire.DatabaseLocator
 import com.duckduckgo.app.fire.FireproofRepository
 import com.duckduckgo.app.fire.WebViewDatabaseLocator
@@ -39,7 +38,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.*
-import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.*
 
@@ -52,13 +50,7 @@ class SQLCookieRemoverTest {
     private val cookieManager = CookieManager.getInstance()
     private val fireproofWebsiteDao = db.fireproofWebsiteDao()
     private val mockPixel: Pixel = mock()
-    private lateinit var crashLogger: FakeCraskLogger
     private val webViewDatabaseLocator = WebViewDatabaseLocator(context)
-
-    @Before
-    fun setup() {
-        crashLogger = FakeCraskLogger()
-    }
 
     @After
     fun after() = runBlocking {
@@ -119,24 +111,14 @@ class SQLCookieRemoverTest {
     private fun givenSQLCookieRemover(
         databaseLocator: DatabaseLocator = webViewDatabaseLocator,
         repository: FireproofRepository = FireproofWebsiteRepositoryImpl(fireproofWebsiteDao, DefaultDispatcherProvider(), mock()),
-        exceptionPixel: CrashLogger = crashLogger,
         pixel: Pixel = mockPixel,
         dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider(),
     ): SQLCookieRemover {
         return SQLCookieRemover(
             databaseLocator,
             repository,
-            exceptionPixel,
             pixel,
             dispatcherProvider,
         )
-    }
-}
-
-internal class FakeCraskLogger : CrashLogger {
-    var crash: CrashLogger.Crash? = null
-
-    override fun logCrash(crash: CrashLogger.Crash) {
-        this.crash = crash
     }
 }

--- a/cookies/cookies-impl/build.gradle
+++ b/cookies/cookies-impl/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 
     implementation project(':di')
     implementation project(':common')
-    implementation project(':anrs-api')
     implementation project(':app-build-config-api')
     implementation project(':privacy-config-api')
     implementation project(':feature-toggles-api')
@@ -50,6 +49,7 @@ dependencies {
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
 
+    implementation "com.squareup.logcat:logcat:_"
     implementation Google.dagger
     implementation AndroidX.core.ktx
     implementation AndroidX.work.runtimeKtx

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/CookiesFeatureNameUtil.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/CookiesFeatureNameUtil.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.cookies.impl
 
+import android.util.Base64
 import com.duckduckgo.cookies.api.CookiesFeatureName
 
 /**
@@ -23,4 +24,22 @@ import com.duckduckgo.cookies.api.CookiesFeatureName
  */
 fun cookiesFeatureValueOf(value: String): CookiesFeatureName? {
     return CookiesFeatureName.values().find { it.value == value }
+}
+
+/**
+ * Redacts the stacktrace for SQL crashes removing the WHERE statement if it exists and returns a base64 string
+ */
+fun redactStacktraceInBase64(stacktrace: String): String {
+    val start = stacktrace.indexOf("WHERE")
+    val redacted = if (start == -1) {
+        stacktrace
+    } else {
+        val finish = stacktrace.substring(start).indexOf("\n") + start
+        if (finish > start) {
+            stacktrace.removeRange(start, finish)
+        } else {
+            stacktrace
+        }
+    }
+    return Base64.encodeToString(redacted.toByteArray(), Base64.NO_WRAP or Base64.NO_PADDING or Base64.URL_SAFE)
 }

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/CookiesPixelName.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/CookiesPixelName.kt
@@ -20,4 +20,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 
 enum class CookiesPixelName(override val pixelName: String) : Pixel.PixelName {
     COOKIE_DB_OPEN_ERROR("m_cookie_db_open_error"),
+    COOKIE_EXPIRE_ERROR("m_cookie_db_expire_error"),
+    COOKIE_DELETE_ERROR("m_cookie_db_delete_error"),
 }

--- a/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/CookiesFeatureNameUtilTest.kt
+++ b/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/CookiesFeatureNameUtilTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.cookies.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CookiesFeatureNameUtilTest {
+
+    @Test
+    fun whenQueryHasWhenThenReturnRedactedBase64Stacktrace() {
+        val ss = redactStacktraceInBase64(WITH_WHEN)
+        assertEquals(WITH_WHEN_BASE634, ss)
+    }
+
+    @Test
+    fun whenQueryDoesNotHaveWhenThenReturnBase64Stacktrace() {
+        val ss = redactStacktraceInBase64(WITHOUT_WHEN)
+        assertEquals(WITHOUT_WHEN_BASE64, ss)
+    }
+
+    @Test
+    fun whenQueryOneLineThenReturnBase64Stacktrace() {
+        val ss = redactStacktraceInBase64(WITHOUT_NEW_LINE)
+        assertEquals(WITHOUT_NEW_LINE_BASE64, ss)
+    }
+
+    companion object {
+        const val WITH_WHEN = """
+            Error on line 1
+            UPDATE test
+            SET test=1
+            WHERE test=0
+            This is a test error
+        """
+        const val WITHOUT_WHEN = """
+            Error on line 1
+            This is a test error
+        """
+
+        const val WITHOUT_NEW_LINE = "Error on line 1 UPDATE test SET test=1 WHERE test=0 This is a test error "
+
+        const val WITH_WHEN_BASE634 =
+            "CiAgICAgICAgICAgIEVycm9yIG9uIGxpbmUgMQogICAgICAgICAgICBVUERBVEUgdGVzdAogICAgICAgICAgICBTRVQgdGVzdD0xCiAgICAgICAgICAgIAogICAgICAg" +
+                "ICAgICBUaGlzIGlzIGEgdGVzdCBlcnJvcgogICAgICAgIA"
+
+        const val WITHOUT_WHEN_BASE64 = "CiAgICAgICAgICAgIEVycm9yIG9uIGxpbmUgMQogICAgICAgICAgICBUaGlzIGlzIGEgdGVzdCBlcnJvcgogICAgICAgIA"
+
+        const val WITHOUT_NEW_LINE_BASE64 = "RXJyb3Igb24gbGluZSAxIFVQREFURSB0ZXN0IFNFVCB0ZXN0PTEgV0hFUkUgdGVzdD0wIFRoaXMgaXMgYSB0ZXN0IGVycm9yIA"
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204599953020604/f 

### Description
This PR replaces the crash pixels for cookie queries and instead adds regular pixels.

### Steps to test this PR

- [ ] In `RealFirstPartyCookiesModifier` force a crash by changing `UPDATE ${SQLCookieRemover.COOKIES_TABLE_NAME}` to `UPDATE fakeTable`
- [ ] Visit cnn.com to force the cookies DB to be created
- [ ] Send the app to the background
- [ ] Filter the logcat by `pixel sent` you should see a `m_cookie_db_expire_error` sent with a `ss` parameter.
- [ ] Get the value of `ss` and decode it with https://www.base64decode.org/
- [ ] The stacktrace should not contain the WHERE clause.
- [ ] Repeat the same with the `SQLCookieRemover` which you can trigger by using the fire button. 
- [ ] In this case the pixel should be `m_cookie_db_delete_error` and the stacktrace should still not contain any personal data.