### PR TITLE
Update reference tests to latest version

### DIFF
--- a/app/src/test/resources/reference_tests/brokensites/tests.json
+++ b/app/src/test/resources/reference_tests/brokensites/tests.json
@@ -3,6 +3,28 @@
         "name": "Broken site report testing",
         "tests": [
             {
+                "name": "Simple test with a common set of fields (without config version)",
+                "siteURL": "https://example.test/",
+                "wasUpgraded": true,
+                "category": "content",
+                "blockedTrackers": ["bad.tracker.test", "tracking.test"],
+                "surrogates": ["surrogate.domain.test", "domain2.test"],
+                "atb": "v123-456g",
+                "blocklistVersion": "abc123",
+                "remoteConfigEtag": "abd142",
+                "remoteConfigVersion": "1234",
+                "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                "expectReportURLParams": [
+                    {"name": "category", "value": "content"},
+                    {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
+                    {"name": "upgradedHttps", "value": "true"},
+                    {"name": "tds", "value": "abc123"},
+                    {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
+                ],
+                "exceptPlatforms": []
+            },
+            {
                 "name": "Simple test with a common set of fields",
                 "siteURL": "https://example.test/",
                 "wasUpgraded": true,
@@ -24,7 +46,9 @@
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
                 ],
-                "exceptPlatforms": []
+                "exceptPlatforms": [
+                    "ios-browser"
+                ]
             },
             {
                 "name": "Test correct encoding of weak etags.",
@@ -48,7 +72,9 @@
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
                 ],
-                "exceptPlatforms": []
+                "exceptPlatforms": [
+                    "ios-browser"
+                ]
             },
             {
                 "name": "Test correct encoding of non-weak etags.",
@@ -72,7 +98,9 @@
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
                 ],
-                "exceptPlatforms": []
+                "exceptPlatforms": [
+                    "ios-browser"
+                ]
             },
             {
                 "name": "Making sure that siteURL gets trimmed - path, query and fragment should be dropped",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.21.1",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1685458917"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1687271744"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-4.1.3.tgz",
-      "integrity": "sha512-4nJnmJvNSiGfzYZkF8A0D1/1jVZ1C3swIK/6xk6XLdVjudqPmYyEeiYb1HrtIzI0IohsVA/+wu2bF5ofdRIwAg=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-4.3.1.tgz",
+      "integrity": "sha512-gdEGeJdregKzau/CVHNadepjpQrFazm0vHGqJmyLPNkP0GMtZGl7pvsp3cJAcY4qGvSEv3oaWA13L7ioZYCZiQ=="
     },
     "node_modules/@duckduckgo/autofill": {
       "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#44cd844b6bb5d8ccfefbd6e025817d800c26ad76",
@@ -89,7 +89,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#364cbb762ca98ebd535ed285ed503c7c647d071b",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#9c24788a14ebc7d24d2a1955da0eac3a34063847",
       "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.0.tgz",
-      "integrity": "sha512-pdL757Ig5a0I+owA42l6tIuEycRuM7FPY4n62h44mRLRfnOxJkkOHd6i89dOpwZlpF6JXBwaAHF6yWzFrt+QyA==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.1.tgz",
+      "integrity": "sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.2.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.21.1",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1685458917"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1687271744"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [x] All tests must pass