### PR TITLE
Update autofill copy

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Активирано по подразбиране</string>
     <string name="settingsHeadingSettings">Настройки</string>
     <string name="settingsPermissionsSetting">Разрешения</string>
-    <string name="settingsAutofillLoginsSetting">Автоматично попълване на данни за вход</string>
+    <string name="settingsAutofillLoginsSetting">Данни за вход</string>
     <string name="settingsSyncSetting">Синхронизиране и архивиране</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Ve výchozím nastavení povoleno</string>
     <string name="settingsHeadingSettings">Nastavení</string>
     <string name="settingsPermissionsSetting">Oprávnění</string>
-    <string name="settingsAutofillLoginsSetting">Automatické vyplňování přihlašovacích údajů</string>
+    <string name="settingsAutofillLoginsSetting">Přihlášení</string>
     <string name="settingsSyncSetting">Synchronizace a zálohování</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Aktiveret som standard</string>
     <string name="settingsHeadingSettings">Indstillinger</string>
     <string name="settingsPermissionsSetting">Tilladelser</string>
-    <string name="settingsAutofillLoginsSetting">Automatisk udfyldning ved login</string>
+    <string name="settingsAutofillLoginsSetting">Logins</string>
     <string name="settingsSyncSetting">Synkronisering og sikkerhedskopiering</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Standardmäßig aktiviert</string>
     <string name="settingsHeadingSettings">Einstellungen</string>
     <string name="settingsPermissionsSetting">Berechtigungen</string>
-    <string name="settingsAutofillLoginsSetting">Anmeldedaten automatisch ausfüllen</string>
+    <string name="settingsAutofillLoginsSetting">Anmeldungen</string>
     <string name="settingsSyncSetting">Synchronisieren und sichern</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Ενεργοποιημένο βάσει προεπιλογής</string>
     <string name="settingsHeadingSettings">Ρυθμίσεις</string>
     <string name="settingsPermissionsSetting">Δικαιώματα</string>
-    <string name="settingsAutofillLoginsSetting">Συνδέσεις αυτόματης συμπλήρωσης</string>
+    <string name="settingsAutofillLoginsSetting">Συνδέσεις</string>
     <string name="settingsSyncSetting">Συγχρονισμός και δημιουργία αντιγράφων ασφαλείας</string>
     <string name="settingsFireButton">Κουμπί Φωτιά</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Habilitado de forma predeterminada</string>
     <string name="settingsHeadingSettings">Ajustes</string>
     <string name="settingsPermissionsSetting">Permisos</string>
-    <string name="settingsAutofillLoginsSetting">Autocompletar inicios de sesión</string>
+    <string name="settingsAutofillLoginsSetting">Inicios de sesión</string>
     <string name="settingsSyncSetting">Sincronización y copia de seguridad</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Vaikimisi sisse lülitatud</string>
     <string name="settingsHeadingSettings">Sätted</string>
     <string name="settingsPermissionsSetting">Load</string>
-    <string name="settingsAutofillLoginsSetting">Sisesta sisselogimisandmed automaatselt</string>
+    <string name="settingsAutofillLoginsSetting">Sisselogimine</string>
     <string name="settingsSyncSetting">Sünkroonimine ja varundamine</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Oletusarvoisesti käytössä</string>
     <string name="settingsHeadingSettings">Asetukset</string>
     <string name="settingsPermissionsSetting">Käyttöoikeudet</string>
-    <string name="settingsAutofillLoginsSetting">Täytä kirjautumistiedot automaattisesti</string>
+    <string name="settingsAutofillLoginsSetting">Kirjautumistiedot</string>
     <string name="settingsSyncSetting">Synkronoi ja varmuuskopioi</string>
     <string name="settingsFireButton">Fire-painike</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Activation par défaut</string>
     <string name="settingsHeadingSettings">Paramètres</string>
     <string name="settingsPermissionsSetting">Autorisations</string>
-    <string name="settingsAutofillLoginsSetting">Saisie automatique des identifiants</string>
+    <string name="settingsAutofillLoginsSetting">Identifiants</string>
     <string name="settingsSyncSetting">Synchronisation et sauvegarde</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Omogućeno prema zadanim postavkama</string>
     <string name="settingsHeadingSettings">Postavke</string>
     <string name="settingsPermissionsSetting">Dozvole</string>
-    <string name="settingsAutofillLoginsSetting">Automatsko popunjavanje prijave</string>
+    <string name="settingsAutofillLoginsSetting">Prijave</string>
     <string name="settingsSyncSetting">Sinkronizacija i sigurnosno kopiranje</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Alapértelmezés szerint engedélyezve</string>
     <string name="settingsHeadingSettings">Beállítások</string>
     <string name="settingsPermissionsSetting">Engedélyek</string>
-    <string name="settingsAutofillLoginsSetting">Bejelentkezési adatok automatikus kitöltése</string>
+    <string name="settingsAutofillLoginsSetting">Bejelentkezések</string>
     <string name="settingsSyncSetting">Szinkronizálás és biztonsági mentés</string>
     <string name="settingsFireButton">Tűz gomb</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Abilitato per impostazione predefinita</string>
     <string name="settingsHeadingSettings">Impostazioni</string>
     <string name="settingsPermissionsSetting">Autorizzazioni</string>
-    <string name="settingsAutofillLoginsSetting">Compilazione automatica dei dati di accesso</string>
+    <string name="settingsAutofillLoginsSetting">Accessi</string>
     <string name="settingsSyncSetting">Sincronizzazione e backup</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Įjungta pagal numatytuosius nustatymus</string>
     <string name="settingsHeadingSettings">Nustatymai</string>
     <string name="settingsPermissionsSetting">Leidimai</string>
-    <string name="settingsAutofillLoginsSetting">Automatiškai užpildyti prisijungimus</string>
+    <string name="settingsAutofillLoginsSetting">Prisijungimai</string>
     <string name="settingsSyncSetting">Sinchronizuoti ir kurti atsarginę kopiją</string>
     <string name="settingsFireButton">Mygtukas „Fire“</string>
 

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Iespējots pēc noklusējuma</string>
     <string name="settingsHeadingSettings">Iestatījumi</string>
     <string name="settingsPermissionsSetting">Atļaujas</string>
-    <string name="settingsAutofillLoginsSetting">Automātiski aizpildīt pieteikšanās datus</string>
+    <string name="settingsAutofillLoginsSetting">Pieteikšanās dati</string>
     <string name="settingsSyncSetting">Sinhronizācija un dublēšana</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Aktivert som standard</string>
     <string name="settingsHeadingSettings">Innstillinger</string>
     <string name="settingsPermissionsSetting">Tillatelser</string>
-    <string name="settingsAutofillLoginsSetting">Fyll inn pålogginger automatisk</string>
+    <string name="settingsAutofillLoginsSetting">Pålogginger</string>
     <string name="settingsSyncSetting">Synkronisering og sikkerhetskopiering</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Standaard ingeschakeld</string>
     <string name="settingsHeadingSettings">Instellingen</string>
     <string name="settingsPermissionsSetting">Toestemmingen</string>
-    <string name="settingsAutofillLoginsSetting">Login met automatisch invullen</string>
+    <string name="settingsAutofillLoginsSetting">Aanmeldgegevens</string>
     <string name="settingsSyncSetting">Synchronisatie en back-up</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Domyślnie włączone</string>
     <string name="settingsHeadingSettings">Ustawienia</string>
     <string name="settingsPermissionsSetting">Uprawnienia</string>
-    <string name="settingsAutofillLoginsSetting">Autouzupełnianie logowania</string>
+    <string name="settingsAutofillLoginsSetting">Dane logowania</string>
     <string name="settingsSyncSetting">Synchronizacja i kopia zapasowa</string>
     <string name="settingsFireButton">Przycisk zabezpieczenia</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Ativado por predefinição</string>
     <string name="settingsHeadingSettings">Definições</string>
     <string name="settingsPermissionsSetting">Permissões</string>
-    <string name="settingsAutofillLoginsSetting">Preenchimento automático de inícios de sessão</string>
+    <string name="settingsAutofillLoginsSetting">Inícios de sessão</string>
     <string name="settingsSyncSetting">Sincronização e cópia de segurança</string>
     <string name="settingsFireButton">Botão de proteção</string>
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Activat în mod implicit</string>
     <string name="settingsHeadingSettings">Setări</string>
     <string name="settingsPermissionsSetting">Permisiuni</string>
-    <string name="settingsAutofillLoginsSetting">Completare automată la autentificare</string>
+    <string name="settingsAutofillLoginsSetting">Conectări</string>
     <string name="settingsSyncSetting">Sincronizare și copiere de rezervă</string>
     <string name="settingsFireButton">Butonul Foc</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Включено по умолчанию</string>
     <string name="settingsHeadingSettings">Настройки</string>
     <string name="settingsPermissionsSetting">Разрешения</string>
