### PR TITLE
Launch BrowserActivity when tapping on dax logo (widget)

### DIFF
--- a/app/src/main/java/com/duckduckgo/widget/SearchAndFavoritesWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchAndFavoritesWidget.kt
@@ -153,6 +153,7 @@ class SearchAndFavoritesWidget : AppWidgetProvider() {
 
             remoteViews.setViewVisibility(R.id.searchInputBox, if (columns == 2) View.INVISIBLE else View.VISIBLE)
             remoteViews.setOnClickPendingIntent(R.id.widgetSearchBarContainer, buildPendingIntent(context))
+            remoteViews.setOnClickPendingIntent(R.id.logo, buildBrowserActivityPendingIntent(context))
 
             voiceSearchWidgetConfigurator.configureVoiceSearch(context, remoteViews, true)
             configureFavoritesGridView(context, appWidgetId, remoteViews, widgetTheme)
@@ -282,6 +283,12 @@ class SearchAndFavoritesWidget : AppWidgetProvider() {
     private fun buildPendingIntent(context: Context): PendingIntent {
         val intent = SystemSearchActivity.fromFavWidget(context)
         return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+    }
+
+    private fun buildBrowserActivityPendingIntent(context: Context): PendingIntent {
+        val intent = BrowserActivity.intent(context)
+        val pendingIntentFlags = if (appBuildConfig.sdkInt >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+        return PendingIntent.getActivity(context, 0, intent, pendingIntentFlags)
     }
 
     private fun buildOnboardingPendingIntent(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required iff your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1201659732216532/f 

### Description
Open app from the widget when tapping on dax logo

### Steps to test this PR

_Tap on dax icon opens app_
- [x] Add both favorites and search widgets to home screen
- [x] Tap on the dax icon on the widget
- [x] Check browser is open

_Tap on search bar opens interstitial scrren_
- [x] Add both favorites and search widgets to home screen
- [x] Tap on the search bar on the widget
- [x] Check interstitial screen is open

_Empty favorites (regression)_
- [x] Clear app data
- [x] Add favorites widget to home screen
- [x] Tap on add favorites on the widget
- [x] Check app is open and instructions to add favorites are displayed


_Non-empty favorites (regression)_
- [x] Add a favorite site
- [x] Add favorites widget to home screen
- [ ] Tap on a favorite on the widget
- [ ] Check app is open and selected site is loaded


### UI changes
No UI changes
