### PR TITLE
Saved Sites: prune objects on app launch / fire button

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.location.GeoLocationPermissions
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
+import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -57,6 +58,7 @@ class ClearPersonalDataActionTest {
     private val mockThirdPartyCookieManager: ThirdPartyCookieManager = mock()
     private val mockAdClickManager: AdClickManager = mock()
     private val mockFireproofWebsiteRepository: FireproofWebsiteRepository = mock()
+    private val mockSavedSitesRepository: SavedSitesRepository = mock()
     private val mockSitePermissionsManager: SitePermissionsManager = mock()
 
     private val fireproofWebsites: LiveData<List<FireproofWebsiteEntity>> = MutableLiveData()
@@ -75,6 +77,7 @@ class ClearPersonalDataActionTest {
             thirdPartyCookieManager = mockThirdPartyCookieManager,
             adClickManager = mockAdClickManager,
             fireproofWebsiteRepository = mockFireproofWebsiteRepository,
+            savedSitesRepository = mockSavedSitesRepository,
             sitePermissionsManager = mockSitePermissionsManager,
         )
         whenever(mockFireproofWebsiteRepository.getFireproofWebsites()).thenReturn(fireproofWebsites)
@@ -126,5 +129,11 @@ class ClearPersonalDataActionTest {
     fun whenClearCalledThenThirdPartyCookieSitesAreCleared() = runTest {
         testee.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = false)
         verify(mockThirdPartyCookieManager).clearAllData()
+    }
+
+    @Test
+    fun whenClearCalledThenSavedSitesPrunesDeleted() = runTest {
+        testee.clearTabsAndAllDataAsync(appInForeground = false, shouldFireDataClearPixel = false)
+        verify(mockSavedSitesRepository).pruneDeleted()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -46,7 +46,9 @@ import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
+import com.duckduckgo.sync.api.DeviceSyncState
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
@@ -78,6 +80,8 @@ object PrivacyModule {
         adClickManager: AdClickManager,
         fireproofWebsiteRepository: FireproofWebsiteRepository,
         sitePermissionsManager: SitePermissionsManager,
+        deviceSyncState: DeviceSyncState,
+        savedSitesRepository: SavedSitesRepository,
         dispatcherProvider: DispatcherProvider,
     ): ClearDataAction {
         return ClearPersonalDataAction(
@@ -93,6 +97,8 @@ object PrivacyModule {
             adClickManager,
             fireproofWebsiteRepository,
             sitePermissionsManager,
+            deviceSyncState,
+            savedSitesRepository,
             dispatcherProvider,
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
+import com.duckduckgo.sync.api.DeviceSyncState
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -67,6 +68,7 @@ class ClearPersonalDataAction(
     private val adClickManager: AdClickManager,
     private val fireproofWebsiteRepository: FireproofWebsiteRepository,
     private val sitePermissionsManager: SitePermissionsManager,
+    private val deviceSyncState: DeviceSyncState,
     private val savedSitesRepository: SavedSitesRepository,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
 ) : ClearDataAction {
@@ -91,7 +93,12 @@ class ClearPersonalDataAction(
             geoLocationPermissions.clearAllButFireproofed()
             sitePermissionsManager.clearAllButFireproof(fireproofDomains)
             thirdPartyCookieManager.clearAllData()
-            savedSitesRepository.pruneDeleted()
+
+            // https://app.asana.com/0/69071770703008/1204375817149200/f
+            if (!deviceSyncState.isUserSignedInOnDevice()) {
+                savedSitesRepository.pruneDeleted()
+            }
+
             clearTabsAsync(appInForeground)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.location.GeoLocationPermissions
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
+import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -66,6 +67,7 @@ class ClearPersonalDataAction(
     private val adClickManager: AdClickManager,
     private val fireproofWebsiteRepository: FireproofWebsiteRepository,
     private val sitePermissionsManager: SitePermissionsManager,
+    private val savedSitesRepository: SavedSitesRepository,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
 ) : ClearDataAction {
 
@@ -89,6 +91,7 @@ class ClearPersonalDataAction(
             geoLocationPermissions.clearAllButFireproofed()
             sitePermissionsManager.clearAllButFireproof(fireproofDomains)
             thirdPartyCookieManager.clearAllData()
+            savedSitesRepository.pruneDeleted()
             clearTabsAsync(appInForeground)
         }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesDataCleaner.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesDataCleaner.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.sync.api.DeviceSyncState
-import com.duckduckgo.sync.api.engine.SyncEngine
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -35,7 +34,6 @@ import kotlinx.coroutines.launch
 )
 class SavedSitesDataCleaner @Inject constructor(
     private val savedSitesRepository: SavedSitesRepository,
-    private val syncEngine: SyncEngine,
     private val deviceSyncState: DeviceSyncState,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesDataCleaner.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesDataCleaner.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.service
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.savedsites.api.SavedSitesRepository
+import com.duckduckgo.sync.api.DeviceSyncState
+import com.duckduckgo.sync.api.engine.SyncEngine
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class SavedSitesDataCleaner @Inject constructor(
+    private val savedSitesRepository: SavedSitesRepository,
+    private val syncEngine: SyncEngine,
+    private val deviceSyncState: DeviceSyncState,
+    @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        // https://app.asana.com/0/69071770703008/1204375817149200/f
+        if (!deviceSyncState.isUserSignedInOnDevice()) {
+            coroutineScope.launch(dispatcherProvider.io()) {
+                savedSitesRepository.pruneDeleted()
+            }
+        }
+    }
+}

--- a/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
+++ b/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
@@ -23,7 +23,6 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
-import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 
@@ -72,15 +71,8 @@ interface SavedSitesEntitiesDao {
         lastModified: String = DatabaseDateFormatter.iso8601(),
     )
 
-    @Query(
-        "update entities set title = '', url = '', deleted = 1, lastModified = :lastModified where entityId != :bookmarksRoot " +
-            "AND entityId != :favoritesRoot",
-    )
-    fun deleteAll(
-        bookmarksRoot: String = SavedSitesNames.BOOKMARKS_ROOT,
-        favoritesRoot: String = SavedSitesNames.FAVORITES_ROOT,
-        lastModified: String = DatabaseDateFormatter.iso8601(),
-    )
+    @Query("delete from entities")
+    fun deleteAll()
 
     @Delete
     fun deletePermanently(entity: Entity)

--- a/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
+++ b/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
@@ -66,13 +66,15 @@ interface SavedSitesEntitiesDao {
     )
     fun allEntitiesInFolderSync(folderId: String): List<Entity>
 
-    @Query("update entities set deleted = 1, lastModified = :lastModified where entityId = :id")
+    @Query("update entities set title = '', url = '', deleted = 1, lastModified = :lastModified where entityId = :id")
     fun delete(
         id: String,
         lastModified: String = DatabaseDateFormatter.iso8601(),
     )
 
-    @Query("update entities set deleted = 1, lastModified = :lastModified where entityId != :bookmarksRoot AND entityId != :favoritesRoot")
+    @Query(
+        "update entities set title = '', url = '', deleted = 1, lastModified = :lastModified where entityId != :bookmarksRoot AND entityId != :favoritesRoot",
+    )
     fun deleteAll(
         bookmarksRoot: String = SavedSitesNames.BOOKMARKS_ROOT,
         favoritesRoot: String = SavedSitesNames.FAVORITES_ROOT,

--- a/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
+++ b/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
@@ -73,7 +73,8 @@ interface SavedSitesEntitiesDao {
     )
 
     @Query(
-        "update entities set title = '', url = '', deleted = 1, lastModified = :lastModified where entityId != :bookmarksRoot AND entityId != :favoritesRoot",
+        "update entities set title = '', url = '', deleted = 1, lastModified = :lastModified where entityId != :bookmarksRoot " +
+            "AND entityId != :favoritesRoot",
     )
     fun deleteAll(
         bookmarksRoot: String = SavedSitesNames.BOOKMARKS_ROOT,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1201493110486074/1204879487866164/f
Task/Issue URL: https://app.asana.com/0/1201493110486074/1204874751768176/f
### Description:

### Steps to test this PR

_Sync Disabled - App open clearing_
- [ ] Open app and add some bookmarks
- [ ] Delete bookmark
- [ ] Bookmark should still be in the DB with deleted flag enabled, and title / url removed (use AppInspector)
- [ ] Force close the app, and open it again
- [ ] Bookmark should be done from the DB 

_Sync Disabled - Fire button_
- [ ] Open app and add some bookmarks
- [ ] Ensure Fire Button config is set to clear all data
- [ ] Delete bookmark
- [ ] Bookmark should still be in the DB with deleted flag enabled, and title / url removed (use AppInspector)
- [ ] Tap on the fire button
- [ ] Bookmark should be done from the DB 