### PR TITLE
AppTP: Make entire view clickable when reporting breakage category

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_report_breakage_category_single_choice.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_report_breakage_category_single_choice.xml
@@ -49,7 +49,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/atp_ReportBreakageCategoriesHint"
-                    app:editable="false"
+                    app:clickable="true"
                     app:endIcon="@drawable/ic_chevron_down_24_small"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"/>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205311544271092/f

### Description
In an oversight, I forgot to apply the changes made in https://github.com/duckduckgo/Android/pull/3439 to the AppTP breakage form as well, so taking care of that now.

### Steps to test this PR
- [x] Enter AppTP reporting flow for a broken app
- [x] Confirm that entire textview is clickable to select the breakage category rather than only the end icon
