### PR TITLE
Disable segment pixel for new installs

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.app.statistics.AtbInitializerListener
 import com.duckduckgo.app.statistics.api.PixelSender
 import com.duckduckgo.app.statistics.api.StatisticsService
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
-import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentsManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.di.DaggerSet
@@ -110,9 +109,8 @@ class StubStatisticsModule {
         statisticsDataStore: StatisticsDataStore,
         statisticsUpdater: StatisticsUpdater,
         listeners: DaggerSet<AtbInitializerListener>,
-        featureSegmentsManager: FeatureSegmentsManager,
     ): MainProcessLifecycleObserver {
-        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners, featureSegmentsManager)
+        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.AtbInitializer
 import com.duckduckgo.app.statistics.AtbInitializerListener
 import com.duckduckgo.app.statistics.api.*
-import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentsManager
 import com.duckduckgo.app.statistics.store.PendingPixelDao
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.di.DaggerSet
@@ -56,9 +55,8 @@ object StatisticsModule {
         statisticsDataStore: StatisticsDataStore,
         statisticsUpdater: StatisticsUpdater,
         listeners: DaggerSet<AtbInitializerListener>,
-        featureSegmentsManager: FeatureSegmentsManager,
     ): MainProcessLifecycleObserver {
-        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners, featureSegmentsManager)
+        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners)
     }
 
     @SingleInstanceIn(AppScope::class)

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/AtbInitializer.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/AtbInitializer.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
-import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentsManager
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -42,7 +41,6 @@ class AtbInitializer(
     private val statisticsDataStore: StatisticsDataStore,
     private val statisticsUpdater: StatisticsUpdater,
     private val listeners: Set<AtbInitializerListener>,
-    private val featureSegmentsManager: FeatureSegmentsManager,
 ) : MainProcessLifecycleObserver {
 
     override fun onResume(owner: LifecycleOwner) {
@@ -64,7 +62,6 @@ class AtbInitializer(
             statisticsUpdater.refreshAppRetentionAtb()
         } else {
             statisticsUpdater.initializeAtb()
-            featureSegmentsManager.enableSendPixelForFeatureSegments()
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204904897721603/f

### Description
Disable sending retention events pixel for new installs.

### Steps to test this PR

_User is not added to the segment_
- Add log in Line 105 on `FeatureSegmentsManager`, before the return line
        (e.g. `Timber.d("Feature Segment isSendPixelEnabled: ${featureSegmentsDataStore.featureSegmentsEnabled}")`
- Fresh install
- Set DDG as default in onboarding
- [x] Check in the log that `isSendPixelEnabled` = false

_Rest of events that need to be tested_ **(Optional)**
- Add log in Line 105 on `FeatureSegmentsManager`, before the return line
        (e.g. `Timber.d("Feature Segment isSendPixelEnabled: ${featureSegmentsDataStore.featureSegmentsEnabled}")`
- Fresh install
- Choose any event from the list in this task: https://app.asana.com/0/0/1204620497244294/f
- [x] Check in the log that `isSendPixelEnabled` = false

_Send daily pixel disabled_
- Add log in Line 105 on `FeatureSegmentsManager`, before the return line
        (e.g. `Timber.d("Feature Segment isSendPixelEnabled: ${featureSegmentsDataStore.featureSegmentsEnabled}")`
- Comment Line 42 in `FeatureSegmentsPixelSender` (so it will be fired in day 0 too)
- Fresh install
- Set as default in onboarding
- Make a search
- Close the app
- Open the app
- [x] Check in the log that `isSendPixelEnabled` = false

### No UI changes
