### PR TITLE
Don't show survey CTA when survey is done

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/survey/api/SurveyRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/api/SurveyRepository.kt
@@ -20,6 +20,7 @@ import androidx.core.app.NotificationManagerCompat
 import com.duckduckgo.app.notification.NotificationRegistrar.NotificationId
 import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
+import com.duckduckgo.app.survey.model.Survey.Status.DONE
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.di.scopes.AppScope
@@ -69,7 +70,7 @@ class SurveyRepositoryImpl @Inject constructor(
     }
 
     override fun shouldShowSurvey(survey: Survey): Boolean {
-        return remainingDaysForShowingSurvey(survey) == 0L
+        return remainingDaysForShowingSurvey(survey) == 0L && survey.status != DONE
     }
 
     private fun validDaysInstalled(survey: Survey): Boolean {

--- a/app/src/test/java/com/duckduckgo/app/survey/api/SurveyRepositoryImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/api/SurveyRepositoryImplTest.kt
@@ -212,6 +212,19 @@ class SurveyRepositoryTest {
     }
 
     @Test
+    fun whenSurveyStatusIsDoneThenShouldNotShowSurvey() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(4)
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.DONE,
+            daysInstalled = -1,
+            url = null,
+        )
+
+        assertFalse(surveyRepository.shouldShowSurvey(survey))
+    }
+
+    @Test
     fun getScheduledSurveyReturnsLastSurvey() {
         val survey = Survey(
             surveyId = "1",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205375055980500/f

### Description
This PR ensures that once the survey is done the survey CTA in the new tab is also removed.

### Steps to test this PR
See attached task description
