### PR TITLE
Fix wrong placeholder icon radius

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import android.graphics.*
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
+import androidx.annotation.DimenRes
+import androidx.annotation.IntegerRes
 import androidx.core.content.ContextCompat.getColor
 import androidx.core.graphics.toColorInt
 import androidx.core.net.toUri
@@ -81,6 +83,7 @@ fun generateDefaultDrawable(
     context: Context,
     domain: String,
     overridePlaceholderCharacter: String? = null,
+    @DimenRes cornerRadius: Int = CommonR.dimen.keyline_0,
 ): Drawable {
     return object : Drawable() {
         private val baseHost: String = domain.toUri().baseHost ?: ""
@@ -92,8 +95,6 @@ fun generateDefaultDrawable(
                 }
                 return baseHost.firstOrNull()?.toString()?.uppercase(Locale.getDefault()) ?: ""
             }
-
-        private val faviconDefaultCornerRadius = context.resources.getDimension(CommonR.dimen.mediumShapeCornerRadius)
         private val faviconDefaultSize = context.resources.getDimension(CommonR.dimen.savedSiteGridItemFavicon)
 
         private val palette = listOf(
@@ -131,7 +132,7 @@ fun generateDefaultDrawable(
             textPaint.typeface = Typeface.DEFAULT_BOLD
             val textWidth: Float = textPaint.measureText(letter) * 0.5f
             val textBaseLineHeight = textPaint.fontMetrics.ascent * -0.4f
-            val radius = (bounds.width() * faviconDefaultCornerRadius) / faviconDefaultSize
+            val radius = (bounds.width() * context.resources.getDimension(cornerRadius)) / faviconDefaultSize
             canvas.drawRoundRect(0f, 0f, bounds.width().toFloat(), bounds.height().toFloat(), radius, radius, backgroundPaint)
             canvas.drawText(letter, centerX - textWidth, centerY + textBaseLineHeight, textPaint)
         }

--- a/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
@@ -21,7 +21,6 @@ import android.graphics.*
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.annotation.DimenRes
-import androidx.annotation.IntegerRes
 import androidx.core.content.ContextCompat.getColor
 import androidx.core.graphics.toColorInt
 import androidx.core.net.toUri

--- a/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetService.kt
+++ b/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetService.kt
@@ -70,7 +70,7 @@ class FavoritesWidgetService : RemoteViewsService() {
         )
 
         private val faviconItemSize = context.resources.getDimension(CommonR.dimen.savedSiteGridItemFavicon).toInt()
-        private val faviconItemCornerRadius = context.resources.getDimension(CommonR.dimen.mediumShapeCornerRadius).toInt()
+        private val faviconItemCornerRadius = com.duckduckgo.mobile.android.R.dimen.searchWidgetFavoritesCornerRadius
 
         private val maxItems: Int
             get() {
@@ -94,11 +94,11 @@ class FavoritesWidgetService : RemoteViewsService() {
                 val bitmap = runBlocking {
                     faviconManager.loadFromDiskWithParams(
                         url = it.url,
-                        cornerRadius = faviconItemCornerRadius,
+                        cornerRadius = context.resources.getDimension(faviconItemCornerRadius).toInt(),
                         width = faviconItemSize,
                         height = faviconItemSize,
                     )
-                        ?: generateDefaultDrawable(context, it.url.extractDomain().orEmpty(), cornerRadius = com.duckduckgo.mobile.android.R.dimen.mediumShapeCornerRadius).toBitmap(faviconItemSize, faviconItemSize)
+                        ?: generateDefaultDrawable(context, it.url.extractDomain().orEmpty(), cornerRadius = faviconItemCornerRadius).toBitmap(faviconItemSize, faviconItemSize)
                 }
                 WidgetFavorite(it.title, it.url, bitmap)
             }

--- a/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetService.kt
+++ b/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetService.kt
@@ -98,7 +98,7 @@ class FavoritesWidgetService : RemoteViewsService() {
                         width = faviconItemSize,
                         height = faviconItemSize,
                     )
-                        ?: generateDefaultDrawable(context, it.url.extractDomain().orEmpty()).toBitmap(faviconItemSize, faviconItemSize)
+                        ?: generateDefaultDrawable(context, it.url.extractDomain().orEmpty(), cornerRadius = com.duckduckgo.mobile.android.R.dimen.mediumShapeCornerRadius).toBitmap(faviconItemSize, faviconItemSize)
                 }
                 WidgetFavorite(it.title, it.url, bitmap)
             }

--- a/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetService.kt
+++ b/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetService.kt
@@ -98,7 +98,11 @@ class FavoritesWidgetService : RemoteViewsService() {
                         width = faviconItemSize,
                         height = faviconItemSize,
                     )
-                        ?: generateDefaultDrawable(context, it.url.extractDomain().orEmpty(), cornerRadius = faviconItemCornerRadius).toBitmap(faviconItemSize, faviconItemSize)
+                        ?: generateDefaultDrawable(
+                            context = context,
+                            domain = it.url.extractDomain().orEmpty(),
+                            cornerRadius = faviconItemCornerRadius,
+                        ).toBitmap(faviconItemSize, faviconItemSize)
                 }
                 WidgetFavorite(it.title, it.url, bitmap)
             }

