### PR TITLE
Add dev setting to change to survey sandbox env

### DIFF
--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
@@ -64,6 +64,10 @@ class DevSettingsActivity : DuckDuckGoActivity() {
         viewModel.onOverrideUAToggled(isChecked)
     }
 
+    private val surveySandboxListener = OnCheckedChangeListener { _, isChecked ->
+        viewModel.onSandboxSurveyToggled(isChecked)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
@@ -101,6 +105,7 @@ class DevSettingsActivity : DuckDuckGoActivity() {
                     binding.overrideUserAgentToggle.quietlySetIsChecked(it.overrideUA, overrideUAListener)
                     binding.overrideUserAgentSelector.isEnabled = it.overrideUA
                     binding.overrideUserAgentSelector.setSecondaryText(it.userAgent)
+                    binding.useSandboxSurvey.quietlySetIsChecked(it.useSandboxSurvey, surveySandboxListener)
                 }
             }.launchIn(lifecycleScope)
 

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.browser.useragent.UserAgentProvider
 import com.duckduckgo.app.dev.settings.db.DevSettingsDataStore
 import com.duckduckgo.app.dev.settings.db.UAOverride
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.survey.api.SurveyEndpointDataStore
 import com.duckduckgo.app.traces.api.StartupTraces
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -43,6 +44,7 @@ class DevSettingsViewModel @Inject constructor(
     private val userAgentProvider: UserAgentProvider,
     private val savedSitesRepository: SavedSitesRepository,
     private val dispatcherProvider: DispatcherProvider,
+    private val surveyEndpointDataStore: SurveyEndpointDataStore,
 ) : ViewModel() {
 
     data class ViewState(
@@ -50,6 +52,7 @@ class DevSettingsViewModel @Inject constructor(
         val startupTraceEnabled: Boolean = false,
         val overrideUA: Boolean = false,
         val userAgent: String = "",
+        val useSandboxSurvey: Boolean = false,
     )
 
     sealed class Command {
@@ -70,6 +73,7 @@ class DevSettingsViewModel @Inject constructor(
                     startupTraceEnabled = startupTraces.isTraceEnabled,
                     overrideUA = devSettingsDataStore.overrideUA,
                     userAgent = userAgentProvider.userAgent("", false),
+                    useSandboxSurvey = surveyEndpointDataStore.useSurveyCustomEnvironmentUrl,
                 ),
             )
         }
@@ -104,6 +108,13 @@ class DevSettingsViewModel @Inject constructor(
         devSettingsDataStore.overrideUA = enabled
         viewModelScope.launch {
             viewState.emit(currentViewState().copy(overrideUA = enabled))
+        }
+    }
+
+    fun onSandboxSurveyToggled(enabled: Boolean) {
+        surveyEndpointDataStore.useSurveyCustomEnvironmentUrl = enabled
+        viewModelScope.launch {
+            viewState.emit(currentViewState().copy(useSandboxSurvey = enabled))
         }
     }
 

--- a/app/src/internal/java/com/duckduckgo/app/survey/api/SurveyEndpointDataStore.kt
+++ b/app/src/internal/java/com/duckduckgo/app/survey/api/SurveyEndpointDataStore.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.survey.api
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface SurveyEndpointDataStore {
+    var useSurveyCustomEnvironmentUrl: Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class SurveyEndpointDataStoreImpl @Inject constructor(
+    context: Context,
+) : SurveyEndpointDataStore {
+
+    private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
+
+    override var useSurveyCustomEnvironmentUrl: Boolean
+        get() = preferences.getBoolean(KEY_SURVEY_USE_ENVIRONMENT_URL, false)
+        set(enabled) = preferences.edit { putBoolean(KEY_SURVEY_USE_ENVIRONMENT_URL, enabled) }
+
+    companion object {
+        private const val FILENAME = "com.duckduckgo.app.survey.api.survey.endpoint.v1"
+        private const val KEY_SURVEY_USE_ENVIRONMENT_URL = "KEY_SURVEY_ENVIRONMENT_URL"
+    }
+}

--- a/app/src/internal/java/com/duckduckgo/app/survey/api/SurveyEndpointInterceptor.kt
+++ b/app/src/internal/java/com/duckduckgo/app/survey/api/SurveyEndpointInterceptor.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.survey.api
+
+import com.duckduckgo.app.global.api.ApiInterceptorPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+import timber.log.Timber
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = ApiInterceptorPlugin::class,
+)
+class SurveyEndpointInterceptor @Inject constructor(
+    private val surveyEndpointDataStore: SurveyEndpointDataStore,
+) : ApiInterceptorPlugin, Interceptor {
+    override fun getInterceptor(): Interceptor = this
+    override fun intercept(chain: Chain): Response {
+        val useCustomUrl = surveyEndpointDataStore.useSurveyCustomEnvironmentUrl
+        val url = chain.request().url
+        val encodedPath = chain.request().url.encodedPath
+        val scheme = chain.request().url.scheme
+
+        if (useCustomUrl && url.toString().contains(SURVEY_HOST)) {
+            val newRequest = chain.request().newBuilder()
+
+            val changedUrl = "$scheme://$SURVEY_SANDBOX_HOST$encodedPath"
+            Timber.v("Survey endpoint changed to $changedUrl")
+            newRequest.url(changedUrl)
+            return chain.proceed(newRequest.build())
+        }
+
+        return chain.proceed(chain.request())
+    }
+
+    companion object {
+        private const val SURVEY_HOST = "https://staticcdn.duckduckgo.com/survey"
+        private const val SURVEY_SANDBOX_HOST = "ddg-sandbox.s3.amazonaws.com"
+    }
+}

--- a/app/src/internal/res/layout/activity_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_dev_settings.xml
@@ -43,6 +43,13 @@
                 app:primaryText="@string/devSettingsScreenGeneralSection" />
 
             <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/useSandboxSurvey"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:primaryText="@string/devSettingsUseSandBoxSurvey"
+                    app:showSwitch="true" />
+
+            <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
                 android:id="@+id/enableAppStartupTrace"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -109,7 +116,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:primaryText="@string/devSettingsScreenUserAgentSelectorTitle" />
-
         </LinearLayout>
     </ScrollView>
 </LinearLayout>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -30,6 +30,7 @@
     <string name="devSettingsClearSavedSites">Clear saved sites</string>
     <string name="devSettingsClearSavedSitesSubtitle">Click here to clear all bookmarks, folders and favorites</string>
     <string name="devSettingsClearSavedSitesConfirmation">Saved sites cleared</string>
+    <string name="devSettingsUseSandBoxSurvey">Use Sandbox Survey</string>
 
     <string name="devSettingsScreenUserAgentSection">User Agent</string>
     <string name="devSettingsScreenUserAgentOverride">Override UserAgent</string>

--- a/app/src/main/java/com/duckduckgo/app/survey/db/SurveyDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/db/SurveyDao.kt
@@ -21,31 +21,31 @@ import androidx.room.*
 import com.duckduckgo.app.survey.model.Survey
 
 @Dao
-abstract class SurveyDao {
+interface SurveyDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract fun insert(survey: Survey)
+    fun insert(survey: Survey)
 
     @Update(onConflict = OnConflictStrategy.REPLACE)
-    abstract fun update(survey: Survey)
+    fun update(survey: Survey)
 
     @Query("select count(1) > 0 from survey where surveyId = :surveyId")
-    abstract fun exists(surveyId: String): Boolean
+    fun exists(surveyId: String): Boolean
 
     @Query("select * from survey where surveyId = :surveyId")
-    abstract fun get(surveyId: String): Survey?
+    fun get(surveyId: String): Survey?
 
     @Query("""select * from survey where status = "SCHEDULED" limit 1""")
-    abstract fun getLiveScheduled(): LiveData<Survey>
+    fun getLiveScheduled(): LiveData<Survey>
 
     @Query("""select * from survey where status = "SCHEDULED"""")
-    abstract fun getScheduled(): List<Survey>
+    fun getScheduled(): List<Survey>
 
     @Query("""delete from survey where status = "SCHEDULED" or status = "NOT_ALLOCATED"""")
-    abstract fun deleteUnusedSurveys()
+    fun deleteUnusedSurveys()
 
     @Transaction
-    open fun cancelScheduledSurveys() {
+    fun cancelScheduledSurveys() {
         getScheduled().forEach {
             it.status = Survey.Status.CANCELLED
             update(it)

--- a/app/src/main/java/com/duckduckgo/app/survey/notification/SurveyAvailableNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/notification/SurveyAvailableNotification.kt
@@ -46,10 +46,11 @@ class SurveyAvailableNotification @Inject constructor(
     private val context: Context,
     private val notificationDao: NotificationDao,
 ) : SchedulableNotification {
-    val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-    val today: String? = formatter.format((Date()))
+    private val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
 
-    override val id = "com.duckduckgo.survey.availablesurvey$today"
+    // ensure id is computed every time the caller gets it
+    override val id
+        get() = "com.duckduckgo.survey.availablesurvey${formatter.format((Date()))}"
 
     override suspend fun canShow(): Boolean {
         return !notificationDao.exists(id)

--- a/app/src/test/java/com/duckduckgo/app/survey/api/SurveyRepositoryImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/api/SurveyRepositoryImplTest.kt
@@ -1,0 +1,265 @@
+package com.duckduckgo.app.survey.api
+
+import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.LiveData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.survey.db.SurveyDao
+import com.duckduckgo.app.survey.model.Survey
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browser.api.UserBrowserProperties
+import java.util.*
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class SurveyRepositoryTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private lateinit var surveyDao: SurveyDao
+    private lateinit var notificationManager: NotificationManagerCompat
+    private val userBrowserProperties: UserBrowserProperties = mock()
+    private val appBuildConfig: AppBuildConfig = mock()
+
+    private lateinit var surveyRepository: SurveyRepository
+
+    @Before
+    fun setup() {
+        surveyDao = FakeSurveyDao()
+        notificationManager = NotificationManagerCompat.from(context)
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.US)
+
+        surveyRepository = SurveyRepositoryImpl(surveyDao, userBrowserProperties, notificationManager, appBuildConfig)
+    }
+
+    @Test
+    fun whenSurveyUrlIsNullThenSurveyIsNotEligible() {
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = null,
+            url = null,
+        )
+
+        assertFalse(surveyRepository.isUserEligibleForSurvey(survey))
+    }
+
+    @Test
+    fun whenLocaleIsNotAllowedThenSurveyIsNotEligible() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.JAPAN)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = null,
+            url = "https://survey.com",
+        )
+
+        assertFalse(surveyRepository.isUserEligibleForSurvey(survey))
+    }
+
+    @Test
+    fun whenRequiredDaysInstalledNullThenSurveyIsNotEligible() {
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = null,
+            url = "https://survey.com",
+        )
+
+        assertFalse(surveyRepository.isUserEligibleForSurvey(survey))
+    }
+
+    @Test
+    fun whenRequiredDaysInstalledMinusOneThenSurveyIsEligible() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = -1,
+            url = "https://survey.com",
+        )
+
+        assertTrue(surveyRepository.isUserEligibleForSurvey(survey))
+    }
+
+    @Test
+    fun whenRetentionDayBellowRequiredDaysThenUserIsEligibleForSurvey() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = 1,
+            url = "https://survey.com",
+        )
+
+        assertTrue(surveyRepository.isUserEligibleForSurvey(survey))
+    }
+
+    @Test
+    fun whenLocaleIsNotAllowedAndRequiredDaysInstalledMetThenSurveyIsNotEligible() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.JAPAN)
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = -1,
+            url = "https://survey.com",
+        )
+
+        assertFalse(surveyRepository.isUserEligibleForSurvey(survey))
+    }
+
+    @Test
+    fun whenLocaleIsCanadaAndRequiredDaysInstalledMetThenSurveyIsEligible() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.CANADA)
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = -1,
+            url = "https://survey.com",
+        )
+
+        assertTrue(surveyRepository.isUserEligibleForSurvey(survey))
+    }
+
+    @Test
+    fun whenLocaleIsUKAndRequiredDaysInstalledMetThenSurveyIsEligible() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.UK)
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = -1,
+            url = "https://survey.com",
+        )
+
+        assertTrue(surveyRepository.isUserEligibleForSurvey(survey))
+    }
+
+    @Test
+    fun whenRequiredDaysInstalledIsNullAndRetentionDaysBelowDefaultDaysThenReturnMinus1() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(4)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = null,
+            url = null,
+        )
+
+        assertEquals(-1, surveyRepository.remainingDaysForShowingSurvey(survey))
+        assertFalse(surveyRepository.shouldShowSurvey(survey))
+    }
+
+    @Test
+    fun whenRequiredDaysInstalledIsNullAndRetentionDaysAboveDefaultDaysThenReturn0() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(31)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = null,
+            url = null,
+        )
+
+        assertEquals(0, surveyRepository.remainingDaysForShowingSurvey(survey))
+        assertTrue(surveyRepository.shouldShowSurvey(survey))
+    }
+
+    @Test
+    fun whenRequiredDaysInstalledIsMinus1AndNotFirstDayThenRemainingDaysToSurveyIsZero() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(4)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = -1,
+            url = null,
+        )
+
+        assertEquals(0, surveyRepository.remainingDaysForShowingSurvey(survey))
+        assertTrue(surveyRepository.shouldShowSurvey(survey))
+    }
+
+    @Test
+    fun whenRequiredDaysInstalledAndDaysInstallNotEnoughThenShouldNotShowSurvey() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(2)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = 4,
+            url = null,
+        )
+
+        assertEquals(2, surveyRepository.remainingDaysForShowingSurvey(survey))
+        assertFalse(surveyRepository.shouldShowSurvey(survey))
+    }
+
+    @Test
+    fun whenRetentionDaysIsAboveRequiredDaysInstalledThenShouldNotShowSurvey() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(4)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = 2,
+            url = null,
+        )
+
+        assertEquals(-2, surveyRepository.remainingDaysForShowingSurvey(survey))
+        assertFalse(surveyRepository.shouldShowSurvey(survey))
+    }
+
+    @Test
+    fun getScheduledSurveyReturnsLastSurvey() {
+        val survey = Survey(
+            surveyId = "1",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = 2,
+            url = null,
+        )
+
+        surveyDao.insert(survey.copy(surveyId = "1"))
+        surveyDao.insert(survey.copy(surveyId = "2"))
+        surveyDao.insert(survey.copy(surveyId = "3"))
+        surveyDao.insert(survey.copy(surveyId = "5"))
+
+        assertEquals(survey.copy(surveyId = "5"), surveyRepository.getScheduledSurvey())
+    }
+}
+
+private class FakeSurveyDao : SurveyDao {
+    private val surveys: MutableMap<String, Survey> = linkedMapOf()
+    override fun insert(survey: Survey) {
+        surveys[survey.surveyId] = survey
+    }
+
+    override fun update(survey: Survey) {
+        insert(survey)
+    }
+
+    override fun exists(surveyId: String): Boolean {
+        return surveys[surveyId] != null
+    }
+
+    override fun get(surveyId: String): Survey? {
+        return surveys[surveyId]
+    }
+
+    override fun getLiveScheduled(): LiveData<Survey> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getScheduled(): List<Survey> {
+        return surveys.values.filter { it.status == Survey.Status.SCHEDULED }
+    }
+
+    override fun deleteUnusedSurveys() {
+        surveys.values
+            .filter {
+                it.status == Survey.Status.SCHEDULED || it.status == Survey.Status.NOT_ALLOCATED
+            }.map { it.surveyId }
+            .forEach { surveys.remove(it) }
+    }
+}

--- a/app/src/testInternal/java/com/duckduckgo/app/survey/api/SurveyEndpointInterceptorTest.kt
+++ b/app/src/testInternal/java/com/duckduckgo/app/survey/api/SurveyEndpointInterceptorTest.kt
@@ -1,0 +1,66 @@
+package com.duckduckgo.app.survey.api
+
+import com.duckduckgo.app.global.api.FakeChain
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class SurveyEndpointInterceptorTest {
+
+    private lateinit var surveyEndpointDataStore: SurveyEndpointDataStore
+    private lateinit var interceptor: SurveyEndpointInterceptor
+
+    @Before
+    fun setup() {
+        surveyEndpointDataStore = FakeSurveyCustomEnvironmentUrl()
+        interceptor = SurveyEndpointInterceptor(surveyEndpointDataStore)
+    }
+
+    @Test
+    fun interceptSurveyUrlWhenEnabled() {
+        surveyEndpointDataStore.useSurveyCustomEnvironmentUrl = true
+
+        val chain = FakeChain(SURVEY_URL)
+        val response = interceptor.intercept(chain)
+
+        assertEquals(SURVEY_SANDBOX_URL, response.request.url.toString())
+    }
+
+    @Test
+    fun doNotInterceptSurveyUrlWhenDisabled() {
+        surveyEndpointDataStore.useSurveyCustomEnvironmentUrl = false
+
+        val chain = FakeChain(SURVEY_URL)
+        val response = interceptor.intercept(chain)
+
+        assertEquals(SURVEY_URL, response.request.url.toString())
+    }
+
+    @Test
+    fun ignoreUnknownUrlWhenEnabled() {
+        surveyEndpointDataStore.useSurveyCustomEnvironmentUrl = true
+
+        val chain = FakeChain(UNKNOWN_URL)
+        val response = interceptor.intercept(chain)
+
+        assertEquals(UNKNOWN_URL, response.request.url.toString())
+    }
+
+    @Test
+    fun ignoreUnknownUrlWhenDisabled() {
+        surveyEndpointDataStore.useSurveyCustomEnvironmentUrl = false
+
+        val chain = FakeChain(UNKNOWN_URL)
+        val response = interceptor.intercept(chain)
+
+        assertEquals(UNKNOWN_URL, response.request.url.toString())
+    }
+}
+
+private const val SURVEY_URL = "https://staticcdn.duckduckgo.com/survey/foo/survey.json"
+private const val SURVEY_SANDBOX_URL = "https://ddg-sandbox.s3.amazonaws.com/survey/foo/survey.json"
+private const val UNKNOWN_URL = "https://unknown.com/survey/foo/survey.json"
+
+private class FakeSurveyCustomEnvironmentUrl(
+    override var useSurveyCustomEnvironmentUrl: Boolean = false,
+) : SurveyEndpointDataStore


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205305054848475/f

### Description
Add a dev setting under Settings -> Dev settins to switch between production and sandbox Surven endpoints


This PR also fixes a bug in the survey logic. When `installationDay` is -1, the survey should be immediately scheduled, but it's not

### Steps to test this PR
**Test dev setting**
- [x] install internal build from this branch
- [x] Pass the onboarding, you can do that by searching something and then select "hide" and "hide the tips for ever" in dax onboarding
- [x] Open a new tab
- [x] Close app and re-open
- [x] Ensure does not appear
- [x] go to settings -> developer settings and set "Use sandbox survey" to ON
- [x] Close and re-open the app
- [x] verify the survey is shown

**Test Bug fixes**
- [x] fresh install internal build and launch
- [x] allow notifications and get passed Dax onboarding ("hide the tips for ever")
- [x] Settings -> developer settings and set "Use sandbox survey" to ON
- [x] close and reopen the app
- [x] verify survey notification and new tab card shows
- [x] don't take the survey, close app and re-open
- [x] verify survey notification is NOT triggered
- [x] verify survey new tab card shows
- [x] In Android settings -> Date & Time, manually set time to tomorrow
- [x] Close and re-open the app
- [x] verify verify survey notification is triggered
- [x] take the survey
- [x] close and re-open app
- [x] verify neither survey notification nor new tab card show
