### PR TITLE
Fix toolbar color when showing SearchBarView

### DIFF
--- a/app/src/main/res/layout/activity_bookmarks.xml
+++ b/app/src/main/res/layout/activity_bookmarks.xml
@@ -29,12 +29,12 @@
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/daxColorSurface"
         android:theme="@style/Widget.DuckDuckGo.ToolbarTheme">
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize">
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/daxColorSurface">
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_downloads.xml
+++ b/app/src/main/res/layout/activity_downloads.xml
@@ -23,16 +23,16 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?daxColorSurface"
-        android:theme="@style/Widget.DuckDuckGo.ToolbarTheme">
+        android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize">
+            android:layout_height="?attr/actionBarSize"
+            android:background="?daxColorSurface">
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
@@ -48,8 +48,8 @@
                 android:layout_height="match_parent"
                 android:layout_margin="@dimen/keyline_2"
                 android:visibility="gone"
-                app:searchHint="@string/search"
-                app:clearActionContentDescription="@string/clearButtonContentDescription"/>
+                app:clearActionContentDescription="@string/clearButtonContentDescription"
+                app:searchHint="@string/search" />
         </FrameLayout>
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/autofill/autofill-impl/src/main/res/layout/activity_autofill_settings.xml
+++ b/autofill/autofill-impl/src/main/res/layout/activity_autofill_settings.xml
@@ -15,25 +15,25 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     tools:context=".ui.credential.management.AutofillManagementActivity">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?daxColorSurface"
-        android:theme="@style/Widget.DuckDuckGo.ToolbarTheme">
+        android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize">
+            android:layout_height="?attr/actionBarSize"
+            android:background="?daxColorSurface">
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
@@ -49,13 +49,13 @@
                 android:layout_height="match_parent"
                 android:layout_margin="@dimen/keyline_2"
                 android:visibility="gone"
-                app:searchHint="@string/autofillManagementSearchLogins"
-                app:clearActionContentDescription="@string/autofillManagementSearchClearDescription"/>
+                app:clearActionContentDescription="@string/autofillManagementSearchClearDescription"
+                app:searchHint="@string/autofillManagementSearchLogins" />
         </FrameLayout>
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205238684397185/f

### Description
Fix toolbar background color when searchBar is visible

### Steps to test this PR

_Bookmarks screen (Light/Dark theme)_
- Install from this branch
- Go to Overflow Menu > Bookmarks
- Tap on search icon in Toolbar
- [x] Check toolbar background color is correct

_Downloads screen (Light/Dark theme)_
- Install from this branch
- Go to Overflow Menu > Downloads
- Tap on search icon in Toolbar
- [x] Check toolbar background color is correct

_Logins screen (Light/Dark theme)_
- Install from this branch
- Go to Overflow Menu > Logins
- Tap on search icon in Toolbar
- [x] Check toolbar background color is correct

### UI changes
| Before  | After |
| ------ | ----- |
<img width="377" alt="Screenshot 2023-08-14 at 16 43 19" src="https://github.com/duckduckgo/Android/assets/20798495/378e94a0-7b4b-4fbc-a30e-e7fab71e3242">|<img width="375" alt="Screenshot 2023-08-14 at 16 54 07" src="https://github.com/duckduckgo/Android/assets/20798495/0f460f47-7b7b-4ce4-b60f-bc418a1d5acb">|
<img width="374" alt="Screenshot 2023-08-14 at 16 44 23" src="https://github.com/duckduckgo/Android/assets/20798495/5b57cc7a-18dc-4dd2-b9f6-cbf27cbf726f">|<img width="380" alt="Screenshot 2023-08-14 at 16 43 02" src="https://github.com/duckduckgo/Android/assets/20798495/4fa51f04-1ce4-49aa-9237-cf1fc407369d">|
