### PR TITLE
Fix CPU load measurement for :vpn process

### DIFF
--- a/app-tracking-protection/vpn-impl/build.gradle
+++ b/app-tracking-protection/vpn-impl/build.gradle
@@ -36,6 +36,7 @@ android {
             includeAndroidResources = true
         }
     }
+    namespace 'com.duckduckgo.mobile.android.vpn'
 }
 
 dependencies {

--- a/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
+++ b/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.duckduckgo.mobile.android.vpn">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -101,6 +100,12 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
+
+        <!-- This is the Worker Service where VPN workers need to bind into -->
+        <service
+            android:name="androidx.work.multiprocess.RemoteWorkerService"
+            android:exported="false"
+            android:process=":vpn" />
 
         <receiver
             android:name=".service.VpnReminderReceiver"

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/WorkerExtensions.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/WorkerExtensions.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn
+
+import android.content.ComponentName
+import androidx.work.Data
+import androidx.work.PeriodicWorkRequest
+import androidx.work.multiprocess.RemoteListenableWorker
+import androidx.work.multiprocess.RemoteWorkerService
+
+/**
+ * Use this extension function to make sure your [PeriodicWorkRequest] runs in the VPN process
+ */
+internal fun PeriodicWorkRequest.Builder.boundToVpnProcess(applicationId: String): PeriodicWorkRequest.Builder {
+    val componentName = ComponentName(applicationId, RemoteWorkerService::class.java.name)
+    val data = Data.Builder()
+        .putString(RemoteListenableWorker.ARGUMENT_PACKAGE_NAME, componentName.packageName)
+        .putString(RemoteListenableWorker.ARGUMENT_CLASS_NAME, componentName.className)
+        .build()
+
+    return this.setInputData(data)
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitor.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitor.kt
@@ -20,7 +20,9 @@ import androidx.annotation.VisibleForTesting
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.VpnScope
+import com.duckduckgo.mobile.android.vpn.boundToVpnProcess
 import com.duckduckgo.mobile.android.vpn.feature.AppTpFeatureConfig
 import com.duckduckgo.mobile.android.vpn.feature.AppTpSetting
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
@@ -35,6 +37,7 @@ import logcat.logcat
 class AppTPCPUMonitor @Inject constructor(
     private val workManager: WorkManager,
     private val appTpFeatureConfig: AppTpFeatureConfig,
+    private val appBuildConfig: AppBuildConfig,
 ) : VpnServiceCallbacks {
 
     companion object {
@@ -46,6 +49,7 @@ class AppTPCPUMonitor @Inject constructor(
         if (appTpFeatureConfig.isEnabled(AppTpSetting.CPUMonitoring)) {
             logcat { "AppTpSetting.CPUMonitoring is enabled, starting monitoring" }
             val work = PeriodicWorkRequestBuilder<CPUMonitorWorker>(4, TimeUnit.HOURS)
+                .boundToVpnProcess(appBuildConfig.applicationId) // this worker is executed in the :vpn process
                 .setInitialDelay(10, TimeUnit.MINUTES) // let the CPU usage settle after VPN restart
                 .build()
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/CPUMonitorWorker.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/CPUMonitorWorker.kt
@@ -17,8 +17,8 @@
 package com.duckduckgo.mobile.android.vpn.health
 
 import android.content.Context
-import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import androidx.work.multiprocess.RemoteCoroutineWorker
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -33,7 +33,7 @@ import logcat.logcat
 class CPUMonitorWorker(
     context: Context,
     workerParams: WorkerParameters,
-) : CoroutineWorker(context, workerParams) {
+) : RemoteCoroutineWorker(context, workerParams) {
     @Inject
     lateinit var deviceShieldPixels: DeviceShieldPixels
 
@@ -46,7 +46,7 @@ class CPUMonitorWorker(
     // TODO: move thresholds to remote config
     private val alertThresholds = listOf(30, 20, 10, 5).sortedDescending()
 
-    override suspend fun doWork(): Result {
+    override suspend fun doRemoteWork(): Result {
         return withContext(dispatcherProvider.io()) {
             try {
                 val avgCPUUsagePercent = cpuUsageReader.readCPUUsage()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/CPUUsageReaderImpl.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/CPUUsageReaderImpl.kt
@@ -30,6 +30,7 @@ import java.io.IOException
 import java.util.*
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
+import logcat.logcat
 
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
@@ -55,6 +56,7 @@ class CPUUsageReaderImpl @Inject constructor() : CPUUsageReader {
     @WorkerThread
     override fun readCPUUsage(): Double {
         val pid = android.os.Process.myPid()
+        logcat { "Reading CPU load for process with pid=$pid" }
         val procFile = File("/proc/$pid/stat")
         val statsText = (FileReader(procFile)).buffered().use(BufferedReader::readText)
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitorTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitorTest.kt
@@ -75,12 +75,14 @@ class AppTPCPUMonitorTest {
     private val mockCPUUsageReader: CPUUsageReader = mock()
     private val mockAppBuildConfig: AppBuildConfig = mock()
     private val mockVpnRemoteConfigDatabase: VpnRemoteConfigDatabase = mock()
+    private val appBuildConfig: AppBuildConfig = mock()
 
     @Before
     fun setup() {
         toggleDao = FakeToggleConfigDao()
         whenever(mockAppBuildConfig.flavor).thenReturn(BuildFlavor.INTERNAL)
         whenever(mockVpnRemoteConfigDatabase.vpnConfigTogglesDao()).thenReturn(toggleDao)
+        whenever(appBuildConfig.applicationId).thenReturn("")
 
         config = AppTpFeatureConfigImpl(
             TestScope(),
@@ -99,7 +101,7 @@ class AppTPCPUMonitorTest {
         workManager = WorkManager.getInstance(context)
         testDriver = WorkManagerTestInitHelper.getTestDriver(context)!!
 
-        cpuMonitor = AppTPCPUMonitor(workManager, config)
+        cpuMonitor = AppTPCPUMonitor(workManager, config, appBuildConfig)
     }
 
     @After

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -72,7 +72,7 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
 
     override fun onMainProcessCreate() {
         configureLogging()
-        Timber.d("onMainProcessCreate $currentProcessName")
+        Timber.d("onMainProcessCreate $currentProcessName with pid=${android.os.Process.myPid()}")
 
         configureDependencyInjection()
         setupActivityLifecycleCallbacks()
@@ -94,7 +94,8 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
 
     override fun onSecondaryProcessCreate(shortProcessName: String) {
         runInSecondaryProcessNamed(VPN_PROCESS_NAME) {
-            Timber.d("Init for secondary process $shortProcessName")
+            configureLogging()
+            Timber.d("Init for secondary process $shortProcessName with pid=${android.os.Process.myPid()}")
             configureDependencyInjection()
             configureUncaughtExceptionHandlerVpn()
             initializeDateLibrary()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205698558631498/f

### Description
Fix CPU measurement, it was measure on the wrong process

### Steps to test this PR

Apply the following patch

```diff
Index: app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitor.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitor.kt b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitor.kt
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitor.kt	(revision 6014434716b85d428c70449a9d2ceeab55f881f2)
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitor.kt	(date 1697118279707)
@@ -50,10 +50,10 @@
             logcat { "AppTpSetting.CPUMonitoring is enabled, starting monitoring" }
             val work = PeriodicWorkRequestBuilder<CPUMonitorWorker>(4, TimeUnit.HOURS)
                 .boundToVpnProcess(appBuildConfig.applicationId) // this worker is executed in the :vpn process
-                .setInitialDelay(10, TimeUnit.MINUTES) // let the CPU usage settle after VPN restart
+                .setInitialDelay(2, TimeUnit.SECONDS) // let the CPU usage settle after VPN restart
                 .build()
 
-            workManager.enqueueUniquePeriodicWork(APP_TRACKER_CPU_MONITOR_WORKER_TAG, ExistingPeriodicWorkPolicy.KEEP, work)
+            workManager.enqueueUniquePeriodicWork(APP_TRACKER_CPU_MONITOR_WORKER_TAG, ExistingPeriodicWorkPolicy.REPLACE, work)
         } else {
             logcat { "AppTpSetting.CPUMonitoring is disabled" }
         }
```

* build app and install
* filter logcat by `with pid=`
* launch app and enable AppTP
- [x] verify the `pid` in `Reading CPU load for process with pid=##` is the one from the VPN process
