### PR TITLE
Display correct number of tracking companies

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/TrackerFeedAdapter.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/TrackerFeedAdapter.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.mobile.android.ui.view.gone
 import com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
 import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.vpn.R
+import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerCompanyBadge
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerFeedItem
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.view.AppsProtectionStateView
 import com.duckduckgo.mobile.android.vpn.ui.util.TextDrawable
@@ -178,8 +179,14 @@ class TrackerFeedAdapter @Inject constructor(
             tracker?.let { item ->
                 with(activityMessage) {
                     val trackersCount = tracker.trackersTotalCount
-                    val trackingCompanies = tracker.trackingCompanyBadges.size
                     val trackingAppName = item.trackingApp.appDisplayName
+
+                    var trackingCompanies = tracker.trackingCompanyBadges.size
+                    if (tracker.trackingCompanyBadges.last() is TrackerCompanyBadge.Extra) {
+                        // Subtracting 1 since badge sizes contains the Extra icon with amount
+                        trackingCompanies += (tracker.trackingCompanyBadges.last() as TrackerCompanyBadge.Extra).amount - 1
+                    }
+
                     val textToStyle = if (trackersCount == 1) {
                         if (trackingCompanies == 1) {
                             resources.getString(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204670807847639/f

### Description
The AppTP tracking activity screen used to show an incorrect number of tracking companies. This PR fixes that.

### Steps to test this PR
- [x] Install from this branch
- [x] Allow AppTP to protect Chrome
- [x] Open Chrome and visit `cnn.com` (or any other website with many trackers)
- [x] Go back to AppTP tracking activity screen
- [x] Make sure there are more than 6 tracking companies detected for Chrome (if not, keep using Chrome)
- [x] Verify that the displayed number of tracking companies is correct when there are more than 7+ companies (see Asana task for screenshots)