-    <string name="settingsAutofillLoginsSetting">Автозаполнение логинов</string>
+    <string name="settingsAutofillLoginsSetting">Логины</string>
     <string name="settingsSyncSetting">Синхронизация</string>
     <string name="settingsFireButton">Кнопка «Тревога»</string>
 

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Predvolene povolené</string>
     <string name="settingsHeadingSettings">Nastavenia</string>
     <string name="settingsPermissionsSetting">Oprávnenia</string>
-    <string name="settingsAutofillLoginsSetting">Automatické vyplňovanie prihlasovacích údajov</string>
+    <string name="settingsAutofillLoginsSetting">Prihlasovacie údaje</string>
     <string name="settingsSyncSetting">Synchronizácia a zálohovanie</string>
     <string name="settingsFireButton">Tlačidlo Fire</string>
 

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Privzeto omogočeno</string>
     <string name="settingsHeadingSettings">Nastavitve</string>
     <string name="settingsPermissionsSetting">Dovoljenja</string>
-    <string name="settingsAutofillLoginsSetting">Samodejno izpolnjevanje obrazcev za prijavo</string>
+    <string name="settingsAutofillLoginsSetting">Prijave</string>
     <string name="settingsSyncSetting">Sinhronizacija in varnostno kopiranje</string>
     <string name="settingsFireButton">Gumb Fire Button</string>
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Aktiverat som standard</string>
     <string name="settingsHeadingSettings">Inställningar</string>
     <string name="settingsPermissionsSetting">Behörigheter</string>
-    <string name="settingsAutofillLoginsSetting">Fyll i inloggningar automatiskt</string>
+    <string name="settingsAutofillLoginsSetting">Inloggningar</string>
     <string name="settingsSyncSetting">Synkronisering och säkerhetskopiering</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -150,7 +150,7 @@
     <string name="settingsWebTrackingProtectionDescription">Varsayılan olarak etkinleştirildi</string>
     <string name="settingsHeadingSettings">Ayarlar</string>
     <string name="settingsPermissionsSetting">İzinler</string>
-    <string name="settingsAutofillLoginsSetting">Girişleri Otomatik Doldur</string>
+    <string name="settingsAutofillLoginsSetting">Giriş bilgileri</string>
     <string name="settingsSyncSetting">Senkronizasyon ve Yedekleme</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="settingsWebTrackingProtectionDescription">Enabled by default</string>
     <string name="settingsHeadingSettings">Settings</string>
     <string name="settingsPermissionsSetting">Permissions</string>
-    <string name="settingsAutofillLoginsSetting">Autofill Logins</string>
+    <string name="settingsAutofillLoginsSetting">Logins</string>
     <string name="settingsSyncSetting">Sync &amp; Backup</string>
     <string name="settingsFireButton">Fire Button</string>
 

--- a/autofill/autofill-impl/src/main/res/layout/autofill_management_credential_list_empty_state.xml
+++ b/autofill/autofill-impl/src/main/res/layout/autofill_management_credential_list_empty_state.xml
@@ -52,22 +52,7 @@
         android:text="@string/credentialManagementNoLoginsSavedTitle"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/emptyPlaceholderSubtitle"
-        app:layout_constraintTop_toBottomOf="@+id/autofillKeyIcon" />
-
-    <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
-        android:id="@+id/emptyPlaceholderSubtitle"
-        app:textType="secondary"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintWidth_percent="0.8"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:breakStrategy="balanced"
-        android:gravity="center"
-        android:text="@string/credentialManagementNoLoginsSavedSubtitle"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/emptyPlaceholderTitle" />
+        app:layout_constraintTop_toBottomOf="@+id/autofillKeyIcon" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
@@ -26,12 +26,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
             android:id="@+id/enabledToggle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             app:primaryText="@string/credentialManagementAutofillToggleLabel"
+            app:secondaryText="@string/credentialManagementAutofillToggleSubtitle"
             app:showSwitch="true"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Запазване на данните за вход</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Запазване на паролата</string>
     <string name="saveLoginDialogNotNow">Не записвай</string>
-    <string name="saveLoginDialogSubtitle">Данните за вход са сигурно съхранени само на Вашето устройство и могат да се управляват от менюто Данни за вход в Настройки.</string>
+    <string name="saveLoginDialogSubtitle">Данните за вход се съхраняват на сигурно място в менюто Данни за вход на Вашето устройство.</string>
     <string name="saveLoginDialogTitle">Искате ли DuckDuckGo да запази данните за вход?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Повече опции</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Последна актуализация на данните за вход %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Запазване и автоматично попълване на данните за вход</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Данните за вход се съхраняват сигурно на Вашето устройство</string>
     <string name="credentialManagementViewMenuEdit">Редактиране</string>
     <string name="credentialManagementViewMenuDelete">Изтриване</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Потребителското име е копирано</string>
     <string name="autofillManagementPasswordCopied">Паролата е копирана</string>
 
-    <string name="autofill_password_generation_offer_title">Използване на парола, генерирана от DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Паролата ще бъде запазена в „Данни за вход“.</string>
-    <string name="autofill_password_generation_offer_accept">Използване на генерирана парола</string>
+    <string name="autofill_password_generation_offer_title">Използване на силна парола от DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Паролите се съхраняват на сигурно място в менюто Данни за вход на Вашето устройство.</string>
+    <string name="autofill_password_generation_offer_accept">Използване на силна парола</string>
     <string name="autofill_password_generation_offer_decline">Създаване на собствена</string>
 
     <string name="deviceNotSupportedTitle">Устройството не се поддържа</string>

--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Предложения</string>
     <string name="credentialManagementNoLoginsSavedTitle">Все още няма запазени данни за вход</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Данните за вход се съхраняват сигурно на Вашето устройство.</string>
 
     <string name="autofillManagementAddLogin">Добавяне на данни за вход</string>
     <string name="autofillManagementSearchLogins">Търсене на данни за вход</string>

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Uložit přihlašovací údaje</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Uložit heslo</string>
     <string name="saveLoginDialogNotNow">Neukládat</string>
-    <string name="saveLoginDialogSubtitle">Přihlašovací údaje se bezpečně ukládají do tvého zařízení a dají se spravovat v nabídce Přihlášení v Nastavení.</string>
+    <string name="saveLoginDialogSubtitle">Přihlašovací údaje jsou bezpečně uložené v zařízení v nabídce Přihlášení.</string>
     <string name="saveLoginDialogTitle">Má DuckDuckGo uložit přihlašovací údaje?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Další možnosti</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Přihlášení naposledy aktualizováno %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Uložit a automaticky vyplnit přihlášení</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Přihlašovací údaje se bezpečně ukládají do tvého zařízení</string>
     <string name="credentialManagementViewMenuEdit">Upravit</string>
     <string name="credentialManagementViewMenuDelete">Smazat</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Uživatelské jméno zkopírováno</string>
     <string name="autofillManagementPasswordCopied">Heslo zkopírováno</string>
 
-    <string name="autofill_password_generation_offer_title">Použít heslo vygenerované DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Heslo se uloží do části Přihlášení.</string>
-    <string name="autofill_password_generation_offer_accept">Použít vygenerované heslo</string>
+    <string name="autofill_password_generation_offer_title">Použít silné heslo od DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Hesla jsou bezpečně uložená v zařízení v nabídce Přihlášení.</string>
+    <string name="autofill_password_generation_offer_accept">Použít silné heslo</string>
     <string name="autofill_password_generation_offer_decline">Vytvořit vlastní</string>
 
     <string name="deviceNotSupportedTitle">Zařízení není podporované</string>

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Navrhované</string>
     <string name="credentialManagementNoLoginsSavedTitle">Zatím nemáš uložené žádné přihlašovací údaje</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Přihlašovací údaje se bezpečně ukládají do tvého zařízení.</string>
 
     <string name="autofillManagementAddLogin">Přidat přihlášení</string>
     <string name="autofillManagementSearchLogins">Hledání přihlašovacích údajů</string>

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Foreslået</string>
     <string name="credentialManagementNoLoginsSavedTitle">Ingen logins gemt endnu</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Login gemmes sikkert på din enhed.</string>
 
     <string name="autofillManagementAddLogin">Tilføj login</string>
     <string name="autofillManagementSearchLogins">Søg logins</string>

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Gem login</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Gem adgangskode</string>
     <string name="saveLoginDialogNotNow">Gem ikke</string>
