### PR TITLE
Add screen to show when we detect device can't support Logins

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsVie
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.InitialiseViewAfterUnlock
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.LaunchDeviceAuth
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowCredentialMode
+import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowDeviceUnsupportedMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowDisabledMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowListMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowLockedMode
@@ -52,6 +53,7 @@ import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsVie
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Locked
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.CredentialMode.Viewing
 import com.duckduckgo.autofill.impl.ui.credential.management.viewing.AutofillManagementCredentialsMode
+import com.duckduckgo.autofill.impl.ui.credential.management.viewing.AutofillManagementDeviceUnsupportedMode
 import com.duckduckgo.autofill.impl.ui.credential.management.viewing.AutofillManagementDisabledMode
 import com.duckduckgo.autofill.impl.ui.credential.management.viewing.AutofillManagementListMode
 import com.duckduckgo.autofill.impl.ui.credential.management.viewing.AutofillManagementLockedMode
@@ -162,6 +164,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
             is ShowUserPasswordCopied -> showCopiedToClipboardSnackbar(CopiedToClipboardDataType.Password)
             is ShowListMode -> showListMode()
             is ShowDisabledMode -> showDisabledMode()
+            is ShowDeviceUnsupportedMode -> showDeviceUnsupportedMode()
             is ShowLockedMode -> showLockMode()
             is LaunchDeviceAuth -> launchDeviceAuth()
             is InitialiseViewAfterUnlock -> setupInitialState()
@@ -250,6 +253,15 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
         }
     }
 
