### PR TITLE
Update reference tests to version 1689778581

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.26.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689232034"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689778581"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -89,7 +89,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#3d94733c3e512c4217180b096975527e80aabc47",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#f705a0026de62e1b6fc13315d79b8f1189b7894d",
       "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-      "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
+      "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.0.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.26.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689232034"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689778581"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205097693997794/f 

 ----- 
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [x] All tests must pass