### PR TITLE
Remove set-as-default dialog from experiment notification

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
@@ -34,20 +34,13 @@ class DefaultBrowserObserver(
         if (appInstallStore.defaultBrowser != isDefaultBrowser) {
             appInstallStore.defaultBrowser = isDefaultBrowser
             when {
-                isDefaultBrowser && appInstallStore.setDefaultBrowserFromNotification -> {
-                    pixel.fire(AppPixelName.DEFAULT_BROWSER_SET_FROM_NOTIFICATION)
-                    appInstallStore.setDefaultBrowserFromNotification = false
-                }
                 isDefaultBrowser -> {
                     val params = mapOf(
                         PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to false.toString(),
                     )
                     pixel.fire(AppPixelName.DEFAULT_BROWSER_SET, params)
                 }
-                else -> {
-                    pixel.fire(AppPixelName.DEFAULT_BROWSER_UNSET)
-                    appInstallStore.setDefaultBrowserFromNotification = false
-                }
+                else -> pixel.fire(AppPixelName.DEFAULT_BROWSER_UNSET)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
@@ -36,8 +36,6 @@ interface AppInstallStore : MainProcessLifecycleObserver {
 
     var newDefaultBrowserDialogCount: Int
 
-    var setDefaultBrowserFromNotification: Boolean
-
     fun hasInstallTimestampRecorded(): Boolean
 }
 
@@ -62,10 +60,6 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
         get() = preferences.getInt(ROLE_MANAGER_BROWSER_DIALOG_KEY, 0)
         set(defaultBrowser) = preferences.edit { putInt(ROLE_MANAGER_BROWSER_DIALOG_KEY, defaultBrowser) }
 
-    override var setDefaultBrowserFromNotification: Boolean
-        get() = preferences.getBoolean(KEY_SET_DEFAULT_BROWSER_FROM_NOTIFICATION, false)
-        set(openFromNotification) = preferences.edit { putBoolean(KEY_SET_DEFAULT_BROWSER_FROM_NOTIFICATION, openFromNotification) }
-
     override fun hasInstallTimestampRecorded(): Boolean = preferences.contains(KEY_TIMESTAMP_UTC)
 
     private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
@@ -84,7 +78,6 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
         const val KEY_TIMESTAMP_UTC = "INSTALL_TIMESTAMP_UTC"
         const val KEY_WIDGET_INSTALLED = "KEY_WIDGET_INSTALLED"
         const val KEY_DEFAULT_BROWSER = "KEY_DEFAULT_BROWSER"
-        const val KEY_SET_DEFAULT_BROWSER_FROM_NOTIFICATION = "SET_DEFAULT_BROWSER_FROM_NOTIFICATION"
         private const val ROLE_MANAGER_BROWSER_DIALOG_KEY = "ROLE_MANAGER_BROWSER_DIALOG_KEY"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationRegistrar.kt
@@ -63,7 +63,7 @@ class NotificationRegistrar @Inject constructor(
         const val Article = 103 // 102 was used for the search notification hence using 103 moving forward
         const val AppFeature = 104
         const val SurveyAvailable = 109 // 105 to 108 were already used previously
-        const val DefaultBrowser = 110
+        // 110 was already used previously
     }
 
     object ChannelType {

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -42,7 +42,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     DEFAULT_BROWSER_NOT_SET("m_db_ns"),
     DEFAULT_BROWSER_UNSET("m_db_u"),
     DEFAULT_BROWSER_DIALOG_NOT_SHOWN("m_dbd_ns"),
-    DEFAULT_BROWSER_SET_FROM_NOTIFICATION("m_default_browser_set_from_notification"),
 
     WIDGET_CTA_SHOWN("m_wc_s"),
     WIDGET_CTA_LAUNCHED("m_wc_l"),

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -16,14 +16,12 @@
 
 package com.duckduckgo.app.settings
 
-import android.app.Activity
 import android.app.ActivityOptions
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.view.View
-import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -109,11 +107,6 @@ class SettingsActivity : DuckDuckGoActivity() {
     private val viewsInternal
         get() = binding.includeSettings.contentSettingsInternal
 
-    private var defaultBrowserLauncher = registerForActivityResult(StartActivityForResult()) { result ->
-        val isBrowserSetAsDefault: Boolean = result.resultCode == Activity.RESULT_OK
-        viewModel.onDefaultBrowserSetFromDialog(isBrowserSetAsDefault)
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -126,7 +119,7 @@ class SettingsActivity : DuckDuckGoActivity() {
         observeViewModel()
 
         intent?.getStringExtra(BrowserActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
-            viewModel.onLaunchedFromNotification(it, this)
+            viewModel.onLaunchedFromNotification(it)
         }
     }
 
@@ -251,13 +244,8 @@ class SettingsActivity : DuckDuckGoActivity() {
             is Command.LaunchPermissionsScreen -> launchPermissionsScreen()
             is Command.LaunchAppearanceScreen -> launchAppearanceScreen()
             is Command.LaunchAboutScreen -> launchAboutScreen()
-            is Command.ShowDefaultBrowserDialog -> showDefaultBrowserDialog(it.intent)
             null -> TODO()
         }
-    }
-
-    private fun showDefaultBrowserDialog(intent: Intent) {
-        defaultBrowserLauncher.launch(intent)
     }
 
     private fun updateDefaultBrowserViewVisibility(it: SettingsViewModel.ViewState) {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -17,8 +17,6 @@
 package com.duckduckgo.app.settings
 
 import android.annotation.SuppressLint
-import android.content.Context
-import android.content.Intent
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -28,9 +26,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
-import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.CheckListItem.CheckItemStatus
 import com.duckduckgo.app.settings.SettingsViewModel.NetPEntryState.Hidden
@@ -79,8 +75,6 @@ class SettingsViewModel @Inject constructor(
     private val networkProtectionWaitlist: NetworkProtectionWaitlist,
     private val dispatcherProvider: DispatcherProvider,
     private val autoconsent: Autoconsent,
-    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
-    private val appInstallStore: AppInstallStore,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(
@@ -124,7 +118,6 @@ class SettingsViewModel @Inject constructor(
         object LaunchPermissionsScreen : Command()
         object LaunchAppearanceScreen : Command()
         object LaunchAboutScreen : Command()
-        data class ShowDefaultBrowserDialog(val intent: Intent) : Command()
     }
 
     private val viewState = MutableStateFlow(ViewState())
@@ -343,39 +336,11 @@ class SettingsViewModel @Inject constructor(
         pixel.fire(SETTINGS_APPEARANCE_PRESSED)
     }
 
-    fun onLaunchedFromNotification(pixelName: String, context: Context) {
-        if (pixelName == DEFAULT_BROWSER_LAUNCHED_FROM_NOTIFICATION) {
-            launchSetAsDefaultBrowserOption(context)
-        }
+    fun onLaunchedFromNotification(pixelName: String) {
         pixel.fire(pixelName)
-    }
-
-    private fun launchSetAsDefaultBrowserOption(context: Context) {
-        if (defaultRoleBrowserDialog.shouldShowDialog()) {
-            val intent = defaultRoleBrowserDialog.createIntent(context)
-            if (intent != null) {
-                viewModelScope.launch { command.send(Command.ShowDefaultBrowserDialog(intent)) }
-            } else {
-                viewModelScope.launch { command.send(Command.LaunchDefaultBrowser) }
-                appInstallStore.setDefaultBrowserFromNotification = true
-            }
-        } else {
-            viewModelScope.launch { command.send(Command.LaunchDefaultBrowser) }
-            appInstallStore.setDefaultBrowserFromNotification = true
-        }
-    }
-
-    fun onDefaultBrowserSetFromDialog(ddgSetAsDefault: Boolean) {
-        defaultRoleBrowserDialog.dialogShown()
-        appInstallStore.defaultBrowser = ddgSetAsDefault
-        if (ddgSetAsDefault) {
-            viewModelScope.launch { viewState.emit(currentViewState().copy(isAppDefaultBrowser = true)) }
-            pixel.fire(DEFAULT_BROWSER_SET_FROM_NOTIFICATION)
-        }
     }
 
     companion object {
         const val EMAIL_PROTECTION_URL = "https://duckduckgo.com/email"
-        const val DEFAULT_BROWSER_LAUNCHED_FROM_NOTIFICATION = "mnot_l_DefaultBrowser"
     }
 }

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -33,12 +33,6 @@
     <string name="netpUnlockedSnackbar">You\'ve unlocked a beta feature!</string>
     <string name="netpUnlockedSnackbarAction">Open</string>
 
-    <!-- Set As Default Notification Experiment -->
-    <string name="setAsDefaultCompetitiveCopyNotificationTitle">Search like nobody’s watching 👀</string>
-    <string name="setAsDefaultCompetitiveCopyNotificationDescription">Google tracks you, we don\'t. Make DuckDuckGo your default browser today.</string>
-    <string name="setAsDefaultSetupCopyNotificationTitle">Almost there! 🚀</string>
-    <string name="setAsDefaultSetupCopyNotificationDescription">More privacy, faster page loads, and cleaner search results are just a tap away. Make DuckDuckGo your default browser today.</string>
-
     <!-- Sasquatch -->
     <string name="webViewErrorTitle">DuckDuckGo can\'t load this page</string>
     <string name="webViewErrorNoConnection">The internet connection appears to be offline.</string>

--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
@@ -45,7 +45,6 @@ class DefaultBrowserObserverTest {
     fun setup() {
         MockitoAnnotations.openMocks(this)
         testee = DefaultBrowserObserver(mockDefaultBrowserDetector, mockAppInstallStore, mockPixel)
-        whenever(mockAppInstallStore.setDefaultBrowserFromNotification).thenReturn(false)
     }
 
     @Test
@@ -89,28 +88,5 @@ class DefaultBrowserObserverTest {
         testee.onResume(mockOwner)
 
         verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_UNSET)
-    }
-
-    @Test
-    fun givenLaunchedFromNotificationWhenDDGIsDefaultBrowserIfItWasNotBeforeThenFireSetPixel() {
-        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(mockAppInstallStore.defaultBrowser).thenReturn(false)
-        whenever(mockAppInstallStore.setDefaultBrowserFromNotification).thenReturn(true)
-
-        testee.onResume(mockOwner)
-
-        verify(mockPixel).fire(AppPixelName.DEFAULT_BROWSER_SET_FROM_NOTIFICATION)
-        verify(mockAppInstallStore).setDefaultBrowserFromNotification = false
-    }
-
-    @Test
-    fun givenLaunchedFromNotificationWhenDDGIsNotDefaultBrowserIfItWasBeforeThenSetDefaultBrowserFromNotificationToFalse() {
-        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
-        whenever(mockAppInstallStore.defaultBrowser).thenReturn(true)
-        whenever(mockAppInstallStore.setDefaultBrowserFromNotification).thenReturn(true)
-
-        testee.onResume(mockOwner)
-
-        verify(mockAppInstallStore).setDefaultBrowserFromNotification = false
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205645143594459/f

### Description

- Remove set-as-default browser dialog logic from disabled experiment
- Remove temporal pixel for setting DDG as default from notification

### Steps to test this PR

_[Optional]_ Smoke test

### No UI changes
