### PR TITLE
Use closest most popular user agent

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
@@ -29,6 +29,8 @@ import com.duckduckgo.app.fakes.FeatureToggleFake
 import com.duckduckgo.app.fakes.UserAgentFake
 import com.duckduckgo.app.fakes.UserAllowListRepositoryFake
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
+import com.duckduckgo.app.statistics.model.Atb
+import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.surrogates.ResourceSurrogates
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.trackerdetection.CloakedCnameDetector
@@ -83,6 +85,7 @@ class WebViewRequestInterceptorTest {
         fakeUserAgent,
         fakeToggle,
         fakeUserAllowListRepository,
+        FakeStatisticsDataStore(),
     )
 
     private var webView: WebView = mock()
@@ -806,5 +809,21 @@ class WebViewRequestInterceptorTest {
         const val DEFAULT =
             "Mozilla/5.0 (Linux; Android 8.1.0; Nexus 6P Build/OPM3.171019.014) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36"
+    }
+
+    class FakeStatisticsDataStore : StatisticsDataStore {
+        override val hasInstallationStatistics: Boolean = false
+
+        override var atb: Atb? = Atb("v123-4")
+
+        override var appRetentionAtb: String? = ""
+
+        override var searchRetentionAtb: String? = ""
+
+        override var variant: String? = ""
+
+        override var referrerVariant: String? = ""
+        override fun saveAtb(atb: Atb) {}
+        override fun clearAtb() {}
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/fakes/UserAgentFake.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fakes/UserAgentFake.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.app.fakes
 
+import com.duckduckgo.privacy.config.api.DefaultPolicy
+import com.duckduckgo.privacy.config.api.DefaultPolicy.DDG
 import com.duckduckgo.privacy.config.api.UserAgent
 
 class UserAgentFake : UserAgent {
@@ -24,4 +26,18 @@ class UserAgentFake : UserAgent {
     override fun isAVersionException(url: String): Boolean = false
 
     override fun isADefaultException(url: String): Boolean = false
+
+    override fun defaultPolicy(): DefaultPolicy = DDG
+
+    override fun isADdgDefaultSite(url: String): Boolean = false
+
+    override fun isADdgFixedSite(url: String): Boolean = false
+
+    override fun closestUserAgentEnabled(): Boolean = false
+
+    override fun ddgFixedUserAgentEnabled(): Boolean = false
+
+    override fun isClosestUserAgentVersion(version: String): Boolean = false
+
+    override fun isDdgFixedUserAgentVersion(version: String): Boolean = false
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
@@ -61,6 +61,7 @@ class ApiRequestInterceptorTest {
             fakeUserAgent,
             fakeToggle,
             fakeUserAllowListRepository,
+            mock(),
         )
 
         testee = ApiRequestInterceptor(

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -117,6 +117,7 @@ class DomainsReferenceTest(private val testCase: TestCase) {
         fakeUserAgent,
         fakeToggle,
         fakeUserAllowListRepository,
+        mock(),
     )
     private val mockGpc: Gpc = mock()
     private val mockAdClickManager: AdClickManager = mock()

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -112,6 +112,7 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
         fakeUserAgent,
         fakeToggle,
         fakeUserAllowListRepository,
+        mock(),
     )
     private val mockGpc: Gpc = mock()
     private val mockAdClickManager: AdClickManager = mock()

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UserAgent.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UserAgent.kt
@@ -41,6 +41,52 @@ interface UserAgent {
      * otherwise.
      */
     fun isADefaultException(url: String): Boolean
+
+    /**
+     * This method returns the default user agent policy [DefaultPolicy]
+     * @return the default policy [DefaultPolicy]
+     */
+    fun defaultPolicy(): DefaultPolicy
+
+    /**
+     * This method takes a [url] and returns `true` or `false` depending if the [url] is in the
+     * DDG default sites list
+     * @return a `true` if the given [url] is in the DDG default sites list and `false` otherwise.
+     */
+    fun isADdgDefaultSite(url: String): Boolean
+
+    /**
+     * This method takes a [url] and returns `true` or `false` depending if the [url] is in the
+     * DDG fixed sites list
+     * @return a `true` if the given [url] is in the DDG fixed sites list and `false` otherwise.
+     */
+    fun isADdgFixedSite(url: String): Boolean
+
+    /**
+     * This method returns `true` or `false` depending if the closest user agent policy is enabled or not
+     * @return a `true` if the closest user agent is enabled and `false` otherwise.
+     */
+    fun closestUserAgentEnabled(): Boolean
+
+    /**
+     * This method returns `true` or `false` depending if the DDG fixed user agent policy is enabled or not
+     * @return a `true` if the DDG fixed user agent is enabled and `false` otherwise.
+     */
+    fun ddgFixedUserAgentEnabled(): Boolean
+
+    /**
+     * This method takes a [version] and returns `true` or `false` depending if the [version] is in the
+     * closest user agent versions list
+     * @return a `true` if the given [version] is in the closest user agent versions and `false` otherwise.
+     */
+    fun isClosestUserAgentVersion(version: String): Boolean
+
+    /**
+     * This method takes a [version] and returns `true` or `false` depending if the [version] is in the
+     * ddg fixed user agent versions list
+     * @return a `true` if the given [version] is in the ddg fixed user agent versions and `false` otherwise.
+     */
+    fun isDdgFixedUserAgentVersion(version: String): Boolean
 }
 
 /** Public data class for User Agent Exceptions */
@@ -48,3 +94,8 @@ data class UserAgentException(
     val domain: String,
     val reason: String,
 )
+
+/** Public enum class for the default policy */
+enum class DefaultPolicy {
+    DDG, DDG_FIXED, CLOSEST
+}

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgent.kt
@@ -18,6 +18,10 @@ package com.duckduckgo.privacy.config.impl.features.useragent
 
 import com.duckduckgo.app.global.UriString
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.DefaultPolicy
+import com.duckduckgo.privacy.config.api.DefaultPolicy.CLOSEST
+import com.duckduckgo.privacy.config.api.DefaultPolicy.DDG
+import com.duckduckgo.privacy.config.api.DefaultPolicy.DDG_FIXED
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.api.UserAgent
 import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
@@ -40,5 +44,38 @@ class RealUserAgent @Inject constructor(
 
     override fun isADefaultException(url: String): Boolean {
         return unprotectedTemporary.isAnException(url) || userAgentRepository.defaultExceptions.any { UriString.sameOrSubdomain(url, it.domain) }
+    }
+
+    override fun defaultPolicy(): DefaultPolicy {
+        return when (userAgentRepository.defaultPolicy) {
+            "ddg" -> { DDG }
+            "ddgFixed" -> { DDG_FIXED }
+            "closest" -> { CLOSEST }
+            else -> { DDG }
+        }
+    }
+
+    override fun isADdgDefaultSite(url: String): Boolean {
+        return userAgentRepository.ddgDefaultSites.any { UriString.sameOrSubdomain(url, it.domain) }
+    }
+
+    override fun isADdgFixedSite(url: String): Boolean {
+        return userAgentRepository.ddgFixedSites.any { UriString.sameOrSubdomain(url, it.domain) }
+    }
+
+    override fun closestUserAgentEnabled(): Boolean {
+        return userAgentRepository.closestUserAgentState
+    }
+
+    override fun ddgFixedUserAgentEnabled(): Boolean {
+        return userAgentRepository.ddgFixedUserAgentState
+    }
+
+    override fun isClosestUserAgentVersion(version: String): Boolean {
+        return userAgentRepository.closestUserAgentVersions.contains(version)
+    }
+
+    override fun isDdgFixedUserAgentVersion(version: String): Boolean {
+        return userAgentRepository.ddgFixedUserAgentVersions.contains(version)
     }
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentFeature.kt
@@ -29,6 +29,31 @@ data class UserAgentExceptionJson(
 )
 
 data class UserAgentSettings(
+    val defaultPolicy: String,
+    val ddgDefaultSites: List<DdgDefaultSite>,
+    val ddgFixedSites: List<DdgFixedSite>,
+    val closestUserAgent: ClosestUserAgent,
+    val ddgFixedUserAgent: DdgFixedUserAgent,
     val omitApplicationSites: List<UserAgentExceptionJson>,
     val omitVersionSites: List<UserAgentExceptionJson>,
+)
+
+data class DdgDefaultSite(
+    val domain: String,
+    val reason: String,
+)
+
+data class DdgFixedSite(
+    val domain: String,
+    val reason: String,
+)
+
+data class ClosestUserAgent(
+    val versions: List<String>,
+    val state: String,
+)
+
+data class DdgFixedUserAgent(
+    val versions: List<String>,
+    val state: String,
 )

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgentTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgentTest.kt
@@ -17,6 +17,9 @@
 package com.duckduckgo.privacy.config.impl.features.useragent
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.privacy.config.api.DefaultPolicy.CLOSEST
+import com.duckduckgo.privacy.config.api.DefaultPolicy.DDG
+import com.duckduckgo.privacy.config.api.DefaultPolicy.DDG_FIXED
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.api.UserAgentException
 import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
@@ -109,6 +112,132 @@ class RealUserAgentTest {
         whenever(mockUserAgentRepository.omitVersionExceptions).thenReturn(CopyOnWriteArrayList())
 
         assertFalse(testee.isAVersionException("http://test.example.com"))
+    }
+
+    fun whenIsDdgDefaultSiteThenReturnTrue() {
+        val ddgDefaultSites =
+            CopyOnWriteArrayList<UserAgentException>().apply {
+                add(UserAgentException("example.com", "my reason here"))
+            }
+        whenever(mockUserAgentRepository.ddgDefaultSites).thenReturn(ddgDefaultSites)
+
+        assertTrue(testee.isADdgDefaultSite("example.com"))
+    }
+
+    fun whenIsNotDdgDefaultSiteThenReturnFalse() {
+        val ddgDefaultSites =
+            CopyOnWriteArrayList<UserAgentException>().apply {
+                add(UserAgentException("foo.com", "my reason here"))
+            }
+        whenever(mockUserAgentRepository.ddgDefaultSites).thenReturn(ddgDefaultSites)
+
+        assertFalse(testee.isADdgDefaultSite("example.com"))
+    }
+
+    fun whenIsDdgFixedSiteThenReturnTrue() {
+        val ddgFixedSites =
+            CopyOnWriteArrayList<UserAgentException>().apply {
+                add(UserAgentException("example.com", "my reason here"))
+            }
+        whenever(mockUserAgentRepository.ddgFixedSites).thenReturn(ddgFixedSites)
+
+        assertTrue(testee.isADdgFixedSite("example.com"))
+    }
+
+    fun whenIsNotDdgFixedSiteThenReturnFalse() {
+        val ddgFixedSites =
+            CopyOnWriteArrayList<UserAgentException>().apply {
+                add(UserAgentException("foo.com", "my reason here"))
+            }
+        whenever(mockUserAgentRepository.ddgFixedSites).thenReturn(ddgFixedSites)
+
+        assertFalse(testee.isADdgFixedSite("example.com"))
+    }
+
+    fun whenDefaultPolicyIsDdgThenReturnDdg() {
+        whenever(mockUserAgentRepository.defaultPolicy).thenReturn("ddg")
+
+        assertEquals(DDG, testee.defaultPolicy())
+    }
+
+    fun whenDefaultPolicyIsDdgFixedThenReturnDdgFixed() {
+        whenever(mockUserAgentRepository.defaultPolicy).thenReturn("ddgFixed")
+
+        assertEquals(DDG_FIXED, testee.defaultPolicy())
+    }
+
+    fun whenDefaultPolicyIsClosestThenReturnClosest() {
+        whenever(mockUserAgentRepository.defaultPolicy).thenReturn("closest")
+
+        assertEquals(CLOSEST, testee.defaultPolicy())
+    }
+
+    @Test
+    fun whenClosestUserAgentEnabledAndClosestUserAgentStateIsTrueThenReturnTrue() {
+        whenever(mockUserAgentRepository.closestUserAgentState).thenReturn(true)
+
+        assertTrue(testee.closestUserAgentEnabled())
+    }
+
+    @Test
+    fun whenClosestUserAgentEnabledAndClosestUserAgentStateIsFalseThenReturnFalse() {
+        whenever(mockUserAgentRepository.closestUserAgentState).thenReturn(false)
+
+        assertFalse(testee.closestUserAgentEnabled())
+    }
+
+    @Test
+    fun whenDdgFixedUserAgentEnabledAndDdgFixedUserAgentStateIsTrueThenReturnTrue() {
+        whenever(mockUserAgentRepository.ddgFixedUserAgentState).thenReturn(true)
+
+        assertTrue(testee.ddgFixedUserAgentEnabled())
+    }
+
+    @Test
+    fun whenDdgFixedUserAgentEnabledAndDdgFixedUserAgentStateIsFalseThenReturnFalse() {
+        whenever(mockUserAgentRepository.ddgFixedUserAgentState).thenReturn(false)
+
+        assertFalse(testee.ddgFixedUserAgentEnabled())
+    }
+
+    fun whenIsClosestUserAgentVersionThenReturnTrue() {
+        val closestVersions =
+            CopyOnWriteArrayList<String>().apply {
+                add("123")
+            }
+        whenever(mockUserAgentRepository.closestUserAgentVersions).thenReturn(closestVersions)
+
+        assertTrue(testee.isClosestUserAgentVersion("123"))
+    }
+
+    fun whenIsNotClosestUserAgentVersionThenReturnFalse() {
+        val closestVersions =
+            CopyOnWriteArrayList<String>().apply {
+                add("456")
+            }
+        whenever(mockUserAgentRepository.closestUserAgentVersions).thenReturn(closestVersions)
+
+        assertFalse(testee.isClosestUserAgentVersion("123"))
+    }
+
+    fun whenIsDdgFixedUserAgentVersionThenReturnTrue() {
+        val ddgFixedVersions =
+            CopyOnWriteArrayList<String>().apply {
+                add("123")
+            }
+        whenever(mockUserAgentRepository.ddgFixedUserAgentVersions).thenReturn(ddgFixedVersions)
+
+        assertTrue(testee.isDdgFixedUserAgentVersion("123"))
+    }
+
+    fun whenIsNotDdgFixedUserAgentVersionThenReturnFalse() {
+        val ddgFixedVersions =
+            CopyOnWriteArrayList<String>().apply {
+                add("456")
+            }
+        whenever(mockUserAgentRepository.ddgFixedUserAgentVersions).thenReturn(ddgFixedVersions)
+
+        assertFalse(testee.isDdgFixedUserAgentVersion("123"))
     }
 
     private fun givenThereAreExceptions() {

--- a/privacy-config/privacy-config-impl/src/test/resources/json/useragent.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/useragent.json
@@ -15,6 +15,27 @@
     }
   ],
   "settings": {
+    "defaultPolicy": "ddg",
+    "ddgDefaultSites": [
+      {
+        "domain": "defaultsite.com",
+        "reason": "Site needs ddg policy"
+      }
+    ],
+    "ddgFixedSites": [
+      {
+        "domain": "fixedsite.com",
+        "reason": "Site needs ddg fixed policy"
+      }
+    ],
+    "closestUserAgent": {
+      "versions": ["123", "456"],
+      "state": "enabled"
+    },
+    "ddgFixedUserAgent": {
+      "versions": ["789", "321"],
+      "state": "enabled"
+    },
     "omitApplicationSites": [
       {
         "domain": "application.com",

--- a/privacy-config/privacy-config-impl/src/test/resources/json/useragent_disabled.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/useragent_disabled.json
@@ -7,6 +7,27 @@
     }
   ],
   "settings": {
+    "defaultPolicy": "ddg",
+    "ddgDefaultSites": [
+      {
+        "domain": "defaultsite.com",
+        "reason": "Site needs ddg policy"
+      }
+    ],
+    "ddgFixedSites": [
+      {
+        "domain": "fixedsite.com",
+        "reason": "Site needs ddg fixed policy"
+      }
+    ],
+    "closestUserAgent": {
+      "versions": ["123", "456"],
+      "state": "enabled"
+    },
+    "ddgFixedUserAgent": {
+      "versions": ["789", "321"],
+      "state": "enabled"
+    },
     "omitApplicationSites": [
       {
         "domain": "cvs.com",

--- a/privacy-config/privacy-config-impl/src/test/resources/json/useragent_min_supported_version.json
+++ b/privacy-config/privacy-config-impl/src/test/resources/json/useragent_min_supported_version.json
@@ -8,6 +8,27 @@
     }
   ],
   "settings": {
+    "defaultPolicy": "ddg",
+    "ddgDefaultSites": [
+      {
+        "domain": "defaultsite.com",
+        "reason": "Site needs ddg policy"
+      }
+    ],
+    "ddgFixedSites": [
+      {
+        "domain": "fixedsite.com",
+        "reason": "Site needs ddg fixed policy"
+      }
+    ],
+    "closestUserAgent": {
+      "versions": ["123", "456"],
+      "state": "enabled"
+    },
+    "ddgFixedUserAgent": {
+      "versions": ["789", "321"],
+      "state": "enabled"
+    },
     "omitApplicationSites": [
       {
         "domain": "cvs.com",

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
@@ -32,13 +32,16 @@ import com.duckduckgo.privacy.config.store.features.trackerallowlist.TrackerAllo
 import com.duckduckgo.privacy.config.store.features.trackingparameters.TrackingParametersDao
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryDao
 import com.duckduckgo.privacy.config.store.features.useragent.UserAgentDao
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentSitesDao
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentStatesDao
+import com.duckduckgo.privacy.config.store.features.useragent.UserAgentVersionsDao
 
 @TypeConverters(
     RuleTypeConverter::class,
 )
 @Database(
     exportSchema = true,
-    version = 14,
+    version = 15,
     entities = [
         TrackerAllowlistEntity::class,
         UnprotectedTemporaryEntity::class,
@@ -55,6 +58,9 @@ import com.duckduckgo.privacy.config.store.features.useragent.UserAgentDao
         TrackingParameterEntity::class,
         TrackingParameterExceptionEntity::class,
         UserAgentExceptionEntity::class,
+        UserAgentSitesEntity::class,
+        UserAgentStatesEntity::class,
+        UserAgentVersionsEntity::class,
     ],
 )
 abstract class PrivacyConfigDatabase : RoomDatabase() {
@@ -70,6 +76,9 @@ abstract class PrivacyConfigDatabase : RoomDatabase() {
     abstract fun ampLinksDao(): AmpLinksDao
     abstract fun trackingParametersDao(): TrackingParametersDao
     abstract fun userAgentDao(): UserAgentDao
+    abstract fun userAgentSitesDao(): UserAgentSitesDao
+    abstract fun userAgentStatesDao(): UserAgentStatesDao
+    abstract fun userAgentVersionsDao(): UserAgentVersionsDao
 }
 
 val MIGRATION_2_3 = object : Migration(2, 3) {

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -122,6 +122,33 @@ data class UserAgentExceptionEntity(
     val omitVersion: Boolean,
 )
 
+@Entity(tableName = "user_agent_sites")
+data class UserAgentSitesEntity(
+    @PrimaryKey val domain: String,
+    val reason: String,
+    val ddgDefaultSite: Boolean,
+    val ddgFixedSite: Boolean,
+)
+
+@Entity(tableName = "user_agent_versions")
+data class UserAgentVersionsEntity(
+    @PrimaryKey val version: String,
+    val closestUserAgent: Boolean,
+    val ddgFixedUserAgent: Boolean,
+)
+
+fun UserAgentSitesEntity.toUserAgentException(): UserAgentException {
+    return UserAgentException(domain = this.domain, reason = this.reason)
+}
+
+@Entity(tableName = "user_agent_states")
+data class UserAgentStatesEntity(
+    @PrimaryKey val id: Int = 1,
+    val defaultPolicy: String,
+    val closestUserAgent: Boolean,
+    val ddgFixedUserAgent: Boolean,
+)
+
 fun UserAgentExceptionEntity.toUserAgentException(): UserAgentException {
     return UserAgentException(domain = this.domain, reason = this.reason)
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentRepository.kt
@@ -20,16 +20,31 @@ import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.privacy.config.api.UserAgentException
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.UserAgentExceptionEntity
+import com.duckduckgo.privacy.config.store.UserAgentSitesEntity
+import com.duckduckgo.privacy.config.store.UserAgentStatesEntity
+import com.duckduckgo.privacy.config.store.UserAgentVersionsEntity
 import com.duckduckgo.privacy.config.store.toUserAgentException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 interface UserAgentRepository {
-    fun updateAll(exceptions: List<UserAgentExceptionEntity>)
+    fun updateAll(
+        exceptions: List<UserAgentExceptionEntity>,
+        sites: List<UserAgentSitesEntity>,
+        states: UserAgentStatesEntity?,
+        versions: List<UserAgentVersionsEntity>,
+    )
     val defaultExceptions: CopyOnWriteArrayList<UserAgentException>
     val omitApplicationExceptions: CopyOnWriteArrayList<UserAgentException>
     val omitVersionExceptions: CopyOnWriteArrayList<UserAgentException>
+    val ddgDefaultSites: CopyOnWriteArrayList<UserAgentException>
+    val ddgFixedSites: CopyOnWriteArrayList<UserAgentException>
+    var defaultPolicy: String
+    var closestUserAgentState: Boolean
+    var ddgFixedUserAgentState: Boolean
+    var closestUserAgentVersions: CopyOnWriteArrayList<String>
+    var ddgFixedUserAgentVersions: CopyOnWriteArrayList<String>
 }
 
 class RealUserAgentRepository(
@@ -39,16 +54,36 @@ class RealUserAgentRepository(
 ) : UserAgentRepository {
 
     private val userAgentDao: UserAgentDao = database.userAgentDao()
+    private val userAgentSitesDao: UserAgentSitesDao = database.userAgentSitesDao()
+    private val userAgentStatesDao: UserAgentStatesDao = database.userAgentStatesDao()
+    private val userAgentVersionsDao: UserAgentVersionsDao = database.userAgentVersionsDao()
     override val defaultExceptions = CopyOnWriteArrayList<UserAgentException>()
     override val omitApplicationExceptions = CopyOnWriteArrayList<UserAgentException>()
     override val omitVersionExceptions = CopyOnWriteArrayList<UserAgentException>()
+    override val ddgDefaultSites = CopyOnWriteArrayList<UserAgentException>()
+    override val ddgFixedSites = CopyOnWriteArrayList<UserAgentException>()
+    override var defaultPolicy: String = "ddg"
+    override var closestUserAgentState: Boolean = false
+    override var ddgFixedUserAgentState: Boolean = false
+    override var closestUserAgentVersions = CopyOnWriteArrayList<String>()
+    override var ddgFixedUserAgentVersions = CopyOnWriteArrayList<String>()
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
     }
 
-    override fun updateAll(exceptions: List<UserAgentExceptionEntity>) {
+    override fun updateAll(
+        exceptions: List<UserAgentExceptionEntity>,
+        sites: List<UserAgentSitesEntity>,
+        states: UserAgentStatesEntity?,
+        versions: List<UserAgentVersionsEntity>,
+    ) {
         userAgentDao.updateAll(exceptions)
+        userAgentSitesDao.updateAll(sites)
+        states?.let {
+            userAgentStatesDao.update(it)
+        }
+        userAgentVersionsDao.updateAll(versions)
         loadToMemory()
     }
 
@@ -59,5 +94,26 @@ class RealUserAgentRepository(
         userAgentDao.getDefaultExceptions().map { defaultExceptions.add(it.toUserAgentException()) }
         userAgentDao.getApplicationExceptions().map { omitApplicationExceptions.add(it.toUserAgentException()) }
         userAgentDao.getVersionExceptions().map { omitVersionExceptions.add(it.toUserAgentException()) }
+
+        ddgDefaultSites.clear()
+        ddgFixedSites.clear()
+        userAgentSitesDao.getDefaultSites().map { ddgDefaultSites.add(it.toUserAgentException()) }
+        userAgentSitesDao.getFixedSites().map { ddgFixedSites.add(it.toUserAgentException()) }
+
+        val states = userAgentStatesDao.get()
+        if (states != null) {
+            defaultPolicy = states.defaultPolicy
+            closestUserAgentState = states.closestUserAgent
+            ddgFixedUserAgentState = states.ddgFixedUserAgent
+        } else {
+            defaultPolicy = "ddg"
+            closestUserAgentState = false
+            ddgFixedUserAgentState = false
+        }
+
+        closestUserAgentVersions.clear()
+        ddgFixedUserAgentVersions.clear()
+        userAgentVersionsDao.getClosestUserAgentVersions().map { closestUserAgentVersions.add(it.version) }
+        userAgentVersionsDao.getDdgFixedUserAgentVerions().map { ddgFixedUserAgentVersions.add(it.version) }
     }
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentSitesDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentSitesDao.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.useragent
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.privacy.config.store.UserAgentSitesEntity
+
+@Dao
+abstract class UserAgentSitesDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertAll(sites: List<UserAgentSitesEntity>)
+
+    @Transaction
+    open fun updateAll(sites: List<UserAgentSitesEntity>) {
+        deleteAll()
+        insertAll(sites)
+    }
+
+    @Query("select * from user_agent_sites where domain = :domain")
+    abstract fun get(domain: String): UserAgentSitesEntity
+
+    @Query("select * from user_agent_sites where ddgDefaultSite = 1")
+    abstract fun getDefaultSites(): List<UserAgentSitesEntity>
+
+    @Query("select * from user_agent_sites where ddgFixedSite = 1")
+    abstract fun getFixedSites(): List<UserAgentSitesEntity>
+
+    @Query("delete from user_agent_sites")
+    abstract fun deleteAll()
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentStatesDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentStatesDao.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.useragent
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.privacy.config.store.UserAgentStatesEntity
+
+@Dao
+abstract class UserAgentStatesDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insert(states: UserAgentStatesEntity)
+
+    @Transaction
+    open fun update(states: UserAgentStatesEntity) {
+        delete()
+        insert(states)
+    }
+
+    @Query("select * from user_agent_states")
+    abstract fun get(): UserAgentStatesEntity?
+
+    @Query("delete from user_agent_states")
+    abstract fun delete()
+}

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentVersionsDao.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentVersionsDao.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.store.features.useragent
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.duckduckgo.privacy.config.store.UserAgentVersionsEntity
+
+@Dao
+abstract class UserAgentVersionsDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertAll(versions: List<UserAgentVersionsEntity>)
+
+    @Transaction
+    open fun updateAll(versions: List<UserAgentVersionsEntity>) {
+        deleteAll()
+        insertAll(versions)
+    }
+
+    @Query("select * from user_agent_versions where closestUserAgent = 1")
+    abstract fun getClosestUserAgentVersions(): List<UserAgentVersionsEntity>
+
+    @Query("select * from user_agent_versions where ddgFixedUserAgent = 1")
+    abstract fun getDdgFixedUserAgentVerions(): List<UserAgentVersionsEntity>
+
+    @Query("delete from user_agent_versions")
+    abstract fun deleteAll()
+}

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/useragent/RealUserAgentRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/useragent/RealUserAgentRepositoryTest.kt
@@ -19,6 +19,9 @@ package com.duckduckgo.privacy.config.store.features.useragent
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.UserAgentExceptionEntity
+import com.duckduckgo.privacy.config.store.UserAgentSitesEntity
+import com.duckduckgo.privacy.config.store.UserAgentStatesEntity
+import com.duckduckgo.privacy.config.store.UserAgentVersionsEntity
 import com.duckduckgo.privacy.config.store.toUserAgentException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -28,6 +31,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyList
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
@@ -42,10 +46,16 @@ class RealUserAgentRepositoryTest {
 
     private val mockDatabase: PrivacyConfigDatabase = mock()
     private val mockUserAgentDao: UserAgentDao = mock()
+    private val mockUserAgentSitesDao: UserAgentSitesDao = mock()
+    private val mockUserAgentStatesDao: UserAgentStatesDao = mock()
+    private val mockUserAgentVersionsDao: UserAgentVersionsDao = mock()
 
     @Before
     fun before() {
         whenever(mockDatabase.userAgentDao()).thenReturn(mockUserAgentDao)
+        whenever(mockDatabase.userAgentSitesDao()).thenReturn(mockUserAgentSitesDao)
+        whenever(mockDatabase.userAgentStatesDao()).thenReturn(mockUserAgentStatesDao)
+        whenever(mockDatabase.userAgentVersionsDao()).thenReturn(mockUserAgentVersionsDao)
         testee =
             RealUserAgentRepository(
                 mockDatabase,
@@ -71,6 +81,24 @@ class RealUserAgentRepositoryTest {
     }
 
     @Test
+    fun whenRepositoryIsCreatedThenUserAgentConfigLoadedIntoMemory() {
+        givenUserAgentDaoContainsConfig()
+        testee =
+            RealUserAgentRepository(
+                mockDatabase,
+                TestScope(),
+                coroutineRule.testDispatcherProvider,
+            )
+
+        assertEquals(testee.closestUserAgentState, true)
+        assertEquals(testee.ddgFixedUserAgentState, true)
+        assertEquals(testee.ddgDefaultSites.first(), userAgentDefaultSiteEntity.toUserAgentException())
+        assertEquals(testee.ddgFixedSites.first(), userAgentFixedSiteEntity.toUserAgentException())
+        assertEquals(testee.closestUserAgentVersions.first(), userAgentClosestVersionEntity.version)
+        assertEquals(testee.ddgFixedUserAgentVersions.first(), userAgentDdgFixedVersionEntity.version)
+    }
+
+    @Test
     fun whenUpdateAllThenUpdateAllCalled() =
         runTest {
             testee =
@@ -80,7 +108,7 @@ class RealUserAgentRepositoryTest {
                     coroutineRule.testDispatcherProvider,
                 )
 
-            testee.updateAll(listOf())
+            testee.updateAll(listOf(), listOf(), anyOrNull(), listOf())
 
             verify(mockUserAgentDao).updateAll(anyList())
         }
@@ -100,11 +128,43 @@ class RealUserAgentRepositoryTest {
             assertEquals(1, testee.omitVersionExceptions.size)
             reset(mockUserAgentDao)
 
-            testee.updateAll(listOf())
+            testee.updateAll(listOf(), listOf(), anyOrNull(), listOf())
 
             assertEquals(0, testee.defaultExceptions.size)
             assertEquals(0, testee.omitApplicationExceptions.size)
             assertEquals(0, testee.omitVersionExceptions.size)
+        }
+
+    @Test
+    fun whenUpdateAllThenPreviousConfigIsCleared() =
+        runTest {
+            givenUserAgentDaoContainsConfig()
+            testee =
+                RealUserAgentRepository(
+                    mockDatabase,
+                    TestScope(),
+                    coroutineRule.testDispatcherProvider,
+                )
+            assertEquals(true, testee.closestUserAgentState)
+            assertEquals(true, testee.ddgFixedUserAgentState)
+            assertEquals("ddgFixed", testee.defaultPolicy)
+            assertEquals(1, testee.ddgDefaultSites.size)
+            assertEquals(1, testee.ddgFixedSites.size)
+            assertEquals(1, testee.closestUserAgentVersions.size)
+            assertEquals(1, testee.ddgFixedUserAgentVersions.size)
+            reset(mockUserAgentStatesDao)
+            reset(mockUserAgentSitesDao)
+            reset(mockUserAgentVersionsDao)
+
+            testee.updateAll(listOf(), listOf(), null, listOf())
+
+            assertEquals(false, testee.closestUserAgentState)
+            assertEquals(false, testee.ddgFixedUserAgentState)
+            assertEquals("ddg", testee.defaultPolicy)
+            assertEquals(0, testee.ddgDefaultSites.size)
+            assertEquals(0, testee.ddgFixedSites.size)
+            assertEquals(0, testee.closestUserAgentVersions.size)
+            assertEquals(0, testee.ddgFixedUserAgentVersions.size)
         }
 
     private fun givenUserAgentDaoContainsExceptions() {
@@ -113,7 +173,20 @@ class RealUserAgentRepositoryTest {
         whenever(mockUserAgentDao.getVersionExceptions()).thenReturn(listOf(userAgentException))
     }
 
+    private fun givenUserAgentDaoContainsConfig() {
+        whenever(mockUserAgentStatesDao.get()).thenReturn(userAgentStatesEntity)
+        whenever(mockUserAgentSitesDao.getDefaultSites()).thenReturn(listOf(userAgentDefaultSiteEntity))
+        whenever(mockUserAgentSitesDao.getFixedSites()).thenReturn(listOf(userAgentFixedSiteEntity))
+        whenever(mockUserAgentVersionsDao.getClosestUserAgentVersions()).thenReturn(listOf(userAgentClosestVersionEntity))
+        whenever(mockUserAgentVersionsDao.getDdgFixedUserAgentVerions()).thenReturn(listOf(userAgentDdgFixedVersionEntity))
+    }
+
     companion object {
         val userAgentException = UserAgentExceptionEntity("example.com", "reason", omitApplication = false, omitVersion = false)
+        val userAgentStatesEntity = UserAgentStatesEntity(defaultPolicy = "ddgFixed", closestUserAgent = true, ddgFixedUserAgent = true)
+        val userAgentDefaultSiteEntity = UserAgentSitesEntity("example.com", "reason", ddgDefaultSite = true, ddgFixedSite = false)
+        val userAgentFixedSiteEntity = UserAgentSitesEntity("example.com", "reason", ddgDefaultSite = false, ddgFixedSite = true)
+        val userAgentClosestVersionEntity = UserAgentVersionsEntity("123", closestUserAgent = true, ddgFixedUserAgent = false)
+        val userAgentDdgFixedVersionEntity = UserAgentVersionsEntity("456", closestUserAgent = false, ddgFixedUserAgent = true)
     }
 }

--- a/user-agent/user-agent-impl/build.gradle
+++ b/user-agent/user-agent-impl/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation project(':user-agent-api')
     implementation project(':feature-toggles-api')
     implementation project(':privacy-config-api')
+    implementation project(':statistics')
 
     implementation Kotlin.stdlib.jdk7
     implementation AndroidX.appCompat


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205442309571985/f

### Description
Sets the user agent based on the config of `ddg`, `ddgFixed` or `closest`.

### Steps to test this PR

**_ddg_**
- [x] Change the config to the one linked in the task
- [x] Type "user agent" in the address bar
- [x] Verify that the `ddg` user agent is used (Has version + application)

It should look something like this:
`Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile DuckDuckGo/5 Safari/537.36`

Desktop:
`Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 DuckDuckGo/5 Safari/537.36`

**_ddgFixed disabled_**
- [x] Change the `defaultPolicy` to "ddgFixed"
- [x] Type "user agent" in the address bar
- [x] Verify that the `ddg` user agent is used (Has version + application)

It should look something like this:
`Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile DuckDuckGo/5 Safari/537.36`

Desktop:
`Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 DuckDuckGo/5 Safari/537.36`

**_ddgFixed_**
- [x] Change the `defaultPolicy` to "ddgFixed"
- [x] Change `ddgFixedUserAgent` state to `enabled`
- [x] Type "user agent" in the address bar
- [x] Verify that the `ddgFixed` user agent is used (No version and `Android 10; K`)

It should look something like this:
`Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile DuckDuckGo/5 Safari/537.36`

Desktop:
`Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 DuckDuckGo/5 Safari/537.36`

**_closest disabled_**
- [x] Change the `defaultPolicy` to "closest"
- [x] Type "user agent" in the address bar
- [x] Verify that the `ddg` user agent is used (Has version + application)

It should look something like this:
`Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile DuckDuckGo/5 Safari/537.36`

Desktop:
`Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 DuckDuckGo/5 Safari/537.36`

**_closest_**
- [x] Change the `defaultPolicy` to "closest"
- [x] Change `closestUserAgent` state to `enabled`
- [x] Type "user agent" in the address bar
- [x] Verify that the `closest` user agent is used (No version, no application and `Android 10; K`)

It should look something like this:
`Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36`

Desktop:
`Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36`

**_ddgDefaultSites_**
- [x] Add `{ "domain":"duckduckgo.com", "reason": "reason" }` to `ddgDefaultSites`
- [x] Type "user agent" in the address bar
- [x] Verify that the `ddg` user agent is used (Has version + application)

It should look something like this:
`Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile DuckDuckGo/5 Safari/537.36`

Desktop:
`Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 DuckDuckGo/5 Safari/537.36`

**_ddgFixedSites_**
- [x] Remove `{ "domain":"duckduckgo.com", "reason": "reason" }` from `ddgDefaultSites`
- [x] Add `{ "domain":"duckduckgo.com", "reason": "reason" }` to `ddgFixedSites`
- [x] Type "user agent" in the address bar
- [x] Verify that the `ddgFixed` user agent is used (No version and `Android 10; K`)

It should look something like this:
`Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile DuckDuckGo/5 Safari/537.36`

Desktop:
`Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 DuckDuckGo/5 Safari/537.36`

**_closestUserAgent versions_**
- [x] Remove `{ "domain":"duckduckgo.com", "reason": "reason" }` from `ddgFixedSites `
- [x] Change the `defaultPolicy` to "ddg"
- [x] Add "397" (Or current ATB) to `closestUserAgent` `versions`
- [x] Type "user agent" in the address bar
- [x] Verify that the `closest` user agent is used (No version, no application, `Android 10; K`)

It should look something like this:
`Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36`

Desktop:
`Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36`

**_ddgFixedUserAgent versions_**
- [x] Remove the version from `closestUserAgent` `versions`
- [x] Add "397" (Or current ATB) to `ddgFixedUserAgent` `versions`
- [x] Type "user agent" in the address bar
- [x] Verify that the `ddgFixed` user agent is used (No version and `Android 10; K`)

It should look something like this:
`Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile DuckDuckGo/5 Safari/537.36`

Desktop:
`Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 DuckDuckGo/5 Safari/537.36`