### PR TITLE
Update autofill to 8.2.0

### DIFF
--- a/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
@@ -7339,6 +7339,10 @@ class AndroidInterface extends _InterfacePrototype.default {
   async isEnabled() {
     return (0, _autofillUtils.autofillEnabled)(this.globalConfig, _appleUtils.processConfig);
   }
+  /**
+   * @returns {Promise<string|undefined>}
+   */
+
 
   async getAlias() {
     const {
@@ -7639,20 +7643,9 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
       if ('configType' in response) {
         this.selectedDetail(response.data, response.configType);
       } else if ('stop' in response) {
-        var _this$activeForm, _this$activeForm$acti;
-
-        // Let input handlers know we've stopped autofilling
-        (_this$activeForm = this.activeForm) === null || _this$activeForm === void 0 ? void 0 : (_this$activeForm$acti = _this$activeForm.activeInput) === null || _this$activeForm$acti === void 0 ? void 0 : _this$activeForm$acti.dispatchEvent(new Event('mouseleave'));
+        await this.onFinishedAutofill();
       } else if ('stateChange' in response) {
-        var _this$activeForm2, _this$activeForm3;
-
-        // Remove decorations before refreshing data to make sure we
-        // remove the currently set icons
-        (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.removeAllDecorations(); // Update for any state that may have changed
-
-        await this.refreshData(); // Add correct icons and behaviour
-
-        (_this$activeForm3 = this.activeForm) === null || _this$activeForm3 === void 0 ? void 0 : _this$activeForm3.recategorizeAllInputs();
+        await this.updateForStateChange();
       }
     });
   }
@@ -7802,13 +7795,13 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
 
   getCurrentInputType() {
-    var _this$activeForm4;
+    var _this$activeForm;
 
     const topContextData = this.getTopContextData();
-    return topContextData !== null && topContextData !== void 0 && topContextData.inputType ? topContextData.inputType : (0, _matching.getInputType)((_this$activeForm4 = this.activeForm) === null || _this$activeForm4 === void 0 ? void 0 : _this$activeForm4.activeInput);
+    return topContextData !== null && topContextData !== void 0 && topContextData.inputType ? topContextData.inputType : (0, _matching.getInputType)((_this$activeForm = this.activeForm) === null || _this$activeForm === void 0 ? void 0 : _this$activeForm.activeInput);
   }
   /**
-   * @returns {Promise<string>}
+   * @returns {Promise<string|undefined>}
    */
 
 
@@ -7817,9 +7810,10 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
       alias
     } = await this.deviceApi.request(new _additionalDeviceApiCalls.GetAlias({
       requiresUserPermission: !this.globalConfig.isApp,
-      shouldConsumeAliasIfProvided: !this.globalConfig.isApp
+      shouldConsumeAliasIfProvided: !this.globalConfig.isApp,
+      isIncontextSignupAvailable: this.inContextSignup.isAvailable()
     }));
