### PR TITLE
Add the ability to set the Switch in a Line item as disabled

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/ComponentViewHolder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/ComponentViewHolder.kt
@@ -276,6 +276,10 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 quietlySetIsChecked(true, null)
                 isEnabled = false
             }
+
+            view.findViewById<TwoLineListItem>(R.id.twoLineSwitchListItemWithSwitchDisabledChecked).apply {
+                quietlySetIsChecked(true, null)
+            }
         }
     }
 

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/DaxListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/DaxListItem.kt
@@ -176,6 +176,16 @@ abstract class DaxListItem(
         trailingSwitch.show()
     }
 
+    fun setSwitchEnabled(enabled: Boolean) {
+        if (enabled) {
+            trailingSwitch.setEnabledOpacity(true)
+            trailingSwitch.isEnabled = true
+        } else {
+            trailingSwitch.setEnabledOpacity(false)
+            trailingSwitch.isEnabled = false
+        }
+    }
+
     /** Sets the trailing icon Visible */
     fun showTrailingIcon() {
         trailingIconContainer.show()

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/OneLineListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/OneLineListItem.kt
@@ -103,6 +103,8 @@ class OneLineListItem @JvmOverloads constructor(
                     hideTrailingItems()
                 }
             }
+            val switchEnabled = getBoolean(R.styleable.OneLineListItem_switchEnabled, true)
+            setSwitchEnabled(switchEnabled)
 
             recycle()
         }

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/TwoLineListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/listitem/TwoLineListItem.kt
@@ -115,6 +115,8 @@ class TwoLineListItem @JvmOverloads constructor(
                     hideTrailingItems()
                 }
             }
+            val switchEnabled = getBoolean(R.styleable.TwoLineListItem_switchEnabled, true)
+            setSwitchEnabled(switchEnabled)
 
             recycle()
         }

--- a/common/common-ui/src/main/res/layout/component_two_line_item.xml
+++ b/common/common-ui/src/main/res/layout/component_two_line_item.xml
@@ -214,6 +214,20 @@
         app:layout_constraintTop_toBottomOf="@id/twoLineSwitchListItemWithDisabledSwitch"/>
 
     <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+        android:id="@+id/twoLineSwitchListItemWithSwitchDisabledChecked"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="Two Line Item Two"
+        app:secondaryText="Checked with switch in disabled state"
+        app:leadingIcon="@drawable/ic_globe_gray_16dp"
+        app:showBetaPill="true"
+        app:showSwitch="true"
+        app:switchEnabled="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/twoLineSwitchListItemWithDisabledSwitchEnabled"/>
+
+    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
             android:id="@+id/twoLineSwitchListItemWithPrimaryTextColorOverlay"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -223,7 +237,7 @@
             app:primaryTextColorOverlay="@color/red_text_color_selector"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/twoLineSwitchListItemWithDisabledSwitchEnabled"/>
+            app:layout_constraintTop_toBottomOf="@id/twoLineSwitchListItemWithSwitchDisabledChecked"/>
 
     <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
             android:id="@+id/twoLineSwitchListItemWithSecondaryTextColorOverlay"

--- a/common/common-ui/src/main/res/values/attrs-lists.xml
+++ b/common/common-ui/src/main/res/values/attrs-lists.xml
@@ -29,6 +29,7 @@
     <attr name="trailingIcon" format="integer"/>
     <attr name="showBetaPill" format="boolean"/>
     <attr name="showSwitch" format="boolean"/>
+    <attr name="switchEnabled" format="boolean"/>
     <attr name="leadingIconBackground">
         <!-- No background. -->
         <enum name="none" value="0" />
@@ -64,6 +65,7 @@
         <attr name="leadingIconSize"/>
         <attr name="trailingIcon"/>
         <attr name="showSwitch"/>
+        <attr name="switchEnabled"/>
     </declare-styleable>
 
     <!--Two Line Item view-->
@@ -79,6 +81,7 @@
         <attr name="trailingIcon"/>
         <attr name="showBetaPill"/>
         <attr name="showSwitch"/>
+        <attr name="switchEnabled"/>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205591898713343/f

### Description
Add the ability to set the Switch in a Line item as disabled.

* Added a switchEnabled attribute to the xml layout
* Added a setSwitchEnabled method to DaxListItem
* Applied to both TwoLineListItem and OneLineListItem

### Steps to test this PR
- install internal build from this branch
- go to Settings -> App Components Design Preview and select List Items
- [ ] Verify the Two line item with byline "Checked with switch in disabled state" looks correct
