### PR TITLE
ADS: Allow set endIcon programmatically on TextInput component

### DIFF
--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/textinput/ComponentTextInputFragment.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/textinput/ComponentTextInputFragment.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.databinding.ComponentTextInputViewBinding
 import com.duckduckgo.mobile.android.ui.view.text.TextInput.Action
 import com.google.android.material.snackbar.Snackbar
@@ -45,7 +46,10 @@ class ComponentTextInputFragment : Fragment() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        binding.outlinedinputtext4.onAction { toastOnClick(it) }
+        binding.outlinedinputtext4.apply {
+            setEndIcon(R.drawable.ic_copy)
+            onAction { toastOnClick(it) }
+        }
         binding.outlinedinputtext6.onAction { toastOnClick(it) }
         binding.outlinedinputtext8.onAction { toastOnClick(it) }
         binding.outlinedinputtext20.onAction { toastOnClick(it) }

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
@@ -55,9 +55,11 @@ interface TextInput {
     fun addTextChangedListener(textWatcher: TextWatcher)
     fun removeTextChangedListener(textWatcher: TextWatcher)
     fun setEndIcon(
-        @DrawableRes endIconRes: Int?,
+        @DrawableRes endIconRes: Int,
         contentDescription: String? = null,
     )
+
+    fun removeEndIcon()
 
     fun onAction(actionHandler: (Action) -> Unit)
 
@@ -172,20 +174,20 @@ class DaxTextInput @JvmOverloads constructor(
     }
 
     override fun setEndIcon(
-        endIconRes: Int?,
+        endIconRes: Int,
         contentDescription: String?,
     ) {
-        if (endIconRes != null) {
-            ContextCompat.getDrawable(context, endIconRes)?.let {
-                setupEndIconDrawable(it, contentDescription.orEmpty())
-            }
-        } else {
-            binding.internalInputLayout.apply {
-                endIconMode = END_ICON_NONE
-                endIconDrawable = null
-                isEndIconVisible = false
-                endIconContentDescription = null
-            }
+        ContextCompat.getDrawable(context, endIconRes)?.let {
+            setupEndIconDrawable(it, contentDescription.orEmpty())
+        }
+    }
+
+    override fun removeEndIcon() {
+        binding.internalInputLayout.apply {
+            endIconMode = END_ICON_NONE
+            endIconDrawable = null
+            isEndIconVisible = false
+            endIconContentDescription = null
         }
     }
 

--- a/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
+++ b/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
@@ -29,7 +29,9 @@ import android.util.SparseArray
 import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.view.inputmethod.EditorInfo
+import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.postDelayed
 import androidx.core.view.updateLayoutParams
@@ -52,6 +54,10 @@ interface TextInput {
 
     fun addTextChangedListener(textWatcher: TextWatcher)
     fun removeTextChangedListener(textWatcher: TextWatcher)
+    fun setEndIcon(
+        @DrawableRes endIconRes: Int?,
+        contentDescription: String? = null,
+    )
 
     fun onAction(actionHandler: (Action) -> Unit)
 
@@ -81,7 +87,7 @@ class DaxTextInput @JvmOverloads constructor(
         ).apply {
             text = getString(R.styleable.DaxTextInput_android_text).orEmpty()
             getDrawable(R.styleable.DaxTextInput_endIcon)?.let {
-                setupEndIcon(it, getString(R.styleable.DaxTextInput_endIconContentDescription).orEmpty())
+                setupEndIconDrawable(it, getString(R.styleable.DaxTextInput_endIconContentDescription).orEmpty())
             }
 
             // This needs to be done after we know that the view has the end icon set
@@ -165,13 +171,31 @@ class DaxTextInput @JvmOverloads constructor(
         binding.internalEditText.removeTextChangedListener(textWatcher)
     }
 
+    override fun setEndIcon(
+        endIconRes: Int?,
+        contentDescription: String?,
+    ) {
+        if (endIconRes != null) {
+            ContextCompat.getDrawable(context, endIconRes)?.let {
+                setupEndIconDrawable(it, contentDescription.orEmpty())
+            }
+        } else {
+            binding.internalInputLayout.apply {
+                endIconMode = END_ICON_NONE
+                endIconDrawable = null
+                isEndIconVisible = false
+                endIconContentDescription = null
+            }
+        }
+    }
+
     override fun onAction(actionHandler: (Action) -> Unit) {
         binding.internalInputLayout.setEndIconOnClickListener {
             actionHandler(PerformEndAction)
         }
     }
 
-    private fun setupEndIcon(
+    private fun setupEndIconDrawable(
         drawable: Drawable,
         contentDescription: String,
     ) {

--- a/common-ui/src/main/res/layout/component_text_input_view.xml
+++ b/common-ui/src/main/res/layout/component_text_input_view.xml
@@ -58,8 +58,7 @@
             android:layout_marginTop="@dimen/keyline_3"
             android:hint="Non-editable text with end icon"
             android:text="This is not editable."
-            app:editable="false"
-            app:endIcon="@drawable/ic_copy" />
+            app:editable="false" />
 
         <com.duckduckgo.mobile.android.ui.view.text.DaxTextInput
             android:id="@+id/outlinedinputtext5"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204667366884988/f

### Description
Added `fun setEndIcon(endIconRes: Int?, contentDescription: String? = null)` method to TextInput interface so we can edit it programmatically and not only from the xml file

### Steps to test this PR (Optional)

- Install from this branch
- Go to Settings > App Components Design Preview
- Select Text Input tab
- [ ] Check there is an end icon set on the 3rd item (Non-editable text with end icon)

### No UI changes
