### PR TITLE
ADS: Custom Expandable Layout for DaxExpandableMenuItem

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/ComponentViewHolder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/ComponentViewHolder.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.ui.view.MessageCta
 import com.duckduckgo.mobile.android.ui.view.MessageCta.Message
 import com.duckduckgo.mobile.android.ui.view.MessageCta.MessageType.REMOTE_PROMO_MESSAGE
+import com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
 import com.duckduckgo.mobile.android.ui.view.expand.DaxExpandableMenuItem
 import com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
 import com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
@@ -324,6 +325,23 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
             view.findViewById<DaxExpandableMenuItem>(R.id.expandable1).apply {
                 setPrimaryButtonClickListener {
                     Snackbar.make(this, component.name, Snackbar.LENGTH_SHORT).show()
+                }
+            }
+            view.findViewById<DaxExpandableMenuItem>(R.id.expandable3).customExpandedLayout?.apply {
+                findViewById<DaxButtonSecondary>(R.id.daxExpandableMenuItemSecondaryButton).apply {
+                    setOnClickListener {
+                        Snackbar.make(this, component.name, Snackbar.LENGTH_SHORT).show()
+                    }
+                }
+            }
+            view.findViewById<DaxExpandableMenuItem>(R.id.expandable4).apply {
+                LayoutInflater.from(context).inflate(R.layout.view_expandable_menu_item_expanded_layout_demo, this, false).apply {
+                    findViewById<DaxButtonSecondary>(R.id.daxExpandableMenuItemSecondaryButton).apply {
+                        setOnClickListener {
+                            Snackbar.make(this, component.name, Snackbar.LENGTH_SHORT).show()
+                        }
+                    }
+                    setExpandableMenuCustomLayout(this)
                 }
             }
         }

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/ComponentViewHolder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/themepreview/ui/component/ComponentViewHolder.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import android.widget.LinearLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.ui.view.MessageCta
@@ -29,6 +30,7 @@ import com.duckduckgo.mobile.android.ui.view.MessageCta.Message
 import com.duckduckgo.mobile.android.ui.view.MessageCta.MessageType.REMOTE_PROMO_MESSAGE
 import com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
 import com.duckduckgo.mobile.android.ui.view.expand.DaxExpandableMenuItem
+import com.duckduckgo.mobile.android.ui.view.expand.daxExpandableMenuItem
 import com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
 import com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
 import com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
@@ -343,6 +345,17 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                     }
                     setExpandableMenuCustomLayout(this)
                 }
+            }
+
+            view.findViewById<LinearLayout>(R.id.expandableItemRootLayout).apply {
+                val expandableMenuItem = context.daxExpandableMenuItem {
+                    setPrimaryText("This is a Menu Item")
+                    setSecondaryText("Created using DSL")
+                    setPrimaryButtonClickListener {
+                        Snackbar.make(rootView, component.name, Snackbar.LENGTH_SHORT).show()
+                    }.build()
+                }
+                addView(expandableMenuItem)
             }
         }
     }

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenu.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenu.kt
@@ -62,4 +62,11 @@ class DaxExpandableMenu @JvmOverloads constructor(
             }
         }
     }
+
+    /** Builder class for creating [DaxExpandableMenu]. */
+    @DaxExpandableMenuDsl
+    class Builder(context: Context) {
+
+    }
+
 }

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenu.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenu.kt
@@ -65,8 +65,5 @@ class DaxExpandableMenu @JvmOverloads constructor(
 
     /** Builder class for creating [DaxExpandableMenu]. */
     @DaxExpandableMenuDsl
-    class Builder(context: Context) {
-
-    }
-
+    class Builder(context: Context)
 }

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuDsl.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuDsl.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.view.expand
+
+@DslMarker
+internal annotation class DaxExpandableMenuDsl

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuItem.kt
@@ -23,9 +23,11 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.annotation.LayoutRes
 import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.databinding.ViewExpandableMenuItemBinding
 import com.duckduckgo.mobile.android.ui.view.gone
@@ -45,6 +47,8 @@ class DaxExpandableMenuItem @JvmOverloads constructor(
     private val binding: ViewExpandableMenuItemBinding by viewBinding()
 
     private var expandedChangedListener: OnExpandedChangedListener? = null
+
+    var customExpandedLayout: View? = null
 
     private var expanded = false
     private var animating = false
@@ -115,6 +119,10 @@ class DaxExpandableMenuItem @JvmOverloads constructor(
                 hidePrimaryButton()
             }
 
+            if (hasValue(R.styleable.DaxExpandableMenuItem_expandedLayout)) {
+                setCustomExpandedLayoutResource(getResourceId(R.styleable.DaxExpandableMenuItem_expandedLayout, 0))
+            }
+
             recycle()
         }
     }
