### PR TITLE
Update content scope scripts to version 4.36.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1321,8 +1321,6 @@
      * @implements {MessagingTransport}
      */
     class WindowsMessagingTransport {
-        config
-
         /**
          * @param {WindowsMessagingConfig} config
          * @param {import('../index.js').MessagingContext} messagingContext
@@ -1822,11 +1820,6 @@
      * @implements {MessagingTransport}
      */
     class WebkitMessagingTransport {
-        /** @type {WebkitMessagingConfig} */
-        config
-        /** @internal */
-        globals
-
         /**
          * @param {WebkitMessagingConfig} config
          * @param {import('../index.js').MessagingContext} messagingContext

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^5.1.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.36.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1692081744"
       },
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
+      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60611066fe8db8ae597d21a6ae731ed5985f0f88",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4b6c64f9e89e6feec6d2dcc36b03d52ac4963c43",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -267,9 +267,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
-      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -907,9 +907,9 @@
       }
     },
     "node_modules/rollup-plugin-copy": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz",
-      "integrity": "sha512-rGUmYYsYsceRJRqLVlE9FivJMxJ7X6jDlP79fmFkL8sJs7VVMSVyA2yfyL+PGyO/vJs4A87hwhgVfz61njI+uQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.5.0.tgz",
+      "integrity": "sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==",
       "dev": true,
       "dependencies": {
         "@types/fs-extra": "^8.0.1",
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.3.tgz",
-      "integrity": "sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==",
+      "version": "5.19.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.4.tgz",
+      "integrity": "sha512-6p1DjHeuluwxDXcuT9VR8p64klWJKo1ILiy19s6C9+0Bh2+NWTX6nD9EPppiER4ICkHDVB1RkVpin/YW2nQn/g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^5.1.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#8.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.35.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.36.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1692081744"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205458963331598/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass