### PR TITLE
Android: Resizing screen causes page reload

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -226,7 +226,7 @@
 
         <activity
             android:name=".BrowserActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout"
             android:exported="true"
             android:label="@string/appDescription"
             android:launchMode="singleTask"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205464181403832/f

### Description
Added `smallestScreenSize` and `screenLayout` to `configChanges` for `BrowserActivity`. 

### Steps to test this PR

Reproduce:
- [x] Install from develop.
- [x] Open the app and navigate on a website.
- [x] Enter split screen with another app.
- [x] Resize / change the split screen ratio between the two apps.
- [x] Notice the website is reloaded in the DDG app with every resize.

Test the fix:
- [x] Install from this branch.
- [x] Open the app and navigate on a website.
- [x] Enter split screen with another app.
- [x] Resize / change the split screen ratio between the two apps.
- [x] Notice the website is NOT reloaded in the DDG app with every resize.

### NO UI changes
