### PR TITLE
Add ua override to remove both app id and version

### DIFF
--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -38,7 +38,7 @@
     <string name="devSettingsScreenUserAgentSelectorTitle">UserAgent</string>
     <string name="devSettingsScreenUserAgentNoAppId">Omit DuckDuckGo AppId</string>
     <string name="devSettingsScreenUserAgentNoVersion">Omit Webview Version</string>
-    <string name="devSettingsScreenUserAgentChrome">Chrome</string>
+    <string name="devSettingsScreenUserAgentChrome">Chrome (no appId and no Version)</string>
     <string name="devSettingsScreenUserAgentFirefox">Firefox</string>
     <string name="devSettingsScreenUserAgentDuckDuckGo">DDG Default</string>
     <string name="devSettingsScreenUserAgentWebView">UA WebView</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205183481775449/f 

### Description
This PR adds a new UA override

### Steps to test this PR

- [x] Build using internal flavour
- [x] Go to fedex.com
- [x] You should a message saying the browser is not compatible
- [x] Go to internal dev settings and override the UA to use no app id and no version
- [x] Go to fedex.com, refresh, you should not see the incompatible browser message
- [x] It make take you a refresh or two for the UA change to happen.

