### PR TITLE
[Allow users to delete bookmarks from edit screen] Android design & implementation

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -673,6 +673,17 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenBookmarkDeletedThenFaviconDeletedAndRepositoryIsUpdated() = runTest {
+        val bookmark =
+            Bookmark(id = UUID.randomUUID().toString(), title = "A title", url = "www.example.com", lastModified = "timestamp")
+
+        testee.onBookmarkDeleted(bookmark)
+
+        verify(mockFaviconManager).deletePersistedFavicon(bookmark.url)
+        verify(mockSavedSitesRepository).delete(bookmark)
+    }
+
+    @Test
     fun whenBookmarkAddedThenRepositoryIsUpdatedAndUserNotified() = runTest {
         val url = "http://www.example.com"
         val title = "A title"
@@ -715,7 +726,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenQuickAccessDeletedThenRepositoryUpdated() = runTest {
+    fun whenDeleteQuickAccessItemCalledWithFavoriteThenRepositoryUpdated() = runTest {
         val savedSite = Favorite(UUID.randomUUID().toString(), "title", "http://example.com", lastModified = "timestamp", 0)
 
         testee.deleteQuickAccessItem(savedSite)
@@ -724,8 +735,26 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenQuickAccessInsertedThenRepositoryUpdated() {
+    fun whenInsertQuickAccessItemCalledWithFavoriteThenRepositoryUpdated() {
         val savedSite = Favorite(UUID.randomUUID().toString(), "title", "http://example.com", lastModified = "timestamp", 0)
+
+        testee.insertQuickAccessItem(savedSite)
+
+        verify(mockSavedSitesRepository).insert(savedSite)
+    }
+
+    @Test
+    fun whenDeleteQuickAccessItemCalledWithBookmarkThenRepositoryUpdated() = runTest {
+        val savedSite = Bookmark(UUID.randomUUID().toString(), "title", "http://example.com", lastModified = "timestamp")
+
+        testee.deleteQuickAccessItem(savedSite)
+
+        verify(mockSavedSitesRepository).delete(savedSite)
+    }
+
+    @Test
+    fun whenInsertQuickAccessItemCalledWithBookmarkThenRepositoryUpdated() {
+        val savedSite = Bookmark(UUID.randomUUID().toString(), "title", "http://example.com", lastModified = "timestamp")
 
         testee.insertQuickAccessItem(savedSite)
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -677,7 +677,7 @@ class BrowserTabViewModelTest {
         val bookmark =
             Bookmark(id = UUID.randomUUID().toString(), title = "A title", url = "www.example.com", lastModified = "timestamp")
 
-        testee.onBookmarkDeleted(bookmark)
+        testee.onSavedSiteDeleted(bookmark)
 
         verify(mockFaviconManager).deletePersistedFavicon(bookmark.url)
         verify(mockSavedSitesRepository).delete(bookmark)

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -321,6 +321,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
         val dialog = EditSavedSiteDialogFragment.instance(savedSite, getParentFolderId(), getParentFolderName())
         dialog.show(supportFragmentManager, EDIT_BOOKMARK_FRAGMENT_TAG)
         dialog.listener = viewModel
+        dialog.deleteBookmarkListener = viewModel
     }
 
     private fun openSavedSite(savedSite: SavedSite) {
@@ -403,6 +404,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
         with(supportFragmentManager) {
             findFragmentByTag(EDIT_BOOKMARK_FRAGMENT_TAG)?.let { dialog ->
                 (dialog as EditSavedSiteDialogFragment).listener = viewModel
+                dialog.deleteBookmarkListener = viewModel
             }
             findFragmentByTag(ADD_BOOKMARK_FOLDER_FRAGMENT_TAG)?.let { dialog ->
                 (dialog as AddBookmarkFolderDialogFragment).listener = viewModel

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -20,6 +20,7 @@ import android.net.Uri
 import androidx.lifecycle.*
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.bookmarks.ui.BookmarksViewModel.Command.*
+import com.duckduckgo.app.bookmarks.ui.EditSavedSiteDialogFragment.DeleteBookmarkListener
 import com.duckduckgo.app.bookmarks.ui.EditSavedSiteDialogFragment.EditSavedSiteListener
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.AddBookmarkFolderDialogFragment.AddBookmarkFolderListener
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.EditBookmarkFolderDialogFragment.EditBookmarkFolderListener
@@ -55,7 +56,7 @@ class BookmarksViewModel @Inject constructor(
     private val pixel: Pixel,
     private val syncEngine: SyncEngine,
     private val dispatcherProvider: DispatcherProvider,
-) : EditSavedSiteListener, AddBookmarkFolderListener, EditBookmarkFolderListener, ViewModel() {
+) : EditSavedSiteListener, AddBookmarkFolderListener, EditBookmarkFolderListener, DeleteBookmarkListener, ViewModel() {
 
     data class ViewState(
         val enableSearch: Boolean = false,
@@ -108,6 +109,10 @@ class BookmarksViewModel @Inject constructor(
             Timber.d("Bookmark: $bookmark from $oldFolderId")
             savedSitesRepository.updateBookmark(bookmark, oldFolderId)
         }
+    }
+
+    override fun onBookmarkDeleted(bookmark: Bookmark) {
+        onDeleteSavedSiteRequested(bookmark)
     }
 
     fun onSelected(savedSite: SavedSite) {

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -111,8 +111,8 @@ class BookmarksViewModel @Inject constructor(
         }
     }
 
-    override fun onBookmarkDeleted(bookmark: Bookmark) {
-        onDeleteSavedSiteRequested(bookmark)
+    override fun onSavedSiteDeleted(savedSite: SavedSite) {
+        onDeleteSavedSiteRequested(savedSite)
     }
 
     fun onSelected(savedSite: SavedSite) {
@@ -213,6 +213,10 @@ class BookmarksViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io()) {
             savedSitesRepository.update(bookmarkFolder)
         }
+    }
+
+    override fun onDeleteBookmarkFolderRequestedFromEdit(bookmarkFolder: BookmarkFolder) {
+        onDeleteBookmarkFolderRequested(bookmarkFolder)
     }
 
     fun onBookmarkFolderDeleted(bookmarkFolder: BookmarkFolder) {

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/EditSavedSiteDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/EditSavedSiteDialogFragment.kt
@@ -18,9 +18,9 @@ package com.duckduckgo.app.bookmarks.ui
 
 import android.os.Bundle
 import android.text.Editable
+import android.view.MenuItem
 import android.view.View
 import android.view.WindowManager
-import androidx.appcompat.widget.Toolbar
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.AddBookmarkFolderDialogFragment
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.extensions.html
@@ -59,7 +59,7 @@ class EditSavedSiteDialogFragment : SavedSiteDialogFragment() {
             setToolbarTitle(getString(R.string.favoriteDialogTitleEdit))
         } else {
             setToolbarTitle(getString(R.string.bookmarkDialogTitleEdit))
-            configureDeleteBookmark(binding.savedSiteAppBar.toolbar)
+            configureBookmarkMenuItemsVisibility()
             binding.savedSiteLocationContainer.visibility = View.VISIBLE
         }
         showAddFolderMenu = true
@@ -140,18 +140,19 @@ class EditSavedSiteDialogFragment : SavedSiteDialogFragment() {
         }
     }
 
-    private fun configureDeleteBookmark(toolbar: Toolbar) {
-        binding.savedSiteAppBar.toolbar.menu.findItem(R.id.action_delete_saved_site).isVisible = true
-        toolbar.setOnMenuItemClickListener { item ->
-            when (item.itemId) {
-                R.id.action_delete_saved_site -> {
-                    showDeleteBookmarkConfirmation(getExistingTitle())
-                    hideKeyboard()
-                    return@setOnMenuItemClickListener true
-                }
-            }
-            false
+    private fun configureBookmarkMenuItemsVisibility() {
+        val toolbar = binding.savedSiteAppBar.toolbar
+        toolbar.menu.findItem(R.id.action_delete_saved_site).isVisible = true
+        toolbar.menu.findItem(R.id.action_confirm_changes).isVisible = true
+    }
+
+    override fun onMenuItemClicked(menuItem: MenuItem): Boolean {
+        if (menuItem.itemId == R.id.action_delete_saved_site) {
+            showDeleteBookmarkConfirmation(getExistingTitle())
+            hideKeyboard()
+            return true
         }
+        return false
     }
 
     private fun showDeleteBookmarkConfirmation(title: String) {

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/SavedSiteDialogFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/SavedSiteDialogFragment.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -44,6 +45,7 @@ abstract class SavedSiteDialogFragment : DialogFragment() {
 
     abstract fun onConfirmation()
     abstract fun configureUI()
+    open fun onMenuItemClicked(menuItem: MenuItem) = false
 
     private var _binding: DialogFragmentSavedSiteBinding? = null
     protected val binding get() = _binding!!
@@ -106,19 +108,17 @@ abstract class SavedSiteDialogFragment : DialogFragment() {
 
     private fun configureToolbar(toolbar: Toolbar) {
         toolbar.inflateMenu(R.menu.edit_saved_site_menu)
-        toolbar.setOnMenuItemClickListener(
-            Toolbar.OnMenuItemClickListener { item ->
-                when (item.itemId) {
-                    R.id.action_confirm_changes -> {
-                        onConfirmation()
-                        hideKeyboard()
-                        dismiss()
-                        return@OnMenuItemClickListener true
-                    }
+        toolbar.setOnMenuItemClickListener { item ->
+            when (item.itemId) {
+                R.id.action_confirm_changes -> {
+                    onConfirmation()
+                    hideKeyboard()
+                    dismiss()
+                    true
                 }
-                false
-            },
-        )
+                else -> onMenuItemClicked(item)
+            }
+        }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -706,6 +706,7 @@ class BrowserTabFragment :
 
         childFragmentManager.findFragmentByTag(ADD_SAVED_SITE_FRAGMENT_TAG)?.let { dialog ->
             (dialog as EditSavedSiteDialogFragment).listener = viewModel
+            dialog.deleteBookmarkListener = viewModel
         }
     }
 
@@ -2289,6 +2290,7 @@ class BrowserTabFragment :
         )
         addBookmarkDialog.show(childFragmentManager, ADD_SAVED_SITE_FRAGMENT_TAG)
         addBookmarkDialog.listener = viewModel
+        addBookmarkDialog.deleteBookmarkListener = viewModel
     }
 
     private fun confirmDeleteSavedSite(savedSite: SavedSite) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2026,15 +2026,15 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    override fun onBookmarkDeleted(bookmark: Bookmark) {
-        command.value = DeleteSavedSiteConfirmation(bookmark)
-        delete(bookmark)
+    override fun onSavedSiteDeleted(savedSite: SavedSite) {
+        command.value = DeleteSavedSiteConfirmation(savedSite)
+        delete(savedSite)
     }
 
-    private fun delete(bookmark: Bookmark) {
+    private fun delete(savedSite: SavedSite) {
         viewModelScope.launch(dispatchers.io()) {
-            faviconManager.deletePersistedFavicon(bookmark.url)
-            savedSitesRepository.delete(bookmark)
+            faviconManager.deletePersistedFavicon(savedSite.url)
+            savedSitesRepository.delete(savedSite)
         }
     }
 

--- a/app/src/main/res/drawable/ic_trash_24.xml
+++ b/app/src/main/res/drawable/ic_trash_24.xml
@@ -5,9 +5,9 @@
     android:viewportHeight="24">
   <path
       android:pathData="M10,10a1,1 0,0 0,-2 0v7a1,1 0,1 0,2 0v-7ZM16,10a1,1 0,1 0,-2 0v7a1,1 0,1 0,2 0v-7Z"
-      android:fillColor="#000"/>
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
   <path
       android:pathData="M8,5L8,4a2,2 0,0 1,2 -2h4a2,2 0,0 1,2 2v1h4a1,1 0,1 1,0 2v11a4,4 0,0 1,-4 4L8,22a4,4 0,0 1,-4 -4L4,7a1,1 0,0 1,0 -2h4ZM6,7v11a2,2 0,0 0,2 2h8a2,2 0,0 0,2 -2L18,7L6,7ZM14,5L14,4h-4v1h4Z"
-      android:fillColor="#000"
+      android:fillColor="?attr/daxColorPrimaryIcon"
       android:fillType="evenOdd"/>
 </vector>

--- a/app/src/main/res/drawable/ic_trash_24.xml
+++ b/app/src/main/res/drawable/ic_trash_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M10,10a1,1 0,0 0,-2 0v7a1,1 0,1 0,2 0v-7ZM16,10a1,1 0,1 0,-2 0v7a1,1 0,1 0,2 0v-7Z"
+      android:fillColor="#000"/>
+  <path
+      android:pathData="M8,5L8,4a2,2 0,0 1,2 -2h4a2,2 0,0 1,2 2v1h4a1,1 0,1 1,0 2v11a4,4 0,0 1,-4 4L8,22a4,4 0,0 1,-4 -4L4,7a1,1 0,0 1,0 -2h4ZM6,7v11a2,2 0,0 0,2 2h8a2,2 0,0 0,2 -2L18,7L6,7ZM14,5L14,4h-4v1h4Z"
+      android:fillColor="#000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/menu/edit_saved_site_menu.xml
+++ b/app/src/main/res/menu/edit_saved_site_menu.xml
@@ -17,6 +17,12 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_delete_saved_site"
+        android:icon="@drawable/ic_trash_24"
+        android:title="@string/delete"
+        android:visible="false"
+        app:showAsAction="always" />
+    <item
         android:id="@+id/action_confirm_changes"
         android:icon="@drawable/ic_check_24"
         android:title="@string/dialogConfirmTitle"

--- a/app/src/main/res/menu/edit_saved_site_menu.xml
+++ b/app/src/main/res/menu/edit_saved_site_menu.xml
@@ -17,7 +17,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/action_delete_saved_site"
+        android:id="@+id/action_delete"
         android:icon="@drawable/ic_trash_24"
         android:title="@string/delete"
         android:visible="false"
@@ -26,6 +26,6 @@
         android:id="@+id/action_confirm_changes"
         android:icon="@drawable/ic_check_24"
         android:title="@string/dialogConfirmTitle"
-        android:visible="false"
+        android:enabled="false"
         app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Сигурни ли сте, че искате да затворите всички раздели?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Отмени</string>
     <string name="closeAppTabsConfirmationDialogClose">Затваряне</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Изтриване на тази отметка?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Тази операция ще изтрие отметката за &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Изтриване на този любим сайт?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Тази операция ще изтрие добавения към любими сайт за &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Изтриване на тази папка с отметки?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Тази операция ще изтрие папката с отметки &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Отмени</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Изтрий</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -769,4 +769,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Opravdu chceš zavřít všechny karty?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Zrušit</string>
     <string name="closeAppTabsConfirmationDialogClose">Zavřít</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Smazat tuhle záložku?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Tímhle smažeš svou záložku &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Smazat tuhle oblíbenou položku?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Tímhle smažeš oblíbenou položku &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Smazat tuhle složku záložek?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Tímhle smažeš složku záložek &lt;b&gt;%1$s&lt;/b&gt; .</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Zrušit</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Smazat</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Er du sikker på, at du vil lukke alle faner?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Annuller</string>
     <string name="closeAppTabsConfirmationDialogClose">Luk</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Vil du slette dette bogmærke?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Dette vil slette dit bogmærke for &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Slet denne favorit?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Dette vil slette &lt;b&gt;%1$s&lt;/b&gt; fra favoritter.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Slet denne bogmærkemappe?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Dette vil slette bogmærkemappen &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Annuller</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Slet</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Bist du sicher, dass du alle Tabs schließen möchtest?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Abbrechen</string>
     <string name="closeAppTabsConfirmationDialogClose">Schließen</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Dieses Lesezeichen löschen?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Dadurch wird dein Lesezeichen für &lt;b&gt;%1$s&lt;/b&gt; gelöscht.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Diesen Favoriten löschen?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Dadurch wird dein Favorit für &lt;b&gt;%1$s&lt;/b&gt; gelöscht.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Diesen Lesezeichenordner löschen?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Dadurch wird dein Lesezeichen-Ordner &lt;b&gt;%1$s&lt;/b&gt; gelöscht.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Abbrechen</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Löschen</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Θέλετε σίγουρα να κλείσετε όλες τις καρτέλες;</string>
     <string name="closeAppTabsConfirmationDialogCancel">Ακύρωση</string>
     <string name="closeAppTabsConfirmationDialogClose">Κλείσιμο</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Διαγραφή αυτού του σελιδοδείκτη;</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Η ενέργεια αυτή θα διαγράψει τον σελιδοδείκτη σας &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Να γίνει διαγραφή αυτού του αγαπημένου;</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Αυτό θα διαγράψει τα αγαπημένα σας για τον ιστότοπο &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Να γίνει διαγραφή αυτού του φακέλου σελιδοδεικτών;</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Αυτό θα διαγράψει τον φάκελο σελιδοδεικτών του ιστότοπου &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Ακύρωση</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Διαγραφή</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">¿Seguro que deseas cerrar todas las pestañas?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Cancelar</string>
     <string name="closeAppTabsConfirmationDialogClose">Cerrar</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">¿Eliminar este marcador?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Esto eliminará tu marcador de &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">¿Eliminar de favoritos?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Esto eliminará &lt;b&gt;%1$s&lt;/b&gt; de tus favoritos.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">¿Eliminar esta carpeta de marcadores?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Esto eliminará la carpeta de marcadores &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Cancelar</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Eliminar</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Kas soovite kindlasti kõik vahekaardid sulgeda?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Loobu</string>
     <string name="closeAppTabsConfirmationDialogClose">Sulge</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Kas kustutada see järjehoidja?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">See kustutab sinu järjehoidja &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Kas kustutada see lemmik?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">See kustutab saidi &lt;b&gt;%1$s&lt;/b&gt; sinu lemmikute hulgast.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Kas kustutada see järjehoidjate kaust?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">See kustutab sinu järjehoidjate kausta &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Loobu</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Kustuta</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Haluatko varmasti sulkea kaikki välilehdet?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Peruuta</string>
     <string name="closeAppTabsConfirmationDialogClose">Sulje</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Poistetaanko tämä kirjanmerkki?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Tämä poistaa kirjanmerkin kohteesta &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Poistetaanko tämä suosikki?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Tämä poistaa suosikkisi sivustolta &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Poistetaanko tämä kirjanmerkkikansio?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Tämä poistaa sivuston &lt;b&gt;%1$s&lt;/b&gt; kirjanmerkkikansion.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Peruuta</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Poista</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Voulez-vous vraiment fermer tous les onglets ?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Annuler</string>
     <string name="closeAppTabsConfirmationDialogClose">Fermer</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Supprimer ce signet ?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Cela supprimera votre signet pour &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Supprimer ce favori ?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Cela supprimera votre favori pour &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Supprimer ce dossier de signets ?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Cela supprimera votre dossier de signets &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Annuler</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Supprimer</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -769,4 +769,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Jesi li siguran da želiš zatvoriti sve kartice?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Odustani</string>
     <string name="closeAppTabsConfirmationDialogClose">Zatvori</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Izbrisati ovu knjižnu oznaku?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Ovo će izbrisati tvoju oznaku za &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Želiš li izbrisati ovaj favorit?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Ovo će izbrisati tvoj favorit: &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Želiš li izbrisati ovu mapu knjižnih oznaka?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Ovo će izbrisati tvoju mapu knjižnih oznaka: &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Odustani</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Izbriši</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Biztosan bezárod az összes lapot?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Mégsem</string>
     <string name="closeAppTabsConfirmationDialogClose">Bezárás</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Törölöd ezt a könyvjelzőt?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Ez törli a(z) &lt;b&gt;%1$s&lt;/b&gt; könyvjelzőt.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Törölöd ezt a kedvencet?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Ez törli a(z) &lt;b&gt;%1$s&lt;/b&gt; kedvencet.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Törölöd ezt a könyvjelzőmappát?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Ez törli a(z) &lt;b&gt;%1$s&lt;/b&gt; könyvjelzőmappát.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Mégsem</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Törlés</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Vuoi davvero chiudere tutte le schede?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Annulla</string>
     <string name="closeAppTabsConfirmationDialogClose">Chiudi</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Eliminare questo segnalibro?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">L\'operazione eliminerà il tuo segnalibro per &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Eliminare questo preferito?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Questo eliminerà il tuo preferito per &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Eliminare questa cartella dei segnalibri?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Questa operazione eliminerà la tua cartella dei segnalibri &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Annulla</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Cancella</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -769,4 +769,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Ar tikrai norite uždaryti visus skirtukus?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Atšaukti</string>
     <string name="closeAppTabsConfirmationDialogClose">Uždaryti</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Ištrinti šią žymę?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Tai ištrins jūsų &lt;b&gt;%1$s&lt;/b&gt; žymę.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Ištrinti šį parankinį?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Tai ištrins jūsų &lt;b&gt;%1$s&lt;/b&gt; parankinį.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Ištrinti šį žymių aplanką?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Tai ištrins jūsų &lt;b&gt;%1$s&lt;/b&gt; žymių aplanką.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Atšaukti</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Trinti</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -765,4 +765,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Vai tiešām vēlies aizvērt visas cilnes?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Atcelt</string>
     <string name="closeAppTabsConfirmationDialogClose">Aizvērt</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Dzēst šo grāmatzīmi?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Tādējādi tiks dzēsta tava &lt;b&gt;%1$s&lt;/b&gt; grāmatzīme.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Izdzēst šo vietni no izlases?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Tādējādi no tavas izlases tiks dzēsta vietne &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Izdzēst šo grāmatzīmju mapi?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Tādējādi tiks dzēsta tava &lt;b&gt;%1$s&lt;/b&gt; grāmatzīmju mape.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Atcelt</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Dzēst</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Er du sikker på at du vil lukke alle fanene?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Avbryt</string>
     <string name="closeAppTabsConfirmationDialogClose">Lukk</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Vil du slette dette bokmerket?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Dette sletter bokmerket for &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Vil du slette denne favoritten?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Dette sletter favorittmerkingen av &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Vil du slette denne bokmerkemappen?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Dette sletter bokmerkemappen for &lt;b&gt;%1$s&lt;/b&gt; .</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Avbryt</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Slett</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Weet je zeker dat je alle tabbladen wilt sluiten?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Annuleren</string>
     <string name="closeAppTabsConfirmationDialogClose">Sluiten</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Deze bladwijzer verwijderen?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Hiermee verwijder je de bladwijzer voor &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Deze website als favoriet verwijderen?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Hiermee verwijder je de website &lt;b&gt;%1$s&lt;/b&gt; als favoriet.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Deze bladwijzermap verwijderen?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Hiermee verwijder je de bladwijzermap voor &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Annuleren</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Verwijderen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -769,4 +769,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Czy na pewno chcesz zamknąć wszystkie karty?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Anuluj</string>
     <string name="closeAppTabsConfirmationDialogClose">Zamknij</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Usunąć tę zakładkę?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Spowoduje to usunięcie zakładki &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Usunąć ten ulubiony element?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Spowoduje to usunięcie ulubionego elementu &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Usunąć ten folder zakładek?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Spowoduje to usunięcie folderu zakładek &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Anuluj</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Usuń</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Tens a certeza de que pretendes fechar todos os separadores?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Cancelar</string>
     <string name="closeAppTabsConfirmationDialogClose">Fechar</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Eliminar este marcador?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Vai eliminar o seu marcador para &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Eliminar este favorito?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Vai eliminar o seu favorito para &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Eliminar esta pasta de marcadores?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Vai eliminar a pasta de marcadores &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Cancelar</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Eliminar</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -765,4 +765,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Sigur dorești să închizi toate filele?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Anulare</string>
     <string name="closeAppTabsConfirmationDialogClose">Închidere</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Ștergi acest marcaj?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Aceasta va șterge marcajul tău pentru &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Dorești să ștergi acest favorit?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Aceasta îți va șterge favoritul pentru &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Ștergi acest folder de marcaje?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Aceasta va șterge folderul tău de marcaje &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Anulare</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Ștergere</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -769,4 +769,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Вы точно хотите закрыть все вкладки?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Отменить</string>
     <string name="closeAppTabsConfirmationDialogClose">Закрыть</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Удалить эту закладку?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Закладка на &lt;b&gt;«%1$s»&lt;/b&gt; будет удалена.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Удалить сайт из избранного?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Сайт &lt;b&gt;%1$s&lt;/b&gt; будет удален из избранного.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Удалить эту папку с закладками?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Папка &lt;b&gt;«%1$s»&lt;/b&gt; будет удалена.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Отменить</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Удалить</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -769,4 +769,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Naozaj chcete zatvoriť všetky karty?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Zrušiť</string>
     <string name="closeAppTabsConfirmationDialogClose">Zatvoriť</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Chcete zmazať túto záložku?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Týmto sa zmaže vaša záložka pre &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Chcete zmazať túto obľúbenú položku?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Týmto sa zmaže vaša obľúbená položka pre &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Chcete zmazať tento priečinok so záložkami?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Týmto sa zmaže priečinok so záložkami &lt;b&gt;%1$s&lt;/b&gt; .</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Zrušiť</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Odstrániť</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -769,4 +769,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Ali ste prepričani, da želite zapreti vse zavihke?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Prekliči</string>
     <string name="closeAppTabsConfirmationDialogClose">Zapri</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Želite izbrisati ta zaznamek?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">S tem boste izbrisali svoj zaznamek za &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Želite izbrisati iz priljubljenih?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">S tem boste iz priljubljenih izbrisali stran &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Želite izbrisati to mapo z zaznamki?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">S tem boste izbrisali svojo mapo z zaznamki &lt;b&gt;%1$s&lt;/b&gt; .</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Prekliči</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Izbriši</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Är du säker på att du vill stänga alla flikar?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Avbryt</string>
     <string name="closeAppTabsConfirmationDialogClose">Stäng</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Vill du radera det här bokmärket?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Ditt bokmärke för &lt;b&gt;%1$s&lt;/b&gt; kommer att raderas.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Vill du radera den här favoriten?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Din favoritmarkering av &lt;b&gt;%1$s&lt;/b&gt; kommer att raderas.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Vill du radera den här bokmärkesmappen?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Din bokmärkesmapp för &lt;b&gt;%1$s&lt;/b&gt; kommer att raderas.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Avbryt</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Ta bort</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -761,4 +761,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Tüm sekmeleri kapatmak istediğinizden emin misiniz?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Vazgeç</string>
     <string name="closeAppTabsConfirmationDialogClose">Kapat</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Bu yer işareti silinsin mi?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">Bu işlem &lt;b&gt;%1$s&lt;/b&gt; için yer işaretinizi siler.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Bu favori silinsin mi?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Bu işlem &lt;b&gt;%1$s&lt;/b&gt; için favorinizi silecektir.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Bu yer işareti klasörü silinsin mi?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">Bu işlem &lt;b&gt;%1$s&lt;/b&gt; yer işareti klasörünüzü silecektir.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Vazgeç</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Sil</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -32,14 +32,4 @@
     <string name="netpSettingsDisconnected">Disabled</string>
     <string name="netpUnlockedSnackbar">You\'ve unlocked a beta feature!</string>
     <string name="netpUnlockedSnackbarAction">Open</string>
-
-    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
-    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Delete this bookmark?</string>
-    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">This will delete your bookmark for &lt;b>%1$s&lt;/b>.</string>
-    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Delete this favorite?</string>
-    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">This will delete your favorite for &lt;b>%1$s&lt;/b>.</string>
-    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Delete this bookmark folder?</string>
-    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">This will delete your &lt;b>%1$s&lt;/b> bookmark folder.</string>
-    <string name="deleteSavedSiteConfirmationDialogCancel">Cancel</string>
-    <string name="deleteSavedSiteConfirmationDialogDelete">Delete</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -33,9 +33,13 @@
     <string name="netpUnlockedSnackbar">You\'ve unlocked a beta feature!</string>
     <string name="netpUnlockedSnackbarAction">Open</string>
 
-    <!-- Edit Bookmark screen, "Delete Bookmark" confirmation prompt -->
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
     <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Delete this bookmark?</string>
     <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">This will delete your bookmark for &lt;b>%1$s&lt;/b>.</string>
-    <string name="deleteBookmarkConfirmationDialogCancel">Cancel</string>
-    <string name="deleteBookmarkConfirmationDialogDelete">Delete</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Delete this favorite?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">This will delete your favorite for &lt;b>%1$s&lt;/b>.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Delete this bookmark folder?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">This will delete your &lt;b>%1$s&lt;/b> bookmark folder.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Cancel</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Delete</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -32,4 +32,10 @@
     <string name="netpSettingsDisconnected">Disabled</string>
     <string name="netpUnlockedSnackbar">You\'ve unlocked a beta feature!</string>
     <string name="netpUnlockedSnackbarAction">Open</string>
+
+    <!-- Edit Bookmark screen, "Delete Bookmark" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Delete this bookmark?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">This will delete your bookmark for &lt;b>%1$s&lt;/b>.</string>
+    <string name="deleteBookmarkConfirmationDialogCancel">Cancel</string>
+    <string name="deleteBookmarkConfirmationDialogDelete">Delete</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -762,4 +762,14 @@
     <string name="closeAppTabsConfirmationDialogDescription">Are you sure you want to close all tabs?</string>
     <string name="closeAppTabsConfirmationDialogCancel">Cancel</string>
     <string name="closeAppTabsConfirmationDialogClose">Close</string>
+
+    <!-- Edit Saved Site screen, "Delete Saved Site" confirmation prompt -->
+    <string name="deleteBookmarkConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark">Delete this bookmark?</string>
+    <string name="deleteBookmarkConfirmationDialogDescription" instruction="Placeholder is the name of the bookmark">This will delete your bookmark for &lt;b>%1$s&lt;/b>.</string>
+    <string name="deleteFavoriteConfirmationDialogTitle" instruction="Dialog title for deleting a favorite site">Delete this favorite?</string>
+    <string name="deleteFavoriteConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">This will delete your favorite for &lt;b>%1$s&lt;/b>.</string>
+    <string name="deleteBookmarkFolderConfirmationDialogTitle" instruction="Dialog title for deleting a bookmark folder">Delete this bookmark folder?</string>
+    <string name="deleteBookmarkFolderConfirmationDialogDescription" instruction="Placeholder is the name of the favorite site">This will delete your &lt;b>%1$s&lt;/b> bookmark folder.</string>
+    <string name="deleteSavedSiteConfirmationDialogCancel">Cancel</string>
+    <string name="deleteSavedSiteConfirmationDialogDelete">Delete</string>
 </resources>

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -170,7 +170,7 @@ class BookmarksViewModelTest {
 
     @Test
     fun whenBookmarkDeletedThenConfirmDeleteSavedSiteCommandAndRepositoryIsUpdated() = runTest {
-        testee.onBookmarkDeleted(bookmark)
+        testee.onSavedSiteDeleted(bookmark)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
         assertNotNull(commandCaptor.value)

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -169,6 +169,17 @@ class BookmarksViewModelTest {
     }
 
     @Test
+    fun whenBookmarkDeletedThenConfirmDeleteSavedSiteCommandAndRepositoryIsUpdated() = runTest {
+        testee.onBookmarkDeleted(bookmark)
+
+        verify(commandObserver).onChanged(commandCaptor.capture())
+        assertNotNull(commandCaptor.value)
+        assertTrue(commandCaptor.value is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
+        verify(faviconManager).deletePersistedFavicon(bookmark.url)
+        verify(savedSitesRepository).delete(bookmark)
+    }
+
+    @Test
     fun whenSavedSiteSelectedThenOpenCommand() {
         testee.onSelected(bookmark)
 

--- a/common/common-ui/src/main/res/drawable/ic_arrow_left_24.xml
+++ b/common/common-ui/src/main/res/drawable/ic_arrow_left_24.xml
@@ -2,9 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="@color/primary_icon_color_selector">
+    android:viewportHeight="24">
   <path
       android:pathData="M12.207,4.707C12.598,4.317 12.598,3.683 12.207,3.293C11.817,2.902 11.183,2.902 10.793,3.293L2.793,11.293C2.402,11.683 2.402,12.317 2.793,12.707L10.793,20.707C11.183,21.098 11.817,21.098 12.207,20.707C12.598,20.317 12.598,19.683 12.207,19.293L5.914,13H20.5C21.052,13 21.5,12.552 21.5,12C21.5,11.448 21.052,11 20.5,11H5.914L12.207,4.707Z"
-      android:fillColor="?attr/daxColorPrimaryIcon"/>
+      android:fillColor="@color/primary_icon_color_selector"/>
 </vector>

--- a/common/common-ui/src/main/res/drawable/ic_check_24.xml
+++ b/common/common-ui/src/main/res/drawable/ic_check_24.xml
@@ -21,6 +21,6 @@
     android:viewportHeight="24">
   <path
       android:pathData="M20.618,4.214c0.434,0.34 0.51,0.97 0.168,1.404l-11,14c-0.186,0.237 -0.47,0.378 -0.772,0.382 -0.301,0.004 -0.589,-0.128 -0.782,-0.36l-5,-6c-0.354,-0.424 -0.296,-1.055 0.128,-1.408 0.424,-0.354 1.055,-0.296 1.408,0.128l4.21,5.05L19.213,4.382c0.34,-0.434 0.97,-0.51 1.404,-0.168z"
-      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillColor="@color/primary_icon_color_selector"
       android:fillType="evenOdd"/>
 </vector>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205194478809823/f

### Description
Added option to delete a bookmark / favorite / folder from the edit screen.
On all edit screens mentioned above the "Confirm" icon now is always displayed, but disabled when there's nothing to save or mandatory fields are empty.

### Steps to test this PR

Delete Bookmark immediately after creating it
- [x] Open the app
- [x] Navigate to a website
- [x] Open the overflow menu and tap on "Add Bookmark"
- [x] Notice the Snackbar at the bottom of the screen with an "Edit" action. Tap on "Edit" and the "Edit Bookmark" screen is opened.
- [x] Notice the Delete icon. Notice the Confirm icon is disabled. It becomes enabled if you make changes to the bookmark.
- [x] Delete the Bookmark by tapping on the "Delete" icon in "Edit Bookmark" screen.
- [x] Test "Undo" as well.

Delete Bookmark after accessing the "Edit" screen from the "Bookmarks" screen
- [x] Open the app
- [x] Navigate to a website
- [x] Open the overflow menu and tap on "Add Bookmark"
- [x] Open the overflow menu again and tap on "Bookmarks"
- [x] Go the the bookmark and tap on the menu icon situated next to the the bookmark. On the popover menu tap on "Edit" and the "Edit Bookmark" screen is opened.
- [x] Notice the Delete icon. Notice the Confirm icon is disabled. It becomes enabled if you make changes to the bookmark.
- [x] Delete the Bookmark by tapping on the "Delete" icon in "Edit Bookmark" screen.
- [x] Test "Undo" as well.

The same as above apply to "Edit Favorite" and "Edit Folder".

Add Bookmark folder
- [x] Open the app
- [x] Open the overflow menu and tap on "Bookmarks"
- [x] On "Bookmarks" screen tap on "Add folder" icon
- [x] Notice the Confirm icon is disabled. It becomes enabled if you add a name for the folder.
- [x] Test that you can add a bookmark folder.

### UI changes
| Edit Bookmark with Confirm icon disabled and Delete icon| Edit Bookmark with Confirm icon enabled and Delete icon |
| ------ | ----- |
|![edit_bookmark_confirm_disabled_light](https://github.com/duckduckgo/Android/assets/7963079/779a83be-abe5-4dfa-a124-40a886da5e58)|![edit_bookmark_confirm_enabled_light](https://github.com/duckduckgo/Android/assets/7963079/e11c9a31-6765-4dc6-9a8f-99eb644725ac)|

| Bookmark delete confirmation prompt  | Snackbar with undo action |
| ------ | ----- |
|![delete_bookmark_confirmation_prompt_light](https://github.com/duckduckgo/Android/assets/7963079/56950b3b-ea6a-4aff-8834-47d6c7e080a5)|![snackbar](https://github.com/duckduckgo/Android/assets/7963079/41b9e7c1-d7e6-4d13-9031-f2b04293fd51)|

| Add folder with Confirm icon disabled  | Add folder with Confirm icon enabled |
| ------ | ----- |
|![add_folder_confirm_disabled_light](https://github.com/duckduckgo/Android/assets/7963079/a93c854e-e414-486b-8175-51690ab3673b)|![add_folder_confirm_enabled_light](https://github.com/duckduckgo/Android/assets/7963079/08fa48e0-5b16-4dc2-96a4-204932a49188)|


