### PR TITLE
Add maestro tests for autofill flows

### DIFF
--- a/.maestro/autofill/0_all.yaml
+++ b/.maestro/autofill/0_all.yaml
@@ -1,0 +1,12 @@
+appId: com.duckduckgo.mobile.android
+name: Autofill - Run all tests
+---
+- launchApp:
+    clearState: true
+- runFlow: ../shared/onboarding.yaml
+- runFlow: 1_autofill_shown_in_overflow.yaml
+
+  # Everything below requires a device has device-level authentication set (e.g., a PIN/Password etc...)
+- runFlow: 2_autofill_reach_creds_management.yaml
+- runFlow: 3_autofill_manually_add_cred.yaml
+- runFlow: 4_search_logins.yaml

--- a/.maestro/autofill/1_autofill_shown_in_overflow.yaml
+++ b/.maestro/autofill/1_autofill_shown_in_overflow.yaml
@@ -1,0 +1,6 @@
+appId: com.duckduckgo.mobile.android
+---
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible: "Logins"
+- tapOn: "Logins"

--- a/.maestro/autofill/2_autofill_reach_creds_management.yaml
+++ b/.maestro/autofill/2_autofill_reach_creds_management.yaml
@@ -1,0 +1,6 @@
+appId: com.duckduckgo.mobile.android
+---
+- assertVisible:
+    text: "No logins saved yet"
+- assertNotVisible:
+    id: searchLogins

--- a/.maestro/autofill/3_autofill_manually_add_cred.yaml
+++ b/.maestro/autofill/3_autofill_manually_add_cred.yaml
@@ -1,0 +1,60 @@
+appId: com.duckduckgo.mobile.android
+---
+- runScript: 3_script.js
+
+- repeat:
+      while:
+          true: ${output.addLogins.counter < output.addLogins.domains.length}
+      commands:
+          - tapOn:
+                  id: addLoginManually
+          - assertVisible:
+                  text: Add Login
+          - assertNotVisible:
+                  id: view_menu_save
+
+          - tapOn:
+                id: usernameEditText
+          - inputText: "user"
+
+          - assertVisible:
+                id: view_menu_save
+
+          - tapOn:
+                id: passwordEditText
+          - inputText: "123"
+
+          - tapOn:
+                id: domainEditText
+          - inputText: "${output.addLogins.domains[output.addLogins.counter]}"
+
+          - tapOn:
+                id: notesEditText
+          - inputText: "a note"
+
+          - tapOn:
+                id: view_menu_save
+                retryTapIfNoChange: false
+
+          - assertVisible: "Login last updated.*"
+
+          - tapOn: "Navigate up"
+
+          - assertVisible:
+                text: "Save and Autofill Logins"
+          - evalScript: ${output.addLogins.counter++}
+
+- assertVisible:
+    text: "#"
+
+- assertVisible:
+    text: "a.example.com"
+
+- assertNotVisible:
+    text: "https://a.example.com"
+
+- assertVisible:
+    text: "fill.dev"
+
+- assertNotVisible:
+    text: "fill.dev/example"

--- a/.maestro/autofill/3_script.js
+++ b/.maestro/autofill/3_script.js
@@ -1,0 +1,4 @@
+output.addLogins = {
+    domains: ["https://a.example.com", "fill.dev/example", "192.168.0.100"],
+    counter: 0
+}

--- a/.maestro/autofill/4_search_logins.yaml
+++ b/.maestro/autofill/4_search_logins.yaml
@@ -1,0 +1,22 @@
+appId: com.duckduckgo.mobile.android
+---
+- tapOn:
+    id: searchLogins
+
+- assertVisible: user
+
+- tapOn:
+    id: omnibarTextInput
+- inputText: "no match"
+
+- assertVisible: "No results for.*"
+
+- eraseText
+
+- tapOn:
+      id: omnibarTextInput
+- inputText: "192"
+
+- assertVisible: 192.168.0.100
+
+- tapOn: "Navigate up"

--- a/.maestro/autofill/smoke.yaml
+++ b/.maestro/autofill/smoke.yaml
@@ -1,0 +1,8 @@
+appId: com.duckduckgo.mobile.android
+name: Autofill Smoke Tests
+---
+- launchApp:
+    clearState: true
+- runFlow: ../shared/onboarding.yaml
+- runFlow: 1_autofill_shown_in_overflow.yaml
+- runFlow: 2_autofill_reach_creds_management.yaml

--- a/.maestro/release_tests/9_-_autofill_available.yaml
+++ b/.maestro/release_tests/9_-_autofill_available.yaml
@@ -1,0 +1,6 @@
+appId: com.duckduckgo.mobile.android
+name: Ensure autofill is available
+---
+- launchApp:
+      clearState: true
+- runFlow: ../autofill/smoke.yaml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ apply from: "$rootDir/code-formatting.gradle"
 
 ext {
     USE_ORCHESTRATOR = project.hasProperty('orchestrator') ? project.property('orchestrator') : false
-    CI_HOME_DIR="${System.getenv('HOME')}/jenkins_static/com.duckduckgo.mobile.android"
+    CI_HOME_DIR = "${System.getenv('HOME')}/jenkins_static/com.duckduckgo.mobile.android"
 }
 
 android {
@@ -441,4 +441,9 @@ tasks.register('jvm_tests') {
 
 tasks.register('androidTestsBuild') {
     dependsOn 'assemblePlayDebug', 'assemblePlayDebugAndroidTest'
+}
+
+task smokeTest(type: Exec) {
+    commandLine 'maestro', 'test', '../.maestro/release_tests'
+    dependsOn 'installPlayRelease'
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203874354762345/f

### Description
Adds maestro tests for main autofill flows.

Note, only a subset of the flows are suitable for a general smoke test as at a certain point it relies on the device/emulator having a PIN/Password set. 

`.maestro/autofill/smoke.yaml`: suitable for general purpose smoke testing (will ensure login option appears in the overflow)
`.maestro/autofill/0_all.yaml`: suitable only if the device has device-level authentication configured

### Steps to test this PR

#### General purpose smoke test
- [x] Run `maestro test .maestro/autofill/smoke.yaml `
- [x] Should all pass

#### With device-auth set
- [x] Ensure you have set a system-level PIN/Password
- [x] Run `maestro test .maestro/autofill/0_all.yaml`
- [x] Should all pass
