### PR TITLE
Update content scope scripts to version 4.33.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -415,16 +415,14 @@
                     const isTainted = hasTaintedMethod(scope);
                     isExempt = !isTainted;
                 }
-                if (debug) {
-                    postDebugMessage(this.camelFeatureName, {
-                        isProxy: true,
-                        action: isExempt ? 'ignore' : 'restrict',
-                        kind: this.property,
-                        documentUrl: document.location.href,
-                        stack: getStack(),
-                        args: debugSerialize(args[2])
-                    });
-                }
+                postDebugMessage(this.camelFeatureName, {
+                    isProxy: true,
+                    action: isExempt ? 'ignore' : 'restrict',
+                    kind: this.property,
+                    documentUrl: document.location.href,
+                    stack: getStack(),
+                    args: debugSerialize(args[2])
+                });
                 // The normal return value
                 if (isExempt) {
                     return DDGReflect.apply(...args)
@@ -466,7 +464,25 @@
         }
     }
 
-    function postDebugMessage (feature, message) {
+    const maxCounter = new Map();
+    function numberOfTimesDebugged (feature) {
+        if (!maxCounter.has(feature)) {
+            maxCounter.set(feature, 1);
+        } else {
+            maxCounter.set(feature, maxCounter.get(feature) + 1);
+        }
+        return maxCounter.get(feature)
+    }
+
+    const DEBUG_MAX_TIMES = 5000;
+
+    function postDebugMessage (feature, message, allowNonDebug = false) {
+        if (!debug && !allowNonDebug) {
+            return
+        }
+        if (numberOfTimesDebugged(feature) > DEBUG_MAX_TIMES) {
+            return
+        }
         if (message.stack) {
             const scriptOrigins = [...getStackTraceOrigins(message.stack)];
             message.scriptOrigins = scriptOrigins;
@@ -6666,6 +6682,8 @@
     let appliedRules = new Set();
     let shouldInjectStyleTag = false;
     let mediaAndFormSelectors = 'video,canvas,embed,object,audio,map,form,input,textarea,select,option,button';
+    let hideTimeouts = [0, 100, 200, 300, 400, 500, 1000, 1500, 2000, 2500, 3000, 5000, 10000];
+    let unhideTimeouts = [750, 1500, 2250, 3000, 4500, 6000, 12000];
 
     /** @type {ElementHiding} */
     let featureInstance;
@@ -6913,6 +6931,8 @@
             const globalRules = this.getFeatureSetting('rules');
             adLabelStrings = this.getFeatureSetting('adLabelStrings');
             shouldInjectStyleTag = this.getFeatureSetting('useStrictHideStyleTag');
+            hideTimeouts = this.getFeatureSetting('hideTimeouts') || hideTimeouts;
+            unhideTimeouts = this.getFeatureSetting('unhideTimeouts') || unhideTimeouts;
             mediaAndFormSelectors = this.getFeatureSetting('mediaAndFormSelectors') || mediaAndFormSelectors;
 
             // determine whether strict hide rules should be injected as a style tag
@@ -6968,8 +6988,6 @@
          * @param {string} rules[].type
          */
         applyRules (rules) {
-            const hideTimeouts = [0, 100, 200, 300, 400, 500, 1000, 1500, 2000, 2500, 3000];
-            const unhideTimeouts = [750, 1500, 2250, 3000];
             const timeoutRules = extractTimeoutRules(rules);
 
             // several passes are made to hide & unhide elements. this is necessary because we're not using
@@ -7011,7 +7029,7 @@
                     lineno: e.lineno,
                     colno: e.colno,
                     stack: e.error?.stack
-                });
+                }, true);
                 this.addDebugFlag();
             };
             globalThis.addEventListener('error', handleUncaughtException);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^5.1.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.32.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.33.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689964986"
       },
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#8def15fe8a4c2fb76730f640507e9fd1d6c1f8a7",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#51c7b30f4c73cadf2800b30a4dca620b3150f33f",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -267,9 +267,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
-      "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
+      "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==",
       "dev": true
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^5.1.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.32.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.33.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1689964986"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass