### PR TITLE
Block the system to wrongly auto-start AppTP/NetP

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -209,5 +209,8 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
     REPORT_VPN_ALWAYS_ON_TRIGGERED("m_vpn_ev_always_on_triggered_c"),
     REPORT_VPN_ALWAYS_ON_TRIGGERED_DAILY("m_vpn_ev_always_on_triggered_d"),
 
+    REPORT_NOTIFY_START_FAILURE("m_vpn_ev_notify_start_failed_d"),
+    REPORT_NOTIFY_START_FAILURE_DAILY("m_vpn_ev_notify_start_failed_c"),
+
     ;
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -342,6 +342,8 @@ interface DeviceShieldPixels {
     fun reportTunnelThreadStopTimeout()
 
     fun reportVpnAlwaysOnTriggered()
+
+    fun notifyStartFailed()
 }
 
 @ContributesBinding(AppScope::class)
@@ -766,6 +768,11 @@ class RealDeviceShieldPixels @Inject constructor(
     override fun reportVpnAlwaysOnTriggered() {
         tryToFireDailyPixel(DeviceShieldPixelNames.REPORT_VPN_ALWAYS_ON_TRIGGERED_DAILY)
         firePixel(DeviceShieldPixelNames.REPORT_VPN_ALWAYS_ON_TRIGGERED)
+    }
+
+    override fun notifyStartFailed() {
+        tryToFireDailyPixel(DeviceShieldPixelNames.REPORT_NOTIFY_START_FAILURE_DAILY)
+        firePixel(DeviceShieldPixelNames.REPORT_NOTIFY_START_FAILURE)
     }
 
     private fun firePixel(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205760598870176/f

### Description
Block the Android system from auto-starting the VPN service when it was previously disabled

### Steps to test this PR

_Test_
- install from this branch
- Ensure always on is disabled for our app
- Enable AppTP and disable it back
- Enable always-on from Android settings
- [x] verify the VPN is not started and the logcat `notifyStart return error, aborting` appears
- Enable AppTP
- [x] verify AppTP is enabled
- Disable always-on for our app
- [x] verify AppTP gets disabled
- re-enable always on for our app
- [x] verify AppTP gets re-enabled

