### PR TITLE
Change image download location to DIRECTORY_DOWNLOADS

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2579,7 +2579,7 @@ class BrowserTabFragment :
     ) {
         pendingFileDownload = PendingFileDownload(
             url = url,
-            subfolder = Environment.DIRECTORY_PICTURES,
+            subfolder = Environment.DIRECTORY_DOWNLOADS,
         )
 
         if (hasWriteStoragePermission()) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1205568113205968/f

### Description
Changes the image download directory to "Downloads".

### Steps to test this PR

- [ ] Download an image.
- [ ] Verify that the image is in the "Downloads" folder.

### UI changes
**Before**

https://github.com/duckduckgo/Android/assets/3471025/a554c240-fc23-4d02-b711-2355615b48a9

**After**

https://github.com/duckduckgo/Android/assets/3471025/57fb993a-fb9c-4095-8574-e69c5c23fab6