-    return (0, _autofillUtils.formatDuckAddress)(alias);
+    return alias ? (0, _autofillUtils.formatDuckAddress)(alias) : alias;
   }
 
   addLogoutListener(handler) {
@@ -8919,8 +8913,6 @@ class InterfacePrototype {
 
     if (this.globalConfig.isMobileApp && inputType === 'identities.emailAddress') {
       this.getAlias().then(alias => {
-        var _form$activeInput;
-
         if (alias) {
           form.autofillEmail(alias);
           /**
@@ -8929,7 +8921,16 @@ class InterfacePrototype {
            */
 
           this.emailProtection.storeReceived(alias);
-        } else (_form$activeInput = form.activeInput) === null || _form$activeInput === void 0 ? void 0 : _form$activeInput.focus();
+        } else {
+          var _form$activeInput;
+
+          (_form$activeInput = form.activeInput) === null || _form$activeInput === void 0 ? void 0 : _form$activeInput.focus();
+        } // Update data from native-side in case the `getAlias` call
+        // has included a successful in-context signup
+
+
+        this.updateForStateChange();
+        this.onFinishedAutofill();
       });
       return;
     }
@@ -9072,6 +9073,25 @@ class InterfacePrototype {
     var _this$uiController4, _this$uiController4$r;
 
     return (_this$uiController4 = this.uiController) === null || _this$uiController4 === void 0 ? void 0 : (_this$uiController4$r = _this$uiController4.removeTooltip) === null || _this$uiController4$r === void 0 ? void 0 : _this$uiController4$r.call(_this$uiController4, 'interface');
+  }
+
+  onFinishedAutofill() {
+    var _this$activeForm, _this$activeForm$acti;
+
+    // Let input handlers know we've stopped autofilling
+    (_this$activeForm = this.activeForm) === null || _this$activeForm === void 0 ? void 0 : (_this$activeForm$acti = _this$activeForm.activeInput) === null || _this$activeForm$acti === void 0 ? void 0 : _this$activeForm$acti.dispatchEvent(new Event('mouseleave'));
+  }
+
+  async updateForStateChange() {
+    var _this$activeForm2, _this$activeForm3;
+
+    // Remove decorations before refreshing data to make sure we
+    // remove the currently set icons
+    (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.removeAllDecorations(); // Update for any state that may have changed
+
+    await this.refreshData(); // Add correct icons and behaviour
+
+    (_this$activeForm3 = this.activeForm) === null || _this$activeForm3 === void 0 ? void 0 : _this$activeForm3.recategorizeAllInputs();
   }
 
   async refreshData() {
@@ -9231,12 +9251,12 @@ class InterfacePrototype {
     return false;
   }
   /**
-   * @returns {Promise<null|string>}
+   * @returns {Promise<string|undefined>}
    */
 
 
   async getAlias() {
-    return null;
+    return undefined;
   } // PM endpoints
 
 
@@ -10571,7 +10591,7 @@ class Form {
    * Adds event listeners and keeps track of them for subsequent removal
    * @param {HTMLElement} el
    * @param {Event['type']} type
-   * @param {() => void} fn
+   * @param {(Event) => void} fn
    * @param {AddEventListenerOptions} [opts]
    */
 
@@ -10643,7 +10663,11 @@ class Form {
           });
         }
       });
-    } // We need click coordinates to position the tooltip when the field is in an iframe
+    }
+    /**
+     * @param {PointerEvent} e
+     * @returns {{ x: number; y: number; } | undefined}
+     */
 
 
     function getMainClickCoords(e) {
@@ -10654,22 +10678,54 @@ class Form {
         x: e.clientX,
         y: e.clientY
       };
+    }
+    /**
+     * @param {Event} e
+     * @param {WeakMap} storedClickCoords
+     * @returns {{ x: number; y: number; } | null}
+     */
+
+
+    function getClickCoords(e, storedClickCoords) {
+      // Get click co-ordinates for pointer events
+      // We need click coordinates to position the tooltip when the field is in an iframe
+      if (e.type === 'pointerdown') {
+        return getMainClickCoords(
+        /** @type {PointerEvent} */
+        e) || null;
+      } // Reuse a previous click co-ordinates if they exist for this element
+
+
+      const click = storedClickCoords.get(input);
+      storedClickCoords.delete(input);
+      return click || null;
     } // Store the click to a label so we can use the click when the field is focused
     // Needed to handle label clicks when the form is in an iframe
 
 
-    let storedClick = new WeakMap();
+    let storedClickCoords = new WeakMap();
     let timeout = null;
+    /**
+     * @param {PointerEvent} e
+     */
 
     const handlerLabel = e => {
+      var _e$target, _e$target$closest;
+
       // Look for e.target OR it's closest parent to be a HTMLLabelElement
-      const control = e.target.closest('label').control;
+      const control =
+      /** @type HTMLElement */
+      (_e$target = e.target) === null || _e$target === void 0 ? void 0 : (_e$target$closest = _e$target.closest('label')) === null || _e$target$closest === void 0 ? void 0 : _e$target$closest.control;
       if (!control) return;
-      storedClick.set(control, getMainClickCoords(e));
+
+      if (e.isTrusted) {
+        storedClickCoords.set(control, getMainClickCoords(e));
+      }
+
       clearTimeout(timeout); // Remove the stored click if the timer expires
 
       timeout = setTimeout(() => {
-        storedClick = new WeakMap();
+        storedClickCoords = new WeakMap();
       }, 1000);
     };
 
