### PR TITLE
Ensure best autofill match is always primary button style

### DIFF
--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/RealAutofillSelectCredentialsListBuilderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/RealAutofillSelectCredentialsListBuilderTest.kt
@@ -88,7 +88,7 @@ class RealAutofillSelectCredentialsListBuilderTest {
     }
 
     @Test
-    fun whenNoPerfectMatchesAndOnePartialMatchThenPartialMatchAddedAsSecondaryButton() {
+    fun whenNoPerfectMatchesAndOnePartialMatchThenPartialMatchAddedAsPrimaryButton() {
         val sortedGroup = Groups(
             perfectMatches = emptyList(),
             partialMatches = mapOf(
@@ -96,7 +96,20 @@ class RealAutofillSelectCredentialsListBuilderTest {
             ),
         )
         val list = testee.buildFlatList(sortedGroup)
-        list[1].assertIsSecondaryButton()
+        list[1].assertIsPrimaryButton()
+    }
+
+    @Test
+    fun whenNoPerfectMatchesAndTwoPartialMatchesInSameDomainThenFirstPartialMatchAddedAsPrimaryButton() {
+        val sortedGroup = Groups(
+            perfectMatches = emptyList(),
+            partialMatches = mapOf(
+                Pair("foo.example.com", listOf(creds(), creds())),
+            ),
+        )
+        val list = testee.buildFlatList(sortedGroup)
+        list[1].assertIsPrimaryButton()
+        list[2].assertIsSecondaryButton()
     }
 
     @Test
@@ -125,6 +138,22 @@ class RealAutofillSelectCredentialsListBuilderTest {
     }
 
     @Test
+    fun whenNoPerfectMatchesAndMultiplePartialMatchesAcrossSitesThenFirstPartialMatchAddedAsPrimaryButton() {
+        val sortedGroup = Groups(
+            perfectMatches = emptyList(),
+            partialMatches = mapOf(
+                Pair("foo.example.com", listOf(creds(), creds())),
+                Pair("bar.example.com", listOf(creds(), creds())),
+            ),
+        )
+        val list = testee.buildFlatList(sortedGroup)
+        list[1].assertIsPrimaryButton()
+        list[2].assertIsSecondaryButton()
+        list[4].assertIsSecondaryButton()
+        list[5].assertIsSecondaryButton()
+    }
+
+    @Test
     fun whenPerfectMatchesAndMultiplePartialMatchesThenListOutputAsExpected() {
         val sortedGroup = Groups(
             perfectMatches = listOf(creds(), creds()),
@@ -145,15 +174,21 @@ class RealAutofillSelectCredentialsListBuilderTest {
         list[6].assertIsSecondaryButton()
     }
 
-    private fun ListItem.assertIsVerticalSpacing() = assertTrue(this is VerticalSpacing)
-    private fun ListItem.assertIsPrimaryButton() = assertTrue(this is ListItem.CredentialPrimaryType)
-    private fun ListItem.assertIsSecondaryButton() = assertTrue(this is ListItem.CredentialSecondaryType)
+    private fun ListItem.assertIsVerticalSpacing() = assertTrue("Not vertical spacing; is ${this.javaClass.simpleName}", this is VerticalSpacing)
+    private fun ListItem.assertIsPrimaryButton() = assertTrue(
+        "Not primary button; is ${this.javaClass.simpleName}",
+        this is ListItem.CredentialPrimaryType,
+    )
+    private fun ListItem.assertIsSecondaryButton() = assertTrue(
+        "Not secondary button; is ${this.javaClass.simpleName}",
+        this is ListItem.CredentialSecondaryType,
+    )
     private fun ListItem.assertIsDomainGroupHeading(name: String) {
-        assertTrue(this is GroupHeading)
+        assertTrue("Not a group heading; is ${this.javaClass.simpleName}", this is GroupHeading)
         assertEquals(String.format("From %s", name), (this as GroupHeading).label)
     }
     private fun ListItem.assertIsFromThisWebsiteGroupHeading() {
-        assertTrue(this is GroupHeading)
+        assertTrue("Not a group heading; is ${this.javaClass.simpleName}", this is GroupHeading)
         assertEquals("From This Website", (this as GroupHeading).label)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204391947652312/f

### Description
When offering to autofill saved logins, we show a list of matching logins. Previously, we'd only apply the primary button style to the first URL which perfectly matched the current page.

With this PR, we instead apply the primary button style to the first URL in the list, regardless of whether that is for a perfect or partial match.


### Steps to test this PR

#### Multiple perfect matches, multiple partial matches
- [x] Visit `Settings->Logins`, and tap the `+` button to manually add the following entries (add username+password to all):
    - [x] url = `fill.dev`
    - [x] url = `fill.dev`
    - [x] url = `foo.fill.dev`
    - [x] url = `foo.fill.dev`
    - [x] url = `bar.fill.dev`
    - [x] url = `bar.fill.dev`
- [x] Visit https://fill.dev/form/login-simple
- [x] Verify the prompt that shows has the very top button (which is a perfect match) as a primary button style
- [x] Verify all other buttons are secondary button style

#### No perfect matches, multiple partial matches
- [x] Visit `Settings->Logins` and manually delete both `fill.dev` perfect matches
- [x] Visit https://fill.dev/form/login-simple (or refresh the page if still there)
- [x] Verify the prompt that shows has the very top button (which is a partial match) as a primary button style
- [x] Verify all other buttons are secondary button style

### UI changes
| Before  | After |
| ------ | ----- |
![2023-05-22-before](https://github.com/duckduckgo/Android/assets/1336281/f14e3d72-8786-4057-a387-abd20bc4bc70)|![2023-05-22-after](https://github.com/duckduckgo/Android/assets/1336281/d9f26d90-3258-439e-959f-94209e13882e)
