### PR TITLE
Make VpnFeaturesRegistryImpl calls async

### DIFF
--- a/app-tracking-protection/app-tracking-api/src/main/java/com/duckduckgo/mobile/android/app/tracking/AppTrackerDetector.kt
+++ b/app-tracking-protection/app-tracking-api/src/main/java/com/duckduckgo/mobile/android/app/tracking/AppTrackerDetector.kt
@@ -16,15 +16,19 @@
 
 package com.duckduckgo.mobile.android.app.tracking
 
+import androidx.annotation.WorkerThread
+
 interface AppTrackerDetector {
     /**
-     * Evaluates whether the specified domain requested by the specified uid is a tracker
+     * Evaluates whether the specified domain requested by the specified uid is a tracker.
+     * This method should be called off the UI thread.
      *
      * @param domain the domain to evaluate
      * @param uid the uid of the app requesting the domain
      *
      * @return [AppTracker] if the request is a tracker, null otherwise
      */
+    @WorkerThread
     fun evaluate(domain: String, uid: Int): AppTracker?
 
     data class AppTracker(

--- a/app-tracking-protection/vpn-api-test/src/main/java/com/duckduckgo/mobile/android/vpn/FakeVpnFeaturesRegistry.kt
+++ b/app-tracking-protection/vpn-api-test/src/main/java/com/duckduckgo/mobile/android/vpn/FakeVpnFeaturesRegistry.kt
@@ -19,27 +19,27 @@ package com.duckduckgo.mobile.android.vpn
 class FakeVpnFeaturesRegistry : VpnFeaturesRegistry {
     private val features = mutableSetOf<String>()
 
-    override fun registerFeature(feature: VpnFeature) {
+    override suspend fun registerFeature(feature: VpnFeature) {
         features.add(feature.featureName)
     }
 
-    override fun unregisterFeature(feature: VpnFeature) {
+    override suspend fun unregisterFeature(feature: VpnFeature) {
         features.remove(feature.featureName)
     }
 
-    override fun isFeatureRunning(feature: VpnFeature): Boolean {
+    override suspend fun isFeatureRunning(feature: VpnFeature): Boolean {
         return features.contains(feature.featureName)
     }
 
-    override fun isFeatureRegistered(feature: VpnFeature): Boolean {
+    override suspend fun isFeatureRegistered(feature: VpnFeature): Boolean {
         return isFeatureRunning(feature)
     }
 
-    override fun isAnyFeatureRunning(): Boolean {
+    override suspend fun isAnyFeatureRunning(): Boolean {
         return features.isNotEmpty()
     }
 
-    override fun isAnyFeatureRegistered(): Boolean {
+    override suspend fun isAnyFeatureRegistered(): Boolean {
         return isAnyFeatureRunning()
     }
 
@@ -47,7 +47,7 @@ class FakeVpnFeaturesRegistry : VpnFeaturesRegistry {
         // no-op
     }
 
-    override fun getRegisteredFeatures(): List<VpnFeature> {
+    override suspend fun getRegisteredFeatures(): List<VpnFeature> {
         return features.map { VpnFeature { it } }
     }
 }

--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistry.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistry.kt
@@ -28,40 +28,40 @@ interface VpnFeaturesRegistry {
      * Call this method to register a feature that requires VPN access.
      * If the VPN is not enabled, it will be enabled.
      */
-    fun registerFeature(feature: VpnFeature)
+    suspend fun registerFeature(feature: VpnFeature)
 
     /**
      * Call this method to unregister a feature that requires VPN access.
      * If the VPN will be disabled if and only if this is the last registered feature.
      */
-    fun unregisterFeature(feature: VpnFeature)
+    suspend fun unregisterFeature(feature: VpnFeature)
 
     /**
      * @return `true` if this feature is registered and the VPN is running, `false` otherwise.
      */
-    fun isFeatureRunning(feature: VpnFeature): Boolean
+    suspend fun isFeatureRunning(feature: VpnFeature): Boolean
 
     /**
      * @return `true` if this feature is registered, `false` otherwise.
      */
-    fun isFeatureRegistered(feature: VpnFeature): Boolean
+    suspend fun isFeatureRegistered(feature: VpnFeature): Boolean
 
     /**
      * @return returns `true` if there's any feature currently using the VPN and the VPN is running, `false` otherwise
      */
-    fun isAnyFeatureRunning(): Boolean
+    suspend fun isAnyFeatureRunning(): Boolean
 
     /**
      * @return returns `true` if there's any feature currently using the VPN, `false` otherwise
      */
-    fun isAnyFeatureRegistered(): Boolean
+    suspend fun isAnyFeatureRegistered(): Boolean
 
     /**
      * Refreshing the feature will cause the VPN to be stopped/restarted if it is enabled and the feature is already registered.
      */
     suspend fun refreshFeature(feature: VpnFeature)
 
-    fun getRegisteredFeatures(): List<VpnFeature>
+    suspend fun getRegisteredFeatures(): List<VpnFeature>
 }
 
 interface VpnFeature {

--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/integration/VpnNetworkStackProvider.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/integration/VpnNetworkStackProvider.kt
@@ -30,5 +30,5 @@ interface VpnNetworkStackProvider {
      * CAll this method to get the VPN network stack to be used in the VPN service.
      */
     @Throws(IllegalStateException::class)
-    fun provideNetworkStack(): VpnNetworkStack
+    suspend fun provideNetworkStack(): VpnNetworkStack
 }

--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/network/ExternalVpnDetector.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/network/ExternalVpnDetector.kt
@@ -23,5 +23,5 @@ interface ExternalVpnDetector {
      *
      * @return returns a boolean that identifies the connection being routed through a VPN
      */
-    fun isExternalVpnDetected(): Boolean
+    suspend fun isExternalVpnDetected(): Boolean
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/app/tracking/NetpRealAppTrackerDetector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/app/tracking/NetpRealAppTrackerDetector.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerType
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
+import kotlinx.coroutines.runBlocking
 import logcat.logcat
 
 class NetpRealAppTrackerDetector constructor(
@@ -45,15 +46,16 @@ class NetpRealAppTrackerDetector constructor(
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : AppTrackerDetector {
 
-    private val isAppTpDisabled: Boolean
-        get() = !vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)
+    private fun isAppTpDisabled(): Boolean {
+        return runBlocking { !vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN) }
+    }
 
     // cache packageId -> app name
     private val appNamesCache = LruCache<String, AppNameResolver.OriginatingApp>(100)
 
     override fun evaluate(domain: String, uid: Int): AppTrackerDetector.AppTracker? {
         // Check if AppTP is enabled first
-        if (isAppTpDisabled) {
+        if (isAppTpDisabled()) {
             logcat { "App tracker detector is DISABLED" }
             return null
         }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
@@ -19,11 +19,14 @@ package com.duckduckgo.mobile.android.vpn
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentType
 import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentsManager
 import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import java.util.UUID
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 import logcat.logcat
 
 private const val PREFS_FILENAME = "com.duckduckgo.mobile.android.vpn.feature.registry.v1"
@@ -33,61 +36,72 @@ internal class VpnFeaturesRegistryImpl(
     private val vpnServiceWrapper: VpnServiceWrapper,
     private val sharedPreferencesProvider: VpnSharedPreferencesProvider,
     private val featureSegmentsManager: FeatureSegmentsManager,
+    private val dispatcherProvider: DispatcherProvider,
 ) : VpnFeaturesRegistry {
+
+    private val mutex = Mutex()
 
     private val preferences: SharedPreferences by lazy {
         sharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME, multiprocess = true, migrate = false)
     }
 
-    @Synchronized
-    override fun registerFeature(feature: VpnFeature) {
-        logcat { "registerFeature: $feature" }
-        preferences.edit(commit = true) {
-            // we use random UUID to force change listener to be called
-            putString(feature.featureName, UUID.randomUUID().toString())
-        }
-        vpnServiceWrapper.restartVpnService(forceRestart = true)
-        featureSegmentsManager.addUserToFeatureSegment(FeatureSegmentType.APP_TP_ENABLED)
-    }
-
-    @Synchronized
-    override fun unregisterFeature(feature: VpnFeature) {
-        if (!preferences.contains(feature.featureName)) return
-
-        preferences.edit(commit = true) {
-            remove(feature.featureName)
-        }
-
-        logcat { "unregisterFeature: $feature" }
-        if (registeredFeatures().isNotEmpty()) {
+    override suspend fun registerFeature(feature: VpnFeature) = withContext(dispatcherProvider.io()) {
+        mutex.lock()
+        try {
+            logcat { "registerFeature: $feature" }
+            preferences.edit(commit = true) {
+                // we use random UUID to force change listener to be called
+                putString(feature.featureName, UUID.randomUUID().toString())
+            }
             vpnServiceWrapper.restartVpnService(forceRestart = true)
-        } else {
-            vpnServiceWrapper.stopService()
+            featureSegmentsManager.addUserToFeatureSegment(FeatureSegmentType.APP_TP_ENABLED)
+        } finally {
+            mutex.unlock()
         }
     }
 
-    override fun isFeatureRunning(feature: VpnFeature): Boolean {
-        return isFeatureRegistered(feature) && vpnServiceWrapper.isServiceRunning()
+    override suspend fun unregisterFeature(feature: VpnFeature) = withContext(dispatcherProvider.io()) {
+        mutex.lock()
+        try {
+            if (preferences.contains(feature.featureName)) {
+                preferences.edit(commit = true) {
+                    remove(feature.featureName)
+                }
+
+                logcat { "unregisterFeature: $feature" }
+                if (registeredFeatures().isNotEmpty()) {
+                    vpnServiceWrapper.restartVpnService(forceRestart = true)
+                } else {
+                    vpnServiceWrapper.stopService()
+                }
+            }
+        } finally {
+            mutex.unlock()
+        }
     }
 
-    override fun isFeatureRegistered(feature: VpnFeature): Boolean {
-        return registeredFeatures().contains(feature.featureName)
+    override suspend fun isFeatureRunning(feature: VpnFeature): Boolean = withContext(dispatcherProvider.io()) {
+        return@withContext isFeatureRegistered(feature) && vpnServiceWrapper.isServiceRunning()
     }
 
-    override fun isAnyFeatureRunning(): Boolean {
-        return isAnyFeatureRegistered() && vpnServiceWrapper.isServiceRunning()
+    override suspend fun isFeatureRegistered(feature: VpnFeature): Boolean = withContext(dispatcherProvider.io()) {
+        return@withContext registeredFeatures().contains(feature.featureName)
     }
 
-    override fun isAnyFeatureRegistered(): Boolean {
-        return registeredFeatures().isNotEmpty()
+    override suspend fun isAnyFeatureRunning(): Boolean = withContext(dispatcherProvider.io()) {
+        return@withContext isAnyFeatureRegistered() && vpnServiceWrapper.isServiceRunning()
     }
 
-    override suspend fun refreshFeature(feature: VpnFeature) {
+    override suspend fun isAnyFeatureRegistered(): Boolean = withContext(dispatcherProvider.io()) {
+        return@withContext registeredFeatures().isNotEmpty()
+    }
+
+    override suspend fun refreshFeature(feature: VpnFeature) = withContext(dispatcherProvider.io()) {
         vpnServiceWrapper.restartVpnService(forceRestart = false)
     }
 
-    override fun getRegisteredFeatures(): List<VpnFeature> {
-        return registeredFeatures().keys.map { VpnFeature { it } }
+    override suspend fun getRegisteredFeatures(): List<VpnFeature> = withContext(dispatcherProvider.io()) {
+        return@withContext registeredFeatures().keys.map { VpnFeature { it } }
     }
 
     private fun registeredFeatures(): Map<String, Any?> {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
@@ -101,8 +101,9 @@ object VpnAppModule {
         context: Context,
         sharedPreferencesProvider: VpnSharedPreferencesProvider,
         featureSegmentsManager: FeatureSegmentsManager,
+        dispatcherProvider: DispatcherProvider,
     ): VpnFeaturesRegistry {
-        return VpnFeaturesRegistryImpl(VpnServiceWrapper(context), sharedPreferencesProvider, featureSegmentsManager)
+        return VpnFeaturesRegistryImpl(VpnServiceWrapper(context), sharedPreferencesProvider, featureSegmentsManager, dispatcherProvider)
     }
 
     @Provides

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/integration/VpnNetworkStackProvider.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/integration/VpnNetworkStackProvider.kt
@@ -30,7 +30,7 @@ class VpnNetworkStackProviderImpl @Inject constructor(
     private val vpnNetworkStacks: PluginPoint<VpnNetworkStack>,
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : VpnNetworkStackProvider {
-    override fun provideNetworkStack(): VpnNetworkStack {
+    override suspend fun provideNetworkStack(): VpnNetworkStack {
         val features = vpnFeaturesRegistry.getRegisteredFeatures()
         val feature = features.firstOrNull { it.featureName == AppTpVpnFeature.APPTP_VPN.featureName }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/network/RealVpnDetector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/network/RealVpnDetector.kt
@@ -32,7 +32,7 @@ class RealExternalVpnDetector @Inject constructor(
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : ExternalVpnDetector {
 
-    override fun isExternalVpnDetected(): Boolean {
+    override suspend fun isExternalVpnDetected(): Boolean {
         // if we're the ones using the VPN, no VPN is detected
         if (vpnFeaturesRegistry.isAnyFeatureRunning()) return false
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldRetentionPixelSender.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldRetentionPixelSender.kt
@@ -16,32 +16,41 @@
 
 package com.duckduckgo.mobile.android.vpn.pixels
 
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.statistics.api.RefreshRetentionAtbPlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 @ContributesMultibinding(AppScope::class)
 class DeviceShieldRetentionPixelSender @Inject constructor(
     private val deviceShieldPixels: DeviceShieldPixels,
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
+    private val coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
 ) : RefreshRetentionAtbPlugin {
 
     override fun onSearchRetentionAtbRefreshed() {
-        if (vpnFeaturesRegistry.isFeatureRunning(AppTpVpnFeature.APPTP_VPN)) {
-            deviceShieldPixels.deviceShieldEnabledOnSearch()
-        } else {
-            deviceShieldPixels.deviceShieldDisabledOnSearch()
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (vpnFeaturesRegistry.isFeatureRunning(AppTpVpnFeature.APPTP_VPN)) {
+                deviceShieldPixels.deviceShieldEnabledOnSearch()
+            } else {
+                deviceShieldPixels.deviceShieldDisabledOnSearch()
+            }
         }
     }
 
     override fun onAppRetentionAtbRefreshed() {
-        if (vpnFeaturesRegistry.isFeatureRunning(AppTpVpnFeature.APPTP_VPN)) {
-            deviceShieldPixels.deviceShieldEnabledOnAppLaunch()
-        } else {
-            deviceShieldPixels.deviceShieldDisabledOnAppLaunch()
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (vpnFeaturesRegistry.isFeatureRunning(AppTpVpnFeature.APPTP_VPN)) {
+                deviceShieldPixels.deviceShieldEnabledOnAppLaunch()
+            } else {
+                deviceShieldPixels.deviceShieldDisabledOnAppLaunch()
+            }
         }
     }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -157,7 +157,9 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), V
         appTpFeatureConfig.isEnabled(AppTpSetting.AlwaysSetDNS)
     }
 
-    private var vpnNetworkStack: VpnNetworkStack by VpnNetworkStackDelegate(provider = { vpnNetworkStackProvider.provideNetworkStack() })
+    private var vpnNetworkStack: VpnNetworkStack by VpnNetworkStackDelegate(provider = {
+        runBlocking { vpnNetworkStackProvider.provideNetworkStack() }
+    },)
 
     private val vpnStateServiceConnection = object : ServiceConnection {
         override fun onServiceConnected(
@@ -252,7 +254,7 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), V
     }
 
     private suspend fun startVpn() = withContext(serviceDispatcher) {
-        fun updateNetworkStackUponRestart() {
+        suspend fun updateNetworkStackUponRestart() {
             logcat { "VPN log: updating the networking stack" }
             logcat { "VPN log: CURRENT network ${vpnNetworkStack.name}" }
             // stop the current networking stack

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpEnabledNotificationContentPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpEnabledNotificationContentPlugin.kt
@@ -39,6 +39,7 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.runBlocking
 
 @ContributesMultibinding(VpnScope::class)
 @SingleInstanceIn(VpnScope::class)
@@ -53,7 +54,7 @@ class AppTpEnabledNotificationContentPlugin @Inject constructor(
     private val notificationPendingIntent by lazy { appTpEnabledNotificationIntentProvider.getOnPressNotificationIntent() }
 
     override fun getInitialContent(): VpnEnabledNotificationContent? {
-        return if (vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)) {
+        return if (runBlocking { vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN) }) {
             return VpnEnabledNotificationContent(
                 title = SpannableStringBuilder(resources.getString(R.string.atp_OnInitialNotification)),
                 message = SpannableStringBuilder(),
@@ -95,7 +96,7 @@ class AppTpEnabledNotificationContentPlugin @Inject constructor(
     }
 
     override fun isActive(): Boolean {
-        return vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)
+        return runBlocking { vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN) }
     }
 
     // This fun interface is provided just for testing purposes

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/RealVpnStateMonitor.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/state/RealVpnStateMonitor.kt
@@ -91,7 +91,7 @@ class RealVpnStateMonitor @Inject constructor(
             } ?: false
         }
 
-        fun vpnKilledBySystem(): Boolean {
+        suspend fun vpnKilledBySystem(): Boolean {
             val lastHeartBeat = vpnHeartBeatDao.hearBeats().maxByOrNull { it.timestamp }
             return lastHeartBeat?.type == VpnServiceHeartbeatMonitor.DATA_HEART_BEAT_TYPE_ALIVE &&
                 !vpnFeaturesRegistry.isAnyFeatureRunning()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingViewModel.kt
@@ -79,10 +79,12 @@ class VpnOnboardingViewModel @Inject constructor(
     )
 
     fun onTurnAppTpOffOn() {
-        if (vpnDetector.isExternalVpnDetected()) {
-            sendCommand(Command.ShowVpnConflictDialog)
-        } else {
-            sendCommand(Command.CheckVPNPermission)
+        viewModelScope.launch(dispatcherProvider.io()) {
+            if (vpnDetector.isExternalVpnDetected()) {
+                sendCommand(Command.ShowVpnConflictDialog)
+            } else {
+                sendCommand(Command.CheckVPNPermission)
+            }
         }
     }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.ActivityScope
@@ -100,6 +101,8 @@ class DeviceShieldTrackerActivity :
     lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     @Inject lateinit var reportBreakageContract: Provider<ReportBreakageContract>
+
+    @Inject lateinit var dispatcherProvider: DispatcherProvider
 
     @Inject
     @AppTpBreakageCategories
@@ -483,12 +486,16 @@ class DeviceShieldTrackerActivity :
 
     private fun startVPN() {
         quietlyToggleAppTpSwitch(true)
-        vpnFeaturesRegistry.registerFeature(AppTpVpnFeature.APPTP_VPN)
+        lifecycleScope.launch(dispatcherProvider.io()) {
+            vpnFeaturesRegistry.registerFeature(AppTpVpnFeature.APPTP_VPN)
+        }
     }
 
     private fun stopDeviceShield() {
         quietlyToggleAppTpSwitch(false)
-        vpnFeaturesRegistry.unregisterFeature(AppTpVpnFeature.APPTP_VPN)
+        lifecycleScope.launch(dispatcherProvider.io()) {
+            vpnFeaturesRegistry.unregisterFeature(AppTpVpnFeature.APPTP_VPN)
+        }
     }
 
     private fun quietlyToggleAppTpSwitch(state: Boolean) {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivityViewModel.kt
@@ -78,14 +78,14 @@ class DeviceShieldTrackerActivityViewModel @Inject constructor(
     }
 
     internal fun onAppTPToggleSwitched(enabled: Boolean) {
-        when {
-            enabled && vpnDetector.isExternalVpnDetected() -> sendCommand(Command.ShowVpnConflictDialog)
-            enabled == true -> sendCommand(Command.CheckVPNPermission)
-            enabled == false -> sendCommand(Command.ShowDisableVpnConfirmationDialog)
-        }
-        // If the VPN is not started due to any issue, the getRunningState() won't be updated and the toggle is kept (wrongly) in ON state
-        // Check after 1 second to ensure this doesn't happen
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            when {
+                enabled && vpnDetector.isExternalVpnDetected() -> sendCommand(Command.ShowVpnConflictDialog)
+                enabled == true -> sendCommand(Command.CheckVPNPermission)
+                enabled == false -> sendCommand(Command.ShowDisableVpnConfirmationDialog)
+            }
+            // If the VPN is not started due to any issue, the getRunningState() won't be updated and the toggle is kept (wrongly) in ON state
+            // Check after 1 second to ensure this doesn't happen
             delay(TimeUnit.SECONDS.toMillis(1))
             refreshVpnRunningState.emit(System.currentTimeMillis())
         }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/integration/VpnNetworkStackProviderTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/integration/VpnNetworkStackProviderTest.kt
@@ -23,12 +23,15 @@ import com.duckduckgo.mobile.android.vpn.VpnFeature
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.network.FakeVpnNetworkStack
 import com.duckduckgo.mobile.android.vpn.network.VpnNetworkStack
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class VpnNetworkStackProviderTest {
 
     private val vpnNetworkStacks: PluginPoint<VpnNetworkStack> = mock()
@@ -46,12 +49,12 @@ class VpnNetworkStackProviderTest {
     }
 
     @Test
-    fun whenProvideNetworkStackAndNoFeaturesRegisteredThenThrowsException() {
+    fun whenProvideNetworkStackAndNoFeaturesRegisteredThenThrowsException() = runTest {
         assertEquals(VpnNetworkStack.EmptyVpnNetworkStack, vpnNetworkStackProvider.provideNetworkStack())
     }
 
     @Test
-    fun whenProviderNetworkStackAndAppTpRegisteredThenReturnNetworkStack() {
+    fun whenProviderNetworkStackAndAppTpRegisteredThenReturnNetworkStack() = runTest {
         vpnFeaturesRegistry.registerFeature(AppTpVpnFeature.APPTP_VPN)
         val networkStack = vpnNetworkStackProvider.provideNetworkStack()
 
@@ -59,14 +62,14 @@ class VpnNetworkStackProviderTest {
     }
 
     @Test
-    fun whenProviderNetworkStackAndUnknownFeatureRegisteredThenThrowsException() {
+    fun whenProviderNetworkStackAndUnknownFeatureRegisteredThenThrowsException() = runTest {
         vpnFeaturesRegistry.registerFeature(VpnFeature { "unknown" })
         vpnNetworkStackProvider.provideNetworkStack()
         assertEquals(VpnNetworkStack.EmptyVpnNetworkStack, vpnNetworkStackProvider.provideNetworkStack())
     }
 
     @Test
-    fun whenProviderNetworkStackAndFeaturesContainAppTpThenReturnNetworkStack() {
+    fun whenProviderNetworkStackAndFeaturesContainAppTpThenReturnNetworkStack() = runTest {
         vpnFeaturesRegistry.registerFeature(VpnFeature { "unknown" })
         vpnFeaturesRegistry.registerFeature(AppTpVpnFeature.APPTP_VPN)
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpEnabledNotificationContentPluginTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpEnabledNotificationContentPluginTest.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsReposi
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
@@ -68,7 +69,7 @@ class AppTpEnabledNotificationContentPluginTest {
         appTrackerBlockingStatsRepository = RealAppTrackerBlockingStatsRepository(db, coroutineTestRule.testDispatcherProvider)
 
         vpnFeaturesRegistry = FakeVpnFeaturesRegistry().apply {
-            registerFeature(AppTpVpnFeature.APPTP_VPN)
+            runBlocking { registerFeature(AppTpVpnFeature.APPTP_VPN) }
         }
 
         plugin = AppTpEnabledNotificationContentPlugin(
@@ -94,7 +95,7 @@ class AppTpEnabledNotificationContentPluginTest {
     }
 
     @Test
-    fun getInitialContentAppTpNotEnabledThenReturnsCorrectNotificationContent() {
+    fun getInitialContentAppTpNotEnabledThenReturnsCorrectNotificationContent() = runTest {
         vpnFeaturesRegistry.unregisterFeature(AppTpVpnFeature.APPTP_VPN)
         assertNull(plugin.getInitialContent())
     }
@@ -263,7 +264,7 @@ class AppTpEnabledNotificationContentPluginTest {
     }
 
     @Test
-    fun isActiveWhenAppTpNotEnabledThenReturnsFalse() {
+    fun isActiveWhenAppTpNotEnabledThenReturnsFalse() = runTest {
         vpnFeaturesRegistry.unregisterFeature(AppTpVpnFeature.APPTP_VPN)
         assertFalse(plugin.isActive())
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -388,6 +388,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:_"
     androidTestImplementation "androidx.test.espresso:espresso-web:_"
 
+    testImplementation project(':vpn-api-test')
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
     testImplementation AndroidX.archCore.testing

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/model/EnableAppTpNotificationTest.kt
@@ -57,6 +57,7 @@ class EnableAppTpNotificationTest {
     fun whenNotificationNotSeenAndOneEasyStepForPrivacyNotificationEnabledThenCanShowIsTrue() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(false)
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zm" })
+        whenever(mockVpnFeaturesRegistry.isFeatureRunning(AppTpVpnFeature.APPTP_VPN)).thenReturn(false)
 
         assertTrue(testee.canShow())
     }
@@ -65,6 +66,7 @@ class EnableAppTpNotificationTest {
     fun whenNotificationNotSeenAndNextLevelPrivacyNotificationEnabledThenCanShowIsTrue() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(false)
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zn" })
+        whenever(mockVpnFeaturesRegistry.isFeatureRunning(AppTpVpnFeature.APPTP_VPN)).thenReturn(false)
 
         assertTrue(testee.canShow())
     }
@@ -73,6 +75,7 @@ class EnableAppTpNotificationTest {
     fun whenNotificationNotSeenAndOtherEnabledThenCanShowIsFalse() = runTest {
         whenever(mockNotificationsDao.exists(any())).thenReturn(false)
         whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "ze" })
+        whenever(mockVpnFeaturesRegistry.isFeatureRunning(AppTpVpnFeature.APPTP_VPN)).thenReturn(false)
 
         assertFalse(testee.canShow())
     }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -103,6 +103,7 @@ import com.duckduckgo.windows.api.ui.WindowsScreenWithEmptyParams
 import com.duckduckgo.windows.api.ui.WindowsWaitlistScreenWithEmptyParams
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
@@ -185,8 +186,7 @@ class SettingsActivity : DuckDuckGoActivity() {
 
         val notificationsEnabled = NotificationManagerCompat.from(this).areNotificationsEnabled()
         viewModel.start(notificationsEnabled)
-        viewModel.startPollingAppTpEnableState()
-        viewModel.startPollingNetPEnableState()
+        viewModel.startPollingVpnState()
     }
 
     override fun onResume() {
@@ -294,6 +294,7 @@ class SettingsActivity : DuckDuckGoActivity() {
     private fun observeViewModel() {
         viewModel.viewState()
             .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
+            .distinctUntilChanged()
             .onEach { viewState ->
                 viewState.let {
                     viewsOther.version.setSecondaryText(it.version)

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -44,7 +44,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
 import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.store.ThemingDataStore
-import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
+import com.duckduckgo.mobile.android.vpn.FakeVpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnRunningState
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnState
@@ -117,9 +117,6 @@ class SettingsViewModelTest {
     private lateinit var autofillCapabilityChecker: AutofillCapabilityChecker
 
     @Mock
-    private lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
-
-    @Mock
     private lateinit var autoconsent: Autoconsent
 
     @Mock
@@ -180,7 +177,7 @@ class SettingsViewModelTest {
             mockAppBuildConfig,
             mockEmailManager,
             autofillCapabilityChecker,
-            vpnFeaturesRegistry,
+            FakeVpnFeaturesRegistry(),
             autoconsent,
             windowsWaitlist,
             windowsFeature,

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -27,7 +27,6 @@ import com.duckduckgo.app.icon.api.AppIcon
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.SettingsViewModel.Command
 import com.duckduckgo.app.settings.SettingsViewModel.Companion.EMAIL_PROTECTION_URL
-import com.duckduckgo.app.settings.SettingsViewModel.NetPState
 import com.duckduckgo.app.settings.clear.AppLinkSettingType
 import com.duckduckgo.app.settings.clear.ClearWhatOption.CLEAR_NONE
 import com.duckduckgo.app.settings.clear.ClearWhenOption.APP_EXIT_ONLY
@@ -45,10 +44,7 @@ import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
 import com.duckduckgo.mobile.android.ui.DuckDuckGoTheme
 import com.duckduckgo.mobile.android.ui.store.ThemingDataStore
 import com.duckduckgo.mobile.android.vpn.FakeVpnFeaturesRegistry
-import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
-import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnRunningState
-import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnState
-import com.duckduckgo.networkprotection.impl.NetPVpnFeature
+import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.networkprotection.impl.waitlist.NetPWaitlistState
 import com.duckduckgo.networkprotection.impl.waitlist.store.NetPWaitlistRepository
 import com.duckduckgo.privacy.config.api.Gpc
@@ -60,7 +56,6 @@ import com.duckduckgo.windows.api.WindowsWaitlistFeature
 import com.duckduckgo.windows.api.WindowsWaitlistState
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
@@ -129,9 +124,6 @@ class SettingsViewModelTest {
     private lateinit var deviceSyncState: DeviceSyncState
 
     @Mock
-    private lateinit var mockVpnStateMonitor: VpnStateMonitor
-
-    @Mock
     private lateinit var mockNetPWaitlistRepository: NetPWaitlistRepository
 
     @Mock
@@ -139,6 +131,8 @@ class SettingsViewModelTest {
 
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry
 
     @Before
     fun before() {
@@ -164,6 +158,8 @@ class SettingsViewModelTest {
 
         whenever(mockNetPWaitlistRepository.getState(any())).thenReturn(NetPWaitlistState.NotUnlocked)
 
+        vpnFeaturesRegistry = FakeVpnFeaturesRegistry()
+
         testee = SettingsViewModel(
             mockThemeSettingsDataStore,
             mockAppSettingsDataStore,
@@ -177,14 +173,14 @@ class SettingsViewModelTest {
             mockAppBuildConfig,
             mockEmailManager,
             autofillCapabilityChecker,
-            FakeVpnFeaturesRegistry(),
+            vpnFeaturesRegistry,
             autoconsent,
             windowsWaitlist,
             windowsFeature,
             deviceSyncState,
-            mockVpnStateMonitor,
             mockNetPWaitlistRepository,
             mockWindowsDownloadLinkFeature,
+            coroutineTestRule.testDispatcherProvider,
         )
 
         runTest {
@@ -839,39 +835,6 @@ class SettingsViewModelTest {
             assertTrue(viewState.showSyncSetting)
             assertTrue(viewState.syncEnabled)
             cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenNetPVpnStateIsEnabledThenViewStateNetPStateShouldBeConnected() = runTest {
-        whenever(mockVpnStateMonitor.getStateFlow(NetPVpnFeature.NETP_VPN)).thenReturn(flowOf(VpnState(state = VpnRunningState.ENABLED)))
-
-        testee.startPollingNetPEnableState()
-
-        testee.viewState().test {
-            assertEquals(NetPState.CONNECTED, awaitItem().networkProtectionState)
-        }
-    }
-
-    @Test
-    fun whenNetPVpnStateIsEnablingThenViewStateNetPStateShouldBeConnecting() = runTest {
-        whenever(mockVpnStateMonitor.getStateFlow(NetPVpnFeature.NETP_VPN)).thenReturn(flowOf(VpnState(state = VpnRunningState.ENABLING)))
-
-        testee.startPollingNetPEnableState()
-
-        testee.viewState().test {
-            assertEquals(NetPState.CONNECTING, awaitItem().networkProtectionState)
-        }
-    }
-
-    @Test
-    fun whenNetPVpnStateIsDisabledThenViewStateNetPStateShouldBeDisconnected() = runTest {
-        whenever(mockVpnStateMonitor.getStateFlow(NetPVpnFeature.NETP_VPN)).thenReturn(flowOf(VpnState(state = VpnRunningState.DISABLED)))
-
-        testee.startPollingNetPEnableState()
-
-        testee.viewState().test {
-            assertEquals(NetPState.DISCONNECTED, awaitItem().networkProtectionState)
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/mobile/android/app/tracking/NetpAppTrackerDetectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/mobile/android/app/tracking/NetpAppTrackerDetectorTest.kt
@@ -25,6 +25,8 @@ import com.duckduckgo.mobile.android.vpn.dao.VpnAppTrackerBlockingDao
 import com.duckduckgo.mobile.android.vpn.processor.requestingapp.AppNameResolver
 import com.duckduckgo.mobile.android.vpn.processor.tcp.tracker.AppTrackerRecorder
 import com.duckduckgo.mobile.android.vpn.trackers.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -53,7 +55,7 @@ class NetpAppTrackerDetectorTest {
         whenever(appNameResolver.getAppNameForPackageId(AppNameResolver.OriginatingApp.unknown().packageId))
             .thenReturn(AppNameResolver.OriginatingApp.unknown())
         whenever(packageManager.getApplicationInfo(any(), eq(0))).thenReturn(ApplicationInfo())
-        whenever(vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)).thenReturn(true)
+        runBlocking { whenever(vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)).thenReturn(true) }
 
         appTrackerDetector = NetpRealAppTrackerDetector(
             appTrackerRepository,
@@ -330,7 +332,7 @@ class NetpAppTrackerDetectorTest {
     }
 
     @Test
-    fun whenAppTpDisabledReturnNull() {
+    fun whenAppTpDisabledReturnNull() = runTest {
         whenever(vpnFeaturesRegistry.isFeatureRegistered(AppTpVpnFeature.APPTP_VPN)).thenReturn(false)
 
         val appTrackerDetectorDisabled = NetpRealAppTrackerDetector(

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetPCohortUpdater.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetPCohortUpdater.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.networkprotection.impl.cohort
 
+import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
@@ -24,6 +25,7 @@ import com.duckduckgo.networkprotection.impl.NetPVpnFeature
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.threeten.bp.LocalDate
 
 @ContributesMultibinding(
@@ -33,13 +35,16 @@ import org.threeten.bp.LocalDate
 class NetPCohortUpdater @Inject constructor(
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
     private val cohortStore: NetpCohortStore,
+    private val dispatcherProvider: DispatcherProvider,
 ) : VpnServiceCallbacks {
     override fun onVpnStarted(coroutineScope: CoroutineScope) {
-        if (vpnFeaturesRegistry.isFeatureRunning(NetPVpnFeature.NETP_VPN)) {
-            // skip if already stored
-            cohortStore.cohortLocalDate?.let { return }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (vpnFeaturesRegistry.isFeatureRunning(NetPVpnFeature.NETP_VPN)) {
+                // skip if already stored
+                cohortStore.cohortLocalDate?.let { return@launch }
 
-            cohortStore.cohortLocalDate = LocalDate.now()
+                cohortStore.cohortLocalDate = LocalDate.now()
+            }
         }
     }
 

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/integration/NetpVpnNetworkStackProviderImpl.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/integration/NetpVpnNetworkStackProviderImpl.kt
@@ -33,7 +33,7 @@ class NetpVpnNetworkStackProviderImpl @Inject constructor(
     private val vpnNetworkStacks: PluginPoint<VpnNetworkStack>,
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : VpnNetworkStackProvider {
-    override fun provideNetworkStack(): VpnNetworkStack {
+    override suspend fun provideNetworkStack(): VpnNetworkStack {
         val features = vpnFeaturesRegistry.getRegisteredFeatures().map { it.featureName }
 
         val networkStack = if (features.contains(NetPVpnFeature.NETP_VPN.featureName)) {

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/metrics/LatencyMonitorCallback.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/metrics/LatencyMonitorCallback.kt
@@ -30,6 +30,7 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
 import logcat.LogPriority
 import logcat.logcat
 
@@ -48,7 +49,7 @@ class LatencyMonitorCallback @Inject constructor(
     }
 
     override fun onVpnStarted(coroutineScope: CoroutineScope) {
-        if (!vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)) {
+        if (runBlocking { !vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN) }) {
             logcat { "NetP not enabled, not starting latency monitor" }
             return
         }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/notification/NetPEnabledNotificationContentPlugin.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/notification/NetPEnabledNotificationContentPlugin.kt
@@ -36,6 +36,7 @@ import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 
 @ContributesMultibinding(VpnScope::class)
 @SingleInstanceIn(VpnScope::class)
@@ -47,7 +48,7 @@ class NetPEnabledNotificationContentPlugin @Inject constructor(
 
     private val onPressIntent by lazy { netPIntentProvider.getOnPressNotificationIntent() }
     override fun getInitialContent(): VpnEnabledNotificationContent? {
-        return if (vpnFeaturesRegistry.isFeatureRunning(NetPVpnFeature.NETP_VPN)) {
+        return if (runBlocking { vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN) }) {
             return VpnEnabledNotificationContent(
                 title = SpannableStringBuilder(resources.getString(R.string.netpEnabledNotificationTitle)),
                 message = SpannableStringBuilder(),
@@ -69,7 +70,7 @@ class NetPEnabledNotificationContentPlugin @Inject constructor(
     }
 
     override fun isActive(): Boolean {
-        return vpnFeaturesRegistry.isFeatureRunning(NetPVpnFeature.NETP_VPN)
+        return runBlocking { vpnFeaturesRegistry.isFeatureRunning(NetPVpnFeature.NETP_VPN) }
     }
 
     // This fun interface is provided just for testing purposes

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/rekey/NetPRekeyScheduler.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/rekey/NetPRekeyScheduler.kt
@@ -30,6 +30,7 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import java.util.concurrent.TimeUnit.HOURS
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
 import logcat.logcat
 
 @ContributesMultibinding(VpnScope::class)
@@ -38,7 +39,7 @@ class NetPRekeyScheduler @Inject constructor(
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
 ) : VpnServiceCallbacks {
     override fun onVpnStarted(coroutineScope: CoroutineScope) {
-        if (vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)) {
+        if (runBlocking { vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN) }) {
             logcat { "NetPRekeyScheduler onVpnStarted called with NetP enabled" }
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/timezone/NetPTimezoneMonitor.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/timezone/NetPTimezoneMonitor.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import logcat.logcat
 
 @SingleInstanceIn(VpnScope::class)
@@ -44,7 +45,7 @@ class NetPTimezoneMonitor @Inject constructor(
     private val context: Context,
 ) : BroadcastReceiver(), VpnServiceCallbacks {
     override fun onVpnStarted(coroutineScope: CoroutineScope) {
-        if (!vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)) {
+        if (runBlocking { !vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN) }) {
             logcat { "NetP not enabled, skip registering timezone monitor" }
             return
         }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/cohort/NetPCohortUpdaterTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/cohort/NetPCohortUpdaterTest.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.networkprotection.impl.NetPVpnFeature
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -47,11 +48,11 @@ class NetPCohortUpdaterTest {
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
-        testee = NetPCohortUpdater(vpnFeaturesRegistry, cohortStore)
+        testee = NetPCohortUpdater(vpnFeaturesRegistry, cohortStore, coroutineRule.testDispatcherProvider)
     }
 
     @Test
-    fun whenNetPIsNotRegisteredThenDoNothingWithCohort() {
+    fun whenNetPIsNotRegisteredThenDoNothingWithCohort() = runTest {
         whenever(vpnFeaturesRegistry.isFeatureRunning(NetPVpnFeature.NETP_VPN)).thenReturn(false)
 
         testee.onVpnStarted(coroutineRule.testScope)
@@ -60,7 +61,7 @@ class NetPCohortUpdaterTest {
     }
 
     @Test
-    fun whenNetPIsRegisteredAndCohortNotSetThenUpdateCohort() {
+    fun whenNetPIsRegisteredAndCohortNotSetThenUpdateCohort() = runTest {
         whenever(vpnFeaturesRegistry.isFeatureRunning(NetPVpnFeature.NETP_VPN)).thenReturn(true)
         whenever(cohortStore.cohortLocalDate).thenReturn(null)
 
@@ -70,7 +71,7 @@ class NetPCohortUpdaterTest {
     }
 
     @Test
-    fun whenNetPIsRegisteredAndCohortetThenDoNothingWithCohort() {
+    fun whenNetPIsRegisteredAndCohortetThenDoNothingWithCohort() = runTest {
         whenever(vpnFeaturesRegistry.isFeatureRunning(NetPVpnFeature.NETP_VPN)).thenReturn(true)
         whenever(cohortStore.cohortLocalDate).thenReturn(LocalDate.of(2023, 1, 1))
 

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/metrics/LatencyMonitorCallbackTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/metrics/LatencyMonitorCallbackTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.networkprotection.impl.fakes.FakeNetworkProtectionReposito
 import com.duckduckgo.networkprotection.store.NetworkProtectionRepository
 import com.duckduckgo.networkprotection.store.NetworkProtectionRepository.ServerDetails
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -69,14 +70,14 @@ class LatencyMonitorCallbackTest {
     }
 
     @Test
-    fun onNativeStartedNetpOffDoNotEnqueueWork() {
+    fun onNativeStartedNetpOffDoNotEnqueueWork() = runTest {
         whenever(mockVpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)).thenReturn(false)
         testee.onVpnStarted(coroutineRule.testScope)
         verifyNoInteractions(mockWorkManager)
     }
 
     @Test
-    fun onNativeStartedNetpOnEnqueueWork() {
+    fun onNativeStartedNetpOnEnqueueWork() = runTest {
         whenever(mockVpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)).thenReturn(true)
         testee.onVpnStarted(coroutineRule.testScope)
         verify(mockWorkManager).enqueueUniquePeriodicWork(

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/notification/NetPEnabledNotificationContentPluginTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/notification/NetPEnabledNotificationContentPluginTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.service.VpnEnabledNotificationContentPlugin
 import com.duckduckgo.networkprotection.impl.NetPVpnFeature
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.*
 import org.junit.Assert.*
@@ -49,14 +50,14 @@ class NetPEnabledNotificationContentPluginTest {
     @Before
     fun setup() {
         vpnFeaturesRegistry = FakeVpnFeaturesRegistry().apply {
-            registerFeature(NetPVpnFeature.NETP_VPN)
+            runBlocking { registerFeature(NetPVpnFeature.NETP_VPN) }
         }
 
         plugin = NetPEnabledNotificationContentPlugin(resources, vpnFeaturesRegistry) { null }
     }
 
     @Test
-    fun getInitialContentNetPDisabledReturnNull() {
+    fun getInitialContentNetPDisabledReturnNull() = runTest {
         vpnFeaturesRegistry.unregisterFeature(NetPVpnFeature.NETP_VPN)
         val content = plugin.getInitialContent()
 
@@ -101,7 +102,7 @@ class NetPEnabledNotificationContentPluginTest {
     }
 
     @Test
-    fun isActiveNetPDisabledReturnFalse() {
+    fun isActiveNetPDisabledReturnFalse() = runTest {
         vpnFeaturesRegistry.unregisterFeature(NetPVpnFeature.NETP_VPN)
         assertFalse(plugin.isActive())
     }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/reconnect/NetpVpnConnectivityLossListenerPluginTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/reconnect/NetpVpnConnectivityLossListenerPluginTest.kt
@@ -97,7 +97,7 @@ class NetpVpnConnectivityLossListenerPluginTest {
     }
 
     @Test
-    fun whenOnVpnConnectedAndNotReconnectingThenDoNothing() {
+    fun whenOnVpnConnectedAndNotReconnectingThenDoNothing() = runTest {
         whenever(vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)).thenReturn(true)
         repository.reconnectStatus = NotReconnecting
         testee.onVpnConnected(coroutineRule.testScope)
@@ -108,7 +108,7 @@ class NetpVpnConnectivityLossListenerPluginTest {
     }
 
     @Test
-    fun whenOnVpnConnectedAndReconnectingFailedThenResetStatusToNotReconnecting() {
+    fun whenOnVpnConnectedAndReconnectingFailedThenResetStatusToNotReconnecting() = runTest {
         whenever(vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)).thenReturn(true)
         repository.reconnectStatus = ReconnectingFailed
         testee.onVpnConnected(coroutineRule.testScope)
@@ -119,7 +119,7 @@ class NetpVpnConnectivityLossListenerPluginTest {
     }
 
     @Test
-    fun whenOnVpnConnectedAndReconnectingThenRecoverSuccessfully() {
+    fun whenOnVpnConnectedAndReconnectingThenRecoverSuccessfully() = runTest {
         whenever(vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)).thenReturn(true)
         repository.reconnectStatus = Reconnecting
         testee.onVpnConnected(coroutineRule.testScope)
@@ -131,7 +131,7 @@ class NetpVpnConnectivityLossListenerPluginTest {
     }
 
     @Test
-    fun whenNetpVpnFeatureIsNotRegisteredThenOnVpnConnectedDoesNothing() {
+    fun whenNetpVpnFeatureIsNotRegisteredThenOnVpnConnectedDoesNothing() = runTest {
         whenever(vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)).thenReturn(false)
 
         testee.onVpnConnected(coroutineRule.testScope)
@@ -143,7 +143,7 @@ class NetpVpnConnectivityLossListenerPluginTest {
     }
 
     @Test
-    fun whenNetpVpnFeatureIsNotRegisteredThenOnVpnConnectivityLossDoesNothing() {
+    fun whenNetpVpnFeatureIsNotRegisteredThenOnVpnConnectivityLossDoesNothing() = runTest {
         whenever(vpnFeaturesRegistry.isFeatureRegistered(NetPVpnFeature.NETP_VPN)).thenReturn(false)
 
         testee.onVpnConnectivityLoss(coroutineRule.testScope)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204763839445752/f

### Description
The `VpnFeaturesRegistry` functionality is backed by a multiprocess shared preferences but all its API is synchronous and called from various different threads, including the UI thread.

This PR:
* moves its API to be async using `suspend` and offload them to `io` dispatcher
* refactors the calling side when necessary

### Steps to test this PR

Aside from CI, perform the following sanity testing

- [x] install from this branch
- [x] smoke test AppTP and VPN
- [x] NP cohort should be assigned correctly
- [x] AppTP/VPN should work correctly, on/off, off/on, on/on
- [x] verify clean install and AppTP onboarding
- [x] verify clean install and VPN onboarding
- [x] verify AppTP / VPN notifications work correctly, on/off, off/on, on/on, off/off
- [x] verify re-key
- [x] verify VPN conflicts UX, during AppTP onboarding, AppTP activity screen and VPN management screen
- [x] verify `m_atp_ev_enabled_on_search_d/c`, `m_atp_ev_disabled_on_search_d/c`, `m_atp_ev_enabled_on_launch_c/d` and `m_atp_ev_disabled_on_launch_c/d` are sent correctly
- [x] verify AppTP quick setting (aka tile) works properly
- [x] verify AppTP can be enabled from disabled notification