-    <string name="saveLoginDialogSubtitle">Logins gemmes sikkert på din enhed og kan administreres fra menuen Logins i Indstillinger.</string>
+    <string name="saveLoginDialogSubtitle">Logins gemmes sikkert på din enhed i menuen Logins.</string>
     <string name="saveLoginDialogTitle">Skal DuckDuckGo gemme dit login?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Flere muligheder</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Login sidst opdateret %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Gem og udfyld automatisk logins</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Login gemmes sikkert på din enhed</string>
     <string name="credentialManagementViewMenuEdit">Rediger</string>
     <string name="credentialManagementViewMenuDelete">Slet</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Brugernavn kopieret</string>
     <string name="autofillManagementPasswordCopied">Adgangskode kopieret</string>
 
-    <string name="autofill_password_generation_offer_title">Brug genereret adgangskode fra DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Adgangskoden vil blive gemt i logins.</string>
-    <string name="autofill_password_generation_offer_accept">Brug genereret adgangskode</string>
+    <string name="autofill_password_generation_offer_title">Brug en stærk adgangskode fra DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Adgangskoder gemmes sikkert på din enhed i menuen Logins.</string>
+    <string name="autofill_password_generation_offer_accept">Brug en stærk adgangskode</string>
     <string name="autofill_password_generation_offer_decline">Opret min egen</string>
 
     <string name="deviceNotSupportedTitle">Enheden understøttes ikke</string>

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Vorgeschlagen</string>
     <string name="credentialManagementNoLoginsSavedTitle">Noch keine Anmeldedaten gespeichert</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Die Anmeldedaten werden sicher auf deinem Gerät gespeichert.</string>
 
     <string name="autofillManagementAddLogin">Anmeldedaten hinzufügen</string>
     <string name="autofillManagementSearchLogins">Anmeldedaten suchen</string>

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Anmeldedaten speichern</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Passwort speichern</string>
     <string name="saveLoginDialogNotNow">Nicht speichern</string>
-    <string name="saveLoginDialogSubtitle">Die Anmeldedaten werden auf diesem Gerät sicher gespeichert und können über das Anmeldedaten-Menü in den Einstellungen verwaltet werden.</string>
+    <string name="saveLoginDialogSubtitle">Anmeldedaten werden sicher auf deinem Gerät im Anmeldedaten-Menü gespeichert.</string>
     <string name="saveLoginDialogTitle">Möchtest du, dass DuckDuckGo deine Anmeldedaten speichert?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Weitere Optionen</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Anmeldedaten zuletzt aktualisiert: %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Anmeldedaten speichern und automatisch ausfüllen</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Die Anmeldedaten werden sicher auf deinem Gerät gespeichert</string>
     <string name="credentialManagementViewMenuEdit">Bearbeiten</string>
     <string name="credentialManagementViewMenuDelete">Löschen</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Benutzername kopiert</string>
     <string name="autofillManagementPasswordCopied">Passwort kopiert</string>
 
-    <string name="autofill_password_generation_offer_title">Generiertes Passwort von DuckDuckGo verwenden?</string>
-    <string name="autofill_password_generation_offer_message">Das Passwort wird in den Anmeldedaten gespeichert.</string>
-    <string name="autofill_password_generation_offer_accept">Generiertes Passwort verwenden</string>
+    <string name="autofill_password_generation_offer_title">Ein sicheres Passwort von DuckDuckGo verwenden?</string>
+    <string name="autofill_password_generation_offer_message">Passwörter werden sicher auf deinem Gerät im Anmeldedaten-Menü gespeichert.</string>
+    <string name="autofill_password_generation_offer_accept">Sicheres Passwort verwenden</string>
     <string name="autofill_password_generation_offer_decline">Eigenes erstellen</string>
 
     <string name="deviceNotSupportedTitle">Gerät nicht unterstützt</string>

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Αποθήκευση σύνδεσης</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Αποθήκευση κωδικού πρόσβασης</string>
     <string name="saveLoginDialogNotNow">Να μην αποθηκευτεί</string>
-    <string name="saveLoginDialogSubtitle">Οι συνδέσεις αποθηκεύονται με ασφάλεια στη συσκευή σας και η διαχείρισή τους γίνεται από το μενού Συνδέσεις, στις Ρυθμίσεις.</string>
+    <string name="saveLoginDialogSubtitle">Οι συνδέσεις αποθηκεύονται με ασφάλεια στη συσκευή σας στο μενού Συνδέσεις.</string>
     <string name="saveLoginDialogTitle">Θέλετε να αποθηκεύσει το DuckDuckGo τη σύνδεσή σας;</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Περισσότερες επιλογές</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Τελευταία ενημέρωση σύνδεσης %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Αποθήκευση και αυτόματη συμπλήρωση στοιχείων σύνδεσης</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Τα στοιχεία σύνδεσης αποθηκεύονται με ασφάλεια στη συσκευή σας</string>
     <string name="credentialManagementViewMenuEdit">Επεξεργασία</string>
     <string name="credentialManagementViewMenuDelete">Διαγραφή</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Το όνομα χρήστη αντιγράφηκε</string>
     <string name="autofillManagementPasswordCopied">Ο κωδικός πρόσβασης αντιγράφηκε</string>
 
-    <string name="autofill_password_generation_offer_title">Χρήση κωδικού πρόσβασης που δημιουργήθηκε από το DuckDuckGo;</string>
-    <string name="autofill_password_generation_offer_message">Ο κωδικός πρόσβασης θα αποθηκευτεί στις Συνδέσεις.</string>
-    <string name="autofill_password_generation_offer_accept">Χρήση του κωδικού πρόσβασης που δημιουργήθηκε</string>
+    <string name="autofill_password_generation_offer_title">Χρησιμοποιείτε ισχυρό κωδικό πρόσβασης από το DuckDuckGo;</string>
+    <string name="autofill_password_generation_offer_message">Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας στο μενού Συνδέσεις.</string>
+    <string name="autofill_password_generation_offer_accept">Χρησιμοποιήστε ισχυρό κωδικό πρόσβασης</string>
     <string name="autofill_password_generation_offer_decline">Δημιουργία δικού μου</string>
 
     <string name="deviceNotSupportedTitle">Η συσκευή δεν υποστηρίζεται</string>

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Προτεινόμενο</string>
     <string name="credentialManagementNoLoginsSavedTitle">Δεν έχουν αποθηκευτεί ακόμα στοιχεία σύνδεσης</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Τα στοιχεία σύνδεσης αποθηκεύονται με ασφάλεια στη συσκευή σας.</string>
 
     <string name="autofillManagementAddLogin">Προσθήκη στοιχείων σύνδεσης</string>
     <string name="autofillManagementSearchLogins">Αναζήτηση στοιχείων σύνδεσης</string>

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Guardar inicio de sesión</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Guardar contraseña</string>
     <string name="saveLoginDialogNotNow">No guardar</string>
-    <string name="saveLoginDialogSubtitle">Los inicios de sesión se almacenan de forma segura en tu dispositivo y se pueden administrar desde el menú de Inicios de Sesión en Ajustes.</string>
+    <string name="saveLoginDialogSubtitle">Los inicios de sesión se almacenan de forma segura en tu dispositivo en el menú Inicios de sesión.</string>
     <string name="saveLoginDialogTitle">¿Quieres que DuckDuckGo guarde tu inicio de sesión?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Más opciones</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Última actualización de inicio de sesión %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Guardar y autocompletar inicios de sesión</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Los inicios de sesión se almacenan de forma segura en tu dispositivo</string>
     <string name="credentialManagementViewMenuEdit">Editar</string>
     <string name="credentialManagementViewMenuDelete">Eliminar</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Nombre de usuario copiado</string>
     <string name="autofillManagementPasswordCopied">Contraseña copiada</string>
 
-    <string name="autofill_password_generation_offer_title">¿Usar contraseña generada por DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">La contraseña se guardará en Inicios de sesión.</string>
-    <string name="autofill_password_generation_offer_accept">Usar contraseña generada</string>
+    <string name="autofill_password_generation_offer_title">¿Usar una contraseña segura de DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Las contraseñas se almacenan de forma segura en tu dispositivo en el menú Inicios de sesión.</string>
+    <string name="autofill_password_generation_offer_accept">Usar contraseña segura</string>
     <string name="autofill_password_generation_offer_decline">Crear la mía propia</string>
 
     <string name="deviceNotSupportedTitle">Dispositivo no compatible</string>

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Sugerencias</string>
     <string name="credentialManagementNoLoginsSavedTitle">Aún no hay inicios de sesión guardados</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Los inicios de sesión se almacenan de forma segura en tu dispositivo.</string>
 
     <string name="autofillManagementAddLogin">Añadir inicio de sesión</string>
     <string name="autofillManagementSearchLogins">Buscar inicios de sesión</string>

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Soovitatud</string>
     <string name="credentialManagementNoLoginsSavedTitle">Sisselogimisandmeid pole veel salvestatud</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Sisselogimisandmed salvestatakse turvaliselt sinu seadmesse.</string>
 
     <string name="autofillManagementAddLogin">Lisa sisselogimisandmed</string>
     <string name="autofillManagementSearchLogins">Otsi sisselogimisandmeid</string>

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Salvesta sisselogimisandmed</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Salvesta parool</string>
     <string name="saveLoginDialogNotNow">Ära salvesta</string>
