### PR TITLE
Fix internal dependencies and add gradle checks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -262,7 +262,7 @@ dependencies {
 
     implementation project(':sync-api')
     implementation project(':sync-impl')
-    implementation project(':sync-internal')
+    internalImplementation project(':sync-internal')
     implementation project(':sync-store')
     implementation project(':sync-lib')
 

--- a/build.gradle
+++ b/build.gradle
@@ -83,19 +83,21 @@ subprojects {
     }
 
     def projectPath = path
-    configurations.all {
+    configurations.configureEach {
         if (name == "compileClasspath" || name.endsWith("CompileClasspath")) {
             incoming.beforeResolve {
                 for (dependency in dependencies) {
                     if (dependency instanceof ProjectDependency) {
                         def dependencyPath = dependency.dependencyProject.path
                         if (dependencyPath == projectPath) continue
-                        // vpn-internal is part of vpn-impl
-                        if (projectPath.endsWith(':vpn-internal') && dependencyPath.endsWith(':vpn-impl')) continue
-                        // network-protection-internal is part of network-protection-impl
-                        if (projectPath.endsWith(':network-protection-internal') && dependencyPath.endsWith(':network-protection-impl')) continue
-                        // sync-internal is part of sync-impl
-                        if (projectPath.endsWith(':sync-internal') && dependencyPath.endsWith(':sync-impl')) continue
+                        // internal modules have to use internalImplementation
+                        // when a non internal configuration is built (i.e. PlayDebug) no internal dependencies should be found
+                        if (dependencyPath.endsWith('internal') && !name.toLowerCase().contains("internal")) {
+                            throw new GradleException("Invalid dependency $projectPath -> $dependencyPath. " +
+                                    "'internal' modules must use internalImplementation")
+                        }
+                        // internal modules can depend on impl
+                        if (projectPath.endsWith('internal') && dependencyPath.endsWith('impl')) continue
                         if (!projectPath.endsWith(":app") && dependencyPath.endsWith("impl")) {
                             throw new GradleException("Invalid dependency $projectPath -> $dependencyPath. " +
                                     "Only :app module can depend on 'impl' modules")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205153634789947/f 

### Description
This PR fixes a wrong use of an internal module that was using implementation instead of internalImplementation. It also adds a check so it doesn't happen again.

### Steps to test this PR

- [x] Using playDebug sync gradle, no error should be shown
- [x] Change any internal dependency to use `implementation` instead of `internalImplementation`
- [x] Sync gradle and you should see an error
- [x] Changing to internalDebug should always build regardless of using `implementation` or `internalImplementation` but the error will be picked up during CI.

