### PR TITLE
Update content scope scripts to version 4.30.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7099,6 +7099,9 @@
             if (this.getFeatureSettingEnabled('safariObject')) {
                 this.safariObjectFix();
             }
+            if (this.getFeatureSettingEnabled('messageHandlers')) {
+                this.messageHandlersFix();
+            }
         }
 
         /**
@@ -7187,6 +7190,48 @@
                 const settings = this.getFeatureSettingEnabled('permissions');
                 permissionsFix(settings);
             }
+        }
+
+        /**
+         * Support for proxying `window.webkit.messageHandlers`
+         */
+        messageHandlersFix () {
+            const settings = this.getFeatureSetting('messageHandlers');
+
+            // Do nothing if `messageHandlers` is absent
+            if (!globalThis.webkit?.messageHandlers) return
+
+            const proxy = new Proxy(globalThis.webkit.messageHandlers, {
+                get (target, messageName, receiver) {
+                    const handlerName = String(messageName);
+
+                    // handle known message names, such as DDG webkit messaging
+                    if (settings.handlerStrategies.reflect.includes(handlerName)) {
+                        return Reflect.get(target, messageName, receiver)
+                    }
+
+                    if (settings.handlerStrategies.undefined.includes(handlerName)) {
+                        return undefined
+                    }
+
+                    if (settings.handlerStrategies.polyfill.includes('*') ||
+                        settings.handlerStrategies.polyfill.includes(handlerName)
+                    ) {
+                        return {
+                            postMessage () {
+                                return Promise.resolve({})
+                            }
+                        }
+                    }
+                    // if we get here, we couldn't handle the message handler name, so we opt for doing nothing.
+                    // It's unlikely we'll ever reach here, since `["*"]' should be present
+                }
+            });
+
+            globalThis.webkit = {
+                ...globalThis.webkit,
+                messageHandlers: proxy
+            };
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^5.1.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.29.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.30.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689964986"
       },
@@ -68,7 +68,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c8d6ff1b1e52274812191b2f35149efcdd07fb2e",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a4f35ad23ac4a0eb9b36b94f1f2aa0f0ebf2855d",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^5.1.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.29.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.30.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689964986"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205177934310069/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass