### PR TITLE
Update logic on force expand search bar

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4408,6 +4408,28 @@ class BrowserTabViewModelTest {
         assertFalse(testee.isActiveTab())
     }
 
+    @Test
+    fun whenUrlIsUpdatedWithDifferentHostThenForceUpdateShouldBeTrue() {
+        val originalUrl = "http://www.example.com/"
+        loadUrl(originalUrl, isBrowserShowing = true)
+        updateUrl(originalUrl, "http://twitter.com/explore", true)
+
+        assertTrue(omnibarViewState().forceExpand)
+    }
+
+    @Test
+    fun whenUrlIsUpdateButSameHostThenForceUpdateShouldBeFalse() = runTest {
+        val originalUrl = "https://www.example.com/search/sss#search=1~grid~0~25"
+        loadUrl(originalUrl, isBrowserShowing = true)
+        updateUrl(
+            originalUrl,
+            "https://www.example.com/search/sss#search=1~grid~0~28",
+            true,
+        )
+
+        assertFalse(omnibarViewState().forceExpand)
+    }
+
     private fun aCredential(): LoginCredentials {
         return LoginCredentials(domain = null, username = null, password = null)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3034,7 +3034,9 @@ class BrowserTabFragment :
 
                 if (shouldUpdateOmnibarTextInput(viewState, viewState.omnibarText)) {
                     omnibar.omnibarTextInput.setText(viewState.omnibarText)
-                    omnibar.appBarLayout.setExpanded(true, true)
+                    if (viewState.forceExpand) {
+                        omnibar.appBarLayout.setExpanded(true, true)
+                    }
                     if (viewState.shouldMoveCaretToEnd) {
                         omnibar.omnibarTextInput.setSelection(viewState.omnibarText.length)
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -283,6 +283,7 @@ class BrowserTabViewModel @Inject constructor(
         val isEditing: Boolean = false,
         val shouldMoveCaretToEnd: Boolean = false,
         val showVoiceSearch: Boolean = false,
+        val forceExpand: Boolean = true,
     )
 
     data class LoadingViewState(
@@ -940,6 +941,7 @@ class BrowserTabViewModel @Inject constructor(
             omnibarText = trimmedInput,
             shouldMoveCaretToEnd = false,
             showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(urlLoaded = urlToNavigate),
+            forceExpand = true,
         )
         browserViewState.value = currentBrowserViewState().copy(browserShowing = true, showClearButton = false)
         autoCompleteViewState.value =
@@ -1140,6 +1142,7 @@ class BrowserTabViewModel @Inject constructor(
             omnibarText = "",
             shouldMoveCaretToEnd = false,
             showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(),
+            forceExpand = true,
         )
         loadingViewState.value = currentLoadingViewState().copy(isLoading = false)
 
@@ -1219,6 +1222,7 @@ class BrowserTabViewModel @Inject constructor(
             omnibarText = omnibarText,
             shouldMoveCaretToEnd = false,
             showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(urlLoaded = url),
+            forceExpand = true,
         )
         val currentBrowserViewState = currentBrowserViewState()
         val domain = site?.domain
@@ -1396,6 +1400,7 @@ class BrowserTabViewModel @Inject constructor(
                 omnibarText = omnibarText,
                 shouldMoveCaretToEnd = false,
                 showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(urlLoaded = url),
+                forceExpand = false,
             ),
         )
         browserViewState.postValue(currentBrowserViewState().copy(isFireproofWebsite = isFireproofWebsite()))
@@ -1809,6 +1814,7 @@ class BrowserTabViewModel @Inject constructor(
                 isEditing = hasFocus,
                 urlLoaded = url ?: "",
             ),
+            forceExpand = true,
         )
 
         val currentBrowserViewState = currentBrowserViewState()
@@ -2602,6 +2608,7 @@ class BrowserTabViewModel @Inject constructor(
             omnibarViewState.value = currentOmnibarViewState().copy(
                 omnibarText = request.site,
                 showVoiceSearch = false,
+                forceExpand = true,
             )
             command.value = HideWebContent
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204721270468631/f

### Description
This PR removes the force expand on the search bar when the url is updated but the host remains the same (`WebNavigationStateChange.UrlUpdated`). See linked task to see sample cases why this is not completely necessary.

### Steps to test this PR

_Bug fix_
- [ ] Install build
- [ ] Visit https://boston.craigslist.org/search/sss#search=1~gallery~0~0
- [ ] Scroll through the page 
- [ ] Verify that the search bar doesn't jump around and only appears when you scroll back up (expected scroll behavior)

_Site change_
- [ ] Install build
- [ ] Visit https://boston.craigslist.org/search/sss#search=1~gallery~0~0
- [ ] Scroll through the page 
- [ ] Verify that search bar is hidden
- [ ] Open an item
- [ ] Verify that new page is opened
- [ ] Verify that search bar is expanded.

_Background_
- [ ] Install build
- [ ] Open duckduckgo.com
- [ ] Search and open the images tab
- [ ] Scroll through the page 
- [ ] Verify that search bar is hidden
- [ ] Background the app
- [ ] Open app again
- [ ] Verify that search bar is expanded.

_Error_
- [ ] Install build
- [ ] Open duckduckgo.com
- [ ] Search for anything
- [ ] Scroll through the results
- [ ] Verify that search bar is hidden
- [ ] Go to airplane mode
- [ ] Press any link
- [ ] Verify that search bar is expanded.

