### PR TITLE
Fix AppTP Bug: Exclusion list wiped on VPN restart - Round 2

### DIFF
--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
@@ -79,7 +78,6 @@ class ExceptionRulesDebugReceiverRegister @Inject constructor(
     private val context: Context,
     private val exclusionRulesRepository: ExclusionRulesRepository,
     private val dispatchers: DispatcherProvider,
-    private val appBuildConfig: AppBuildConfig,
 ) : VpnServiceCallbacks {
 
     private val exceptionRulesSavedState = mutableListOf<AppTrackerExceptionRule>()
@@ -108,7 +106,13 @@ class ExceptionRulesDebugReceiverRegister @Inject constructor(
         coroutineScope: CoroutineScope,
         vpnStopReason: VpnStopReason,
     ) {
-        logcat { "Debug receiver ExceptionRulesDebugReceiver restoring exception rules" }
+        if (shouldSaveRules.get()) {
+            // We haven't saved any rules yet - noop
+            logcat { "Debug receiver ExceptionRulesDebugReceiver will not restore rules. Rules size = ${exceptionRulesSavedState.size} " }
+            return
+        }
+
+        logcat { "Debug receiver ExceptionRulesDebugReceiver restoring exception rules of size = ${exceptionRulesSavedState.size}" }
 
         coroutineScope.launch(dispatchers.io()) {
             exclusionRulesRepository.deleteAllTrackerRules()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205207024178124/f

### Description
Fix issue where `ExceptionRulesDebugReceiverRegister` was wiping the database in `onVPNStop` even if `exceptionRulesSavedState` was empty. Increase logging slightly for easier debugging of future issues.

### Steps to test this PR
- [x] Install AppTP from this branch
- [x] Confirm there are rules in `vpn_app_tracker_exception_rules` table using Database Inspectore
- [x] Stop the VPN
- [x] Make sure that the `vpn_app_tracker_exception_rules` table is still not empty