### PR TITLE
Improve app link handling

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser.applinks
 
 import android.os.Build
 import com.duckduckgo.app.global.UriString
+import com.duckduckgo.app.global.extractDomain
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -44,6 +45,8 @@ class DuckDuckGoAppLinksHandler @Inject constructor(
 
     var previousUrl: String? = null
     var isAUserQuery = false
+    var hasTriggeredForDomain = false
+    private val alwaysTriggerList = listOf("app.digid.nl")
 
     override fun handleAppLink(
         isForMainFrame: Boolean,
@@ -57,10 +60,11 @@ class DuckDuckGoAppLinksHandler @Inject constructor(
         }
 
         previousUrl?.let {
-            if (UriString.sameOrSubdomain(it, urlString) || UriString.sameOrSubdomain(urlString, it)) {
-                if (isAUserQuery) {
+            if (isSameOrSubdomain(it, urlString)) {
+                if (isAUserQuery || !hasTriggeredForDomain || alwaysTriggerList.contains(urlString.extractDomain())) {
                     previousUrl = urlString
                     launchAppLink()
+                    hasTriggeredForDomain = true
                 }
                 return false
             }
@@ -68,10 +72,19 @@ class DuckDuckGoAppLinksHandler @Inject constructor(
 
         previousUrl = urlString
         launchAppLink()
+        hasTriggeredForDomain = true
         return shouldHaltWebNavigation
     }
 
+    private fun isSameOrSubdomain(
+        previousUrlString: String,
+        currentUrlString: String,
+    ) = UriString.sameOrSubdomain(previousUrlString, currentUrlString) || UriString.sameOrSubdomain(currentUrlString, previousUrlString)
+
     override fun updatePreviousUrl(urlString: String?) {
+        if (urlString == null || previousUrl?.let { isSameOrSubdomain(it, urlString) } == false) {
+            hasTriggeredForDomain = false
+        }
         previousUrl = urlString
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: 
https://app.asana.com/0/488551667048375/1205272113478379/f
### Description
This PR adds:
- A list of domains for which we will always show an app link snackbar.
- A flag to trigger the snackbar on same or subdomains if it hasn't been shown yet.

### Steps to test this PR
- [x] Install Digid from the Play Store
- [x] Install Amazon from the Play Store

_Ask every time_
- [x] Make sure the app link behavior is set to "Ask every time" in "Settings" > "Permissions".
- [x] Go to https://www.mijnpensioenoverzicht.nl/
- [x] Click "Log in with DigiD" > "Using the DigiD app" > "On this device"
- [x] Verify that the snackbar is shown.
- [x] Go back and do the previous step again.
- [x] Verify that the snackbar is shown.
- [x] Go to Amazon.com
- [x] Verify that the snackbar is shown.

_Always_
- [x] Change the setting to "Always" in "Settings" > "Permissions".
- [x] Go to https://www.mijnpensioenoverzicht.nl/
- [x] Click "Log in with DigiD" > "Using the DigiD app" > "On this device"
- [x] Verify that the app is opened (No snackbar).
- [x] Go back and do the previous step again.
- [x] Verify that the app is opened.
- [x] Go to Amazon.com
- [x] Verify that the snackbar is shown.
