### PR TITLE
Change text dialog to allow only one button

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/dialogs/DialogsFragment.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/dialogs/DialogsFragment.kt
@@ -186,6 +186,24 @@ class DialogsFragment : Fragment() {
             }
         }
 
+        view.findViewById<Button>(R.id.textAlertDialogOneButton)?.let {
+            it.setOnClickListener {
+                TextAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.text_dialog_title)
+                    .setMessage(R.string.text_dialog_message)
+                    .setCancellable(true)
+                    .setPositiveButton(R.string.text_dialog_positive)
+                    .addEventListener(
+                        object : TextAlertDialogBuilder.EventListener() {
+                            override fun onPositiveButtonClicked() {
+                                Snackbar.make(it, "Positive Button Clicked", Snackbar.LENGTH_SHORT).show()
+                            }
+                        },
+                    )
+                    .show()
+            }
+        }
+
         view.findViewById<Button>(R.id.stackedAlertDialogWithImageButton)?.let {
             it.setOnClickListener {
                 StackedAlertDialogBuilder(requireContext())

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -166,6 +166,11 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         binding.textAlertDialogCancelButton.isVisible = !isDestructiveVersion
         binding.textAlertDialogCancelDestructiveButton.isVisible = isDestructiveVersion
 
+        if (negativeButtonText.isEmpty()) {
+            binding.textAlertDialogCancelDestructiveButton.gone()
+            binding.textAlertDialogCancelButton.gone()
+        }
+
         if (isDestructiveVersion) {
             setButtonListener(binding.textAlertDialogPositiveDestructiveButton, positiveButtonText, dialog) { listener.onPositiveButtonClicked() }
             setButtonListener(binding.textAlertDialogCancelDestructiveButton, negativeButtonText, dialog) { listener.onNegativeButtonClicked() }
@@ -199,9 +204,6 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     private fun checkRequiredFieldsSet() {
         if (positiveButtonText.isEmpty()) {
             throw Exception("TextAlertDialog: You must always provide a Positive Button")
-        }
-        if (negativeButtonText.isEmpty()) {
-            throw Exception("TextAlertDialog: You must always provide a Negative Button")
         }
         if (titleText.isEmpty()) {
             throw Exception("TextAlertDialog: You must always provide a Title")

--- a/common/common-ui/src/main/res/layout/fragment_components_dialogs.xml
+++ b/common/common-ui/src/main/res/layout/fragment_components_dialogs.xml
@@ -65,6 +65,14 @@
             android:layout_height="wrap_content" />
 
         <com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
+                android:id="@+id/textAlertDialogOneButton"
+                app:buttonSize="large"
+                android:text="Text Alert Dialog With One Button"
+                android:layout_marginTop="16dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        <com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
             app:buttonSize="large"
             android:id="@+id/stackedAlertDialogWithImageButton"
             android:layout_width="match_parent"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205678967478266/f 

### Description
Allow text dialogs to have only a primary button

### Steps to test this PR

- [ ] Go to internal settings and dialogs
- [ ] Click on Text Alert Dialog With One Button
- [ ] Dialog should have one button only

