### PR TITLE
Update tests to point to new privacy page URL

### DIFF
--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -11,7 +11,7 @@ tags:
 
 - tapOn:
     text: "search or type URL"
-- inputText: "https://privacy-test-pages.glitch.me"
+- inputText: "https://privacy-test-pages.site"
 - tapOn:
     id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
 - assertVisible:

--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -11,7 +11,7 @@ tags:
 
 - tapOn:
     text: "search or type URL"
-- inputText: "https://privacy-test-pages.glitch.me"
+- inputText: "https://privacy-test-pages.site"
 - tapOn:
     id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
 - assertVisible:

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -11,7 +11,7 @@ tags:
 
 - tapOn:
     text: "search or type URL"
-- inputText: "https://privacy-test-pages.glitch.me"
+- inputText: "https://privacy-test-pages.site"
 - tapOn:
     id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
 - assertVisible:

--- a/.maestro/favorites/favorites_bookmarks_undo.yaml
+++ b/.maestro/favorites/favorites_bookmarks_undo.yaml
@@ -11,7 +11,7 @@ tags:
 
 - tapOn:
     text: "search or type URL"
-- inputText: "https://privacy-test-pages.glitch.me"
+- inputText: "https://privacy-test-pages.site"
 - tapOn:
     id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
 - assertVisible:

--- a/.maestro/favorites/favorites_menu_add_remove.yaml
+++ b/.maestro/favorites/favorites_menu_add_remove.yaml
@@ -11,7 +11,7 @@ tags:
 
 - tapOn:
     text: "search or type URL"
-- inputText: "https://privacy-test-pages.glitch.me"
+- inputText: "https://privacy-test-pages.site"
 - tapOn:
     id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
 - assertVisible:

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -11,7 +11,7 @@ tags:
 
 - tapOn:
     text: "search or type URL"
-- inputText: "https://privacy-test-pages.glitch.me"
+- inputText: "https://privacy-test-pages.site"
 - tapOn:
     id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
 - assertVisible:

--- a/.maestro/privacy_tests/10_-_Query_Parameters,_utm_source_and_1_standard_parameter.yaml
+++ b/.maestro/privacy_tests/10_-_Query_Parameters,_utm_source_and_1_standard_parameter.yaml
@@ -5,7 +5,7 @@ tags:
 - launchApp:
     clearState: true
 - runFlow: ../shared/onboarding.yaml
-- inputText: "https://privacy-test-pages.glitch.me/privacy-protections/query-parameters/"
+- inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
 - pressKey: Enter
 - assertVisible:
     text: ".*Got It.*"

--- a/.maestro/privacy_tests/11_-_Query_Parameters,_utm_source_and_utm_medium.yaml
+++ b/.maestro/privacy_tests/11_-_Query_Parameters,_utm_source_and_utm_medium.yaml
@@ -5,7 +5,7 @@ tags:
 - launchApp:
     clearState: true
 - runFlow: ../shared/onboarding.yaml
-- inputText: "https://privacy-test-pages.glitch.me/privacy-protections/query-parameters/"
+- inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
 - pressKey: Enter
 - assertVisible:
     text: ".*Got It.*"

--- a/.maestro/privacy_tests/12_-_Query_Parameters,_fbclid,_fb_source_and_1_standard_parameter.yaml
+++ b/.maestro/privacy_tests/12_-_Query_Parameters,_fbclid,_fb_source_and_1_standard_parameter.yaml
@@ -5,7 +5,7 @@ tags:
 - launchApp:
     clearState: true
 - runFlow: ../shared/onboarding.yaml
-- inputText: "https://privacy-test-pages.glitch.me/privacy-protections/query-parameters/"
+- inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
 - pressKey: Enter
 - assertVisible:
     text: ".*Got It.*"

--- a/.maestro/privacy_tests/13_-_Query_Parameters,_link_which_should_not_be_rewritten.yaml
+++ b/.maestro/privacy_tests/13_-_Query_Parameters,_link_which_should_not_be_rewritten.yaml
@@ -5,7 +5,7 @@ tags:
 - launchApp:
     clearState: true
 - runFlow: ../shared/onboarding.yaml
