### PR TITLE
Set orientation to landscape when entering full screen

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint
 import android.app.Activity.RESULT_OK
 import android.app.ActivityOptions
 import android.content.*
+import android.content.pm.ActivityInfo
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
@@ -3410,12 +3411,14 @@ class BrowserTabFragment :
 
         private fun goFullScreen() {
             Timber.i("Entering full screen")
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
             binding.webViewFullScreenContainer.show()
             activity?.toggleFullScreen()
         }
 
         private fun exitFullScreen() {
             Timber.i("Exiting full screen")
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
             binding.webViewFullScreenContainer.removeAllViews()
             binding.webViewFullScreenContainer.gone()
             activity?.toggleFullScreen()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: 
https://github.com/duckduckgo/Android/issues/3250

### Description
Hi! I'm interested in fixing the issue.
This pull request code is adapted from how Lightning Browser works when YouTube video enters full screen mode. Here's I attach the source code of it. https://github.com/anthonycr/Lightning-Browser/blob/browser2/app/src/main/java/acr/browser/lightning/browser/BrowserActivity.kt please look at method `showCustomView()` and `hideCustomView()`. 
So, this code will make the app turn into landscape mode whenever it enters full screen mode. I haven't tested it on Twitter or TikTok that could have vertical video format.

### Steps to test this PR
Same as Issue URL

_Feature 1_
- [ ]
- [ ]

### UI changes
Before
![Media_230620_232036](https://github.com/duckduckgo/Android/assets/2264036/3938251c-a796-4187-a4a2-13aeb96e164b)

After
![Media_230620_232350](https://github.com/duckduckgo/Android/assets/2264036/9e10c873-2ca4-400c-9bc2-7fb7dd166404)
