### PR TITLE
Implementation task: Undoing disabling/enabling privacy protections does not work

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2330,24 +2330,14 @@ class BrowserTabFragment :
         binding.rootView.makeSnackbarWithNoBottomInset(
             HtmlCompat.fromHtml(getString(R.string.privacyProtectionEnabledConfirmationMessage, domain), FROM_HTML_MODE_LEGACY),
             Snackbar.LENGTH_LONG,
-        ).apply {
-            setAction(R.string.undoSnackbarAction) {
-                viewModel.onEnablePrivacyProtectionSnackbarUndoClicked(domain)
-            }
-            show()
-        }
+        ).show()
     }
 
     private fun privacyProtectionDisabledConfirmation(domain: String) {
         binding.rootView.makeSnackbarWithNoBottomInset(
             HtmlCompat.fromHtml(getString(R.string.privacyProtectionDisabledConfirmationMessage, domain), FROM_HTML_MODE_LEGACY),
             Snackbar.LENGTH_LONG,
-        ).apply {
-            setAction(R.string.undoSnackbarAction) {
-                viewModel.onDisablePrivacyProtectionSnackbarUndoClicked(domain)
-            }
-            show()
-        }
+        ).show()
     }
 
     private fun launchSharePageChooser(url: String) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205337199677965/f

### Description
Removed the undo action as the feature has changed.

### Steps to test this PR

- [x] Install from this branch.
- [x] Navigate to any website
- [x] From  the overflow menu tap on `Disable Privacy Protection`.
- [x] Notice a snackbar is displayed and it doesn't have a `Undo` action.
- [x] The same applies the `Enable Privacy Protection`.

### UI changes
| Disabled  | Enabled |
| ------ | ----- |
|![snackbar_disabled_short_text](https://github.com/duckduckgo/Android/assets/7963079/877f1ef8-0e0e-4d70-9061-44acbeba68c4)|![snackbar_enabled_short_text](https://github.com/duckduckgo/Android/assets/7963079/0f3a6ede-fc76-4c50-9a94-4ccf214c3231)|