@@ -10683,17 +10739,13 @@ class Form {
       const isLabel = e.target instanceof HTMLLabelElement;
       const input = isLabel ? e.target.control : e.target;
       if (!input || !this.inputs.all.has(input)) return;
-      let click = null;
       if ((0, _autofillUtils.wasAutofilledByChrome)(input)) return;
-      if (!(0, _inputTypeConfig.canBeInteractedWith)(input)) return; // Checks for pointerdown event. Needed for positioning when fields are within an iframe
+      if (!(0, _inputTypeConfig.canBeInteractedWith)(input)) return;
+      const clickCoords = getClickCoords(e, storedClickCoords);
 
       if (e.type === 'pointerdown') {
-        click = getMainClickCoords(e);
-        if (!click) return;
-      } else if (storedClick) {
-        // Reuse a previous click if one exists for this element
-        click = storedClick.get(input);
-        storedClick.delete(input);
+        // Only allow real user clicks with co-ordinates through
+        if (!e.isTrusted || !clickCoords) return;
       }
 
       if (this.shouldOpenTooltip(e, input)) {
@@ -10711,7 +10763,7 @@ class Form {
         this.device.attachTooltip({
           form: this,
           input: input,
-          click: click,
+          click: clickCoords,
           trigger: 'userInitiated',
           triggerMetaData: {
             // An 'icon' click is very different to a field click or focus.
@@ -10768,7 +10820,7 @@ class Form {
       return true;
     }
 
-    if (this.device.globalConfig.isExtension) {
+    if (this.device.globalConfig.isExtension || this.device.globalConfig.isMobileApp) {
       // Don't open the tooltip on input focus whenever it's showing in-context signup
       if (isIncontextSignupAvailable) return false;
     }
@@ -14659,15 +14711,21 @@ class InContextSignup {
     await ((_this$device$uiContro = this.device.uiController) === null || _this$device$uiContro === void 0 ? void 0 : _this$device$uiContro.removeTooltip('stateChange')); // Make sure the input doesn't have focus so we can focus on it again
 
     const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput;
-    activeInput === null || activeInput === void 0 ? void 0 : activeInput.blur(); // Focus on the active input to open the tooltip
+    activeInput === null || activeInput === void 0 ? void 0 : activeInput.blur(); // Select the active input to open the tooltip
 
-    const focusActiveInput = () => {
+    const selectActiveInput = () => {
       activeInput === null || activeInput === void 0 ? void 0 : activeInput.focus();
     };
 
-    document.hasFocus() ? focusActiveInput() : document.addEventListener('visibilitychange', focusActiveInput, {
-      once: true
-    });
+    if (document.hasFocus()) {
+      selectActiveInput();
+    } else {
+      document.addEventListener('visibilitychange', () => {
+        selectActiveInput();
+      }, {
+        once: true
+      });
+    }
   }
 
   isPermanentlyDismissed() {
@@ -16684,6 +16742,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
+    window.addEventListener('pointerup', this, true);
   }
 
   /**
@@ -16693,6 +16752,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
+    window.removeEventListener('pointerup', this, true);
   }
   /**
    * @param {import('./UIController').AttachArgs} args
@@ -16849,6 +16909,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
           break;
         }
+
+      case 'pointerup':
+        {
+          this._pointerUpListener(event);
+
+          break;
+        }
     }
   } // Global listener for event delegation
 
@@ -16860,20 +16927,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     if (e.target.nodeName === 'DDG-AUTOFILL') {
       e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-
-      if (!activeTooltip) {
-        console.warn('Could not get activeTooltip');
-      } else {
-        activeTooltip.dispatchClick();
-      }
+      e.stopImmediatePropagation(); // Ignore pointer down events, we'll handle them on pointer up
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
       });
+    }
+  } // Global listener for event delegation
+
+
+  _pointerUpListener(e) {
+    if (!e.isTrusted) return; // Ignore events on the Dax icon, we handle those elsewhere
+
+    if ((0, _autofillUtils.isEventWithinDax)(e, e.target)) return; // @ts-ignore
+
+    if (e.target.nodeName === 'DDG-AUTOFILL') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const isMainMouseButton = e.button === 0;
+      if (!isMainMouseButton) return;
+      const activeTooltip = this.getActiveTooltip();
+      activeTooltip === null || activeTooltip === void 0 ? void 0 : activeTooltip.dispatchClick();
     }
   }
 
@@ -19097,14 +19171,15 @@ exports.autofillFeatureTogglesSchema = autofillFeatureTogglesSchema;
 
 const getAliasParamsSchema = _zod.z.object({
   requiresUserPermission: _zod.z.boolean(),
-  shouldConsumeAliasIfProvided: _zod.z.boolean()
+  shouldConsumeAliasIfProvided: _zod.z.boolean(),
+  isIncontextSignupAvailable: _zod.z.boolean().optional()
 });
 
 exports.getAliasParamsSchema = getAliasParamsSchema;
 
 const getAliasResultSchema = _zod.z.object({
   success: _zod.z.object({
-    alias: _zod.z.string()
+    alias: _zod.z.string().optional()
   })
 });
 

--- a/node_modules/@duckduckgo/autofill/dist/autofill.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill.js
@@ -3663,6 +3663,10 @@ class AndroidInterface extends _InterfacePrototype.default {
   async isEnabled() {
     return (0, _autofillUtils.autofillEnabled)(this.globalConfig, _appleUtils.processConfig);
   }
+  /**
+   * @returns {Promise<string|undefined>}
+   */
+
 
   async getAlias() {
     const {
@@ -3963,20 +3967,9 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
       if ('configType' in response) {
         this.selectedDetail(response.data, response.configType);
       } else if ('stop' in response) {
-        var _this$activeForm, _this$activeForm$acti;
-
-        // Let input handlers know we've stopped autofilling
-        (_this$activeForm = this.activeForm) === null || _this$activeForm === void 0 ? void 0 : (_this$activeForm$acti = _this$activeForm.activeInput) === null || _this$activeForm$acti === void 0 ? void 0 : _this$activeForm$acti.dispatchEvent(new Event('mouseleave'));
+        await this.onFinishedAutofill();
       } else if ('stateChange' in response) {
-        var _this$activeForm2, _this$activeForm3;
-
-        // Remove decorations before refreshing data to make sure we
-        // remove the currently set icons
-        (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.removeAllDecorations(); // Update for any state that may have changed
-
-        await this.refreshData(); // Add correct icons and behaviour
-
-        (_this$activeForm3 = this.activeForm) === null || _this$activeForm3 === void 0 ? void 0 : _this$activeForm3.recategorizeAllInputs();
+        await this.updateForStateChange();
       }
     });
   }
@@ -4126,13 +4119,13 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
 
   getCurrentInputType() {
-    var _this$activeForm4;
+    var _this$activeForm;
 
     const topContextData = this.getTopContextData();
-    return topContextData !== null && topContextData !== void 0 && topContextData.inputType ? topContextData.inputType : (0, _matching.getInputType)((_this$activeForm4 = this.activeForm) === null || _this$activeForm4 === void 0 ? void 0 : _this$activeForm4.activeInput);
+    return topContextData !== null && topContextData !== void 0 && topContextData.inputType ? topContextData.inputType : (0, _matching.getInputType)((_this$activeForm = this.activeForm) === null || _this$activeForm === void 0 ? void 0 : _this$activeForm.activeInput);
   }
   /**
-   * @returns {Promise<string>}
+   * @returns {Promise<string|undefined>}
    */
 
 
@@ -4141,9 +4134,10 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
       alias
     } = await this.deviceApi.request(new _additionalDeviceApiCalls.GetAlias({
       requiresUserPermission: !this.globalConfig.isApp,
-      shouldConsumeAliasIfProvided: !this.globalConfig.isApp
+      shouldConsumeAliasIfProvided: !this.globalConfig.isApp,
+      isIncontextSignupAvailable: this.inContextSignup.isAvailable()
     }));
-    return (0, _autofillUtils.formatDuckAddress)(alias);
+    return alias ? (0, _autofillUtils.formatDuckAddress)(alias) : alias;
   }
 
   addLogoutListener(handler) {
@@ -5243,8 +5237,6 @@ class InterfacePrototype {
 
     if (this.globalConfig.isMobileApp && inputType === 'identities.emailAddress') {
       this.getAlias().then(alias => {
-        var _form$activeInput;
-
         if (alias) {
           form.autofillEmail(alias);
           /**
@@ -5253,7 +5245,16 @@ class InterfacePrototype {
            */
 
           this.emailProtection.storeReceived(alias);
-        } else (_form$activeInput = form.activeInput) === null || _form$activeInput === void 0 ? void 0 : _form$activeInput.focus();
+        } else {
+          var _form$activeInput;
+
+          (_form$activeInput = form.activeInput) === null || _form$activeInput === void 0 ? void 0 : _form$activeInput.focus();
+        } // Update data from native-side in case the `getAlias` call
+        // has included a successful in-context signup
+
+
+        this.updateForStateChange();
+        this.onFinishedAutofill();
       });
       return;
     }
@@ -5396,6 +5397,25 @@ class InterfacePrototype {
     var _this$uiController4, _this$uiController4$r;
 
     return (_this$uiController4 = this.uiController) === null || _this$uiController4 === void 0 ? void 0 : (_this$uiController4$r = _this$uiController4.removeTooltip) === null || _this$uiController4$r === void 0 ? void 0 : _this$uiController4$r.call(_this$uiController4, 'interface');
+  }
+
+  onFinishedAutofill() {
+    var _this$activeForm, _this$activeForm$acti;
+
+    // Let input handlers know we've stopped autofilling
+    (_this$activeForm = this.activeForm) === null || _this$activeForm === void 0 ? void 0 : (_this$activeForm$acti = _this$activeForm.activeInput) === null || _this$activeForm$acti === void 0 ? void 0 : _this$activeForm$acti.dispatchEvent(new Event('mouseleave'));
+  }
+
+  async updateForStateChange() {
+    var _this$activeForm2, _this$activeForm3;
+
+    // Remove decorations before refreshing data to make sure we
+    // remove the currently set icons
+    (_this$activeForm2 = this.activeForm) === null || _this$activeForm2 === void 0 ? void 0 : _this$activeForm2.removeAllDecorations(); // Update for any state that may have changed
+
+    await this.refreshData(); // Add correct icons and behaviour
+
+    (_this$activeForm3 = this.activeForm) === null || _this$activeForm3 === void 0 ? void 0 : _this$activeForm3.recategorizeAllInputs();
   }
 
   async refreshData() {
@@ -5555,12 +5575,12 @@ class InterfacePrototype {
     return false;
   }
   /**
-   * @returns {Promise<null|string>}
+   * @returns {Promise<string|undefined>}
    */
 
 
   async getAlias() {
-    return null;
+    return undefined;
   } // PM endpoints
 
 
@@ -6895,7 +6915,7 @@ class Form {
    * Adds event listeners and keeps track of them for subsequent removal
    * @param {HTMLElement} el
    * @param {Event['type']} type
-   * @param {() => void} fn
+   * @param {(Event) => void} fn
    * @param {AddEventListenerOptions} [opts]
    */
 
@@ -6967,7 +6987,11 @@ class Form {
           });
         }
       });
-    } // We need click coordinates to position the tooltip when the field is in an iframe
+    }
+    /**
+     * @param {PointerEvent} e
+     * @returns {{ x: number; y: number; } | undefined}
+     */
 
 
     function getMainClickCoords(e) {
@@ -6978,22 +7002,54 @@ class Form {
         x: e.clientX,
         y: e.clientY
       };
+    }
+    /**
+     * @param {Event} e
+     * @param {WeakMap} storedClickCoords
+     * @returns {{ x: number; y: number; } | null}
+     */
+
+
+    function getClickCoords(e, storedClickCoords) {
+      // Get click co-ordinates for pointer events
+      // We need click coordinates to position the tooltip when the field is in an iframe
+      if (e.type === 'pointerdown') {
+        return getMainClickCoords(
+        /** @type {PointerEvent} */
+        e) || null;
+      } // Reuse a previous click co-ordinates if they exist for this element
+
+
+      const click = storedClickCoords.get(input);
+      storedClickCoords.delete(input);
+      return click || null;
     } // Store the click to a label so we can use the click when the field is focused
     // Needed to handle label clicks when the form is in an iframe
 
 
-    let storedClick = new WeakMap();
+    let storedClickCoords = new WeakMap();
     let timeout = null;
+    /**
+     * @param {PointerEvent} e
+     */
 
     const handlerLabel = e => {
+      var _e$target, _e$target$closest;
+
       // Look for e.target OR it's closest parent to be a HTMLLabelElement
-      const control = e.target.closest('label').control;
+      const control =
+      /** @type HTMLElement */
+      (_e$target = e.target) === null || _e$target === void 0 ? void 0 : (_e$target$closest = _e$target.closest('label')) === null || _e$target$closest === void 0 ? void 0 : _e$target$closest.control;
       if (!control) return;
-      storedClick.set(control, getMainClickCoords(e));
+
+      if (e.isTrusted) {
+        storedClickCoords.set(control, getMainClickCoords(e));
+      }
+
       clearTimeout(timeout); // Remove the stored click if the timer expires
 
       timeout = setTimeout(() => {
-        storedClick = new WeakMap();
+        storedClickCoords = new WeakMap();
       }, 1000);
     };
 
@@ -7007,17 +7063,13 @@ class Form {
       const isLabel = e.target instanceof HTMLLabelElement;
       const input = isLabel ? e.target.control : e.target;
       if (!input || !this.inputs.all.has(input)) return;
-      let click = null;
       if ((0, _autofillUtils.wasAutofilledByChrome)(input)) return;
-      if (!(0, _inputTypeConfig.canBeInteractedWith)(input)) return; // Checks for pointerdown event. Needed for positioning when fields are within an iframe
+      if (!(0, _inputTypeConfig.canBeInteractedWith)(input)) return;
+      const clickCoords = getClickCoords(e, storedClickCoords);
 
       if (e.type === 'pointerdown') {
-        click = getMainClickCoords(e);
-        if (!click) return;
-      } else if (storedClick) {
-        // Reuse a previous click if one exists for this element
-        click = storedClick.get(input);
-        storedClick.delete(input);
+        // Only allow real user clicks with co-ordinates through
+        if (!e.isTrusted || !clickCoords) return;
       }
 
       if (this.shouldOpenTooltip(e, input)) {
@@ -7035,7 +7087,7 @@ class Form {
         this.device.attachTooltip({
           form: this,
           input: input,
-          click: click,
+          click: clickCoords,
           trigger: 'userInitiated',
           triggerMetaData: {
             // An 'icon' click is very different to a field click or focus.
@@ -7092,7 +7144,7 @@ class Form {
       return true;
     }
 
-    if (this.device.globalConfig.isExtension) {
+    if (this.device.globalConfig.isExtension || this.device.globalConfig.isMobileApp) {
       // Don't open the tooltip on input focus whenever it's showing in-context signup
       if (isIncontextSignupAvailable) return false;
     }
@@ -10983,15 +11035,21 @@ class InContextSignup {
     await ((_this$device$uiContro = this.device.uiController) === null || _this$device$uiContro === void 0 ? void 0 : _this$device$uiContro.removeTooltip('stateChange')); // Make sure the input doesn't have focus so we can focus on it again
 
     const activeInput = (_this$device$activeFo = this.device.activeForm) === null || _this$device$activeFo === void 0 ? void 0 : _this$device$activeFo.activeInput;
-    activeInput === null || activeInput === void 0 ? void 0 : activeInput.blur(); // Focus on the active input to open the tooltip
+    activeInput === null || activeInput === void 0 ? void 0 : activeInput.blur(); // Select the active input to open the tooltip
 
-    const focusActiveInput = () => {
+    const selectActiveInput = () => {
       activeInput === null || activeInput === void 0 ? void 0 : activeInput.focus();
     };
 
-    document.hasFocus() ? focusActiveInput() : document.addEventListener('visibilitychange', focusActiveInput, {
-      once: true
-    });
+    if (document.hasFocus()) {
+      selectActiveInput();
+    } else {
+      document.addEventListener('visibilitychange', () => {
+        selectActiveInput();
+      }, {
+        once: true
+      });
+    }
   }
 
   isPermanentlyDismissed() {
@@ -13008,6 +13066,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     this._options = options;
     this._htmlTooltipOptions = Object.assign({}, _HTMLTooltip.defaultOptions, htmlTooltipOptions);
     window.addEventListener('pointerdown', this, true);
+    window.addEventListener('pointerup', this, true);
   }
 
   /**
@@ -13017,6 +13076,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
   destroy() {
     this.removeTooltip();
     window.removeEventListener('pointerdown', this, true);
+    window.removeEventListener('pointerup', this, true);
   }
   /**
    * @param {import('./UIController').AttachArgs} args
@@ -13173,6 +13233,13 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
           break;
         }
+
+      case 'pointerup':
+        {
+          this._pointerUpListener(event);
+
+          break;
+        }
     }
   } // Global listener for event delegation
 
@@ -13184,20 +13251,27 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
     if (e.target.nodeName === 'DDG-AUTOFILL') {
       e.preventDefault();
-      e.stopImmediatePropagation();
-      const isMainMouseButton = e.button === 0;
-      if (!isMainMouseButton) return;
-      const activeTooltip = this.getActiveTooltip();
-
-      if (!activeTooltip) {
-        console.warn('Could not get activeTooltip');
-      } else {
-        activeTooltip.dispatchClick();
-      }
+      e.stopImmediatePropagation(); // Ignore pointer down events, we'll handle them on pointer up
     } else {
       this.removeTooltip().catch(e => {
         console.error('error removing tooltip', e);
       });
+    }
+  } // Global listener for event delegation
+
+
+  _pointerUpListener(e) {
+    if (!e.isTrusted) return; // Ignore events on the Dax icon, we handle those elsewhere
+
+    if ((0, _autofillUtils.isEventWithinDax)(e, e.target)) return; // @ts-ignore
+
+    if (e.target.nodeName === 'DDG-AUTOFILL') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const isMainMouseButton = e.button === 0;
+      if (!isMainMouseButton) return;
+      const activeTooltip = this.getActiveTooltip();
+      activeTooltip === null || activeTooltip === void 0 ? void 0 : activeTooltip.dispatchClick();
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@duckduckgo/autoconsent": "^5.1.0",
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.34.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1692081744"
@@ -64,7 +64,7 @@
       "integrity": "sha512-/ZUdNt+FLhtT40f53Pl/TwOLX1Rr4vCyzgDXQjtXBHF7vSaQJLRdkDkiEm4P24HAxNbg+WGeleJUiIEyQgfp2A=="
     },
     "node_modules/@duckduckgo/autofill": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#40bcd0d347b51d14e8114f191df2817d8dcb4284",
+      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#20a6aeddbd86b43fd83c42aa45fdd9ec6db0e0f7",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@duckduckgo/autoconsent": "^5.1.0",
-    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.1.2",
+    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.2.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.34.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1692081744"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205338112741811/1205338112741811
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.2.0


## Description
Updates Autofill to version [8.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.2.0).

### Autofill 8.2.0 release notes
## What's Changed
* Updates for iOS in-context signup support by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/347
* Trigger tooltip option on pointer up by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/333


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.1.2...8.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).