### PR TITLE
Update content scope scripts to latest version

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -433,6 +433,27 @@
     }
 
     /**
+     * @param {*[]} argsArray
+     * @returns {string}
+     */
+    function debugSerialize (argsArray) {
+        const maxSerializedSize = 1000;
+        const serializedArgs = argsArray.map((arg) => {
+            try {
+                const serializableOut = JSON.stringify(arg);
+                if (serializableOut.length > maxSerializedSize) {
+                    return `<truncated, length: ${serializableOut.length}, value: ${serializableOut.substring(0, maxSerializedSize)}...>`
+                }
+                return serializableOut
+            } catch (e) {
+                // Sometimes this happens when we can't serialize an object to string but we still wish to log it and make other args readable
+                return '<unserializable>'
+            }
+        });
+        return JSON.stringify(serializedArgs)
+    }
+
+    /**
      * @template {object} P
      * @typedef {object} ProxyObject<P>
      * @property {(target?: object, thisArg?: P, args?: object) => void} apply
@@ -474,7 +495,7 @@
                         kind: this.property,
                         documentUrl: document.location.href,
                         stack: getStack(),
-                        args: JSON.stringify(args[2])
+                        args: debugSerialize(args[2])
                     });
                 }
                 // The normal return value
@@ -603,12 +624,7 @@
     }
 
     function parseVersionString (versionString) {
-        const [major = 0, minor = 0, patch = 0] = versionString.split('.').map(Number);
-        return {
-            major,
-            minor,
-            patch
-        }
+        return versionString.split('.').map(Number)
     }
 
     /**
@@ -617,12 +633,20 @@
      * @returns {boolean}
      */
     function satisfiesMinVersion (minVersionString, applicationVersionString) {
-        const { major: minMajor, minor: minMinor, patch: minPatch } = parseVersionString(minVersionString);
-        const { major, minor, patch } = parseVersionString(applicationVersionString);
-
-        return (major > minMajor ||
-                (major >= minMajor && minor > minMinor) ||
-                (major >= minMajor && minor >= minMinor && patch >= minPatch))
+        const minVersions = parseVersionString(minVersionString);
+        const currentVersions = parseVersionString(applicationVersionString);
+        const maxLength = Math.max(minVersions.length, currentVersions.length);
+        for (let i = 0; i < maxLength; i++) {
+            const minNumberPart = minVersions[i] || 0;
+            const currentVersionPart = currentVersions[i] || 0;
+            if (currentVersionPart > minNumberPart) {
+                return true
+            }
+            if (currentVersionPart < minNumberPart) {
+                return false
+            }
+        }
+        return true
     }
 
     /**
@@ -778,6 +802,9 @@
         apple: [
             ...baseFeatures,
             'webCompat'
+        ],
+        'apple-isolated': [
+            'duckPlayer'
         ],
         android: [
             ...baseFeatures,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.1.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.20.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.21.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1685458917"
       },
@@ -23,33 +23,33 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
+      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#59894070863714a2ced7ad3cf5b9b11dd4cd53d4",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a275d9836eba2662e4a96080911d142059d331ef",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -272,9 +272,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
-      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.7",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.7.tgz",
-      "integrity": "sha512-/bi0Zm2C6VAexlGgLlVxA0P2lru/sdLyfCVaRMfKVo9nWxbmz7f/sD8VPybPeSUJaJcwmCJis9pBIhcVcG1QcQ==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.0.tgz",
+      "integrity": "sha512-pdL757Ig5a0I+owA42l6tIuEycRuM7FPY4n62h44mRLRfnOxJkkOHd6i89dOpwZlpF6JXBwaAHF6yWzFrt+QyA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.1.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.20.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.21.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1685458917"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass