### PR TITLE
Add Delay to privacy tests

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/EspressoUtils.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/EspressoUtils.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.espresso
+
+import android.view.*
+import androidx.test.espresso.*
+import androidx.test.espresso.matcher.*
+import org.hamcrest.*
+
+// used to introduce a delay not blocking main thread
+fun waitFor(delay: Long): ViewAction {
+    return object : ViewAction {
+        override fun getConstraints(): Matcher<View> = ViewMatchers.isRoot()
+        override fun getDescription(): String = "wait for $delay milliseconds"
+        override fun perform(uiController: UiController, v: View?) {
+            uiController.loopMainThreadForAtLeast(delay)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.espresso.privacy
 
 import android.webkit.WebView
+import androidx.test.core.app.*
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
@@ -32,9 +33,7 @@ import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.espresso.PrivacyTest
-import com.duckduckgo.espresso.WebViewIdlingResource
-import com.duckduckgo.espresso.waitForView
+import com.duckduckgo.espresso.*
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -47,12 +46,7 @@ import org.junit.Test
 class FingerprintProtectionTest {
 
     @get:Rule
-    var activityScenarioRule = activityScenarioRule<BrowserActivity>(
-        BrowserActivity.intent(
-            InstrumentationRegistry.getInstrumentation().targetContext,
-            queryExtra = "https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/",
-        ),
-    )
+    var activityScenarioRule = activityScenarioRule<BrowserActivity>()
 
     @Test @PrivacyTest
     fun whenProtectionsAreFingerprintProtected() {
@@ -63,8 +57,15 @@ class FingerprintProtectionTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
+        onView(isRoot()).perform(waitFor(2000))
 
-        activityScenarioRule.scenario.onActivity {
+        val scenario = ActivityScenario.launch<BrowserActivity>(
+            BrowserActivity.intent(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                "https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/",
+            ),
+        )
+        scenario.onActivity {
             webView = it.findViewById(R.id.browserWebView)
         }
 

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -39,14 +39,18 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.util.concurrent.TimeUnit
 import org.hamcrest.CoreMatchers.containsString
+import org.junit.*
 import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
 
 class FingerprintProtectionTest {
 
     @get:Rule
     var activityScenarioRule = activityScenarioRule<BrowserActivity>()
+
+    @Before
+    fun before() {
+        onView(isRoot()).perform(waitFor(2000))
+    }
 
     @Test @PrivacyTest
     fun whenProtectionsAreFingerprintProtected() {
@@ -57,7 +61,6 @@ class FingerprintProtectionTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
-        onView(isRoot()).perform(waitFor(2000))
 
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -39,18 +39,14 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.util.concurrent.TimeUnit
 import org.hamcrest.CoreMatchers.containsString
-import org.junit.*
 import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
 
 class FingerprintProtectionTest {
 
     @get:Rule
     var activityScenarioRule = activityScenarioRule<BrowserActivity>()
-
-    @Before
-    fun before() {
-        onView(isRoot()).perform(waitFor(2000))
-    }
 
     @Test @PrivacyTest
     fun whenProtectionsAreFingerprintProtected() {
@@ -61,6 +57,7 @@ class FingerprintProtectionTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
+        onView(isRoot()).perform(waitFor(2000))
 
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.espresso.privacy
 
 import android.webkit.WebView
+import androidx.test.core.app.*
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
@@ -29,9 +30,7 @@ import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.espresso.PrivacyTest
-import com.duckduckgo.espresso.WebViewIdlingResource
-import com.duckduckgo.espresso.waitForView
+import com.duckduckgo.espresso.*
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -44,15 +43,17 @@ import org.junit.Test
 class RequestBlockingTest {
 
     @get:Rule
-    var activityScenarioRule = activityScenarioRule<BrowserActivity>(
-        BrowserActivity.intent(
-            InstrumentationRegistry.getInstrumentation().targetContext,
-            "https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/?run",
-        ),
-    )
+    var activityScenarioRule = activityScenarioRule<BrowserActivity>()
 
     @Test @PrivacyTest
     fun whenProtectionsAreEnabledRequestBlockedCorrectly() {
+        ActivityScenario.launch<BrowserActivity>(
+            BrowserActivity.intent(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                "https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/?run",
+            ),
+        )
+
         onView(isRoot()).perform(waitForView(withId(R.id.pageLoadingIndicator)))
 
         val results = onWebView()
@@ -70,14 +71,21 @@ class RequestBlockingTest {
     @Test @PrivacyTest
     fun whenProtectionsAreDisabledRequestAreNotBlocked() {
         val waitTime = 16000L
-        IdlingPolicies.setMasterPolicyTimeout(waitTime * 10, TimeUnit.MILLISECONDS)
-        IdlingPolicies.setIdlingResourceTimeout(waitTime * 10, TimeUnit.MILLISECONDS)
+        IdlingPolicies.setMasterPolicyTimeout(waitTime, TimeUnit.MILLISECONDS)
+        IdlingPolicies.setIdlingResourceTimeout(waitTime, TimeUnit.MILLISECONDS)
 
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
+        onView(isRoot()).perform(waitFor(2000))
 
-        activityScenarioRule.scenario.onActivity {
+        val scenario = ActivityScenario.launch<BrowserActivity>(
+            BrowserActivity.intent(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                "https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/?run",
+            ),
+        )
+        scenario.onActivity {
             webView = it.findViewById(R.id.browserWebView)
         }
 

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
@@ -47,6 +47,8 @@ class RequestBlockingTest {
 
     @Test @PrivacyTest
     fun whenProtectionsAreEnabledRequestBlockedCorrectly() {
+        onView(isRoot()).perform(waitFor(2000))
+
         ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
                 InstrumentationRegistry.getInstrumentation().targetContext,

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
@@ -35,22 +35,20 @@ import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.util.concurrent.TimeUnit
-import org.junit.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
 
 class RequestBlockingTest {
 
     @get:Rule
     var activityScenarioRule = activityScenarioRule<BrowserActivity>()
 
-    @Before
-    fun before() {
-        onView(isRoot()).perform(waitFor(2000))
-    }
-
     @Test @PrivacyTest
     fun whenProtectionsAreEnabledRequestBlockedCorrectly() {
+        onView(isRoot()).perform(waitFor(2000))
+
         ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
                 InstrumentationRegistry.getInstrumentation().targetContext,
@@ -81,6 +79,7 @@ class RequestBlockingTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
+        onView(isRoot()).perform(waitFor(2000))
 
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
@@ -35,20 +35,22 @@ import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.util.concurrent.TimeUnit
+import org.junit.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Rule
-import org.junit.Test
 
 class RequestBlockingTest {
 
     @get:Rule
     var activityScenarioRule = activityScenarioRule<BrowserActivity>()
 
+    @Before
+    fun before() {
+        onView(isRoot()).perform(waitFor(2000))
+    }
+
     @Test @PrivacyTest
     fun whenProtectionsAreEnabledRequestBlockedCorrectly() {
-        onView(isRoot()).perform(waitFor(2000))
-
         ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
                 InstrumentationRegistry.getInstrumentation().targetContext,
@@ -79,7 +81,6 @@ class RequestBlockingTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
-        onView(isRoot()).perform(waitFor(2000))
 
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
@@ -34,15 +34,19 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.util.concurrent.TimeUnit
 import org.hamcrest.*
+import org.junit.*
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Rule
-import org.junit.Test
 
 class SurrogatesTest {
 
     @get:Rule
     var activityScenarioRule = activityScenarioRule<BrowserActivity>()
+
+    @Before
+    fun before() {
+        onView(isRoot()).perform(waitFor(2000))
+    }
 
     @Test @PrivacyTest
     fun whenProtectionsAreEnabledSurrogatesAreLoaded() {
@@ -53,7 +57,6 @@ class SurrogatesTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
-        onView(isRoot()).perform(waitFor(2000))
 
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
@@ -90,7 +93,6 @@ class SurrogatesTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
-        onView(isRoot()).perform(waitFor(2000))
 
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
@@ -17,10 +17,9 @@
 package com.duckduckgo.espresso.privacy
 
 import android.webkit.WebView
+import androidx.test.core.app.*
+import androidx.test.espresso.*
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.IdlingPolicies
-import androidx.test.espresso.IdlingRegistry
-import androidx.test.espresso.IdlingResource
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.espresso.web.model.Atoms.script
@@ -29,13 +28,12 @@ import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.espresso.PrivacyTest
-import com.duckduckgo.espresso.WebViewIdlingResource
-import com.duckduckgo.espresso.waitForView
+import com.duckduckgo.espresso.*
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.util.concurrent.TimeUnit
+import org.hamcrest.*
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -44,12 +42,7 @@ import org.junit.Test
 class SurrogatesTest {
 
     @get:Rule
-    var activityScenarioRule = activityScenarioRule<BrowserActivity>(
-        BrowserActivity.intent(
-            InstrumentationRegistry.getInstrumentation().targetContext,
-            "https://privacy-test-pages.glitch.me/privacy-protections/surrogates/",
-        ),
-    )
+    var activityScenarioRule = activityScenarioRule<BrowserActivity>()
 
     @Test @PrivacyTest
     fun whenProtectionsAreEnabledSurrogatesAreLoaded() {
@@ -60,8 +53,15 @@ class SurrogatesTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
+        onView(isRoot()).perform(waitFor(2000))
 
-        activityScenarioRule.scenario.onActivity {
+        val scenario = ActivityScenario.launch<BrowserActivity>(
+            BrowserActivity.intent(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                "https://privacy-test-pages.glitch.me/privacy-protections/surrogates/",
+            ),
+        )
+        scenario.onActivity {
             webView = it.findViewById(R.id.browserWebView)
         }
 
@@ -91,7 +91,13 @@ class SurrogatesTest {
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
 
-        activityScenarioRule.scenario.onActivity {
+        val scenario = ActivityScenario.launch<BrowserActivity>(
+            BrowserActivity.intent(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                "https://privacy-test-pages.glitch.me/privacy-protections/surrogates/",
+            ),
+        )
+        scenario.onActivity {
             webView = it.findViewById(R.id.browserWebView)
         }
 

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
@@ -90,6 +90,7 @@ class SurrogatesTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
+        onView(isRoot()).perform(waitFor(2000))
 
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
@@ -34,19 +34,15 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.util.concurrent.TimeUnit
 import org.hamcrest.*
-import org.junit.*
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
 
 class SurrogatesTest {
 
     @get:Rule
     var activityScenarioRule = activityScenarioRule<BrowserActivity>()
-
-    @Before
-    fun before() {
-        onView(isRoot()).perform(waitFor(2000))
-    }
 
     @Test @PrivacyTest
     fun whenProtectionsAreEnabledSurrogatesAreLoaded() {
@@ -57,6 +53,7 @@ class SurrogatesTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
+        onView(isRoot()).perform(waitFor(2000))
 
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
@@ -93,6 +90,7 @@ class SurrogatesTest {
         var webView: WebView? = null
 
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
+        onView(isRoot()).perform(waitFor(2000))
 
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetector.kt
@@ -91,7 +91,9 @@ class TrackerDetectorImpl @Inject constructor(
         val isATrackerAllowed = result.isATracker && !result.matches
         val shouldBlock = result.matches && !isSiteAContentBlockingException && !isInTrackerAllowList && !isInAdClickAllowList && !sameEntity
 
-        Timber.i("FLAKY: shouldBlock $shouldBlock, because result.matches ${result.matches}, isSiteAContentBlockingException $isSiteAContentBlockingException, isInTrackerAllowList $isInTrackerAllowList, isInAdClickAllowList $isInAdClickAllowList, sameEntity $sameEntity")
+        Timber.i(
+            "FLAKY: shouldBlock $shouldBlock, because result.matches ${result.matches}, isSiteAContentBlockingException $isSiteAContentBlockingException, isInTrackerAllowList $isInTrackerAllowList, isInAdClickAllowList $isInAdClickAllowList, sameEntity $sameEntity",
+        )
 
         val status = when {
             sameEntity -> TrackerStatus.SAME_ENTITY_ALLOWED

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetector.kt
@@ -91,6 +91,8 @@ class TrackerDetectorImpl @Inject constructor(
         val isATrackerAllowed = result.isATracker && !result.matches
         val shouldBlock = result.matches && !isSiteAContentBlockingException && !isInTrackerAllowList && !isInAdClickAllowList && !sameEntity
 
+        Timber.i("FLAKY: shouldBlock $shouldBlock, because result.matches ${result.matches}, isSiteAContentBlockingException $isSiteAContentBlockingException, isInTrackerAllowList $isInTrackerAllowList, isInAdClickAllowList $isInAdClickAllowList, sameEntity $sameEntity")
+
         val status = when {
             sameEntity -> TrackerStatus.SAME_ENTITY_ALLOWED
             isDocumentInAllowedList -> TrackerStatus.USER_ALLOWED

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetector.kt
@@ -91,10 +91,6 @@ class TrackerDetectorImpl @Inject constructor(
         val isATrackerAllowed = result.isATracker && !result.matches
         val shouldBlock = result.matches && !isSiteAContentBlockingException && !isInTrackerAllowList && !isInAdClickAllowList && !sameEntity
 
-        Timber.i(
-            "FLAKY: shouldBlock $shouldBlock, because result.matches ${result.matches}, isSiteAContentBlockingException $isSiteAContentBlockingException, isInTrackerAllowList $isInTrackerAllowList, isInAdClickAllowList $isInAdClickAllowList, sameEntity $sameEntity",
-        )
-
         val status = when {
             sameEntity -> TrackerStatus.SAME_ENTITY_ALLOWED
             isDocumentInAllowedList -> TrackerStatus.USER_ALLOWED

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetector.kt
@@ -91,6 +91,10 @@ class TrackerDetectorImpl @Inject constructor(
         val isATrackerAllowed = result.isATracker && !result.matches
         val shouldBlock = result.matches && !isSiteAContentBlockingException && !isInTrackerAllowList && !isInAdClickAllowList && !sameEntity
 
+        Timber.i(
+            "FLAKY: shouldBlock $shouldBlock, because result.matches ${result.matches}, isSiteAContentBlockingException $isSiteAContentBlockingException, isInTrackerAllowList $isInTrackerAllowList, isInAdClickAllowList $isInAdClickAllowList, sameEntity $sameEntity",
+        )
+
         val status = when {
             sameEntity -> TrackerStatus.SAME_ENTITY_ALLOWED
             isDocumentInAllowedList -> TrackerStatus.USER_ALLOWED


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205316272499589/f

### Description
Adds a delay to privacy tests to ensure config initialization happens before run.

### Steps to test this PR
Ensure https://github.com/duckduckgo/Android/actions/runs/5963265139 finishes successfully

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
