### PR TITLE
Enable segment pixel with new parameter

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.statistics.AtbInitializerListener
 import com.duckduckgo.app.statistics.api.PixelSender
 import com.duckduckgo.app.statistics.api.StatisticsService
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
+import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentsManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.di.DaggerSet
@@ -109,8 +110,9 @@ class StubStatisticsModule {
         statisticsDataStore: StatisticsDataStore,
         statisticsUpdater: StatisticsUpdater,
         listeners: DaggerSet<AtbInitializerListener>,
+        featureSegmentsManager: FeatureSegmentsManager,
     ): MainProcessLifecycleObserver {
-        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners)
+        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners, featureSegmentsManager)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StatisticsModule.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.AtbInitializer
 import com.duckduckgo.app.statistics.AtbInitializerListener
 import com.duckduckgo.app.statistics.api.*
+import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentsManager
 import com.duckduckgo.app.statistics.store.PendingPixelDao
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.di.DaggerSet
@@ -55,8 +56,9 @@ object StatisticsModule {
         statisticsDataStore: StatisticsDataStore,
         statisticsUpdater: StatisticsUpdater,
         listeners: DaggerSet<AtbInitializerListener>,
+        featureSegmentsManager: FeatureSegmentsManager,
     ): MainProcessLifecycleObserver {
-        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners)
+        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners, featureSegmentsManager)
     }
 
     @SingleInstanceIn(AppScope::class)

--- a/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
@@ -20,6 +20,7 @@ import androidx.annotation.VisibleForTesting
 import com.duckduckgo.app.global.AppUrl
 import com.duckduckgo.app.global.plugins.pixel.PixelInterceptorPlugin
 import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.api.featureusage.pixel.FeatureSegmentsPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.StatisticsPixelName
 import com.duckduckgo.di.scopes.AppScope
@@ -65,6 +66,7 @@ class AtbAndAppVersionPixelRemovalInterceptor @Inject constructor() : Intercepto
             AppPixelName.EMAIL_USE_ADDRESS.pixelName,
             AppPixelName.EMAIL_COPIED_TO_CLIPBOARD.pixelName,
             StatisticsPixelName.BROWSER_DAILY_ACTIVE_FEATURE_STATE.pixelName,
+            FeatureSegmentsPixelName.DAILY_USER_EVENT_SEGMENT.pixelName,
             "m_atp_unprotected_apps_bucket_",
         )
     }

--- a/app/src/test/java/com/duckduckgo/app/statistics/AtbInitializerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/AtbInitializerTest.kt
@@ -18,12 +18,14 @@ package com.duckduckgo.app.statistics
 
 import com.duckduckgo.app.referral.StubAppReferrerFoundStateListener
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
+import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentsManager
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -34,13 +36,14 @@ class AtbInitializerTest {
 
     private val statisticsDataStore: StatisticsDataStore = mock()
     private val statisticsUpdater: StatisticsUpdater = mock()
+    private val mockFeatureSegmentsManager: FeatureSegmentsManager = mock()
     private lateinit var appReferrerStateListener: AtbInitializerListener
 
     @Test
     fun whenReferrerInformationInstantlyAvailableThenAtbInitialized() = runTest {
         whenever(statisticsDataStore.hasInstallationStatistics).thenReturn(false)
         appReferrerStateListener = StubAppReferrerFoundStateListener(referrer = "xx")
-        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener), mockFeatureSegmentsManager)
 
         testee.initialize()
 
@@ -51,7 +54,7 @@ class AtbInitializerTest {
     fun whenReferrerInformationQuicklyAvailableThenAtbInitialized() = runTest {
         whenever(statisticsDataStore.hasInstallationStatistics).thenReturn(false)
         appReferrerStateListener = StubAppReferrerFoundStateListener(referrer = "xx", mockDelayMs = 1000L)
-        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener), mockFeatureSegmentsManager)
 
         testee.initialize()
 
@@ -62,7 +65,7 @@ class AtbInitializerTest {
     fun whenReferrerInformationTimesOutThenAtbInitialized() = runTest {
         whenever(statisticsDataStore.hasInstallationStatistics).thenReturn(false)
         appReferrerStateListener = StubAppReferrerFoundStateListener(referrer = "xx", mockDelayMs = Long.MAX_VALUE)
-        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener), mockFeatureSegmentsManager)
 
         testee.initialize()
 
@@ -72,10 +75,27 @@ class AtbInitializerTest {
     @Test
     fun whenAlreadyInitializedThenRefreshCalled() = runTest {
         configureAlreadyInitialized()
-        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener))
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener), mockFeatureSegmentsManager)
 
         testee.initialize()
         verify(statisticsUpdater).refreshAppRetentionAtb()
