### PR TITLE
add pixel when we override local duck address

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/email/sync/EmailSync.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/sync/EmailSync.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.email.sync
 
 import com.duckduckgo.app.email.db.*
 import com.duckduckgo.app.email.sync.Adapters.Companion.adapter
+import com.duckduckgo.app.pixels.*
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.*
 import com.duckduckgo.settings.api.*
@@ -74,7 +75,7 @@ class EmailSync @Inject constructor(
             if (!emailDataStore.emailToken.isNullOrBlank() && !emailDataStore.emailUsername.isNullOrBlank()) {
                 if (duckUsername != emailDataStore.emailUsername) {
                     storeNewCredentials(duckUsername, personalAccessToken)
-                    pixel.fire(DUCK_EMAIL_OVERRIDE_PIXEL)
+                    pixel.fire(AppPixelName.DUCK_EMAIL_OVERRIDE_PIXEL)
                     return true
                 }
             } else {
@@ -102,7 +103,6 @@ class EmailSync @Inject constructor(
 
     companion object {
         const val DUCK_EMAIL_SETTING = "email_protection_generation"
-        const val DUCK_EMAIL_OVERRIDE_PIXEL = "m_sync_duck_address_override"
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/email/sync/EmailSync.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/sync/EmailSync.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.email.sync
 
 import com.duckduckgo.app.email.db.*
 import com.duckduckgo.app.email.sync.Adapters.Companion.adapter
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.*
 import com.duckduckgo.settings.api.*
 import com.squareup.anvil.annotations.*
@@ -32,6 +33,7 @@ import timber.log.*
 class EmailSync @Inject constructor(
     private val emailDataStore: EmailDataStore,
     private val syncSettingsListener: SyncSettingsListener,
+    private val pixel: Pixel,
 ) : SyncableSetting {
 
     private var listener: () -> Unit = {}
@@ -72,6 +74,7 @@ class EmailSync @Inject constructor(
             if (!emailDataStore.emailToken.isNullOrBlank() && !emailDataStore.emailUsername.isNullOrBlank()) {
                 if (duckUsername != emailDataStore.emailUsername) {
                     storeNewCredentials(duckUsername, personalAccessToken)
+                    pixel.fire(DUCK_EMAIL_OVERRIDE_PIXEL)
                     return true
                 }
             } else {
@@ -99,6 +102,7 @@ class EmailSync @Inject constructor(
 
     companion object {
         const val DUCK_EMAIL_SETTING = "email_protection_generation"
+        const val DUCK_EMAIL_OVERRIDE_PIXEL = "m_sync_duck_address_override"
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -248,6 +248,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
 
     EMAIL_ENABLED("email_enabled"),
     EMAIL_DISABLED("email_disabled"),
+    DUCK_EMAIL_OVERRIDE_PIXEL("m_sync_duck_address_override"),
 
     EMAIL_COPIED_TO_CLIPBOARD("email_generated_button"),
     EMAIL_DID_SHOW_WAITLIST_DIALOG("email_did_show_waitlist_dialog"),

--- a/app/src/test/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/email/AppEmailManagerTest.kt
@@ -60,7 +60,7 @@ class AppEmailManagerTest {
     private val mockEmailService: EmailService = mock()
     private val mockEmailDataStore: EmailDataStore = FakeEmailDataStore()
     private val mockSyncSettingsListener = mock<SyncSettingsListener>()
-    private val emailSyncableSetting = EmailSync(mockEmailDataStore, mockSyncSettingsListener)
+    private val emailSyncableSetting = EmailSync(mockEmailDataStore, mockSyncSettingsListener, mock())
     private val mockPixel: Pixel = mock()
     lateinit var testee: AppEmailManager
 

--- a/app/src/test/java/com/duckduckgo/app/email/EmailSyncTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/email/EmailSyncTest.kt
@@ -2,6 +2,8 @@ package com.duckduckgo.app.email
 
 import com.duckduckgo.app.email.db.*
 import com.duckduckgo.app.email.sync.*
+import com.duckduckgo.app.pixels.*
+import com.duckduckgo.app.statistics.pixels.*
 import com.duckduckgo.settings.api.*
 import com.squareup.moshi.*
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -14,8 +16,9 @@ class EmailSyncTest {
 
     private val emailDataStoreMock = mock<EmailDataStore>()
     private val syncSettingsListenerMock = mock<SyncSettingsListener>()
+    private val pixelMock = mock<Pixel>()
 
-    private val testee = EmailSync(emailDataStoreMock, syncSettingsListenerMock)
+    private val testee = EmailSync(emailDataStoreMock, syncSettingsListenerMock, pixelMock)
 
     @Test
     fun whenUserSignedInThenReturnAccountInfo() {
@@ -76,6 +79,16 @@ class EmailSyncTest {
 
         verify(emailDataStoreMock).emailUsername = "email"
         verify(emailDataStoreMock).emailToken = "token"
+    }
+
+    @Test
+    fun whenDeduplicateRemoteAddressWithDifferentLocalAddressThenPixelEvent() {
+        whenever(emailDataStoreMock.emailUsername).thenReturn("username2")
+        whenever(emailDataStoreMock.emailToken).thenReturn("token2")
+
+        testee.deduplicate("{\"username\":\"email\",\"personal_access_token\":\"token\"}")
+
+        verify(pixelMock).fire(AppPixelName.DUCK_EMAIL_OVERRIDE_PIXEL)
     }
 
     @Test


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1205601700770183/f

### Description
Adds a pixel when overriding a local duck address when first sync.

### Steps to test this PR

_Feature 1_
- [ ] one device has duck address
- [ ] enables sync
- [ ] second device has a different duck address
- [ ] enables sync
- [ ] pixel should be sent

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