-    <string name="saveLoginDialogSubtitle">Sisselogimisandmed salvestatakse turvaliselt selles seadmes ja neid saab hallata sätete menüüst Sisselogimisandmed.</string>
+    <string name="saveLoginDialogSubtitle">Logisid hoitakse turvaliselt sinu seadmes logide menüüs.</string>
     <string name="saveLoginDialogTitle">Kas soovid, et DuckDuckGo salvestaks sinu sisselogimisandmed?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Veel valikuid</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Sisselogimist värskendati viimati %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Salvesta ja täida sisselogimisandmed automaatselt</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Sisselogimisandmed salvestatakse turvaliselt sinu seadmesse</string>
     <string name="credentialManagementViewMenuEdit">Redigeeri</string>
     <string name="credentialManagementViewMenuDelete">Kustuta</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Kasutajanimi on kopeeritud</string>
     <string name="autofillManagementPasswordCopied">Parool on kopeeritud</string>
 
-    <string name="autofill_password_generation_offer_title">Kas kasutada DuckDuckGo loodud parooli?</string>
-    <string name="autofill_password_generation_offer_message">Parool salvestatakse sisselogimisandmetesse.</string>
-    <string name="autofill_password_generation_offer_accept">Kasuta loodud parooli</string>
+    <string name="autofill_password_generation_offer_title">Kas kasutada DuckDuckGo tugevat parooli?</string>
+    <string name="autofill_password_generation_offer_message">Paroole hoitakse turvaliselt sinu seadmes sisselogimisandmete menüüs.</string>
+    <string name="autofill_password_generation_offer_accept">Kasuta tugevat parooli</string>
     <string name="autofill_password_generation_offer_decline">Loon selle ise</string>
 
     <string name="deviceNotSupportedTitle">Seadet ei toetata</string>

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Tallenna kirjautumistiedot</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Tallenna salasana</string>
     <string name="saveLoginDialogNotNow">Älä tallenna</string>
-    <string name="saveLoginDialogSubtitle">Kirjautumistiedot tallennetaan turvallisesti laitteellesi. Niitä voi hallita asetusten kirjautumistiedot-valikosta.</string>
+    <string name="saveLoginDialogSubtitle">Kirjautumistiedot tallennetaan turvallisesti laitteellesi kirjautumistiedot-valikkoon.</string>
     <string name="saveLoginDialogTitle">Haluatko, että DuckDuckGo tallentaa kirjautumistietosi?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Lisää vaihtoehtoja</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Kirjautumistiedot päivitetty viimeksi %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Tallenna ja täytä kirjautumistiedot automaattisesti</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Kirjautumiset tallennetaan laitteellesi turvallisesti</string>
     <string name="credentialManagementViewMenuEdit">Muokkaa</string>
     <string name="credentialManagementViewMenuDelete">Poista</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Käyttäjätunnus kopioitu</string>
     <string name="autofillManagementPasswordCopied">Salasana kopioitu</string>
 
-    <string name="autofill_password_generation_offer_title">Haluatko käyttää DuckDuckGon luomaa salasanaa?</string>
-    <string name="autofill_password_generation_offer_message">Salasana tallennetaan Kirjautumiset-osioon.</string>
-    <string name="autofill_password_generation_offer_accept">Käytä luotua salasanaa</string>
+    <string name="autofill_password_generation_offer_title">Käytetäänkö DuckDuckGon vahvaa salasanaa?</string>
+    <string name="autofill_password_generation_offer_message">Salasanat tallennetaan turvallisesti laitteellesi kirjautumistiedot-valikkoon.</string>
+    <string name="autofill_password_generation_offer_accept">Käytä vahvaa salasanaa</string>
     <string name="autofill_password_generation_offer_decline">Luo oma</string>
 
     <string name="deviceNotSupportedTitle">Laitetta ei tueta</string>

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Ehdotettu</string>
     <string name="credentialManagementNoLoginsSavedTitle">Kirjautumistietoja ei ole vielä tallennettu</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Kirjautumiset tallennetaan laitteellesi turvallisesti.</string>
 
     <string name="autofillManagementAddLogin">Lisää kirjautumistiedot</string>
     <string name="autofillManagementSearchLogins">Hae kirjautumistietoja</string>

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Enregistrer l\'identifiant</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Enregistrer le mot de passe</string>
     <string name="saveLoginDialogNotNow">Ne pas enregistrer</string>
-    <string name="saveLoginDialogSubtitle">Les identifiants sont stockés en toute sécurité sur votre appareil et peuvent être gérés à partir du menu Identifiants dans Paramètres.</string>
+    <string name="saveLoginDialogSubtitle">Les identifiants de connexion sont stockés en toute sécurité sur votre appareil dans le menu Identifiants.</string>
     <string name="saveLoginDialogTitle">Voulez-vous que DuckDuckGo enregistre votre identifiant ?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Plus d\'options</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Dernière mise à jour de l\'identifiant %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Enregistrer et saisir automatiquement les identifiants</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Les identifiants de connexion sont stockés en toute sécurité sur votre appareil</string>
     <string name="credentialManagementViewMenuEdit">Modifier</string>
     <string name="credentialManagementViewMenuDelete">Supprimer</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Nom d\'utilisateur copié</string>
     <string name="autofillManagementPasswordCopied">Mot de passe copié</string>
 
-    <string name="autofill_password_generation_offer_title">Utiliser le mot de passe généré par DuckDuckGo ?</string>
-    <string name="autofill_password_generation_offer_message">Le mot de passe sera enregistré dans les identifiants.</string>
-    <string name="autofill_password_generation_offer_accept">Utiliser le mot de passe généré</string>
+    <string name="autofill_password_generation_offer_title">Utiliser un mot de passe fort généré par DuckDuckGo ?</string>
+    <string name="autofill_password_generation_offer_message">Les mots de passe sont stockés en toute sécurité sur votre appareil dans le menu Identifiants.</string>
+    <string name="autofill_password_generation_offer_accept">Utiliser un mot de passe fort</string>
     <string name="autofill_password_generation_offer_decline">Créer le mien</string>
 
     <string name="deviceNotSupportedTitle">Appareil non pris en charge</string>

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Suggéré</string>
     <string name="credentialManagementNoLoginsSavedTitle">Aucun identifiant enregistré pour l\'instant</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Les identifiants de connexion sont stockés en toute sécurité sur votre appareil.</string>
 
     <string name="autofillManagementAddLogin">Ajouter un identifiant</string>
     <string name="autofillManagementSearchLogins">Recherche d\'identifiants</string>

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Predloženo</string>
     <string name="credentialManagementNoLoginsSavedTitle">Još nema spremljenih prijava</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Prijave su sigurno pohranjene na tvom uređaju.</string>
 
     <string name="autofillManagementAddLogin">Dodaj prijavu</string>
     <string name="autofillManagementSearchLogins">Pretraživanje prijava</string>

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Spremi prijavu</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Spremi lozinku</string>
     <string name="saveLoginDialogNotNow">Nemoj spremiti</string>
-    <string name="saveLoginDialogSubtitle">Prijave se sigurno spremaju na tvom uređaju i njima se može upravljati putem izbornika Prijave u Postavkama.</string>
+    <string name="saveLoginDialogSubtitle">Prijave su sigurno pohranjene na tvom uređaju u izborniku Prijave.</string>
     <string name="saveLoginDialogTitle">Želiš li da DuckDuckGo spremi tvoju prijavu?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Dodatne mogućnosti</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Prijava zadnji put ažurirana %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Spremi i automatski popuni prijave</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Prijave su sigurno pohranjene na tvom uređaju</string>
     <string name="credentialManagementViewMenuEdit">Uredi</string>
     <string name="credentialManagementViewMenuDelete">Izbriši</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Korisničko ime je kopirano</string>
     <string name="autofillManagementPasswordCopied">Lozinka je kopirana</string>
 
-    <string name="autofill_password_generation_offer_title">Koristiti generiranu lozinku iz DuckDuckGoa?</string>
-    <string name="autofill_password_generation_offer_message">Lozinka će biti spremljena u Prijavama.</string>
-    <string name="autofill_password_generation_offer_accept">Koristi generiranu lozinku</string>
+    <string name="autofill_password_generation_offer_title">Koristiti jaku lozinku od DuckDuckGoa?</string>
+    <string name="autofill_password_generation_offer_message">Lozinke su sigurno pohranjene na tvom uređaju u izborniku Prijava.</string>
+    <string name="autofill_password_generation_offer_accept">Koristi jaku lozinku</string>
     <string name="autofill_password_generation_offer_decline">Izradi vlastitu</string>
 
     <string name="deviceNotSupportedTitle">Uređaj nije podržan</string>

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Bejelentkezés mentése</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Jelszó mentése</string>
     <string name="saveLoginDialogNotNow">Mentés mellőzése</string>
