### PR TITLE
Android ANR: com.duckduckgo.app.tabs.db.TabsDbSanitizer.onStart(TabsDbSanitizer.kt:37)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -17,29 +17,26 @@
 package com.duckduckgo.app.tabs.db
 
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 
 @SingleInstanceIn(AppScope::class)
 class TabsDbSanitizer @Inject constructor(
     private val tabRepository: TabRepository,
     private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : MainProcessLifecycleObserver {
 
     override fun onStart(owner: LifecycleOwner) {
-        runBlocking {
-            launch { purgeTabsDatabaseAsync() }
+        appCoroutineScope.launch(dispatchers.main()) {
+            tabRepository.purgeDeletableTabs()
         }
-    }
-
-    private suspend fun purgeTabsDatabaseAsync() = withContext(dispatchers.io()) {
-        tabRepository.purgeDeletableTabs()
     }
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/app/utils/ConflatedJob.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/app/utils/ConflatedJob.kt
@@ -42,4 +42,8 @@ class ConflatedJob {
     fun start() {
         job?.start()
     }
+
+    suspend fun join() {
+        job?.join()
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205112415074827/f

### Description
Removed `runblocking` block in `TabDbSanitizer` class. 

### Steps to test this PR

- [x] Install from this branch.
- [x] Regression testing on tabs:
        - create tabs
        - delete tabs
        - rotate screen while on TabSwitcherActivity
        - switch between foreground / background (this triggers the purge for deletable tabs).

### NO UI changes