+    }
+
+    @Test
+    fun whenStatisticsNotStoredThenDontEnableFeatureSegment() {
+        whenever(statisticsDataStore.hasInstallationStatistics).thenReturn(false)
+        appReferrerStateListener = StubAppReferrerFoundStateListener(referrer = "xx")
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener), mockFeatureSegmentsManager)
+
+        verify(mockFeatureSegmentsManager, never()).enableSendPixelForFeatureSegments()
+    }
+
+    @Test
+    fun whenStatisticsStoredThenDontEnableFeatureSegment() {
+        configureAlreadyInitialized()
+        testee = AtbInitializer(TestScope(), statisticsDataStore, statisticsUpdater, setOf(appReferrerStateListener), mockFeatureSegmentsManager)
+
+        verify(mockFeatureSegmentsManager, never()).enableSendPixelForFeatureSegments()
     }
 
     private fun configureAlreadyInitialized() {

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/AtbInitializer.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/AtbInitializer.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
+import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentsManager
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -41,6 +42,7 @@ class AtbInitializer(
     private val statisticsDataStore: StatisticsDataStore,
     private val statisticsUpdater: StatisticsUpdater,
     private val listeners: Set<AtbInitializerListener>,
+    private val featureSegmentsManager: FeatureSegmentsManager,
 ) : MainProcessLifecycleObserver {
 
     override fun onResume(owner: LifecycleOwner) {
@@ -62,6 +64,7 @@ class AtbInitializer(
             statisticsUpdater.refreshAppRetentionAtb()
         } else {
             statisticsUpdater.initializeAtb()
+            featureSegmentsManager.enableSendPixelForFeatureSegments()
         }
     }
 }

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/featureusage/FeatureSegmentsManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/featureusage/FeatureSegmentsManager.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentType.TEN_SEA
 import com.duckduckgo.app.statistics.api.featureusage.FeatureSegmentType.TWO_SEARCHES_MADE
 import com.duckduckgo.app.statistics.api.featureusage.db.FeatureSegmentsDataStore
 import com.duckduckgo.app.statistics.api.featureusage.pixel.FeatureSegmentsPixelName.DAILY_USER_EVENT_SEGMENT
+import com.duckduckgo.app.statistics.api.featureusage.pixel.FeatureSegmentsPixelParameters
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -36,7 +37,7 @@ import javax.inject.Inject
 interface FeatureSegmentsManager {
     fun addUserToFeatureSegment(segment: FeatureSegmentType)
     fun searchMade()
-    fun fireFeatureSegmentsPixel()
+    fun fireFeatureSegmentsPixel(retentionDay: Long)
     fun restartDailySearchCount()
     fun lastRetentionDayPixelSent(): Int
     fun updateLastRetentionDayPixelSent(retentionDay: Int)
@@ -79,8 +80,9 @@ class FeatureSegmentManagerImpl @Inject constructor(
         }
     }
 
-    override fun fireFeatureSegmentsPixel() {
-        val params = getUserFeatureSegments().map { it.key to it.value.toString() }.toMap()
+    override fun fireFeatureSegmentsPixel(retentionDay: Long) {
+        val params = getUserFeatureSegments().map { it.key to it.value.toString() }.toMap().toMutableMap()
+        params[FeatureSegmentsPixelParameters.DAYS_SINCE_APP_INSTALL] = retentionDay.toString()
         pixel.fire(DAILY_USER_EVENT_SEGMENT, params)
     }
 

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/featureusage/pixel/FeatureSegmentsPixelName.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/featureusage/pixel/FeatureSegmentsPixelName.kt
@@ -21,3 +21,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 enum class FeatureSegmentsPixelName(override val pixelName: String) : Pixel.PixelName {
     DAILY_USER_EVENT_SEGMENT("m_daily_user_event_segment"),
 }
+
+object FeatureSegmentsPixelParameters {
+    const val DAYS_SINCE_APP_INSTALL = "days_since_app_install"
+}

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/featureusage/pixel/FeatureSegmentsPixelSender.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/featureusage/pixel/FeatureSegmentsPixelSender.kt
@@ -42,7 +42,7 @@ class FeatureSegmentsPixelSender @Inject constructor(
             browserProperties.daysSinceInstalled() - 1 > featureSegmentsManager.lastRetentionDayPixelSent() &&
             featureSegmentsManager.isSendPixelEnabled()
         if (shouldFireSegmentPixel) {
-            featureSegmentsManager.fireFeatureSegmentsPixel()
+            featureSegmentsManager.fireFeatureSegmentsPixel(browserProperties.daysSinceInstalled())
             val retentionDayPixelSent = browserProperties.daysSinceInstalled() - 1
             featureSegmentsManager.updateLastRetentionDayPixelSent(retentionDayPixelSent.toInt())
             featureSegmentsManager.restartDailySearchCount()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204954184560576/f

### Description
Add new parameter to `m_daily_user_event_segment` pixel

### Steps to test this PR

_Existing user won't be sending the pixel with new parameter_
- You need an older version app without this implementation
- Install from this branch
- [ ] Check pixel is not sent when opening the app (filter by `Pixel sent: m_daily_user_event_segment` in Logcat)

_New parameter is sent with pixel_
- Comment _Line 41_ after `val shouldFireSegmentPixel =` and _Line 42_. In this way, the pixel is sent every time the app is opened.
- Fresh install
- Set DDG as default in onboarding _(optional)_
- Use fire button _(optional)_
- Close app
- Open app
- [ ] Check pixel is sent with new parameter `days_since_app_install` and _(optional)_ parameters `set_as_default` and `fire_button_used` set to true (filter by `Pixel sent: m_daily_user_event_segment` in Logcat)
