### PR TITLE
Restructure maestro tests for better reusability

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -80,7 +80,8 @@ jobs:
           name: ${{ github.sha }}
           app-file: apk/release.apk
           android-api-level: 30
-          workspace: .maestro/release_tests
+          workspace: .maestro
+          include-tags: smokeTest
 
       - name: Notifications permissions Android 13+
         if: always()

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -81,7 +81,7 @@ jobs:
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
-          include-tags: smokeTest
+          include-tags: releaseTest
 
       - name: Notifications permissions Android 13+
         if: always()

--- a/.maestro/app_tp/app_tp_onboarding.yaml
+++ b/.maestro/app_tp/app_tp_onboarding.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "SmokeTest: AppTP onboarding"
 tags:
-    - smokeTest
+    - releaseTest
 ---
 - launchApp:
       clearState: true

--- a/.maestro/app_tp/app_tp_onboarding.yaml
+++ b/.maestro/app_tp/app_tp_onboarding.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "SmokeTest: AppTP onboarding"
+name: "ReleaseTest: AppTP onboarding"
 tags:
     - releaseTest
 ---

--- a/.maestro/app_tp/app_tp_onboarding.yaml
+++ b/.maestro/app_tp/app_tp_onboarding.yaml
@@ -1,4 +1,7 @@
 appId: com.duckduckgo.mobile.android
+name: "SmokeTest: AppTP onboarding"
+tags:
+    - smokeTest
 ---
 - launchApp:
       clearState: true

--- a/.maestro/autofill/smoke.yaml
+++ b/.maestro/autofill/smoke.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "SmokeTest: Autofill screen is reachable from overflow menu"
+name: "ReleaseTest: Autofill screen is reachable from overflow menu"
 tags:
     - releaseTest
 ---

--- a/.maestro/autofill/smoke.yaml
+++ b/.maestro/autofill/smoke.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "SmokeTest: Autofill screen is reachable from overflow menu"
 tags:
-    - smokeTest
+    - releaseTest
 ---
 - launchApp:
     clearState: true

--- a/.maestro/autofill/smoke.yaml
+++ b/.maestro/autofill/smoke.yaml
@@ -1,8 +1,9 @@
 appId: com.duckduckgo.mobile.android
-name: Autofill Smoke Tests
+name: "SmokeTest: Autofill screen is reachable from overflow menu"
+tags:
+    - smokeTest
 ---
 - launchApp:
     clearState: true
 - runFlow: ../shared/onboarding.yaml
 - runFlow: 1_autofill_shown_in_overflow.yaml
-- runFlow: 2_autofill_reach_creds_management.yaml

--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "SmokeTest: Bookmarks can be added and deleted"
+name: "ReleaseTest: Bookmarks can be added and deleted"
 tags:
     - releaseTest
 ---

--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -1,4 +1,7 @@
 appId: com.duckduckgo.mobile.android
+name: "SmokeTest: Bookmarks can be added and deleted"
+tags:
+    - smokeTest
 ---
 - launchApp:
     clearState: true
@@ -18,32 +21,29 @@ appId: com.duckduckgo.mobile.android
     text: ".*keep browsing.*"
 - tapOn:
     text: "got it"
-# Add favorite from menu button
 - tapOn:
     id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
 - assertVisible:
-    text: "add favorite"
+    text: "add bookmark"
 - tapOn:
-    text: "add favorite"
-# Navigate to bookmarks screen
+    text: "add bookmark"
 - tapOn:
     id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
 - assertVisible:
     text: "bookmarks"
 - tapOn:
     text: "bookmarks"
-# Remove favorite from bookmarks screen
+- assertVisible:
+    text: "No favorites added yet"
+- assertVisible:
+    text: "Privacy Test Pages - Home"
 - tapOn:
     id: "com.duckduckgo.mobile.android:id/trailingIcon"
