### PR TITLE
Ensure the new DDG logo renders correctly on Android M devices.

### DIFF
--- a/app/src/main/res/layout/activity_system_search.xml
+++ b/app/src/main/res/layout/activity_system_search.xml
@@ -61,7 +61,7 @@
                         android:layout_height="wrap_content"
                         android:importantForAccessibility="no"
                         android:padding="4dp"
-                        android:src="@drawable/ic_ddg_logo"
+                        app:srcCompat="@drawable/ic_ddg_logo"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/content_about_duck_duck_go.xml
+++ b/app/src/main/res/layout/content_about_duck_duck_go.xml
@@ -43,7 +43,7 @@
             android:layout_gravity="center"
             android:layout_marginTop="20dp"
             android:contentDescription="@string/duckDuckGoLogoDescription"
-            android:src="@drawable/logo_full" />
+            app:srcCompat="@drawable/logo_full" />
 
         <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -61,7 +61,7 @@
                     android:contentDescription="@string/duckDuckGoLogoDescription"
                     android:maxWidth="180dp"
                     android:maxHeight="180dp"
-                    android:src="@drawable/logo_full"
+                    app:srcCompat="@drawable/logo_full"
                     android:visibility="gone" />
 
                 <com.duckduckgo.mobile.android.ui.view.MessageCta

--- a/app/src/main/res/layout/include_omnibar_toolbar.xml
+++ b/app/src/main/res/layout/include_omnibar_toolbar.xml
@@ -94,7 +94,7 @@
                             android:gravity="center"
                             android:importantForAccessibility="no"
                             android:padding="4dp"
-                            android:src="@drawable/ic_ddg_logo"
+                            app:srcCompat="@drawable/ic_ddg_logo"
                             android:visibility="gone" />
 
                         <ImageView


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204623212032711/f

### Description

On Android M devices, the DDG logo isn't rendering properly, showing only a circle. This PR switches to using `app:srcCompat` to reference the logo which fixes the issue.


### Steps to test this PR

Test **both** on an Android M device|emulator and a newer API

- [x] Clear through all the onboarding dialogs, doing some searches and opening new tabs until eventually you see the large DDG logo. Verify this renders correctly.
- [x] Perform a search; verify the dax icon inside the omnibar renders correctly
- [x] Click Overflow->Settings->About DuckDuckGo. Verify the DDG logo renders correctly
- [x] Add widget to home screen. Click the widget. Verify the dax icon inside the omnibar renders correctly


### UI changes
| Before  | After |
| ------ | ----- |
|![new-tab-before](https://github.com/duckduckgo/Android/assets/1336281/26904867-890b-4907-a5a0-0af41ec2a33c)|![new-tab-after](https://github.com/duckduckgo/Android/assets/1336281/dc35a819-6d33-4b38-8cf5-36e7865dbd32)|
![search-omnibar-before](https://github.com/duckduckgo/Android/assets/1336281/a64b34cb-77b4-40d5-a699-592b9ea2b09d)|![search-omnibar-after](https://github.com/duckduckgo/Android/assets/1336281/1fb9dd1d-c10f-42f2-83a8-ea5723daa9c4)
![about-before](https://github.com/duckduckgo/Android/assets/1336281/6bd54ddb-b248-41a6-8a9a-f4394bb2370e)|![about-after](https://github.com/duckduckgo/Android/assets/1336281/671835fe-ac2d-4903-ada8-fffbecb8c865)
![widget-launch-before](https://github.com/duckduckgo/Android/assets/1336281/f451bc25-10a5-4dbc-af1b-6f369bd36975)|![widget-launch-after](https://github.com/duckduckgo/Android/assets/1336281/97d70266-5d39-4348-9f6c-0f5142257d21)







