### PR TITLE
Remove close icon on 2nd auth screen

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncSetupFlowFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncSetupFlowFragment.kt
@@ -27,6 +27,8 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.global.DuckDuckGoFragment
 import com.duckduckgo.app.global.FragmentViewModelFactory
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.mobile.android.ui.view.hide
+import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.FragmentSyncSetupBinding
@@ -92,6 +94,7 @@ class SyncSetupFlowFragment : DuckDuckGoFragment(R.layout.fragment_sync_setup) {
     private fun renderViewState(viewState: ViewState) {
         when (viewState.viewMode) {
             InitialSetupScreen -> {
+                binding.closeIcon.show()
                 binding.contentIllustration.setImageResource(R.drawable.ic_sync_128)
                 binding.contentTitle.text = getString(R.string.sync_enable_sync_title)
                 binding.contentBody.text = getString(R.string.sync_enable_sync_content)
@@ -105,6 +108,7 @@ class SyncSetupFlowFragment : DuckDuckGoFragment(R.layout.fragment_sync_setup) {
                 }
             }
             SyncAnotherDeviceScreen -> {
+                binding.closeIcon.hide()
                 binding.contentIllustration.setImageResource(R.drawable.ic_connect_device_128)
                 binding.contentTitle.text = getString(R.string.sync_another_device_title)
                 binding.contentBody.text = getString(R.string.sync_another_device_content)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205331909141487/f 

### Description
Hides X close icon on the second auth flow screen. That addresses some user feedback-

### Steps to test this PR

_Feature 1_
- [x] Settings -> Sync -> Toggle On 
- [x] Ensure first screen shows X close icon
- [x] click on "Turn on Sync"
- [x] Ensure X close icon doesn't show in the second screen
- [x] Additionally: back button works as usual

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
