### PR TITLE
Bug: Bookmarks in folders don’t open

### DIFF
--- a/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
@@ -1,0 +1,50 @@
+appId: com.duckduckgo.mobile.android
+name: "ReleaseTest: Bookmark open and back navigation"
+tags:
+    - releaseTest
+---
+- launchApp:
+      clearState: true
+      stopApp: true
+
+- runFlow: ../shared/onboarding.yaml
+
+- tapOn:
+      text: "search or type URL"
+- inputText: "https://www.search-company.site/"
+- tapOn:
+      id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+      text: ".*keep browsing.*"
+- tapOn:
+      text: "got it"
+- assertVisible:
+      text: "Search engine"
+- tapOn:
+      text: "https://www.search-company.site/"
+- inputText: "https://privacy-test-pages.glitch.me"
+- tapOn:
+      id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+      text: "Privacy Test Pages"
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+      text: "add bookmark"
+- tapOn:
+      text: "add bookmark"
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+      text: "bookmarks"
+- tapOn:
+      text: "bookmarks"
+- assertVisible:
+      text: "Privacy Test Pages - Home"
+- tapOn:
+      text: "Privacy Test Pages - Home"
+- assertVisible:
+      text: "Privacy Test Pages"
+- tapOn: "back"
+- assertVisible:
+      text: "Search engine"

--- a/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
@@ -1,0 +1,162 @@
+appId: com.duckduckgo.mobile.android
+name: "ReleaseTest: Bookmark open and back navigation"
+tags:
+    - releaseTest
+---
+- launchApp:
+      clearState: true
+      stopApp: true
+
+- runFlow: ../shared/onboarding.yaml
+
+- tapOn:
+      text: "search or type URL"
+- inputText: "https://privacy-test-pages.glitch.me/"
+- tapOn:
+      id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+      text: ".*keep browsing.*"
+- tapOn:
+      text: "got it"
+- assertVisible:
+      text: "Privacy Test Pages"
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+      text: "add bookmark"
+- tapOn:
+      text: "add bookmark"
+- tapOn:
+      text: "https://privacy-test-pages.glitch.me/"
+- inputText: "https://www.search-company.site/"
+- tapOn:
+    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- assertVisible:
+    text: "Search engine"
+- tapOn:
+      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+      text: "bookmarks"
+- tapOn:
+      text: "bookmarks"
+- assertVisible:
+      text: "Privacy Test Pages - Home"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/trailingIcon"
+- assertVisible:
+    text: "Edit"
+- tapOn:
+    text: "edit"
+- assertVisible:
+    text: "Location"
+- assertVisible:
+    text: "Bookmarks"
+- tapOn:
+    text: "bookmarks"
+- assertVisible:
+    text: "Select Location"
+- assertVisible:
+    text: "Bookmarks"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/action_add_folder"
+- assertVisible:
+    text: "Add Folder"
+- assertVisible:
+    text: "Bookmarks"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/titleInput"
+- inputText: "Folder1"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
+- assertVisible:
+    text: "Select Location"
+- assertVisible:
+    text: "Bookmarks"
+- assertVisible:
+    text: "Folder1"
+- tapOn:
+    text: "Folder1"
+- assertVisible:
+    text: "Edit Bookmark"
+- assertVisible:
+    text: "Folder1"
+- tapOn:
+    text: "Folder1"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/action_add_folder"
+- assertVisible:
+    text: "Add Folder"
+- assertVisible:
+    text: "Bookmarks"
+- inputText: "Folder2"
+- tapOn:
+    text: "Bookmarks"
+- assertVisible:
+    text: "Select Location"
+- assertVisible:
+    text: "Bookmarks"
+- assertVisible:
+    text: "Folder1"
+- tapOn:
+    text: "Folder1"
+- assertVisible:
+    text: "Add Folder"
+- assertVisible:
+    text: "Folder2"
+- assertVisible:
+    text: "Folder1"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
+- assertVisible:
+    text: "Select Location"
+- assertVisible:
+    text: "Bookmarks"
+- assertVisible:
+    text: "Folder1"
+- tapOn:
+    text: "Folder1"
+- assertVisible:
+    text: "Edit Bookmark"
+- assertVisible:
+    text: "Folder1"
+- tapOn:
+    text: "Folder1"
+- assertVisible:
+    text: "Select Location"
+- assertVisible:
+    text: "Folder1"
+- assertVisible:
+    text: "Folder2"
+- tapOn:
+    text: "Folder2"
+- assertVisible:
+    text: "Edit Bookmark"
+- assertVisible:
+    text: "Folder2"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
+- assertVisible:
+    text: "Bookmarks"
+- assertVisible:
+    text: "Folder1"
+- assertNotVisible:
+    text: "Privacy Test Pages - Home"
+- tapOn:
+    text: "Folder1"
+- assertVisible:
+    text: "Folder2"
+- tapOn:
+    text: "Folder1"
+- assertVisible:
+    text: "Folder2"
+- tapOn:
+    text: "Folder2"
+- assertVisible:
+    text: "Privacy Test Pages - Home"
+- tapOn:
+    text: "Privacy Test Pages - Home"
+- assertVisible:
+    text: "Privacy Test Pages"
+- tapOn: "back"
+- assertVisible:
+    text: "Search engine"

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -28,12 +28,12 @@ import android.view.MenuItem
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.ConcatAdapter
+import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.AddBookmarkFolderDialogFragment
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.BookmarkFoldersActivity.Companion.KEY_BOOKMARK_FOLDER_ID
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.BookmarkFoldersAdapter
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.EditBookmarkFolderDialogFragment
-import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.R.plurals
 import com.duckduckgo.app.browser.databinding.ActivityBookmarksBinding
