### PR TITLE
Android: Don't show the option to "Open Image in Background Tab" in case of data URLs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewLongPressHandler.kt
@@ -67,13 +67,19 @@ class WebViewLongPressHandler @Inject constructor(
         when (longPressTargetType) {
             WebView.HitTestResult.IMAGE_TYPE -> {
                 if (isLinkSupported(longPressTargetUrl)) {
-                    addImageMenuOptions(menu)
+                    addDownloadImageMenuOptions(menu)
+                    if (!URLUtil.isDataUrl(longPressTargetUrl)) {
+                        addImageMenuOptions(menu)
+                    }
                 }
             }
             WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE -> {
                 if (isLinkSupported(longPressTargetUrl)) {
-                    addImageMenuOptions(menu)
-                    addLinkMenuOptions(menu)
+                    addDownloadImageMenuOptions(menu)
+                    if (!URLUtil.isDataUrl(longPressTargetUrl)) {
+                        addImageMenuOptions(menu)
+                        addLinkMenuOptions(menu)
+                    }
                 }
             }
             WebView.HitTestResult.SRC_ANCHOR_TYPE -> {
@@ -92,8 +98,11 @@ class WebViewLongPressHandler @Inject constructor(
         }
     }
 
-    private fun addImageMenuOptions(menu: ContextMenu) {
+    private fun addDownloadImageMenuOptions(menu: ContextMenu) {
         menu.add(0, CONTEXT_MENU_ID_DOWNLOAD_IMAGE, CONTEXT_MENU_ID_DOWNLOAD_IMAGE, R.string.downloadImage)
+    }
+
+    private fun addImageMenuOptions(menu: ContextMenu) {
         menu.add(0, CONTEXT_MENU_ID_OPEN_IMAGE_IN_NEW_BACKGROUND_TAB, CONTEXT_MENU_ID_OPEN_IMAGE_IN_NEW_BACKGROUND_TAB, R.string.openImageInNewTab)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/WebViewLongPressHandlerTest.kt
@@ -107,15 +107,17 @@ class WebViewLongPressHandlerTest {
     }
 
     @Test
-    fun whenUserLongPressesWithImageTypeThenDownloadImageMenuAdded() {
+    fun whenUserLongPressesWithImageTypeThenDownloadImageMenuAddedAndOpenImageInBackgroundItemAdded() {
         testee.handleLongPress(HitTestResult.IMAGE_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verifyDownloadImageItemAdded()
+        verifyOpenImageInBackgroundItemAdded()
     }
 
     @Test
-    fun whenUserLongPressesWithAnchorImageTypeThenDownloadImageMenuAdded() {
+    fun whenUserLongPressesWithAnchorImageTypeThenDownloadImageMenuAddedOpenImageInBackgroundItemAdded() {
         testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, HTTPS_IMAGE_URL, mockMenu)
         verifyDownloadImageItemAdded()
+        verifyOpenImageInBackgroundItemAdded()
     }
 
     @Test
@@ -125,9 +127,17 @@ class WebViewLongPressHandlerTest {
     }
 
     @Test
-    fun whenUserLongPressesWithImageTypeWhichIsADataUriThenDownloadImageMenuAdded() {
+    fun whenUserLongPressesWithImageTypeWhichIsADataUriThenDownloadImageMenuAddedAndOpenImageInBackgroundItemNotAdded() {
         testee.handleLongPress(HitTestResult.IMAGE_TYPE, DATA_URI_IMAGE_URL, mockMenu)
         verifyDownloadImageItemAdded()
+        verifyOpenImageInBackgroundItemNotAdded()
+    }
+
+    @Test
+    fun whenUserLongPressesWithAnchorImageTypeWhichIsADataUriThenDownloadImageMenuAddedAndOpenImageInBackgroundItemNotAdded() {
+        testee.handleLongPress(HitTestResult.SRC_IMAGE_ANCHOR_TYPE, DATA_URI_IMAGE_URL, mockMenu)
+        verifyDownloadImageItemAdded()
+        verifyOpenImageInBackgroundItemNotAdded()
     }
 
     @Test
@@ -165,6 +175,24 @@ class WebViewLongPressHandlerTest {
 
     private fun verifyDownloadImageItemAdded() {
         verify(mockMenu).add(anyInt(), eq(WebViewLongPressHandler.CONTEXT_MENU_ID_DOWNLOAD_IMAGE), anyInt(), eq(R.string.downloadImage))
+    }
+
+    private fun verifyOpenImageInBackgroundItemNotAdded() {
+        verify(mockMenu, never()).add(
+            anyInt(),
+            eq(WebViewLongPressHandler.CONTEXT_MENU_ID_OPEN_IMAGE_IN_NEW_BACKGROUND_TAB),
+            anyInt(),
+            eq(R.string.openImageInNewTab),
+        )
+    }
+
+    private fun verifyOpenImageInBackgroundItemAdded() {
+        verify(mockMenu).add(
+            anyInt(),
+            eq(WebViewLongPressHandler.CONTEXT_MENU_ID_OPEN_IMAGE_IN_NEW_BACKGROUND_TAB),
+            anyInt(),
+            eq(R.string.openImageInNewTab),
+        )
     }
 
     private fun verifyNewForegroundTabItemAdded() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205377355311840/f

### Description
Updated the long press menu to show only the download image option in case of data URLs.

### Steps to test this PR

Test `https` image URLs (same as in develop)
- [x] Install from this branch.
- [x] Search for "cats" and go to "Images".
- [x] Long press on an image and notice you see 2 options: `Download Image` and `Open Image in Background Tab`.

Test `data` image URLs (changed)
- [x] Install from this branch.
- [x] Open https://codebeautify.org/image-to-base64-converter link.
- [x] Upload an image and notice the preview.
- [x] Long press on the preview and notice you see 1 option: `Download Image`.

### UI changes
| Before (data image URLs) | After (data image URLs) |
| ------ | ----- |
|!(Upload before screenshot)|(Upload after screenshot)|
|![dowlonad_and_open_image](https://github.com/duckduckgo/Android/assets/7963079/8568014d-1783-4dbd-8e82-89840b70baf7)|![download_image](https://github.com/duckduckgo/Android/assets/7963079/8cfef751-64d6-496b-95f9-205d0f10e41f)|
