### PR TITLE
Maestro appTP test: make vpn dialog handling optional

### DIFF
--- a/.maestro/app_tp/app_tp_onboarding.yaml
+++ b/.maestro/app_tp/app_tp_onboarding.yaml
@@ -32,8 +32,9 @@ tags:
 - tapOn:
     text: "Enable App Tracking Protection"
     index: 1
-- assertVisible: "Connection request"
-- tapOn: "OK"
+- tapOn:
+    text: "OK"
+    optional: true
 - assertVisible:
       text: "Good news! App Tracking Protection is now enabled.*"
 - assertVisible: "Got it!"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205234542811814/f

### Description
Makes it so that the VPN permission dialog step is optional. 
- Otherwise, this appTP test will only pass once and require the APK to be uninstalled and reinstalled before the test will run again.
- Even if the dialog doesn't show (because permission was accepted before on a previous test run), the later assertions would catch a problem if app TP couldn't be enabled.

### Steps to test this PR

- [x] Fresh install app
- [x] Run `maestro test .maestro/app_tp/app_tp_onboarding.yaml`
- [x] Ensure tests pass
- [x] Run again and verify they still pass 2nd time around
