### PR TITLE
Only show voice search button when address bar is empty

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -934,7 +934,7 @@ class BrowserTabViewModel @Inject constructor(
         omnibarViewState.value = currentOmnibarViewState().copy(
             omnibarText = trimmedInput,
             shouldMoveCaretToEnd = false,
-            showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(urlLoaded = urlToNavigate),
+            showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(),
             forceExpand = true,
         )
         browserViewState.value = currentBrowserViewState().copy(browserShowing = true, showClearButton = false, browserError = OMITTED)
@@ -1215,7 +1215,7 @@ class BrowserTabViewModel @Inject constructor(
         omnibarViewState.value = currentOmnibarViewState.copy(
             omnibarText = omnibarText,
             shouldMoveCaretToEnd = false,
-            showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(urlLoaded = url),
+            showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(),
             forceExpand = true,
         )
         val currentBrowserViewState = currentBrowserViewState()
@@ -1393,7 +1393,7 @@ class BrowserTabViewModel @Inject constructor(
             currentOmnibarViewState.copy(
                 omnibarText = omnibarText,
                 shouldMoveCaretToEnd = false,
-                showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(urlLoaded = url),
+                showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(),
                 forceExpand = false,
             ),
         )
@@ -1806,9 +1806,10 @@ class BrowserTabViewModel @Inject constructor(
             isEditing = hasFocus,
             showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(
                 isEditing = hasFocus,
-                urlLoaded = url ?: "",
+                currentText = query,
             ),
             forceExpand = true,
+            omnibarText = query,
         )
 
         val currentBrowserViewState = currentBrowserViewState()
@@ -2865,7 +2866,7 @@ class BrowserTabViewModel @Inject constructor(
 
     fun voiceSearchDisabled() {
         omnibarViewState.value = currentOmnibarViewState().copy(
-            showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(urlLoaded = url ?: ""),
+            showVoiceSearch = voiceSearchAvailability.shouldShowVoiceSearch(),
         )
     }
 

--- a/voice-search/voice-search-api/src/main/java/com/duckduckgo/voice/api/VoiceSearchAvailability.kt
+++ b/voice-search/voice-search-api/src/main/java/com/duckduckgo/voice/api/VoiceSearchAvailability.kt
@@ -21,6 +21,6 @@ interface VoiceSearchAvailability {
     val isVoiceSearchAvailable: Boolean
     fun shouldShowVoiceSearch(
         isEditing: Boolean = false,
-        urlLoaded: String = "",
+        currentText: String = "",
     ): Boolean
 }

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailability.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailability.kt
@@ -56,16 +56,8 @@ class RealVoiceSearchAvailability @Inject constructor(
 
     override fun shouldShowVoiceSearch(
         isEditing: Boolean,
-        urlLoaded: String,
+        currentText: String,
     ): Boolean {
-        // Show microphone icon only when:
-        // - user is editing the address bar OR
-        // - address bar is empty (initial state / new tab) OR
-        // - DDG SERP is shown OR (address bar doesn't contain a website)
-        return if (isVoiceSearchAvailable) {
-            isEditing || urlLoaded.isEmpty() || urlLoaded.startsWith(URL_DDG_SERP)
-        } else {
-            false
-        }
+        return isVoiceSearchAvailable && isEditing && currentText.isEmpty()
     }
 }

--- a/voice-search/voice-search-impl/src/test/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailabilityTest.kt
+++ b/voice-search/voice-search-impl/src/test/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailabilityTest.kt
@@ -113,94 +113,64 @@ class RealVoiceSearchAvailabilityTest {
 
         val result = testee.shouldShowVoiceSearch(
             isEditing = true,
-            urlLoaded = "https://duckduckgo.com/?q=hello",
+            currentText = "",
         )
 
         assertFalse(result)
     }
 
     @Test
-    fun whenVoiceSearchSupportedAndIsEditingUrlThenShouldShowVoiceSearchTrue() {
+    fun whenVoiceSearchSupportedAndIsEditingWithEmptyTextThenShouldShowVoiceSearchTrue() {
         setupRemoteConfig(voiceSearchEnabled = true, minSdk = 30, excludedManufacturers = emptyArray())
         setupDeviceConfig(manufacturer = "Google", sdkInt = 31, languageTag = "en-US", isOnDeviceSpeechRecognitionAvailable = true)
         setupUserSettings(true)
 
         val result = testee.shouldShowVoiceSearch(
             isEditing = true,
-            urlLoaded = "www.fb.com",
+            currentText = "",
         )
 
         assertTrue(result)
     }
 
     @Test
-    fun whenVoiceSearchSupportedAndIsEditingUrlAndUserDisabledThenShouldShowVoiceSearchTrue() {
+    fun whenVoiceSearchSupportedAndIsEditingWithTextThenShouldShowVoiceSearchFalse() {
+        setupRemoteConfig(voiceSearchEnabled = true, minSdk = 30, excludedManufacturers = emptyArray())
+        setupDeviceConfig(manufacturer = "Google", sdkInt = 31, languageTag = "en-US", isOnDeviceSpeechRecognitionAvailable = true)
+        setupUserSettings(true)
+
+        val result = testee.shouldShowVoiceSearch(
+            isEditing = true,
+            currentText = "something",
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenVoiceSearchSupportedAndIsEditingUrlAndUserDisabledThenShouldShowVoiceSearchFalse() {
         setupRemoteConfig(voiceSearchEnabled = true, minSdk = 30, excludedManufacturers = emptyArray())
         setupDeviceConfig(manufacturer = "Google", sdkInt = 31, languageTag = "en-US", isOnDeviceSpeechRecognitionAvailable = true)
         setupUserSettings(false)
 
         val result = testee.shouldShowVoiceSearch(
             isEditing = true,
-            urlLoaded = "www.fb.com",
         )
 
         assertFalse(result)
     }
 
     @Test
-    fun whenVoiceSearchSupportedAndIsEditingSERPThenShouldShowVoiceSearchTrue() {
-        setupRemoteConfig(voiceSearchEnabled = true, minSdk = 30, excludedManufacturers = emptyArray())
-        setupDeviceConfig(manufacturer = "Google", sdkInt = 31, languageTag = "en-US", isOnDeviceSpeechRecognitionAvailable = true)
-        setupUserSettings(true)
-
-        val result = testee.shouldShowVoiceSearch(
-            isEditing = true,
-            urlLoaded = "https://duckduckgo.com/?q=hello",
-        )
-
-        assertTrue(result)
-    }
-
-    @Test
-    fun whenVoiceSearchSupportedAndUrlShownInAddressBarThenShouldShowVoiceSearchFalse() {
+    fun whenVoiceSearchSupportedAndNotEditingThenShouldShowVoiceSearchFalse() {
         setupRemoteConfig(voiceSearchEnabled = true, minSdk = 30, excludedManufacturers = emptyArray())
         setupDeviceConfig(manufacturer = "Google", sdkInt = 31, languageTag = "en-US", isOnDeviceSpeechRecognitionAvailable = true)
         setupUserSettings(true)
 
         val result = testee.shouldShowVoiceSearch(
             isEditing = false,
-            urlLoaded = "www.fb.com",
         )
 
         assertFalse(result)
-    }
-
-    @Test
-    fun whenVoiceSearchSupportedAndSERPShownThenShouldShowVoiceSearchTrue() {
-        setupRemoteConfig(voiceSearchEnabled = true, minSdk = 30, excludedManufacturers = emptyArray())
-        setupDeviceConfig(manufacturer = "Google", sdkInt = 31, languageTag = "en-US", isOnDeviceSpeechRecognitionAvailable = true)
-        setupUserSettings(true)
-
-        val result = testee.shouldShowVoiceSearch(
-            isEditing = false,
-            urlLoaded = "https://duckduckgo.com/?q=hello",
-        )
-
-        assertTrue(result)
-    }
-
-    @Test
-    fun whenVoiceSearchSupportedAndUrlEmptyThenShouldShowVoiceSearchTrue() {
-        setupRemoteConfig(voiceSearchEnabled = true, minSdk = 30, excludedManufacturers = emptyArray())
-        setupDeviceConfig(manufacturer = "Google", sdkInt = 31, languageTag = "en-US", isOnDeviceSpeechRecognitionAvailable = true)
-        setupUserSettings(true)
-
-        val result = testee.shouldShowVoiceSearch(
-            isEditing = false,
-            urlLoaded = "",
-        )
-
-        assertTrue(result)
     }
 
     @Test
@@ -211,7 +181,6 @@ class RealVoiceSearchAvailabilityTest {
 
         val result = testee.shouldShowVoiceSearch(
             isEditing = false,
-            urlLoaded = "",
         )
 
         assertFalse(result)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205567106615258/f

### Description
Only show voice search button when address bar is in initial state, or being edited with empty query

### Steps to test this PR
_Icon not shown when typing_
- [x] Run on a device with Android 13 and language set to English US
- [x] Open a new tab
- [x] Check there's a microphone button on the address bar
- [x] Start typing
- [x] Check the icon disappears as soon as you start typing

_Icon not show on SERP_
- [x] Run on a device with Android 13 and language set to English US
- [x] Type a query on the address bar
- [x] Check there's no microphone button on the search results page

_Icon not show on page loaded_
- [x] Run on a device with Android 13 and language set to English US
- [x] Visit a website
- [x] Check there's no microphone button on the search bar

_Icon not show on editing_
- [x] Run on a device with Android 13 and language set to English US
- [x] Visit a website or perform a search
- [x] Tap on the address bar
- [x] Check there's no icon



### UI changes
![addressbar](https://github.com/duckduckgo/Android/assets/6297834/42bd5726-fc7e-4eca-b4d0-88b90d7a29ea)
![searchresult](https://github.com/duckduckgo/Android/assets/6297834/6bcae59f-9361-459f-8096-e3e57960463a)
![edit](https://github.com/duckduckgo/Android/assets/6297834/f57545e9-fa89-4797-89f4-b5c292f4553b)

