### PR TITLE
Add isForMainFrame browser error check

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -30,6 +30,7 @@ import androidx.core.net.toUri
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anrs.api.CrashLogger
 import com.duckduckgo.app.accessibility.AccessibilityManager
+import com.duckduckgo.app.browser.WebViewErrorResponse.BAD_URL
 import com.duckduckgo.app.browser.WebViewErrorResponse.CONNECTION
 import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.WebViewPixelName.WEB_RENDERER_GONE_CRASH
@@ -411,9 +412,9 @@ class BrowserWebViewClient @Inject constructor(
         error: WebResourceError?,
     ) {
         error?.let {
-            val error = parseErrorResponse(it)
-            if (error != OMITTED) {
-                webViewClientListener?.onReceivedError(error)
+            val parsedError = parseErrorResponse(it)
+            if (parsedError != OMITTED && request?.isForMainFrame == true) {
+                webViewClientListener?.onReceivedError(parsedError)
             }
         }
         super.onReceivedError(view, request, error)
@@ -422,7 +423,7 @@ class BrowserWebViewClient @Inject constructor(
     private fun parseErrorResponse(error: WebResourceError): WebViewErrorResponse {
         return if (error.errorCode == ERROR_HOST_LOOKUP) {
             when (error.description) {
-                "net::ERR_NAME_NOT_RESOLVED" -> WebViewErrorResponse.BAD_URL
+                "net::ERR_NAME_NOT_RESOLVED" -> BAD_URL
                 "net::ERR_INTERNET_DISCONNECTED" -> CONNECTION
                 else -> OMITTED
             }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1205515626714180/f

### Description
Adds `isForMainFrame` check when showing browser error.

### Steps to test this PR

- [ ] Checkout develop
- [ ] Go to https://worldometers.info
- [ ] Verify that the browser error is shown
- [ ] Checkout this branch
- [ ] Go to https://worldometers.info
- [ ] Verify that browser error is not shown