### PR TITLE
Add content scope scripts feature toggle

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -169,9 +169,18 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenInjectContentScopeScriptsToDom() = runTest {
+    fun whenOnPageStartedCalledAndContentScopeScriptsIsEnabledThenInjectContentScopeScriptsToDom() = runTest {
+        whenever(contentScopeScripts.isEnabled()).thenReturn(true)
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         verify(contentScopeScripts).getScript()
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnPageStartedCalledAndContentScopeScriptsIsDisabledThenDoNotInjectContentScopeScriptsToDom() = runTest {
+        whenever(contentScopeScripts.isEnabled()).thenReturn(false)
+        testee.onPageStarted(webView, EXAMPLE_URL, null)
+        verify(contentScopeScripts, times(0)).getScript()
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -169,18 +169,9 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledAndContentScopeScriptsIsEnabledThenInjectContentScopeScriptsToDom() = runTest {
-        whenever(contentScopeScripts.isEnabled()).thenReturn(true)
+    fun whenOnPageStartedCalledThenInjectContentScopeScripts() = runTest {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
-        verify(contentScopeScripts).getScript()
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenOnPageStartedCalledAndContentScopeScriptsIsDisabledThenDoNotInjectContentScopeScriptsToDom() = runTest {
-        whenever(contentScopeScripts.isEnabled()).thenReturn(false)
-        testee.onPageStarted(webView, EXAMPLE_URL, null)
-        verify(contentScopeScripts, times(0)).getScript()
+        verify(contentScopeScripts).injectContentScopeScripts(webView)
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
@@ -82,18 +82,9 @@ class UrlExtractingWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledAndContentScopeScriptsIsEnabledThenInjectContentScopeScriptsToDom() = runTest {
-        whenever(contentScopeScripts.isEnabled()).thenReturn(true)
+    fun whenOnPageStartedCalledThenInjectContentScopeScripts() = runTest {
         testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
-        verify(contentScopeScripts).getScript()
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenOnPageStartedCalledAndContentScopeScriptsIsDisabledThenDoNotInjectContentScopeScriptsToDom() = runTest {
-        whenever(contentScopeScripts.isEnabled()).thenReturn(false)
-        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
-        verify(contentScopeScripts, times(0)).getScript()
+        verify(contentScopeScripts).injectContentScopeScripts(mockWebView)
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
@@ -34,6 +34,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -81,9 +82,18 @@ class UrlExtractingWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenInjectContentScopeScriptsToDom() = runTest {
+    fun whenOnPageStartedCalledAndContentScopeScriptsIsEnabledThenInjectContentScopeScriptsToDom() = runTest {
+        whenever(contentScopeScripts.isEnabled()).thenReturn(true)
         testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
         verify(contentScopeScripts).getScript()
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnPageStartedCalledAndContentScopeScriptsIsDisabledThenDoNotInjectContentScopeScriptsToDom() = runTest {
+        whenever(contentScopeScripts.isEnabled()).thenReturn(false)
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        verify(contentScopeScripts, times(0)).getScript()
     }
 
     @UiThreadTest

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -261,9 +261,7 @@ class BrowserWebViewClient @Inject constructor(
         }
         lastPageStarted = url
         browserAutofillConfigurator.configureAutofillForCurrentPage(webView, url)
-        if (contentScopeScripts.isEnabled()) {
-            webView.evaluateJavascript("javascript:${contentScopeScripts.getScript()}", null)
-        }
+        contentScopeScripts.injectContentScopeScripts(webView)
         loginDetector.onEvent(WebNavigationEvent.OnPageStarted(webView))
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -261,7 +261,9 @@ class BrowserWebViewClient @Inject constructor(
         }
         lastPageStarted = url
         browserAutofillConfigurator.configureAutofillForCurrentPage(webView, url)
-        webView.evaluateJavascript("javascript:${contentScopeScripts.getScript()}", null)
+        if (contentScopeScripts.isEnabled()) {
+            webView.evaluateJavascript("javascript:${contentScopeScripts.getScript()}", null)
+        }
         loginDetector.onEvent(WebNavigationEvent.OnPageStarted(webView))
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
@@ -56,9 +56,7 @@ class UrlExtractingWebViewClient(
                 thirdPartyCookieManager.processUriForThirdPartyCookies(webView, url.toUri())
             }
         }
-        if (contentScopeScripts.isEnabled()) {
-            webView.evaluateJavascript("javascript:${contentScopeScripts.getScript()}", null)
-        }
+        contentScopeScripts.injectContentScopeScripts(webView)
         Timber.d("AMP link detection: Injecting JS for URL extraction")
         urlExtractor.injectUrlExtractionJS(webView)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
@@ -56,7 +56,9 @@ class UrlExtractingWebViewClient(
                 thirdPartyCookieManager.processUriForThirdPartyCookies(webView, url.toUri())
             }
         }
-        webView.evaluateJavascript("javascript:${contentScopeScripts.getScript()}", null)
+        if (contentScopeScripts.isEnabled()) {
+            webView.evaluateJavascript("javascript:${contentScopeScripts.getScript()}", null)
+        }
         Timber.d("AMP link detection: Injecting JS for URL extraction")
         urlExtractor.injectUrlExtractionJS(webView)
     }

--- a/content-scope-scripts/content-scope-scripts-api/build.gradle
+++ b/content-scope-scripts/content-scope-scripts-api/build.gradle
@@ -25,6 +25,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 dependencies {
     implementation project(':di')
     implementation project(':common')
+    api project(':feature-toggles-api')
 
     anvil project(':anvil-compiler')
     implementation project(':anvil-annotations')

--- a/content-scope-scripts/content-scope-scripts-api/src/main/java/com/duckduckgo/contentscopescripts/api/ContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-api/src/main/java/com/duckduckgo/contentscopescripts/api/ContentScopeScripts.kt
@@ -22,10 +22,10 @@ import android.webkit.WebView
 interface ContentScopeScripts {
 
     /**
-     * This method returns a [String] which contains the content scope scripts JS code to be injected.
-     * @return a [String] containing the JS content scope code.
+     * This method injects the content scope scripts JS code into the [WebView].
+     * It requires a [WebView] instance.
      */
-    fun getScript(): String
+    fun injectContentScopeScripts(webView: WebView)
 
     /**
      * This method adds the JS interface for Content Scope Scripts to create a bridge between JS and our client.
@@ -38,10 +38,4 @@ interface ContentScopeScripts {
      * It requires a JSON message [String] and a [WebView] instance.
      */
     fun sendMessage(message: String, webView: WebView)
-
-    /**
-     * This method returns the enabled state for Content Scope Scripts
-     * @return a [Boolean] of true when enabled and false when disabled.
-     */
-    fun isEnabled(): Boolean
 }

--- a/content-scope-scripts/content-scope-scripts-api/src/main/java/com/duckduckgo/contentscopescripts/api/ContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-api/src/main/java/com/duckduckgo/contentscopescripts/api/ContentScopeScripts.kt
@@ -38,4 +38,10 @@ interface ContentScopeScripts {
      * It requires a JSON message [String] and a [WebView] instance.
      */
     fun sendMessage(message: String, webView: WebView)
+
+    /**
+     * This method returns the enabled state for Content Scope Scripts
+     * @return a [Boolean] of true when enabled and false when disabled.
+     */
+    fun isEnabled(): Boolean
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
-    featureName = "contentScopeScripts",
+    featureName = "clientContentFeatures",
 )
 
 interface ContentScopeScriptsFeature {

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.contentscopescripts.impl
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "contentScopeScripts",
+)
+
+interface ContentScopeScriptsFeature {
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
+}

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -34,6 +34,7 @@ import javax.inject.Inject
 
 interface CoreContentScopeScripts {
     fun getScript(): String
+    fun isEnabled(): Boolean
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -45,6 +46,7 @@ class RealContentScopeScripts @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val unprotectedTemporary: UnprotectedTemporary,
     private val fingerprintProtectionManager: FingerprintProtectionManager,
+    private val contentScopeScriptsFeature: ContentScopeScriptsFeature,
 ) : CoreContentScopeScripts {
 
     private var cachedContentScopeJson: String = getContentScopeJson("", emptyList())
@@ -90,6 +92,10 @@ class RealContentScopeScripts @Inject constructor(
             cacheContentScopeJS()
         }
         return cachedContentScopeJS
+    }
+
+    override fun isEnabled(): Boolean {
+        return contentScopeScriptsFeature.self().isEnabled()
     }
 
     private fun getPluginParameters(): PluginParameters {

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/RealMessagingContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/RealMessagingContentScopeScripts.kt
@@ -58,6 +58,10 @@ class RealMessagingContentScopeScripts @Inject constructor(
         webView.evaluateJavascript(ReplyHandler.constructReply(message, messageCallback, messageSecret), null)
     }
 
+    override fun isEnabled(): Boolean {
+        return coreContentScopeScripts.isEnabled()
+    }
+
     companion object {
         private val messageInterface = getSecret()
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/RealMessagingContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/RealMessagingContentScopeScripts.kt
@@ -42,9 +42,15 @@ class RealMessagingContentScopeScripts @Inject constructor(
     private fun getCallbackKeyValuePair() = "\"messageCallback\":\"$messageCallback\""
     private fun getInterfaceKeyValuePair() = "\"messageInterface\":\"${messageInterface}\""
 
-    override fun getScript(): String {
+    private fun getScript(): String {
         return coreContentScopeScripts.getScript()
             .replace(messagingParameters, "${getSecretKeyValuePair()},${getCallbackKeyValuePair()},${getInterfaceKeyValuePair()}")
+    }
+
+    override fun injectContentScopeScripts(webView: WebView) {
+        if (coreContentScopeScripts.isEnabled()) {
+            webView.evaluateJavascript("javascript:${getScript()}", null)
+        }
     }
 
     override fun addJsInterface(webView: WebView) {
@@ -56,10 +62,6 @@ class RealMessagingContentScopeScripts @Inject constructor(
 
     override fun sendMessage(message: String, webView: WebView) {
         webView.evaluateJavascript(ReplyHandler.constructReply(message, messageCallback, messageSecret), null)
-    }
-
-    override fun isEnabled(): Boolean {
-        return coreContentScopeScripts.isEnabled()
     }
 
     companion object {

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -20,10 +20,14 @@ import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.contentscopescripts.api.ContentScopeConfigPlugin
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -42,6 +46,7 @@ class RealContentScopeScriptsTest {
     private val mockAppBuildConfig: AppBuildConfig = mock()
     private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
     private val mockFingerprintProtectionManager: FingerprintProtectionManager = mock()
+    private val mockContentScopeScriptsFeature: ContentScopeScriptsFeature = mock()
 
     lateinit var testee: CoreContentScopeScripts
 
@@ -54,6 +59,7 @@ class RealContentScopeScriptsTest {
             mockAppBuildConfig,
             mockUnprotectedTemporary,
             mockFingerprintProtectionManager,
+            mockContentScopeScriptsFeature,
         )
         whenever(mockPlugin1.config()).thenReturn(config1)
         whenever(mockPlugin2.config()).thenReturn(config2)
@@ -186,6 +192,38 @@ class RealContentScopeScriptsTest {
         verify(mockUnprotectedTemporary, times(4)).unprotectedTemporaryExceptions
         verify(mockUserAllowListRepository, times(3)).domainsInUserAllowList()
         verify(mockContentScopeJsReader, times(2)).getContentScopeJS()
+    }
+
+    @Test
+    fun whenContentScopeScriptsIsEnabledThenReturnTrue() {
+        whenever(mockContentScopeScriptsFeature.self()).thenReturn(EnabledToggle())
+        assertTrue(testee.isEnabled())
+    }
+
+    @Test
+    fun whenContentScopeScriptsIsDisabledThenReturnFalse() {
+        whenever(mockContentScopeScriptsFeature.self()).thenReturn(DisabledToggle())
+        assertFalse(testee.isEnabled())
+    }
+
+    class EnabledToggle : Toggle {
+        override fun isEnabled(): Boolean {
+            return true
+        }
+
+        override fun setEnabled(state: State) {
+            // not implemented
+        }
+    }
+
+    class DisabledToggle : Toggle {
+        override fun isEnabled(): Boolean {
+            return false
+        }
+
+        override fun setEnabled(state: State) {
+            // not implemented
+        }
     }
 
     companion object {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204659079168053/f

### Description
This PR adds the ability to enable/disable Content Scope Scripts via remote config.

### Steps to test this PR
- [x] Go to https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/
- [x] Verify: `navigator.getBattery() - (object) - { "charging": true, "chargingTime": 0, "level": 1 }`
- [x] Override the remote config URL with the JSON blob linked in the task
- [x] Restart the app
- [x] Go to https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/
- [x] Verify: `navigator.getBattery() - (object) - { "charging": false, "chargingTime": null, "level": 1 }` (Or the actual battery status if using a physical device)