-    index: 0
 - assertVisible:
     text: "Delete"
 - tapOn:
     text: "delete"
-# When a favorite is removed, it still stays as Bookmark
-- assertVisible:
-    text: "No favorites added yet"
 - assertNotVisible:
+    text: "Privacy Test Pages - Home"
+- assertVisible:
     text: "No bookmarks added yet"
-# Undo Snackbar should be visible
-- assertVisible: "Undo"

--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "SmokeTest: Bookmarks can be added and deleted"
 tags:
-    - smokeTest
+    - releaseTest
 ---
 - launchApp:
     clearState: true

--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "SmokeTest: General website browsing works"
+name: "ReleaseTest: General website browsing works"
 tags:
   - releaseTest
 ---

--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -1,8 +1,11 @@
 appId: com.duckduckgo.mobile.android
+name: "SmokeTest: General website browsing works"
+tags:
+  - smokeTest
 ---
 - launchApp:
-      clearState: true
-      stopApp: true
+    clearState: true
+    stopApp: true
 - assertVisible:
     text: ".*Not to worry! Searching and browsing privately.*"
 - tapOn: "let's do it!"

--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "SmokeTest: General website browsing works"
 tags:
-  - smokeTest
+  - releaseTest
 ---
 - launchApp:
     clearState: true

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -2,3 +2,6 @@ appStartup:
   enabled: false
 appSize:
   enabled: false
+
+flows:
+ - "**"

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "SmokeTest: Deleting a favorite does not delete bookmark"
+name: "ReleaseTest: Deleting a favorite does not delete bookmark"
 tags:
     - releaseTest
 ---

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "SmokeTest: Deleting a favorite does not delete bookmark"
 tags:
-    - smokeTest
+    - releaseTest
 ---
 - launchApp:
     clearState: true

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -1,4 +1,7 @@
 appId: com.duckduckgo.mobile.android
+name: "SmokeTest: Deleting a favorite does not delete bookmark"
+tags:
+    - smokeTest
 ---
 - launchApp:
     clearState: true
@@ -25,28 +28,25 @@ appId: com.duckduckgo.mobile.android
     text: "add favorite"
 - tapOn:
     text: "add favorite"
-# Remove favorite from menu button
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-    text: "remove favorite"
-- tapOn:
-    text: "remove favorite"
-# Re-add favorite from menu button
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-    text: "add favorite"
-- tapOn:
-    text: "add favorite"
-# Check favorites from bookmarks screen
+# Navigate to bookmarks screen
 - tapOn:
     id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
 - assertVisible:
     text: "bookmarks"
 - tapOn:
     text: "bookmarks"
+# Remove favorite from bookmarks screen
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/trailingIcon"
+    index: 0
+- assertVisible:
+    text: "Delete"
+- tapOn:
+    text: "delete"
+# When a favorite is removed, it still stays as Bookmark
+- assertVisible:
+    text: "No favorites added yet"
 - assertNotVisible:
     text: "No bookmarks added yet"
-- assertVisible:
-    text: "Privacy Test Pages - Home"
+# Undo Snackbar should be visible
+- assertVisible: "Undo"

--- a/.maestro/favorites/favorites_bookmarks_undo.yaml
+++ b/.maestro/favorites/favorites_bookmarks_undo.yaml
@@ -1,8 +1,11 @@
 appId: com.duckduckgo.mobile.android
+name: "SmokeTest: Can undo a deleted favorite"
+tags:
+    - smokeTest
 ---
 - launchApp:
-      clearState: true
-      stopApp: true
+    clearState: true
+    stopApp: true
 - assertVisible:
     text: ".*Not to worry! Searching and browsing privately.*"
 - tapOn: "let's do it!"
@@ -18,29 +21,32 @@ appId: com.duckduckgo.mobile.android
     text: ".*keep browsing.*"
 - tapOn:
     text: "got it"
+# Add favorite from menu button
 - tapOn:
-      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
 - assertVisible:
