### PR TITLE
Remove Experiment Audience, Timing and Cadence

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/AndroidNotificationSchedulerTest.kt
@@ -128,42 +128,6 @@ class AndroidNotificationSchedulerTest {
         assertNotificationScheduled(ClearDataNotificationWorker::class.javaObjectType.name)
     }
 
-    @Test
-    fun givenAudienceLeverVariantThenBothNotificationsAreScheduled() = runTest {
-        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zs" })
-        whenever(privacyNotification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(PrivacyNotificationWorker::class.javaObjectType.name)
-        assertNotificationScheduled(ClearDataNotificationWorker::class.javaObjectType.name)
-    }
-
-    @Test
-    fun givenTimingLeverVariantThenBothNotificationsAreScheduled() = runTest {
-        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zt" })
-        whenever(privacyNotification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(PrivacyNotificationWorker::class.javaObjectType.name)
-        assertNotificationScheduled(ClearDataNotificationWorker::class.javaObjectType.name)
-    }
-
-    @Test
-    fun givenCadenceLeverVariantThenBothNotificationsAreScheduled() = runTest {
-        whenever(mockVariantManager.getVariant()).thenReturn(VariantManager.ACTIVE_VARIANTS.first { it.key == "zu" })
-        whenever(privacyNotification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
-
-        testee.scheduleNextNotification()
-
-        assertNotificationScheduled(PrivacyNotificationWorker::class.javaObjectType.name)
-        assertNotificationScheduled(ClearDataNotificationWorker::class.javaObjectType.name)
-    }
-
     private fun assertNotificationScheduled(
         workerName: String?,
         tag: String = NotificationScheduler.UNUSED_APP_WORK_REQUEST_TAG,

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -26,9 +26,6 @@ import com.duckduckgo.app.notification.model.ClearDataNotification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.isAudienceLeverEnabled
-import com.duckduckgo.app.statistics.isCadenceLeverEnabled
-import com.duckduckgo.app.statistics.isTimingLeverEnabled
 import com.duckduckgo.di.scopes.AppScope
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
@@ -54,39 +51,12 @@ class NotificationScheduler(
     }
 
     private suspend fun scheduleInactiveUserNotifications() {
-        when {
-            variantManager.isAudienceLeverEnabled() -> {
-                if (!isWorkScheduled(UNUSED_APP_WORK_REQUEST_TAG)) {
-                    scheduleUnusedAppNotifications(
-                        1L to TimeUnit.DAYS,
-                        3L to TimeUnit.DAYS,
-                    )
-                }
-            }
-            variantManager.isTimingLeverEnabled() -> {
-                if (!isWorkScheduled(UNUSED_APP_WORK_REQUEST_TAG)) {
-                    scheduleUnusedAppNotifications(
-                        30L to TimeUnit.MINUTES,
-                        2L to TimeUnit.DAYS,
-                    )
-                }
-            }
-            variantManager.isCadenceLeverEnabled() -> {
-                if (!isWorkScheduled(UNUSED_APP_WORK_REQUEST_TAG)) {
-                    scheduleUnusedAppNotifications(
-                        30L to TimeUnit.MINUTES,
-                        1L to TimeUnit.DAYS,
-                    )
-                }
-            }
-            else -> {
-                workManager.cancelAllWorkByTag(UNUSED_APP_WORK_REQUEST_TAG)
-                scheduleUnusedAppNotifications(
-                    PRIVACY_DELAY_DURATION_IN_DAYS to TimeUnit.DAYS,
-                    CLEAR_DATA_DELAY_DURATION_IN_DAYS to TimeUnit.DAYS,
-                )
-            }
-        }
+        workManager.cancelAllWorkByTag(UNUSED_APP_WORK_REQUEST_TAG)
+
+        scheduleUnusedAppNotifications(
+            PRIVACY_DELAY_DURATION_IN_DAYS to TimeUnit.DAYS,
+            CLEAR_DATA_DELAY_DURATION_IN_DAYS to TimeUnit.DAYS,
+        )
     }
 
     private suspend fun scheduleUnusedAppNotifications(

--- a/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -17,9 +17,6 @@
 package com.duckduckgo.app.statistics
 
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.AudienceLever
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.CadenceLever
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.TimingLever
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -53,42 +50,6 @@ class VariantManagerTest {
                 fail("Duplicate variant name found: ${it.key}")
             }
         }
-    }
-
-    @Test
-    fun pushNotificationControlVariantHasExpectedWeightAndNoFeatures() {
-        val variant = variants.first { it.key == "zr" }
-
-        assertEqualsDouble(1.0, variant.weight)
-        assertEquals(0, variant.features.size)
-        assertEquals(0, variant.features.size)
-    }
-
-    @Test
-    fun pushNotificationAudienceLeverExperimentalVariantHasExpectedWeightAndFeatures() {
-        val variant = variants.first { it.key == "zs" }
-
-        assertEqualsDouble(1.0, variant.weight)
-        assertEquals(1, variant.features.size)
-        assertTrue(variant.hasFeature(AudienceLever))
-    }
-
-    @Test
-    fun pushNotificationTimingLeverExperimentalVariantHasExpectedWeightAndFeatures() {
-        val variant = variants.first { it.key == "zt" }
-
-        assertEqualsDouble(1.0, variant.weight)
-        assertEquals(1, variant.features.size)
-        assertTrue(variant.hasFeature(TimingLever))
-    }
-
-    @Test
-    fun pushNotificationCadenceLeverExperimentalVariantHasExpectedWeightAndFeatures() {
-        val variant = variants.first { it.key == "zu" }
-
-        assertEqualsDouble(1.0, variant.weight)
-        assertEquals(1, variant.features.size)
-        assertTrue(variant.hasFeature(CadenceLever))
     }
 
     @Suppress("SameParameterValue")

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -19,9 +19,6 @@ package com.duckduckgo.app.statistics
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.VariantManager.Companion.referrerVariant
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.AudienceLever
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.CadenceLever
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.TimingLever
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import java.util.*
@@ -31,11 +28,7 @@ import timber.log.Timber
 interface VariantManager {
 
     // variant-dependant features listed here
-    sealed class VariantFeature {
-        object AudienceLever : VariantFeature()
-        object TimingLever : VariantFeature()
-        object CadenceLever : VariantFeature()
-    }
+    sealed class VariantFeature
 
     companion object {
 
@@ -49,12 +42,6 @@ interface VariantManager {
             // the future if we can filter by app version
             Variant(key = "sc", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
             Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
-
-            // Experiment: Change push notification audience, timing and cadence
-            Variant(key = "zr", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "zs", weight = 1.0, features = listOf(AudienceLever), filterBy = { noFilter() }),
-            Variant(key = "zt", weight = 1.0, features = listOf(TimingLever), filterBy = { noFilter() }),
-            Variant(key = "zu", weight = 1.0, features = listOf(CadenceLever), filterBy = { noFilter() }),
         )
 
         val REFERRER_VARIANTS = listOf(
@@ -184,10 +171,6 @@ class ExperimentationVariantManager(
         return activeVariants[randomizedIndex]
     }
 }
-
-fun VariantManager.isAudienceLeverEnabled() = this.getVariant().hasFeature(AudienceLever)
-fun VariantManager.isTimingLeverEnabled() = this.getVariant().hasFeature(TimingLever)
-fun VariantManager.isCadenceLeverEnabled() = this.getVariant().hasFeature(CadenceLever)
 
 /**
  * A variant which can be used for experimentation.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205393984088163/f

### Description
Remove Experiment Audience, Timing and Cadence

### Steps to test this PR
- Change delay for engagement notifications in `AndroidNotificationScheduler` to, for example, 15 and 25 seconds (_Lines 57 & 58_)
- Fresh install
- Allow notifications in onboarding
- [ ] Check Privacy Protection notification appears in 15 seconds after inactive
- [ ] Check Clear Data notification appears in 30 seconds after inactive

### No UI changes
