### PR TITLE
report battery optimizations true/false in AppTP breakage

### DIFF
--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/bugreport/DeviceInfoCollectorTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/bugreport/DeviceInfoCollectorTest.kt
@@ -44,7 +44,7 @@ class DeviceInfoCollectorTest {
         whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.PLAY)
         whenever(appBuildConfig.sdkInt).thenReturn(30)
 
-        deviceInfoCollector = DeviceInfoCollector(appBuildConfig)
+        deviceInfoCollector = DeviceInfoCollector(appBuildConfig, { false })
     }
 
     @Test
@@ -53,8 +53,21 @@ class DeviceInfoCollectorTest {
 
         assertEquals("deviceInfo", deviceInfoCollector.collectorName)
 
-        assertEquals(2, state.length())
+        assertEquals(3, state.length())
         assertEquals("PLAY", state.get("buildFlavor"))
         assertEquals(30, state.get("os"))
+        assertEquals("true", state.get("batteryOptimizations"))
+    }
+
+    @Test
+    fun whenIgnoringBatteryOptimizationsThenReportBatteryOptimizationsTrue() = runTest {
+        val state = DeviceInfoCollector(appBuildConfig, { true }).collectVpnRelatedState()
+
+        assertEquals("deviceInfo", deviceInfoCollector.collectorName)
+
+        assertEquals(3, state.length())
+        assertEquals("PLAY", state.get("buildFlavor"))
+        assertEquals(30, state.get("os"))
+        assertEquals("false", state.get("batteryOptimizations"))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205234536443733/f

### Description
See [asana](https://app.asana.com/0/488551667048375/1205234536443733/f) task

### Steps to test this PR
- [x] enable AppTP
- [x] report breakage for any app
- [x] verify the report contains `"batteryOptimizations":"false"` or `"batteryOptimizations":"true"` depending on whether DDG app has battery setting set to `Unrestricted` or any other value resp