+    private fun showDeviceUnsupportedMode() {
+        resetToolbar()
+
+        supportFragmentManager.commit {
+            supportFragmentManager.findFragmentByTag(TAG_UNSUPPORTED)?.let { remove(it) }
+            replace(R.id.fragment_container_view, AutofillManagementDeviceUnsupportedMode.instance(), TAG_UNSUPPORTED)
+        }
+    }
+
     private fun resetToolbar() {
         setTitle(R.string.autofillManagementScreenTitle)
         binding.toolbar.menu.clear()
@@ -305,6 +317,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
         private const val EXTRAS_SUGGESTIONS_FOR_URL = "extras_suggestions_for_url"
         private const val TAG_LOCKED = "tag_fragment_locked"
         private const val TAG_DISABLED = "tag_fragment_disabled"
+        private const val TAG_UNSUPPORTED = "tag_fragment_unsupported"
         private const val TAG_CREDENTIAL = "tag_fragment_credential"
         private const val TAG_ALL_CREDENTIALS = "tag_fragment_credentials_list"
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsVie
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.InitialiseViewAfterUnlock
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.LaunchDeviceAuth
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowCredentialMode
+import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowDeviceUnsupportedMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowDisabledMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowListMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowLockedMode
@@ -192,6 +193,12 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     suspend fun launchDeviceAuth() {
+        if (!autofillStore.autofillAvailable) {
+            Timber.d("Can't access secure storage so can't offer autofill functionality")
+            deviceUnsupported()
+            return
+        }
+
         if (!deviceAuthenticator.hasValidDeviceAuthentication()) {
             Timber.d("Can't show device auth as there is no valid device authentication")
             disabled()
@@ -244,6 +251,14 @@ class AutofillSettingsViewModel @Inject constructor(
         addCommand(ExitLockedMode)
         addCommand(ShowDisabledMode)
         _viewState.value = _viewState.value.copy(credentialMode = Disabled)
+    }
+
+    private fun deviceUnsupported() {
+        // Remove backstack modes if they are present
+        addCommand(ExitListMode)
+        addCommand(ExitCredentialMode)
+        addCommand(ExitLockedMode)
+        addCommand(ShowDeviceUnsupportedMode)
     }
 
     private fun addCommand(command: Command) {
@@ -420,6 +435,7 @@ class AutofillSettingsViewModel @Inject constructor(
         object ShowListMode : Command()
         object ShowCredentialMode : Command()
         object ShowDisabledMode : Command()
+        object ShowDeviceUnsupportedMode : Command()
         object ShowLockedMode : Command()
         object LaunchDeviceAuth : Command()
         object ExitCredentialMode : Command()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDeviceUnsupportedMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDeviceUnsupportedMode.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.management.viewing
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.global.DuckDuckGoFragment
+import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementDeviceUnsupportedBinding
+import com.duckduckgo.di.scopes.FragmentScope
+
+@InjectWith(FragmentScope::class)
+class AutofillManagementDeviceUnsupportedMode : DuckDuckGoFragment() {
+
+    private lateinit var binding: FragmentAutofillManagementDeviceUnsupportedBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = FragmentAutofillManagementDeviceUnsupportedBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    companion object {
+        fun instance() = AutofillManagementDeviceUnsupportedMode()
+    }
+}

--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_device_unsupported.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_device_unsupported.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2022 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorPrimaryDark"
+    android:fillViewport="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/disabled_icon"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="80dp"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_autofill_keychain"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+            android:id="@+id/disabled_title"
+            app:typography="h2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/keyline_7"
+            android:layout_marginTop="@dimen/keyline_2"
+            android:breakStrategy="balanced"
+            android:gravity="center"
+            android:text="@string/deviceNotSupportedTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/disabled_icon" />
+
+        <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+            android:id="@+id/disabled_subtitle"
+            app:textType="secondary"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/keyline_7"
+            android:layout_marginTop="@dimen/keyline_4"
+            android:breakStrategy="balanced"
+            android:gravity="center"
+            android:text="@string/deviceNotSupportedSubtitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:paddingBottom="@dimen/keyline_5"
+            app:layout_constraintTop_toBottomOf="@+id/disabled_title" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -19,4 +19,8 @@
     <string name="autofill_password_generation_offer_message">Password will be saved in Logins.</string>
     <string name="autofill_password_generation_offer_accept">Use Generated Password</string>
     <string name="autofill_password_generation_offer_decline">Create My Own</string>
+
+    <string name="deviceNotSupportedTitle">Device not supported</string>
+    <string name="deviceNotSupportedSubtitle">To store Logins securely, we need to encrypt and store them on your device. Because your device does not support encrypted storage, Logins is unavailable.</string>
+
 </resources>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -383,7 +383,27 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
+    fun whenLaunchDeviceAuthWithDeviceUnsupportedThenEmitUnsupportedModeCommand() = runTest {
+        configureDeviceToBeUnsupported()
+        testee.launchDeviceAuth()
+
+        testee.commands.test {
+            assertEquals(
+                listOf(
+                    ExitListMode,
+                    ExitCredentialMode,
+                    ExitLockedMode,
+                    ShowDeviceUnsupportedMode,
+                ),
+                this.expectMostRecentItem().toList(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenLaunchDeviceAuthThenUpdateStateToIsAuthenticatingAndEmitLaunchDeviceCommand() = runTest {
+        configureDeviceToBeSupported()
         configureDeviceToHaveValidAuthentication(true)
         configureStoreToHaveThisManyCredentialsStored(1)
         testee.launchDeviceAuth()
@@ -423,6 +443,7 @@ class AutofillSettingsViewModelTest {
 
     @Test
     fun whenLaunchedDeviceAuthHasEndedAndLaunchedAgainThenEmitLaunchDeviceCommandTwice() = runTest {
+        configureDeviceToBeSupported()
         configureDeviceToHaveValidAuthentication(true)
         configureStoreToHaveThisManyCredentialsStored(1)
         testee.launchDeviceAuth()
@@ -439,6 +460,7 @@ class AutofillSettingsViewModelTest {
 
     @Test
     fun whenLaunchDeviceAuthWithNoValidAuthenticationThenShowDisabledViewAndAuthNotLaunched() = runTest {
+        configureDeviceToBeSupported()
         configureDeviceToHaveValidAuthentication(false)
         testee.launchDeviceAuth()
         testee.commands.test {
@@ -501,6 +523,14 @@ class AutofillSettingsViewModelTest {
 
     private fun configureDeviceToHaveValidAuthentication(hasValidAuth: Boolean) {
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(hasValidAuth)
+    }
+
+    private fun configureDeviceToBeUnsupported() {
+        whenever(mockStore.autofillAvailable).thenReturn(false)
+    }
+
+    private fun configureDeviceToBeSupported() {
+        whenever(mockStore.autofillAvailable).thenReturn(true)
     }
 
     private fun someCredentials(): LoginCredentials {

--- a/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
+++ b/secure-storage/secure-storage-impl/src/main/java/com/duckduckgo/securestorage/impl/RealSecureStorage.kt
@@ -29,6 +29,7 @@ import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
@@ -97,7 +98,7 @@ class RealSecureStorage @Inject constructor(
                 }
             }
         } else {
-            emptyFlow()
+            flowOf(emptyList())
         }
 
     override suspend fun websiteLoginDetailsWithCredentials(): Flow<List<WebsiteLoginDetailsWithCredentials>> =
@@ -110,7 +111,7 @@ class RealSecureStorage @Inject constructor(
                 }
             }
         } else {
-            emptyFlow()
+            flowOf(emptyList())
         }
 
     override suspend fun updateWebsiteLoginDetailsWithCredentials(

--- a/secure-storage/secure-storage-impl/src/test/java/com/duckduckgo/securestorage/impl/RealSecureStorageTest.kt
+++ b/secure-storage/secure-storage-impl/src/test/java/com/duckduckgo/securestorage/impl/RealSecureStorageTest.kt
@@ -235,20 +235,22 @@ class RealSecureStorageTest {
     }
 
     @Test
-    fun whenNoSecureStorageRepositoryGetWebsiteCredentialsForDomainThenFlowReturnsNothing() = runTest {
+    fun whenNoSecureStorageRepositoryGetWebsiteCredentialsForDomainThenFlowReturnsEmptyList() = runTest {
         setUpNoSecureStorageRepository()
 
         testee.websiteLoginDetailsWithCredentialsForDomain("test").test {
-            this.awaitComplete()
+            assertTrue(this.awaitItem().isEmpty())
+            this.cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun whenNoSecureStorageRepositoryGetWebsiteCredentialsThenFlowReturnsNothing() = runTest {
+    fun whenNoSecureStorageRepositoryGetWebsiteCredentialsThenFlowReturnsEmptyList() = runTest {
         setUpNoSecureStorageRepository()
 
         testee.websiteLoginDetailsWithCredentials().test {
-            this.awaitComplete()
+            assertTrue(this.awaitItem().isEmpty())
+            this.cancelAndIgnoreRemainingEvents()
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204628156369973/f

### Description
Adds a screen which shows when a user tries to access Logins on a device where it is unsupported. Unsupported devices are where we can't access EncryptedSharedPreferences.

There's about to be another set of autofill string changes coming that will bring translations for this along with it.

### Steps to test this PR

_Logins still works as normal_
- [x] Access Overflow->Logins
- [x] Add a login
- [x] Verify it still works as normal

_Simulate an supported device_
- [x] Modify `RealSecureStorageKeyStore.encryptedPreferences()` so that it returns `null`. Build and install.
- [x] Access Overflow->Logins
- [x] Verify you see the "Device not supported" screen
- [x] Verify you can't do anything else in there (e.g., can't add a login)

### UI changes
<img src="https://github.com/duckduckgo/Android/assets/1336281/2ca8a8ca-4161-4104-aec6-5a6952deee73" width="50%" />