--- a/app/src/main/res/drawable/search_widget_favorite_favicon_dark_background.xml
+++ b/app/src/main/res/drawable/search_widget_favorite_favicon_dark_background.xml
@@ -16,5 +16,5 @@
 
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/white6" />
-    <corners android:radius="@dimen/smallShapeCornerRadius" />
+    <corners android:radius="@dimen/searchWidgetFavoritesCornerRadius" />
 </shape>

--- a/app/src/main/res/drawable/search_widget_favorite_favicon_daynight_background.xml
+++ b/app/src/main/res/drawable/search_widget_favorite_favicon_daynight_background.xml
@@ -16,5 +16,5 @@
 
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/favoriteFaviconBackgroundColor" />
-    <corners android:radius="@dimen/smallShapeCornerRadius" />
+    <corners android:radius="@dimen/searchWidgetFavoritesCornerRadius" />
 </shape>

--- a/app/src/main/res/drawable/search_widget_favorite_favicon_light_background.xml
+++ b/app/src/main/res/drawable/search_widget_favorite_favicon_light_background.xml
@@ -16,5 +16,5 @@
 
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/black3" />
-    <corners android:radius="@dimen/smallShapeCornerRadius" />
+    <corners android:radius="@dimen/searchWidgetFavoritesCornerRadius" />
 </shape>

--- a/common/common-ui/src/main/res/values/design-system-dimensions.xml
+++ b/common/common-ui/src/main/res/values/design-system-dimensions.xml
@@ -129,6 +129,7 @@
     <dimen name="searchWidgetFavoritesTopMargin">16dp</dimen>
     <dimen name="searchWidgetFavoritesVerticalSpacing">20dp</dimen>
     <dimen name="searchWidgetFavoritesHorizontalSpacing">4dp</dimen>
+    <dimen name="searchWidgetFavoritesCornerRadius">10dp</dimen>
 
     <dimen name="messageCtaCloseButtonSize">40dp</dimen>
     <dimen name="messageCtaIllustrationSize">64dp</dimen>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205173497854945/f 

### Description
* Do not round corners when creating placeholder icon, except for the widget
    * Generally, we rely on the surface displaying the placeholder to do the corner rounding, however, this is not possible on the widget due to some 
platform limitations in API < 31. That's why the widget needs to apply a different treatment. Up until now, all placeholders were provided with a 
radius optimized for the widget, which caused them to have a different shape than the actual favicons
* Fix wrong radius in widget background and icons. Shapes were not aligned, and also not aligned with de designs in Figma

### Steps to test this PR

_Placeholder favicon for favorites, fireproofed and tab switcher_
- [x] Save a site without a favicon as favorite (or force fallback to placeholder, instructions below). Also fireproof it and leave it open in a tab
- [x] Save a site with a favicon. Also fireproof it and leave it open in a tab
- [x] Check that both placeholder and favicon have the same shape in bookmarks, favorites (clear address bar), fireproofed sites, tab switcher, and widgets

_Placeholder favicon for location permissions_ 
- [x] Force Google maps to fallback to placeholder
- [x] Open Google maps in the browser and click on "Your location"
- [x] Check that icon with and without fallback has the same shape

#### How to force fallback to placeholder 
Example for wikipedia

in `FavoritesWidgetService#onDataSetChanged()` replace `url = it.url` with ` url = if (it.url.contains("wikipedia")) "" else it.url`

in `FaviconImageView.ImageView.loadFavicon( bitmap: Bitmap?,  domain: String, placeholder: String? = null)` replace `.load(bitmap)` with `.load(if (domain.contains("wikipedia")) null else bitmap)` 



### UI changes
## Bookmarks
![bookmarks](https://github.com/duckduckgo/Android/assets/6297834/c1aebe25-777e-457a-ace9-60ac6ebc5940)
## Favorites
![favs](https://github.com/duckduckgo/Android/assets/6297834/05233801-8723-482e-b8ac-d247c4870f3d)
## Fireproofed sites
![fireproof](https://github.com/duckduckgo/Android/assets/6297834/0d5dc5ac-8b64-47d9-9727-fc033e488c96)
## Location permissions dialog
![locationpermissions](https://github.com/duckduckgo/Android/assets/6297834/7a2b2389-8f75-405d-8f6e-bb6c0c234e78)
![locationpermissionsplaceholder](https://github.com/duckduckgo/Android/assets/6297834/a56e4c20-29eb-4dcc-a0ba-96c62c8dc28d)
## Tab switcher
![tabswitcher](https://github.com/duckduckgo/Android/assets/6297834/fe3ac692-8b9c-4d0b-b692-92511ac5a30e)
## Widgets (background color manually set to yellow to better illustrate the fact that shapes were not aligned)
![widgets](https://github.com/duckduckgo/Android/assets/6297834/930a5190-0629-4fad-aac1-2a0e18f1209d)