-    <string name="saveLoginDialogSubtitle">A bejelentkezési adatokat az eszközöd biztonságosan tárolja, ezen adatok pedig a Beállítások &gt; Bejelentkezések menüpontban kezelhetők.</string>
+    <string name="saveLoginDialogSubtitle">A rendszer biztonságosan tárolja az eszköz Bejelentkezés menüjében elérhető bejelentkezési adatokat.</string>
     <string name="saveLoginDialogTitle">A DuckDuckGo mentse a bejelentkezést?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">További lehetőségek</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Bejelentkezés utolsó frissítése: %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Bejelentkezések mentése és automatikus kitöltése</string>
+    <string name="credentialManagementAutofillToggleSubtitle">A bejelentkezési adatokat az eszközöd biztonságosan tárolja</string>
     <string name="credentialManagementViewMenuEdit">Szerkesztés</string>
     <string name="credentialManagementViewMenuDelete">Törlés</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Felhasználónév másolva</string>
     <string name="autofillManagementPasswordCopied">Jelszó másolva</string>
 
-    <string name="autofill_password_generation_offer_title">DuckDuckGo által generált jelszó használata?</string>
-    <string name="autofill_password_generation_offer_message">A jelszó mentve lesz a Bejelentkezésekben.</string>
-    <string name="autofill_password_generation_offer_accept">Generált jelszó használata</string>
+    <string name="autofill_password_generation_offer_title">A DuckDuckGo által kínált erős jelszót kívánsz használni?</string>
+    <string name="autofill_password_generation_offer_message">A rendszer biztonságosan tárolja az eszköz Bejelentkezés menüjében elérhető jelszavakat.</string>
+    <string name="autofill_password_generation_offer_accept">Erős jelszó használata</string>
     <string name="autofill_password_generation_offer_decline">Saját létrehozása</string>
 
     <string name="deviceNotSupportedTitle">Az eszköz nem támogatott</string>

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Javasolt</string>
     <string name="credentialManagementNoLoginsSavedTitle">Még nincsenek mentett bejelentkezési adatok</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">A bejelentkezési adatokat az eszközöd biztonságosan tárolja.</string>
 
     <string name="autofillManagementAddLogin">Bejelentkezési adatok hozzáadása</string>
     <string name="autofillManagementSearchLogins">Bejelentkezési adatok keresése</string>

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Salva dati di accesso</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Salva password</string>
     <string name="saveLoginDialogNotNow">Non salvare</string>
-    <string name="saveLoginDialogSubtitle">I dati di accesso sono archiviati in modo sicuro sul tuo dispositivo e possono essere gestiti dal menu Accessi, in Impostazioni.</string>
+    <string name="saveLoginDialogSubtitle">Gli accessi sono archiviati in modo sicuro sul tuo dispositivo nel menu Accessi.</string>
     <string name="saveLoginDialogTitle">Vuoi che DuckDuckGo salvi i dati di accesso?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Altre opzioni</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Ultimo aggiornamento dei dati di accesso %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Salva e compila automaticamente i dati di accesso</string>
+    <string name="credentialManagementAutofillToggleSubtitle">I dati di accesso sono archiviati in modo sicuro sul tuo dispositivo</string>
     <string name="credentialManagementViewMenuEdit">Modifica</string>
     <string name="credentialManagementViewMenuDelete">Cancella</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Nome utente copiato</string>
     <string name="autofillManagementPasswordCopied">Password copiata</string>
 
-    <string name="autofill_password_generation_offer_title">Usare la password generata da DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">La password verrà salvata in Accessi.</string>
-    <string name="autofill_password_generation_offer_accept">Usa password generata</string>
+    <string name="autofill_password_generation_offer_title">Usare una password complessa da DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Le password sono archiviate in modo sicuro sul tuo dispositivo nel menu Accessi.</string>
+    <string name="autofill_password_generation_offer_accept">Usa una password complessa</string>
     <string name="autofill_password_generation_offer_decline">Crea la mia</string>
 
     <string name="deviceNotSupportedTitle">Dispositivo non supportato</string>

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Suggerimenti</string>
     <string name="credentialManagementNoLoginsSavedTitle">Non ci sono ancora dati di accesso salvati</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">I dati di accesso sono archiviati in modo sicuro sul tuo dispositivo.</string>
 
     <string name="autofillManagementAddLogin">Aggiungi dati di accesso</string>
     <string name="autofillManagementSearchLogins">Cerca dati di accesso</string>

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Siūloma</string>
     <string name="credentialManagementNoLoginsSavedTitle">Dar nėra išsaugotų prisijungimų</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Prisijungimai saugiai laikomi jūsų įrenginyje.</string>
 
     <string name="autofillManagementAddLogin">Pridėti prisijungimą</string>
     <string name="autofillManagementSearchLogins">Ieškoti prisijungimų</string>

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Išsaugoti prisijungimą</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Išsaugoti slaptažodį</string>
     <string name="saveLoginDialogNotNow">Neišsaugokite</string>
-    <string name="saveLoginDialogSubtitle">Prisijungimai saugiai laikomi tik šiame įrenginyje, o juos galima tvarkyti nustatymuose, prisijungimų meniu.</string>
+    <string name="saveLoginDialogSubtitle">Prisijungimai saugiai saugomi jūsų įrenginio meniu „Prisijungimai“.</string>
     <string name="saveLoginDialogTitle">Ar norite, kad „DuckDuckGo“ išsaugotų jūsų prisijungimą?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Daugiau parinkčių</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Prisijungimas paskutinį kartą atnaujintas %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Išsaugoti ir automatiškai pildyti prisijungimus</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Prisijungimai saugiai laikomi jūsų įrenginyje</string>
     <string name="credentialManagementViewMenuEdit">Redaguoti</string>
     <string name="credentialManagementViewMenuDelete">Trinti</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Naudotojo vardas nukopijuotas</string>
     <string name="autofillManagementPasswordCopied">Slaptažodis nukopijuotas</string>
 
-    <string name="autofill_password_generation_offer_title">Naudoti sugeneruotą slaptažodį iš „DuckDuckGo“?</string>
-    <string name="autofill_password_generation_offer_message">Slaptažodis bus išsaugotas prisijungimų lange.</string>
-    <string name="autofill_password_generation_offer_accept">Naudoti sugeneruotą slaptažodį</string>
+    <string name="autofill_password_generation_offer_title">Naudoti stiprų „DuckDuckGo“ slaptažodį?</string>
+    <string name="autofill_password_generation_offer_message">Slaptažodžiai saugiai saugomi jūsų įrenginio meniu „Prisijungimai“.</string>
+    <string name="autofill_password_generation_offer_accept">Naudoti stiprų slaptažodį</string>
     <string name="autofill_password_generation_offer_decline">Sukurti savo</string>
 
     <string name="deviceNotSupportedTitle">Nepalaikomas įrenginys</string>

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Ieteikts</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nav saglabātu pieteikšanās datu</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Pieteikšanās dati tiek droši saglabāti tavā ierīcē.</string>
 
     <string name="autofillManagementAddLogin">Pievienot pieteikšanās datus</string>
     <string name="autofillManagementSearchLogins">Meklēt pieteikšanās datus</string>

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Saglabāt pieteikšanās datus</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Saglabāt paroli</string>
     <string name="saveLoginDialogNotNow">Nesaglabāt</string>
-    <string name="saveLoginDialogSubtitle">Pieteikšanās dati tiek droši saglabāti tavā ierīcē, un tos var pārvaldīt no iestatījumu izvēlnes Pieteikšanās dati.</string>
+    <string name="saveLoginDialogSubtitle">Pieteikšanās dati tiek droši saglabāti tavā ierīcē, izvēlnē Pieteikšanās dati.</string>
     <string name="saveLoginDialogTitle">Vai vēlies, lai DuckDuckGo saglabātu tavus pieteikšanās datus?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Citas iespējas</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Pieteikšanās dati pēdējo reizi atjaunināti %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Saglabāt un automātiski aizpildīt pieteikšanās datus</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Pieteikšanās dati tiek droši saglabāti tavā ierīcē</string>
     <string name="credentialManagementViewMenuEdit">Rediģēt</string>
     <string name="credentialManagementViewMenuDelete">Dzēst</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Lietotājvārds nokopēts</string>
     <string name="autofillManagementPasswordCopied">Parole nokopēta</string>
 
