### PR TITLE
Add support for filename * in Content-Disposition & prioritize it over filename

### DIFF
--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DownloaderUtilTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DownloaderUtilTest.kt
@@ -191,26 +191,102 @@ class DownloaderUtilTest {
 
     @Test
     fun whenContentDispositionWithAttachmentAndFilenameBetweenQuotesAndSpaceAfterSemicolonThenCorrectFilenameExtracted() {
-        assertEquals("filename.jpg", DownloaderUtil.parseContentDisposition("""attachment; filename="filename.jpg""""))
+        assertEquals("filename.jpg", DownloaderUtil.fileNameFromContentDisposition("""attachment; filename="filename.jpg""""))
     }
 
     @Test
     fun whenContentDispositionWithAttachmentAndFilenameBetweenQuotesAndSpacesBeforeAndAfterSemicolonThenCorrectFilenameExtracted() {
-        assertEquals("filename.jpg", DownloaderUtil.parseContentDisposition("""attachment ; filename="filename.jpg""""))
+        assertEquals("filename.jpg", DownloaderUtil.fileNameFromContentDisposition("""attachment ; filename="filename.jpg""""))
     }
 
     @Test
     fun whenContentDispositionWithAttachmentAndFilenameBetweenQuotesAndNoSpacesThenCorrectFilenameExtracted() {
-        assertEquals("filename.jpg", DownloaderUtil.parseContentDisposition("""attachment;filename="filename.jpg""""))
+        assertEquals("filename.jpg", DownloaderUtil.fileNameFromContentDisposition("""attachment;filename="filename.jpg""""))
     }
 
     @Test
     fun whenContentDispositionWithAttachmentAndFilenameWithoutQuotesAndWithSpaceAfterSemicolonThenCorrectFilenameExtracted() {
-        assertEquals("filename.jpg", DownloaderUtil.parseContentDisposition("""attachment; filename=filename.jpg"""))
+        assertEquals("filename.jpg", DownloaderUtil.fileNameFromContentDisposition("""attachment; filename=filename.jpg"""))
     }
 
     @Test
     fun whenContentDispositionWithInlineAndFilenameBetweenQuotesAndSpaceAfterSemicolonThenCorrectFilenameExtracted() {
-        assertEquals("filename.jpg", DownloaderUtil.parseContentDisposition("""inline; filename="filename.jpg""""))
+        assertEquals("filename.jpg", DownloaderUtil.fileNameFromContentDisposition("""inline; filename="filename.jpg""""))
+    }
+
+    @Test
+    fun whenContentDispositionWithAttachmentAndFilenameEncodedThenEncodedFilenameExtracted() {
+        assertEquals(
+            "%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt",
+            DownloaderUtil.fileNameFromContentDisposition(
+                """attachment; filename*= "%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt"""",
+            ),
+        )
+    }
+
+    @Test
+    fun whenContentDispositionWithAttachmentAndFilenameStarEncodedThenDecodedFilenameExtracted() {
+        assertEquals(
+            "中文文件名测试.txt",
+            DownloaderUtil.fileNameFromContentDisposition(
+                """attachment; filename*=utf-8''%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt""",
+            ),
+        )
+    }
+
+    @Test
+    fun whenContentDispositionWithAttachmentAndFilenameStarEncodedAndFilenameThenDecodedFilenameExtracted() {
+        assertEquals(
+            "中文文件名测试.txt",
+            DownloaderUtil.fileNameFromContentDisposition(
+                """
+                    attachment; 
+                    filename*=utf-8''%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt; 
+                    filename= "%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun whenContentDispositionWithAttachmentAndFilenameAndFilenameStarEncodedThenDecodedFilenameExtracted() {
+        assertEquals(
+            "中文文件名测试.txt",
+            DownloaderUtil.fileNameFromContentDisposition(
+                """
+                    attachment; 
+                    filename= "%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt; 
+                    filename*=utf-8''%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt;
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun whenContentDispositionWithAttachmentAndFilenameStarEncodedWithNoEncodingAndFilenameThenDecodedFilenameExtractedFallback() {
+        assertEquals(
+            "%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt",
+            DownloaderUtil.fileNameFromContentDisposition(
+                """
+                    attachment; 
+                    filename*=%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt; 
+                    filename= "%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun whenContentDispositionWithInlineAndFilenameStarEncodedAndFilenameThenDecodedFilenameExtracted() {
+        assertEquals(
+            "中文文件名测试.txt",
+            DownloaderUtil.fileNameFromContentDisposition(
+                """
+                    inline; 
+                    filename= "%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt; 
+                    filename*=utf-8''%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.txt;
+                """.trimIndent(),
+            ),
+        )
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1202994708537217/f

### Description
Support getting filename from `filename*` and prioritize over `filename`

### Steps to test this PR
- Download the file from https://user.fm/files/v2-a5fa215da9e2d03e1cd4d0674dfdd34c/%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.zip
- Check that the filename is "中文文件名测试.zip” instead of "%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D%E6%B5%8B%E8%AF%95.zip”

### UI changes
| Before  | After |
| ------ | ----- |
![image](https://github.com/duckduckgo/Android/assets/6297834/cddc73ee-dffa-4545-b5fe-993d6368f66d)|![image](https://github.com/duckduckgo/Android/assets/6297834/dfa194bf-2eed-43b0-bbb6-a09ef2c2b72d)|
