### PR TITLE
Log registration errors

### DIFF
--- a/network-protection/network-protection-impl/build.gradle
+++ b/network-protection/network-protection-impl/build.gradle
@@ -24,6 +24,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     anvil project(':anvil-compiler')
+    implementation project(':anrs-api')
     implementation project(':anvil-annotations')
     implementation project(':app-build-config-api')
     implementation project(':browser-api')

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/configuration/WgTunnel.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/configuration/WgTunnel.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.networkprotection.impl.configuration
 
+import com.duckduckgo.anrs.api.CrashLogger
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.networkprotection.impl.configuration.WgTunnel.WgTunnelData
 import com.squareup.anvil.annotations.ContributesBinding
@@ -48,6 +49,7 @@ fun Map<InetAddress, Int>.toCidrString(): Set<String> {
 class RealWgTunnel @Inject constructor(
     private val deviceKeys: DeviceKeys,
     private val wgServerApi: WgServerApi,
+    private val crashLogger: CrashLogger,
 ) : WgTunnel {
 
     override suspend fun establish(): WgTunnelData? {
@@ -80,6 +82,7 @@ class RealWgTunnel @Inject constructor(
                 }
         } catch (e: Throwable) {
             logcat(LogPriority.ERROR) { "Error getting WgTunnelData: ${e.asLog()}" }
+            crashLogger.logCrash(CrashLogger.Crash(shortName = "m_netp_ev_key_registration_error", t = e))
             null
         }
     }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/configuration/WgTunnelTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/configuration/WgTunnelTest.kt
@@ -1,0 +1,82 @@
+package com.duckduckgo.networkprotection.impl.configuration
+
+import android.os.Build.VERSION
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.anrs.api.CrashLogger
+import com.duckduckgo.mobile.android.vpn.prefs.FakeVpnSharedPreferencesProvider
+import com.duckduckgo.networkprotection.impl.store.RealNetworkProtectionRepository
+import com.duckduckgo.networkprotection.store.RealNetworkProtectionPrefs
+import com.wireguard.config.InetAddresses
+import java.lang.reflect.Field
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class WgTunnelTest {
+
+    private val wgServerApi: WgServerApi = mock()
+    private val crashLogger: CrashLogger = mock()
+    private val serverData = WgServerApi.WgServerData(
+        serverName = "name",
+        publicKey = "public key",
+        publicEndpoint = "1.1.1.1:443",
+        address = "10.0.0.1/32",
+        location = "Furadouro",
+        gateway = "10.1.1.1",
+    )
+    private lateinit var wgTunnel: WgTunnel
+
+    @Before
+    fun setup() {
+        val networkProtectionPrefs = RealNetworkProtectionPrefs(FakeVpnSharedPreferencesProvider())
+        val networkProtectionRepository = RealNetworkProtectionRepository(networkProtectionPrefs)
+        val deviceKeys = RealDeviceKeys(networkProtectionRepository, WgKeyPairGenerator())
+        setFinalStatic(VERSION::class.java.getField("SDK_INT"), 29)
+
+        runBlocking {
+            whenever(wgServerApi.registerPublicKey(eq(deviceKeys.publicKey)))
+                .thenReturn(serverData.copy(publicKey = deviceKeys.publicKey))
+        }
+
+        wgTunnel = RealWgTunnel(deviceKeys, wgServerApi, crashLogger)
+    }
+
+    @Test
+    fun establishThenReturnWgTunnelData() = runTest {
+        val actual = wgTunnel.establish()!!.copy(userSpaceConfig = "")
+        val expected = WgTunnel.WgTunnelData(
+            serverName = serverData.serverName,
+            userSpaceConfig = "",
+            serverLocation = serverData.location,
+            serverIP = serverData.publicEndpoint.substringBefore(":"),
+            gateway = serverData.gateway,
+            tunnelAddress = mapOf(
+                InetAddresses.parse(serverData.address.substringBefore("/")) to serverData.address.substringAfter("/").toInt(),
+            ),
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun establishErrorThenLogError() = runTest {
+        whenever(wgServerApi.registerPublicKey(any())).thenReturn(serverData)
+
+        assertNull(wgTunnel.establish())
+        verify(crashLogger).logCrash(any<CrashLogger.Crash>())
+    }
+
+    @Throws(Exception::class)
+    fun setFinalStatic(field: Field, newValue: Any?) {
+        field.setAccessible(true)
+        field.set(null, newValue)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205712062668046/f

### Description
Log crash when registration fails

### Steps to test this PR
* Apply the following patch
```diff
Index: statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt b/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt
--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt	(revision 219cf9110ac5db4eb11bb7c5bc8e93a2f34870f7)
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt	(date 1697137715073)
@@ -52,7 +52,7 @@
             .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_INTERVAL, BACKOFF_TIME_UNIT)
             .build()
 
-        workManager.enqueueUniquePeriodicWork(WORK_REQUEST_TAG, ExistingPeriodicWorkPolicy.KEEP, request)
+        workManager.enqueueUniquePeriodicWork(WORK_REQUEST_TAG, ExistingPeriodicWorkPolicy.REPLACE, request)
     }
 
     companion object {
```

* Throw an error in `RealWgTunnel::establish()`
* Build, install and enable NP
- [ ] verify NP doesn't enable
- [ ] force close the app and re-open it
- [ ] verify `m_d_ac_g` logs with the proper information

