### PR TITLE
Experiment 2: Push notification audience, timing and cadence to increase retention

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
@@ -118,19 +118,43 @@ class AndroidNotificationSchedulerTest {
     }
 
     @Test
-    fun givenControlVariantWhenClearNotificationAndPrivacyNotificationCanShowThenOnlyPrivacyNotificationIsScheduled() = runTest {
+    fun givenControlVariantWhenClearNotificationAndPrivacyNotificationCanShowThenBothNotificationsAreScheduled() = runTest {
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(true)
 
         testee.scheduleNextNotification()
 
         assertNotificationScheduled(PrivacyNotificationWorker::class.javaObjectType.name)
-        assertNotificationNotScheduled(ClearDataNotificationWorker::class.javaObjectType.name)
+        assertNotificationScheduled(ClearDataNotificationWorker::class.javaObjectType.name)
     }
 
     @Test
-    fun givenBugFixVariantWhenClearNotificationAndPrivacyNotificationCanShowThenBothNotificationsAreScheduled() = runTest {
-        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zq" })
+    fun givenAudienceLeverVariantThenBothNotificationsAreScheduled() = runTest {
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zs" })
+        whenever(privacyNotification.canShow()).thenReturn(true)
+        whenever(clearNotification.canShow()).thenReturn(true)
+
+        testee.scheduleNextNotification()
+
+        assertNotificationScheduled(PrivacyNotificationWorker::class.javaObjectType.name)
+        assertNotificationScheduled(ClearDataNotificationWorker::class.javaObjectType.name)
+    }
+
+    @Test
+    fun givenTimingLeverVariantThenBothNotificationsAreScheduled() = runTest {
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zt" })
+        whenever(privacyNotification.canShow()).thenReturn(true)
+        whenever(clearNotification.canShow()).thenReturn(true)
+
+        testee.scheduleNextNotification()
+
+        assertNotificationScheduled(PrivacyNotificationWorker::class.javaObjectType.name)
+        assertNotificationScheduled(ClearDataNotificationWorker::class.javaObjectType.name)
+    }
+
+    @Test
+    fun givenCadenceLeverVariantThenBothNotificationsAreScheduled() = runTest {
+        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zu" })
         whenever(privacyNotification.canShow()).thenReturn(true)
         whenever(clearNotification.canShow()).thenReturn(true)
 

--- a/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -17,6 +17,9 @@
 package com.duckduckgo.app.statistics
 
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.AudienceLever
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.CadenceLever
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.TimingLever
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -50,6 +53,42 @@ class VariantManagerTest {
                 fail("Duplicate variant name found: ${it.key}")
             }
         }
+    }
+
+    @Test
+    fun pushNotificationControlVariantHasExpectedWeightAndNoFeatures() {
+        val variant = variants.first { it.key == "zr" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(0, variant.features.size)
+        assertEquals(0, variant.features.size)
+    }
+
+    @Test
+    fun pushNotificationAudienceLeverExperimentalVariantHasExpectedWeightAndFeatures() {
+        val variant = variants.first { it.key == "zs" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertTrue(variant.hasFeature(AudienceLever))
+    }
+
+    @Test
+    fun pushNotificationTimingLeverExperimentalVariantHasExpectedWeightAndFeatures() {
+        val variant = variants.first { it.key == "zt" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertTrue(variant.hasFeature(TimingLever))
+    }
+
+    @Test
+    fun pushNotificationCadenceLeverExperimentalVariantHasExpectedWeightAndFeatures() {
+        val variant = variants.first { it.key == "zu" }
+
+        assertEqualsDouble(1.0, variant.weight)
+        assertEquals(1, variant.features.size)
+        assertTrue(variant.hasFeature(CadenceLever))
     }
 
     @Suppress("SameParameterValue")

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -19,7 +19,9 @@ package com.duckduckgo.app.statistics
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.VariantManager.Companion.referrerVariant
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NotificationSchedulingBugFix
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.AudienceLever
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.CadenceLever
+import com.duckduckgo.app.statistics.VariantManager.VariantFeature.TimingLever
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import java.util.*
@@ -30,7 +32,9 @@ interface VariantManager {
 
     // variant-dependant features listed here
     sealed class VariantFeature {
-        object NotificationSchedulingBugFix : VariantFeature()
+        object AudienceLever : VariantFeature()
+        object TimingLever : VariantFeature()
+        object CadenceLever : VariantFeature()
     }
 
     companion object {
@@ -46,9 +50,11 @@ interface VariantManager {
             Variant(key = "sc", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
             Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
 
-            // Experiment: Increase retention through push notification bug fix
-            Variant(key = "zp", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "zq", weight = 1.0, features = listOf(NotificationSchedulingBugFix), filterBy = { noFilter() }),
+            // Experiment: Change push notification audience, timing and cadence
+            Variant(key = "zr", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
+            Variant(key = "zs", weight = 1.0, features = listOf(AudienceLever), filterBy = { noFilter() }),
+            Variant(key = "zt", weight = 1.0, features = listOf(TimingLever), filterBy = { noFilter() }),
+            Variant(key = "zu", weight = 1.0, features = listOf(CadenceLever), filterBy = { noFilter() }),
         )
 
         val REFERRER_VARIANTS = listOf(
@@ -179,7 +185,9 @@ class ExperimentationVariantManager(
     }
 }
 
-fun VariantManager.isNotificationSchedulingBugFixEnabled() = this.getVariant().hasFeature(NotificationSchedulingBugFix)
+fun VariantManager.isAudienceLeverEnabled() = this.getVariant().hasFeature(AudienceLever)
+fun VariantManager.isTimingLeverEnabled() = this.getVariant().hasFeature(TimingLever)
+fun VariantManager.isCadenceLeverEnabled() = this.getVariant().hasFeature(CadenceLever)
 
 /**
  * A variant which can be used for experimentation.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205196199549738/f

### Description
Remove previous variants for notification bug fix experiment and add new push notification audience, timing and cadence experiment instead.

### Steps to test this PR

_Control variant_
- set `fun VariantManager.isAudienceLeverEnabled() =` **_false_**
- set `fun VariantManager.isTimingLeverEnabled() = ` **_false_**
- set `fun VariantManager.isCadenceLeverEnabled() =` **_false_**
- edit notification delay time to second or minutes so you can test the notifications showing in a shorter time. _e.g. notification1:20sec, notification 2: 40sec_ 
- Fresh install from this branch
- Allow notifications
- [x] check privacy notification appears in 20 seconds **after inactive**
- [x] check data clear notification appears in 40 seconds **after inactive**

_Audience variant_
- set `fun VariantManager.isAudienceLeverEnabled() =` **_true_**
- set `fun VariantManager.isTimingLeverEnabled() = ` **_false_**
- set `fun VariantManager.isCadenceLeverEnabled() =` **_false_**
- edit notification delay time to second or minutes so you can test the notifications showing in a shorter time. _e.g. notification1:20sec, notification 2: 40sec_ 
- Fresh install from this branch
- Allow notifications
- [x] check privacy notification appears in 20 seconds **since first open the app**
- [x] check data clear notification appears in 40 seconds **since first open the app**

_Audience variant_
- set `fun VariantManager.isAudienceLeverEnabled() =` **_false_**
- set `fun VariantManager.isTimingLeverEnabled() = ` **_true_**
- set `fun VariantManager.isCadenceLeverEnabled() =` **_false_**
- edit notification delay time to second or minutes so you can test the notifications showing in a shorter time. _e.g. notification1:20sec, notification 2: 40sec_ 
- Fresh install from this branch
- Allow notifications
- [x] check privacy notification appears in 20 seconds **since first open the app**
- [x] check data clear notification appears in 40 seconds **since first open the app**

_Audience variant_
- set `fun VariantManager.isAudienceLeverEnabled() =` **_false_**
- set `fun VariantManager.isTimingLeverEnabled() = ` **_false_**
- set `fun VariantManager.isCadenceLeverEnabled() =` **_true_**
- edit notification delay time to second or minutes so you can test the notifications showing in a shorter time. _e.g. notification1:20sec, notification 2: 40sec_ 
- Fresh install from this branch
- Allow notifications
- [x] check privacy notification appears in 20 seconds **since first open the app**
- [x] check data clear notification appears in 40 seconds **since first open the app**

### No UI changes
