### PR TITLE
Restrict dialogs showing when triggered from inactive tabs

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4335,6 +4335,39 @@ class BrowserTabViewModelTest {
         }
     }
 
+    @Test
+    fun whenMultipleTabsAndViewModelIsForActiveTabThenActiveTabReturnsTrue() {
+        val tabId = "abc123"
+        selectedTabLiveData.value = aTabEntity(id = tabId)
+        loadTabWithId("foo")
+        loadTabWithId("bar")
+        loadTabWithId(tabId)
+        assertTrue(testee.isActiveTab())
+    }
+
+    @Test
+    fun whenMultipleTabsAndViewModelIsForInactiveTabThenActiveTabReturnsFalse() {
+        val tabId = "abc123"
+        selectedTabLiveData.value = aTabEntity(id = tabId)
+        loadTabWithId(tabId)
+        loadTabWithId("foo")
+        loadTabWithId("bar")
+        assertFalse(testee.isActiveTab())
+    }
+
+    @Test
+    fun whenSingleTabThenActiveTabReturnsTrue() {
+        val tabId = "abc123"
+        selectedTabLiveData.value = aTabEntity(id = tabId)
+        loadTabWithId(tabId)
+        assertTrue(testee.isActiveTab())
+    }
+
+    @Test
+    fun whenNoTabsThenActiveTabReturnsFalse() {
+        assertFalse(testee.isActiveTab())
+    }
+
     private fun aCredential(): LoginCredentials {
         return LoginCredentials(domain = null, username = null, password = null)
     }
