### PR TITLE
AppTP: Remove prepopulation of AppTrackerEntity

### DIFF
--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallback.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallback.kt
@@ -53,25 +53,6 @@ internal class VpnDatabaseCallback(
         }
     }
 
-    override fun onOpen(db: SupportSQLiteDatabase) {
-        ioThread {
-            prepopulateTrackerEntities()
-        }
-    }
-
-    private fun prepopulateTrackerEntities() {
-        context.resources.openRawResource(R.raw.full_app_trackers_blocklist).bufferedReader()
-            .use { it.readText() }
-            .also {
-                val blocklist = getFullAppTrackerBlockingList(it)
-                with(vpnDatabase.get().vpnAppTrackerBlockingDao()) {
-                    if (!hasTrackerEntities()) {
-                        insertTrackerEntities(blocklist.entities)
-                    }
-                }
-            }
-    }
-
     @VisibleForTesting
     internal fun prepopulateAppTrackerBlockingList() {
         context.resources.openRawResource(R.raw.full_app_trackers_blocklist).bufferedReader()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: 
https://app.asana.com/0/488551667048375/1201722332762154/f

### Description
Remove the prepopulation method as we no longer need it.