### PR TITLE
Sync: DataObserver should not be triggered when sync in progress

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataObserver.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataObserver.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
+import com.duckduckgo.sync.api.SyncState.IN_PROGRESS
 import com.duckduckgo.sync.api.SyncState.OFF
 import com.duckduckgo.sync.api.SyncStateMonitor
 import com.duckduckgo.sync.api.engine.SyncEngine
@@ -55,6 +56,7 @@ class SavedSitesSyncDataObserver @Inject constructor(
             .onEach { state ->
                 when (state) {
                     OFF -> cancelSavedSitesChanges()
+                    IN_PROGRESS -> cancelSavedSitesChanges()
                     else -> observeSavedSitesChanges()
                 }
             }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1204942882074644/f 

### Description
When Sync is in progress, we shouldn’t listen to underlying changes. This is because when a sync is in progress, it could be modifying the SavedSites. The Observer is then triggered since changes are applied to the db. 