-    <string name="autofill_password_generation_offer_title">Vai izmantot DuckDuckGo ģenerētu paroli?</string>
-    <string name="autofill_password_generation_offer_message">Parole tiks saglabāta Pieteikšanās datos.</string>
-    <string name="autofill_password_generation_offer_accept">Izmantot ģenerētu paroli</string>
+    <string name="autofill_password_generation_offer_title">Vai izmantot spēcīgu DuckDuckGo paroli?</string>
+    <string name="autofill_password_generation_offer_message">Paroles tiek droši saglabātas tavā ierīcē, izvēlnē Pieteikšanās dati.</string>
+    <string name="autofill_password_generation_offer_accept">Izmantot spēcīgu paroli</string>
     <string name="autofill_password_generation_offer_decline">Izveidot savu</string>
 
     <string name="deviceNotSupportedTitle">Ierīce netiek atbalstīta</string>

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Forslag</string>
     <string name="credentialManagementNoLoginsSavedTitle">Ingen pålogginger er lagret ennå</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Pålogginger lagres på enheten din på en sikker måte.</string>
 
     <string name="autofillManagementAddLogin">Legg til pålogging</string>
     <string name="autofillManagementSearchLogins">Søk i pålogginger</string>

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Lagre påloggingen</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Lagre passordet</string>
     <string name="saveLoginDialogNotNow">Ikke lagre</string>
-    <string name="saveLoginDialogSubtitle">Pålogginger lagres trygt på enheten din og kan administreres i påloggingsmenyen i innstillinger.</string>
+    <string name="saveLoginDialogSubtitle">Pålogginger lagres trygt på enheten din i påloggingsmenyen.</string>
     <string name="saveLoginDialogTitle">Vil du at DuckDuckGo skal lagre påloggingen din?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Flere alternativer</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Pålogging sist oppdatert %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Lagre og fyll inn pålogginger automatisk</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Pålogginger lagres på enheten din på en sikker måte</string>
     <string name="credentialManagementViewMenuEdit">Rediger</string>
     <string name="credentialManagementViewMenuDelete">Slett</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Brukernavnet er kopiert</string>
     <string name="autofillManagementPasswordCopied">Passordet er kopiert</string>
 
-    <string name="autofill_password_generation_offer_title">Vil du bruke et generert passord fra DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Passord blir lagret i pålogginger.</string>
-    <string name="autofill_password_generation_offer_accept">Bruk generert passord</string>
+    <string name="autofill_password_generation_offer_title">Vil du bruke et sterkt passord fra DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Passord lagres trygt på enheten din i påloggingsmenyen.</string>
+    <string name="autofill_password_generation_offer_accept">Bruk sterkt passord</string>
     <string name="autofill_password_generation_offer_decline">Opprett eget passord</string>
 
     <string name="deviceNotSupportedTitle">Enheten støttes ikke</string>

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Login opslaan</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Wachtwoord opslaan</string>
     <string name="saveLoginDialogNotNow">Niet opslaan</string>
-    <string name="saveLoginDialogSubtitle">Aanmeldgegevens worden veilig opgeslagen op je apparaat en kunnen worden beheerd via het menu Aanmeldgegevens in Instellingen.</string>
+    <string name="saveLoginDialogSubtitle">Aanmeldgegevens worden veilig opgeslagen op je apparaat in het menu </string>
     <string name="saveLoginDialogTitle">Wil je dat DuckDuckGo je login opslaat?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Meer opties</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Aanmeldgegevens laatste bijgewerkt op %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Aanmeldgegevens opslaan en automatisch invullen</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Aanmeldgegevens worden veilig opgeslagen op je apparaat</string>
     <string name="credentialManagementViewMenuEdit">Bewerken</string>
     <string name="credentialManagementViewMenuDelete">Verwijderen</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Gebruikersnaam gekopieerd</string>
     <string name="autofillManagementPasswordCopied">Wachtwoord gekopieerd</string>
 
-    <string name="autofill_password_generation_offer_title">Gegenereerd wachtwoord van DuckDuckGo gebruiken?</string>
-    <string name="autofill_password_generation_offer_message">Wachtwoord wordt opgeslagen in aanmeldgegevens.</string>
-    <string name="autofill_password_generation_offer_accept">Gegenereerd wachtwoord gebruiken</string>
+    <string name="autofill_password_generation_offer_title">Een sterk wachtwoord van DuckDuckGo gebruiken?</string>
+    <string name="autofill_password_generation_offer_message">Wachtwoorden worden veilig opgeslagen op je apparaat in het menu \'Aanmeldingen\'.</string>
+    <string name="autofill_password_generation_offer_accept">Sterk wachtwoord gebruiken</string>
     <string name="autofill_password_generation_offer_decline">Zelf wachtwoord aanmaken</string>
 
     <string name="deviceNotSupportedTitle">Apparaat wordt niet ondersteund</string>

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Login opslaan</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Wachtwoord opslaan</string>
     <string name="saveLoginDialogNotNow">Niet opslaan</string>
-    <string name="saveLoginDialogSubtitle">Aanmeldgegevens worden veilig opgeslagen op je apparaat in het menu </string>
+    <string name="saveLoginDialogSubtitle">Aanmeldgegevens worden veilig opgeslagen op je apparaat in het menu \'Aanmeldingen\'.</string>
     <string name="saveLoginDialogTitle">Wil je dat DuckDuckGo je login opslaat?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Meer opties</string>
 

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Aanbevolen</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nog geen aanmeldgegevens opgeslagen</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Aanmeldgegevens worden veilig opgeslagen op je apparaat.</string>
 
     <string name="autofillManagementAddLogin">Aanmeldgegevens toevoegen</string>
     <string name="autofillManagementSearchLogins">Aanmeldgegevens zoeken</string>

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Zapisz logowanie</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Zapisz hasło</string>
     <string name="saveLoginDialogNotNow">Nie zapisuj</string>
-    <string name="saveLoginDialogSubtitle">Dane logowania są bezpiecznie przechowywane na Twoim urządzeniu i można nimi zarządzać w sekcji Loginy menu Ustawienia.</string>
+    <string name="saveLoginDialogSubtitle">Loginy są bezpiecznie przechowywane na Twoim urządzeniu w menu Loginy.</string>
     <string name="saveLoginDialogTitle">Czy chcesz zapisać dane logowania w DuckDuckGo?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Więcej opcji</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Ostatnia aktualizacja loginu: %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Zapisz i autouzupełniaj loginy</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Dane logowania są bezpiecznie przechowywane na Twoim urządzeniu</string>
     <string name="credentialManagementViewMenuEdit">Edytuj</string>
     <string name="credentialManagementViewMenuDelete">Usuń</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Skopiowano nazwę użytkownika</string>
     <string name="autofillManagementPasswordCopied">Skopiowano hasło</string>
 
-    <string name="autofill_password_generation_offer_title">Użyć hasła wygenerowanego z DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Hasło zostanie zapisane w Danych logowania.</string>
-    <string name="autofill_password_generation_offer_accept">Użyj wygenerowanego hasła</string>
+    <string name="autofill_password_generation_offer_title">Użyć silnego hasła z DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Hasła są bezpiecznie przechowywane na Twoim urządzeniu w menu Loginy.</string>
+    <string name="autofill_password_generation_offer_accept">Użyj silnego hasła</string>
     <string name="autofill_password_generation_offer_decline">Utwórz własne</string>
 
     <string name="deviceNotSupportedTitle">Urządzenie nie jest obsługiwane</string>

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Sugerowane</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nie zapisano jeszcze żadnych loginów</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Dane logowania są bezpiecznie przechowywane na Twoim urządzeniu.</string>
 
     <string name="autofillManagementAddLogin">Dodaj login</string>
     <string name="autofillManagementSearchLogins">Wyszukiwanie loginów</string>

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Sugerido</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nenhum início de sessão guardado</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Os inícios de sessão são armazenados com segurança no teu dispositivo.</string>
 
     <string name="autofillManagementAddLogin">Adicionar início de sessão</string>
     <string name="autofillManagementSearchLogins">Pesquisar inícios de sessão</string>

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Guardar início de sessão</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Guardar palavra-passe</string>
     <string name="saveLoginDialogNotNow">Não guardar</string>
-    <string name="saveLoginDialogSubtitle">Os inícios de sessão são armazenados com segurança no teu dispositivo, e podes efetuar a gestão dos mesmos a partir do menu Inícios de sessão nas Definições.</string>
+    <string name="saveLoginDialogSubtitle">Os dados de início de sessão são armazenados de forma segura no teu dispositivo no menu Inícios de sessão.</string>
     <string name="saveLoginDialogTitle">Queres que o DuckDuckGo guarde o teu início de sessão?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Mais opções</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Dados de início de sessão atualizados pela última vez em %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Guardar e preencher dados de início de sessão automaticamente</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Os inícios de sessão são armazenados com segurança no teu dispositivo</string>
     <string name="credentialManagementViewMenuEdit">Editar</string>
     <string name="credentialManagementViewMenuDelete">Eliminar</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Nome de utilizador copiado</string>
     <string name="autofillManagementPasswordCopied">Palavra-passe copiada</string>
 
