### PR TITLE
Request landscape orientation when going full screen

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.browser
 
+import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Message
@@ -47,6 +48,7 @@ class BrowserChromeClient @Inject constructor(
 
     override fun onShowCustomView(
         view: View,
+        /* requestedOrientation: Int, */
         callback: CustomViewCallback?,
     ) {
         Timber.d("on show custom view")
@@ -56,7 +58,7 @@ class BrowserChromeClient @Inject constructor(
         }
 
         customView = view
-        webViewClientListener?.goFullScreen(view)
+        webViewClientListener?.goFullScreen(view, /* requestedOrientation */ ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE)
     }
 
     override fun onHideCustomView() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3163,7 +3163,7 @@ class BrowserTabFragment :
         private fun renderFullscreenMode(viewState: BrowserViewState) {
             activity?.isImmersiveModeEnabled()?.let {
                 if (viewState.isFullScreen) {
-                    if (!it) goFullScreen()
+                    if (!it) goFullScreen(viewState.fullScreenRequestedOrientation)
                 } else {
                     if (it) exitFullScreen()
                 }
@@ -3462,10 +3462,10 @@ class BrowserTabFragment :
             }
         }
 
-        private fun goFullScreen() {
+        private fun goFullScreen(requestedOrientation: Int) {
             Timber.i("Entering full screen")
             binding.webViewFullScreenContainer.show()
-            activity?.toggleFullScreen()
+            activity?.toggleFullScreen(requestedOrientation)
             showToast(R.string.fullScreenMessage, Toast.LENGTH_SHORT)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser
 
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.net.Uri
 import android.net.http.SslCertificate
@@ -224,6 +225,7 @@ class BrowserTabViewModel @Inject constructor(
     data class BrowserViewState(
         val browserShowing: Boolean = false,
         val isFullScreen: Boolean = false,
+        val fullScreenRequestedOrientation: Int = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED,
         val isDesktopBrowsingMode: Boolean = false,
         val canChangeBrowsingMode: Boolean = false,
         val showPrivacyShield: Boolean = false,
@@ -340,7 +342,7 @@ class BrowserTabViewModel @Inject constructor(
         class SendEmail(val emailAddress: String) : Command()
         object ShowKeyboard : Command()
         object HideKeyboard : Command()
-        class ShowFullScreen(val view: View) : Command()
+        class ShowFullScreen(val view: View, val requestedOrientation: Int) : Command()
         class DownloadImage(
             val url: String,
             val requestUserConfirmation: Boolean,
@@ -1146,16 +1148,20 @@ class BrowserTabViewModel @Inject constructor(
         deleteTabPreview(tabId)
     }
 
-    override fun goFullScreen(view: View) {
-        command.value = ShowFullScreen(view)
+    override fun goFullScreen(view: View, requestedOrientation: Int) {
+        command.value = ShowFullScreen(view, requestedOrientation)
 
         val currentState = currentBrowserViewState()
-        browserViewState.value = currentState.copy(isFullScreen = true)
+        browserViewState.value = currentState.copy(
+            isFullScreen = true,
+            fullScreenRequestedOrientation = requestedOrientation)
     }
 
     override fun exitFullScreen() {
         val currentState = currentBrowserViewState()
-        browserViewState.value = currentState.copy(isFullScreen = false)
+        browserViewState.value = currentState.copy(
+            isFullScreen = false,
+            fullScreenRequestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED)
     }
 
     override fun navigationStateChanged(newWebNavigationState: WebNavigationState) {

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -51,7 +51,7 @@ interface WebViewClientListener {
     fun sendEmailRequested(emailAddress: String)
     fun sendSmsRequested(telephoneNumber: String)
     fun dialTelephoneNumberRequested(telephoneNumber: String)
-    fun goFullScreen(view: View)
+    fun goFullScreen(view: View, requestedOrientation: Int)
     fun exitFullScreen()
     fun showFileChooser(
         filePathCallback: ValueCallback<Array<Uri>>,

--- a/app/src/main/java/com/duckduckgo/app/global/view/ActivityExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ActivityExtension.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.global.view
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
 import android.view.View
@@ -55,13 +56,14 @@ fun Context.fadeTransitionConfig(): Bundle? {
     return config.toBundle()
 }
 
-fun FragmentActivity.toggleFullScreen() {
+fun FragmentActivity.toggleFullScreen(requestedOrientation: Int = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) {
     val newUiOptions = window.decorView.systemUiVisibility
         .xor(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
         .xor(View.SYSTEM_UI_FLAG_FULLSCREEN)
         .xor(View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
 
     window.decorView.systemUiVisibility = newUiOptions
+    this.requestedOrientation = requestedOrientation
 }
 
 fun FragmentActivity.isImmersiveModeEnabled(): Boolean {


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/3250

### Description

### Steps to test this PR
* Open a YouTube video
* After playback starts, tap the full screen button
* Observe full screen playback **in landscape mode** rather than portrait

### Notes
* Unfortunately, Android seems to have removed [the onShowCustomView API
](https://developer.android.com/reference/android/webkit/WebChromeClient#onShowCustomView(android.view.View,%20int,%20android.webkit.WebChromeClient.CustomViewCallback)) which allowed the WebView to specify full screen orientation. In that case, we might want to force landscape, as in this PR, because our browser orientation seems to be locked in portrait.
* I left the code which allows the WebView to specify the orientation, in case someone had feedback on another way we could find the requested orientation. If there is no longer any way to do this on Android, we can remove this code and just set landscape in `toggleFullScreen` without piping through `BrowserViewState`.

### UI changes
| Before  | After |
| ------ | ----- |
![Before - Portrait](https://github.com/duckduckgo/Android/assets/108155811/3e1b32cb-5402-4662-b6cc-b6501768d47f)|![After - Landscape](https://github.com/duckduckgo/Android/assets/108155811/a2bafbf5-3264-4552-a9dc-4da0989fb0b3)|