### PR TITLE
Better internal settings to force load a custom config

### DIFF
--- a/privacy-config/privacy-config-impl/build.gradle
+++ b/privacy-config/privacy-config-impl/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation Google.android.material
     implementation AndroidX.constraintLayout
     implementation JakeWharton.timber
+    implementation "com.jakewharton.threetenabp:threetenabp:_"
 
     implementation KotlinX.coroutines.core
 
@@ -71,6 +72,7 @@ dependencies {
     testImplementation "androidx.test:runner:_"
     testImplementation Testing.robolectric
     testImplementation CashApp.turbine
+    testImplementation "org.threeten:threetenbp:_"
 
     androidTestImplementation project(path: ':common-test')
     testImplementation project(path: ':common-test')

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -33,6 +33,8 @@ import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.Unprote
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.format.DateTimeFormatter
 import timber.log.Timber
 
 interface PrivacyConfigPersister {
@@ -76,7 +78,16 @@ class RealPrivacyConfigPersister @Inject constructor(
             database.runInTransaction {
                 persisterPreferences.setSignature(currentPluginHashCode)
                 privacyFeatureTogglesRepository.deleteAll()
-                privacyConfigRepository.insert(PrivacyConfig(version = jsonPrivacyConfig.version, readme = jsonPrivacyConfig.readme, eTag = eTag))
+                privacyConfigRepository.insert(
+                    PrivacyConfig(
+                        version = jsonPrivacyConfig.version,
+                        readme = jsonPrivacyConfig.readme,
+                        eTag = eTag,
+                        timestamp = FORMATTER_SECONDS.format(
+                            LocalDateTime.now(),
+                        ),
+                    ),
+                )
                 unprotectedTemporaryRepository.updateAll(jsonPrivacyConfig.unprotectedTemporary)
                 jsonPrivacyConfig.features.forEach { feature ->
                     feature.value?.let { jsonObject ->
@@ -98,6 +109,10 @@ class RealPrivacyConfigPersister @Inject constructor(
         edit {
             putInt(PRIVACY_SIGNATURE_KEY, value)
         }
+    }
+
+    companion object {
+        private val FORMATTER_SECONDS: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
     }
 }
 

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/workers/RemoteConfigDownloadWorker.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/workers/RemoteConfigDownloadWorker.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.impl.ConfigDownloadResult.Success
 import com.duckduckgo.privacy.config.impl.PrivacyConfigDownloader
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -50,7 +51,7 @@ class PrivacyConfigDownloadWorker(
     override suspend fun doWork(): Result {
         return withContext(dispatcherProvider.io()) {
             val result = privacyConfigDownloader.download()
-            return@withContext if (result) {
+            return@withContext if (result is Success) {
                 Result.success()
             } else {
                 Result.retry()

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
@@ -18,13 +18,14 @@ package com.duckduckgo.privacy.config.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.privacy.config.impl.ConfigDownloadResult.Error
+import com.duckduckgo.privacy.config.impl.ConfigDownloadResult.Success
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.impl.network.PrivacyConfigService
 import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -58,12 +59,12 @@ class RealPrivacyConfigDownloaderTest {
                     TestFailingPrivacyConfigService(),
                     mockPrivacyConfigPersister,
                 )
-            assertFalse(testee.download())
+            assertTrue(testee.download() is Error)
         }
 
     @Test
     fun whenDownloadIsSuccessfulThenReturnTrue() =
-        runTest { assertTrue(testee.download()) }
+        runTest { assertTrue(testee.download() is Success) }
 
     @Test
     fun whenDownloadIsSuccessfulThenPersistPrivacyConfigCalled() =

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
@@ -148,7 +148,7 @@ class RealPrivacyConfigPersisterTest {
     @Test
     fun whenPersistPrivacyConfigAndVersionIsLowerThanPreviousOneStoredThenDoNothing() =
         runTest {
-            privacyRepository.insert(PrivacyConfig(version = 3, readme = "readme", eTag = "eTag"))
+            privacyRepository.insert(PrivacyConfig(version = 3, readme = "readme", eTag = "eTag", timestamp = "2023-01-02"))
 
             testee.persistPrivacyConfig(getJsonPrivacyConfig())
 
@@ -160,7 +160,7 @@ class RealPrivacyConfigPersisterTest {
     fun whenPersistPrivacyConfigAndVersionIsLowerThanPreviousOneAndDifferentPluginsThenStoreNewConfig() =
         runTest {
             sharedPreferences.edit().putInt("plugin_signature", 0)
-            privacyRepository.insert(PrivacyConfig(version = 3, readme = "readme", eTag = "eTag"))
+            privacyRepository.insert(PrivacyConfig(version = 3, readme = "readme", eTag = "eTag", timestamp = "2023-01-02"))
 
             testee.persistPrivacyConfig(getJsonPrivacyConfig())
 
@@ -171,7 +171,7 @@ class RealPrivacyConfigPersisterTest {
     @Test
     fun whenPersistPrivacyConfigAndVersionIsEqualsThanPreviousOneStoredThenDoNothing() =
         runTest {
-            privacyRepository.insert(PrivacyConfig(version = 2, readme = "readme", eTag = "eTag"))
+            privacyRepository.insert(PrivacyConfig(version = 2, readme = "readme", eTag = "eTag", timestamp = "2023-01-02"))
 
             testee.persistPrivacyConfig(getJsonPrivacyConfig())
 
@@ -183,7 +183,7 @@ class RealPrivacyConfigPersisterTest {
     fun whenPersistPrivacyConfigAndVersionIsEqualsThanPreviousOneStoredAndDifferentPluginsThenUpdateConfig() =
         runTest {
             sharedPreferences.edit().putInt("plugin_signature", 0)
-            privacyRepository.insert(PrivacyConfig(version = 2, readme = "readme", eTag = "eTag"))
+            privacyRepository.insert(PrivacyConfig(version = 2, readme = "readme", eTag = "eTag", timestamp = "2023-01-02"))
 
             testee.persistPrivacyConfig(getJsonPrivacyConfig())
 
@@ -194,7 +194,7 @@ class RealPrivacyConfigPersisterTest {
     @Test
     fun whenPersistPrivacyConfigAndVersionIsHigherThanPreviousOneStoredThenStoreNewConfig() =
         runTest {
-            privacyRepository.insert(PrivacyConfig(version = 1, readme = "readme", eTag = "eTag"))
+            privacyRepository.insert(PrivacyConfig(version = 1, readme = "readme", eTag = "eTag", timestamp = "2023-01-02"))
 
             testee.persistPrivacyConfig(getJsonPrivacyConfig())
 
@@ -205,7 +205,7 @@ class RealPrivacyConfigPersisterTest {
     fun whenPersistPrivacyConfigAndVersionIsHigherThanPreviousOneStoredAndDifferentPluginsThenStoreNewConfig() =
         runTest {
             sharedPreferences.edit().putInt("plugin_signature", 0)
-            privacyRepository.insert(PrivacyConfig(version = 1, readme = "readme", eTag = "eTag"))
+            privacyRepository.insert(PrivacyConfig(version = 1, readme = "readme", eTag = "eTag", timestamp = "2023-01-02"))
 
             testee.persistPrivacyConfig(getJsonPrivacyConfig())
 

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/workers/PrivacyConfigDownloadWorkerTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/workers/PrivacyConfigDownloadWorkerTest.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import androidx.work.ListenableWorker
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.privacy.config.impl.ConfigDownloadResult.Error
+import com.duckduckgo.privacy.config.impl.ConfigDownloadResult.Success
 import com.duckduckgo.privacy.config.impl.PrivacyConfigDownloader
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -49,7 +51,7 @@ class PrivacyConfigDownloadWorkerTest {
     @Test
     fun whenDoWorkIfDownloadReturnsTrueThenReturnSuccess() =
         runTest {
-            whenever(mockPrivacyConfigDownloader.download()).thenReturn(true)
+            whenever(mockPrivacyConfigDownloader.download()).thenReturn(Success)
 
             val worker =
                 TestListenableWorkerBuilder<PrivacyConfigDownloadWorker>(context = context).build()
@@ -64,7 +66,7 @@ class PrivacyConfigDownloadWorkerTest {
     @Test
     fun whenDoWorkIfDownloadReturnsFalseThenReturnRetry() =
         runTest {
-            whenever(mockPrivacyConfigDownloader.download()).thenReturn(false)
+            whenever(mockPrivacyConfigDownloader.download()).thenReturn(Error("error"))
 
             val worker =
                 TestListenableWorkerBuilder<PrivacyConfigDownloadWorker>(context = context).build()

--- a/privacy-config/privacy-config-internal/build.gradle
+++ b/privacy-config/privacy-config-internal/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     anvil project(path: ':anvil-compiler')
     implementation project(path: ':anvil-annotations')
     implementation project(path: ':privacy-config-api')
+    implementation project(path: ':privacy-config-impl')
+    implementation project(path: ':privacy-config-store')
     implementation project(path: ':di')
     implementation project(path: ':common-utils')
     implementation project(path: ':common-ui')
@@ -42,6 +44,8 @@ dependencies {
     implementation AndroidX.core.ktx
 
     implementation AndroidX.appCompat
+    implementation AndroidX.lifecycle.viewModelKtx
+    implementation AndroidX.lifecycle.runtime.ktx
     implementation Google.android.material
     implementation AndroidX.constraintLayout
     implementation Square.okHttp3.okHttp

--- a/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalViewModel.kt
+++ b/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalViewModel.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.internal
+
+import android.webkit.URLUtil
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.privacy.config.api.PRIVACY_REMOTE_CONFIG_URL
+import com.duckduckgo.privacy.config.impl.ConfigDownloadResult.Error
+import com.duckduckgo.privacy.config.impl.ConfigDownloadResult.Success
+import com.duckduckgo.privacy.config.impl.PrivacyConfigDownloader
+import com.duckduckgo.privacy.config.internal.PrivacyConfigInternalViewModel.Command.ConfigDownloaded
+import com.duckduckgo.privacy.config.internal.PrivacyConfigInternalViewModel.Command.ConfigError
+import com.duckduckgo.privacy.config.internal.PrivacyConfigInternalViewModel.Command.Loading
+import com.duckduckgo.privacy.config.internal.store.DevPrivacyConfigSettingsDataStore
+import com.duckduckgo.privacy.config.store.PrivacyConfig
+import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
+import javax.inject.Inject
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+@ContributesViewModel(ActivityScope::class)
+class PrivacyConfigInternalViewModel @Inject constructor(
+    private val privacyConfigRepository: PrivacyConfigRepository,
+    private val downloader: PrivacyConfigDownloader,
+    private val store: DevPrivacyConfigSettingsDataStore,
+    private val dispatcherProvider: DispatcherProvider,
+) : ViewModel() {
+
+    private val command = Channel<Command>(1, DROP_OLDEST)
+    internal fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    private val viewState = MutableStateFlow(ViewState())
+
+    fun viewState(): StateFlow<ViewState> {
+        return viewState
+    }
+
+    data class ViewState(
+        val latestVersionLoaded: String = "",
+        val timestamp: String = "",
+        val latestUrl: String = "",
+        val customUrl: String = "",
+        val toggleState: Boolean = false,
+    )
+
+    fun start() {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitLatestConfig()
+        }
+    }
+
+    fun download() {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            sendCommand(Loading)
+            privacyConfigRepository.insert(PrivacyConfig(version = -1, readme = "", eTag = "", timestamp = ""))
+            when (val result = downloader.download()) {
+                is Success -> {
+                    sendCommand(ConfigDownloaded(getCurrentUrl()))
+                    emitLatestConfig()
+                }
+                is Error -> {
+                    sendCommand(ConfigError(result.error ?: "Unknown error"))
+                }
+            }
+        }
+    }
+
+    fun changeCustomUrl(url: String) {
+        store.remotePrivacyConfigUrl = url
+    }
+
+    fun changeToggleState(value: Boolean) {
+        store.useCustomPrivacyConfigUrl = value
+    }
+    fun canUrlBeChanged(): Boolean {
+        val storedUrl = store.remotePrivacyConfigUrl
+        val isCustomSettingEnabled = store.useCustomPrivacyConfigUrl
+        val canBeChanged = isCustomSettingEnabled && !storedUrl.isNullOrEmpty() && URLUtil.isValidUrl(storedUrl)
+        store.canUrlBeChanged = canBeChanged
+        return canBeChanged
+    }
+
+    private suspend fun emitLatestConfig() {
+        val url = getCurrentUrl()
+        val config = privacyConfigRepository.get()
+        viewState.emit(
+            viewState.value.copy(
+                latestVersionLoaded = config?.version.toString(),
+                timestamp = config?.timestamp.orEmpty(),
+                latestUrl = url.orEmpty(),
+                customUrl = store.remotePrivacyConfigUrl.orEmpty(),
+                toggleState = store.useCustomPrivacyConfigUrl,
+            ),
+        )
+    }
+
+    private fun getCurrentUrl(): String {
+        return if (store.useCustomPrivacyConfigUrl) {
+            store.remotePrivacyConfigUrl.orEmpty()
+        } else {
+            PRIVACY_REMOTE_CONFIG_URL
+        }
+    }
+
+    private fun sendCommand(newCommand: Command) {
+        viewModelScope.launch {
+            command.send(newCommand)
+        }
+    }
+    sealed class Command {
+        data class ConfigError(val message: String) : Command()
+        data class ConfigDownloaded(val url: String) : Command()
+        object Loading : Command()
+    }
+}

--- a/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/store/DevPrivacyConfigSettingsDataStore.kt
+++ b/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/store/DevPrivacyConfigSettingsDataStore.kt
@@ -26,6 +26,7 @@ import javax.inject.Inject
 interface DevPrivacyConfigSettingsDataStore {
     var remotePrivacyConfigUrl: String?
     var useCustomPrivacyConfigUrl: Boolean
+    var canUrlBeChanged: Boolean
 }
 
 @ContributesBinding(AppScope::class)
@@ -39,6 +40,10 @@ class DevPrivacyConfigSettingsDataStoreImpl @Inject constructor(private val cont
         get() = preferences.getBoolean(KEY_CUSTOM_REMOTE_PRIVACY_CONFIG_ENABLED, false)
         set(enabled) = preferences.edit { putBoolean(KEY_CUSTOM_REMOTE_PRIVACY_CONFIG_ENABLED, enabled) }
 
+    override var canUrlBeChanged: Boolean
+        get() = preferences.getBoolean(KEY_URL_CHANGED, false)
+        set(enabled) = preferences.edit { putBoolean(KEY_URL_CHANGED, enabled) }
+
     private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
 
     private fun selectedRemotePrivacyConfigUrlSavedValue(): String? {
@@ -49,5 +54,6 @@ class DevPrivacyConfigSettingsDataStoreImpl @Inject constructor(private val cont
         private const val FILENAME = "com.duckduckgo.privacy.config.internal.settings"
         private const val KEY_SELECTED_REMOTE_PRIVACY_CONFIG = "KEY_SELECTED_REMOTE_PRIVACY_CONFIG"
         private const val KEY_CUSTOM_REMOTE_PRIVACY_CONFIG_ENABLED = "KEY_CUSTOM_REMOTE_PRIVACY_CONFIG_ENABLED"
+        private const val KEY_URL_CHANGED = "KEY_URL_CHANGED"
     }
 }

--- a/privacy-config/privacy-config-internal/src/main/res/layout/activity_privacy_config_internal_settings.xml
+++ b/privacy-config/privacy-config-internal/src/main/res/layout/activity_privacy_config_internal_settings.xml
@@ -39,7 +39,21 @@
             app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu" />
     </com.google.android.material.appbar.AppBarLayout>
 
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progress"
+            app:indicatorColor="?attr/daxColorSecondaryText"
+            android:indeterminate="true"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:visibility="invisible"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
     <ScrollView
+            android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="64dp"
@@ -51,34 +65,89 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
-                android:id="@+id/help"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/keyline_3"
-                android:text="Hint: you can use something like https://www.jsonblob.com/ and use https://jsonblob.com/api/jsonBlob/ID as the URL \n\nUsing an endpoint with a bad formatted config could lead to the app crashing.\n\nTo reload the config, restart the app." />
+            <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/currentVersion"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:primaryText="Supported Version"
+                    app:secondaryText="v4"
+            />
+
+            <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/latestVersion"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:primaryText="Latest Version Loaded"
+                    app:secondaryText="12345667"
+            />
+
+            <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/timestamp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:primaryText="Latest Loaded Date"
+                    app:secondaryText="12345667"
+            />
+
+            <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/latestUrl"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:primaryText="Latest Loaded URL"
+                    app:secondaryText="12345667"
+            />
 
             <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
                 android:id="@+id/endpointToggle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:primaryText="Use Custom Endpoint?"
+                app:primaryText="Use Custom URL? (disabled uses real config)"
                 app:showSwitch="true" />
 
             <com.duckduckgo.mobile.android.ui.view.text.DaxTextInput
                 android:id="@+id/urlInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="@dimen/keyline_3"
+                android:layout_marginRight="@dimen/keyline_3"
+                android:layout_marginLeft="@dimen/keyline_3"
                 android:hint="Add your custom URL here"
                 app:editable="true" />
 
             <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
                 android:id="@+id/validation"
+                android:visibility="gone"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/keyline_3"
-                android:layout_margin="@dimen/keyline_3" />
+                app:textType="secondary"
+                app:typography="body2_bold"
+                android:layout_marginRight="@dimen/keyline_3"
+                android:layout_marginLeft="@dimen/keyline_3" />
+
+            <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+                    android:id="@+id/help"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/keyline_3"
+                    app:textType="secondary"
+                    app:typography="body2"
+                    android:text="Hint: you can use something like https://www.jsonblob.com/ and use https://jsonblob.com/api/ID as the URL"
+            />
+
+            <com.duckduckgo.mobile.android.ui.view.button.DaxButtonPrimary
+                    android:id="@+id/load"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Force load config"
+                    android:layout_marginRight="@dimen/keyline_3"
+                    android:layout_marginLeft="@dimen/keyline_3" />
+
+            <com.duckduckgo.mobile.android.ui.view.button.DaxButtonDestructive
+                    android:id="@+id/reset"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Reset to default"
+                    android:layout_marginRight="@dimen/keyline_3"
+                    android:layout_marginLeft="@dimen/keyline_3" />
         </LinearLayout>
     </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/privacy-config/privacy-config-internal/src/main/res/values/donottranslate.xml
+++ b/privacy-config/privacy-config-internal/src/main/res/values/donottranslate.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2023 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="ok">OK</string>
+</resources>

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabase.kt
@@ -41,7 +41,7 @@ import com.duckduckgo.privacy.config.store.features.useragent.UserAgentVersionsD
 )
 @Database(
     exportSchema = true,
-    version = 16,
+    version = 17,
     entities = [
         TrackerAllowlistEntity::class,
         UnprotectedTemporaryEntity::class,
@@ -119,4 +119,10 @@ val MIGRATION_15_16 = object : Migration(15, 16) {
     }
 }
 
-val ALL_MIGRATIONS = arrayOf(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_13_14, MIGRATION_15_16)
+val MIGRATION_16_17 = object : Migration(16, 17) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("DELETE FROM privacy_config")
+    }
+}
+
+val ALL_MIGRATIONS = arrayOf(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_13_14, MIGRATION_15_16, MIGRATION_16_17)

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -153,6 +153,7 @@ data class PrivacyConfig(
     val version: Long,
     val readme: String,
     val eTag: String?,
+    val timestamp: String?,
 )
 
 fun PrivacyConfig.toPrivacyConfigData(): PrivacyConfigData {

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/RealPrivacyConfigRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/RealPrivacyConfigRepositoryTest.kt
@@ -37,7 +37,7 @@ class RealPrivacyConfigRepositoryTest {
 
     @Test
     fun whenInsertPrivacyConfigThenCallInsert() {
-        val privacyConfig = PrivacyConfig(id = 1, version = 1, readme = "readme", eTag = "eTag")
+        val privacyConfig = PrivacyConfig(id = 1, version = 1, readme = "readme", eTag = "eTag", timestamp = "2023-01-01")
 
         testee.insert(privacyConfig)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205661297103827/f 

### Description
This PR improves the internal settings to load a new remote config

### Steps to test this PR

- [x] Install the internal flavour
- [x] Go to `https://privacy-test-pages.site/privacy-protections/gpc/` and run the test
- [x] The top frame header should have a value of 1
- [x] Go to internal settings and override remote config url
- [x] Add `https://jsonblob.com/1163450390598770688` as the URL
- [x] Click on `Force load config` 
- [x] You should get an error message
- [x] Change the URL to `https://jsonblob.com/api/1163450390598770688`
- [x] ClIck on `Force load config`
- [x] You should now get a success message and the config version should have changed to `2697446999567` and the latest loaded date and URL should be updated.
- [x] Go back to the test page, execute the test again and the value should not be 1
- [x] Click on reset to default
- [x] The config version, url and loaded date should have changed to the default one.
- [x] Go back to the test page and execute the test, value should be 1
