### PR TITLE
Move Email Protection event pixels to autofill-impl module

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3475,10 +3475,10 @@ class BrowserTabViewModelTest {
         whenever(mockEmailManager.getCohort()).thenReturn("cohort")
         whenever(mockEmailManager.getLastUsedDate()).thenReturn("2021-01-01")
 
-        testee.usePrivateDuckAddress("", "foo@example.com")
+        testee.consumeAliasAndCopyToClipboard()
 
         verify(mockPixel).enqueueFire(
-            AppPixelName.EMAIL_USE_ALIAS,
+            AppPixelName.EMAIL_COPIED_TO_CLIPBOARD,
             mapOf(Pixel.PixelParameter.COHORT to "cohort", Pixel.PixelParameter.LAST_USED_DAY to "2021-01-01"),
         )
     }
@@ -3523,30 +3523,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenConsumeAliasThenPixelSent() {
-        whenever(mockEmailManager.getAlias()).thenReturn("alias")
-        whenever(mockEmailManager.getCohort()).thenReturn("cohort")
-        whenever(mockEmailManager.getLastUsedDate()).thenReturn("2021-01-01")
-
-        testee.usePrivateDuckAddress("", "foo@example.com")
-
-        verify(mockPixel).enqueueFire(
-            AppPixelName.EMAIL_USE_ALIAS,
-            mapOf(Pixel.PixelParameter.COHORT to "cohort", Pixel.PixelParameter.LAST_USED_DAY to "2021-01-01"),
-        )
-    }
-
-    @Test
-    fun whenCancelAutofillTooltipThenPixelSent() {
-        whenever(mockEmailManager.getAlias()).thenReturn("alias")
-        whenever(mockEmailManager.getCohort()).thenReturn("cohort")
-
-        testee.cancelAutofillTooltip()
-
-        verify(mockPixel).enqueueFire(AppPixelName.EMAIL_TOOLTIP_DISMISSED, mapOf(Pixel.PixelParameter.COHORT to "cohort"))
-    }
-
-    @Test
     fun whenUseAddressThenInjectAddressCommandSent() {
         whenever(mockEmailManager.getEmailAddress()).thenReturn("address")
 
@@ -3555,20 +3531,6 @@ class BrowserTabViewModelTest {
         assertCommandIssued<Command.InjectEmailAddress> {
             assertEquals("address", this.duckAddress)
         }
-    }
-
-    @Test
-    fun whenUseAddressThenPixelSent() {
-        whenever(mockEmailManager.getEmailAddress()).thenReturn("address")
-        whenever(mockEmailManager.getCohort()).thenReturn("cohort")
-        whenever(mockEmailManager.getLastUsedDate()).thenReturn("2021-01-01")
-
-        testee.usePersonalDuckAddress("", "")
-
-        verify(mockPixel).enqueueFire(
-            AppPixelName.EMAIL_USE_ADDRESS,
-            mapOf(Pixel.PixelParameter.COHORT to "cohort", Pixel.PixelParameter.LAST_USED_DAY to "2021-01-01"),
-        )
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1007,10 +1007,6 @@ class BrowserTabFragment :
         acceptGeneratedPassword(originalUrl)
     }
 
-    override fun onRejectToUseEmailProtection(originalUrl: String) {
-        viewModel.cancelAutofillTooltip()
-    }
-
     override fun onUseEmailProtectionPrivateAlias(originalUrl: String, duckAddress: String) {
         viewModel.usePrivateDuckAddress(originalUrl, duckAddress)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2726,22 +2726,10 @@ class BrowserTabViewModel @Inject constructor(
      */
     fun usePrivateDuckAddress(originalUrl: String, duckAddress: String) {
         command.postValue(InjectEmailAddress(duckAddress = duckAddress, originalUrl = originalUrl, autoSaveLogin = true))
-        pixel.enqueueFire(
-            AppPixelName.EMAIL_USE_ALIAS,
-            mapOf(PixelParameter.COHORT to emailManager.getCohort(), PixelParameter.LAST_USED_DAY to emailManager.getLastUsedDate()),
-        )
     }
 
     fun usePersonalDuckAddress(originalUrl: String, duckAddress: String) {
         command.postValue(InjectEmailAddress(duckAddress = duckAddress, originalUrl = originalUrl, autoSaveLogin = false))
-        pixel.enqueueFire(
-            AppPixelName.EMAIL_USE_ADDRESS,
-            mapOf(PixelParameter.COHORT to emailManager.getCohort(), PixelParameter.LAST_USED_DAY to emailManager.getLastUsedDate()),
-        )
-    }
-
-    fun cancelAutofillTooltip() {
-        pixel.enqueueFire(AppPixelName.EMAIL_TOOLTIP_DISMISSED, mapOf(PixelParameter.COHORT to emailManager.getCohort()))
     }
 
     fun download(pendingFileDownload: PendingFileDownload) {

--- a/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/AtbAndAppVersionPixelRemovalInterceptor.kt
@@ -72,9 +72,6 @@ class AtbAndAppVersionPixelRemovalInterceptor @Inject constructor(
 object PixelInterceptorPixelsRequiringDataCleaning : PixelRequiringDataCleaningPlugin {
     override fun names(): List<String> {
         return listOf(
-            AppPixelName.EMAIL_TOOLTIP_DISMISSED.pixelName,
-            AppPixelName.EMAIL_USE_ALIAS.pixelName,
-            AppPixelName.EMAIL_USE_ADDRESS.pixelName,
             AppPixelName.EMAIL_COPIED_TO_CLIPBOARD.pixelName,
             StatisticsPixelName.BROWSER_DAILY_ACTIVE_FEATURE_STATE.pixelName,
             "m_atp_unprotected_apps_bucket_",

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -246,11 +246,9 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     FIRE_ANIMATION_SETTINGS_OPENED("m_fas_o"),
     FIRE_ANIMATION_NEW_SELECTED("m_fas_s"),
 
-    EMAIL_TOOLTIP_DISMISSED("email_tooltip_dismissed"),
     EMAIL_ENABLED("email_enabled"),
     EMAIL_DISABLED("email_disabled"),
-    EMAIL_USE_ALIAS("email_filled_random"),
-    EMAIL_USE_ADDRESS("email_filled_main"),
+
     EMAIL_COPIED_TO_CLIPBOARD("email_generated_button"),
     EMAIL_DID_SHOW_WAITLIST_DIALOG("email_did_show_waitlist_dialog"),
     EMAIL_DID_PRESS_WAITLIST_DIALOG_NOTIFY_ME("email_did_press_waitlist_dialog_notify_me"),

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillEventListener.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillEventListener.kt
@@ -52,12 +52,6 @@ interface AutofillEventListener {
     fun onUseEmailProtectionPrivateAlias(originalUrl: String, duckAddress: String)
 
     /**
-     * Called when user chooses not to autofill any duck address.
-     * @param originalUrl the URL of the page that prompted the user to use a duck address
-     */
-    fun onRejectToUseEmailProtection(originalUrl: String)
-
-    /**
      * Called when user chooses to autofill a login credential to a web page.
      * @param originalUrl the URL of the page that prompted the user to use a login credential
      * @param selectedCredentials the login credential that the user chose to autofill

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -16,7 +16,13 @@
 
 package com.duckduckgo.autofill.impl.pixel
 
+import com.duckduckgo.app.global.plugins.pixel.PixelRequiringDataCleaningPlugin
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_TOOLTIP_DISMISSED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ADDRESS
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ALIAS
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
 
 enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName {
     AUTOFILL_SAVE_LOGIN_PROMPT_SHOWN("m_autofill_logins_save_login_inline_displayed"),
@@ -55,4 +61,22 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
 
     AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED("m_autofill_logins_settings_enabled"),
     AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED("m_autofill_logins_settings_disabled"),
+
+    EMAIL_USE_ALIAS("email_filled_random"),
+    EMAIL_USE_ADDRESS("email_filled_main"),
+    EMAIL_TOOLTIP_DISMISSED("email_tooltip_dismissed"),
+}
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelRequiringDataCleaningPlugin::class,
+)
+object AutofillPixelsRequiringDataCleaning : PixelRequiringDataCleaningPlugin {
+    override fun names(): List<String> {
+        return listOf(
+            EMAIL_USE_ALIAS.pixelName,
+            EMAIL_USE_ADDRESS.pixelName,
+            EMAIL_TOOLTIP_DISMISSED.pixelName,
+        )
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205568952724508/f 

### Description
Currently there are some pixels and logic for Email Protection events that are in app module that would be better placed in `autofill-impl`.

### Steps to test this PR

In `AtbAndAppVersionPixelRemovalInterceptor`, replace line 47 with the following:
`val url = if (isInPixelsList(pixel).also { if (it) Timber.e("xxx cleaning pixel %s", pixel) }) {`
   - this adds a log statement, that you should filter for in logcat


#### Email protection used, personal address
- [x] Sign into Email Protection if not already signed in
- [x] Visit https://fill.dev/form/registration-email and tap on Dax icon in email field
- [x] Choose the top option (your personal duck address)
- [x] Verify in logcat you see `cleaning pixel email_filled_main_android_phone`

#### Email protection used, private alias
- [x] Tap on Dax icon again, and this time choose the bottom option (to use a private alias)
- [x] Verify in logcat you see `cleaning pixel email_filled_random_android_phone`

#### Email protection not used
- [x] Tap on Dax icon again, and this time dismiss the dialog
- [x] Verify in logcat you see `cleaning pixel email_tooltip_dismissed_android_phone`
        