### PR TITLE
Sync: M2Pixels

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncDataPersister.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncDataPersister.kt
@@ -47,7 +47,7 @@ class CredentialsSyncDataPersister @Inject constructor(
     override fun persist(
         changes: SyncChangesResponse,
         conflictResolution: SyncConflictResolution,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         if (appBuildConfig.isInternalBuild()) checkMainThread()
 
         return if (changes.type == CREDENTIALS) {
@@ -64,7 +64,7 @@ class CredentialsSyncDataPersister @Inject constructor(
     private fun process(
         changes: SyncChangesResponse,
         conflictResolution: SyncConflictResolution,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         if (changes.jsonString.isEmpty()) {
             Timber.d("Sync-autofill-Persist: merging completed, no entries to merge")
             return Success(false)
@@ -97,7 +97,7 @@ class CredentialsSyncDataPersister @Inject constructor(
     private fun processEntries(
         credentials: credentialsSyncEntries,
         conflictResolution: SyncConflictResolution,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         credentialsSyncStore.serverModifiedSince = credentials.last_modified
         credentialsSyncStore.clientModifiedSince = credentialsSyncStore.startTimeStamp
         Timber.d("Sync-autofill-Persist: updating credentials server last_modified to ${credentialsSyncStore.serverModifiedSince}")

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategy.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategy.kt
@@ -35,7 +35,7 @@ class CredentialsLastModifiedWinsStrategy(
     override fun processEntries(
         credentials: credentialsSyncEntries,
         clientModifiedSince: String,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         Timber.d("Sync-autofill-Persist: ======= MERGING TIMESTAMP =======")
         return kotlin.runCatching {
             runBlocking(dispatchers.io()) {
@@ -53,7 +53,7 @@ class CredentialsLastModifiedWinsStrategy(
             return Error(reason = "LastModified merge failed with error $it")
         }.let {
             Timber.d("Sync-autofill-Persist: merging completed")
-            Success(true)
+            Success()
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategy.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategy.kt
@@ -33,7 +33,7 @@ class CredentialsLocalWinsStrategy(
     override fun processEntries(
         credentials: credentialsSyncEntries,
         clientModifiedSince: String,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         Timber.d("Sync-autofill-Persist: ======= MERGING LOCALWINS =======")
         return kotlin.runCatching {
             runBlocking(dispatchers.io()) {
@@ -49,7 +49,7 @@ class CredentialsLocalWinsStrategy(
             return Error(reason = "LocalWins merge failed with error $it")
         }.let {
             Timber.d("Sync-autofill-Persist: merging completed")
-            Success(true)
+            Success()
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CredentialsMergeStrategy.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CredentialsMergeStrategy.kt
@@ -22,5 +22,5 @@ import com.duckduckgo.sync.api.engine.SyncMergeResult
 
 interface CredentialsMergeStrategy {
     @WorkerThread
-    fun processEntries(credentials: credentialsSyncEntries, clientModifiedSince: String): SyncMergeResult<Boolean>
+    fun processEntries(credentials: credentialsSyncEntries, clientModifiedSince: String): SyncMergeResult
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategy.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategy.kt
@@ -34,7 +34,7 @@ class CredentialsRemoteWinsStrategy constructor(
     override fun processEntries(
         credentials: credentialsSyncEntries,
         clientModifiedSince: String,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         Timber.d("Sync-autofill-Persist: ======= MERGING REMOTEWINS =======")
         return kotlin.runCatching {
             runBlocking(dispatchers.io()) {
@@ -52,7 +52,7 @@ class CredentialsRemoteWinsStrategy constructor(
             return Error(reason = "RemoteWins merge failed with error $it")
         }.let {
             Timber.d("Sync-autofill-Persist: merging completed")
-            Success(true)
+            Success()
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategy.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategy.kt
@@ -34,7 +34,7 @@ class CredentialsDedupStrategy(
     override fun processEntries(
         credentials: credentialsSyncEntries,
         clientModifiedSince: String,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         Timber.d("Sync-autofill-Persist: ======= MERGING DEDUPLICATION =======")
 
         return kotlin.runCatching {
@@ -62,7 +62,7 @@ class CredentialsDedupStrategy(
             return Error(reason = "DeDup merge failed with error $it")
         }.let {
             Timber.d("Sync-autofill-Persist: merging completed")
-            Success(true)
+            Success()
         }
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncDataPersisterTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncDataPersisterTest.kt
@@ -157,12 +157,12 @@ internal class CredentialsSyncDataPersisterTest {
 }
 
 private class FakeCredentialsMergeStrategy : CredentialsMergeStrategy {
-    var result: SyncMergeResult<Boolean> = Success(true)
+    var result: SyncMergeResult = Success(false)
 
     override fun processEntries(
         credentials: credentialsSyncEntries,
         clientModifiedSince: String,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         return result
     }
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/app/global/formatters/time/DatabaseDateFormatter.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/app/global/formatters/time/DatabaseDateFormatter.kt
@@ -18,10 +18,12 @@ package com.duckduckgo.app.global.formatters.time
 
 import org.threeten.bp.Duration
 import org.threeten.bp.Instant
+import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
+import java.sql.Timestamp
 
 class DatabaseDateFormatter {
 
@@ -42,6 +44,10 @@ class DatabaseDateFormatter {
 
         fun iso8601(date: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)): String {
             return date.format(DateTimeFormatter.ISO_INSTANT)
+        }
+
+        fun iso8601Date(timestamp: String): LocalDate {
+            return OffsetDateTime.parse(timestamp).toLocalDate()
         }
 
         fun millisIso8601(date: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)): Long {

--- a/common/common-utils/src/main/java/com/duckduckgo/app/global/formatters/time/DatabaseDateFormatter.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/app/global/formatters/time/DatabaseDateFormatter.kt
@@ -23,7 +23,6 @@ import org.threeten.bp.LocalDateTime
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
-import java.sql.Timestamp
 
 class DatabaseDateFormatter {
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncPersister.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncPersister.kt
@@ -45,12 +45,12 @@ class SavedSitesSyncPersister @Inject constructor(
     override fun persist(
         changes: SyncChangesResponse,
         conflictResolution: SyncConflictResolution,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         return if (changes.type == BOOKMARKS) {
             Timber.d("Sync-Feature: received remote changes, merging with resolution $conflictResolution")
             val result = process(changes, conflictResolution)
             Timber.d("Sync-Feature: merging bookmarks finished with $result")
-            Success(true)
+            result
         } else {
             Timber.d("Sync-Feature: no bookmarks to merge")
             Success(false)
@@ -64,7 +64,7 @@ class SavedSitesSyncPersister @Inject constructor(
     fun process(
         changes: SyncChangesResponse,
         conflictResolution: SyncConflictResolution,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         val result = when (val validation = validateChanges(changes)) {
             is SyncDataValidationResult.Error -> SyncMergeResult.Error(reason = validation.reason)
             is SyncDataValidationResult.Success -> processEntries(validation.data, conflictResolution)
@@ -107,7 +107,7 @@ class SavedSitesSyncPersister @Inject constructor(
     private fun processEntries(
         bookmarks: SyncBookmarkEntries,
         conflictResolution: SyncConflictResolution,
-    ): SyncMergeResult<Boolean> {
+    ): SyncMergeResult {
         Timber.d("Sync-Feature: updating bookmarks last_modified to ${bookmarks.last_modified}")
         savedSitesSyncStore.modifiedSince = bookmarks.last_modified
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesSyncPersisterAlgorithm.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesSyncPersisterAlgorithm.kt
@@ -61,7 +61,7 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
     ): SyncMergeResult {
         var orphans = false
 
-        val processIds: MutableList<String> = mutableListOf()
+        val processIds: MutableList<String> = mutableListOf(SavedSitesNames.BOOKMARKS_ROOT)
         val allResponseIds = bookmarks.entries.filterNot { it.deleted != null }.map { it.id }
         val allFolders = bookmarks.entries.filter { it.isFolder() }.filterNot { it.id == SavedSitesNames.FAVORITES_ROOT }
         val allFolderIds = allFolders.map { it.id }
@@ -79,6 +79,9 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
         // check all children, the ones that are not in allFolders don't have a parent
         val foldersWithoutParent = allFolderIds.filterNot { allChildren.contains(it) }
         foldersWithoutParent.forEach { folderId ->
+            if (repository.getFolder(folderId) != null) {
+                processIds.add(folderId)
+            }
             processFolder(folderId, "", bookmarks.entries, bookmarks.last_modified, processIds, conflictResolution)
         }
 
@@ -86,7 +89,10 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
         val allBookmarkIds = bookmarks.entries.filter { it.isBookmark() }.map { it.id }
         val bookmarksWithoutParent = allBookmarkIds.filterNot { allChildren.contains(it) }
         bookmarksWithoutParent.forEach { bookmarkId ->
-            processBookmark(
+            if (repository.getSavedSite(bookmarkId) != null) {
+                processIds.add(bookmarkId)
+            }
+            processChild(
                 conflictResolution,
                 bookmarkId,
                 processIds,
@@ -129,9 +135,10 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
             Timber.d("Sync-Feature: processing folder $folderId with parentId $parentId")
             Timber.d("Sync-Feature: can't find folder $folderId")
         } else {
-            processBookmarkFolder(conflictResolution, remoteFolder, parentId, lastModified, processIds)
+            processBookmarkFolder(conflictResolution, remoteFolder, parentId, lastModified)
             remoteFolder.folder?.children?.forEach { child ->
-                processBookmark(conflictResolution, child, processIds, remoteUpdates, folderId, lastModified)
+                processIds.add(child)
+                processChild(conflictResolution, child, processIds, remoteUpdates, folderId, lastModified)
             }
         }
     }
@@ -141,7 +148,6 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
         remoteFolder: SyncBookmarkEntry,
         parentId: String,
         lastModified: String,
-        processIds: MutableList<String>,
     ) {
         val folder = decryptFolder(remoteFolder, parentId, lastModified)
         if (folder.id != SavedSitesNames.BOOKMARKS_ROOT && folder.id != SavedSitesNames.FAVORITES_ROOT) {
@@ -153,10 +159,9 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
                 TIMESTAMP -> timestampStrategy.processBookmarkFolder(folder)
             }
         }
-        processIds.add(folder.id)
     }
 
-    private fun processBookmark(
+    private fun processChild(
         conflictResolution: SyncConflictResolution,
         child: String,
         processIds: MutableList<String>,
@@ -165,21 +170,13 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
         lastModified: String,
     ) {
         Timber.d("Sync-Feature: processing id $child")
-        processIds.add(child)
         val childEntry = entries.find { it.id == child }
         if (childEntry == null) {
             Timber.d("Sync-Feature: id $child not present in the payload, omitting")
         } else {
             when {
                 childEntry.isBookmark() -> {
-                    Timber.d("Sync-Feature: child $child is a Bookmark")
-                    val bookmark = decryptBookmark(childEntry, folderId, lastModified)
-                    when (conflictResolution) {
-                        DEDUPLICATION -> deduplicationStrategy.processBookmark(bookmark, folderId)
-                        REMOTE_WINS -> remoteWinsStrategy.processBookmark(bookmark, folderId)
-                        LOCAL_WINS -> localWinsStrategy.processBookmark(bookmark, folderId)
-                        TIMESTAMP -> timestampStrategy.processBookmark(bookmark, folderId)
-                    }
+                    processBookmark(childEntry, conflictResolution, folderId, lastModified)
                 }
 
                 childEntry.isFolder() -> {
@@ -187,6 +184,22 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
                     processFolder(childEntry.id, folderId, entries, lastModified, processIds, conflictResolution)
                 }
             }
+        }
+    }
+
+    private fun processBookmark(
+        childEntry: SyncBookmarkEntry,
+        conflictResolution: SyncConflictResolution,
+        folderId: String,
+        lastModified: String,
+    ) {
+        Timber.d("Sync-Feature: child ${childEntry.id} is a Bookmark")
+        val bookmark = decryptBookmark(childEntry, folderId, lastModified)
+        when (conflictResolution) {
+            DEDUPLICATION -> deduplicationStrategy.processBookmark(bookmark, folderId)
+            REMOTE_WINS -> remoteWinsStrategy.processBookmark(bookmark, folderId)
+            LOCAL_WINS -> localWinsStrategy.processBookmark(bookmark, folderId)
+            TIMESTAMP -> timestampStrategy.processBookmark(bookmark, folderId)
         }
     }
 

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -59,6 +59,7 @@ interface Pixel {
         const val EMAIL = "email"
         const val MESSAGE_SHOWN = "message"
         const val ACTION_SUCCESS = "success"
+        const val SYNC = "sync"
     }
 
     object PixelValues {

--- a/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/Models.kt
+++ b/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/Models.kt
@@ -24,7 +24,11 @@ sealed class ModifiedSince(open val value: String) {
 }
 
 // TODO: https://app.asana.com/0/0/1204958251694095/f
-data class SyncChangesRequest(val type: SyncableType, val jsonString: String, val modifiedSince: ModifiedSince) {
+data class SyncChangesRequest(
+    val type: SyncableType,
+    val jsonString: String,
+    val modifiedSince: ModifiedSince,
+) {
 
     fun isEmpty(): Boolean {
         return this.jsonString.isEmpty()
@@ -41,7 +45,10 @@ data class SyncChangesRequest(val type: SyncableType, val jsonString: String, va
     }
 }
 
-data class SyncChangesResponse(val type: SyncableType, val jsonString: String) {
+data class SyncChangesResponse(
+    val type: SyncableType,
+    val jsonString: String,
+) {
 
     companion object {
         fun empty(type: SyncableType): SyncChangesResponse {
@@ -56,17 +63,20 @@ enum class SyncableType(val field: String) {
 }
 
 // TODO: document api, when is it expected each case? https://app.asana.com/0/0/1204958251694095/f
-sealed class SyncMergeResult<out R> {
+sealed class SyncMergeResult {
 
-    data class Success<out T>(val data: T) : SyncMergeResult<T>()
+    data class Success(
+        val orphans: Boolean = false,
+    ) : SyncMergeResult()
+
     data class Error(
         val code: Int = -1,
         val reason: String,
-    ) : SyncMergeResult<Nothing>()
+    ) : SyncMergeResult()
 
     override fun toString(): String {
         return when (this) {
-            is Success<*> -> "Success[data=$data]"
+            is Success -> "Success[orphans=$orphans]"
             is Error -> "Error[exception=$code, $reason]"
         }
     }

--- a/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/SyncableDataPersister.kt
+++ b/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/SyncableDataPersister.kt
@@ -25,7 +25,7 @@ interface SyncableDataPersister {
     fun persist(
         changes: SyncChangesResponse,
         conflictResolution: SyncConflictResolution,
-    ): SyncMergeResult<Boolean>
+    ): SyncMergeResult
 
     /**
      * Sync Feature has been disabled / device has been removed

--- a/sync/sync-impl/build.gradle
+++ b/sync/sync-impl/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     implementation project(path: ':app-build-config-api')
     implementation project(path: ':privacy-config-api')
+    implementation project(':statistics')
 
     anvil project(path: ':anvil-compiler')
     implementation project(path: ':anvil-annotations')

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncStateMonitor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncStateMonitor.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.sync.impl
 
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.statistics.api.BrowserFeatureStateReporterPlugin
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.SyncState

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -156,4 +156,5 @@ data class ErrorResponse(
 enum class API_CODE(val code: Int) {
     INVALID_LOGIN_CREDENTIALS(401),
     NOT_MODIFIED(304),
+    COUNT_LIMIT(409),
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
@@ -26,6 +26,8 @@ import com.duckduckgo.sync.impl.AppQREncoder
 import com.duckduckgo.sync.impl.QREncoder
 import com.duckduckgo.sync.impl.engine.AppSyncStateRepository
 import com.duckduckgo.sync.impl.engine.SyncStateRepository
+import com.duckduckgo.sync.impl.stats.RealSyncStatsRepository
+import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.EncryptedSharedPrefsProvider
 import com.duckduckgo.sync.store.SharedPrefsProvider
 import com.duckduckgo.sync.store.SyncDatabase
@@ -83,5 +85,13 @@ object SyncStoreModule {
     @Provides
     fun provideSyncStateRepository(syncDatabase: SyncDatabase): SyncStateRepository {
         return AppSyncStateRepository(syncDatabase.syncAttemptsDao())
+    }
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun provideSyncStatsRepository(
+        syncStateRepository: SyncStateRepository,
+    ): SyncStatsRepository {
+        return RealSyncStatsRepository(syncStateRepository)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.engine.SyncOperation.DISCARD
 import com.duckduckgo.sync.impl.engine.SyncOperation.EXECUTE
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.IN_PROGRESS
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
@@ -49,6 +50,7 @@ class RealSyncEngine @Inject constructor(
     private val syncApiClient: SyncApiClient,
     private val syncScheduler: SyncScheduler,
     private val syncStateRepository: SyncStateRepository,
+    private val syncPixels: SyncPixels,
     private val providerPlugins: PluginPoint<SyncableDataProvider>,
     private val persisterPlugins: PluginPoint<SyncableDataPersister>,
 ) : SyncEngine {
@@ -164,6 +166,7 @@ class RealSyncEngine @Inject constructor(
         return when (val result = syncApiClient.patch(changes)) {
             is Error -> {
                 Timber.d("Sync-Feature: patch failed ${result.reason}")
+                syncPixels.fireSyncAttemptErrorPixel(changes.type.toString())
             }
 
             is Success -> {
@@ -181,6 +184,7 @@ class RealSyncEngine @Inject constructor(
         when (val result = syncApiClient.get(changes.type, changes.modifiedSince.value)) {
             is Error -> {
                 Timber.d("Sync-Feature: get failed ${result.reason}")
+                syncPixels.fireSyncAttemptErrorPixel(changes.type.toString())
             }
 
             is Success -> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
@@ -205,7 +205,17 @@ class RealSyncEngine @Inject constructor(
         conflictResolution: SyncConflictResolution,
     ) {
         persisterPlugins.getPlugins().map {
-            it.persist(remoteChanges, conflictResolution)
+            when (val result = it.persist(remoteChanges, conflictResolution)) {
+                is SyncMergeResult.Success -> {
+                    if (result.orphans) {
+                        syncPixels.fireOrphanPresentPixel(remoteChanges.type.toString())
+                    }
+                }
+
+                else -> {
+                    syncPixels.firePersisterErrorPixel(remoteChanges.type.toString())
+                }
+            }
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncApiClient.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncApiClient.kt
@@ -26,8 +26,6 @@ import com.duckduckgo.sync.api.engine.SyncableType.CREDENTIALS
 import com.duckduckgo.sync.impl.API_CODE
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncApi
-import com.duckduckgo.sync.impl.pixels.SyncPixelValues.Feature.Autofill
-import com.duckduckgo.sync.impl.pixels.SyncPixelValues.Feature.Bookmarks
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
@@ -102,7 +100,7 @@ class AppSyncApiClient @Inject constructor(
                 when (result.code) {
                     API_CODE.NOT_MODIFIED.code -> Result.Success(SyncChangesResponse.empty(type))
                     API_CODE.COUNT_LIMIT.code -> {
-                        syncPixels.fireCountLimitPixel(Bookmarks)
+                        syncPixels.fireCountLimitPixel(BOOKMARKS.toString())
                         Result.Error(result.code, result.reason)
                     }
                     else -> Result.Error(result.code, result.reason)
@@ -126,7 +124,7 @@ class AppSyncApiClient @Inject constructor(
                 when (result.code) {
                     API_CODE.NOT_MODIFIED.code -> Result.Success(SyncChangesResponse.empty(type))
                     API_CODE.COUNT_LIMIT.code -> {
-                        syncPixels.fireCountLimitPixel(Autofill)
+                        syncPixels.fireCountLimitPixel(CREDENTIALS.toString())
                         Result.Error(result.code, result.reason)
                     }
                     else -> Result.Error(result.code, result.reason)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncStateRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncStateRepository.kt
@@ -65,6 +65,5 @@ class AppSyncStateRepository @Inject constructor(private val syncAttemptDao: Syn
 
     override fun attempts(): List<SyncAttempt> {
         return syncAttemptDao.allAttempts()
-
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncStateRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncStateRepository.kt
@@ -34,6 +34,8 @@ interface SyncStateRepository {
     fun updateSyncState(state: SyncAttemptState)
 
     fun clearAll()
+
+    fun attempts(): List<SyncAttempt>
 }
 
 class AppSyncStateRepository @Inject constructor(private val syncAttemptDao: SyncAttemptDao) : SyncStateRepository {
@@ -59,5 +61,10 @@ class AppSyncStateRepository @Inject constructor(private val syncAttemptDao: Syn
 
     override fun clearAll() {
         syncAttemptDao.clear()
+    }
+
+    override fun attempts(): List<SyncAttempt> {
+        return syncAttemptDao.allAttempts()
+
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncDailyReportingWorker.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncDailyReportingWorker.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.pixels
+
+import android.content.Context
+import androidx.lifecycle.LifecycleOwner
+import androidx.work.BackoffPolicy
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.HOURS
+import javax.inject.Inject
+
+@ContributesWorker(AppScope::class)
+class SyncDailyReportingWorker(
+    context: Context,
+    workerParameters: WorkerParameters
+) : CoroutineWorker(context, workerParameters) {
+
+    @Inject
+    lateinit var syncPixels: SyncPixels
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
+
+    override suspend fun doWork(): Result {
+        return withContext(dispatchers.io()) {
+            syncPixels.fireStatsPixel()
+            return@withContext Result.success()
+        }
+    }
+}
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class SyncDailyReportingWorkerScheduler @Inject constructor(
+    private val workManager: WorkManager,
+) : MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        Timber.v("Scheduling sync daily reporting worker")
+        val workerRequest = PeriodicWorkRequestBuilder<SyncDailyReportingWorker>(24, HOURS)
+            .addTag(DAILY_REPORTING_SYNC_WORKER_TAG)
+            .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+            .build()
+        workManager.enqueueUniquePeriodicWork(DAILY_REPORTING_SYNC_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, workerRequest)
+    }
+
+    companion object {
+        private const val DAILY_REPORTING_SYNC_WORKER_TAG = "DAILY_REPORTING_SYNC_WORKER_TAG"
+    }
+}
+

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncDailyReportingWorker.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncDailyReportingWorker.kt
@@ -29,16 +29,16 @@ import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.withContext
-import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.HOURS
 import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 @ContributesWorker(AppScope::class)
 class SyncDailyReportingWorker(
     context: Context,
-    workerParameters: WorkerParameters
+    workerParameters: WorkerParameters,
 ) : CoroutineWorker(context, workerParameters) {
 
     @Inject
@@ -77,4 +77,3 @@ class SyncDailyReportingWorkerScheduler @Inject constructor(
         private const val DAILY_REPORTING_SYNC_WORKER_TAG = "DAILY_REPORTING_SYNC_WORKER_TAG"
     }
 }
-

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.pixels
+
+import android.content.Context
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.stats.SyncStatsRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface SyncPixels {
+    fun fireStatsPixel()
+}
+
+@ContributesBinding(AppScope::class)
+class RealSyncPixels @Inject constructor(
+    private val pixel: Pixel,
+    private val context: Context,
+    private val statsRepository: SyncStatsRepository
+) : SyncPixels {
+    override fun fireStatsPixel() {
+
+
+
+    }
+}
+
+enum class SyncPixelName(override val pixelName: String): Pixel.PixelName {
+
+}
+
+object SyncPixelValues {
+
+}
+
+object SyncPixelParameters {
+
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -33,7 +33,7 @@ interface SyncPixels {
 
     fun fireDecryptFailurePixel()
 
-    fun fireCountLimitPixel()
+    fun fireCountLimitPixel(feature: Feature)
 }
 
 @ContributesBinding(AppScope::class)
@@ -83,8 +83,13 @@ class RealSyncPixels @Inject constructor(
         pixel.fire(SyncPixelName.SYNC_DECRYPT_FAILURE)
     }
 
-    override fun fireCountLimitPixel() {
-        pixel.fire(SyncPixelName.SYNC_COUNT_LIMIT)
+    override fun fireCountLimitPixel(feature: Feature) {
+        pixel.fire(
+            SyncPixelName.SYNC_COUNT_LIMIT,
+            mapOf(
+                SyncPixelParameters.FEATURE to feature.toString(),
+            ),
+        )
     }
 }
 
@@ -105,10 +110,9 @@ object SyncPixelParameters {
 }
 
 object SyncPixelValues {
-    sealed class Feature{
-        object Bookmarks: Feature()
-        object Autofill: Feature()
-        object Settings: Feature()
+    sealed class Feature {
+        object Bookmarks : Feature()
+        object Autofill : Feature()
+        object Settings : Feature()
     }
-
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -30,24 +30,31 @@ interface SyncPixels {
 @ContributesBinding(AppScope::class)
 class RealSyncPixels @Inject constructor(
     private val pixel: Pixel,
-    private val context: Context,
     private val statsRepository: SyncStatsRepository
 ) : SyncPixels {
     override fun fireStatsPixel() {
-
-
-
+        val dailyStats = statsRepository.getDailyStats()
+        pixel.fire(
+            SyncPixelName.SYNC_SUCCESS_RATE,
+            mapOf(
+                SyncPixelParameters.RATE to dailyStats.successRate.toString(),
+            ),
+        )
+        pixel.fire(
+            SyncPixelName.SYNC_DAILY_ATTEMPTS,
+            mapOf(
+                SyncPixelParameters.ATTEMPTS to dailyStats.attempts.toString(),
+            ),
+        )
     }
 }
 
-enum class SyncPixelName(override val pixelName: String): Pixel.PixelName {
-
-}
-
-object SyncPixelValues {
-
+enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
+    SYNC_SUCCESS_RATE("m_sync_daily_success_rate"),
+    SYNC_DAILY_ATTEMPTS("m_sync_daily_attempts"),
 }
 
 object SyncPixelParameters {
-
+    const val ATTEMPTS = "attempts"
+    const val RATE = "rate"
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.sync.impl.pixels
 
-import android.content.Context
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
@@ -30,7 +29,7 @@ interface SyncPixels {
 @ContributesBinding(AppScope::class)
 class RealSyncPixels @Inject constructor(
     private val pixel: Pixel,
-    private val statsRepository: SyncStatsRepository
+    private val statsRepository: SyncStatsRepository,
 ) : SyncPixels {
     override fun fireStatsPixel() {
         val dailyStats = statsRepository.getDailyStats()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -25,9 +25,9 @@ import javax.inject.Inject
 interface SyncPixels {
     fun fireStatsPixel()
 
-    fun fireMergeConflictPixel(feature: String)
-
     fun fireOrphanPresentPixel(feature: String)
+
+    fun firePersisterErrorPixel(feature: String)
 
     fun fireEncryptFailurePixel()
 
@@ -59,18 +59,18 @@ class RealSyncPixels @Inject constructor(
         )
     }
 
-    override fun fireMergeConflictPixel(feature: String) {
+    override fun fireOrphanPresentPixel(feature: String) {
         pixel.fire(
-            SyncPixelName.SYNC_MERGE_CONFLICT,
+            SyncPixelName.SYNC_ORPHAN_PRESENT,
             mapOf(
                 SyncPixelParameters.FEATURE to feature,
             ),
         )
     }
 
-    override fun fireOrphanPresentPixel(feature: String) {
+    override fun firePersisterErrorPixel(feature: String) {
         pixel.fire(
-            SyncPixelName.SYNC_ORPHAN_PRESENT,
+            SyncPixelName.SYNC_PERSISTER_FAILURE,
             mapOf(
                 SyncPixelParameters.FEATURE to feature,
             ),
@@ -107,12 +107,12 @@ class RealSyncPixels @Inject constructor(
 enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SUCCESS_RATE("m_sync_daily_success_rate"),
     SYNC_DAILY_ATTEMPTS("m_sync_daily_attempts"),
-    SYNC_MERGE_CONFLICT("m_sync_merge_conflict"),
     SYNC_ORPHAN_PRESENT("m_sync_orphan_present"),
     SYNC_ENCRYPT_FAILURE("m_sync_encrypt_failure"),
     SYNC_DECRYPT_FAILURE("m_sync_decrypt_failure"),
     SYNC_COUNT_LIMIT("m_sync_count_limit"),
     SYNC_ATTEMPT_FAILURE("m_sync_attempt_failure"),
+    SYNC_PERSISTER_FAILURE("m_sync_attempt_failure"),
 }
 
 object SyncPixelParameters {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
@@ -16,22 +16,10 @@
 
 package com.duckduckgo.sync.impl.stats
 
-import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
-import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
-import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
-import com.duckduckgo.savedsites.api.models.SavedSites
-import com.duckduckgo.sync.impl.engine.AppSyncStateRepository
 import com.duckduckgo.sync.impl.engine.SyncStateRepository
-import com.duckduckgo.sync.store.dao.SyncAttemptDao
 import com.duckduckgo.sync.store.model.SyncAttempt
-import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
-import kotlinx.coroutines.flow.Flow
-import org.threeten.bp.LocalDate
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
 import java.math.RoundingMode
-import java.text.DecimalFormat
 import javax.inject.Inject
 
 /**
@@ -48,7 +36,7 @@ interface SyncStatsRepository {
 
 data class DailyStats(
     val attempts: Int,
-    val successRate: Double
+    val successRate: Double,
 )
 
 class RealSyncStatsRepository @Inject constructor(private val syncStateRepository: SyncStateRepository) : SyncStatsRepository {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.sync.impl.engine.AppSyncStateRepository
 import com.duckduckgo.sync.impl.engine.SyncStateRepository
 import com.duckduckgo.sync.store.dao.SyncAttemptDao
+import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
 import org.threeten.bp.LocalDate
@@ -42,7 +43,7 @@ data class DailyStats(
 class RealSyncStatsRepository @Inject constructor(private val syncStateRepository: SyncStateRepository) : SyncStatsRepository {
     override fun getDailyStats(): DailyStats {
         val attempts = syncStateRepository.attempts().filter {
-            DatabaseDateFormatter.iso8601Date(it.timestamp).isEqual(LocalDate.now(ZoneOffset.UTC))
+            it.today()
         }
         val successfulAttempts = attempts.filter { it.state == SUCCESS }.size
         val totalAttempts = attempts.size

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
@@ -17,12 +17,16 @@
 package com.duckduckgo.sync.impl.stats
 
 import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
+import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
+import com.duckduckgo.savedsites.api.models.SavedSites
 import com.duckduckgo.sync.impl.engine.AppSyncStateRepository
 import com.duckduckgo.sync.impl.engine.SyncStateRepository
 import com.duckduckgo.sync.store.dao.SyncAttemptDao
 import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
+import kotlinx.coroutines.flow.Flow
 import org.threeten.bp.LocalDate
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneOffset
@@ -30,8 +34,15 @@ import java.math.RoundingMode
 import java.text.DecimalFormat
 import javax.inject.Inject
 
+/**
+ * The Repository that fetches all stats related to [SyncAttempt]
+ */
 interface SyncStatsRepository {
 
+    /**
+     * Returns yesterday's [DailyStats]
+     * @return [DailyStats]
+     */
     fun getDailyStats(): DailyStats
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.stats
+
+import com.duckduckgo.sync.impl.engine.AppSyncStateRepository
+import com.duckduckgo.sync.impl.engine.SyncStateRepository
+import com.duckduckgo.sync.store.dao.SyncAttemptDao
+import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
+import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
+import java.math.RoundingMode
+import java.text.DecimalFormat
+import javax.inject.Inject
+
+interface SyncStatsRepository {
+
+    fun getDailyStats(): DailyStats
+
+}
+
+data class DailyStats(val attempts: Int, val successRate: Double)
+
+class RealSyncStatsRepository @Inject constructor(private val syncStateRepository: SyncStateRepository): SyncStatsRepository {
+    override fun getDailyStats(): DailyStats {
+        val attempts = syncStateRepository.attempts()
+        val successfulAttempts = attempts.filter { it.state == SUCCESS }.size
+        val totalAttempts = attempts.size
+
+        val successRate = if (totalAttempts > 0 ){
+            successfulAttempts.toDouble() / totalAttempts.toDouble() * 100
+        } else {
+            0.0
+        }
+
+        val roundedUp = successRate.toBigDecimal().setScale(2, RoundingMode.UP).toDouble()
+        return DailyStats(totalAttempts, roundedUp)
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
@@ -42,7 +42,7 @@ data class DailyStats(
 class RealSyncStatsRepository @Inject constructor(private val syncStateRepository: SyncStateRepository) : SyncStatsRepository {
     override fun getDailyStats(): DailyStats {
         val attempts = syncStateRepository.attempts().filter {
-            it.today()
+            it.yesterday()
         }
         val successfulAttempts = attempts.filter { it.state == SUCCESS }.size
         val totalAttempts = attempts.size

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncCryptoTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncCryptoTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import com.duckduckgo.sync.api.SyncCrypto
+import com.duckduckgo.sync.crypto.DecryptResult
+import com.duckduckgo.sync.crypto.EncryptResult
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.store.SyncStore
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class SyncCryptoTest {
+
+    private val nativeLib: SyncLib = mock()
+    private val syncStore: SyncStore = mock()
+    private val syncPixels: SyncPixels = mock()
+
+    private lateinit var syncCrypto: SyncCrypto
+
+    @Before
+    fun setup() {
+        syncCrypto = RealSyncCrypto(nativeLib, syncStore, syncPixels)
+    }
+
+    @Test
+    fun whenEncryptFailsThenPixelIsSentAndResultIsEmpty() {
+        whenever(nativeLib.encryptData(any(), any())).thenReturn(EncryptResult(1, "not encrypted"))
+
+        val result = syncCrypto.encrypt("something")
+
+        verify(syncPixels).fireEncryptFailurePixel()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun whenEncryptSucceedsThenPixelIsNotSentAndResultIsEncrypted() {
+        whenever(nativeLib.encryptData(any(), any())).thenReturn(EncryptResult(0L, "not encrypted"))
+
+        val result = syncCrypto.encrypt("something")
+
+        verifyNoInteractions(syncPixels)
+
+        assertFalse(result.isEmpty())
+    }
+
+    @Test
+    fun whenDecryptFailsThenPixelIsSentAndResultIsEmpty() {
+        whenever(nativeLib.decryptData(any(), any())).thenReturn(DecryptResult(1, "not decrypted"))
+
+        val result = syncCrypto.decrypt("something")
+
+        verify(syncPixels).fireDecryptFailurePixel()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun whenDecryptSucceedsThenPixelIsNotSentAndResultIsDecrypted() {
+        whenever(nativeLib.decryptData(any(), any())).thenReturn(DecryptResult(0L, "not decrypted"))
+
+        val result = syncCrypto.decrypt("something")
+
+        verifyNoInteractions(syncPixels)
+
+        assertFalse(result.isEmpty())
+    }
+
+    @Test
+    fun whenDataToDecryptIsEmptyThenPixelIsNotSentAndResultIsEmpty() {
+        val result = syncCrypto.decrypt("")
+
+        verifyNoInteractions(syncPixels)
+
+        assertTrue(result.isEmpty())
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/FakeSyncableDataPersister.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/FakeSyncableDataPersister.kt
@@ -21,13 +21,13 @@ import com.duckduckgo.sync.api.engine.SyncMergeResult
 import com.duckduckgo.sync.api.engine.SyncableDataPersister
 import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResolution
 
-class FakeSyncableDataPersister() : SyncableDataPersister {
+class FakeSyncableDataPersister(private val orphans: Boolean = false) : SyncableDataPersister {
 
     override fun persist(
         changes: SyncChangesResponse,
         conflictResolution: SyncConflictResolution,
-    ): SyncMergeResult<Boolean> {
-        return SyncMergeResult.Success(false)
+    ): SyncMergeResult {
+        return SyncMergeResult.Success(orphans)
     }
 
     override fun onSyncDisabled() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncApiClientTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncApiClientTest.kt
@@ -21,8 +21,13 @@ import com.duckduckgo.sync.TestSyncFixtures
 import com.duckduckgo.sync.api.engine.ModifiedSince.FirstSync
 import com.duckduckgo.sync.api.engine.SyncChangesRequest
 import com.duckduckgo.sync.api.engine.SyncableType.BOOKMARKS
+import com.duckduckgo.sync.api.engine.SyncableType.CREDENTIALS
+import com.duckduckgo.sync.impl.API_CODE
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncApi
+import com.duckduckgo.sync.impl.pixels.SyncPixelValues.Feature.Autofill
+import com.duckduckgo.sync.impl.pixels.SyncPixelValues.Feature.Bookmarks
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.SyncStore
 import junit.framework.Assert.assertEquals
 import junit.framework.Assert.assertTrue
@@ -31,20 +36,23 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 internal class SyncApiClientTest {
 
     private val syncStore: SyncStore = mock()
     private val syncApi: SyncApi = mock()
+    private val syncPixels: SyncPixels = mock()
     private lateinit var apiClient: AppSyncApiClient
 
-    val patchAllError = Result.Error(-1, "Patch All Error")
-    val getAllError = Result.Error(-1, "Get All Error")
+    private val patchAllError = Result.Error(-1, "Patch All Error")
+    private val getAllError = Result.Error(-1, "Get All Error")
+    private val getCountLimitError = Result.Error(API_CODE.COUNT_LIMIT.code, "Get Count Limit Error")
 
     @Before
     fun before() {
-        apiClient = AppSyncApiClient(syncStore, syncApi)
+        apiClient = AppSyncApiClient(syncStore, syncApi, syncPixels)
     }
 
     @Test
@@ -97,7 +105,7 @@ internal class SyncApiClientTest {
     }
 
     @Test
-    fun whenGetAndTokenEmptyThenReturnError() {
+    fun whenGetBookmarksAndTokenEmptyThenReturnError() {
         whenever(syncStore.token).thenReturn("")
 
         val result = apiClient.get(BOOKMARKS, "")
@@ -106,11 +114,49 @@ internal class SyncApiClientTest {
     }
 
     @Test
-    fun whenGetAndApiFailsThenResultIsError() {
+    fun whenGetCredentialsBookmarksAndTokenEmptyThenReturnError() {
+        whenever(syncStore.token).thenReturn("")
+
+        val result = apiClient.get(CREDENTIALS, "")
+
+        assertEquals(result, Result.Error(reason = "Token Empty"))
+    }
+
+    @Test
+    fun whenGetBookmarksAndApiFailsThenResultIsError() {
         whenever(syncStore.token).thenReturn(TestSyncFixtures.token)
         whenever(syncApi.getBookmarks(any(), any())).thenReturn(getAllError)
 
         val result = apiClient.get(BOOKMARKS, "")
+        assertTrue(result is Result.Error)
+    }
+
+    @Test
+    fun whenGetCredentialsAndApiFailsThenResultIsError() {
+        whenever(syncStore.token).thenReturn(TestSyncFixtures.token)
+        whenever(syncApi.getCredentials(any(), any())).thenReturn(getAllError)
+
+        val result = apiClient.get(CREDENTIALS, "")
+        assertTrue(result is Result.Error)
+    }
+
+    @Test
+    fun whenGetBookmarksAndApiCountLimitFailsThenResultIsError() {
+        whenever(syncStore.token).thenReturn(TestSyncFixtures.token)
+        whenever(syncApi.getBookmarks(any(), any())).thenReturn(getCountLimitError)
+
+        val result = apiClient.get(BOOKMARKS, "")
+        verify(syncPixels).fireCountLimitPixel(Bookmarks)
+        assertTrue(result is Result.Error)
+    }
+
+    @Test
+    fun whenGetCredentialsAndApiCountLimitFailsThenResultIsError() {
+        whenever(syncStore.token).thenReturn(TestSyncFixtures.token)
+        whenever(syncApi.getCredentials(any(), any())).thenReturn(getCountLimitError)
+
+        val result = apiClient.get(CREDENTIALS, "")
+        verify(syncPixels).fireCountLimitPixel(Autofill)
         assertTrue(result is Result.Error)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncApiClientTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncApiClientTest.kt
@@ -25,8 +25,6 @@ import com.duckduckgo.sync.api.engine.SyncableType.CREDENTIALS
 import com.duckduckgo.sync.impl.API_CODE
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncApi
-import com.duckduckgo.sync.impl.pixels.SyncPixelValues.Feature.Autofill
-import com.duckduckgo.sync.impl.pixels.SyncPixelValues.Feature.Bookmarks
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.SyncStore
 import junit.framework.Assert.assertEquals
@@ -146,7 +144,7 @@ internal class SyncApiClientTest {
         whenever(syncApi.getBookmarks(any(), any())).thenReturn(getCountLimitError)
 
         val result = apiClient.get(BOOKMARKS, "")
-        verify(syncPixels).fireCountLimitPixel(Bookmarks)
+        verify(syncPixels).fireCountLimitPixel(BOOKMARKS.toString())
         assertTrue(result is Result.Error)
     }
 
@@ -156,7 +154,7 @@ internal class SyncApiClientTest {
         whenever(syncApi.getCredentials(any(), any())).thenReturn(getCountLimitError)
 
         val result = apiClient.get(CREDENTIALS, "")
-        verify(syncPixels).fireCountLimitPixel(Autofill)
+        verify(syncPixels).fireCountLimitPixel(CREDENTIALS.toString())
         assertTrue(result is Result.Error)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncEngineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncEngineTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.BACKGROUND_SYNC
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.DATA_CHANGE
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
 import com.duckduckgo.sync.api.engine.SyncableType.BOOKMARKS
+import com.duckduckgo.sync.impl.API_CODE
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.engine.SyncOperation.DISCARD
@@ -400,6 +401,12 @@ internal class SyncEngineTest {
     private fun givenGetError() {
         whenever(syncApiClient.get(any(), any())).thenReturn(
             Result.Error(400, "get failed"),
+        )
+    }
+
+    private fun givenGetCountLimitError() {
+        whenever(syncApiClient.get(any(), any())).thenReturn(
+            Result.Error(API_CODE.COUNT_LIMIT.code, "get failed"),
         )
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncEngineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncEngineTest.kt
@@ -27,7 +27,6 @@ import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.BACKGROUND_SYNC
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.DATA_CHANGE
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
 import com.duckduckgo.sync.api.engine.SyncableType.BOOKMARKS
-import com.duckduckgo.sync.impl.API_CODE
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.engine.SyncOperation.DISCARD
@@ -371,6 +370,19 @@ internal class SyncEngineTest {
         verifyNoInteractions(syncApiClient)
     }
 
+    @Test
+    fun whenPersistingChangesAndOrphansPresentThenPixelIsSent() {
+        givenLocalChanges()
+        givenGetSuccess()
+        givenPatchSuccess()
+
+        whenever(persisterPlugins.getPlugins()).thenReturn(listOf(FakeSyncableDataPersister(true)))
+
+        syncEngine.triggerSync(FEATURE_READ)
+
+        verify(syncPixels).fireOrphanPresentPixel(any())
+    }
+
     private fun givenNoLocalChanges() {
         val fakePersisterPlugin = FakeSyncableDataPersister()
         val fakeProviderPlugin = FakeSyncableDataProvider(SyncChangesRequest.empty())
@@ -403,12 +415,6 @@ internal class SyncEngineTest {
     private fun givenGetError() {
         whenever(syncApiClient.get(any(), any())).thenReturn(
             Result.Error(400, "get failed"),
-        )
-    }
-
-    private fun givenGetCountLimitError() {
-        whenever(syncApiClient.get(any(), any())).thenReturn(
-            Result.Error(API_CODE.COUNT_LIMIT.code, "get failed"),
         )
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncEngineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncEngineTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.engine.SyncOperation.DISCARD
 import com.duckduckgo.sync.impl.engine.SyncOperation.EXECUTE
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
 import com.duckduckgo.sync.store.model.SyncAttemptState.IN_PROGRESS
@@ -50,13 +51,14 @@ internal class SyncEngineTest {
     private val syncApiClient: SyncApiClient = mock()
     private val syncScheduler: SyncScheduler = mock()
     private val syncStateRepository: SyncStateRepository = mock()
+    private val syncPixels: SyncPixels = mock()
     private val providerPlugins: PluginPoint<SyncableDataProvider> = mock()
     private val persisterPlugins: PluginPoint<SyncableDataPersister> = mock()
     private lateinit var syncEngine: RealSyncEngine
 
     @Before
     fun before() {
-        syncEngine = RealSyncEngine(syncApiClient, syncScheduler, syncStateRepository, providerPlugins, persisterPlugins)
+        syncEngine = RealSyncEngine(syncApiClient, syncScheduler, syncStateRepository, syncPixels, providerPlugins, persisterPlugins)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
@@ -43,7 +43,7 @@ class SyncStatsRepositoryTest {
     }
 
     @Test
-    fun whenNoAttemptsThenDailyStatsIsEmpty(){
+    fun whenNoAttemptsThenDailyStatsIsEmpty() {
         whenever(syncStateRepository.attempts()).thenReturn(emptyList())
 
         val stats = repository.getDailyStats()
@@ -53,7 +53,7 @@ class SyncStatsRepositoryTest {
     }
 
     @Test
-    fun whenOnlyPastAttemptsThenDailyStatsHasCorrectData(){
+    fun whenOnlyPastAttemptsThenDailyStatsHasCorrectData() {
         val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.DAYS))
         val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
 
@@ -65,7 +65,7 @@ class SyncStatsRepositoryTest {
     }
 
     @Test
-    fun whenOnlyTodayAttemptsThenDailyStatsHasCorrectData(){
+    fun whenOnlyTodayAttemptsThenDailyStatsHasCorrectData() {
         val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
         val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
 
@@ -77,7 +77,7 @@ class SyncStatsRepositoryTest {
     }
 
     @Test
-    fun whenOnlySuccessfulAttemptsThenDailyStatsHasCorrectData(){
+    fun whenOnlySuccessfulAttemptsThenDailyStatsHasCorrectData() {
         val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
         val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
 
@@ -90,7 +90,7 @@ class SyncStatsRepositoryTest {
     }
 
     @Test
-    fun whenOnlyFailedAttemptsThenDailyStatsHasCorrectData(){
+    fun whenOnlyFailedAttemptsThenDailyStatsHasCorrectData() {
         val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
         val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = FAIL)
 
@@ -107,7 +107,7 @@ class SyncStatsRepositoryTest {
     }
 
     @Test
-    fun whenFewAttemptsThenDailyStatsHasCorrectData(){
+    fun whenFewAttemptsThenDailyStatsHasCorrectData() {
         val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
         val first = SyncAttempt(timestamp = lastSyncTimestamp, state = FAIL)
         val second = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
@@ -123,5 +123,4 @@ class SyncStatsRepositoryTest {
         assertTrue(stats.attempts == 6)
         assertTrue(stats.successRate == 66.67)
     }
-
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
@@ -53,6 +53,30 @@ class SyncStatsRepositoryTest {
     }
 
     @Test
+    fun whenOnlyPastAttemptsThenDailyStatsHasCorrectData(){
+        val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.DAYS))
+        val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
+
+        whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
+
+        val stats = repository.getDailyStats()
+
+        assertTrue(stats.attempts == 0)
+    }
+
+    @Test
+    fun whenOnlyTodayAttemptsThenDailyStatsHasCorrectData(){
+        val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
+        val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
+
+        whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
+
+        val stats = repository.getDailyStats()
+
+        assertTrue(stats.attempts == 0)
+    }
+
+    @Test
     fun whenOnlySuccessfulAttemptsThenDailyStatsHasCorrectData(){
         val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
         val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.stats
+
+import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter.Companion.timestamp
+import com.duckduckgo.sync.impl.engine.SyncStateRepository
+import com.duckduckgo.sync.store.model.SyncAttempt
+import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
+import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.threeten.bp.Instant
+import org.threeten.bp.ZoneOffset
+import org.threeten.bp.format.DateTimeFormatter
+import org.threeten.bp.temporal.ChronoUnit
+
+class SyncStatsRepositoryTest {
+
+    private var syncStateRepository: SyncStateRepository = mock()
+
+    private lateinit var repository: SyncStatsRepository
+
+    @Before
+    fun setup() {
+        repository = RealSyncStatsRepository(syncStateRepository)
+    }
+
+    @Test
+    fun whenNoAttemptsThenDailyStatsIsEmpty(){
+        whenever(syncStateRepository.attempts()).thenReturn(emptyList())
+
+        val stats = repository.getDailyStats()
+
+        assertTrue(stats.attempts == 0)
+        assertTrue(stats.successRate == 0.00)
+    }
+
+    @Test
+    fun whenOnlySuccessfulAttemptsThenDailyStatsHasCorrectData(){
+        val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
+        val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
+
+        whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
+
+        val stats = repository.getDailyStats()
+
+        assertTrue(stats.attempts == 1)
+        assertTrue(stats.successRate == 100.0)
+    }
+
+    @Test
+    fun whenOnlyFailedAttemptsThenDailyStatsHasCorrectData(){
+        val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
+        val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = FAIL)
+
+        whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
+
+        val stats = repository.getDailyStats()
+
+        assertTrue(stats.attempts == 1)
+        assertTrue(stats.successRate == 0.00)
+    }
+
+    private fun timestamp(instant: Instant): String {
+        return instant.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT)
+    }
+
+    @Test
+    fun whenFewAttemptsThenDailyStatsHasCorrectData(){
+        val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
+        val first = SyncAttempt(timestamp = lastSyncTimestamp, state = FAIL)
+        val second = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
+        val third = SyncAttempt(timestamp = lastSyncTimestamp, state = FAIL)
+        val fourth = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
+        val fifth = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
+        val sixth = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
+
+        whenever(syncStateRepository.attempts()).thenReturn(listOf(first, second, third, fourth, fifth, sixth))
+
+        val stats = repository.getDailyStats()
+
+        assertTrue(stats.attempts == 6)
+        assertTrue(stats.successRate == 66.67)
+    }
+
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
@@ -73,7 +73,7 @@ class SyncStatsRepositoryTest {
 
         val stats = repository.getDailyStats()
 
-        assertTrue(stats.attempts == 0)
+        assertTrue(stats.attempts == 1)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
@@ -65,8 +65,8 @@ class SyncStatsRepositoryTest {
     }
 
     @Test
-    fun whenOnlyTodayAttemptsThenDailyStatsHasCorrectData() {
-        val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
+    fun whenOnlyYesterdayAttemptsThenDailyStatsHasCorrectData() {
+        val lastSyncTimestamp = timestamp(Instant.now().minus(1, ChronoUnit.DAYS))
         val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
 
         whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
@@ -77,8 +77,20 @@ class SyncStatsRepositoryTest {
     }
 
     @Test
-    fun whenOnlySuccessfulAttemptsThenDailyStatsHasCorrectData() {
+    fun whenOnlyTodayAttemptsThenDailyStatsHasCorrectData() {
         val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
+        val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
+
+        whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
+
+        val stats = repository.getDailyStats()
+
+        assertTrue(stats.attempts == 0)
+    }
+
+    @Test
+    fun whenOnlySuccessfulAttemptsThenDailyStatsHasCorrectData() {
+        val lastSyncTimestamp = timestamp(Instant.now().minus(1, ChronoUnit.DAYS))
         val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
 
         whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
@@ -91,7 +103,7 @@ class SyncStatsRepositoryTest {
 
     @Test
     fun whenOnlyFailedAttemptsThenDailyStatsHasCorrectData() {
-        val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
+        val lastSyncTimestamp = timestamp(Instant.now().minus(1, ChronoUnit.DAYS))
         val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = FAIL)
 
         whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
@@ -108,7 +120,7 @@ class SyncStatsRepositoryTest {
 
     @Test
     fun whenFewAttemptsThenDailyStatsHasCorrectData() {
-        val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.MINUTES))
+        val lastSyncTimestamp = timestamp(Instant.now().minus(1, ChronoUnit.DAYS))
         val first = SyncAttempt(timestamp = lastSyncTimestamp, state = FAIL)
         val second = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
         val third = SyncAttempt(timestamp = lastSyncTimestamp, state = FAIL)

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/dao/SyncAttemptDao.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/dao/SyncAttemptDao.kt
@@ -36,4 +36,7 @@ interface SyncAttemptDao {
 
     @Query("SELECT * FROM sync_attempts ORDER BY id DESC LIMIT 1")
     fun attempts(): Flow<SyncAttempt?>
+
+    @Query("SELECT * FROM sync_attempts ORDER BY id DESC LIMIT 1")
+    fun allAttempts(): List<SyncAttempt>
 }

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/dao/SyncAttemptDao.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/dao/SyncAttemptDao.kt
@@ -34,9 +34,9 @@ interface SyncAttemptDao {
     @Query("DELETE from sync_attempts")
     fun clear()
 
-    @Query("SELECT * FROM sync_attempts ORDER BY id DESC LIMIT 1")
+    @Query("SELECT * FROM sync_attempts ORDER BY id DESC")
     fun attempts(): Flow<SyncAttempt?>
 
-    @Query("SELECT * FROM sync_attempts ORDER BY id DESC LIMIT 1")
+    @Query("SELECT * FROM sync_attempts ORDER BY id DESC")
     fun allAttempts(): List<SyncAttempt>
 }

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.sync.store.model
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.duckduckgo.app.global.formatters.time.DatabaseDateFormatter
+import org.threeten.bp.LocalDate
+import org.threeten.bp.ZoneOffset
 
 @Entity(
     tableName = "sync_attempts",
@@ -28,7 +30,11 @@ data class SyncAttempt(
     val timestamp: String = DatabaseDateFormatter.iso8601(),
     val state: SyncAttemptState,
     val meta: String = "",
-)
+) {
+    fun today(): Boolean {
+        return DatabaseDateFormatter.iso8601Date(this.timestamp).isEqual(LocalDate.now(ZoneOffset.UTC))
+    }
+}
 
 enum class SyncAttemptState {
     IN_PROGRESS,

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
@@ -31,8 +31,8 @@ data class SyncAttempt(
     val state: SyncAttemptState,
     val meta: String = "",
 ) {
-    fun today(): Boolean {
-        return DatabaseDateFormatter.iso8601Date(this.timestamp).isEqual(LocalDate.now(ZoneOffset.UTC))
+    fun yesterday(): Boolean {
+        return DatabaseDateFormatter.iso8601Date(this.timestamp).isEqual(LocalDate.now(ZoneOffset.UTC).minusDays(1))
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL:  https://app.asana.com/0/488551667048375/1204998012054462/f

### Description
This PR adds the necessary pixels for Sync M2

### Steps to test this PR

_DAUs_
Modify FeatureRetentionPixelSender so it sends pixels even if they same day was already sent.
Remove the if statement in line 63

- [ ] Open app and enable sync
- [ ] Force close the app and open it again
- [ ] Verify m_browser_feature_daily_active_user_d is sent with parameter sync = 1

_Daily Success Rate_
Modify SyncDailyReportingWorkerScheduler so it schedules the Worker every minute instead of every 24 hours
Modify line 45 in SyncStatsRepository so it doesn’t filter by sync operations of the day before

 - [ ]Open app and enable sync
- [ ] Do some changes in syncable objects so sync operations are triggered
 - [ ]Force close the app and open it again
- [ ] Verify m_sync_daily_success_rate is sent
- [ ] Verify m_sync_daily_attempts is sent

_Encryption_
Modify RealSyncCrypto so it always fails when encrypting / decrypting

- [ ] Open app and enable sync
- [ ] Do some changes in syncable objects so sync operations are triggered
- [ ] Verify m_sync_encrypt_failure is sent

_Decryption (needs two devices)_

- [ ] Open app and add some bookmarks
- [ ] Make some changes in first device
- [ ] Join the first device’s account
- [ ] Verify m_sync_decrypt_failure is sent
