### PR TITLE
fix gradle deamon memory struggling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ org.gradle.caching=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+org.gradle.daemon.idletimeout=10000
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 


### PR DESCRIPTION
### Description
I noticed a big memory usage from android studio after some builds, 
thourgh VisualVM i noticed that Gradle Deamon stays idle for a long time after build and keeps also reference to 
org.jetbrains.kotlin.daemon.KotlinCompileDaemon. 
Each one keeps up to 4gb ram 

### Steps to test this PR
Try multiple build and each time you can notice that at build time studio requires up to 14gb ram but after process finish 
returns to normal memory usage  
