### PR TITLE
Update content scope scripts to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.3.3",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.21.1",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.22.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1687271744"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#260329ad8021115235d64ddd76c24629f93a7212",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#658da08e53cb0cc3dbf41042e7ea2c238ce4bc32",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.3.3",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.21.1",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.22.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1687271744"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass