### PR TITLE
Add AppTP connectivity handler

### DIFF
--- a/app-tracking-protection/app-tracking-api/src/main/java/com/duckduckgo/mobile/android/app/tracking/AppTrackingProtection.kt
+++ b/app-tracking-protection/app-tracking-api/src/main/java/com/duckduckgo/mobile/android/app/tracking/AppTrackingProtection.kt
@@ -42,4 +42,9 @@ interface AppTrackingProtection {
      * This method will restart the App Tracking Protection feature by disabling it and re-enabling back again
      */
     fun restart()
+
+    /**
+     * This method will stop the App Tracking Protection feature
+     */
+    fun stop()
 }

--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSetting.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSetting.kt
@@ -21,6 +21,7 @@ enum class AppTpSetting(override val value: String, override val defaultValue: B
     CPUMonitoring("cpuMonitoring"),
     ProtectGames("protectGames"),
     ExceptionLists("exceptionLists", defaultValue = true),
+    RestartOnConnectivityLoss("restartOnConnectivityLoss", defaultValue = true),
 }
 
 interface SettingName {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/app/tracking/AppTPVpnConnectivityLossListener.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/app/tracking/AppTPVpnConnectivityLossListener.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.mobile.android.app.tracking
 
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
@@ -47,24 +50,37 @@ class AppTPVpnConnectivityLossListener @Inject constructor(
     private val appTrackingProtection: AppTrackingProtection,
     private val appTpFeatureConfig: AppTpFeatureConfig,
     private val dispatcherProvider: DispatcherProvider,
+    private val context: Context,
 ) : VpnConnectivityLossListenerPlugin, VpnServiceCallbacks {
 
+    private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
+
     private var connectivityLostEvents = 0
+    private var reconnectAttempts: Int
+        get() = preferences.getInt(RECONNECT_ATTEMPTS, 0)
+        set(value) = preferences.edit(commit = true) { putInt(RECONNECT_ATTEMPTS, value) }
 
     override fun onVpnConnected(coroutineScope: CoroutineScope) {
-        coroutineScope.launch {
+        coroutineScope.launch(dispatcherProvider.io()) {
             if (isActive()) {
                 connectivityLostEvents = 0
+                reconnectAttempts = 0
             }
         }
     }
 
     override fun onVpnConnectivityLoss(coroutineScope: CoroutineScope) {
-        coroutineScope.launch {
+        coroutineScope.launch(dispatcherProvider.io()) {
             if (isActive() && connectivityLostEvents++ > 1) {
-                logcat(LogPriority.WARN) { "AppTP detected connectivity loss, re-configuring..." }
                 connectivityLostEvents = 0
-                appTrackingProtection.restart()
+                if (reconnectAttempts++ > 2) {
+                    logcat(LogPriority.WARN) { "AppTP detected connectivity loss, again, give up..." }
+                    reconnectAttempts = 0
+                    appTrackingProtection.stop()
+                } else {
+                    logcat(LogPriority.WARN) { "AppTP detected connectivity loss, re-configuring..." }
+                    appTrackingProtection.restart()
+                }
             }
         }
     }
@@ -79,6 +95,9 @@ class AppTPVpnConnectivityLossListener @Inject constructor(
 
     override fun onVpnStarted(coroutineScope: CoroutineScope) {
         connectivityLostEvents = 0
+        coroutineScope.launch(dispatcherProvider.io()) {
+            reconnectAttempts = 0
+        }
     }
 
     override fun onVpnReconfigured(coroutineScope: CoroutineScope) {
@@ -87,5 +106,10 @@ class AppTPVpnConnectivityLossListener @Inject constructor(
 
     override fun onVpnStopped(coroutineScope: CoroutineScope, vpnStopReason: VpnStateMonitor.VpnStopReason) {
         connectivityLostEvents = 0
+    }
+
+    companion object {
+        private const val FILENAME = "com.duckduckgo.mobile.android.app.tracking.conn.loss"
+        private const val RECONNECT_ATTEMPTS = "RECONNECT_ATTEMPTS"
     }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/app/tracking/AppTPVpnConnectivityLossListener.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/app/tracking/AppTPVpnConnectivityLossListener.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.app.tracking
+
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.di.scopes.VpnScope
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
+import com.duckduckgo.mobile.android.vpn.service.connectivity.VpnConnectivityLossListenerPlugin
+import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
+import com.duckduckgo.networkprotection.api.NetworkProtectionState
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import logcat.logcat
+
+@ContributesMultibinding(
+    scope = VpnScope::class,
+    boundType = VpnConnectivityLossListenerPlugin::class,
+)
+@ContributesMultibinding(
+    scope = VpnScope::class,
+    boundType = VpnServiceCallbacks::class,
+)
+@SingleInstanceIn(VpnScope::class)
+class AppTPVpnConnectivityLossListener @Inject constructor(
+    private val networkProtectionState: NetworkProtectionState,
+    private val appTrackingProtection: AppTrackingProtection,
+    private val appTpFeatureConfig: AppTpFeatureConfig,
+    private val dispatcherProvider: DispatcherProvider,
+) : VpnConnectivityLossListenerPlugin, VpnServiceCallbacks {
+
+    private var connectivityLostEvents = 0
+
+    override fun onVpnConnected(coroutineScope: CoroutineScope) {
+        coroutineScope.launch {
+            if (isActive()) {
+                connectivityLostEvents = 0
+            }
+        }
+    }
+
+    override fun onVpnConnectivityLoss(coroutineScope: CoroutineScope) {
+        coroutineScope.launch {
+            if (isActive() && connectivityLostEvents++ > 1) {
+                logcat(LogPriority.WARN) { "AppTP detected connectivity loss, re-configuring..." }
+                connectivityLostEvents = 0
+                appTrackingProtection.restart()
+            }
+        }
+    }
+
+    private suspend fun isActive(): Boolean = withContext(dispatcherProvider.io()) {
+        fun isFeatureEnabled(): Boolean {
+            return appTpFeatureConfig.isEnabled(AppTpSetting.RestartOnConnectivityLoss)
+        }
+
+        return@withContext isFeatureEnabled() && appTrackingProtection.isEnabled() && !networkProtectionState.isEnabled()
+    }
+
+    override fun onVpnStarted(coroutineScope: CoroutineScope) {
+        connectivityLostEvents = 0
+    }
+
+    override fun onVpnReconfigured(coroutineScope: CoroutineScope) {
+        connectivityLostEvents = 0
+    }
+
+    override fun onVpnStopped(coroutineScope: CoroutineScope, vpnStopReason: VpnStateMonitor.VpnStopReason) {
+        connectivityLostEvents = 0
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/app/tracking/RealAppTrackingProtection.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/app/tracking/RealAppTrackingProtection.kt
@@ -53,4 +53,10 @@ class RealAppTrackingProtection @Inject constructor(
             vpnFeaturesRegistry.refreshFeature(AppTpVpnFeature.APPTP_VPN)
         }
     }
+
+    override fun stop() {
+        coroutineScope.launch {
+            vpnFeaturesRegistry.unregisterFeature(AppTpVpnFeature.APPTP_VPN)
+        }
+    }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/RestartOnConnectivityLossSettingPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/RestartOnConnectivityLossSettingPlugin.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.feature.settings
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.vpn.feature.*
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.Moshi
+import javax.inject.Inject
+import logcat.LogPriority
+import logcat.asLog
+import logcat.logcat
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AppTpSettingPlugin::class,
+)
+class RestartOnConnectivityLossSettingPlugin @Inject constructor(
+    private val appTpFeatureConfig: AppTpFeatureConfig,
+) : AppTpSettingPlugin {
+    private val jsonAdapter = Moshi.Builder().build().adapter(JsonConfigModel::class.java)
+
+    override fun store(name: SettingName, jsonString: String): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val name = appTpSettingValueOf(name.value)
+        if (name == settingName) {
+            logcat { "Received configuration: $jsonString" }
+            runCatching {
+                jsonAdapter.fromJson(jsonString)?.state?.let { state ->
+                    appTpFeatureConfig.edit { setEnabled(settingName, state == "enabled") }
+                }
+            }.onFailure {
+                logcat(LogPriority.WARN) { it.asLog() }
+            }
+            return true
+        }
+
+        return false
+    }
+
+    override val settingName: SettingName = AppTpSetting.RestartOnConnectivityLoss
+
+    private data class JsonConfigModel(val state: String?)
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/app/tracking/AppTPVpnConnectivityLossListenerTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/app/tracking/AppTPVpnConnectivityLossListenerTest.kt
@@ -1,0 +1,178 @@
+package com.duckduckgo.mobile.android.app.tracking
+
+import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
+import com.duckduckgo.mobile.android.vpn.feature.FakeAppTpFeatureConfig
+import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
+import com.duckduckgo.networkprotection.api.NetworkProtectionState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.*
+
+@ExperimentalCoroutinesApi
+class AppTPVpnConnectivityLossListenerTest {
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    private val networkProtectionState: NetworkProtectionState = mock()
+    private val appTrackingProtection: AppTrackingProtection = mock()
+    private lateinit var appTpFeatureConfig: AppTpFeatureConfig
+    private lateinit var listener: AppTPVpnConnectivityLossListener
+
+    @Before
+    fun setup() {
+        appTpFeatureConfig = FakeAppTpFeatureConfig()
+        appTpFeatureConfig.edit().setEnabled(AppTpSetting.RestartOnConnectivityLoss, true)
+
+        listener = AppTPVpnConnectivityLossListener(
+            networkProtectionState,
+            appTrackingProtection,
+            appTpFeatureConfig,
+            coroutinesTestRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun onVpnConnectivityLossThenRestartAppTPThirdConsecutiveTime() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, times(2)).restart()
+    }
+
+    @Test
+    fun whenRestartOnConnectivityLossIsDisabledThenNoop() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+        appTpFeatureConfig.edit().setEnabled(AppTpSetting.RestartOnConnectivityLoss, false)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, never()).restart()
+    }
+
+    @Test
+    fun onVpnConnectivityLossNetPEnabledThenNoop() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, never()).restart()
+    }
+
+    @Test
+    fun onVpnConnectivityLossAppTPDisabledThenNoop() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(false)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, never()).restart()
+    }
+
+    @Test
+    fun onVpnConnectedResetsConnectivityLossCounter() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnected(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, never()).restart()
+    }
+
+    @Test
+    fun onVpnStartedResetsConnectivityLossCounter() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnStarted(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, never()).restart()
+    }
+
+    @Test
+    fun onVpnReconfiguredResetsConnectivityLossCounter() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnReconfigured(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, never()).restart()
+    }
+
+    @Test
+    fun onVpnStartingDoesNotAffectNormalBehavior() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnStarting(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, times(1)).restart()
+    }
+
+    @Test
+    fun onVpnStartFailedDoesNotAffectNormalBehavior() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnStartFailed(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, times(1)).restart()
+    }
+
+    @Test
+    fun onVpnStoppedResetsConnectivityLossCounter() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+        listener.onVpnStopped(coroutinesTestRule.testScope, VpnStateMonitor.VpnStopReason.SELF_STOP)
+        listener.onVpnConnectivityLoss(coroutinesTestRule.testScope)
+
+        verify(appTrackingProtection, never()).restart()
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureConfigImplTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpFeatureConfigImplTest.kt
@@ -29,9 +29,9 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@ExperimentalCoroutinesApi
 class AppTpFeatureConfigImplTest {
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @get:Rule
     var coroutineRule = CoroutineTestRule()
 
@@ -62,6 +62,7 @@ class AppTpFeatureConfigImplTest {
                 AppTpSetting.CPUMonitoring -> assertFalse(config.isEnabled(setting))
                 AppTpSetting.ProtectGames -> assertFalse(config.isEnabled(setting))
                 AppTpSetting.ExceptionLists -> assertTrue(config.isEnabled(setting))
+                AppTpSetting.RestartOnConnectivityLoss -> assertTrue(config.isEnabled(setting))
             }
         }
     }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSettingTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpSettingTest.kt
@@ -30,6 +30,7 @@ class AppTpSettingTest {
                 AppTpSetting.CPUMonitoring -> assertFalse(setting.defaultValue)
                 AppTpSetting.ProtectGames -> assertFalse(setting.defaultValue)
                 AppTpSetting.ExceptionLists -> assertTrue(setting.defaultValue)
+                AppTpSetting.RestartOnConnectivityLoss -> assertTrue(setting.defaultValue)
                 else -> throw java.lang.IllegalStateException("Missing AppTpSetting default checks")
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205307434865662/f

### Description
Add an AppTP-sspecific connectivity handler

### Steps to test this PR
_(Use an emulator)_
- [x] Modify the `hasDeviceConnectivity()` method to always return true
- [x] install internal build from this branch
- [x] enable AppTP
- [x] filter logs by`NetworkConnectivityHealthHandler`
- [x] Disable the WIFI of your computer (this will cause connectivity issues detected as VPN connectivity loss)
- [x] verify AppTP is restarted in the third attempt
