### PR TITLE
Android: Handle SSL protocol error

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -968,7 +968,7 @@ class BrowserTabFragment :
         omnibar.shieldIcon.isInvisible = true
         webView?.onPause()
         webView?.hide()
-        errorView.errorMessage.text = getString(errorType.errorId, url)
+        errorView.errorMessage.text = getString(errorType.errorId, url).html(requireContext())
         if (appTheme.isLightModeEnabled()) {
             errorView.yetiIcon?.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_yeti_light)
         } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -961,14 +961,14 @@ class BrowserTabFragment :
         errorView.errorLayout.gone()
     }
 
-    private fun showError(errorType: WebViewErrorResponse) {
+    private fun showError(errorType: WebViewErrorResponse, url: String?) {
         binding.browserLayout.gone()
         newBrowserTab.newTabLayout.gone()
         omnibar.appBarLayout.setExpanded(true)
         omnibar.shieldIcon.isInvisible = true
         webView?.onPause()
         webView?.hide()
-        errorView.errorMessage.setText(errorType.errorId)
+        errorView.errorMessage.text = getString(errorType.errorId, url)
         if (appTheme.isLightModeEnabled()) {
             errorView.yetiIcon?.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_yeti_light)
         } else {
@@ -1224,7 +1224,7 @@ class BrowserTabFragment :
                 includeShortcutToViewCredential = it.includeShortcutToViewCredential,
             )
 
-            is Command.WebViewError -> showError(it.errorType)
+            is Command.WebViewError -> showError(it.errorType, it.url)
             else -> {
                 // NO OP
             }
@@ -3176,7 +3176,7 @@ class BrowserTabFragment :
                     }
                 } else if (errorChanged) {
                     if (viewState.browserError != OMITTED) {
-                        showError(viewState.browserError)
+                        showError(viewState.browserError, webView?.url)
                     } else {
                         if (browserShowing) {
                             showBrowser()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -466,7 +466,7 @@ class BrowserTabViewModel @Inject constructor(
             val messageResourceId: Int,
         ) : Command()
 
-        data class WebViewError(val errorType: WebViewErrorResponse) : Command()
+        data class WebViewError(val errorType: WebViewErrorResponse, val url: String) : Command()
     }
 
     sealed class NavigationCommand : Command() {
@@ -2823,10 +2823,10 @@ class BrowserTabViewModel @Inject constructor(
         return false
     }
 
-    override fun onReceivedError(errorType: WebViewErrorResponse) {
+    override fun onReceivedError(errorType: WebViewErrorResponse, url: String) {
         browserViewState.value =
             currentBrowserViewState().copy(browserError = errorType, showPrivacyShield = false, showDaxIcon = false, showSearchIcon = false)
-        command.postValue(WebViewError(errorType))
+        command.postValue(WebViewError(errorType, url))
     }
 
     fun onAutofillMenuSelected() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -414,7 +414,7 @@ class BrowserWebViewClient @Inject constructor(
         error?.let {
             val parsedError = parseErrorResponse(it)
             if (parsedError != OMITTED && request?.isForMainFrame == true) {
-                webViewClientListener?.onReceivedError(parsedError)
+                webViewClientListener?.onReceivedError(parsedError, request.url.toString())
             }
         }
         super.onReceivedError(view, request, error)
@@ -427,6 +427,8 @@ class BrowserWebViewClient @Inject constructor(
                 "net::ERR_INTERNET_DISCONNECTED" -> CONNECTION
                 else -> OMITTED
             }
+        } else if (error.errorCode == ERROR_FAILED_SSL_HANDSHAKE && error.description == "net::ERR_SSL_PROTOCOL_ERROR") {
+            WebViewErrorResponse.SSL_PROTOCOL_ERROR
         } else {
             OMITTED
         }
@@ -454,4 +456,5 @@ enum class WebViewErrorResponse(@StringRes val errorId: Int) {
     BAD_URL(R.string.webViewErrorBadUrl),
     CONNECTION(R.string.webViewErrorNoConnection),
     OMITTED(R.string.webViewErrorNoConnection),
+    SSL_PROTOCOL_ERROR(R.string.webViewErrorSslProtocol),
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -94,5 +94,5 @@ interface WebViewClientListener {
     fun prefetchFavicon(url: String)
     fun linkOpenedInNewTab(): Boolean
     fun isActiveTab(): Boolean
-    fun onReceivedError(errorType: WebViewErrorResponse)
+    fun onReceivedError(errorType: WebViewErrorResponse, url: String)
 }

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -43,4 +43,5 @@
     <string name="webViewErrorTitle">DuckDuckGo can\'t load this page</string>
     <string name="webViewErrorNoConnection">The internet connection appears to be offline.</string>
     <string name="webViewErrorBadUrl">A server with the specified hostname could not be found.</string>
+    <string name="webViewErrorSslProtocol">The certificate for this server is invalid. You might be connecting to a server that is pretending to be \"%1$s\" which could put your confidential information at risk.</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -43,5 +43,5 @@
     <string name="webViewErrorTitle">DuckDuckGo can\'t load this page</string>
     <string name="webViewErrorNoConnection">The internet connection appears to be offline.</string>
     <string name="webViewErrorBadUrl">A server with the specified hostname could not be found.</string>
-    <string name="webViewErrorSslProtocol">The certificate for this server is invalid. You might be connecting to a server that is pretending to be \"%1$s\" which could put your confidential information at risk.</string>
+    <string name="webViewErrorSslProtocol"><![CDATA[The certificate for this server is invalid. You might be connecting to a server that is pretending to be <b>%1$s</b> which could put your confidential information at risk.]]></string>
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205507540854792/f

### Description
Updated to show an error screen when ssl protocol handshake error is encountered. 

### Steps to test this PR

- [x] Install from this branch.
- [x] Navigate to an insecure page (https, but no certificate, e.g router admin page).
- [x] Notice there is no shield icon shown. Notice the Yeti image with the below text, where the website_url is bold:
Title: `DuckDuckGo can't load this page.`
Description: `The certificate for this server is invalid. You might be connecting to a server that is pretending to be [website_url] which could put your confidential information at risk.`

### UI changes
| Before  | After |
| ------ | ----- |
|![ssl_protocol_error_before](https://github.com/duckduckgo/Android/assets/7963079/b54ccbd4-70f2-491a-9620-957b929a051a)|![ssl_error](https://github.com/duckduckgo/Android/assets/7963079/fe14a019-f07d-403f-a89f-9c820aea7d41)|


