### PR TITLE
Fix DRM permissions

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -209,6 +209,7 @@ class BrowserChromeClientTest {
         testee.onPermissionRequest(mockPermission)
 
         verify(mockPermission, never()).grant(any())
+        verify(mockPermission).deny()
     }
 
     @ExperimentalCoroutinesApi

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -78,7 +78,7 @@ class BrowserChromeClientTest {
         mockFileChooserParams = mock()
         testee.webViewClientListener = mockWebViewClientListener
         webView = TestWebView(getInstrumentation().targetContext)
-        whenever(mockDrm.getDrmPermissionsForRequest(any(), any())).thenReturn(arrayOf())
+        whenever(mockDrm.isDrmAllowedForUrl(any())).thenReturn(false)
         mockSitePermissionsManager.stub { onBlocking { getSitePermissionsAllowedToAsk(any(), any()) }.thenReturn(arrayOf()) }
     }
 
@@ -192,7 +192,7 @@ class BrowserChromeClientTest {
         val mockPermission: PermissionRequest = mock()
         whenever(mockPermission.resources).thenReturn(permissions)
         whenever(mockPermission.origin).thenReturn("https://open.spotify.com".toUri())
-        whenever(mockDrm.getDrmPermissionsForRequest(any(), any())).thenReturn(permissions)
+        whenever(mockDrm.isDrmAllowedForUrl(any())).thenReturn(true)
         testee.onPermissionRequest(mockPermission)
 
         verify(mockPermission).grant(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
@@ -204,7 +204,7 @@ class BrowserChromeClientTest {
         val mockPermission: PermissionRequest = mock()
         whenever(mockPermission.resources).thenReturn(permissions)
         whenever(mockPermission.origin).thenReturn("https://www.example.com".toUri())
-        whenever(mockDrm.getDrmPermissionsForRequest(any(), any())).thenReturn(arrayOf())
+        whenever(mockDrm.isDrmAllowedForUrl(any())).thenReturn(false)
 
         testee.onPermissionRequest(mockPermission)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -138,10 +138,14 @@ class BrowserChromeClient @Inject constructor(
     }
 
     override fun onPermissionRequest(request: PermissionRequest) {
-        val drmPermissions = drm.getDrmPermissionsForRequest(request.origin.toString(), request.resources)
-        if (drmPermissions.isNotEmpty()) {
-            request.grant(drmPermissions)
+        if (request.resources.contains(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)) {
+            if (drm.isDrmAllowedForUrl(request.origin.toString())) {
+                request.grant(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
+            } else {
+                request.deny()
+            }
         }
+
         appCoroutineScope.launch(coroutineDispatcher.io()) {
             val permissionsAllowedToAsk = sitePermissionsManager.getSitePermissionsAllowedToAsk(request.origin.toString(), request.resources)
             if (permissionsAllowedToAsk.isNotEmpty()) {

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Drm.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Drm.kt
@@ -19,9 +19,8 @@ package com.duckduckgo.privacy.config.api
 /** Public interface for the DRM feature */
 interface Drm {
     /**
-     * This method takes a [url] and an [Array<String>] returns an `Array<String>` depending on the
-     * [url]
-     * @return an `Array<String>` if the given [url] is in the eme list and an empty array
+     * This method takes a [url] of the page requesting DRM permissions
+     * @return an `true` if the given [url] is allowed DRM, `false`
      * otherwise.
      */
     fun isDrmAllowedForUrl(

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Drm.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Drm.kt
@@ -24,10 +24,9 @@ interface Drm {
      * @return an `Array<String>` if the given [url] is in the eme list and an empty array
      * otherwise.
      */
-    fun getDrmPermissionsForRequest(
+    fun isDrmAllowedForUrl(
         url: String,
-        resources: Array<String>,
-    ): Array<String>
+    ): Boolean
 }
 
 /** Public data class for Drm Exceptions */

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
@@ -43,7 +43,7 @@ class RealDrmTest {
     val testee: RealDrm = RealDrm(mockFeatureToggle, mockDrmRepository, mockUserAllowListRepository, mockUnprotectedTemporary)
 
     @Test
-    fun whenGetDrmPermissionsForRequestIfFeatureIsEnabledAndProtectedMediaIdIsRequestedThenPermissionIsReturned() {
+    fun whenIsDrmAllowedForUrlIfFeatureIsEnabledAndProtectedMediaIdIsRequestedThenTrueIsReturned() {
         giveFeatureIsEnabled()
         givenUrlIsInExceptionList()
 
@@ -52,7 +52,7 @@ class RealDrmTest {
     }
 
     @Test
-    fun whenGetDrmPermissionsForRequestIfFeatureIsEnabledAndDomainIsNotInExceptionsListThenNoPermissionsAreReturned() {
+    fun whenIsDrmAllowedForUrlIfFeatureIsEnabledAndDomainIsNotInExceptionsListThenFalseIsReturned() {
         giveFeatureIsEnabled()
         givenUrlIsNotInExceptionList()
 
@@ -61,14 +61,14 @@ class RealDrmTest {
     }
 
     @Test
-    fun whenGetDrmPermissionsForRequestIfFeatureIsDisableThenNoPermissionsAreReturned() {
+    fun whenIsDrmAllowedForUrlIfFeatureIsDisableThenFalseIsReturned() {
         val url = "https://open.spotify.com"
 
         assertFalse(testee.isDrmAllowedForUrl(url))
     }
 
     @Test
-    fun whenGetDrmPermissionsForRequestAndIsInUserAllowListThenNoPermissionsAreReturned() {
+    fun whenIsDrmAllowedForUrlAndIsInUserAllowListThenTrueIsReturned() {
         giveFeatureIsEnabled()
         givenUrlIsNotInExceptionList()
         givenUriIsInUserAllowList()
@@ -78,7 +78,7 @@ class RealDrmTest {
     }
 
     @Test
-    fun whenGetDrmPermissionsForRequestAndIsInUnprotectedTemporaryThenNoPermissionsAreReturned() {
+    fun whenIsDrmAllowedForUrlAndIsInUnprotectedTemporaryThenTrueIsReturned() {
         giveFeatureIsEnabled()
         givenUrlIsNotInExceptionList()
         givenUrlIsInUnprotectedTemporary()

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.privacy.config.impl.features.drm
 
-import android.webkit.PermissionRequest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.feature.toggles.api.FeatureToggle
@@ -48,27 +47,8 @@ class RealDrmTest {
         giveFeatureIsEnabled()
         givenUrlIsInExceptionList()
 
-        val permissions = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
         val url = "https://open.spotify.com"
-
-        val value = testee.getDrmPermissionsForRequest(url, permissions)
-
-        assertEquals(1, value.size)
-        assertEquals(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID, value.first())
-    }
-
-    @Test
-    fun whenGetDrmPermissionsForRequestIfFeatureIsEnabledAndProtectedMediaIdIsNotRequestedThenNoPermissionsAreReturned() {
-        giveFeatureIsEnabled()
-        givenUrlIsInExceptionList()
-
-        val permissions =
-            arrayOf(PermissionRequest.RESOURCE_MIDI_SYSEX, PermissionRequest.RESOURCE_VIDEO_CAPTURE, PermissionRequest.RESOURCE_AUDIO_CAPTURE)
-        val url = "https://open.spotify.com"
-
-        val value = testee.getDrmPermissionsForRequest(url, permissions)
-
-        assertEquals(0, value.size)
+        assertTrue(testee.isDrmAllowedForUrl(url))
     }
 
     @Test
@@ -76,23 +56,15 @@ class RealDrmTest {
         giveFeatureIsEnabled()
         givenUrlIsNotInExceptionList()
 
-        val permissions =
-            arrayOf(PermissionRequest.RESOURCE_MIDI_SYSEX, PermissionRequest.RESOURCE_VIDEO_CAPTURE, PermissionRequest.RESOURCE_AUDIO_CAPTURE)
         val url = "https://test.com"
-
-        val value = testee.getDrmPermissionsForRequest(url, permissions)
-
-        assertEquals(0, value.size)
+        assertFalse(testee.isDrmAllowedForUrl(url))
     }
 
     @Test
     fun whenGetDrmPermissionsForRequestIfFeatureIsDisableThenNoPermissionsAreReturned() {
-        val permissions = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
         val url = "https://open.spotify.com"
 
-        val value = testee.getDrmPermissionsForRequest(url, permissions)
-
-        assertEquals(0, value.size)
+        assertFalse(testee.isDrmAllowedForUrl(url))
     }
 
     @Test
@@ -101,12 +73,8 @@ class RealDrmTest {
         givenUrlIsNotInExceptionList()
         givenUriIsInUserAllowList()
 
-        val permissions = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
         val url = "https://open.spotify.com"
-
-        val value = testee.getDrmPermissionsForRequest(url, permissions)
-
-        assertEquals(0, value.size)
+        assertTrue(testee.isDrmAllowedForUrl(url))
     }
 
     @Test
@@ -115,12 +83,8 @@ class RealDrmTest {
         givenUrlIsNotInExceptionList()
         givenUrlIsInUnprotectedTemporary()
 
-        val permissions = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
         val url = "https://open.spotify.com"
-
-        val value = testee.getDrmPermissionsForRequest(url, permissions)
-
-        assertEquals(0, value.size)
+        assertTrue(testee.isDrmAllowedForUrl(url))
     }
 
     private fun giveFeatureIsEnabled() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205710253534934/f

### Description
* Make sure we deny DRM explicitly to avoid website hangs
* If users disable protections, DRM should be allowed
* Similarly, if we temporarily disable all protections for a site via `unprotectedTemporary`, DRM should be allowed

### Steps to test this PR
- [x] Try to load https://shaka-player-demo.appspot.com/support.html - it should be blank
- [x] Install from this branch
- [x] Load https://shaka-player-demo.appspot.com/support.html - it should now show available DRMs and `com.widevine.alpha` should be `null`
- [x] Disable protections for the site and reload it. `com.widevine.alpha` should now be a non-null object
- [x] Re-enable protections and override PrivacyConfig to add `shaka-player-demo.appspot.com` to `eme` exceptions. You can use this one (version may need an update): https://jsonblob.com/api/jsonBlob/1160261143960084480
- [x] Load https://shaka-player-demo.appspot.com/support.html - `com.widevine.alpha` should be a non-null object
- [x] Update the config and add `shaka-player-demo.appspot.com` to `unprotectedTemporary`
- [x] Load https://shaka-player-demo.appspot.com/support.html - `com.widevine.alpha` should be a non-null object