### PR TITLE
Check validity of extracted AMP links

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3985,20 +3985,12 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUrlExtractedAndIsNotNullThenIssueLoadExtractedUrlCommandWithExtractedUrl() {
+    fun whenUrlExtractedThenIssueLoadExtractedUrlCommand() {
+        whenever(mockAmpLinks.processDestinationUrl(anyString(), anyOrNull())).thenReturn("http://example.com")
         testee.onUrlExtracted("http://foo.com", "http://example.com")
-        verify(mockAmpLinks).lastAmpLinkInfo = AmpLinkInfo(ampLink = "http://foo.com")
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         val issuedCommand = commandCaptor.allValues.find { it is LoadExtractedUrl }
         assertEquals("http://example.com", (issuedCommand as LoadExtractedUrl).extractedUrl)
-    }
-
-    @Test
-    fun whenUrlExtractedAndIsNullThenIssueLoadExtractedUrlCommandWithInitialUrl() {
-        testee.onUrlExtracted("http://foo.com", null)
-        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        val issuedCommand = commandCaptor.allValues.find { it is LoadExtractedUrl }
-        assertEquals("http://foo.com", (issuedCommand as LoadExtractedUrl).extractedUrl)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.app.browser.*
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
-import com.duckduckgo.contentscopescripts.api.ContentScopeScripts
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -34,7 +33,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -54,7 +52,6 @@ class UrlExtractingWebViewClientTest {
     private val thirdPartyCookieManager: ThirdPartyCookieManager = mock()
     private val urlExtractor: DOMUrlExtractor = mock()
     private val mockWebView: WebView = mock()
-    private val contentScopeScripts: ContentScopeScripts = mock()
 
     @UiThreadTest
     @Before
@@ -68,7 +65,6 @@ class UrlExtractingWebViewClientTest {
             TestScope(),
             coroutinesTestRule.testDispatcherProvider,
             urlExtractor,
-            contentScopeScripts,
         )
         whenever(cookieManagerProvider.get()).thenReturn(cookieManager)
     }
@@ -78,13 +74,6 @@ class UrlExtractingWebViewClientTest {
     fun whenOnPageStartedCalledThenInjectUrlExtractionJS() {
         testee.onPageStarted(mockWebView, BrowserWebViewClientTest.EXAMPLE_URL, null)
         verify(urlExtractor).injectUrlExtractionJS(mockWebView)
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenOnPageStartedCalledThenInjectContentScopeScripts() = runTest {
-        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
-        verify(contentScopeScripts).injectContentScopeScripts(mockWebView)
     }
 
     @UiThreadTest

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2796,14 +2796,7 @@ class BrowserTabViewModel @Inject constructor(
         initialUrl: String,
         extractedUrl: String?,
     ) {
-        val destinationUrl: String = if (extractedUrl != null) {
-            ampLinks.lastAmpLinkInfo = AmpLinkInfo(ampLink = initialUrl)
-            Timber.d("AMP link detection: Success! Loading extracted URL: $extractedUrl")
-            extractedUrl
-        } else {
-            Timber.d("AMP link detection: Failed! Loading initial URL: $initialUrl")
-            initialUrl
-        }
+        val destinationUrl = ampLinks.processDestinationUrl(initialUrl, extractedUrl)
         command.postValue(LoadExtractedUrl(extractedUrl = destinationUrl))
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -68,7 +68,6 @@ import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
 import com.duckduckgo.app.trackerdetection.CloakedCnameDetector
 import com.duckduckgo.app.trackerdetection.TrackerDetector
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.contentscopescripts.api.ContentScopeScripts
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
 import com.duckduckgo.di.scopes.AppScope
@@ -114,7 +113,6 @@ class BrowserModule {
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
         urlExtractor: DOMUrlExtractor,
-        contentScopeScripts: ContentScopeScripts,
     ): UrlExtractingWebViewClient {
         return UrlExtractingWebViewClient(
             webViewHttpAuthStore,
@@ -125,7 +123,6 @@ class BrowserModule {
             appCoroutineScope,
             dispatcherProvider,
             urlExtractor,
-            contentScopeScripts,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.contentscopescripts.api.ContentScopeScripts
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import kotlinx.coroutines.*
 import timber.log.Timber
@@ -43,7 +42,6 @@ class UrlExtractingWebViewClient(
     private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val urlExtractor: DOMUrlExtractor,
-    private val contentScopeScripts: ContentScopeScripts,
 ) : WebViewClient() {
 
     var urlExtractionListener: UrlExtractionListener? = null
@@ -56,7 +54,6 @@ class UrlExtractingWebViewClient(
                 thirdPartyCookieManager.processUriForThirdPartyCookies(webView, url.toUri())
             }
         }
-        contentScopeScripts.injectContentScopeScripts(webView)
         Timber.d("AMP link detection: Injecting JS for URL extraction")
         urlExtractor.injectUrlExtractionJS(webView)
     }

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/AmpLinks.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/AmpLinks.kt
@@ -33,6 +33,13 @@ interface AmpLinks {
      */
     fun extractCanonicalFromAmpLink(url: String): AmpLinkType?
 
+    /**
+     * This method takes an [initialUrl] and a [extractedUrl]. It returns a [String] containing
+     * the destination URL after checking extracted URL validity.
+     * @return the [String] containing the destination URL.
+     */
+    fun processDestinationUrl(initialUrl: String, extractedUrl: String?): String
+
     /** The last AMP link and its destination URL. */
     var lastAmpLinkInfo: AmpLinkInfo?
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/RealAmpLinksTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/amplinks/RealAmpLinksTest.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.amplinks.AmpLinksRepository
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -44,5 +45,36 @@ class RealAmpLinksTest {
     fun whenIsExceptionCalledAndDomainIsInUserAllowListThenReturnTrue() {
         whenever(mockUserAllowListRepository.isUrlInUserAllowList(anyString())).thenReturn(true)
         assertTrue(testee.isAnException("test.com"))
+    }
+
+    @Test
+    fun whenProcessDestinationUrlAndExtractedUrlIsNullThenReturnInitialUrl() {
+        val destinationUrl = testee.processDestinationUrl("https://example.com", null)
+        assertEquals("https://example.com", destinationUrl)
+    }
+
+    @Test
+    fun whenProcessDestinationUrlAndExtractedUrlIsAnExceptionThenReturnInitialUrl() {
+        whenever(mockUserAllowListRepository.isUrlInUserAllowList(anyString())).thenReturn(true)
+        val destinationUrl = testee.processDestinationUrl("https://example.com", "https://foo.com")
+        assertEquals("https://example.com", destinationUrl)
+    }
+
+    @Test
+    fun whenProcessDestinationUrlAndExtractedUrlDoesNotStartWithHttpOrHttpsThenReturnInitialUrl() {
+        val destinationUrl = testee.processDestinationUrl("https://example.com", "foo.com")
+        assertEquals("https://example.com", destinationUrl)
+    }
+
+    @Test
+    fun whenProcessDestinationUrlAndExtractedUrlStartsWithHttpThenReturnExtractedUrl() {
+        val destinationUrl = testee.processDestinationUrl("https://example.com", "http://foo.com")
+        assertEquals("http://foo.com", destinationUrl)
+    }
+
+    @Test
+    fun whenProcessDestinationUrlAndExtractedUrlStartsWithHttpsThenReturnExtractedUrl() {
+        val destinationUrl = testee.processDestinationUrl("https://example.com", "https://foo.com")
+        assertEquals("https://foo.com", destinationUrl)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: 
https://app.asana.com/0/488551667048375/1205278186816256/f

### Description
Validates the extracted AMP link canonical URL.

### Steps to test this PR

- [x] Navigate to https://privacy-test-pages.glitch.me/privacy-protections/amp/
- [x] Verify that the links in "First Party Cloaked AMP Links" display the expected URL.
- [x] Point at the config linked in the task and restart the app.
- [x] Go to the BBC link listed under "First Party Cloaked AMP Links".
- [x] Verify that the AMP link is loaded.
