### PR TITLE
Remove divider for last item in tracker feed

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedFragment.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedFragment.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldActivit
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldActivityFeedViewModel.Command.TrackerListDisplayed
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.DeviceShieldActivityFeedViewModel.TrackerFeedViewState
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerFeedItem
+import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.view.TrackerDividerItemDecoration
 import com.google.android.material.snackbar.Snackbar
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -81,6 +82,7 @@ class DeviceShieldActivityFeedFragment : DuckDuckGoFragment() {
         with(binding.activityRecyclerView) {
             layoutManager = StickyHeadersLinearLayoutManager<TrackerFeedAdapter>(this@DeviceShieldActivityFeedFragment.requireContext())
             adapter = trackerFeedAdapter
+            addItemDecoration(TrackerDividerItemDecoration(context))
         }
 
         lifecycleScope.launch {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModel.kt
@@ -131,7 +131,9 @@ class DeviceShieldActivityFeedViewModel @Inject constructor(
     fun trackerListDisplayed(viewState: TrackerFeedViewState) {
         viewModelScope.launch {
             if (viewState.trackers.isNotEmpty() && viewState.trackers.first() != TrackerLoadingSkeleton) {
-                command.send(Command.TrackerListDisplayed(viewState.trackers.size))
+                command.send(
+                    Command.TrackerListDisplayed(viewState.trackers.count { it is TrackerFeedItem.TrackerFeedData }),
+                )
             }
         }
     }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -192,8 +192,10 @@ class DeviceShieldTrackerActivity :
     override fun onTrackerListShowed(totalTrackers: Int) {
         if (totalTrackers >= MIN_ROWS_FOR_ALL_ACTIVITY) {
             binding.ctaShowAll.show()
+            binding.dividerCtaShowAll.show()
         } else {
             binding.ctaShowAll.gone()
+            binding.dividerCtaShowAll.gone()
         }
         viewModel.showAppTpEnabledCtaIfNeeded()
     }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/TrackerFeedAdapter.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/TrackerFeedAdapter.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.vpn.R
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerCompanyBadge
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerFeedItem
+import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerFeedItem.TrackerFeedData
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.view.AppsProtectionStateView
 import com.duckduckgo.mobile.android.vpn.ui.util.TextDrawable
 import com.facebook.shimmer.ShimmerFrameLayout
@@ -57,7 +58,8 @@ class TrackerFeedAdapter @Inject constructor(
         position: Int,
     ) {
         when (holder) {
-            is TrackerFeedViewHolder -> holder.bind(trackerFeedItems[position] as TrackerFeedItem.TrackerFeedData, onAppClick)
+            is TrackerFeedViewHolder ->
+                holder.bind(trackerFeedItems[position] as TrackerFeedItem.TrackerFeedData, onAppClick)
             is TrackerSkeletonViewHolder -> holder.bind()
             is TrackerFeedHeaderViewHolder -> holder.bind(trackerFeedItems[position] as TrackerFeedItem.TrackerFeedItemHeader)
             is TrackerAppsProtectionStateViewHolder ->

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/TrackerDividerItemDecoration.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/TrackerDividerItemDecoration.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.ui.tracker_activity.view
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.mobile.android.R
+import com.duckduckgo.mobile.android.ui.view.getColorFromAttr
+
+class TrackerDividerItemDecoration(val context: Context) : RecyclerView.ItemDecoration() {
+    private val dividerPaint = Paint()
+
+    init {
+        dividerPaint.color = context.getColorFromAttr(R.attr.daxColorLines)
+        dividerPaint.strokeWidth = context.resources.getDimensionPixelSize(R.dimen.horizontalDividerHeight).toFloat()
+    }
+
+    override fun onDraw(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
+        val startPadding =
+            context.resources.getDimensionPixelSize(R.dimen.listItemImageContainerSize) +
+                2 * context.resources.getDimensionPixelSize(R.dimen.keyline_4)
+        val start = parent.paddingLeft + startPadding
+        val end = parent.width - parent.paddingRight
+
+        val childCount = parent.childCount
+        for (i in 0 until childCount - 1) {
+            val child = parent.getChildAt(i)
+            val params = child.layoutParams as RecyclerView.LayoutParams
+
+            val top = child.bottom + params.bottomMargin
+            val bottom = top + dividerPaint.strokeWidth
+
+            canvas.drawLine(start.toFloat(), top.toFloat(), end.toFloat(), bottom, dividerPaint)
+        }
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_activity.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_activity.xml
@@ -130,16 +130,20 @@
                     android:id="@+id/cta_show_all"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/keyline_4"
                     android:background="?attr/selectableItemBackground"
                     android:gravity="center_vertical"
                     android:minHeight="@dimen/keyline_7"
                     android:paddingStart="72dp"
-                    android:paddingTop="@dimen/keyline_2"
+                    android:paddingTop="@dimen/keyline_empty"
                     android:paddingEnd="@dimen/keyline_4"
                     android:paddingBottom="@dimen/keyline_empty"
                     android:text="@string/atp_ActivityCtaShowAll"
                     android:visibility="gone" />
+
+                <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
+                    android:id="@+id/divider_cta_show_all"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"/>
 
                 <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
                     android:layout_width="match_parent"

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/view_device_shield_activity_entry.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/view_device_shield_activity_entry.xml
@@ -80,12 +80,4 @@
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_chevron_forward_small_24" />
 
-    <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:defaultPadding="false"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/activity_message" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205217801169328/f 

### Description
* Remove divider from the last item
* Add full width divider below "View All Recent Activity"
* Fix bug that caused "View All Recent Activity" to be shown when there were only 4 apps with trackers blocked

### Steps to test this PR

_Recent activity isn't shown anymore with trackers blocked in 4 apps_
- [x] Enable AppTP
- [x] Open 4 apps with trackers
- [x] Open main AppTP view
- [x] Check "View All Recent Activity" isn't shown in the list

_Recent activity shows with trackers blocked in 5 apps_
- [x] Enable AppTP
- [x] Open 5 apps with trackers
- [x] Open main AppTP view
- [x] Check "View All Recent Activity" is shown in the list
- [x] Check there is no divider below the last app, but below "View All Recent Activity" instead


_Last item in activity has no divider_
- [x] Enable AppTP
- [x] Open 5 apps with trackers
- [x] Open main AppTP view
- [x] Tap on "View All Recent Activity" 
- [x] Check the last item doesn't have a divider

### UI changes

![recent.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xNBXzxGm7JvnNf4UHqZ9/d78f83be-2836-4537-9550-29a91649b1e6/recent.png)

![empty.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xNBXzxGm7JvnNf4UHqZ9/a9a6d794-def0-4c67-969b-71ac2073ba8f/empty.png)

![4apps2.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xNBXzxGm7JvnNf4UHqZ9/8b6c3c68-d14b-496c-ba39-3cf07195433a/4apps2.png)

![5apps.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xNBXzxGm7JvnNf4UHqZ9/50bba63d-75c2-448b-b9fd-aac435050a7b/5apps.png)

