### PR TITLE
Show snackbar with UNDO button when deleting a login

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/domain/app/LoginCredentials.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/domain/app/LoginCredentials.kt
@@ -33,7 +33,11 @@ data class LoginCredentials(
     val lastUpdatedMillis: Long? = null,
 ) : Parcelable {
     override fun toString(): String {
-        return "LoginCredentials(id=$id, domain=$domain, username=$username, password=********," +
-            " domainTitle=$domainTitle, lastUpdatedMillis=$lastUpdatedMillis, notes=$notes"
+        return """
+            LoginCredentials(
+                id=$id, domain=$domain, username=$username, password=********, domainTitle=$domainTitle, 
+                lastUpdatedMillis=$lastUpdatedMillis, notesLength=${notes?.length ?: 0}
+            )
+        """.trimIndent()
     }
 }

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/store/AutofillStore.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/store/AutofillStore.kt
@@ -94,8 +94,9 @@ interface AutofillStore {
 
     /**
      * Deletes the credential with the given ID
+     * @return the deleted LoginCredentials, or null if the deletion couldn't be performed
      */
-    suspend fun deleteCredentials(id: Long)
+    suspend fun deleteCredentials(id: Long): LoginCredentials?
 
     /**
      * Updates the given login credentials, replacing what was saved before for the credentials with the specified ID
@@ -103,6 +104,14 @@ interface AutofillStore {
      * @return The saved credential if it saved successfully, otherwise null
      */
     suspend fun updateCredentials(credentials: LoginCredentials): LoginCredentials?
+
+    /**
+     * Used to reinsert a credential that was previously deleted
+     * This supports the ability to give user a brief opportunity to 'undo' a deletion
+     *
+     * This is similar to a normal save, except it will preserve the original ID and last modified time
+     */
+    suspend fun reinsertCredentials(credentials: LoginCredentials)
 
     /**
      * Searches the saved login credentials for a match to the given URL, username and password

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsVie
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ExitLockedMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.InitialiseViewAfterUnlock
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.LaunchDeviceAuth
+import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.OfferUserUndoDeletion
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowCredentialMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowDeviceUnsupportedMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ShowDisabledMode
@@ -162,6 +163,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
             is ShowCredentialMode -> showCredentialMode()
             is ShowUserUsernameCopied -> showCopiedToClipboardSnackbar(CopiedToClipboardDataType.Username)
             is ShowUserPasswordCopied -> showCopiedToClipboardSnackbar(CopiedToClipboardDataType.Password)
+            is OfferUserUndoDeletion -> showUserCredentialDeletedWithUndoAction(command)
             is ShowListMode -> showListMode()
             is ShowDisabledMode -> showDisabledMode()
             is ShowDeviceUnsupportedMode -> showDeviceUnsupportedMode()
@@ -186,6 +188,16 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
             is CopiedToClipboardDataType.Password -> R.string.autofillManagementPasswordCopied
         }
         Snackbar.make(binding.root, getString(stringResourceId), Snackbar.LENGTH_SHORT).show()
+    }
+
+    private fun showUserCredentialDeletedWithUndoAction(command: OfferUserUndoDeletion) {
+        val snackbar = Snackbar.make(binding.root, R.string.autofillManagementDeletedConfirmation, Snackbar.LENGTH_LONG)
+        if (command.credentials != null) {
+            snackbar.setAction(R.string.autofillManagementUndoDeletion) {
+                viewModel.reinsertCredentials(command.credentials)
+            }
+        }
+        snackbar.show()
     }
 
     private fun showListMode() {
@@ -284,6 +296,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
             searchBar.hideKeyboard()
         }
     }
+
     private fun isSearchBarVisible(): Boolean = binding.searchBar.isVisible
 
     override fun onBackPressed() {

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -23,4 +23,7 @@
     <string name="deviceNotSupportedTitle">Device not supported</string>
     <string name="deviceNotSupportedSubtitle">To store Logins securely, we need to encrypt and store them on your device. Because your device does not support encrypted storage, Logins is unavailable.</string>
 
+    <string name="autofillManagementDeletedConfirmation">Login deleted</string>
+    <string name="autofillManagementUndoDeletion">Undo</string>
+
 </resources>

--- a/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-store/src/test/java/com/duckduckgo/autofill/store/SecureStoreBackedAutofillStoreTest.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -413,6 +414,31 @@ class SecureStoreBackedAutofillStoreTest {
 
         val results = testee.getCredentials(visitedSite)
         assertEquals(1, results.size)
+    }
+
+    @Test
+    fun whenReinsertingLoginCredentialsThenAllFieldsPreserved() = runTest {
+        setupTesteeWithAutofillAvailable()
+        val originalCredentials = LoginCredentials(
+            id = 123,
+            domain = "example.com",
+            username = "user",
+            password = "abc123",
+            domainTitle = "title",
+            notes = "notes",
+            lastUpdatedMillis = 1000,
+        )
+        testee.reinsertCredentials(originalCredentials)
+
+        val reinsertedCredentials = secureStore.getWebsiteLoginDetailsWithCredentials(123)
+        assertNotNull("Failed to find credentials", reinsertedCredentials)
+        assertEquals(originalCredentials.id, reinsertedCredentials!!.details.id)
+        assertEquals(originalCredentials.username, reinsertedCredentials.details.username)
+        assertEquals(originalCredentials.domain, reinsertedCredentials.details.domain)
+        assertEquals(originalCredentials.domainTitle, reinsertedCredentials.details.domainTitle)
+        assertEquals(originalCredentials.lastUpdatedMillis, reinsertedCredentials.details.lastUpdatedMillis)
+        assertEquals(originalCredentials.notes, reinsertedCredentials.notes)
+        assertEquals(originalCredentials.password, reinsertedCredentials.password)
     }
 
     private fun List<LoginCredentials>.assertHasNoLoginCredentials(

--- a/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorageModels.kt
+++ b/secure-storage/secure-storage-api/src/main/java/com/duckduckgo/securestorage/api/SecureStorageModels.kt
@@ -27,7 +27,15 @@ data class WebsiteLoginDetailsWithCredentials(
     val details: WebsiteLoginDetails,
     val password: String?,
     val notes: String? = null,
-)
+) {
+    override fun toString(): String {
+        return """
+            WebsiteLoginDetailsWithCredentials(
+                "details=$details, password=********, notesLength=${notes?.length ?: 0}"
+            )
+        """.trimIndent()
+    }
+}
 
 /**
  * Public data class that wraps all data that should only be covered with l1 encryption.
@@ -45,4 +53,12 @@ data class WebsiteLoginDetails(
     val id: Long? = null,
     val domainTitle: String? = null,
     val lastUpdatedMillis: Long? = null,
-)
+) {
+    override fun toString(): String {
+        return """
+            WebsiteLoginDetails(
+                id=$id, username=$username, domainTitle=$domainTitle, lastUpdatedMillis=$lastUpdatedMillis
+            )
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204238566022609/f

### Description
Adds a snackbar shown to the user after they delete a login from the login management screen (both in list view, and in details view). 

The snackbar will have an UNDO button on it, which will reinsert the login credential back into the DB if pressed.


🌏 Translations will follow separately.


### Steps to test this PR

#### Deleting (not tapping undo): from the details screen
- [x] Add a login (Settings->Logins-> `+` button)
- [x] Tap on the overflow menu top right, and choose to **Delete**. Confirm deletion.
- [x] Verify you see the snackbar showing login was deleted
- [x] Verify you are returned to the list view
- [x] Verify the credential is deleted

#### Deleting (AND tapping undo): from the details screen
- [x] Add a login (Settings->Logins-> `+` button).
- [x] Tap on the overflow menu top right, and choose to **Delete**. Confirm deletion.
- [x] Verify you see the snackbar showing login was deleted
- [x] Verify you are returned to the list view
- [x] Verify the credential is deleted
- [x] Tap the snackbar's UNDO button
- [x] Verify the credential reappears and has the same contents


#### Deleting (not tapping undo): from the list view
- [x] Add a login (Settings->Logins-> `+` button)
- [x] Hit back to return to the list view
- [x] Tap on the overflow menu on the login credential, and choose to **Delete**. Confirm deletion.
- [x] Verify you see the snackbar showing login was deleted
- [x] Verify the credential is deleted

#### Deleting (AND tapping undo): from the list view
- [x] Add a login (Settings->Logins-> `+` button)
- [x] Hit back to return to the list view
- [x] Tap on the overflow menu on the login credential, and choose to **Delete**. Confirm deletion.
- [x] Verify you see the snackbar showing login was deleted
- [x] Tap the snackbar's UNDO button
- [x] Verify the credential reappears and has the same contents


### UI changes
<img src="https://github.com/duckduckgo/Android/assets/1336281/f2620528-4dbd-4622-8df0-255d60ab0cf8" width="50%" />
