### PR TITLE
enable back encrypt/decrypt pixel errors

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -78,11 +78,11 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireEncryptFailurePixel() {
-        // pixel.fire(SyncPixelName.SYNC_ENCRYPT_FAILURE)
+        pixel.fire(SyncPixelName.SYNC_ENCRYPT_FAILURE)
     }
 
     override fun fireDecryptFailurePixel() {
-        // pixel.fire(SyncPixelName.SYNC_DECRYPT_FAILURE)
+        pixel.fire(SyncPixelName.SYNC_DECRYPT_FAILURE)
     }
 
     override fun fireCountLimitPixel(feature: String) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205581521828305/f 

### Description
Re-add encrypt/decrypt pixels now that sync is only triggered for users with sync enabled.

### Steps to test this PR

_Feature 1_
- [ ] with sync disabled
- [ ] Perform actions that will trigger sync (e.g: access bookmarks, opening the app, add a bookmark, etc.)
- [ ] ensure not pixel is sent
- [ ] with sync enabled
- [ ] it should work as usual (if need to produce an error, hardcode a line to throw an error when encrypt happens)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
