### PR TITLE
Add support for privacy config v4

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/AdClickAttributionFeature.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/AdClickAttributionFeature.kt
@@ -16,11 +16,13 @@
 
 package com.duckduckgo.adclick.impl
 
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+
 data class AdClickAttributionFeature(
     val state: String,
     val minSupportedVersion: Int?,
     val settings: AdClickAttributionSettings,
-    val exceptions: List<AdClickAttributionException>,
+    val exceptions: List<FeatureException>,
 )
 
 data class AdClickAttributionSettings(
@@ -41,5 +43,3 @@ data class AdClickAttributionAllowlist(
     val blocklistEntry: String?,
     val host: String?,
 )
-
-data class AdClickAttributionException(val domain: String, val reason: String)

--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -735,11 +735,11 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("domain", String::class.asClassName())
-                    .addParameter("reason", String::class.asClassName())
+                    .addParameter("reason", String::class.asClassName().copy(nullable = true))
                     .build(),
             )
             .addProperty(PropertySpec.builder("domain", String::class.asClassName()).initializer("domain").build())
-            .addProperty(PropertySpec.builder("reason", String::class.asClassName()).initializer("reason").build())
+            .addProperty(PropertySpec.builder("reason", String::class.asClassName().copy(nullable = true)).initializer("reason").build())
             .build()
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/cookies/impl/features/firstparty/RealFirstPartyCookiesModifierTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/cookies/impl/features/firstparty/RealFirstPartyCookiesModifierTest.kt
@@ -26,12 +26,11 @@ import com.duckduckgo.app.fire.WebViewDatabaseLocator
 import com.duckduckgo.app.global.DefaultDispatcherProvider
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.cookies.api.CookieException
 import com.duckduckgo.cookies.impl.SQLCookieRemover
 import com.duckduckgo.cookies.store.CookiesRepository
 import com.duckduckgo.cookies.store.FirstPartyCookiePolicyEntity
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
-import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
 import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -154,7 +153,7 @@ class RealFirstPartyCookiesModifierTest {
             givenDatabaseWithCookies((THRESHOLD + 1).toLong())
             whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions).thenReturn(
                 listOf(
-                    UnprotectedTemporaryException(
+                    FeatureException(
                         "example.com",
                         "reason",
                     ),
@@ -182,7 +181,7 @@ class RealFirstPartyCookiesModifierTest {
         withContext(Dispatchers.Main) {
             givenDatabaseWithCookies((THRESHOLD + 1).toLong())
             whenever(mockCookiesRepository.exceptions).thenReturn(
-                listOf(CookieException(domain = "example.com", reason = "test")),
+                listOf(FeatureException(domain = "example.com", reason = "test")),
             )
             val sqlCookieRemover = givenRealFirstPartyCookiesModifier()
 

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeature.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeature.kt
@@ -16,12 +16,12 @@
 
 package com.duckduckgo.autoconsent.impl
 
-import com.duckduckgo.autoconsent.store.AutoconsentExceptionEntity
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 data class AutoconsentFeature(
     val state: String,
     val minSupportedVersion: Int?,
-    val exceptions: List<AutoconsentExceptionEntity>,
+    val exceptions: List<FeatureException>,
     val settings: Settings,
 )
 

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeaturePlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/AutoconsentFeaturePlugin.kt
@@ -49,7 +49,7 @@ class AutoconsentFeaturePlugin @Inject constructor(
             }.orEmpty()
 
             val exceptions = autoconsentFeature?.exceptions?.map {
-                AutoconsentExceptionEntity(domain = it.domain, reason = it.reason)
+                AutoconsentExceptionEntity(domain = it.domain, reason = it.reason.orEmpty())
             }.orEmpty()
 
             autoconsentRepository.updateAll(exceptions, disabledCmps)

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
@@ -24,8 +24,8 @@ import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.autoconsent.api.AutoconsentCallback
 import com.duckduckgo.autoconsent.store.AutoconsentSettingsRepository
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
-import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
 
 class FakePluginPoint : PluginPoint<MessageHandlerPlugin> {
     val plugin = FakeMessageHandlerPlugin()
@@ -59,8 +59,8 @@ class FakeUnprotected(private val exceptionList: List<String>) : UnprotectedTemp
         return exceptionList.contains(url.toUri().domain())
     }
 
-    override val unprotectedTemporaryExceptions: List<UnprotectedTemporaryException>
-        get() = exceptionList.map { UnprotectedTemporaryException(domain = it, reason = "A reason") }
+    override val unprotectedTemporaryExceptions: List<FeatureException>
+        get() = exceptionList.map { FeatureException(domain = it, reason = "A reason") }
 }
 
 class FakeUserAllowlist(private val userAllowList: List<String>) : UserAllowListRepository {

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/RealAutoconsentTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/RealAutoconsentTest.kt
@@ -20,8 +20,8 @@ import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.autoconsent.api.AutoconsentFeatureName
-import com.duckduckgo.autoconsent.store.AutoconsentExceptionEntity
 import com.duckduckgo.autoconsent.store.AutoconsentRepository
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import org.junit.Assert.*
 import org.junit.Before
@@ -47,7 +47,7 @@ class RealAutoconsentTest {
     @Before
     fun setup() {
         whenever(mockFeatureToggle.isFeatureEnabled(AutoconsentFeatureName.Autoconsent.value)).thenReturn(true)
-        whenever(mockAutoconsentRepository.exceptions).thenReturn(listOf(AutoconsentExceptionEntity("exception.com", "reason")))
+        whenever(mockAutoconsentRepository.exceptions).thenReturn(listOf(FeatureException("exception.com", "reason")))
         autoconsent = RealAutoconsent(
             pluginPoint,
             settingsRepository,

--- a/autoconsent/autoconsent-store/build.gradle
+++ b/autoconsent/autoconsent-store/build.gradle
@@ -8,6 +8,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation project(path: ':autoconsent-api')
+    implementation project(path: ':feature-toggles-api')
     implementation project(path: ':common-utils')
 
     implementation AndroidX.core.ktx

--- a/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentDatabaseModels.kt
+++ b/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentDatabaseModels.kt
@@ -18,12 +18,17 @@ package com.duckduckgo.autoconsent.store
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 @Entity(tableName = "autoconsent_exceptions")
 data class AutoconsentExceptionEntity(
     @PrimaryKey val domain: String,
     val reason: String,
 )
+
+fun AutoconsentExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
+}
 
 @Entity(tableName = "autoconsent_disabled_cmps")
 data class DisabledCmpsEntity(

--- a/autoconsent/autoconsent-store/src/test/java/com/duckduckgo/autoconsent/store/RealAutoconsentRepositoryTest.kt
+++ b/autoconsent/autoconsent-store/src/test/java/com/duckduckgo/autoconsent/store/RealAutoconsentRepositoryTest.kt
@@ -54,7 +54,7 @@ class RealAutoconsentRepositoryTest {
 
         repository = RealAutoconsentRepository(mockDatabase, TestScope(), coroutineRule.testDispatcherProvider)
 
-        assertEquals(exception, repository.exceptions.first())
+        assertEquals(exception.toFeatureException(), repository.exceptions.first())
         assertEquals(disabledCmp, repository.disabledCmps.first())
     }
 

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/Autofill.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/Autofill.kt
@@ -26,9 +26,3 @@ interface Autofill {
      */
     fun isAnException(url: String): Boolean
 }
-
-/** Public data class for Autofill Exceptions */
-data class AutofillException(
-    val domain: String,
-    val reason: String,
-)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/feature/plugin/AutofillFeatureExceptionStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/feature/plugin/AutofillFeatureExceptionStore.kt
@@ -32,7 +32,7 @@ class AutofillFeatureExceptionStore @Inject constructor(
 ) : FeatureExceptions.Store {
     override fun insertAll(exception: List<FeatureExceptions.FeatureException>) {
         autofillFeatureRepository.updateAllExceptions(
-            exception.map { AutofillExceptionEntity(domain = it.domain, reason = it.reason) },
+            exception.map { AutofillExceptionEntity(domain = it.domain, reason = it.reason.orEmpty()) },
         )
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/RealAutofillTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/RealAutofillTest.kt
@@ -17,8 +17,8 @@
 package com.duckduckgo.autofill.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.duckduckgo.autofill.api.AutofillException
 import com.duckduckgo.autofill.store.feature.AutofillFeatureRepository
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.Assert.*
@@ -71,8 +71,8 @@ class RealAutofillTest {
 
     private fun givenThereAreExceptions() {
         val exceptions =
-            CopyOnWriteArrayList<AutofillException>().apply {
-                add(AutofillException("example.com", "my reason here"))
+            CopyOnWriteArrayList<FeatureException>().apply {
+                add(FeatureException("example.com", "my reason here"))
             }
         whenever(mockAutofillRepository.exceptions).thenReturn(exceptions)
     }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillDatabaseModels.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillDatabaseModels.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.autofill.store
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.duckduckgo.autofill.api.AutofillException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 @Entity(tableName = "autofill_exceptions")
 data class AutofillExceptionEntity(
@@ -26,6 +26,6 @@ data class AutofillExceptionEntity(
     val reason: String,
 )
 
-fun AutofillExceptionEntity.toAutofillException(): AutofillException {
-    return AutofillException(domain = this.domain, reason = this.reason)
+fun AutofillExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/feature/AutofillFeatureRepository.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/feature/AutofillFeatureRepository.kt
@@ -17,18 +17,18 @@
 package com.duckduckgo.autofill.store.feature
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.autofill.api.AutofillException
 import com.duckduckgo.autofill.store.AutofillDao
 import com.duckduckgo.autofill.store.AutofillDatabase
 import com.duckduckgo.autofill.store.AutofillExceptionEntity
-import com.duckduckgo.autofill.store.toAutofillException
+import com.duckduckgo.autofill.store.toFeatureException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 interface AutofillFeatureRepository {
     fun updateAllExceptions(exceptions: List<AutofillExceptionEntity>)
-    val exceptions: CopyOnWriteArrayList<AutofillException>
+    val exceptions: CopyOnWriteArrayList<FeatureException>
 }
 
 class RealAutofillFeatureRepository(
@@ -38,7 +38,7 @@ class RealAutofillFeatureRepository(
 ) : AutofillFeatureRepository {
 
     private val autofillDao: AutofillDao = database.autofillDao()
-    override val exceptions = CopyOnWriteArrayList<AutofillException>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
@@ -51,6 +51,6 @@ class RealAutofillFeatureRepository(
 
     private fun loadToMemory() {
         exceptions.clear()
-        autofillDao.getAll().map { exceptions.add(it.toAutofillException()) }
+        autofillDao.getAll().map { exceptions.add(it.toFeatureException()) }
     }
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -21,9 +21,9 @@ import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.contentscopescripts.api.ContentScopeConfigPlugin
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
-import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi.Builder
@@ -56,7 +56,7 @@ class RealContentScopeScripts @Inject constructor(
 
     private var cachedUserPreferencesJson: String = emptyJson
 
-    private var cachedUnprotectTemporaryExceptions = CopyOnWriteArrayList<UnprotectedTemporaryException>()
+    private var cachedUnprotectTemporaryExceptions = CopyOnWriteArrayList<FeatureException>()
     private var cachedUnprotectTemporaryExceptionsJson: String = emptyJsonList
 
     private lateinit var cachedContentScopeJS: String
@@ -128,7 +128,7 @@ class RealContentScopeScripts @Inject constructor(
         }
     }
 
-    private fun cacheUserUnprotectedTemporaryExceptions(unprotectedTemporaryExceptions: List<UnprotectedTemporaryException>) {
+    private fun cacheUserUnprotectedTemporaryExceptions(unprotectedTemporaryExceptions: List<FeatureException>) {
         cachedUnprotectTemporaryExceptions.clear()
         if (unprotectedTemporaryExceptions.isEmpty()) {
             cachedUnprotectTemporaryExceptionsJson = emptyJsonList
@@ -154,10 +154,10 @@ class RealContentScopeScripts @Inject constructor(
         return jsonAdapter.toJson(userUnprotectedDomains)
     }
 
-    private fun getUnprotectedTemporaryJson(unprotectedTemporaryExceptions: List<UnprotectedTemporaryException>): String {
-        val type = Types.newParameterizedType(MutableList::class.java, UnprotectedTemporaryException::class.java)
+    private fun getUnprotectedTemporaryJson(unprotectedTemporaryExceptions: List<FeatureException>): String {
+        val type = Types.newParameterizedType(MutableList::class.java, FeatureException::class.java)
         val moshi = Builder().build()
-        val jsonAdapter: JsonAdapter<List<UnprotectedTemporaryException>> = moshi.adapter(type)
+        val jsonAdapter: JsonAdapter<List<FeatureException>> = moshi.adapter(type)
         return jsonAdapter.toJson(unprotectedTemporaryExceptions)
     }
 
@@ -173,7 +173,7 @@ class RealContentScopeScripts @Inject constructor(
     private fun getPlatformKeyValuePair() = "\"platform\":{\"name\":\"android\"}"
     private fun getSessionKeyValuePair() = "\"sessionKey\":\"${fingerprintProtectionManager.getSeed()}\""
 
-    private fun getContentScopeJson(config: String, unprotectedTemporaryExceptions: List<UnprotectedTemporaryException>): String = (
+    private fun getContentScopeJson(config: String, unprotectedTemporaryExceptions: List<FeatureException>): String = (
         "{\"features\":{$config},\"unprotectedTemporary\":${getUnprotectedTemporaryJson(unprotectedTemporaryExceptions)}}"
         )
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -20,11 +20,11 @@ import com.duckduckgo.app.global.plugins.PluginPoint
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.contentscopescripts.api.ContentScopeConfigPlugin
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
-import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
@@ -245,7 +245,7 @@ class RealContentScopeScriptsTest {
             "\$ANDROID_MESSAGING_PARAMETERS\$})"
         const val versionCode = 1234
         const val sessionKey = "5678"
-        val unprotectedTemporaryException = UnprotectedTemporaryException(domain = "example.com", reason = "reason")
-        val unprotectedTemporaryException2 = UnprotectedTemporaryException(domain = "foo.com", reason = "reason2")
+        val unprotectedTemporaryException = FeatureException(domain = "example.com", reason = "reason")
+        val unprotectedTemporaryException2 = FeatureException(domain = "foo.com", reason = "reason2")
     }
 }

--- a/cookies/cookies-api/src/main/java/com/duckduckgo/cookies/api/CookiesFeatureName.kt
+++ b/cookies/cookies-api/src/main/java/com/duckduckgo/cookies/api/CookiesFeatureName.kt
@@ -20,6 +20,3 @@ package com.duckduckgo.cookies.api
 enum class CookiesFeatureName(val value: String) {
     Cookie("cookie"),
 }
-
-/** Public data class for Cookie Exceptions. */
-data class CookieException(val domain: String, val reason: String)

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeature.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeature.kt
@@ -16,12 +16,12 @@
 
 package com.duckduckgo.cookies.impl.features
 
-import com.duckduckgo.cookies.api.CookieException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 data class CookiesFeature(
     val state: String,
     val minSupportedVersion: Int?,
-    val exceptions: List<CookieException>,
+    val exceptions: List<FeatureException>,
     val settings: Settings,
 )
 

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeaturePlugin.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeaturePlugin.kt
@@ -51,7 +51,7 @@ class CookiesFeaturePlugin @Inject constructor(
             val cookiesFeature: CookiesFeature? = jsonAdapter.fromJson(jsonString)
 
             val exceptions = cookiesFeature?.exceptions?.map {
-                CookieExceptionEntity(domain = it.domain, reason = it.reason)
+                CookieExceptionEntity(domain = it.domain, reason = it.reason.orEmpty())
             }.orEmpty()
 
             val maxAge = cookiesFeature?.settings?.firstPartyCookiePolicy?.maxAge ?: DEFAULT_MAX_AGE

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesDatabaseModels.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesDatabaseModels.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.cookies.store
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.duckduckgo.cookies.api.CookieException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 @Entity(tableName = "first_party_cookie_policy")
 data class FirstPartyCookiePolicyEntity(
@@ -39,6 +39,6 @@ data class CookieEntity(
     val json: String,
 )
 
-fun CookieExceptionEntity.toCookieException(): CookieException {
-    return CookieException(domain = this.domain, reason = this.reason)
+fun CookieExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesRepository.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.cookies.store
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.cookies.api.CookieException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -25,7 +25,7 @@ import kotlinx.coroutines.launch
 interface CookiesRepository {
     fun updateAll(exceptions: List<CookieExceptionEntity>, firstPartyTrackerCookiePolicy: FirstPartyCookiePolicyEntity)
     var firstPartyCookiePolicy: FirstPartyCookiePolicyEntity
-    val exceptions: List<CookieException>
+    val exceptions: List<FeatureException>
 }
 
 class RealCookieRepository constructor(
@@ -36,7 +36,7 @@ class RealCookieRepository constructor(
 
     private val cookiesDao: CookiesDao = database.cookiesDao()
 
-    override val exceptions = CopyOnWriteArrayList<CookieException>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
     override var firstPartyCookiePolicy = FirstPartyCookiePolicyEntity(threshold = DEFAULT_THRESHOLD, maxAge = DEFAULT_MAX_AGE)
 
     init {
@@ -56,7 +56,7 @@ class RealCookieRepository constructor(
     private fun loadToMemory() {
         exceptions.clear()
         cookiesDao.getAllCookieExceptions().map {
-            exceptions.add(it.toCookieException())
+            exceptions.add(it.toFeatureException())
         }
         firstPartyCookiePolicy =
             cookiesDao.getFirstPartyCookiePolicy()

--- a/cookies/cookies-store/src/test/java/com/duckduckgo/cookies/store/RealCookieRepositoryTest.kt
+++ b/cookies/cookies-store/src/test/java/com/duckduckgo/cookies/store/RealCookieRepositoryTest.kt
@@ -54,7 +54,7 @@ class RealCookieRepositoryTest {
             coroutineRule.testDispatcherProvider,
         )
 
-        assertEquals(cookieExceptionEntity.toCookieException(), testee.exceptions.first())
+        assertEquals(cookieExceptionEntity.toFeatureException(), testee.exceptions.first())
         assertEquals(THRESHOLD, testee.firstPartyCookiePolicy.threshold)
         assertEquals(MAX_AGE, testee.firstPartyCookiePolicy.maxAge)
     }

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureExceptions.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureExceptions.kt
@@ -20,7 +20,7 @@ object FeatureExceptions {
         fun insertAll(exception: List<FeatureException>)
     }
 
-    data class FeatureException(val domain: String, val reason: String)
+    data class FeatureException(val domain: String, val reason: String?)
 
     val EMPTY_STORE = object : Store {
         override fun insertAll(exception: List<FeatureException>) {}

--- a/privacy-config/privacy-config-api/build.gradle
+++ b/privacy-config/privacy-config-api/build.gradle
@@ -31,6 +31,7 @@ kotlin {
 }
 
 dependencies {
+    implementation project(path: ':feature-toggles-api')
     implementation Kotlin.stdlib.jdk7
 }
 

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/AmpLinks.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/AmpLinks.kt
@@ -47,9 +47,6 @@ interface AmpLinks {
 /** Public data class for AMP Link Info. */
 data class AmpLinkInfo(val ampLink: String, var destinationUrl: String? = null)
 
-/** Public data class for AMP Link Exceptions. */
-data class AmpLinkException(val domain: String, val reason: String)
-
 /** Public sealed class for AMP Link Type. */
 sealed class AmpLinkType {
     class ExtractedAmpLink(val extractedUrl: String) : AmpLinkType()

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/ContentBlocking.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/ContentBlocking.kt
@@ -26,9 +26,3 @@ interface ContentBlocking {
      */
     fun isAnException(url: String): Boolean
 }
-
-/** Public data class for Content Blocking Exceptions */
-data class ContentBlockingException(
-    val domain: String,
-    val reason: String,
-)

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Drm.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Drm.kt
@@ -29,9 +29,3 @@ interface Drm {
         resources: Array<String>,
     ): Array<String>
 }
-
-/** Public data class for Drm Exceptions */
-data class DrmException(
-    val domain: String,
-    val reason: String,
-)

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Https.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Https.kt
@@ -26,9 +26,3 @@ interface Https {
      */
     fun isAnException(url: String): Boolean
 }
-
-/** Public data class for Https Exceptions */
-data class HttpsException(
-    val domain: String,
-    val reason: String,
-)

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -28,4 +28,4 @@ enum class PrivacyFeatureName(val value: String) {
     UserAgentFeatureName("customUserAgent"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v3/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/TrackingParameters.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/TrackingParameters.kt
@@ -27,6 +27,3 @@ interface TrackingParameters {
     /** The last tracking parameter cleaned URL. */
     var lastCleanedUrl: String?
 }
-
-/** Public data class for Tracking Parameter Exceptions. */
-data class TrackingParameterException(val domain: String, val reason: String)

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UnprotectedTemporary.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UnprotectedTemporary.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.privacy.config.api
 
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+
 /** Public interface for the Unprotected Temporary feature */
 interface UnprotectedTemporary {
     /**
@@ -27,8 +29,5 @@ interface UnprotectedTemporary {
     fun isAnException(url: String): Boolean
 
     /** The unprotected temporary exceptions list */
-    val unprotectedTemporaryExceptions: List<UnprotectedTemporaryException>
+    val unprotectedTemporaryExceptions: List<FeatureException>
 }
-
-/** Public data class for Unprotected Temporary Exceptions. */
-data class UnprotectedTemporaryException(val domain: String, val reason: String)

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UserAgent.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UserAgent.kt
@@ -89,12 +89,6 @@ interface UserAgent {
     fun isDdgFixedUserAgentVersion(version: String): Boolean
 }
 
-/** Public data class for User Agent Exceptions */
-data class UserAgentException(
-    val domain: String,
-    val reason: String,
-)
-
 /** Public enum class for the default policy */
 enum class DefaultPolicy {
     DDG, DDG_FIXED, CLOSEST

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksFeature.kt
@@ -16,13 +16,13 @@
 
 package com.duckduckgo.privacy.config.impl.features.amplinks
 
-import com.duckduckgo.privacy.config.api.AmpLinkException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 data class AmpLinksFeature(
     val state: String,
     val minSupportedVersion: Int?,
     val settings: AmpLinkSettings,
-    val exceptions: List<AmpLinkException>,
+    val exceptions: List<FeatureException>,
 )
 
 data class AmpLinkSettings(

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksPlugin.kt
@@ -48,7 +48,7 @@ class AmpLinksPlugin @Inject constructor(
             val ampLinksFeature: AmpLinksFeature? = jsonAdapter.fromJson(jsonString)
 
             ampLinksFeature?.exceptions?.map {
-                exceptions.add(AmpLinkExceptionEntity(it.domain, it.reason))
+                exceptions.add(AmpLinkExceptionEntity(it.domain, it.reason.orEmpty()))
             }
 
             ampLinksFeature?.settings?.linkFormats?.map {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingFeature.kt
@@ -16,10 +16,10 @@
 
 package com.duckduckgo.privacy.config.impl.features.contentblocking
 
-import com.duckduckgo.privacy.config.store.ContentBlockingExceptionEntity
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 data class ContentBlockingFeature(
     val state: String,
     val minSupportedVersion: Int?,
-    val exceptions: List<ContentBlockingExceptionEntity>,
+    val exceptions: List<FeatureException>,
 )

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingPlugin.kt
@@ -49,7 +49,7 @@ class ContentBlockingPlugin @Inject constructor(
 
             val contentBlockingFeature: ContentBlockingFeature? = jsonAdapter.fromJson(jsonString)
             contentBlockingFeature?.exceptions?.map {
-                contentBlockingExceptions.add(ContentBlockingExceptionEntity(it.domain, it.reason))
+                contentBlockingExceptions.add(ContentBlockingExceptionEntity(it.domain, it.reason.orEmpty()))
             }
             contentBlockingRepository.updateAll(contentBlockingExceptions)
             val isEnabled = contentBlockingFeature?.state == "enabled"

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmFeature.kt
@@ -16,10 +16,10 @@
 
 package com.duckduckgo.privacy.config.impl.features.drm
 
-import com.duckduckgo.privacy.config.store.DrmExceptionEntity
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 data class DrmFeature(
     val state: String,
     val minSupportedVersion: Int?,
-    val exceptions: List<DrmExceptionEntity>,
+    val exceptions: List<FeatureException>,
 )

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmPlugin.kt
@@ -49,7 +49,7 @@ class DrmPlugin @Inject constructor(
 
             val drmFeature: DrmFeature? = jsonAdapter.fromJson(jsonString)
             drmFeature?.exceptions?.map {
-                drmExceptions.add(DrmExceptionEntity(it.domain, it.reason))
+                drmExceptions.add(DrmExceptionEntity(it.domain, it.reason.orEmpty()))
             }
             drmRepository.updateAll(drmExceptions)
             val isEnabled = drmFeature?.state == "enabled"

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsFeature.kt
@@ -16,10 +16,10 @@
 
 package com.duckduckgo.privacy.config.impl.features.https
 
-import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 data class HttpsFeature(
     val state: String,
     val minSupportedVersion: Int?,
-    val exceptions: List<HttpsExceptionEntity>,
+    val exceptions: List<FeatureException>,
 )

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsPlugin.kt
@@ -49,7 +49,7 @@ class HttpsPlugin @Inject constructor(
 
             val httpsFeature: HttpsFeature? = jsonAdapter.fromJson(jsonString)
             httpsFeature?.exceptions?.map {
-                httpsExceptions.add(HttpsExceptionEntity(it.domain, it.reason))
+                httpsExceptions.add(HttpsExceptionEntity(it.domain, it.reason.orEmpty()))
             }
             httpsRepository.updateAll(httpsExceptions)
             val isEnabled = httpsFeature?.state == "enabled"

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersFeature.kt
@@ -16,13 +16,13 @@
 
 package com.duckduckgo.privacy.config.impl.features.trackingparameters
 
-import com.duckduckgo.privacy.config.api.TrackingParameterException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 data class TrackingParametersFeature(
     val state: String,
     val minSupportedVersion: Int?,
     val settings: TrackingParametersSettings,
-    val exceptions: List<TrackingParameterException>,
+    val exceptions: List<FeatureException>,
 )
 
 data class TrackingParametersSettings(

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersPlugin.kt
@@ -46,7 +46,7 @@ class TrackingParametersPlugin @Inject constructor(
             val trackingParametersFeature: TrackingParametersFeature? = jsonAdapter.fromJson(jsonString)
 
             trackingParametersFeature?.exceptions?.map {
-                exceptions.add(TrackingParameterExceptionEntity(it.domain, it.reason))
+                exceptions.add(TrackingParameterExceptionEntity(it.domain, it.reason.orEmpty()))
             }
 
             trackingParametersFeature?.settings?.parameters?.map {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporary.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporary.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.privacy.config.impl.features.unprotectedtemporary
 
 import com.duckduckgo.app.global.UriString
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
-import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -33,7 +33,7 @@ class RealUnprotectedTemporary @Inject constructor(private val repository: Unpro
         return matches(url)
     }
 
-    override val unprotectedTemporaryExceptions: List<UnprotectedTemporaryException>
+    override val unprotectedTemporaryExceptions: List<FeatureException>
         get() = repository.exceptions
 
     private fun matches(url: String): Boolean {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentFeature.kt
@@ -16,36 +16,23 @@
 
 package com.duckduckgo.privacy.config.impl.features.useragent
 
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+
 data class UserAgentFeature(
     val state: String,
     val minSupportedVersion: Int?,
-    val exceptions: List<UserAgentExceptionJson>,
+    val exceptions: List<FeatureException>,
     val settings: UserAgentSettings,
-)
-
-data class UserAgentExceptionJson(
-    val domain: String,
-    val reason: String,
 )
 
 data class UserAgentSettings(
     val defaultPolicy: String?,
-    val ddgDefaultSites: List<DdgDefaultSite>,
-    val ddgFixedSites: List<DdgFixedSite>,
+    val ddgDefaultSites: List<FeatureException>,
+    val ddgFixedSites: List<FeatureException>,
     val closestUserAgent: ClosestUserAgent?,
     val ddgFixedUserAgent: DdgFixedUserAgent?,
-    val omitApplicationSites: List<UserAgentExceptionJson>,
-    val omitVersionSites: List<UserAgentExceptionJson>,
-)
-
-data class DdgDefaultSite(
-    val domain: String,
-    val reason: String,
-)
-
-data class DdgFixedSite(
-    val domain: String,
-    val reason: String,
+    val omitApplicationSites: List<FeatureException>,
+    val omitVersionSites: List<FeatureException>,
 )
 
 data class ClosestUserAgent(

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/useragent/UserAgentPlugin.kt
@@ -67,22 +67,22 @@ class UserAgentPlugin @Inject constructor(
             val versionExceptionList = versionList subtract applicationList subtract exceptionsList
 
             defaultExceptionList.forEach {
-                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = false))
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason.orEmpty(), omitApplication = false, omitVersion = false))
             }
             applicationAndVersionExceptionsList.forEach {
-                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = true, omitVersion = true))
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason.orEmpty(), omitApplication = true, omitVersion = true))
             }
             applicationExceptionList.forEach {
-                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = true, omitVersion = false))
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason.orEmpty(), omitApplication = true, omitVersion = false))
             }
             versionExceptionList.forEach {
-                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason, omitApplication = false, omitVersion = true))
+                userAgentExceptions.add(UserAgentExceptionEntity(it.domain, it.reason.orEmpty(), omitApplication = false, omitVersion = true))
             }
             ddgDefaultSitesList.forEach {
-                userAgentSites.add(UserAgentSitesEntity(it.domain, it.reason, ddgDefaultSite = true, ddgFixedSite = false))
+                userAgentSites.add(UserAgentSitesEntity(it.domain, it.reason.orEmpty(), ddgDefaultSite = true, ddgFixedSite = false))
             }
             ddgFixedSitesList.forEach {
-                userAgentSites.add(UserAgentSitesEntity(it.domain, it.reason, ddgDefaultSite = false, ddgFixedSite = true))
+                userAgentSites.add(UserAgentSitesEntity(it.domain, it.reason.orEmpty(), ddgDefaultSite = false, ddgFixedSite = true))
             }
             closestUserAgentVersionList.forEach {
                 userAgentVersions.add(UserAgentVersionsEntity(it, closestUserAgent = true, ddgFixedUserAgent = false))

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
@@ -17,8 +17,8 @@
 package com.duckduckgo.privacy.config.impl.features.contentblocking
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
-import com.duckduckgo.privacy.config.api.ContentBlockingException
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.contentblocking.ContentBlockingRepository
@@ -91,8 +91,8 @@ class RealContentBlockingTest {
 
     private fun givenThereAreExceptions() {
         val exceptions =
-            CopyOnWriteArrayList<ContentBlockingException>().apply {
-                add(ContentBlockingException("example.com", "my reason here"))
+            CopyOnWriteArrayList<FeatureException>().apply {
+                add(FeatureException("example.com", "my reason here"))
             }
         whenever(mockContentBlockingRepository.exceptions).thenReturn(exceptions)
     }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
@@ -19,8 +19,8 @@ package com.duckduckgo.privacy.config.impl.features.drm
 import android.webkit.PermissionRequest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
-import com.duckduckgo.privacy.config.api.DrmException
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.drm.DrmRepository
@@ -128,12 +128,12 @@ class RealDrmTest {
     }
 
     private fun givenUrlIsInExceptionList() {
-        val exceptions = CopyOnWriteArrayList<DrmException>().apply { add(DrmException("open.spotify.com", "my reason here")) }
+        val exceptions = CopyOnWriteArrayList<FeatureException>().apply { add(FeatureException("open.spotify.com", "my reason here")) }
         whenever(mockDrmRepository.exceptions).thenReturn(exceptions)
     }
 
     private fun givenUrlIsNotInExceptionList() {
-        whenever(mockDrmRepository.exceptions).thenReturn(CopyOnWriteArrayList<DrmException>())
+        whenever(mockDrmRepository.exceptions).thenReturn(CopyOnWriteArrayList<FeatureException>())
     }
 
     private fun givenUriIsInUserAllowList() {

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/RealHttpsTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/RealHttpsTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.features.https
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
-import com.duckduckgo.privacy.config.api.HttpsException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
 import java.util.concurrent.CopyOnWriteArrayList
@@ -82,8 +82,8 @@ class RealHttpsTest {
 
     private fun givenThereAreExceptions() {
         val exceptions =
-            CopyOnWriteArrayList<HttpsException>().apply {
-                add(HttpsException("example.com", "my reason here"))
+            CopyOnWriteArrayList<FeatureException>().apply {
+                add(FeatureException("example.com", "my reason here"))
             }
         whenever(mockHttpsRepository.exceptions).thenReturn(exceptions)
     }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.impl.features.unprotectedtemporary
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.Assert.*
@@ -53,15 +53,15 @@ class RealUnprotectedTemporaryTest {
 
     @Test
     fun whenIsAnExceptionAndDomainIsNotListedInTheExceptionsListThenReturnFalse() {
-        val exceptions = CopyOnWriteArrayList<UnprotectedTemporaryException>()
+        val exceptions = CopyOnWriteArrayList<FeatureException>()
         whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptions)
 
         assertFalse(testee.isAnException("http://test.example.com"))
     }
 
     private fun givenThereAreExceptions() {
-        val exceptions = CopyOnWriteArrayList<UnprotectedTemporaryException>()
-        exceptions.add(UnprotectedTemporaryException("example.com", "my reason here"))
+        val exceptions = CopyOnWriteArrayList<FeatureException>()
+        exceptions.add(FeatureException("example.com", "my reason here"))
 
         whenever(mockUnprotectedTemporaryRepository.exceptions).thenReturn(exceptions)
     }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgentTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/useragent/RealUserAgentTest.kt
@@ -17,11 +17,11 @@
 package com.duckduckgo.privacy.config.impl.features.useragent
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.api.DefaultPolicy.CLOSEST
 import com.duckduckgo.privacy.config.api.DefaultPolicy.DDG
 import com.duckduckgo.privacy.config.api.DefaultPolicy.DDG_FIXED
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
-import com.duckduckgo.privacy.config.api.UserAgentException
 import com.duckduckgo.privacy.config.store.features.useragent.UserAgentRepository
 import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.Assert.*
@@ -116,8 +116,8 @@ class RealUserAgentTest {
 
     fun whenIsDdgDefaultSiteThenReturnTrue() {
         val ddgDefaultSites =
-            CopyOnWriteArrayList<UserAgentException>().apply {
-                add(UserAgentException("example.com", "my reason here"))
+            CopyOnWriteArrayList<FeatureException>().apply {
+                add(FeatureException("example.com", "my reason here"))
             }
         whenever(mockUserAgentRepository.ddgDefaultSites).thenReturn(ddgDefaultSites)
 
@@ -126,8 +126,8 @@ class RealUserAgentTest {
 
     fun whenIsNotDdgDefaultSiteThenReturnFalse() {
         val ddgDefaultSites =
-            CopyOnWriteArrayList<UserAgentException>().apply {
-                add(UserAgentException("foo.com", "my reason here"))
+            CopyOnWriteArrayList<FeatureException>().apply {
+                add(FeatureException("foo.com", "my reason here"))
             }
         whenever(mockUserAgentRepository.ddgDefaultSites).thenReturn(ddgDefaultSites)
 
@@ -136,8 +136,8 @@ class RealUserAgentTest {
 
     fun whenIsDdgFixedSiteThenReturnTrue() {
         val ddgFixedSites =
-            CopyOnWriteArrayList<UserAgentException>().apply {
-                add(UserAgentException("example.com", "my reason here"))
+            CopyOnWriteArrayList<FeatureException>().apply {
+                add(FeatureException("example.com", "my reason here"))
             }
         whenever(mockUserAgentRepository.ddgFixedSites).thenReturn(ddgFixedSites)
 
@@ -146,8 +146,8 @@ class RealUserAgentTest {
 
     fun whenIsNotDdgFixedSiteThenReturnFalse() {
         val ddgFixedSites =
-            CopyOnWriteArrayList<UserAgentException>().apply {
-                add(UserAgentException("foo.com", "my reason here"))
+            CopyOnWriteArrayList<FeatureException>().apply {
+                add(FeatureException("foo.com", "my reason here"))
             }
         whenever(mockUserAgentRepository.ddgFixedSites).thenReturn(ddgFixedSites)
 
@@ -242,8 +242,8 @@ class RealUserAgentTest {
 
     private fun givenThereAreExceptions() {
         val exceptions =
-            CopyOnWriteArrayList<UserAgentException>().apply {
-                add(UserAgentException("example.com", "my reason here"))
+            CopyOnWriteArrayList<FeatureException>().apply {
+                add(FeatureException("example.com", "my reason here"))
             }
         whenever(mockUserAgentRepository.defaultExceptions).thenReturn(exceptions)
         whenever(mockUserAgentRepository.omitApplicationExceptions).thenReturn(exceptions)

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/amplinks/AmpFormatReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/amplinks/AmpFormatReferenceTest.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.privacy.config.impl.referencetests.amplinks
 
 import com.duckduckgo.app.FileUtilities
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
-import com.duckduckgo.privacy.config.api.AmpLinkException
 import com.duckduckgo.privacy.config.api.AmpLinkType
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
@@ -88,7 +88,7 @@ class AmpFormatReferenceTest(private val testCase: TestCase) {
 
     private fun mockAmpLinks() {
         val jsonAdapter: JsonAdapter<AmpLinksFeature> = moshi.adapter(AmpLinksFeature::class.java)
-        val exceptions = CopyOnWriteArrayList<AmpLinkException>()
+        val exceptions = CopyOnWriteArrayList<FeatureException>()
         val ampLinkFormats = CopyOnWriteArrayList<Regex>()
         val jsonObject: JSONObject = FileUtilities.getJsonObjectFromFile(
             AmpFormatReferenceTest::class.java.classLoader!!,

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/amplinks/AmpKeywordReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/amplinks/AmpKeywordReferenceTest.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.privacy.config.impl.referencetests.amplinks
 
 import com.duckduckgo.app.FileUtilities
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
-import com.duckduckgo.privacy.config.api.AmpLinkException
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
@@ -86,7 +86,7 @@ class AmpKeywordReferenceTest(private val testCase: TestCase) {
 
     private fun mockAmpLinks() {
         val jsonAdapter: JsonAdapter<AmpLinksFeature> = moshi.adapter(AmpLinksFeature::class.java)
-        val exceptions = CopyOnWriteArrayList<AmpLinkException>()
+        val exceptions = CopyOnWriteArrayList<FeatureException>()
         val ampLinkKeywords = CopyOnWriteArrayList<String>()
         val jsonObject: JSONObject = FileUtilities.getJsonObjectFromFile(
             AmpKeywordReferenceTest::class.java.classLoader!!,

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/gpc/GpcHeaderReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/gpc/GpcHeaderReferenceTest.kt
@@ -30,8 +30,8 @@ import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.duckduckgo.privacy.config.store.GpcExceptionEntity
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
+import com.duckduckgo.privacy.config.store.toFeatureException
 import com.duckduckgo.privacy.config.store.toGpcException
-import com.duckduckgo.privacy.config.store.toUnprotectedTemporaryException
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.util.concurrent.CopyOnWriteArrayList
@@ -104,7 +104,7 @@ class GpcHeaderReferenceTest(private val testCase: TestCase) {
 
         val isEnabled = gpcFeature?.state == "enabled"
         val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(
-            config?.unprotectedTemporary?.map { it.toUnprotectedTemporaryException() } ?: emptyList(),
+            config?.unprotectedTemporary?.map { it.toFeatureException() } ?: emptyList(),
         )
 
         whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, isEnabled)).thenReturn(isEnabled)

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/trackingparameters/TrackingParameterReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/trackingparameters/TrackingParameterReferenceTest.kt
@@ -18,9 +18,9 @@ package com.duckduckgo.privacy.config.impl.referencetests.trackingparameters
 
 import com.duckduckgo.app.FileUtilities
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
-import com.duckduckgo.privacy.config.api.TrackingParameterException
 import com.duckduckgo.privacy.config.api.TrackingParameters
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.impl.features.trackingparameters.RealTrackingParameters
@@ -86,7 +86,7 @@ class TrackingParameterReferenceTest(private val testCase: TestCase) {
 
     private fun mockTrackingParameters() {
         val jsonAdapter: JsonAdapter<TrackingParametersFeature> = moshi.adapter(TrackingParametersFeature::class.java)
-        val exceptions = CopyOnWriteArrayList<TrackingParameterException>()
+        val exceptions = CopyOnWriteArrayList<FeatureException>()
         val trackingParameters = CopyOnWriteArrayList<String>()
         val jsonObject: JSONObject = FileUtilities.getJsonObjectFromFile(
             TrackingParameterReferenceTest::class.java.classLoader!!,

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -19,16 +19,10 @@ package com.duckduckgo.privacy.config.store
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverter
-import com.duckduckgo.privacy.config.api.AmpLinkException
-import com.duckduckgo.privacy.config.api.ContentBlockingException
-import com.duckduckgo.privacy.config.api.DrmException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.api.GpcException
 import com.duckduckgo.privacy.config.api.GpcHeaderEnabledSite
-import com.duckduckgo.privacy.config.api.HttpsException
 import com.duckduckgo.privacy.config.api.PrivacyConfigData
-import com.duckduckgo.privacy.config.api.TrackingParameterException
-import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
-import com.duckduckgo.privacy.config.api.UserAgentException
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -64,8 +58,8 @@ data class DrmExceptionEntity(
     val reason: String,
 )
 
-fun DrmExceptionEntity.toDrmException(): DrmException {
-    return DrmException(domain = this.domain, reason = this.reason)
+fun DrmExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }
 
 @Entity(tableName = "unprotected_temporary")
@@ -80,8 +74,8 @@ data class HttpsExceptionEntity(
     val reason: String,
 )
 
-fun HttpsExceptionEntity.toHttpsException(): HttpsException {
-    return HttpsException(domain = this.domain, reason = this.reason)
+fun HttpsExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }
 
 @Entity(tableName = "gpc_header_enabled_sites")
@@ -110,8 +104,8 @@ data class ContentBlockingExceptionEntity(
     val reason: String,
 )
 
-fun ContentBlockingExceptionEntity.toContentBlockingException(): ContentBlockingException {
-    return ContentBlockingException(domain = this.domain, reason = this.reason)
+fun ContentBlockingExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }
 
 @Entity(tableName = "user_agent_exceptions")
@@ -137,8 +131,8 @@ data class UserAgentVersionsEntity(
     val ddgFixedUserAgent: Boolean,
 )
 
-fun UserAgentSitesEntity.toUserAgentException(): UserAgentException {
-    return UserAgentException(domain = this.domain, reason = this.reason)
+fun UserAgentSitesEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }
 
 @Entity(tableName = "user_agent_states")
@@ -149,8 +143,8 @@ data class UserAgentStatesEntity(
     val ddgFixedUserAgent: Boolean,
 )
 
-fun UserAgentExceptionEntity.toUserAgentException(): UserAgentException {
-    return UserAgentException(domain = this.domain, reason = this.reason)
+fun UserAgentExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }
 
 @Entity(tableName = "privacy_config")
@@ -192,16 +186,16 @@ data class TrackingParameterExceptionEntity(
     val reason: String,
 )
 
-fun AmpLinkExceptionEntity.toAmpLinkException(): AmpLinkException {
-    return AmpLinkException(domain = this.domain, reason = this.reason)
+fun AmpLinkExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }
 
-fun TrackingParameterExceptionEntity.toTrackingParameterException(): TrackingParameterException {
-    return TrackingParameterException(domain = this.domain, reason = this.reason)
+fun TrackingParameterExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }
 
-fun UnprotectedTemporaryEntity.toUnprotectedTemporaryException(): UnprotectedTemporaryException {
-    return UnprotectedTemporaryException(domain = this.domain, reason = this.reason)
+fun UnprotectedTemporaryEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
 }
 
 class Adapters {

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/amplinks/AmpLinksRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/amplinks/AmpLinksRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.store.features.amplinks
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.privacy.config.api.AmpLinkException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.store.*
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
@@ -25,7 +25,7 @@ import kotlinx.coroutines.launch
 
 interface AmpLinksRepository {
     fun updateAll(exceptions: List<AmpLinkExceptionEntity>, ampLinkFormats: List<AmpLinkFormatEntity>, ampKeywords: List<AmpKeywordEntity>)
-    val exceptions: List<AmpLinkException>
+    val exceptions: List<FeatureException>
     val ampLinkFormats: List<Regex>
     val ampKeywords: List<String>
 }
@@ -38,7 +38,7 @@ class RealAmpLinksRepository(
 
     private val ampLinksDao: AmpLinksDao = database.ampLinksDao()
 
-    override val exceptions = CopyOnWriteArrayList<AmpLinkException>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
     override val ampLinkFormats = CopyOnWriteArrayList<Regex>()
     override val ampKeywords = CopyOnWriteArrayList<String>()
 
@@ -60,7 +60,7 @@ class RealAmpLinksRepository(
     private fun loadToMemory() {
         exceptions.clear()
         ampLinksDao.getAllExceptions().map {
-            exceptions.add(it.toAmpLinkException())
+            exceptions.add(it.toFeatureException())
         }
 
         ampLinkFormats.clear()

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/contentblocking/ContentBlockingRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/contentblocking/ContentBlockingRepository.kt
@@ -17,17 +17,17 @@
 package com.duckduckgo.privacy.config.store.features.contentblocking
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.privacy.config.api.ContentBlockingException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.store.ContentBlockingExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
-import com.duckduckgo.privacy.config.store.toContentBlockingException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 interface ContentBlockingRepository {
     fun updateAll(exceptions: List<ContentBlockingExceptionEntity>)
-    val exceptions: CopyOnWriteArrayList<ContentBlockingException>
+    val exceptions: CopyOnWriteArrayList<FeatureException>
 }
 
 class RealContentBlockingRepository(
@@ -37,7 +37,7 @@ class RealContentBlockingRepository(
 ) : ContentBlockingRepository {
 
     private val contentBlockingDao: ContentBlockingDao = database.contentBlockingDao()
-    override val exceptions = CopyOnWriteArrayList<ContentBlockingException>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
@@ -50,6 +50,6 @@ class RealContentBlockingRepository(
 
     private fun loadToMemory() {
         exceptions.clear()
-        contentBlockingDao.getAll().map { exceptions.add(it.toContentBlockingException()) }
+        contentBlockingDao.getAll().map { exceptions.add(it.toFeatureException()) }
     }
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/drm/DrmRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/drm/DrmRepository.kt
@@ -17,17 +17,17 @@
 package com.duckduckgo.privacy.config.store.features.drm
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.privacy.config.api.DrmException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.store.DrmExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
-import com.duckduckgo.privacy.config.store.toDrmException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 interface DrmRepository {
     fun updateAll(exceptions: List<DrmExceptionEntity>)
-    val exceptions: CopyOnWriteArrayList<DrmException>
+    val exceptions: CopyOnWriteArrayList<FeatureException>
 }
 
 class RealDrmRepository(
@@ -38,7 +38,7 @@ class RealDrmRepository(
     DrmRepository {
 
     private val drmDao: DrmDao = database.drmDao()
-    override val exceptions = CopyOnWriteArrayList<DrmException>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
@@ -54,7 +54,7 @@ class RealDrmRepository(
     private fun loadToMemory() {
         exceptions.clear()
         drmDao.getAll().map {
-            exceptions.add(it.toDrmException())
+            exceptions.add(it.toFeatureException())
         }
     }
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
@@ -17,17 +17,17 @@
 package com.duckduckgo.privacy.config.store.features.https
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.privacy.config.api.HttpsException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
-import com.duckduckgo.privacy.config.store.toHttpsException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 interface HttpsRepository {
     fun updateAll(exceptions: List<HttpsExceptionEntity>)
-    val exceptions: CopyOnWriteArrayList<HttpsException>
+    val exceptions: CopyOnWriteArrayList<FeatureException>
 }
 
 class RealHttpsRepository(
@@ -37,7 +37,7 @@ class RealHttpsRepository(
 ) : HttpsRepository {
 
     private val httpsDao: HttpsDao = database.httpsDao()
-    override val exceptions = CopyOnWriteArrayList<HttpsException>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
@@ -50,6 +50,6 @@ class RealHttpsRepository(
 
     private fun loadToMemory() {
         exceptions.clear()
-        httpsDao.getAll().map { exceptions.add(it.toHttpsException()) }
+        httpsDao.getAll().map { exceptions.add(it.toFeatureException()) }
     }
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackingparameters/TrackingParametersRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackingparameters/TrackingParametersRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.store.features.trackingparameters
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.privacy.config.api.TrackingParameterException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.store.*
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
@@ -25,7 +25,7 @@ import kotlinx.coroutines.launch
 
 interface TrackingParametersRepository {
     fun updateAll(exceptions: List<TrackingParameterExceptionEntity>, parameters: List<TrackingParameterEntity>)
-    val exceptions: List<TrackingParameterException>
+    val exceptions: List<FeatureException>
     val parameters: List<String>
 }
 
@@ -37,7 +37,7 @@ class RealTrackingParametersRepository(
 
     private val trackingParametersDao: TrackingParametersDao = database.trackingParametersDao()
 
-    override val exceptions = CopyOnWriteArrayList<TrackingParameterException>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
     override val parameters = CopyOnWriteArrayList<String>()
 
     init {
@@ -57,7 +57,7 @@ class RealTrackingParametersRepository(
     private fun loadToMemory() {
         exceptions.clear()
         trackingParametersDao.getAllExceptions().map {
-            exceptions.add(it.toTrackingParameterException())
+            exceptions.add(it.toFeatureException())
         }
 
         parameters.clear()

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
@@ -17,17 +17,17 @@
 package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.privacy.config.api.UnprotectedTemporaryException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
-import com.duckduckgo.privacy.config.store.toUnprotectedTemporaryException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 interface UnprotectedTemporaryRepository {
     fun updateAll(exceptions: List<UnprotectedTemporaryEntity>)
-    val exceptions: CopyOnWriteArrayList<UnprotectedTemporaryException>
+    val exceptions: CopyOnWriteArrayList<FeatureException>
 }
 
 class RealUnprotectedTemporaryRepository(
@@ -38,7 +38,7 @@ class RealUnprotectedTemporaryRepository(
 
     private val unprotectedTemporaryDao: UnprotectedTemporaryDao =
         database.unprotectedTemporaryDao()
-    override val exceptions = CopyOnWriteArrayList<UnprotectedTemporaryException>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
@@ -51,6 +51,6 @@ class RealUnprotectedTemporaryRepository(
 
     private fun loadToMemory() {
         exceptions.clear()
-        unprotectedTemporaryDao.getAll().map { exceptions.add(it.toUnprotectedTemporaryException()) }
+        unprotectedTemporaryDao.getAll().map { exceptions.add(it.toFeatureException()) }
     }
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentRepository.kt
@@ -17,13 +17,13 @@
 package com.duckduckgo.privacy.config.store.features.useragent
 
 import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.privacy.config.api.UserAgentException
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.UserAgentExceptionEntity
 import com.duckduckgo.privacy.config.store.UserAgentSitesEntity
 import com.duckduckgo.privacy.config.store.UserAgentStatesEntity
 import com.duckduckgo.privacy.config.store.UserAgentVersionsEntity
-import com.duckduckgo.privacy.config.store.toUserAgentException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -35,11 +35,11 @@ interface UserAgentRepository {
         states: UserAgentStatesEntity?,
         versions: List<UserAgentVersionsEntity>,
     )
-    val defaultExceptions: CopyOnWriteArrayList<UserAgentException>
-    val omitApplicationExceptions: CopyOnWriteArrayList<UserAgentException>
-    val omitVersionExceptions: CopyOnWriteArrayList<UserAgentException>
-    val ddgDefaultSites: CopyOnWriteArrayList<UserAgentException>
-    val ddgFixedSites: CopyOnWriteArrayList<UserAgentException>
+    val defaultExceptions: CopyOnWriteArrayList<FeatureException>
+    val omitApplicationExceptions: CopyOnWriteArrayList<FeatureException>
+    val omitVersionExceptions: CopyOnWriteArrayList<FeatureException>
+    val ddgDefaultSites: CopyOnWriteArrayList<FeatureException>
+    val ddgFixedSites: CopyOnWriteArrayList<FeatureException>
     var defaultPolicy: String
     var closestUserAgentState: Boolean
     var ddgFixedUserAgentState: Boolean
@@ -57,11 +57,11 @@ class RealUserAgentRepository(
     private val userAgentSitesDao: UserAgentSitesDao = database.userAgentSitesDao()
     private val userAgentStatesDao: UserAgentStatesDao = database.userAgentStatesDao()
     private val userAgentVersionsDao: UserAgentVersionsDao = database.userAgentVersionsDao()
-    override val defaultExceptions = CopyOnWriteArrayList<UserAgentException>()
-    override val omitApplicationExceptions = CopyOnWriteArrayList<UserAgentException>()
-    override val omitVersionExceptions = CopyOnWriteArrayList<UserAgentException>()
-    override val ddgDefaultSites = CopyOnWriteArrayList<UserAgentException>()
-    override val ddgFixedSites = CopyOnWriteArrayList<UserAgentException>()
+    override val defaultExceptions = CopyOnWriteArrayList<FeatureException>()
+    override val omitApplicationExceptions = CopyOnWriteArrayList<FeatureException>()
+    override val omitVersionExceptions = CopyOnWriteArrayList<FeatureException>()
+    override val ddgDefaultSites = CopyOnWriteArrayList<FeatureException>()
+    override val ddgFixedSites = CopyOnWriteArrayList<FeatureException>()
     override var defaultPolicy: String = "ddg"
     override var closestUserAgentState: Boolean = false
     override var ddgFixedUserAgentState: Boolean = false
@@ -91,17 +91,17 @@ class RealUserAgentRepository(
         defaultExceptions.clear()
         omitApplicationExceptions.clear()
         omitVersionExceptions.clear()
-        userAgentDao.getDefaultExceptions().map { defaultExceptions.add(it.toUserAgentException()) }
-        userAgentDao.getApplicationExceptions().map { omitApplicationExceptions.add(it.toUserAgentException()) }
-        userAgentDao.getVersionExceptions().map { omitVersionExceptions.add(it.toUserAgentException()) }
+        userAgentDao.getDefaultExceptions().map { defaultExceptions.add(it.toFeatureException()) }
+        userAgentDao.getApplicationExceptions().map { omitApplicationExceptions.add(it.toFeatureException()) }
+        userAgentDao.getVersionExceptions().map { omitVersionExceptions.add(it.toFeatureException()) }
 
         ddgDefaultSites.clear()
         ddgFixedSites.clear()
-        userAgentSitesDao.getDefaultSites().map { ddgDefaultSites.add(it.toUserAgentException()) }
-        userAgentSitesDao.getFixedSites().map { ddgFixedSites.add(it.toUserAgentException()) }
+        userAgentSitesDao.getDefaultSites().map { ddgDefaultSites.add(it.toFeatureException()) }
+        userAgentSitesDao.getFixedSites().map { ddgFixedSites.add(it.toFeatureException()) }
 
         val states = userAgentStatesDao.get()
-        if (states != null) {
+        if (states?.defaultPolicy != null && states.closestUserAgent != null && states.ddgFixedUserAgent != null) {
             defaultPolicy = states.defaultPolicy
             closestUserAgentState = states.closestUserAgent
             ddgFixedUserAgentState = states.ddgFixedUserAgent

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/amplinks/RealAmpLinksRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/amplinks/RealAmpLinksRepositoryTest.kt
@@ -60,7 +60,7 @@ class RealAmpLinksRepositoryTest {
             coroutineRule.testDispatcherProvider,
         )
 
-        assertEquals(ampLinkExceptionEntity.toAmpLinkException(), testee.exceptions.first())
+        assertEquals(ampLinkExceptionEntity.toFeatureException(), testee.exceptions.first())
         assertEquals(ampLinkFormatEntity.format, testee.ampLinkFormats.first().toString())
         assertEquals(ampKeywordEntity.keyword, testee.ampKeywords.first())
     }

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/contentblocking/RealContentBlockingRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/contentblocking/RealContentBlockingRepositoryTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.store.features.contentblocking
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.privacy.config.store.ContentBlockingExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
-import com.duckduckgo.privacy.config.store.toContentBlockingException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -60,7 +60,7 @@ class RealContentBlockingRepositoryTest {
             )
 
         assertEquals(
-            contentBlockingException.toContentBlockingException(),
+            contentBlockingException.toFeatureException(),
             testee.exceptions.first(),
         )
     }

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/drm/RealDrmRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/drm/RealDrmRepositoryTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.store.features.drm
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.privacy.config.store.DrmExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
-import com.duckduckgo.privacy.config.store.toDrmException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -54,7 +54,7 @@ class RealDrmRepositoryTest {
 
         testee = RealDrmRepository(mockDatabase, this, coroutineRule.testDispatcherProvider)
 
-        assertEquals(drmException.toDrmException(), testee.exceptions.first())
+        assertEquals(drmException.toFeatureException(), testee.exceptions.first())
     }
 
     @Test

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/https/RealHttpsRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/https/RealHttpsRepositoryTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.store.features.https
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
-import com.duckduckgo.privacy.config.store.toHttpsException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -65,7 +65,7 @@ class RealHttpsRepositoryTest {
                 coroutineRule.testDispatcherProvider,
             )
 
-        assertEquals(httpException.toHttpsException(), testee.exceptions.first())
+        assertEquals(httpException.toFeatureException(), testee.exceptions.first())
     }
 
     @Test

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackingparameters/RealTrackingParametersRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackingparameters/RealTrackingParametersRepositoryTest.kt
@@ -62,7 +62,7 @@ class RealTrackingParametersRepositoryTest {
             coroutineRule.testDispatcherProvider,
         )
 
-        assertEquals(trackingParameterExceptionEntity.toTrackingParameterException(), testee.exceptions.first())
+        assertEquals(trackingParameterExceptionEntity.toFeatureException(), testee.exceptions.first())
         assertEquals(trackingParameterEntity.parameter, testee.parameters.first().toString())
     }
 

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
-import com.duckduckgo.privacy.config.store.toUnprotectedTemporaryException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -65,7 +65,7 @@ class RealUnprotectedTemporaryRepositoryTest {
                 coroutineRule.testDispatcherProvider,
             )
 
-        assertEquals(unprotectedTemporaryException.toUnprotectedTemporaryException(), testee.exceptions.first())
+        assertEquals(unprotectedTemporaryException.toFeatureException(), testee.exceptions.first())
     }
 
     @Test

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/useragent/RealUserAgentRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/useragent/RealUserAgentRepositoryTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.privacy.config.store.UserAgentExceptionEntity
 import com.duckduckgo.privacy.config.store.UserAgentSitesEntity
 import com.duckduckgo.privacy.config.store.UserAgentStatesEntity
 import com.duckduckgo.privacy.config.store.UserAgentVersionsEntity
-import com.duckduckgo.privacy.config.store.toUserAgentException
+import com.duckduckgo.privacy.config.store.toFeatureException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -67,7 +67,7 @@ class RealUserAgentRepositoryTest {
     @Test
     fun whenRepositoryIsCreatedThenExceptionsLoadedIntoMemory() {
         givenUserAgentDaoContainsExceptions()
-        val actual = userAgentException.toUserAgentException()
+        val actual = userAgentException.toFeatureException()
         testee =
             RealUserAgentRepository(
                 mockDatabase,
@@ -92,8 +92,8 @@ class RealUserAgentRepositoryTest {
 
         assertEquals(testee.closestUserAgentState, true)
         assertEquals(testee.ddgFixedUserAgentState, true)
-        assertEquals(testee.ddgDefaultSites.first(), userAgentDefaultSiteEntity.toUserAgentException())
-        assertEquals(testee.ddgFixedSites.first(), userAgentFixedSiteEntity.toUserAgentException())
+        assertEquals(testee.ddgDefaultSites.first(), userAgentDefaultSiteEntity.toFeatureException())
+        assertEquals(testee.ddgFixedSites.first(), userAgentFixedSiteEntity.toFeatureException())
         assertEquals(testee.closestUserAgentVersions.first(), userAgentClosestVersionEntity.version)
         assertEquals(testee.ddgFixedUserAgentVersions.first(), userAgentDdgFixedVersionEntity.version)
     }

--- a/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/RequestFiltererFeature.kt
+++ b/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/RequestFiltererFeature.kt
@@ -16,12 +16,12 @@
 
 package com.duckduckgo.request.filterer.impl
 
-import com.duckduckgo.request.filterer.store.RequestFiltererExceptionEntity
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 data class RequestFiltererFeature(
     val state: String,
     val minSupportedVersion: Int?,
-    val exceptions: List<RequestFiltererExceptionEntity>,
+    val exceptions: List<FeatureException>,
     val settings: Settings,
 )
 

--- a/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/plugins/RequestFiltererFeaturePlugin.kt
+++ b/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/plugins/RequestFiltererFeaturePlugin.kt
@@ -48,7 +48,7 @@ class RequestFiltererFeaturePlugin @Inject constructor(
             val requestFiltererFeature: RequestFiltererFeature? = jsonAdapter.fromJson(jsonString)
 
             val exceptions = requestFiltererFeature?.exceptions?.map {
-                RequestFiltererExceptionEntity(domain = it.domain, reason = it.reason)
+                RequestFiltererExceptionEntity(domain = it.domain, reason = it.reason.orEmpty())
             }.orEmpty()
 
             val windowInMs = requestFiltererFeature?.settings?.windowInMs ?: DEFAULT_WINDOW_IN_MS

--- a/request-filterer/request-filterer-impl/src/test/java/com/duckduckgo/request/filterer/impl/RequestFiltererImplTest.kt
+++ b/request-filterer/request-filterer-impl/src/test/java/com/duckduckgo/request/filterer/impl/RequestFiltererImplTest.kt
@@ -19,12 +19,12 @@ package com.duckduckgo.request.filterer.impl
 import android.webkit.WebResourceRequest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.request.filterer.api.RequestFiltererFeatureName
 import com.duckduckgo.request.filterer.impl.RequestFiltererImpl.Companion.ORIGIN
 import com.duckduckgo.request.filterer.impl.RequestFiltererImpl.Companion.REFERER
-import com.duckduckgo.request.filterer.store.RequestFiltererExceptionEntity
 import com.duckduckgo.request.filterer.store.RequestFiltererRepository
 import com.duckduckgo.request.filterer.store.SettingsEntity
 import java.util.concurrent.CopyOnWriteArrayList
@@ -81,8 +81,8 @@ class RequestFiltererImplTest {
 
     @Test
     fun whenUrlInExceptionsListThenReturnFalse() {
-        val exceptions = CopyOnWriteArrayList<RequestFiltererExceptionEntity>().apply {
-            add(RequestFiltererExceptionEntity("http://test.com", "my reason here"))
+        val exceptions = CopyOnWriteArrayList<FeatureException>().apply {
+            add(FeatureException("http://test.com", "my reason here"))
         }
 
         whenever(mockRepository.exceptions).thenReturn(exceptions)

--- a/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererDatabaseModels.kt
+++ b/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererDatabaseModels.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.request.filterer.store
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 
 @Entity(tableName = "settings_entity")
 data class SettingsEntity(
@@ -31,3 +32,7 @@ data class RequestFiltererExceptionEntity(
     @PrimaryKey val domain: String,
     val reason: String,
 )
+
+fun RequestFiltererExceptionEntity.toFeatureException(): FeatureException {
+    return FeatureException(domain = this.domain, reason = this.reason)
+}

--- a/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererRepository.kt
+++ b/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererRepository.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.request.filterer.store
 
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -24,10 +25,10 @@ import kotlinx.coroutines.launch
 interface RequestFiltererRepository {
     fun updateAll(exceptions: List<RequestFiltererExceptionEntity>, settings: SettingsEntity)
     var settings: SettingsEntity
-    val exceptions: List<RequestFiltererExceptionEntity>
+    val exceptions: List<FeatureException>
 }
 
-class RealRequestFiltererRepository constructor(
+class RealRequestFiltererRepository(
     val database: RequestFiltererDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
@@ -35,7 +36,7 @@ class RealRequestFiltererRepository constructor(
 
     private val requestFiltererDao: RequestFiltererDao = database.requestFiltererDao()
 
-    override val exceptions = CopyOnWriteArrayList<RequestFiltererExceptionEntity>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
     override var settings = SettingsEntity(windowInMs = DEFAULT_WINDOW_IN_MS)
 
     init {
@@ -55,7 +56,7 @@ class RealRequestFiltererRepository constructor(
     private fun loadToMemory() {
         exceptions.clear()
         requestFiltererDao.getAllRequestFiltererExceptions().map {
-            exceptions.add(it)
+            exceptions.add(it.toFeatureException())
         }
         settings = requestFiltererDao.getSettings() ?: SettingsEntity(windowInMs = DEFAULT_WINDOW_IN_MS)
     }

--- a/request-filterer/request-filterer-store/src/test/java/com/duckduckgo/request/filterer/store/RealRequestFiltererRepositoryTest.kt
+++ b/request-filterer/request-filterer-store/src/test/java/com/duckduckgo/request/filterer/store/RealRequestFiltererRepositoryTest.kt
@@ -55,7 +55,7 @@ class RealRequestFiltererRepositoryTest {
             coroutineRule.testDispatcherProvider,
         )
 
-        assertEquals(requestFiltererExceptionEntity, testee.exceptions.first())
+        assertEquals(requestFiltererExceptionEntity.toFeatureException(), testee.exceptions.first())
         assertEquals(WINDOW_IN_MS, testee.settings.windowInMs)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1205690187399816/f 

### Description
Add support for remote config v4

### Steps to test this PR

_Update_
- [ ] Install from develop
- [ ] Check the DB for the different features (privacy_config.db, autoconsent, autofill, cookies, etc). Go to the different exceptions tables and seen that the column for reasons has content
- [ ] Update from this branch
- [ ] The app should not crash
- [ ] Check the DBs and the reason column should now be null but domains should still be there.

_New install_
- [ ] Install from this branch
- [ ] The app should not crash
- [ ] Check the DBs and the reason column should now be null but domains should still be there.

_Tests_
- [ ] Privacy Tests should pass, see https://github.com/duckduckgo/Android/actions/runs/6510081560