-    text: "add bookmark"
+    text: "add favorite"
 - tapOn:
-    text: "add bookmark"
+    text: "add favorite"
+# Navigate to bookmarks screen
 - tapOn:
-      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
 - assertVisible:
     text: "bookmarks"
 - tapOn:
     text: "bookmarks"
-- assertVisible:
-    text: "No favorites added yet"
-- assertVisible:
-    text: "Privacy Test Pages - Home"
+# Remove favorite from bookmarks screen
 - tapOn:
-      id: "com.duckduckgo.mobile.android:id/trailingIcon"
+    id: "com.duckduckgo.mobile.android:id/trailingIcon"
+    index: 0
 - assertVisible:
     text: "Delete"
 - tapOn:
     text: "delete"
+# Undo remove favorite from bookmarks screen
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/snackbar_action"
 - assertNotVisible:
-    text: "Privacy Test Pages - Home"
-- assertVisible:
+    text: "No favorites added yet"
+- assertNotVisible:
     text: "No bookmarks added yet"

--- a/.maestro/favorites/favorites_bookmarks_undo.yaml
+++ b/.maestro/favorites/favorites_bookmarks_undo.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "SmokeTest: Can undo a deleted favorite"
+name: "ReleaseTest: Can undo a deleted favorite"
 tags:
     - releaseTest
 ---

--- a/.maestro/favorites/favorites_bookmarks_undo.yaml
+++ b/.maestro/favorites/favorites_bookmarks_undo.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "SmokeTest: Can undo a deleted favorite"
 tags:
-    - smokeTest
+    - releaseTest
 ---
 - launchApp:
     clearState: true

--- a/.maestro/favorites/favorites_menu_add_remove.yaml
+++ b/.maestro/favorites/favorites_menu_add_remove.yaml
@@ -1,4 +1,7 @@
 appId: com.duckduckgo.mobile.android
+name: "SmokeTest: Can add and remove favorites"
+tags:
+    - smokeTest
 ---
 - launchApp:
     clearState: true
@@ -25,25 +28,28 @@ appId: com.duckduckgo.mobile.android
     text: "add favorite"
 - tapOn:
     text: "add favorite"
-# Navigate to bookmarks screen
+# Remove favorite from menu button
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+    text: "remove favorite"
+- tapOn:
+    text: "remove favorite"
+# Re-add favorite from menu button
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+    text: "add favorite"
+- tapOn:
+    text: "add favorite"
+# Check favorites from bookmarks screen
 - tapOn:
     id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
 - assertVisible:
     text: "bookmarks"
 - tapOn:
     text: "bookmarks"
-# Remove favorite from bookmarks screen
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/trailingIcon"
-    index: 0
-- assertVisible:
-    text: "Delete"
-- tapOn:
-    text: "delete"
-# Undo remove favorite from bookmarks screen
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/snackbar_action"
-- assertNotVisible:
-    text: "No favorites added yet"
 - assertNotVisible:
     text: "No bookmarks added yet"
+- assertVisible:
+    text: "Privacy Test Pages - Home"

--- a/.maestro/favorites/favorites_menu_add_remove.yaml
+++ b/.maestro/favorites/favorites_menu_add_remove.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "SmokeTest: Can add and remove favorites"
+name: "ReleaseTest: Can add and remove favorites"
 tags:
     - releaseTest
 ---

--- a/.maestro/favorites/favorites_menu_add_remove.yaml
+++ b/.maestro/favorites/favorites_menu_add_remove.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "SmokeTest: Can add and remove favorites"
 tags:
-    - smokeTest
+    - releaseTest
 ---
 - launchApp:
     clearState: true

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "SmokeTest: Fire button is working"
 tags:
-    - smokeTest
+    - releaseTest
 ---
 - launchApp:
     clearState: true

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "SmokeTest: Fire button is working"
+name: "ReleaseTest: Fire button is working"
 tags:
     - releaseTest
 ---

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -1,4 +1,7 @@
 appId: com.duckduckgo.mobile.android
