### PR TITLE
Update reference tests to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.16.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1684247991"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1684508073"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -89,7 +89,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#7a700510121a715cdc31ef8562601ae34207ee1a",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#e03d1bb77d2dbf3394c73d31e656592c5cf3c0b0",
       "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -272,9 +272,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.1.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.7.tgz",
-      "integrity": "sha512-WCuw/o4GSwDGMoonES8rcvwsig77dGCMbZDrZr2x4ZZiNW4P/gcoZXe/0twgtobcTkmg9TuKflxYL/DuwDyJzg==",
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.3.tgz",
+      "integrity": "sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==",
       "dev": true
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.0.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.16.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1684247991"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1684508073"
   }
 }

--- a/privacy-config/privacy-config-impl/src/test/resources/reference_tests/trackingparameters/config_reference.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/reference_tests/trackingparameters/config_reference.json
@@ -11,10 +11,32 @@
             ],
             "settings": {
                 "parameters": [
-                    "utm_[a-z]+",
-                    "reg*exp",
+                    "utm_source",
+                    "utm_medium",
+                    "utm_campaign",
+                    "utm_term",
+                    "utm_content",
                     "gclid",
-                    "fbclid"
+                    "fbclid",
+                    "fb_action_ids",
+                    "fb_action_types",
+                    "fb_source",
+                    "fb_ref",
+                    "ga_source",
+                    "ga_medium",
+                    "ga_term",
+                    "ga_content",
+                    "ga_campaign",
+                    "ga_place",
+                    "action_object_map",
+                    "action_type_map",
+                    "action_ref_map",
+                    "gs_l",
+                    "mkt_tok",
+                    "hmb_campaign",
+                    "hmb_source",
+                    "hmb_medium",
+                    "bad."
                 ]
             }
         }

--- a/privacy-config/privacy-config-impl/src/test/resources/reference_tests/trackingparameters/tests.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/reference_tests/trackingparameters/tests.json
@@ -41,24 +41,6 @@
                 "exceptPlatforms": []
             },
             {
-                "name": "Tracking parameters that match a regular expression are removed",
-                "testURL": "http://www.example.com/test.html?utm_source=test&utm_medium=test&utm_campaign=test&utm_term=test&utm_content=test",
-                "expectURL": "http://www.example.com/test.html",
-                "exceptPlatforms": []
-            },
-            {
-                "name": "Tracking parameters that only case-insensitively match a regular expressions are not removed",
-                "testURL": "http://www.example.com/test.html?utm_NOPE=test",
-                "expectURL": "http://www.example.com/test.html?utm_NOPE=test",
-                "exceptPlatforms": []
-            },
-            {
-                "name": "Tracking parameters only literally matching regular expression are not removed",
-                "testURL": "http://www.example.com/test.html?reg*exp=test&regexp=test",
-                "expectURL": "http://www.example.com/test.html?reg*exp=test",
-                "exceptPlatforms": []
-            },
-            {
                 "name": "Duplicate plain-text tracking parameters are removed",
                 "testURL": "http://www.example.com/test.html?gclid=123&gclid=456&test=test&gclid=789",
                 "expectURL": "http://www.example.com/test.html?test=test",
@@ -117,7 +99,7 @@
             },
             {
                 "name": "Tracking parameters are removed correctly even when some parameters have no value",
-                "testURL": "http://www.example.com/test.html?a=123&fbclid&gclid&regexp&utm_tracker&b=456",
+                "testURL": "http://www.example.com/test.html?a=123&fbclid&gclid&b=456",
                 "expectURL": "http://www.example.com/test.html?a=123&b=456",
                 "exceptPlatforms": []
             },
@@ -132,6 +114,24 @@
                 "testURL": "http://www.example.com/test.html?c=%7B%7D&d=20220406%2Fus-east-1",
                 "expectURL": "http://www.example.com/test.html?c=%7B%7D&d=20220406%2Fus-east-1",
                 "exceptPlatforms": []
+            },
+            {
+                "name": "Ensure URLs aren't malformed by percent encoding",
+                "testURL": "https://example.com/trk/v1?prof=5555&camp=55559&kct=blah&kchid=123456&criteriaid=blah:blah&campaignid=55556666888&locphy=1234&adgroupid=5555555555&cid=6765676&kdv=g&kext=&kpg=&kpid=&queryStr=blah%20blah&url=https://www.example2.com/landing?show=all&CMP_ID=123456=6666&k_clickid=_1234567_666&utm_id=very-long_string:with-many_symbols&msclkid=1234237546jsdhgkjshf&utm_source=blah&utm_medium=test&utm_campaign=p%3AB%20%7C%20s%3ABC%20%7C%20ct%3ANBPS%20%7C%20ct2%3Axx%20%7C%20g%3Axx%20%7C%20c1%3ABike%20%7C%20c2%3ATrainers%2BAccessories%20%7C%20b%3AWahoo%20Fitness%20%7C%20mt%3Axx&utm_term=blah%20blah&utm_content=blah%20blah%20%E2%80%94%20General%20Terms",
+                "expectURL": "https://example.com/trk/v1?prof=5555&camp=55559&kct=blah&kchid=123456&criteriaid=blah:blah&campaignid=55556666888&locphy=1234&adgroupid=5555555555&cid=6765676&kdv=g&kext=&kpg=&kpid=&queryStr=blah%20blah&url=https://www.example2.com/landing?show=all&CMP_ID=123456=6666&k_clickid=_1234567_666&utm_id=very-long_string:with-many_symbols&msclkid=1234237546jsdhgkjshf",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Ensure parameters aren't treated as a regex if they have special characters",
+                "testURL": "https://example.com/test.html?badx=123",
+                "expectURL": "https://example.com/test.html?badx=123",
+                "exceptPlatforms": [
+                    "ios-browser",
+                    "macos-browser",
+                    "safari-extension",
+                    "android-browser",
+                    "windows-browser"
+                ]
             }
         ]
     }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [x] All tests must pass