@@ -178,6 +186,18 @@ class DaxExpandableMenuItem @JvmOverloads constructor(
 
     fun setExpandedChangeListener(listener: OnExpandedChangedListener) {
         expandedChangedListener = listener
+    }
+
+    fun setExpandableMenuCustomLayout(view: View) {
+        customExpandedLayout = view
+        binding.daxExpandableLayoutContent.removeAllViews()
+        binding.daxExpandableLayoutContent.addView(customExpandedLayout)
+    }
+
+    private fun setCustomExpandedLayoutResource(@LayoutRes expandedLayoutResource: Int) {
+        LayoutInflater.from(context).inflate(expandedLayoutResource, this, false).apply {
+            setExpandableMenuCustomLayout(this)
+        }
     }
 
     override fun onFinishInflate() {

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuItem.kt
@@ -241,7 +241,64 @@ class DaxExpandableMenuItem @JvmOverloads constructor(
             }
         }
     }
+
+    /** Builder class for creating [ExpandableLayout]. */
+    @DaxExpandableMenuItemDsl
+    class Builder(context: Context) {
+        private val expandableMenuItem = DaxExpandableMenuItem(context)
+
+        fun setPrimaryText(value: String) = apply {
+            this.expandableMenuItem.setPrimaryText(value)
+        }
+        fun setPrimaryTextColor(value: ColorStateList?) =  apply {
+            this.expandableMenuItem.setPrimaryTextColor(value)
+        }
+
+        fun setSecondaryText(value: String?) = apply {
+            this.expandableMenuItem.setSecondaryText(value)
+        }
+
+        fun setLeadingIconDrawable(value: Drawable) = apply {
+            this.expandableMenuItem.setLeadingIconDrawable(value)
+        }
+
+        fun setLeadingIconVisibility(value: Boolean) = apply {
+            this.expandableMenuItem.setLeadingIconVisibility(value)
+        }
+
+        fun setLeadingIconBackgroundType(value: ImageBackground) = apply {
+            this.expandableMenuItem.setLeadingIconBackgroundType(value)
+        }
+
+        fun setLeadingIconSize(value: LeadingIconSize) = apply {
+            this.expandableMenuItem.setLeadingIconSize(value)
+        }
+        fun setPrimaryButtonText(value: String?) = apply {
+            this.expandableMenuItem.setPrimaryButtonText(value)
+        }
+        fun setPrimaryButtonClickListener(value: () -> Unit) = apply {
+            this.expandableMenuItem.setPrimaryButtonClickListener(value)
+        }
+
+        fun setExpandedChangeListener(value: OnExpandedChangedListener) = apply {
+            this.expandableMenuItem.setExpandedChangeListener(value)
+        }
+
+        fun setExpandedLayout(value: View) = apply {
+            this.expandableMenuItem.customExpandedLayout = value
+        }
+
+        fun build() = this.expandableMenuItem
+    }
 }
