### PR TITLE
Update voice search icon in widget based on settings

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/widget/VoiceSearchWidgetUpdaterReceiverTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/widget/VoiceSearchWidgetUpdaterReceiverTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.widget
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class VoiceSearchWidgetUpdaterReceiverTest {
+
+    private val testee = VoiceSearchWidgetUpdaterReceiver()
+    private val updater: WidgetUpdater = mock()
+
+    @Before
+    fun setup() {
+        testee.widgetUpdater = updater
+    }
+
+    @Test
+    fun whenProcessIntentThenShouldUpdateWidgets() {
+        val intent = Intent().apply {
+            action = Intent.ACTION_LOCALE_CHANGED
+        }
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        testee.processIntent(context, intent)
+
+        verify(updater).updateWidgets(any())
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -505,7 +505,7 @@
         </receiver>
 
         <receiver
-            android:name="com.duckduckgo.widget.VoiceSearchWidgetUpdater"
+            android:name="com.duckduckgo.widget.VoiceSearchWidgetUpdaterReceiver"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.LOCALE_CHANGED" />

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -265,6 +265,8 @@ class SystemSearchActivity : DuckDuckGoActivity() {
             voiceSearchLauncher.registerResultsCallback(this, this, WIDGET) {
                 if (it is VoiceSearchLauncher.Event.VoiceRecognitionSuccess) {
                     viewModel.onUserSelectedToEditQuery(it.result)
+                } else if (it is VoiceSearchLauncher.Event.VoiceSearchDisabled) {
+                    viewModel.voiceSearchDisabled()
                 }
             }
             voiceSearch.setOnClickListener {
@@ -366,6 +368,9 @@ class SystemSearchActivity : DuckDuckGoActivity() {
             }
             is DeleteSavedSiteConfirmation -> {
                 confirmDeleteSavedSite(command.savedSite)
+            }
+            is UpdateVoiceSearch -> {
+                configureVoiceSearch()
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.onboarding.store.isNewUser
 import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.UpdateVoiceSearch
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite
@@ -91,6 +92,8 @@ class SystemSearchViewModel @Inject constructor(
         data class ShowAppNotFoundMessage(val appName: String) : Command()
         object DismissKeyboard : Command()
         data class EditQuery(val query: String) : Command()
+
+        object UpdateVoiceSearch : Command()
     }
 
     val onboardingViewState: MutableLiveData<OnboardingViewState> = MutableLiveData()
@@ -345,5 +348,9 @@ class SystemSearchViewModel @Inject constructor(
             }
             else -> throw IllegalArgumentException("Illegal SavedSite to delete received")
         }
+    }
+
+    fun voiceSearchDisabled() {
+        command.value = UpdateVoiceSearch
     }
 }

--- a/app/src/main/java/com/duckduckgo/widget/VoiceSearchWidgetUpdaterReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/widget/VoiceSearchWidgetUpdaterReceiver.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.widget
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_LOCALE_CHANGED
+import dagger.android.AndroidInjection
+import javax.inject.Inject
+
+class VoiceSearchWidgetUpdaterReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var widgetUpdater: WidgetUpdater
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        AndroidInjection.inject(this, context)
+        if (intent.action == ACTION_LOCALE_CHANGED) {
+            widgetUpdater.updateWidgets(context)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/widget/VoiceSearchWidgetUpdaterReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/widget/VoiceSearchWidgetUpdaterReceiver.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.Intent.ACTION_LOCALE_CHANGED
 import dagger.android.AndroidInjection
+import org.jetbrains.annotations.VisibleForTesting
 import javax.inject.Inject
 
 class VoiceSearchWidgetUpdaterReceiver : BroadcastReceiver() {
@@ -32,6 +33,11 @@ class VoiceSearchWidgetUpdaterReceiver : BroadcastReceiver() {
         intent: Intent,
     ) {
         AndroidInjection.inject(this, context)
+        processIntent(context, intent)
+    }
+
+    @VisibleForTesting
+    fun processIntent(context: Context, intent: Intent) {
         if (intent.action == ACTION_LOCALE_CHANGED) {
             widgetUpdater.updateWidgets(context)
         }

--- a/app/src/main/java/com/duckduckgo/widget/VoiceSearchWidgetUpdaterReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/widget/VoiceSearchWidgetUpdaterReceiver.kt
@@ -21,8 +21,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.Intent.ACTION_LOCALE_CHANGED
 import dagger.android.AndroidInjection
-import org.jetbrains.annotations.VisibleForTesting
 import javax.inject.Inject
+import org.jetbrains.annotations.VisibleForTesting
 
 class VoiceSearchWidgetUpdaterReceiver : BroadcastReceiver() {
 

--- a/app/src/main/java/com/duckduckgo/widget/WidgetUpdater.kt
+++ b/app/src/main/java/com/duckduckgo/widget/WidgetUpdater.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2023 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,24 +17,21 @@
 package com.duckduckgo.widget
 
 import android.appwidget.AppWidgetManager
-import android.appwidget.AppWidgetManager.ACTION_APPWIDGET_UPDATE
-import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.Intent.ACTION_LOCALE_CHANGED
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
 
-class VoiceSearchWidgetUpdater : BroadcastReceiver() {
-    override fun onReceive(
-        context: Context,
-        intent: Intent,
-    ) {
-        if (intent.action == ACTION_LOCALE_CHANGED) {
-            updateWidgets(context.applicationContext)
-        }
-    }
+interface WidgetUpdater {
+    fun updateWidgets(context: Context)
+}
 
-    private fun updateWidgets(context: Context) {
+@ContributesBinding(AppScope::class)
+class WidgetUpdaterImpl @Inject constructor() : WidgetUpdater {
+
+    override fun updateWidgets(context: Context) {
         AppWidgetManager.getInstance(context).getAppWidgetIds(ComponentName(context, SearchWidget::class.java))?.also {
             broadcastUpdate(
                 it,
@@ -66,7 +63,7 @@ class VoiceSearchWidgetUpdater : BroadcastReceiver() {
         clazz: Class<*>,
     ) {
         val intent = Intent(context, clazz)
-        intent.action = ACTION_APPWIDGET_UPDATE
+        intent.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
         intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, id)
         context.sendBroadcast(intent)
     }

--- a/app/src/main/java/com/duckduckgo/widget/WidgetVoiceSearchStatusListener.kt
+++ b/app/src/main/java/com/duckduckgo/widget/WidgetVoiceSearchStatusListener.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.widget
+
+import android.content.Context
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.voice.api.VoiceSearchStatusListener
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class WidgetVoiceSearchStatusListener @Inject constructor(
+    private val context: Context,
+    private val widgetUpdater: WidgetUpdater,
+) : VoiceSearchStatusListener {
+
+    override fun voiceSearchStatusChanged() {
+        widgetUpdater.updateWidgets(context)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckDuckGo
+import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.UpdateVoiceSearch
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.SystemSearchResultsViewState
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
@@ -383,6 +384,14 @@ class SystemSearchViewModelTest {
         val viewState = testee.resultsViewState.value as SystemSearchViewModel.Suggestions.QuickAccessItems
         assertEquals(1, viewState.favorites.size)
         assertEquals(savedSite, viewState.favorites.first().favorite)
+    }
+
+    @Test
+    fun whenVoiceSearchDisabledThenShouldEmitUpdateVoiceSearchCommand() {
+        testee.voiceSearchDisabled()
+
+        verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertEquals(UpdateVoiceSearch, commandCaptor.lastValue)
     }
 
     private suspend fun whenOnboardingShowing() {

--- a/app/src/test/java/com/duckduckgo/widget/WidgetVoiceSearchStatusListenerTest.kt
+++ b/app/src/test/java/com/duckduckgo/widget/WidgetVoiceSearchStatusListenerTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.widget
+
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class WidgetVoiceSearchStatusListenerTest {
+
+    private val widgetUpdater: WidgetUpdater = mock()
+    private val testee = WidgetVoiceSearchStatusListener(mock(), widgetUpdater)
+
+    @Test
+    fun whenVoiceSearchStatusChangedThenShouldUpdateWidgets() {
+        testee.voiceSearchStatusChanged()
+
+        verify(widgetUpdater).updateWidgets(any())
+    }
+}

--- a/voice-search/voice-search-api/src/main/java/com/duckduckgo/voice/api/VoiceSearchStatusListener.kt
+++ b/voice-search/voice-search-api/src/main/java/com/duckduckgo/voice/api/VoiceSearchStatusListener.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.voice.api
+
+interface VoiceSearchStatusListener {
+    fun voiceSearchStatusChanged()
+}

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/di/VoiceSearchModule.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/di/VoiceSearchModule.kt
@@ -21,6 +21,7 @@ import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.voice.api.VoiceSearchStatusListener
 import com.duckduckgo.voice.impl.remoteconfig.RealVoiceSearchFeatureRepository
 import com.duckduckgo.voice.impl.remoteconfig.VoiceSearchFeatureRepository
 import com.duckduckgo.voice.impl.remoteconfig.VoiceSearchSetting
@@ -44,8 +45,8 @@ import kotlinx.coroutines.CoroutineScope
 object VoiceSearchModule {
     @SingleInstanceIn(AppScope::class)
     @Provides
-    fun provideVoiceSearchRepository(dataStore: VoiceSearchDataStore): VoiceSearchRepository {
-        return RealVoiceSearchRepository(dataStore)
+    fun provideVoiceSearchRepository(dataStore: VoiceSearchDataStore, voiceSearchStatusListener: VoiceSearchStatusListener): VoiceSearchRepository {
+        return RealVoiceSearchRepository(dataStore, voiceSearchStatusListener)
     }
 
     @SingleInstanceIn(AppScope::class)

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/listeningmode/VoiceSearchActivity.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/listeningmode/VoiceSearchActivity.kt
@@ -23,7 +23,6 @@ import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.os.Bundle
-import android.view.WindowManager
 import androidx.core.view.postDelayed
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -51,8 +50,7 @@ class VoiceSearchActivity : DuckDuckGoActivity() {
         const val VOICE_SEARCH_ERROR = 1
     }
 
-    @Inject
-    lateinit var appBuildConfig: AppBuildConfig
+    @Inject lateinit var appBuildConfig: AppBuildConfig
 
     private val viewModel: VoiceSearchViewModel by bindViewModel()
     private val binding: ActivityVoiceSearchBinding by viewBinding()
@@ -67,11 +65,13 @@ class VoiceSearchActivity : DuckDuckGoActivity() {
         observeViewModel()
     }
 
+    @SuppressLint("NewApi")
     private fun configureViews() {
-        window.setFlags(
-            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
-            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
-        )
+        if (appBuildConfig.sdkInt >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(false)
+            window.statusBarColor = Color.TRANSPARENT
+            window.navigationBarColor = Color.TRANSPARENT
+        }
         binding.indicator.onAction {
             if (it == INDICATOR_CLICKED) {
                 viewModel.userInitiatesSearchComplete()

--- a/voice-search/voice-search-impl/src/main/res/drawable/ic_microphone_dark.xml
+++ b/voice-search/voice-search-impl/src/main/res/drawable/ic_microphone_dark.xml
@@ -20,9 +20,9 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="?attr/daxColorWhite"
+        android:fillColor="@color/white84"
         android:pathData="M9,6C9,4.3432 10.3431,3 12,3C13.6569,3 15,4.3432 15,6V11C15,12.6569 13.6569,14 12,14C10.3431,14 9,12.6569 9,11V6Z" />
     <path
-        android:fillColor="?attr/daxColorWhite"
+        android:fillColor="@color/white84"
         android:pathData="M7,19C6.4477,19 6,19.4477 6,20C6,20.5523 6.4477,21 7,21H17C17.5523,21 18,20.5523 18,20C18,19.4477 17.5523,19 17,19H13V17.9291C16.3923,17.4439 19,14.5265 19,11C19,10.4477 18.5523,10 18,10C17.4477,10 17,10.4477 17,11C17,13.7614 14.7614,16 12,16C9.2386,16 7,13.7614 7,11C7,10.4477 6.5523,10 6,10C5.4477,10 5,10.4477 5,11C5,14.5265 7.6077,17.4439 11,17.9291V19H7Z" />
 </vector>

--- a/voice-search/voice-search-impl/src/main/res/layout/activity_voice_search.xml
+++ b/voice-search/voice-search-impl/src/main/res/layout/activity_voice_search.xml
@@ -19,13 +19,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:alpha="0.85"
-    android:background="?attr/daxColorBackground">
+    android:background="?attr/daxColorBackground"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:layout_marginTop="@dimen/keyline_5"
         android:background="@android:color/transparent"
         android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
         app:layout_constraintTop_toTopOf="parent"

--- a/voice-search/voice-search-store/build.gradle
+++ b/voice-search/voice-search-store/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation AndroidX.room.runtime
     implementation AndroidX.room.ktx
 
+    implementation project(':voice-search-api')
+
     testImplementation Testing.junit4
 }
 android {

--- a/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchRepository.kt
+++ b/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchRepository.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.voice.store
 
+import com.duckduckgo.voice.api.VoiceSearchStatusListener
+
 interface VoiceSearchRepository {
     fun declinePermissionForever()
     fun acceptRationaleDialog()
@@ -36,6 +38,7 @@ interface VoiceSearchRepository {
 
 class RealVoiceSearchRepository constructor(
     private val dataStore: VoiceSearchDataStore,
+    private val voiceSearchStatusListener: VoiceSearchStatusListener,
 ) : VoiceSearchRepository {
     override fun declinePermissionForever() {
         dataStore.permissionDeclinedForever = true
@@ -59,6 +62,7 @@ class RealVoiceSearchRepository constructor(
 
     override fun setVoiceSearchUserEnabled(enabled: Boolean) {
         dataStore.isVoiceSearchEnabled = enabled
+        voiceSearchStatusListener.voiceSearchStatusChanged()
     }
 
     override fun declineNoMicAccessDialog() {

--- a/voice-search/voice-search-store/src/test/java/com/duckduckgo/voice/store/RealVoiceSearchRepositoryTest.kt
+++ b/voice-search/voice-search-store/src/test/java/com/duckduckgo/voice/store/RealVoiceSearchRepositoryTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.voice.store
 
+import com.duckduckgo.voice.api.VoiceSearchStatusListener
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -25,12 +26,12 @@ import org.junit.Test
 class RealVoiceSearchRepositoryTest {
 
     private lateinit var testee: RealVoiceSearchRepository
-    private lateinit var dataSource: FakeVoiceSearchDataStore
+    private var dataSource = FakeVoiceSearchDataStore()
+    private var voiceSearchStatusListener = FakeVoiceSearchStatusListener()
 
     @Before
     fun setUp() {
-        dataSource = FakeVoiceSearchDataStore()
-        testee = RealVoiceSearchRepository(dataSource)
+        testee = RealVoiceSearchRepository(dataSource, voiceSearchStatusListener)
     }
 
     @Test
@@ -70,6 +71,13 @@ class RealVoiceSearchRepositoryTest {
     }
 
     @Test
+    fun whenSetVoiceSearchEnabledThenListenerShouldBeCalled() {
+        testee.setVoiceSearchUserEnabled(true)
+
+        assertTrue(voiceSearchStatusListener.statusChanged)
+    }
+
+    @Test
     fun whenDismissVoiceSearchThenCountVoiceSearchDismissedValueShouldIncrease() {
         assertEquals(0, testee.countVoiceSearchDismissed())
 
@@ -95,4 +103,13 @@ class FakeVoiceSearchDataStore : VoiceSearchDataStore {
     override var isVoiceSearchEnabled: Boolean = false
     override var countVoiceSearchDismissed: Int = 0
     override var noMicAccessDialogDeclined: Boolean = false
+}
+
+class FakeVoiceSearchStatusListener : VoiceSearchStatusListener {
+
+    var statusChanged: Boolean = false
+        private set
+    override fun voiceSearchStatusChanged() {
+        statusChanged = true
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205518480388653/f

### Description
* Update widgets whenever voice search feature is toggled on/off
* Fix dark search widget not showing voice search icon

### Steps to test this PR

_Feature 1_
- [x] On a compatible device (Android 13, language English_US) add all DDG widgets to the screen
- [x] Open the app, go to accessibility settings, and toggle voice search
- [x] Check the icon on the widget updates accordingly

_Feature 2_
- [x] On a compatible device (Android 13, language English_US) add all DDG widgets to the screen
- [x] Open the app, go to accessibility settings, and make sure voice search is on
- [x] Tap the voice search icon on the address bar, and grant all all permissions
- [x] Once the voice search screen is shown, press the back button
- [x] Repeat the 2 previous steps two more times
- [x] When the dialog appears, tap on remove voice search
- [x] Check the icon on the widget disappears

### UI changes
![voicesearchwidget](https://github.com/duckduckgo/Android/assets/6297834/3dcef818-15f2-40c6-aa54-e64d320746e0)

