### PR TITLE
Update content scope scripts to version 4.34.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -415,14 +415,17 @@
                     const isTainted = hasTaintedMethod(scope);
                     isExempt = !isTainted;
                 }
-                postDebugMessage(this.camelFeatureName, {
-                    isProxy: true,
-                    action: isExempt ? 'ignore' : 'restrict',
-                    kind: this.property,
-                    documentUrl: document.location.href,
-                    stack: getStack(),
-                    args: debugSerialize(args[2])
-                });
+                // Keep this here as getStack() is expensive
+                if (debug) {
+                    postDebugMessage(this.camelFeatureName, {
+                        isProxy: true,
+                        action: isExempt ? 'ignore' : 'restrict',
+                        kind: this.property,
+                        documentUrl: document.location.href,
+                        stack: getStack(),
+                        args: debugSerialize(args[2])
+                    });
+                }
                 // The normal return value
                 if (isExempt) {
                     return DDGReflect.apply(...args)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^5.1.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.33.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.34.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1692081744"
       },
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#51c7b30f4c73cadf2800b30a4dca620b3150f33f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#13ba2572f7012ff80da673044a4b7b8c8d006cf1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^5.1.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.33.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.34.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1692081744"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205289848854590/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass