### PR TITLE
Restructure maestro ad-click detection tests to use tags and shared onboarding flow

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -60,7 +60,8 @@ jobs:
           name: ${{ github.sha }}
           app-file: apk/release.apk
           android-api-level: 30
-          workspace: .maestro/ad_click_detection_flows
+          workspace: .maestro
+          include-tags: adClickTest
 
       - name: Privacy Tests
         if: always()

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -62,7 +62,8 @@ jobs:
           api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
           name: ${{ github.sha }}
           app-file: apk/release.apk
-          workspace: .maestro/ad_click_detection_flows
+          workspace: .maestro
+          include-tags: adClickTest
 
       - name: Privacy Tests
         if: always()

--- a/.maestro/ad_click_detection_flows/10_-_m.js_bing-provided;_ad_domain_provided_but_incorrect_(dsl_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/10_-_m.js_bing-provided;_ad_domain_provided_but_incorrect_(dsl_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-10"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/11_-_y.js_bing-provided;_ad_domain_provided_but_it's_not_a_domain_(i.e.,_abcedf)_(u3_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/11_-_y.js_bing-provided;_ad_domain_provided_but_it's_not_a_domain_(i.e.,_abcedf)_(u3_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-11"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/12_-_m.js_bing-provided;_ad_domain_provided_but_it's_not_a_domain_(i.e.,_abcedf)__(dsl_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/12_-_m.js_bing-provided;_ad_domain_provided_but_it's_not_a_domain_(i.e.,_abcedf)__(dsl_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-12"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/13_-_y.js_bing-provided;_ad_domain_provided_but_it's_a_subdomain_of_advertiser_(i.e.,_foo.www.search-company-site)_(u3_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/13_-_y.js_bing-provided;_ad_domain_provided_but_it's_a_subdomain_of_advertiser_(i.e.,_foo.www.search-company-site)_(u3_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-13"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/14_-_m.js_bing-provided;_ad_domain_provided_but_it's_a_subdomain_of_advertiser_(i.e.,_foo.www.search-company-site)__(dsl_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/14_-_m.js_bing-provided;_ad_domain_provided_but_it's_a_subdomain_of_advertiser_(i.e.,_foo.www.search-company-site)__(dsl_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-14"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/1_-_y.js_heuristic;_no_ad_domain_param;_u3_param_included.yaml
+++ b/.maestro/ad_click_detection_flows/1_-_y.js_heuristic;_no_ad_domain_param;_u3_param_included.yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-1"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/2_-_m.js_heuristic;_no_ad_domain_param;_dsl_param_included.yaml
+++ b/.maestro/ad_click_detection_flows/2_-_m.js_heuristic;_no_ad_domain_param;_dsl_param_included.yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-2"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/3_-_y.js_heuristic;_no_ad_domain_param,_but_missing_u3_param.yaml
+++ b/.maestro/ad_click_detection_flows/3_-_y.js_heuristic;_no_ad_domain_param,_but_missing_u3_param.yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-3"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/4_-_m.js_heuristic;_no_ad_domain_param,_but_missing_dsl_param.yaml
+++ b/.maestro/ad_click_detection_flows/4_-_m.js_heuristic;_no_ad_domain_param,_but_missing_dsl_param.yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-4"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/5_-_y.js_heuristic;_ad_domain_provided,_but_empty_(u3_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/5_-_y.js_heuristic;_ad_domain_provided,_but_empty_(u3_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-5"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/6_-_m.js_heuristic;_ad_domain_provided,_but_empty_(dsl_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/6_-_m.js_heuristic;_ad_domain_provided,_but_empty_(dsl_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-6"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/7_-_y.js_bing-provided;_ad_domain_provided_(u3_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/7_-_y.js_bing-provided;_ad_domain_provided_(u3_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-6" # scroll until the ad-id-6 instead of ad-id-7 (context: https://app.asana.com/0/0/1204397066248823/1204415854211764/f)
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/8_-_m.js_bing-provided;_ad_domain_provided_(dsl_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/8_-_m.js_bing-provided;_ad_domain_provided_(dsl_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-8"
 - pressKey: Enter
 - assertVisible:

--- a/.maestro/ad_click_detection_flows/9_-_y.js_bing-provided;_ad_domain_provided_but_incorrect_(u3_not_needed).yaml
+++ b/.maestro/ad_click_detection_flows/9_-_y.js_bing-provided;_ad_domain_provided_but_incorrect_(u3_not_needed).yaml
@@ -1,13 +1,12 @@
 appId: com.duckduckgo.mobile.android
+tags:
+    - adClickTest
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    text: ".*Not to worry! Searching and browsing privately.*"
-- tapOn: "let's do it!"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- runFlow: ../shared/onboarding.yaml
+
 - inputText: "https://www.search-company.site/#ad-id-9"
 - pressKey: Enter
 - assertVisible:


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205258019391736/f

### Description
Restructures the maestro ad-click detection tests to use a tag `adClickTest` and utilise the shared onboarding flow.

### Steps to test this PR
- [ ] Ensure privacy dashboard e2e workflow passed: https://github.com/duckduckgo/Android/actions/runs/5867320667 (or if a failure, it's not because of these changes and the failure is because of known ANR that is getting fixed elsewhere)