### PR TITLE
Android: Fix whenDownloadUrlIsTooLargeAndToInputDataCalledThenAddCompressedUrl

### DIFF
--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/PendingFileDownloadCompressTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/PendingFileDownloadCompressTest.kt
@@ -22,14 +22,12 @@ import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class PendingFileDownloadCompressTest {
 
-    @Ignore
     @Test
     fun whenDownloadUrlIsTooLargeAndToInputDataCalledThenAddCompressedUrl() {
         val largeUrl =
@@ -38,7 +36,7 @@ class PendingFileDownloadCompressTest {
             """.trimIndent()
         val expectedEncodedUrl =
             """
-            H4sIAAAAAAAAAO3RTWrDMBAF4NOkq/woaROFgigl4HvIkrDV2FaQxk57+84kgQbvun+GkcfP1sjw
+            H4sIAAAAAAAA/+3RTWrDMBAF4NOkq/woaROFgigl4HvIkrDV2FaQxk57+84kgQbvun+GkcfP1sjw
             tUSX8r7ZuNZmWttLLOsmpaYLa5f6e/rh2mL2Sn1zvbi2t0Yt1XKrbsUBmQuvLpmqUnwtdqeqknah
             uTneE6UeyaORRFre6A0tXj+3ux2Hb7JstSzyzZFLz+owq70Uj+mMjNAyQssILSM0j9AnPavDrPZS
             8iedsYPPKXoOvuxk+VbIuvOKsnWBn+qcrHe2UA4uxClkzh5bVoM/89NYQl7ZJgz09Ooa6imGKyd/


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1200905986587319/1204686614376690/f

### Description
Updated test.

### Steps to test this PR
Tests in `PendingFileDownloadCompressTest` should pass.

### NO UI changes
