### PR TITLE
Update content scope scripts to version 4.22.4

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -361,7 +361,7 @@
     };
 
     /**
-     * Handles the processing of a config setting.
+     * Processes a structured config setting and returns the value according to its type
      * @param {*} configSetting
      * @param {*} [defaultValue]
      * @returns
@@ -824,15 +824,16 @@
         'clickToLoad',
         'windowsPermissionUsage',
         'webCompat',
-        'duckPlayer'
+        'duckPlayer',
+        'harmfulApis'
     ]);
 
     /** @typedef {baseFeatures[number]|otherFeatures[number]} FeatureName */
     /** @type {Record<string, FeatureName[]>} */
     const platformSupport = {
         apple: [
-            ...baseFeatures,
-            'webCompat'
+            'webCompat',
+            ...baseFeatures
         ],
         'apple-isolated': [
             'duckPlayer'
@@ -844,7 +845,8 @@
         windows: [
             ...baseFeatures,
             'windowsPermissionUsage',
-            'duckPlayer'
+            'duckPlayer',
+            'harmfulApis'
         ],
         firefox: [
             ...baseFeatures,
@@ -2573,12 +2575,13 @@
         }
 
         /**
+         * Return a specific setting from the feature settings
          * @param {string} featureKeyName
          * @param {string} [featureName]
          * @returns {any}
          */
         getFeatureSetting (featureKeyName, featureName) {
-            let result = this._getFeatureSetting(featureName);
+            let result = this._getFeatureSettings(featureName);
             if (featureKeyName === 'domains') {
                 throw new Error('domains is a reserved feature setting key name')
             }
@@ -2599,15 +2602,17 @@
         }
 
         /**
+         * Return the settings object for a feature
          * @param {string} [featureName] - The name of the feature to get the settings for; defaults to the name of the feature
          * @returns {any}
          */
-        _getFeatureSetting (featureName) {
+        _getFeatureSettings (featureName) {
             const camelFeatureName = featureName || camelcase(this.name);
             return this.#args?.featureSettings?.[camelFeatureName]
         }
 
         /**
+         * For simple boolean settings, return true if the setting is 'enabled'
          * @param {string} featureKeyName
          * @param {string} [featureName]
          * @returns {boolean}
@@ -2618,13 +2623,14 @@
         }
 
         /**
+         * Given a config key, interpret the value as a list of domain overrides, and return the elements that match the current page
          * @param {string} featureKeyName
          * @return {any[]}
          */
         matchDomainFeatureSetting (featureKeyName) {
             const domain = this.#args?.site.domain;
             if (!domain) return []
-            const domains = this._getFeatureSetting()?.[featureKeyName] || [];
+            const domains = this._getFeatureSettings()?.[featureKeyName] || [];
             return domains.filter((rule) => {
                 if (Array.isArray(rule.domain)) {
                     return rule.domain.some((domainRule) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.3.3",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.22.1",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.22.4",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1687534075"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1b5548805ed1d5af4bb6432ea23890797540fbdd",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#630eb2c4cf94055e630fd5b7daae71bed893ad0a",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.3.3",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#7.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.22.1",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.22.4",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1687534075"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204964860447173/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass