### PR TITLE
Fix incorrect autofill tooltip style on dialogs

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/CustomAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/CustomAlertDialogBuilder.kt
@@ -21,7 +21,6 @@ import android.view.LayoutInflater
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.viewbinding.ViewBinding
-import com.duckduckgo.mobile.android.R.style
 import com.duckduckgo.mobile.android.databinding.DialogCustomAlertBinding
 import com.duckduckgo.mobile.android.ui.view.gone
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -95,7 +94,7 @@ class CustomAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         val binding: DialogCustomAlertBinding = DialogCustomAlertBinding.inflate(LayoutInflater.from(context))
         binding.customDialogContent.addView(customBinding?.root)
 
-        val dialogBuilder = MaterialAlertDialogBuilder(context, style.Widget_DuckDuckGo_Dialog)
+        val dialogBuilder = MaterialAlertDialogBuilder(context)
             .setView(binding.root)
             .apply {
                 setCancelable(false)

--- a/common/common-ui/src/main/res/values/widgets.xml
+++ b/common/common-ui/src/main/res/values/widgets.xml
@@ -226,7 +226,7 @@
     <!-- Dialogs -->
     <style name="Widget.DuckDuckGo.Dialog" parent="@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog">
         <item name="shapeAppearanceOverlay">@style/Widget.DuckDuckGo.DialogCorners</item>
-        <item name="android:background">?attr/daxColorSurface</item>
+        <item name="colorOnSurface">?attr/daxColorSurface</item>
     </style>
 
     <style name="Widget.DuckDuckGo.LegacyDialog" parent="Theme.AppCompat.Light.Dialog.Alert">


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: 
https://app.asana.com/0/488551667048375/1204064393605065/f

### Description
Fix wrong background for autofill tooltip. Using `background` to set a background color caused an artifact to appear on autofill tooltip. Using `colorOnSurface` instead

### Steps to test this PR
Settings -> Web tracking protection -> Unprotected Sites -> Add or edit -> Long press on text field


### UI changes
| Before  | After |
| ------ | ----- |
![tooltip before](https://github.com/duckduckgo/Android/assets/6297834/441f1e99-7c57-4553-a71a-dfb2e669d284) |![tooltip after](https://github.com/duckduckgo/Android/assets/6297834/5eea2f33-3614-4a89-9576-4b89c9b91ee7) |
![tooltip before light](https://github.com/duckduckgo/Android/assets/6297834/c544789f-2752-4d9b-80c8-6ece8ee17068) | ![tooltip after light](https://github.com/duckduckgo/Android/assets/6297834/617b729c-27bd-47f1-9b9f-e1b59623e80b) |