+
+@JvmSynthetic
+@DaxExpandableMenuItemDsl
+inline fun Context.daxExpandableMenuItem(
+    block: DaxExpandableMenuItem.Builder.() -> Unit
+): DaxExpandableMenuItem =
+    DaxExpandableMenuItem.Builder(this).apply(block).build()
+
 
 fun ViewGroup.measureWrapContentHeight(): Int {
     this.measure(

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuItem.kt
@@ -250,7 +250,7 @@ class DaxExpandableMenuItem @JvmOverloads constructor(
         fun setPrimaryText(value: String) = apply {
             this.expandableMenuItem.setPrimaryText(value)
         }
-        fun setPrimaryTextColor(value: ColorStateList?) =  apply {
+        fun setPrimaryTextColor(value: ColorStateList?) = apply {
             this.expandableMenuItem.setPrimaryTextColor(value)
         }
 
@@ -295,10 +295,9 @@ class DaxExpandableMenuItem @JvmOverloads constructor(
 @JvmSynthetic
 @DaxExpandableMenuItemDsl
 inline fun Context.daxExpandableMenuItem(
-    block: DaxExpandableMenuItem.Builder.() -> Unit
+    block: DaxExpandableMenuItem.Builder.() -> Unit,
 ): DaxExpandableMenuItem =
     DaxExpandableMenuItem.Builder(this).apply(block).build()
-
 
 fun ViewGroup.measureWrapContentHeight(): Int {
     this.measure(

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuItemDsl.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/expand/DaxExpandableMenuItemDsl.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.ui.view.expand
+
+@DslMarker
+internal annotation class DaxExpandableMenuItemDsl

--- a/common/common-ui/src/main/res/layout/component_expandable_layout.xml
+++ b/common/common-ui/src/main/res/layout/component_expandable_layout.xml
@@ -97,7 +97,16 @@
 
     </com.duckduckgo.mobile.android.ui.view.expand.DaxExpandableMenu>
 
+    <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
+        android:id="@+id/expandableItemLayout"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        app:primaryText="Expandable Item"/>
 
-
+    <LinearLayout
+        android:id="@+id/expandableItemRootLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"/>
 
 </LinearLayout>

--- a/common/common-ui/src/main/res/layout/component_expandable_layout.xml
+++ b/common/common-ui/src/main/res/layout/component_expandable_layout.xml
@@ -32,6 +32,7 @@
         app:primaryText="Expandable Layout"/>
 
     <com.duckduckgo.mobile.android.ui.view.expand.DaxExpandableMenu
+        android:id="@+id/expandableMenu"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/keyline_4"
@@ -47,7 +48,7 @@
             app:primaryText="Google Play"
             app:leadingIcon="@drawable/ic_dax_icon"
             app:leadingIconSize="small"
-            app:secondaryText="This is a test."/>
+            app:secondaryText="Expandable Menu Item with a text."/>
 
         <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
             android:layout_width="match_parent"
@@ -62,7 +63,7 @@
             app:primaryText="Email"
             app:leadingIcon="@drawable/ic_email_16"
             app:leadingIconSize="small"
-            app:secondaryText="This is a test."
+            app:secondaryText="Expandable Menu Item with a text and button"
             app:primaryButtonText="Add Email"/>
 
         <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
@@ -78,8 +79,21 @@
             app:primaryText="Sync"
             app:leadingIcon="@drawable/ic_globe_gray_16dp"
             app:leadingIconSize="small"
-            app:secondaryText="This is a test."
-            app:primaryButtonText="Go to Sync Settings"/>
+            app:expandedLayout="@layout/view_expandable_menu_item_expanded_layout_demo" />
+
+        <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:fullWidth="false"
+            app:defaultPadding="false"/>
+
+        <com.duckduckgo.mobile.android.ui.view.expand.DaxExpandableMenuItem
+            android:id="@+id/expandable4"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="Sync Custom Layout"
+            app:leadingIcon="@drawable/ic_globe_gray_16dp"
+            app:leadingIconSize="small" />
 
     </com.duckduckgo.mobile.android.ui.view.expand.DaxExpandableMenu>
 

--- a/common/common-ui/src/main/res/layout/view_expandable_menu_item_expanded_layout_demo.xml
+++ b/common/common-ui/src/main/res/layout/view_expandable_menu_item_expanded_layout_demo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2023 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingEnd="@dimen/keyline_4">
+
+    <com.duckduckgo.mobile.android.ui.view.text.DaxTextView
+        android:id="@+id/daxExpandableMenuItemSecondaryText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/keyline_4"
+        android:text="@string/text_dialog_message"
+        app:textType="secondary"
+        app:typography="body2" />
+
+    <com.duckduckgo.mobile.android.ui.view.button.DaxButtonPrimary
+        android:id="@+id/daxExpandableMenuItemPrimaryButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:layout_marginBottom="@dimen/keyline_2"
+        android:text="Primary"
+        app:buttonSize="small" />
+
+    <com.duckduckgo.mobile.android.ui.view.button.DaxButtonSecondary
+        android:id="@+id/daxExpandableMenuItemSecondaryButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:layout_marginBottom="@dimen/keyline_2"
+        android:text="Secondary"
+        app:buttonSize="small" />
+
+
+</LinearLayout>

--- a/common/common-ui/src/main/res/values/attrs-expandablelemenu.xml
+++ b/common/common-ui/src/main/res/values/attrs-expandablelemenu.xml
@@ -12,6 +12,7 @@
     <attr name="leadingIcon"/>
     <attr name="leadingIconBackground"/>
     <attr name="leadingIconSize"/>
+    <attr name="expandedLayout" format="reference" />
 
     <!--Exposed part-->
     <attr name="secondaryText"/>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205738768210349/f

### Description
Adds the ability to set a custom expandable layout in DaxExpandableMenuItem

```
<com.duckduckgo.mobile.android.ui.view.expand.DaxExpandableMenuItem
    android:id="@+id/expandable3”
    android:layout_width=“match_parent”
    android:layout_height=“wrap_content”
    app:primaryText=“Sync”
    app:leadingIcon="@drawable/ic_globe_gray_16dp”
    app:leadingIconSize=“small”
    app:expandedLayout="@layout/view_expandable_menu_item_expanded_layout_demo” />

```

```
LayoutInflater.from(context).inflate(R.layout.view_expandable_menu_item_expanded_layout_demo, this, false).apply {
    findViewById<DaxButtonSecondary>(R.id.daxExpandableMenuItemSecondaryButton).apply {
        setOnClickListener {
            Snackbar.make(this, component.name, Snackbar.LENGTH_SHORT).show()
        }
    }
    setExpandableMenuCustomLayout(this)

```