-- inputText: "https://privacy-test-pages.glitch.me/privacy-protections/query-parameters/"
+- inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
 - pressKey: Enter
 - assertVisible:
     text: ".*Got It.*"

--- a/.maestro/tabs/open_multiple_tabs.yaml
+++ b/.maestro/tabs/open_multiple_tabs.yaml
@@ -14,7 +14,7 @@ tags:
       text: ".*I'll also upgrade the security of your connection if possible.*"
 - tapOn:
     text: "search or type URL"
-- inputText: "https://privacy-test-pages.glitch.me"
+- inputText: "https://privacy-test-pages.site"
 - tapOn:
     id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
 - assertVisible:

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/CookiesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/CookiesTest.kt
@@ -50,7 +50,7 @@ class CookiesTest {
     var activityScenarioRule = activityScenarioRule<BrowserActivity>(
         BrowserActivity.intent(
             InstrumentationRegistry.getInstrumentation().targetContext,
-            queryExtra = "https://privacy-test-pages.glitch.me/privacy-protections/storage-blocking/?store",
+            queryExtra = "https://privacy-test-pages.site/privacy-protections/storage-blocking/?store",
         ),
     )
 

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -62,7 +62,7 @@ class FingerprintProtectionTest {
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
                 InstrumentationRegistry.getInstrumentation().targetContext,
-                "https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/",
+                "https://privacy-test-pages.site/privacy-protections/fingerprinting/",
             ),
         )
         scenario.onActivity {

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
@@ -50,7 +50,7 @@ class GpcTest {
     var activityScenarioRule = activityScenarioRule<BrowserActivity>(
         BrowserActivity.intent(
             InstrumentationRegistry.getInstrumentation().targetContext,
-            queryExtra = "https://privacy-test-pages.glitch.me/privacy-protections/gpc/",
+            queryExtra = "https://privacy-test-pages.site/privacy-protections/gpc/",
         ),
     )
 

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/HttpsUpgradesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/HttpsUpgradesTest.kt
@@ -52,7 +52,7 @@ class HttpsUpgradesTest {
     var activityScenarioRule = activityScenarioRule<BrowserActivity>(
         BrowserActivity.intent(
             InstrumentationRegistry.getInstrumentation().targetContext,
-            queryExtra = "http://privacy-test-pages.glitch.me/privacy-protections/https-upgrades/",
+            queryExtra = "http://privacy-test-pages.site/privacy-protections/https-upgrades/",
         ),
     )
 

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
@@ -52,7 +52,7 @@ class RequestBlockingTest {
         ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
                 InstrumentationRegistry.getInstrumentation().targetContext,
-                "https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/?run",
+                "https://privacy-test-pages.site/privacy-protections/request-blocking/?run",
             ),
         )
 
@@ -84,7 +84,7 @@ class RequestBlockingTest {
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
                 InstrumentationRegistry.getInstrumentation().targetContext,
-                "https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/?run",
+                "https://privacy-test-pages.site/privacy-protections/request-blocking/?run",
             ),
         )
         scenario.onActivity {

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
@@ -58,7 +58,7 @@ class SurrogatesTest {
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
                 InstrumentationRegistry.getInstrumentation().targetContext,
-                "https://privacy-test-pages.glitch.me/privacy-protections/surrogates/",
+                "https://privacy-test-pages.site/privacy-protections/surrogates/",
             ),
         )
         scenario.onActivity {
@@ -95,7 +95,7 @@ class SurrogatesTest {
         val scenario = ActivityScenario.launch<BrowserActivity>(
             BrowserActivity.intent(
                 InstrumentationRegistry.getInstrumentation().targetContext,
-                "https://privacy-test-pages.glitch.me/privacy-protections/surrogates/",
+                "https://privacy-test-pages.site/privacy-protections/surrogates/",
             ),
         )
         scenario.onActivity {

--- a/app/src/internal/java/com/duckduckgo/app/audit/AuditSettingsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/audit/AuditSettingsViewModel.kt
@@ -90,15 +90,15 @@ class AuditSettingsViewModel @Inject constructor(
         const val STEP_1 = "https://cnn.com"
         const val STEP_2 = "https://gizmodo.com"
         const val STEP_3 = "https://httpbin.org/basic-auth/u/pw"
-        const val REQUEST_BLOCKING = "https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/?run"
-        const val HTTPS_UPGRADES = "http://privacy-test-pages.glitch.me/privacy-protections/https-upgrades/?run"
-        const val FIRE_BUTTON_STORE = "https://privacy-test-pages.glitch.me/privacy-protections/storage-blocking/?store"
-        const val FIRE_BUTTON_RETRIEVE = "https://privacy-test-pages.glitch.me/privacy-protections/storage-blocking/?retrive"
-        const val COOKIES_3P_STORE = "https://privacy-test-pages.glitch.me/privacy-protections/storage-blocking/?store"
-        const val COOKIES_3P_RETRIEVE = "https://privacy-test-pages.glitch.me/privacy-protections/storage-blocking/?retrive"
-        const val GPC = "https://privacy-test-pages.glitch.me/privacy-protections/gpc/?run"
+        const val REQUEST_BLOCKING = "https://privacy-test-pages.site/privacy-protections/request-blocking/?run"
+        const val HTTPS_UPGRADES = "http://privacy-test-pages.site/privacy-protections/https-upgrades/?run"
+        const val FIRE_BUTTON_STORE = "https://privacy-test-pages.site/privacy-protections/storage-blocking/?store"
+        const val FIRE_BUTTON_RETRIEVE = "https://privacy-test-pages.site/privacy-protections/storage-blocking/?retrive"
+        const val COOKIES_3P_STORE = "https://privacy-test-pages.site/privacy-protections/storage-blocking/?store"
+        const val COOKIES_3P_RETRIEVE = "https://privacy-test-pages.site/privacy-protections/storage-blocking/?retrive"
+        const val GPC = "https://privacy-test-pages.site/privacy-protections/gpc/?run"
         const val GPC_OTHER = "https://global-privacy-control.glitch.me/"
-        const val SURROGATES = "https://privacy-test-pages.glitch.me/privacy-protections/surrogates/"
-        val domainsUsed = listOf("privacy-test-pages.glitch.me", "privacy-test-pages.glitch.me")
+        const val SURROGATES = "https://privacy-test-pages.site/privacy-protections/surrogates/"
+        val domainsUsed = listOf("privacy-test-pages.site", "privacy-test-pages.site")
     }
 }

--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -294,7 +294,7 @@
                     "globalprivacycontrol.org",
                     "washingtonpost.com",
                     "nytimes.com",
-                    "privacy-test-pages.glitch.me"
+                    "privacy-test-pages.site"
                 ]
             }
         },

--- a/privacy-config/privacy-config-impl/src/test/resources/json/gpc.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/gpc.json
@@ -14,7 +14,7 @@
       "globalprivacycontrol.org",
       "washingtonpost.com",
       "nytimes.com",
-      "privacy-test-pages.glitch.me"
+      "privacy-test-pages.site"
     ]
   }
 }

--- a/privacy-config/privacy-config-impl/src/test/resources/json/gpc_min_supported_version.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/gpc_min_supported_version.json
@@ -15,7 +15,7 @@
       "globalprivacycontrol.org",
       "washingtonpost.com",
       "nytimes.com",
-      "privacy-test-pages.glitch.me"
+      "privacy-test-pages.site"
     ]
   }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205442219109577/f 

### Description
Updates the URLs for the privacy test pages since we've moved them to new infrastructure.

`Current: privacy-test-pages.glitch.me`
`New:     privacy-test-pages.site`

ℹ️  Note, `global-privacy-control.glitch.me` remains deliberately, as per [link](https://app.asana.com/0/0/1205403548898249/1205420985241292/f)

### Steps to test this PR

- [ ] Ensure maestro e2e tests pass (https://github.com/duckduckgo/Android/actions/runs/6157390651)
- [ ] Ensure privacy tests passed (https://github.com/duckduckgo/Android/actions/runs/6223122120)