-    <string name="autofill_password_generation_offer_title">Utilizar palavra-passe gerada pelo DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">A palavra-passe será guardada em Início de sessão.</string>
-    <string name="autofill_password_generation_offer_accept">Utilizar palavra-passe gerada</string>
+    <string name="autofill_password_generation_offer_title">Utilizar uma palavra-passe forte do DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">As palavras-passe são armazenadas de forma segura no teu dispositivo no menu Inícios de sessão.</string>
+    <string name="autofill_password_generation_offer_accept">Utilizar palavra-passe forte</string>
     <string name="autofill_password_generation_offer_decline">Criar a minha própria palavra-passe</string>
 
     <string name="deviceNotSupportedTitle">Dispositivo não suportado</string>

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Salvează autentificarea</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Salvează parola</string>
     <string name="saveLoginDialogNotNow">Nu salva</string>
-    <string name="saveLoginDialogSubtitle">Datele de conectare sunt stocate în siguranță pe dispozitivul tău și pot fi gestionate din Setări, meniul Date de conectare.</string>
+    <string name="saveLoginDialogSubtitle">Conexiunile sunt stocate în siguranță pe dispozitivul dvs. în meniul Conectări.</string>
     <string name="saveLoginDialogTitle">Vrei ca DuckDuckGo să îți salveze datele de conectare?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Mai multe opțiuni</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Ultima actualizare a datelor de autentificare %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Salvează și completează automat datele de autentificare</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Datele de conectare sunt stocate în siguranță pe dispozitivul tău</string>
     <string name="credentialManagementViewMenuEdit">Editează</string>
     <string name="credentialManagementViewMenuDelete">Ștergere</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Numele de utilizator a fost copiat</string>
     <string name="autofillManagementPasswordCopied">Parolă copiată</string>
 
-    <string name="autofill_password_generation_offer_title">Vrei să folosești parola generată de DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Parola va fi salvată în Datele de conectare.</string>
-    <string name="autofill_password_generation_offer_accept">Folosește parola generată</string>
+    <string name="autofill_password_generation_offer_title">Folosiți o parolă puternică de la DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Parolele sunt stocate în siguranță pe dispozitivul dvs. în meniul Autentificări.</string>
+    <string name="autofill_password_generation_offer_accept">Utilizați o parolă puternică</string>
     <string name="autofill_password_generation_offer_decline">Îmi creez propria parolă</string>
 
     <string name="deviceNotSupportedTitle">Dispozitivul nu este acceptat</string>

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Sugerat</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nu au fost salvate încă date de autentificare</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Datele de conectare sunt stocate în siguranță pe dispozitivul tău.</string>
 
     <string name="autofillManagementAddLogin">Adaugă date de autentificare</string>
     <string name="autofillManagementSearchLogins">Date de autentificare pentru căutare</string>

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Рекомендации</string>
     <string name="credentialManagementNoLoginsSavedTitle">Сохраненных логинов пока нет</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Учетные данные сохранены и защищены на вашем устройстве.</string>
 
     <string name="autofillManagementAddLogin">Добавить логин</string>
     <string name="autofillManagementSearchLogins">Поиск логинов</string>

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Сохранить логин</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Сохранить пароль</string>
     <string name="saveLoginDialogNotNow">Не сохранять</string>
-    <string name="saveLoginDialogSubtitle">Учетные данные надежно хранятся на вашем устройстве, а проконтролировать их можно в меню «Логины» в «Настройках».</string>
+    <string name="saveLoginDialogSubtitle">Учетные данные надежно хранятся на вашем устройстве в меню «Логины».</string>
     <string name="saveLoginDialogTitle">Хотите, чтобы DuckDuckGo сохранил логин?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Другие параметры</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Последнее обновление логина: %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Сохранить и заполнять автоматически</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Учетные данные надежно хранятся на вашем устройстве</string>
     <string name="credentialManagementViewMenuEdit">Редактировать</string>
     <string name="credentialManagementViewMenuDelete">Удалить</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Имя пользователя скопировано</string>
     <string name="autofillManagementPasswordCopied">Пароль скопирован</string>
 
-    <string name="autofill_password_generation_offer_title">Использовать пароль, сгенерированный DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Пароль будет сохранен в разделе «Логины».</string>
-    <string name="autofill_password_generation_offer_accept">Использовать предложенный</string>
+    <string name="autofill_password_generation_offer_title">Как насчет надежного пароля от DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Пароли надежно хранятся на вашем устройстве в меню «Логины».</string>
+    <string name="autofill_password_generation_offer_accept">Применить надежный пароль</string>
     <string name="autofill_password_generation_offer_decline">Создать собственный</string>
 
     <string name="deviceNotSupportedTitle">Устройство не поддерживается</string>

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Navrhované</string>
     <string name="credentialManagementNoLoginsSavedTitle">Zatiaľ nie sú uložené žiadne prihlásenia</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Prihlasovacie údaje sú zabezpečeným spôsobom uložené vo vašom zariadení.</string>
 
     <string name="autofillManagementAddLogin">Pridať prihlásenie</string>
     <string name="autofillManagementSearchLogins">Vyhľadávanie prihlásení</string>

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Uložiť prihlasovacie údaje</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Uložiť heslo</string>
     <string name="saveLoginDialogNotNow">Neukladať</string>
-    <string name="saveLoginDialogSubtitle">Prihlasovacie údaje sú zabezpečene uložené len v tomto zariadení a môžete ich spravovať v ponuke Prihlasovacie údaje v Nastaveniach.</string>
+    <string name="saveLoginDialogSubtitle">Prihlasovacie údaje sú bezpečne uložené v zariadení v ponuke Prihlásenia.</string>
     <string name="saveLoginDialogTitle">Chcete, aby DuckDuckGo uložil vaše prihlasovacie údaje?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Ďalšie možnosti</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Naposledy aktualizované prihlásenie %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Uložiť a automaticky vyplniť prihlásenia</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Prihlasovacie údaje sú zabezpečeným spôsobom uložené vo vašom zariadení.</string>
     <string name="credentialManagementViewMenuEdit">Upraviť</string>
     <string name="credentialManagementViewMenuDelete">Vymazať</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Meno používateľa bolo skopírované</string>
     <string name="autofillManagementPasswordCopied">Heslo bolo skopírované</string>
 
-    <string name="autofill_password_generation_offer_title">Použiť vygenerované heslo z DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Heslo sa uloží do prihlasovacích údajov.</string>
-    <string name="autofill_password_generation_offer_accept">Použiť vygenerované heslo</string>
+    <string name="autofill_password_generation_offer_title">Používate silné heslo od DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Heslá sú bezpečne uložené na vašom zariadení v ponuke Prihlásenia.</string>
+    <string name="autofill_password_generation_offer_accept">Používanie silného hesla</string>
     <string name="autofill_password_generation_offer_decline">Vytvoriť vlastné</string>
 
     <string name="deviceNotSupportedTitle">Nepodporované zariadenie</string>

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Shrani prijavo</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Shrani geslo</string>
     <string name="saveLoginDialogNotNow">Ne shrani</string>
-    <string name="saveLoginDialogSubtitle">Prijave so varno shranjene v tej napravi in jih lahko upravljate v razdelku Prijave v nastavitvah.</string>
+    <string name="saveLoginDialogSubtitle">Prijave so varno shranjene v vaši napravi v meniju Prijave.</string>
     <string name="saveLoginDialogTitle">Ali želite, da DuckDuckGo shrani vašo prijavo?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Več možnosti</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Prijavni podatki nazadnje posodobljeni %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Shrani in samodejno izpolni prijavne podatke</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Prijave so varno shranjene v vaši napravi.</string>
     <string name="credentialManagementViewMenuEdit">Uredi</string>
     <string name="credentialManagementViewMenuDelete">Izbriši</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Uporabniško ime je bilo kopirano</string>
     <string name="autofillManagementPasswordCopied">Geslo je bilo kopirano</string>
 