+name: "SmokeTest: Fire button is working"
+tags:
+    - smokeTest
 ---
 - launchApp:
     clearState: true

--- a/.maestro/release_tests/9_-_autofill_available.yaml
+++ b/.maestro/release_tests/9_-_autofill_available.yaml
@@ -1,6 +1,0 @@
-appId: com.duckduckgo.mobile.android
-name: Ensure autofill is available
----
-- launchApp:
-      clearState: true
-- runFlow: ../autofill/smoke.yaml

--- a/.maestro/tabs/open_multiple_tabs.yaml
+++ b/.maestro/tabs/open_multiple_tabs.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "SmokeTest: Multiple tabs can be opened"
 tags:
-    - smokeTest
+    - releaseTest
 ---
 - launchApp:
       clearState: true

--- a/.maestro/tabs/open_multiple_tabs.yaml
+++ b/.maestro/tabs/open_multiple_tabs.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "SmokeTest: Multiple tabs can be opened"
+name: "ReleaseTest: Multiple tabs can be opened"
 tags:
     - releaseTest
 ---

--- a/.maestro/tabs/open_multiple_tabs.yaml
+++ b/.maestro/tabs/open_multiple_tabs.yaml
@@ -1,4 +1,7 @@
 appId: com.duckduckgo.mobile.android
+name: "SmokeTest: Multiple tabs can be opened"
+tags:
+    - smokeTest
 ---
 - launchApp:
       clearState: true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -454,7 +454,12 @@ tasks.register('androidTestsBuild') {
     dependsOn 'assemblePlayDebug', 'assemblePlayDebugAndroidTest'
 }
 
-tasks.register('smokeTest', Exec) {
-    commandLine 'maestro', 'test', '--include-tags', 'smokeTest', '../.maestro'
+tasks.register('releaseTestLocal', Exec) {
+    commandLine 'maestro', 'test', '--include-tags', 'releaseTest', '../.maestro'
     dependsOn 'installPlayRelease'
+}
+
+tasks.register('releaseTestCloud', Exec) {
+    commandLine 'maestro', 'cloud', '--include-tags', 'releaseTest', "build/outputs/apk/play/release/duckduckgo-${buildVersionName()}-play-release.apk", '../.maestro'
+    dependsOn 'assemblePlayRelease'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -454,7 +454,7 @@ tasks.register('androidTestsBuild') {
     dependsOn 'assemblePlayDebug', 'assemblePlayDebugAndroidTest'
 }
 
-task smokeTest(type: Exec) {
-    commandLine 'maestro', 'test', '../.maestro/release_tests'
+tasks.register('smokeTest', Exec) {
+    commandLine 'maestro', 'test', '--include-tags', 'smokeTest', '../.maestro'
     dependsOn 'installPlayRelease'
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205234542811811/f

### Description
Restructures the maestro release tests to use tagging instead of relying on them being in a certain folder. This approach will allow for more flexibility and reduce the need for so much duplication across the tests.

### Steps to test this PR

_Run tests locally_
- [ ] Run `./gradlew releaseTestLocal` and ensure all tests pass
- ℹ️ This is equivalent to running `maestro test --include-tags releaseTest .maestro`

_Ensure tests run on maestro cloud when triggered locally_
- [ ] Run `./gradlew releaseTestCloud` and ensure all tests pass
- ℹ️ This is equivalent to running `maestro cloud --include-tags releaseTest app/build/outputs/apk/play/release/duckduckgo-5.165.1-play-release.apk .maestro`

_Ensure CI end-to-end tests pass_
The E2E tests won't run against this branch automatically (they run against `develop` overnight). 
- [ ] Instead, verify they passed here where it was manually run against this branch: https://github.com/duckduckgo/Android/actions/runs/5811552784
