### PR TITLE
QR reader supports recovery and connect code

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -57,7 +57,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
 
     private fun configureListeners() {
         binding.pasteCodeButton.setOnClickListener {
-            viewModel.onPasteCodeClicked(codeType)
+            viewModel.onPasteCodeClicked()
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -66,7 +66,7 @@ class SyncConnectActivity : DuckDuckGoActivity() {
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
 
-        binding.qrCodeReader.decodeSingle { result -> viewModel.onConnectQRScanned(result) }
+        binding.qrCodeReader.decodeSingle { result -> viewModel.onQRCodeScanned(result) }
 
         observeUiEvents()
         configureListeners()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -76,9 +76,9 @@ class SyncConnectViewModel @Inject constructor(
         }
     }
 
-    fun onConnectQRScanned(qrCode: String) {
+    fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            when (syncAccountRepository.connectDevice(qrCode)) {
+            when (syncAccountRepository.processCode(qrCode)) {
                 is Error -> command.send(Command.Error)
                 is Success -> command.send(LoginSucess)
             }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInitialSetupViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInitialSetupViewModel.kt
@@ -183,7 +183,7 @@ constructor(
 
     fun onQRScanned(contents: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val result = syncAccountRepository.login(contents)
+            val result = syncAccountRepository.processCode(contents)
             if (result is Error) {
                 command.send(Command.ShowMessage("$result"))
             }
@@ -193,7 +193,7 @@ constructor(
 
     fun onConnectQRScanned(contents: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val result = syncAccountRepository.connectDevice(contents)
+            val result = syncAccountRepository.processCode(contents)
             when (result) {
                 is Error -> {
                     command.send(Command.ShowMessage("$result"))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -54,7 +54,7 @@ class SyncLoginActivity : DuckDuckGoActivity() {
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
 
-        binding.qrCodeReader.decodeSingle { result -> viewModel.onConnectQRScanned(result) }
+        binding.qrCodeReader.decodeSingle { result -> viewModel.onQRCodeScanned(result) }
 
         observeUiEvents()
         configureListeners()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -58,9 +58,9 @@ class SyncLoginViewModel @Inject constructor(
         }
     }
 
-    fun onConnectQRScanned(qrCode: String) {
+    fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val result = syncAccountRepository.login(qrCode)
+            val result = syncAccountRepository.processCode(qrCode)
             if (result is Error) {
                 command.send(Command.Error)
             } else {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -359,7 +359,7 @@ class AppSyncAccountRepositoryTest {
     }
 
     @Test
-    fun whenConnectingFromAuthenticatedDeviceThenConnectsDevice() {
+    fun whenProcessConnectCodeFromAuthenticatedDeviceThenConnectsDevice() {
         givenAuthenticatedDevice()
         whenever(nativeLib.seal(jsonRecoveryKey, primaryKey)).thenReturn(encryptedRecoveryCode)
         whenever(syncApi.connect(token, deviceId, encryptedRecoveryCode)).thenReturn(Result.Success(true))
@@ -371,7 +371,7 @@ class AppSyncAccountRepositoryTest {
     }
 
     @Test
-    fun whenConnectingFromUnauthenticatedDeviceThenAccountCreatedAndConnects() {
+    fun whenProcessConnectCodeFromUnauthenticatedDeviceThenAccountCreatedAndConnects() {
         whenever(syncStore.primaryKey).thenReturn(primaryKey)
         whenever(syncStore.isSignedIn()).thenReturn(false).thenReturn(true)
         whenever(syncStore.userId).thenReturn(userId)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -219,10 +219,10 @@ class AppSyncAccountRepositoryTest {
     }
 
     @Test
-    fun whenLoginFromQRSucceedsThenAccountPersisted() {
+    fun whenProcessJsonRecoveryCodeSucceedsThenAccountPersisted() {
         prepareForLoginSuccess()
 
-        val result = syncRepo.login(jsonRecoveryKeyEncoded)
+        val result = syncRepo.processCode(jsonRecoveryKeyEncoded)
 
         assertEquals(Result.Success(true), result)
         verify(syncStore).storeCredentials(
@@ -240,7 +240,7 @@ class AppSyncAccountRepositoryTest {
         prepareToProvideDeviceIds()
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(failedLoginKeys)
 
-        val result = syncRepo.login(jsonRecoveryKey)
+        val result = syncRepo.processCode(jsonRecoveryKey)
 
         assertTrue(result is Result.Error)
     }
@@ -250,7 +250,7 @@ class AppSyncAccountRepositoryTest {
         prepareToProvideDeviceIds()
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(failedLoginKeys)
 
-        val result = syncRepo.login(jsonRecoveryKeyEncoded)
+        val result = syncRepo.processCode(jsonRecoveryKeyEncoded)
 
         assertTrue(result is Result.Error)
     }
@@ -262,20 +262,20 @@ class AppSyncAccountRepositoryTest {
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
         whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, deviceFactor)).thenReturn(loginFailed)
 
-        val result = syncRepo.login(jsonRecoveryKey)
+        val result = syncRepo.processCode(jsonRecoveryKey)
 
         assertTrue(result is Result.Error)
     }
 
     @Test
-    fun whenLoginFromQRFailsThenReturnError() {
+    fun whenProcessJsonRecoveryCodeFailsThenReturnError() {
         prepareToProvideDeviceIds()
         prepareForEncryption()
         whenever(nativeLib.prepareForLogin(primaryKey = primaryKey)).thenReturn(validLoginKeys)
         whenever(nativeLib.decrypt(encryptedData = protectedEncryptionKey, secretKey = stretchedPrimaryKey)).thenReturn(decryptedSecretKey)
         whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, deviceFactor)).thenReturn(loginFailed)
 
-        val result = syncRepo.login(jsonRecoveryKeyEncoded)
+        val result = syncRepo.processCode(jsonRecoveryKeyEncoded)
 
         assertTrue(result is Result.Error)
     }
@@ -288,7 +288,7 @@ class AppSyncAccountRepositoryTest {
         whenever(nativeLib.decrypt(encryptedData = protectedEncryptionKey, secretKey = stretchedPrimaryKey)).thenReturn(invalidDecryptedSecretKey)
         whenever(syncApi.login(userId, hashedPassword, deviceId, deviceName, deviceFactor)).thenReturn(loginSuccess)
 
-        val result = syncRepo.login(jsonRecoveryKey)
+        val result = syncRepo.processCode(jsonRecoveryKey)
 
         assertTrue(result is Result.Error)
     }
@@ -359,19 +359,19 @@ class AppSyncAccountRepositoryTest {
     }
 
     @Test
-    fun whenConnectingUsingQRFromAuthenticatedDeviceThenConnectsDevice() {
+    fun whenConnectingFromAuthenticatedDeviceThenConnectsDevice() {
         givenAuthenticatedDevice()
         whenever(nativeLib.seal(jsonRecoveryKey, primaryKey)).thenReturn(encryptedRecoveryCode)
         whenever(syncApi.connect(token, deviceId, encryptedRecoveryCode)).thenReturn(Result.Success(true))
 
-        val result = syncRepo.connectDevice(jsonConnectKeyEncoded)
+        val result = syncRepo.processCode(jsonConnectKeyEncoded)
 
         verify(syncApi).connect(token, deviceId, encryptedRecoveryCode)
         assertTrue(result is Success)
     }
 
     @Test
-    fun whenConnectingUsingQRFromUnauthenticatedDeviceThenAccountCreatedAndConnects() {
+    fun whenConnectingFromUnauthenticatedDeviceThenAccountCreatedAndConnects() {
         whenever(syncStore.primaryKey).thenReturn(primaryKey)
         whenever(syncStore.isSignedIn()).thenReturn(false).thenReturn(true)
         whenever(syncStore.userId).thenReturn(userId)
@@ -382,7 +382,7 @@ class AppSyncAccountRepositoryTest {
         whenever(nativeLib.seal(jsonRecoveryKey, primaryKey)).thenReturn(encryptedRecoveryCode)
         whenever(syncApi.connect(token, deviceId, encryptedRecoveryCode)).thenReturn(Result.Success(true))
 
-        val result = syncRepo.connectDevice(jsonConnectKeyEncoded)
+        val result = syncRepo.processCode(jsonConnectKeyEncoded)
 
         verify(syncApi).connect(token, deviceId, encryptedRecoveryCode)
         assertTrue(result is Success)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -73,7 +73,7 @@ internal class EnterCodeViewModelTest {
     }
 
     @Test
-    fun whenUserClicksOnPasteCodeWithRecoveryCodeThenLoginWithCode() = runTest {
+    fun whenUserClicksOnPasteCodeWithRecoveryCodeThenProcessCode() = runTest {
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
         whenever(syncAccountRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
 
@@ -87,7 +87,7 @@ internal class EnterCodeViewModelTest {
     }
 
     @Test
-    fun whenUserClicksOnPasteCodeWithConnectCodeThenConnectWithCode() = runTest {
+    fun whenUserClicksOnPasteCodeWithConnectCodeThenProcessCode() = runTest {
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonConnectKeyEncoded)
         whenever(syncAccountRepository.processCode(jsonConnectKeyEncoded)).thenReturn(Success(true))
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
-import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSucess
@@ -68,7 +67,7 @@ internal class EnterCodeViewModelTest {
     fun whenUserClicksOnPasteCodeThenClipboardIsPasted() = runTest {
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
 
-        testee.onPasteCodeClicked(Code.RECOVERY_CODE)
+        testee.onPasteCodeClicked()
 
         verify(clipboard).pasteFromClipboard()
     }
@@ -76,9 +75,9 @@ internal class EnterCodeViewModelTest {
     @Test
     fun whenUserClicksOnPasteCodeWithRecoveryCodeThenLoginWithCode() = runTest {
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
-        whenever(syncAccountRepository.login(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
+        whenever(syncAccountRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
 
-        testee.onPasteCodeClicked(Code.RECOVERY_CODE)
+        testee.onPasteCodeClicked()
 
         testee.commands().test {
             val command = awaitItem()
@@ -90,9 +89,9 @@ internal class EnterCodeViewModelTest {
     @Test
     fun whenUserClicksOnPasteCodeWithConnectCodeThenConnectWithCode() = runTest {
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonConnectKeyEncoded)
-        whenever(syncAccountRepository.connectDevice(jsonConnectKeyEncoded)).thenReturn(Success(true))
+        whenever(syncAccountRepository.processCode(jsonConnectKeyEncoded)).thenReturn(Success(true))
 
-        testee.onPasteCodeClicked(Code.CONNECT_CODE)
+        testee.onPasteCodeClicked()
 
         testee.commands().test {
             val command = awaitItem()
@@ -104,9 +103,9 @@ internal class EnterCodeViewModelTest {
     @Test
     fun whenPastedCodeFailsThenEmitError() = runTest {
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
-        whenever(syncAccountRepository.login(jsonRecoveryKeyEncoded)).thenReturn(Error(reason = "error"))
+        whenever(syncAccountRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Error(reason = "error"))
 
-        testee.onPasteCodeClicked(Code.RECOVERY_CODE)
+        testee.onPasteCodeClicked()
 
         testee.viewState().test {
             val item = awaitItem()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -78,9 +78,9 @@ class SyncConnectViewModelTest {
 
     @Test
     fun whenUserScansConnectQRCodeAndConnectDeviceSucceedsThenCommandIsLoginSuccess() = runTest {
-        whenever(syncRepostitory.connectDevice(jsonConnectKeyEncoded)).thenReturn(Result.Success(true))
+        whenever(syncRepostitory.processCode(jsonConnectKeyEncoded)).thenReturn(Result.Success(true))
         testee.commands().test {
-            testee.onConnectQRScanned(jsonConnectKeyEncoded)
+            testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.LoginSucess)
             cancelAndIgnoreRemainingEvents()
@@ -89,9 +89,9 @@ class SyncConnectViewModelTest {
 
     @Test
     fun whenUserScansConnectQRCodeAndConnectDeviceFailsThenCommandIsError() = runTest {
-        whenever(syncRepostitory.connectDevice(jsonConnectKeyEncoded)).thenReturn(Result.Error(reason = "error"))
+        whenever(syncRepostitory.processCode(jsonConnectKeyEncoded)).thenReturn(Result.Error(reason = "error"))
         testee.commands().test {
-            testee.onConnectQRScanned(jsonConnectKeyEncoded)
+            testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.Error)
             cancelAndIgnoreRemainingEvents()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -57,7 +57,7 @@ class SyncLoginViewModelTest {
     }
 
     @Test
-    fun whenQRScannedThenPerformLoginAndEmitResult() = runTest {
+    fun whenProcessRecoveryCodeThenPerformLoginAndEmitResult() = runTest {
         whenever(syncRepostitory.processCode(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
 
         testee.commands().test {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -58,10 +58,10 @@ class SyncLoginViewModelTest {
 
     @Test
     fun whenQRScannedThenPerformLoginAndEmitResult() = runTest {
-        whenever(syncRepostitory.login(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
+        whenever(syncRepostitory.processCode(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
 
         testee.commands().test {
-            testee.onConnectQRScanned(jsonRecoveryKeyEncoded)
+            testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.LoginSucess)
             cancelAndIgnoreRemainingEvents()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205212671337474/f 

### Description
Sync QR code reader supports both recovery and connect code, no matter which auth flow the user started.

### Steps to test this PR
(for testing you will need 2 devices)

_Feature 1_
- [x] install app in 2 devices, both unauthenticated
- [x] on deviceA, enable Sync
- [x] on deviceB, go to settings -> sync -> toggle On
- [x] Click on Turn On sync
- [x] Click on Sync another device
- [x] Read QR code from device A
- [x] Ensure device B logs into device A account
- [ ] ...
- [x] on device B, logout from sync account (toggle off)
- [x] on device B, toggle on again
- [x] Click on "Recover your synced data"
- [x] read QR code from device A
- [x] Ensure device B logs into device A account

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
