### PR TITLE
Disable no engagement notifications experiment

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -30,7 +30,6 @@ import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.notification.model.SchedulableNotificationPlugin
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.di.scopes.AppScope
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -75,13 +75,11 @@ object NotificationModule {
         workManager: WorkManager,
         clearDataNotification: ClearDataNotification,
         privacyProtectionNotification: PrivacyProtectionNotification,
-        variantManager: VariantManager,
     ): AndroidNotificationScheduler {
         return NotificationScheduler(
             workManager,
             clearDataNotification,
             privacyProtectionNotification,
-            variantManager,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -23,8 +23,6 @@ import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.notification.model.ClearDataNotification
 import com.duckduckgo.app.notification.model.PrivacyProtectionNotification
 import com.duckduckgo.app.notification.model.SchedulableNotification
-import com.duckduckgo.app.statistics.VariantManager
-import com.duckduckgo.app.statistics.isNoEngagementNotificationEnabled
 import com.duckduckgo.di.scopes.AppScope
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -41,7 +39,6 @@ class NotificationScheduler(
     private val workManager: WorkManager,
     private val clearDataNotification: SchedulableNotification,
     private val privacyNotification: SchedulableNotification,
-    private val variantManager: VariantManager,
 ) : AndroidNotificationScheduler {
 
     override suspend fun scheduleNextNotification() {
@@ -49,10 +46,9 @@ class NotificationScheduler(
     }
 
     private suspend fun scheduleInactiveUserNotifications() {
-        if (!variantManager.isNoEngagementNotificationEnabled()) {
-            workManager.cancelAllWorkByTag(UNUSED_APP_WORK_REQUEST_TAG)
-            scheduleUnusedAppNotifications()
-        }
+        workManager.cancelAllWorkByTag(UNUSED_APP_WORK_REQUEST_TAG)
+
+        scheduleUnusedAppNotifications()
     }
 
     private suspend fun scheduleUnusedAppNotifications() {

--- a/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/VariantManagerTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.statistics
 
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NoEngagementNotifications
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -51,24 +50,6 @@ class VariantManagerTest {
                 fail("Duplicate variant name found: ${it.key}")
             }
         }
-    }
-
-    @Test
-    fun pushNotificationControlVariantHasExpectedWeightAndNoFeatures() {
-        val variant = variants.first { it.key == "mc" }
-
-        assertEqualsDouble(1.0, variant.weight)
-        assertEquals(0, variant.features.size)
-        assertEquals(0, variant.features.size)
-    }
-
-    @Test
-    fun pushNotificationCompetitiveCopyExperimentalVariantHasExpectedWeightAndFeatures() {
-        val variant = variants.first { it.key == "md" }
-
-        assertEqualsDouble(1.0, variant.weight)
-        assertEquals(1, variant.features.size)
-        assertTrue(variant.hasFeature(NoEngagementNotifications))
     }
 
     @Suppress("SameParameterValue")

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.statistics
 import androidx.annotation.WorkerThread
 import com.duckduckgo.app.statistics.VariantManager.Companion.DEFAULT_VARIANT
 import com.duckduckgo.app.statistics.VariantManager.Companion.referrerVariant
-import com.duckduckgo.app.statistics.VariantManager.VariantFeature.NoEngagementNotifications
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import java.util.Locale
@@ -29,9 +28,7 @@ import timber.log.Timber
 interface VariantManager {
 
     // variant-dependant features listed here
-    sealed class VariantFeature {
-        object NoEngagementNotifications : VariantFeature()
-    }
+    sealed class VariantFeature
 
     companion object {
 
@@ -45,10 +42,6 @@ interface VariantManager {
             // the future if we can filter by app version
             Variant(key = "sc", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
             Variant(key = "se", weight = 0.0, features = emptyList(), filterBy = { isSerpRegionToggleCountry() }),
-
-            // Experiment: Remove engagement notifications
-            Variant(key = "mc", weight = 1.0, features = emptyList(), filterBy = { noFilter() }),
-            Variant(key = "md", weight = 1.0, features = listOf(NoEngagementNotifications), filterBy = { noFilter() }),
         )
 
         val REFERRER_VARIANTS = listOf(
@@ -178,8 +171,6 @@ class ExperimentationVariantManager(
         return activeVariants[randomizedIndex]
     }
 }
-
-fun VariantManager.isNoEngagementNotificationEnabled() = this.getVariant().hasFeature(NoEngagementNotifications)
 
 /**
  * A variant which can be used for experimentation.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205645143594461/f

### Description
Disable and remove no-notifications experiment form the code

### Steps to test this PR

Change delay time to schedule engagement notifications in `AndroidNotificationScheduler.kt` so you can see notifications after seconds instead days

_(Optional) Engagement notifications_

- Uninstall previous version of the app or clear storage
- Install from this branch
- [ ] Check you see engagement notifications after the delay time

### No UI changes
