### PR TITLE
AppTPCompanyDetailsAdapter, index out of bounds exceptions

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyDetailsAdapter.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyDetailsAdapter.kt
@@ -80,9 +80,8 @@ class AppTPCompanyDetailsAdapter : RecyclerView.Adapter<AppTPCompanyDetailsAdapt
             DiffCallback(oldData, newData).run { DiffUtil.calculateDiff(this) }
         }
 
-        items.clear().also { items.addAll(newData) }
-
         withContext(Dispatchers.Main) {
+            items.clear().also { items.addAll(newData) }
             diffResult.dispatchUpdatesTo(this@AppTPCompanyDetailsAdapter)
         }
     }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
@@ -185,7 +185,7 @@ class AppTPCompanyTrackersActivity : DuckDuckGoActivity() {
         )
         binding.includeToolbar.appTrackedAgo.text = viewState.lastTrackerBlockedAgo
 
-        lifecycleScope.launch(dispatcherProvider.io()) {
+        lifecycleScope.launch {
             itemsAdapter.updateData(viewState.trackingCompanies)
         }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
@@ -150,25 +150,23 @@ class AppTPCompanyTrackersViewModel @Inject constructor(
         packageName: String,
     ) {
         viewModelScope.launch(dispatchers.io()) {
-            withContext(dispatchers.io()) {
-                if (checked) {
-                    deviceShieldPixels.didEnableAppProtectionFromDetail()
-                    excludedAppsRepository.manuallyEnabledApp(packageName)
-                } else {
-                    deviceShieldPixels.didDisableAppProtectionFromDetail()
-                    excludedAppsRepository.manuallyExcludeApp(packageName)
-                }
-                command.send(Command.RestartVpn)
-                val protectionState = excludedAppsRepository.getAppProtectionStatus(packageName)
-
-                viewStateFlow.emit(
-                    viewStateFlow.value.copy(
-                        toggleChecked = protectionState == PROTECTED,
-                        bannerState = protectionState.getBannerState(),
-                        toggleEnabled = protectionState != UNPROTECTED_THROUGH_NETP,
-                    ),
-                )
+            if (checked) {
+                deviceShieldPixels.didEnableAppProtectionFromDetail()
+                excludedAppsRepository.manuallyEnabledApp(packageName)
+            } else {
+                deviceShieldPixels.didDisableAppProtectionFromDetail()
+                excludedAppsRepository.manuallyExcludeApp(packageName)
             }
+            command.send(Command.RestartVpn)
+            val protectionState = excludedAppsRepository.getAppProtectionStatus(packageName)
+
+            viewStateFlow.emit(
+                viewStateFlow.value.copy(
+                    toggleChecked = protectionState == PROTECTED,
+                    bannerState = protectionState.getBannerState(),
+                    toggleEnabled = protectionState != UNPROTECTED_THROUGH_NETP,
+                ),
+            )
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205530419817941/f

### Description
Fixed crash in AppTPCompanyDetailsAdapter.

### Steps to test this PR

- [ ] Install from this branch.
- [ ] Enable AppTP and wait to have some trackers blocked.
- [ ] Tap on one of the trackers to see the company details. 
- [ ] Toggle OFF/ON to disable/enable protections from the button positioned on the top right. The app should not crash.

### NO UI changes
