### PR TITLE
Remove the notification style from XML

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/res/layout/notification_device_shield_disabled.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/notification_device_shield_disabled.xml
@@ -24,7 +24,6 @@
     <TextView
             tools:ignore="DeprecatedWidgetInXml"
             android:id="@+id/deviceShieldNotificationHeader"
-            style="@style/TextAppearance.Compat.Notification"
             android:layout_gravity="center"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/notification_device_shield_report.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/notification_device_shield_report.xml
@@ -25,7 +25,6 @@
     <TextView
         tools:ignore="DeprecatedWidgetInXml"
         android:id="@+id/deviceShieldNotificationText"
-        style="@style/TextAppearance.Compat.Notification"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/notification_device_shield_revoked.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/notification_device_shield_revoked.xml
@@ -24,7 +24,6 @@
     <TextView
         tools:ignore="DeprecatedWidgetInXml"
         android:id="@+id/deviceShieldNotificationHeader"
-        style="@style/TextAppearance.Compat.Notification"
         android:layout_gravity="center"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/notification_vpn_enabled.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/notification_vpn_enabled.xml
@@ -24,7 +24,6 @@
     <TextView
         tools:ignore="DeprecatedWidgetInXml"
         android:id="@+id/deviceShieldNotificationHeader"
-        style="@style/TextAppearance.Compat.Notification"
         android:layout_weight="1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205523868092365/f

### Description
TextView `style` defined in the AppTP notifications seems to conflict (and crash) in some devices as we also use `setStyle` in the notification builder.
This PR so removes the `style` attribute from the XML custom notification layout(s)

### Steps to test this PR
Test that all AppTP enable/disable/revoke/report notifications display properly