@@ -4514,6 +4547,14 @@ class BrowserTabViewModelTest {
 
     private suspend fun givenRemoteMessage(remoteMessage: RemoteMessage) {
         remoteMessageFlow.send(remoteMessage)
+    }
+
+    private fun aTabEntity(id: String): TabEntity {
+        return TabEntity(tabId = id, position = 0)
+    }
+
+    private fun loadTabWithId(tabId: String) {
+        testee.loadData(tabId, initialUrl = null, skipHome = false, favoritesOnboarding = false)
     }
 
     private fun loadUrl(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -163,15 +163,7 @@ class BrowserChromeClient @Inject constructor(
         url: String,
         message: String,
         result: JsResult,
-    ): Boolean {
-        if (webViewClientListener?.isActiveTab() == true) {
-            return false
-        }
-
-        Timber.v("onJsAlert called but is not the active tab; suppressing dialog")
-        result.cancel()
-        return true
-    }
+    ): Boolean = shouldSuppressJavascriptDialog(result)
 
     /**
      * Called when a site's javascript tries to create a javascript prompt dialog
@@ -183,15 +175,7 @@ class BrowserChromeClient @Inject constructor(
         message: String?,
         defaultValue: String?,
         result: JsPromptResult,
-    ): Boolean {
-        if (webViewClientListener?.isActiveTab() == true) {
-            return false
-        }
-
-        Timber.v("onJsPrompt called but is not the active tab; suppressing dialog")
-        result.cancel()
-        return true
-    }
+    ): Boolean = shouldSuppressJavascriptDialog(result)
 
     /**
      * Called when a site's javascript tries to create a javascript confirmation dialog
@@ -202,12 +186,20 @@ class BrowserChromeClient @Inject constructor(
         url: String?,
         message: String?,
         result: JsResult,
-    ): Boolean {
+    ): Boolean = shouldSuppressJavascriptDialog(result)
+
+    /**
+     * Determines if we should allow or suppress a javascript dialog from being shown
+     *
+     * If suppressing it, we also cancel the pending javascript result so JS execution can continue
+     * @return false to allow it to happen as normal; return true to suppress it from being shown
+     */
+    private fun shouldSuppressJavascriptDialog(result: JsResult): Boolean {
         if (webViewClientListener?.isActiveTab() == true) {
             return false
         }
 
-        Timber.v("onJsConfirm called but is not the active tab; suppressing dialog")
+        Timber.v("javascript dialog attempting to show but is not the active tab; suppressing dialog")
         result.cancel()
         return true
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -154,6 +154,64 @@ class BrowserChromeClient @Inject constructor(
         webViewClientListener?.closeCurrentTab()
     }
 
+    /**
+     * Called when a site's javascript tries to create a javascript alert dialog
+     * @return false to allow it to happen as normal; return true to suppress it from being shown
+     */
+    override fun onJsAlert(
+        view: WebView?,
+        url: String,
+        message: String,
+        result: JsResult,
+    ): Boolean {
+        if (webViewClientListener?.isActiveTab() == true) {
+            return false
+        }
+
+        Timber.v("onJsAlert called but is not the active tab; suppressing dialog")
+        result.cancel()
+        return true
+    }
+
+    /**
+     * Called when a site's javascript tries to create a javascript prompt dialog
+     * @return false to allow it to happen as normal; return true to suppress it from being shown
+     */
+    override fun onJsPrompt(
+        view: WebView?,
+        url: String?,
+        message: String?,
+        defaultValue: String?,
+        result: JsPromptResult,
+    ): Boolean {
+        if (webViewClientListener?.isActiveTab() == true) {
+            return false
+        }
+
+        Timber.v("onJsPrompt called but is not the active tab; suppressing dialog")
+        result.cancel()
+        return true
+    }
+
+    /**
+     * Called when a site's javascript tries to create a javascript confirmation dialog
+     * @return false to allow it to happen as normal; return true to suppress it from being shown
+     */
+    override fun onJsConfirm(
+        view: WebView?,
+        url: String?,
+        message: String?,
+        result: JsResult,
+    ): Boolean {
+        if (webViewClientListener?.isActiveTab() == true) {
+            return false
+        }
+
+        Timber.v("onJsConfirm called but is not the active tab; suppressing dialog")
+        result.cancel()
+        return true
+    }
+
     override fun onGeolocationPermissionsShowPrompt(
         origin: String,
         callback: GeolocationPermissions.Callback,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1299,6 +1299,11 @@ class BrowserTabFragment :
     }
 
     private fun askSiteLocationPermission(domain: String) {
+        if (!isActiveTab) {
+            Timber.v("Will not launch a dialog for an inactive tab")
+            return
+        }
+
         val binding = ContentSiteLocationPermissionDialogBinding.inflate(layoutInflater)
 
         val title = domain.websiteFromGeoLocationsApiOrigin()
@@ -1531,6 +1536,11 @@ class BrowserTabFragment :
         activities: List<ResolveInfo>,
         useFirstActivityFound: Boolean,
     ) {
+        if (!isActiveTab) {
+            Timber.v("Will not launch a dialog for an inactive tab")
+            return
+        }
+
         if (activities.size == 1 || useFirstActivityFound) {
             val activity = activities.first()
             val appTitle = activity.loadLabel(pm)
@@ -1547,6 +1557,11 @@ class BrowserTabFragment :
         context: Context,
         fireproofWebsite: FireproofWebsiteEntity,
     ) {
+        if (!isActiveTab) {
+            Timber.v("Will not launch a dialog for an inactive tab")
+            return
+        }
+
         val isShowing = loginDetectionDialog?.isShowing()
 
         if (isShowing != true) {
@@ -1578,6 +1593,11 @@ class BrowserTabFragment :
         context: Context,
         fireproofWebsite: FireproofWebsiteEntity,
     ) {
+        if (!isActiveTab) {
+            Timber.v("Will not launch a dialog for an inactive tab")
+            return
+        }
+
         val isShowing = automaticFireproofDialog?.isShowing()
 
         if (isShowing != true) {
@@ -1699,6 +1719,11 @@ class BrowserTabFragment :
     }
 
     private fun showAuthenticationDialog(request: BasicAuthenticationRequest) {
+        if (!isActiveTab) {
+            Timber.v("Will not launch a dialog for an inactive tab")
+            return
+        }
+
         val authDialogBinding = HttpAuthenticationBinding.inflate(layoutInflater)
         authDialogBinding.httpAuthInformationText.text = getString(R.string.authenticationDialogMessage, request.site)
         CustomAlertDialogBuilder(requireActivity())
@@ -3450,6 +3475,11 @@ class BrowserTabFragment :
         permissionsToRequest: Array<String>,
         request: PermissionRequest,
     ) {
+        if (!isActiveTab) {
+            Timber.v("Will not launch a dialog for an inactive tab")
+            return
+        }
+
         activity?.let {
             sitePermissionsDialogLauncher.askForSitePermission(it, webView?.url.orEmpty(), tabId, permissionsToRequest, request, this)
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2833,6 +2833,14 @@ class BrowserTabViewModel @Inject constructor(
         return isLinkOpenedInNewTab
     }
 
+    override fun isActiveTab(): Boolean {
+        liveSelectedTab.value?.let {
+            return it.tabId == tabId
+        }
+
+        return false
+    }
+
     fun onAutofillMenuSelected() {
         command.value = LaunchAutofillSettings
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -89,4 +89,5 @@ interface WebViewClientListener {
 
     fun prefetchFavicon(url: String)
     fun linkOpenedInNewTab(): Boolean
+    fun isActiveTab(): Boolean
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205077297202827/f

### Description
Restricts background tabs from showing user-facing dialogs (which would otherwise appear over the active tab)

### Steps to test this PR

_Testing Javascript-driven dialogs_
- [x] Visit https://jsfiddle.net/cdrussell/xwqbmtgL/35/show
- [x] Tap on some of the buttons, both the "immediately" ones and the delayed ones **while staying on the same tab**
- [x] Ensure all the dialogs appear as they normally would (the rough UI for these dialogs is nothing new in this PR)
- [x] Now tap on one of the "after 5 seconds" buttons and quickly switch to another tab. 
- [x] Wait >5 seconds
- [x] Verify the dialog doesn't show over the new tab

_Testing native-driven dialogs_
- [x] Visit https://jsfiddle.net/cdrussell/fmey4cgt/show
- [x] Tap on the "exploit me" button
- [x] Verify no dialog shows over the new tab that is launched