-    <string name="autofill_password_generation_offer_title">Želite uporabiti geslo, ki ga je ustvaril DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Geslo bo shranjeno v razdelku Prijave.</string>
-    <string name="autofill_password_generation_offer_accept">Uporabi ustvarjeno geslo</string>
+    <string name="autofill_password_generation_offer_title">Želite uporabiti močno geslo od DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Gesla so varno shranjena v napravi v meniju Prijave.</string>
+    <string name="autofill_password_generation_offer_accept">Uporabi močno geslo</string>
     <string name="autofill_password_generation_offer_decline">Ustvari svoje</string>
 
     <string name="deviceNotSupportedTitle">Naprava ni podprta</string>

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Predlagano</string>
     <string name="credentialManagementNoLoginsSavedTitle">Podatki za prijavo še niso shranjeni</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Prijave so varno shranjene v vaši napravi.</string>
 
     <string name="autofillManagementAddLogin">Dodajanje podatkov za prijavo</string>
     <string name="autofillManagementSearchLogins">Iskanje podatkov za prijavo</string>

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Spara inloggning</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Spara lösenord</string>
     <string name="saveLoginDialogNotNow">Spara inte</string>
-    <string name="saveLoginDialogSubtitle">Inloggningar lagras säkert på din enhet, och kan hanteras genom menyn Inloggningar i inställningarna.</string>
+    <string name="saveLoginDialogSubtitle">Inloggningar lagras säkert på din enhet i menyn Inloggningar.</string>
     <string name="saveLoginDialogTitle">Vill du att DuckDuckGo ska spara din inloggning?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Fler alternativ</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Inloggningen uppdaterades senast %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Spara och fyll i inloggningar automatiskt</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Inloggningar lagras säkert på din enhet</string>
     <string name="credentialManagementViewMenuEdit">Redigera</string>
     <string name="credentialManagementViewMenuDelete">Ta bort</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Användarnamn kopierat</string>
     <string name="autofillManagementPasswordCopied">Lösenord kopierat</string>
 
-    <string name="autofill_password_generation_offer_title">Använd genererat lösenord från DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Lösenordet sparas i Inloggningar.</string>
-    <string name="autofill_password_generation_offer_accept">Använd genererat lösenord</string>
+    <string name="autofill_password_generation_offer_title">Använd ett starkt lösenord från DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Lösenord lagras säkert på din enhet i menyn Inloggningar.</string>
+    <string name="autofill_password_generation_offer_accept">Använd starkt lösenord</string>
     <string name="autofill_password_generation_offer_decline">Skapa mitt eget</string>
 
     <string name="deviceNotSupportedTitle">Enheten stöds inte</string>

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Förslag</string>
     <string name="credentialManagementNoLoginsSavedTitle">Inga inloggningar sparade ännu</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Inloggningar lagras säkert på din enhet.</string>
 
     <string name="autofillManagementAddLogin">Lägg till inloggning</string>
     <string name="autofillManagementSearchLogins">Sök inloggningar</string>

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -65,7 +65,6 @@
 
     <string name="credentialManagementSuggestionsLabel">Önerilen</string>
     <string name="credentialManagementNoLoginsSavedTitle">Henüz kaydedilmiş Giriş yok</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Giriş bilgileri cihazınızda güvenli bir şekilde saklanır.</string>
 
     <string name="autofillManagementAddLogin">Giriş Ekle</string>
     <string name="autofillManagementSearchLogins">Giriş ara</string>

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Girişi Kaydet</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Şifre Kaydet</string>
     <string name="saveLoginDialogNotNow">Kaydetme</string>
-    <string name="saveLoginDialogSubtitle">Giriş bilgileri cihazınızdaki Giriş Bilgileri menüsünde güvenli bir şekilde saklanır.\'daki Giriş Bilgileri menüsünden yönetilebilir.</string>
+    <string name="saveLoginDialogSubtitle">Giriş bilgileri cihazınızdaki Giriş Bilgileri menüsünde güvenli bir şekilde saklanır.</string>
     <string name="saveLoginDialogTitle">DuckDuckGo\'nun Girişinizi kaydetmesini istiyor musunuz?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Diğer Seçenekler</string>
 

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Girişi Kaydet</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Şifre Kaydet</string>
     <string name="saveLoginDialogNotNow">Kaydetme</string>
-    <string name="saveLoginDialogSubtitle">Giriş bilgileri yalnızca bu cihazda güvenli bir şekilde saklanır ve Ayarlar\'daki Giriş Bilgileri menüsünden yönetilebilir.</string>
+    <string name="saveLoginDialogSubtitle">Giriş bilgileri cihazınızdaki Giriş Bilgileri menüsünde güvenli bir şekilde saklanır.\'daki Giriş Bilgileri menüsünden yönetilebilir.</string>
     <string name="saveLoginDialogTitle">DuckDuckGo\'nun Girişinizi kaydetmesini istiyor musunuz?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Diğer Seçenekler</string>
 
@@ -60,6 +60,7 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Son giriş güncelleme: %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Girişleri Kaydet ve Otomatik Doldur</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Giriş bilgileri cihazınızda güvenli bir şekilde saklanır</string>
     <string name="credentialManagementViewMenuEdit">Düzenle</string>
     <string name="credentialManagementViewMenuDelete">Sil</string>
 
@@ -78,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Kullanıcı adı kopyalandı</string>
     <string name="autofillManagementPasswordCopied">Şifre kopyalandı</string>
 
-    <string name="autofill_password_generation_offer_title">DuckDuckGo\'dan oluşturulan şifre kullanılsın mı?</string>
-    <string name="autofill_password_generation_offer_message">Şifre, Girişlere kaydedilecektir.</string>
-    <string name="autofill_password_generation_offer_accept">Oluşturulan Şifreyi Kullan</string>
+    <string name="autofill_password_generation_offer_title">DuckDuckGo\'nun oluşturduğu güçlü bir şifre kullanmak ister misiniz?</string>
+    <string name="autofill_password_generation_offer_message">Şifreler cihazınızdaki Oturum Açma menüsünde güvenli bir şekilde saklanır.</string>
+    <string name="autofill_password_generation_offer_accept">Güçlü Şifre Kullan</string>
     <string name="autofill_password_generation_offer_decline">Kendiminkini Oluştur</string>
 
     <string name="deviceNotSupportedTitle">Cihaz desteklenmiyor</string>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -26,7 +26,7 @@
     <string name="saveLoginDialogButtonSave">Save Login</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Save Password</string>
     <string name="saveLoginDialogNotNow">Don\'t Save</string>
-    <string name="saveLoginDialogSubtitle">Logins are stored securely on your device, and can be managed from the Logins menu in Settings.</string>
+    <string name="saveLoginDialogSubtitle">Logins are stored securely on your device in the Logins menu.</string>
     <string name="saveLoginDialogTitle">Do you want DuckDuckGo to save your Login?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">More Options</string>
 
@@ -60,12 +60,12 @@
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Login last updated %1$s</string>
 
     <string name="credentialManagementAutofillToggleLabel">Save and Autofill Logins</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Logins are stored securely on your device</string>
     <string name="credentialManagementViewMenuEdit">Edit</string>
     <string name="credentialManagementViewMenuDelete">Delete</string>
 
     <string name="credentialManagementSuggestionsLabel">Suggested</string>
     <string name="credentialManagementNoLoginsSavedTitle">No Logins saved yet</string>
-    <string name="credentialManagementNoLoginsSavedSubtitle">Logins are stored securely on your device.</string>
 
     <string name="autofillManagementAddLogin">Add Login</string>
     <string name="autofillManagementSearchLogins">Search logins</string>
@@ -79,9 +79,9 @@
     <string name="autofillManagementUsernameCopied">Username copied</string>
     <string name="autofillManagementPasswordCopied">Password copied</string>
 
-    <string name="autofill_password_generation_offer_title">Use generated password from DuckDuckGo?</string>
-    <string name="autofill_password_generation_offer_message">Password will be saved in Logins.</string>
-    <string name="autofill_password_generation_offer_accept">Use Generated Password</string>
+    <string name="autofill_password_generation_offer_title">Use a strong password from DuckDuckGo?</string>
+    <string name="autofill_password_generation_offer_message">Passwords are stored securely on your device in the Logins menu.</string>
+    <string name="autofill_password_generation_offer_accept">Use Strong Password</string>
     <string name="autofill_password_generation_offer_decline">Create My Own</string>
 
     <string name="deviceNotSupportedTitle">Device not supported</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205728058149510/f 

### Description
Updates some of the Autofill copy. Includes:
- Changing `Autofill Logins`to `Logins`
- Moving a line which only showed when there were no logins, to always showing below the enabled/disabled toggle
- Using a shorter form of the copy which starts `Logins are stored securely...`

### Steps to test this PR

_Feature 1_
- [ ] Visit `Settings`, and verify the word is `Logins` (before, it was "Autofill Logins")
- [ ] Tap on `Logins`. 
- [ ] Verify you see the text below the toggle that `Logins are stored securely...` and that it stays there both when you have have no logins and when you have some

### UI changes
![combined](https://github.com/duckduckgo/Android/assets/1336281/360dd274-9b73-48b9-b600-289eb4e6dee6)
