### PR TITLE
Update content scope scripts to latest version

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -2,50 +2,8 @@
 (function () {
     'use strict';
 
-    /* global false */
-
-    let dummyWindow;
-    if ('document' in globalThis &&
-        // Prevent infinate recursion of injection into Chrome
-        globalThis.location.href !== 'about:blank') {
-        const injectionElement = getInjectionElement();
-        // injectionElement is null in some playwright context tests
-        if (injectionElement) {
-            dummyWindow = document.createElement('iframe');
-            dummyWindow.style.display = 'none';
-            injectionElement.appendChild(dummyWindow);
-        }
-    }
-
-    let dummyContentWindow = dummyWindow?.contentWindow;
-    // @ts-expect-error - Symbol is not defined on window
-    const dummySymbol = dummyContentWindow?.Symbol;
-    const iteratorSymbol = dummySymbol?.iterator;
-
-    // Capture prototype to prevent overloading
-    function captureGlobal (globalName) {
-        const global = dummyWindow?.contentWindow?.[globalName];
-
-        // if we were unable to create a dummy window, return the global
-        // this still has the advantage of preventing aliasing of the global through shawdowing
-        if (!global) {
-            return globalThis[globalName]
-        }
-
-        // Alias the iterator symbol to the local symbol so for loops work
-        if (iteratorSymbol &&
-            global?.prototype &&
-            iteratorSymbol in global.prototype) {
-            global.prototype[Symbol.iterator] = global.prototype[iteratorSymbol];
-        }
-        return global
-    }
-
-    const Set$1 = captureGlobal('Set');
-    const Reflect$1 = captureGlobal('Reflect');
-
-    // Clean up the dummy window
-    dummyWindow?.remove();
+    const Set$1 = globalThis.Set;
+    const Reflect$1 = globalThis.Reflect;
 
     /* global cloneInto, exportFunction, false */
     // Tests don't define this variable so fallback to behave like chrome
@@ -2563,8 +2521,8 @@
             /** @satisfies {Storage} */
             const instance = new MemoryStorage();
             const storage = new Proxy(instance, {
-                set (target, prop, value, receiver) {
-                    Reflect$1.apply(target.setItem, target, [prop, value], receiver);
+                set (target, prop, value) {
+                    Reflect$1.apply(target.setItem, target, [prop, value]);
                     return true
                 },
                 get (target, prop) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.1.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.19.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.20.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1685458917"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4e56a8a23d5097b721fc517920c2582e660966d9",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#59894070863714a2ced7ad3cf5b9b11dd4cd53d4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.1.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.19.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.20.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1685458917"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass