### PR TITLE
Plugin point for pixels which get data stripped

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
@@ -37,8 +37,8 @@ class AtbAndAppVersionPixelRemovalInterceptor @Inject constructor(
     private val pixelsPlugin: PluginPoint<PixelRequiringDataCleaningPlugin>,
 ) : Interceptor, PixelInterceptorPlugin {
 
-    val pixels: List<String> by lazy {
-        pixelsPlugin.getPlugins().flatMap { it.names() }.distinct()
+    val pixels: Set<String> by lazy {
+        pixelsPlugin.getPlugins().flatMap { it.names() }.toSet()
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
@@ -16,9 +16,10 @@
 
 package com.duckduckgo.app.global.api
 
-import androidx.annotation.VisibleForTesting
 import com.duckduckgo.app.global.AppUrl
+import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.global.plugins.pixel.PixelInterceptorPlugin
+import com.duckduckgo.app.global.plugins.pixel.PixelRequiringDataCleaningPlugin
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.StatisticsPixelName
@@ -32,7 +33,14 @@ import okhttp3.Response
     scope = AppScope::class,
     boundType = PixelInterceptorPlugin::class,
 )
-class AtbAndAppVersionPixelRemovalInterceptor @Inject constructor() : Interceptor, PixelInterceptorPlugin {
+class AtbAndAppVersionPixelRemovalInterceptor @Inject constructor(
+    private val pixelsPlugin: PluginPoint<PixelRequiringDataCleaningPlugin>,
+) : Interceptor, PixelInterceptorPlugin {
+
+    val pixels: List<String> by lazy {
+        pixelsPlugin.getPlugins().flatMap { it.names() }.distinct()
+    }
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request().newBuilder()
         val pixel = chain.request().url.pathSegments.last()
@@ -55,11 +63,15 @@ class AtbAndAppVersionPixelRemovalInterceptor @Inject constructor() : Intercepto
     private fun isInPixelsList(pixel: String): Boolean {
         return pixels.firstOrNull { pixel.startsWith(it) } != null
     }
+}
 
-    companion object {
-        // list of pixels (pixel name or prefix) for which we'll remove the ATB and App version information
-        @VisibleForTesting
-        internal val pixels = listOf(
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelRequiringDataCleaningPlugin::class,
+)
+object PixelInterceptorPixelsRequiringDataCleaning : PixelRequiringDataCleaningPlugin {
+    override fun names(): List<String> {
+        return listOf(
             AppPixelName.EMAIL_TOOLTIP_DISMISSED.pixelName,
             AppPixelName.EMAIL_USE_ALIAS.pixelName,
             AppPixelName.EMAIL_USE_ADDRESS.pixelName,

--- a/common/common-utils/src/main/java/com/duckduckgo/app/global/plugins/pixel/PixelRequiringDataCleaningPlugin.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/app/global/plugins/pixel/PixelRequiringDataCleaningPlugin.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.plugins.pixel
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.AppScope
+
+/**
+ * A plugin point for pixels that require data cleaning.
+ * Pixels specified through this mechanism will have their ATB and App version information removed before pixel is sent.
+ */
+@ContributesPluginPoint(AppScope::class)
+interface PixelRequiringDataCleaningPlugin {
+    /**
+     * List of pixels (pixel name or prefix) for which we'll remove the ATB and App version information
+     */
+    fun names(): List<String>
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205520159940704/f 

### Description
Introduces a plugin point for defining pixels which should have their ATB and app version removed. These pixels are already defined, but defining them via the plugin point approach allows for more flexibility in _where_ the pixels are defined, allowing them to be created in other modules but still contribute towards this list which the `AtbAndAppVersionPixelRemovalInterceptor` will use.

### Steps to test this PR

- [ ] Take one of the pixels in the list and trigger the scenario where it will be used
  - e.g., `AppPixelName.EMAIL_USE_ADDRESS`
   - log into Email Protectio 
   - visit https://fill.dev/form/registration-email
   - tap on the email field
   - choose to use the personal duck address
   - verify in the logs or with a breakpoint that this is picked up as a special case and ATP/app version are removed by `AtbAndAppVersionPixelRemovalInterceptor` (e.g., add `Timber.d("Removing ATB and app version from pixel $pixel")` at line 49)