### PR TITLE
Move expensive css getScript() call to a background thread

### DIFF
--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/RealMessagingContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/RealMessagingContentScopeScriptsTest.kt
@@ -17,11 +17,15 @@
 package com.duckduckgo.contentscopescripts.impl.messaging
 
 import android.webkit.WebView
+import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.contentscopescripts.api.ContentScopeScripts
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -31,7 +35,11 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
+@ExperimentalCoroutinesApi
 class RealMessagingContentScopeScriptsTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val mockCoreContentScopeScripts: CoreContentScopeScripts = mock()
     private val mockMessageHandlerPlugins: PluginPoint<MessageHandlerPlugin> = mock()
@@ -41,11 +49,17 @@ class RealMessagingContentScopeScriptsTest {
 
     @Before
     fun setUp() {
-        messagingContentScopeScripts = RealMessagingContentScopeScripts(mockCoreContentScopeScripts, mockMessageHandlerPlugins)
+        messagingContentScopeScripts =
+            RealMessagingContentScopeScripts(
+                mockCoreContentScopeScripts,
+                mockMessageHandlerPlugins,
+                coroutineTestRule.testScope,
+                coroutineTestRule.testDispatcherProvider,
+            )
     }
 
     @Test
-    fun whenEnabledAndInjectContentScopeScriptsThenPopulateMessagingParameters() {
+    fun whenEnabledAndInjectContentScopeScriptsThenPopulateMessagingParameters() = runTest {
         whenever(mockCoreContentScopeScripts.isEnabled()).thenReturn(true)
         whenever(mockCoreContentScopeScripts.getScript()).thenReturn(coreContentScopeJs)
         messagingContentScopeScripts.injectContentScopeScripts(mockWebView)
@@ -63,7 +77,7 @@ class RealMessagingContentScopeScriptsTest {
     }
 
     @Test
-    fun whenDisabledAndInjectContentScopeScriptsThenDoNothing() {
+    fun whenDisabledAndInjectContentScopeScriptsThenDoNothing() = runTest {
         whenever(mockCoreContentScopeScripts.isEnabled()).thenReturn(false)
         messagingContentScopeScripts.injectContentScopeScripts(mockWebView)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205630541437755/f 

### Description
Moves content scope script's calls to `getScript()` (which can be expensive) away from the main thread

### Steps to test this PR

Ensure c-s-s still works as expected (@joshliebe , will lean on you here to define the best way to verify this 🙏)