@@ -62,6 +62,7 @@ import java.util.*
 import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
+@ContributeToActivityStarter(BookmarksScreenNoParams::class)
 class BookmarksActivity : DuckDuckGoActivity() {
 
     @Inject
@@ -325,7 +326,9 @@ class BookmarksActivity : DuckDuckGoActivity() {
     }
 
     private fun openSavedSite(savedSite: SavedSite) {
-        startActivity(BrowserActivity.intent(this, savedSite.url))
+        val resultValue = Intent()
+        resultValue.putExtra(SAVED_SITE_URL_EXTRA, savedSite.url)
+        setResult(RESULT_OK, resultValue)
         finish()
     }
 
@@ -424,6 +427,8 @@ class BookmarksActivity : DuckDuckGoActivity() {
     }
 
     companion object {
+        const val SAVED_SITE_URL_EXTRA = "SAVED_SITE_URL_EXTRA"
+
         fun intent(
             context: Context,
             bookmarkFolder: BookmarkFolder? = null,

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -25,6 +25,8 @@ import android.text.SpannableString
 import android.text.style.StyleSpan
 import android.view.Menu
 import android.view.MenuItem
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.ConcatAdapter
@@ -89,6 +91,15 @@ class BookmarksActivity : DuckDuckGoActivity() {
 
     private val searchBar
         get() = binding.searchBar
+
+    private val startBookmarkFoldersActivityForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            if (result.resultCode == RESULT_OK) {
+                result.data?.getStringExtra(SAVED_SITE_URL_EXTRA)?.let {
+                    viewModel.onBookmarkFoldersActivityResult(it)
+                }
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -176,7 +187,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
         ) {
             when (it) {
                 is BookmarksViewModel.Command.ConfirmDeleteSavedSite -> confirmDeleteSavedSite(it.savedSite)
-                is BookmarksViewModel.Command.OpenSavedSite -> openSavedSite(it.savedSite)
+                is BookmarksViewModel.Command.OpenSavedSite -> openSavedSite(it.savedSiteUrl)
                 is BookmarksViewModel.Command.ShowEditSavedSite -> showEditSavedSiteDialog(it.savedSite)
                 is BookmarksViewModel.Command.ImportedSavedSites -> showImportedSavedSites(it.importSavedSitesResult)
                 is BookmarksViewModel.Command.ExportedSavedSites -> showExportedSavedSites(it.exportSavedSitesResult)
@@ -325,9 +336,9 @@ class BookmarksActivity : DuckDuckGoActivity() {
         dialog.deleteBookmarkListener = viewModel
     }
 
-    private fun openSavedSite(savedSite: SavedSite) {
+    private fun openSavedSite(url: String) {
         val resultValue = Intent()
-        resultValue.putExtra(SAVED_SITE_URL_EXTRA, savedSite.url)
+        resultValue.putExtra(SAVED_SITE_URL_EXTRA, url)
         setResult(RESULT_OK, resultValue)
         finish()
     }
@@ -358,7 +369,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
     }
 
     private fun openBookmarkFolder(bookmarkFolder: BookmarkFolder) {
-        startActivity(intent(this, bookmarkFolder))
+        startBookmarkFoldersActivityForResult.launch(intent(this, bookmarkFolder))
     }
 
     private fun editBookmarkFolder(bookmarkFolder: BookmarkFolder) {

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksScreens.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksScreens.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.bookmarks.ui
+
+import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
+
+/**
+ * Use this model to launch the Bookmarks screen
+ */
+object BookmarksScreenNoParams : ActivityParams

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -66,7 +66,7 @@ class BookmarksViewModel @Inject constructor(
     )
 
     sealed class Command {
-        class OpenSavedSite(val savedSite: SavedSite) : Command()
+        class OpenSavedSite(val savedSiteUrl: String) : Command()
         class ConfirmDeleteSavedSite(val savedSite: SavedSite) : Command()
         class ShowEditSavedSite(val savedSite: SavedSite) : Command()
         class OpenBookmarkFolder(val bookmarkFolder: BookmarkFolder) : Command()
@@ -119,7 +119,7 @@ class BookmarksViewModel @Inject constructor(
         if (savedSite is Favorite) {
             pixel.fire(AppPixelName.FAVORITE_BOOKMARKS_ITEM_PRESSED)
         }
-        command.value = OpenSavedSite(savedSite)
+        command.value = OpenSavedSite(savedSite.url)
     }
 
     fun onEditSavedSiteRequested(savedSite: SavedSite) {
@@ -262,5 +262,9 @@ class BookmarksViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io() + NonCancellable) {
             savedSitesRepository.insertFolderBranch(folderBranch)
         }
+    }
+
+    fun onBookmarkFoldersActivityResult(savedSiteUrl: String) {
+        command.value = OpenSavedSite(savedSiteUrl)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1884,7 +1884,8 @@ class BrowserTabFragment :
             override fun onBackKey(): Boolean {
                 omnibar.omnibarTextInput.hideKeyboard()
                 binding.focusDummy.requestFocus()
-                return true
+                //  Allow the event to be handled by the next receiver.
+                return false
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -85,6 +85,7 @@ class BrowserViewModel @Inject constructor(
         data class ShowAppEnjoymentPrompt(val promptCount: PromptCount) : Command()
         data class ShowAppRatingPrompt(val promptCount: PromptCount) : Command()
         data class ShowAppFeedbackPrompt(val promptCount: PromptCount) : Command()
+        data class OpenSavedSite(val url: String) : Command()
     }
 
     var viewState: MutableLiveData<ViewState> = MutableLiveData<ViewState>().also {
@@ -275,5 +276,9 @@ class BrowserViewModel @Inject constructor(
 
     fun onLaunchedFromNotification(pixelName: String) {
         pixel.fire(pixelName)
+    }
+
+    fun onBookmarksActivityResult(url: String) {
+        command.value = Command.OpenSavedSite(url)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -331,4 +331,14 @@ class BookmarksViewModelTest {
 
         verify(savedSitesRepository).insertFolderBranch(folderBranch)
     }
+
+    @Test
+    fun whenOnBookmarkFoldersActivityResultCalledThenOpenSavedSiteCommandSent() {
+        val savedSiteUrl = "https://www.example.com"
+
+        testee.onBookmarkFoldersActivityResult(savedSiteUrl)
+
+        verify(commandObserver).onChanged(commandCaptor.capture())
+        assertEquals(savedSiteUrl, (commandCaptor.value as BookmarksViewModel.Command.OpenSavedSite).savedSiteUrl)
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -255,6 +255,16 @@ class BrowserViewModelTest {
         verify(mockPixel).fire(pixelName)
     }
 
+    @Test
+    fun whenOnBookmarksActivityResultCalledThenOpenSavedSiteCommandTriggered() {
+        val bookmarkUrl = "https://www.example.com"
+
+        testee.onBookmarksActivityResult(bookmarkUrl)
+
+        verify(mockCommandObserver).onChanged(commandCaptor.capture())
+        assertEquals(Command.OpenSavedSite(bookmarkUrl), commandCaptor.lastValue)
+    }
+
     companion object {
         const val TAB_ID = "TAB_ID"
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1205402504525897/f

### Description
Fixed the open bookmark from folder flow. Added maestro tests. 

### Steps to test this PR

Test open bookmark from folder and navigate back:
- [x] Install from this branch.
- [x] Navigate to a website and bookmark it.
- [x] Navigate to another website.
- [x] Go to the `Bookmarks` screen.
- [x] Move the bookmark to another folder.
- [x] Open the bookmark from that folder.
- [x] Notice the bookmark is opened in the current tab, not a new one.
- [x] Tap on the back button and notice you see the previous website (the app doesn't close). 
- [x] Go to the `Bookmarks` screen again.
- [x] Move the bookmark to another folder inside a folder.
- [x] Open the bookmark from that folder.
- [x] Notice the bookmark is opened in the current tab, not a new one.
- [x] Tap on the back button and notice you see the previous website (the app doesn't close). 

Test open bookmark and navigate back:
- [x] Install from this branch.
- [x] Navigate to a website and bookmark it.
- [x] Navigate to another website.
- [x] Go to the `Bookmarks` screen.
- [x] Open the bookmark.
- [x] Notice the bookmark is opened in the current tab, not a new one.
- [x] Tap on the back button and notice you see the previous website (the app doesn't close). 

Test the gesture navigation in Production to notice the issue:
- [x] Enable `Gesture navigation` on your device.
- [x] Install the Production version (or install from develop).
- [x] Open a new tab. Notice the keyboard is shown.
- [x] Swipe back. Notice the keyboard is hidden.
- [x] Swipe back. Notice nothing happens.
- [x] Swipe back. Notice the app is closed.

Test the fixed gesture navigation:
- [x] Enable `Gesture navigation` on your device.
- [x] Install from this branch.
- [x] Open a new tab. Notice the keyboard is shown.
- [x] Swipe back. Notice the keyboard is hidden.
- [x] Swipe back. Notice the app is closed.

Run the 2 maestro tests:
- [x] open_bookmark_and_navigate_back.yaml
- [x] open_bookmark_in_folder_and_navigate_back.yaml

### NO UI changes
