### PR TITLE
Update content scope scripts to version 4.27.1

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -178,7 +178,7 @@
      * @returns {boolean} if we infer the document is framed
      */
     function isBeingFramed () {
-        if ('ancestorOrigins' in globalThis.location) {
+        if (globalThis.location && 'ancestorOrigins' in globalThis.location) {
             return globalThis.location.ancestorOrigins.length > 0
         }
         return globalThis.top !== globalThis.window
@@ -6270,7 +6270,7 @@
                 get: () => this.getFeatureAttr('pixelDepth', 24)
             });
 
-            window.addEventListener('resize', function () {
+            globalThis.window.addEventListener('resize', function () {
                 setWindowDimensions();
             });
             setWindowDimensions();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^4.3.3",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.27.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.27.1",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689858388"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f98760680ffb8efe7bcad359d4ab4826b483d4e6",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#082084d24a80cac43ece93ad229e10a87c928975",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -272,9 +272,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
-      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==",
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
+      "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -449,9 +449,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
-      "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
+      "version": "5.19.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
+      "integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^4.3.3",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.27.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.27.1",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689858388"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205119826833459/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass