### PR TITLE
First sync per feature

### DIFF
--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
@@ -31,7 +31,7 @@ import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
 import com.duckduckgo.autofill.sync.inMemoryAutofillDatabase
-import com.duckduckgo.sync.api.engine.SyncableType
+import com.duckduckgo.sync.api.engine.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -89,7 +89,7 @@ internal class CredentialsSyncDataProviderTest {
 
         assertTrue(result.type == SyncableType.CREDENTIALS)
         assertTrue(result.jsonString.findOccurrences("id") == 2)
-        assertTrue(result.modifiedSince == "0")
+        assertTrue(result.modifiedSince is ModifiedSince.FirstSync)
     }
 
     @Test
@@ -106,7 +106,7 @@ internal class CredentialsSyncDataProviderTest {
 
         assertTrue(result.type == SyncableType.CREDENTIALS)
         assertTrue(result.jsonString.findOccurrences("id") == 1)
-        assertTrue(result.modifiedSince == "2022-08-30T00:00:00Z")
+        assertTrue(result.modifiedSince == ModifiedSince.Timestamp("2022-08-30T00:00:00Z"))
     }
 
     @Test

--- a/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/Models.kt
+++ b/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/Models.kt
@@ -18,15 +18,25 @@ package com.duckduckgo.sync.api.engine
 
 import com.duckduckgo.sync.api.engine.SyncableType.BOOKMARKS
 
+sealed class ModifiedSince(open val value: String) {
+    object FirstSync : ModifiedSince(value = "0")
+    data class Timestamp(override val value: String) : ModifiedSince(value)
+}
+
 // TODO: https://app.asana.com/0/0/1204958251694095/f
-data class SyncChangesRequest(val type: SyncableType, val jsonString: String, val modifiedSince: String) {
+data class SyncChangesRequest(val type: SyncableType, val jsonString: String, val modifiedSince: ModifiedSince) {
 
     fun isEmpty(): Boolean {
         return this.jsonString.isEmpty()
     }
+
+    fun isFirstSync(): Boolean {
+        return this.modifiedSince is ModifiedSince.FirstSync
+    }
+
     companion object {
         fun empty(): SyncChangesRequest {
-            return SyncChangesRequest(BOOKMARKS, "", "")
+            return SyncChangesRequest(BOOKMARKS, "", ModifiedSince.FirstSync)
         }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
@@ -18,9 +18,7 @@ package com.duckduckgo.sync.impl.engine
 
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.sync.api.engine.SyncChangesRequest
-import com.duckduckgo.sync.api.engine.SyncChangesResponse
-import com.duckduckgo.sync.api.engine.SyncEngine
+import com.duckduckgo.sync.api.engine.*
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.ACCOUNT_CREATION
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.ACCOUNT_LOGIN
@@ -28,13 +26,11 @@ import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.APP_OPEN
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.BACKGROUND_SYNC
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.DATA_CHANGE
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
-import com.duckduckgo.sync.api.engine.SyncableDataPersister
 import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResolution
 import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResolution.DEDUPLICATION
 import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResolution.LOCAL_WINS
 import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResolution.REMOTE_WINS
 import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResolution.TIMESTAMP
-import com.duckduckgo.sync.api.engine.SyncableDataProvider
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.engine.SyncOperation.DISCARD
@@ -65,7 +61,7 @@ class RealSyncEngine @Inject constructor(
             FEATURE_READ -> performSync(trigger)
             DATA_CHANGE -> performSync(trigger)
             ACCOUNT_CREATION -> sendLocalData()
-            ACCOUNT_LOGIN -> mergeRemoteData()
+            ACCOUNT_LOGIN -> performSync(trigger)
         }
     }
 
@@ -98,27 +94,6 @@ class RealSyncEngine @Inject constructor(
         syncStateRepository.updateSyncState(SUCCESS)
     }
 
-    private fun mergeRemoteData() {
-        Timber.d("Sync-Feature: fetching remote data")
-        syncStateRepository.store(SyncAttempt(state = IN_PROGRESS, meta = "Account Login"))
-
-        // get remote changes and deduplicate them locally
-        getChanges().forEach {
-            getRemoteChanges(it, DEDUPLICATION)
-        }
-
-        // there might be changes locally that need to be patched
-        getChanges().forEach {
-            if (it.isEmpty()) {
-                Timber.d("Sync-Feature: ${it.type} local data empty, nothing to send")
-            } else {
-                Timber.d("Sync-Feature: ${it.type}  sending local data $it")
-                patchLocalChanges(it, LOCAL_WINS)
-            }
-        }
-        syncStateRepository.updateSyncState(SUCCESS)
-    }
-
     private fun performSync(trigger: SyncTrigger) {
         if (syncInProgress()) {
             Timber.d("Sync-Feature: sync already in progress, throttling")
@@ -126,17 +101,43 @@ class RealSyncEngine @Inject constructor(
             Timber.d("Sync-Feature: starting to sync")
             syncStateRepository.store(SyncAttempt(state = IN_PROGRESS, meta = trigger.toString()))
 
-            // TODO: Is this good enough? Should we make the calls in parallel?
-            getChanges().forEach {
-                if (it.isEmpty()) {
-                    Timber.d("Sync-Feature: no changes to sync for $it, asking for remote changes")
-                    getRemoteChanges(it, TIMESTAMP)
-                } else {
-                    Timber.d("Sync-Feature: $it changes to update $it")
-                    patchLocalChanges(it, TIMESTAMP)
-                }
-            }
+            val changes = getChanges()
+            performFirstSync(changes.filter { it.isFirstSync() })
+            performRegularSync(changes.filter { !it.isFirstSync() })
+
+            Timber.d("Sync-Feature: Sync finished")
             syncStateRepository.updateSyncState(SUCCESS)
+        }
+    }
+
+    private fun performRegularSync(regularSyncChanges: List<SyncChangesRequest>) {
+        regularSyncChanges.forEach { changes ->
+            if (changes.isEmpty()) {
+                Timber.d("Sync-Feature: no changes to sync for $changes, asking for remote changes")
+                getRemoteChanges(changes, TIMESTAMP)
+            } else {
+                Timber.d("Sync-Feature: $changes changes to update $changes")
+                patchLocalChanges(changes, TIMESTAMP)
+            }
+        }
+    }
+
+    private fun performFirstSync(firstSyncChanges: List<SyncChangesRequest>) {
+        val types = firstSyncChanges.map { it.type }
+
+        firstSyncChanges.forEach { changes ->
+            Timber.d("Sync-Feature: first sync for ${changes.type}, asking for remote changes")
+            getRemoteChanges(changes, DEDUPLICATION)
+        }
+
+        // give a chance to send changes after dedup
+        getChanges().filter { it.type in types }.forEach { changes ->
+            if (changes.isEmpty()) {
+                Timber.d("Sync-Feature: no changes to sync for $changes")
+            } else {
+                Timber.d("Sync-Feature: $changes changes to update $changes")
+                patchLocalChanges(changes, LOCAL_WINS)
+            }
         }
     }
 
@@ -177,7 +178,7 @@ class RealSyncEngine @Inject constructor(
         conflictResolution: SyncConflictResolution,
     ) {
         Timber.d("Sync-Feature: receive remote change $changes")
-        when (val result = syncApiClient.get(changes.type, changes.modifiedSince)) {
+        when (val result = syncApiClient.get(changes.type, changes.modifiedSince.value)) {
             is Error -> {
                 Timber.d("Sync-Feature: get failed ${result.reason}")
             }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncApiClientTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncApiClientTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl.engine
 
 import com.duckduckgo.app.FileUtilities
 import com.duckduckgo.sync.TestSyncFixtures
+import com.duckduckgo.sync.api.engine.ModifiedSince.FirstSync
 import com.duckduckgo.sync.api.engine.SyncChangesRequest
 import com.duckduckgo.sync.api.engine.SyncableType.BOOKMARKS
 import com.duckduckgo.sync.impl.Result
@@ -67,7 +68,7 @@ internal class SyncApiClientTest {
     @Test
     fun whenPatchAndBookmarkChangesThenApiIsSuccessful() {
         val updatesJSON = FileUtilities.loadText(javaClass.classLoader!!, "data_sync_sent_bookmarks.json")
-        val bookmarksChanges = SyncChangesRequest(BOOKMARKS, updatesJSON, "")
+        val bookmarksChanges = SyncChangesRequest(BOOKMARKS, updatesJSON, FirstSync)
         whenever(syncStore.token).thenReturn(TestSyncFixtures.token)
         whenever(syncApi.patch(any(), any())).thenReturn(Result.Success(JSONObject()))
 
@@ -78,7 +79,7 @@ internal class SyncApiClientTest {
     @Test
     fun whenPatchAndBookmarkChangesThenApiFails() {
         val updatesJSON = FileUtilities.loadText(javaClass.classLoader!!, "data_sync_sent_bookmarks.json")
-        val bookmarksChanges = SyncChangesRequest(BOOKMARKS, updatesJSON, "0")
+        val bookmarksChanges = SyncChangesRequest(BOOKMARKS, updatesJSON, FirstSync)
         whenever(syncStore.token).thenReturn(TestSyncFixtures.token)
         whenever(syncApi.patch(any(), any())).thenReturn(patchAllError)
 
@@ -89,7 +90,7 @@ internal class SyncApiClientTest {
     @Test
     fun whenMappingChangesThenGeneratedObjectIsCorrect() {
         val updatesJSON = FileUtilities.loadText(javaClass.classLoader!!, "data_sync_sent_bookmarks.json")
-        val bookmarksChanges = SyncChangesRequest(BOOKMARKS, updatesJSON, "0")
+        val bookmarksChanges = SyncChangesRequest(BOOKMARKS, updatesJSON, FirstSync)
         val changes = apiClient.mapRequest(listOf(bookmarksChanges))
         assertTrue(changes.get("client_timestamp") != null)
         assertTrue(changes.get("bookmarks") != null)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205093266805616/f 

### Description
SyncEngine performs a different sync process if it's feature first sync, no matter what the trigger was.
 
### Steps to test this PR
(using 2 devices)

_Feature 1_
- [x] checkout develop
- [x] install app on both devices
- [x] create an account in one device
- [x] login with the other device
- [x] create some logins in both devices
- [x] checkout this branch
- [x] open the app
- [x] ensure both devices are in sync for credentials

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
