### PR TITLE
Report TLS parsing errors

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -212,5 +212,6 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
     REPORT_NOTIFY_START_FAILURE("m_vpn_ev_notify_start_failed_d"),
     REPORT_NOTIFY_START_FAILURE_DAILY("m_vpn_ev_notify_start_failed_c"),
 
+    REPORT_TLS_PARSING_ERROR_CODE_DAILY("m_atp_tls_parsing_error_code_%d_d"),
     ;
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -344,6 +344,8 @@ interface DeviceShieldPixels {
     fun reportVpnAlwaysOnTriggered()
 
     fun notifyStartFailed()
+
+    fun reportTLSParsingError(errorCode: Int)
 }
 
 @ContributesBinding(AppScope::class)
@@ -773,6 +775,10 @@ class RealDeviceShieldPixels @Inject constructor(
     override fun notifyStartFailed() {
         tryToFireDailyPixel(DeviceShieldPixelNames.REPORT_NOTIFY_START_FAILURE_DAILY)
         firePixel(DeviceShieldPixelNames.REPORT_NOTIFY_START_FAILURE)
+    }
+
+    override fun reportTLSParsingError(errorCode: Int) {
+        tryToFireDailyPixel(String.format(Locale.US, DeviceShieldPixelNames.REPORT_TLS_PARSING_ERROR_CODE_DAILY.pixelName, errorCode))
     }
 
     private fun firePixel(

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/integration/NgVpnNetworkStackTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/integration/NgVpnNetworkStackTest.kt
@@ -71,6 +71,8 @@ class NgVpnNetworkStackTest {
             trackingProtectionAppsRepository,
             appTpLocalFeature,
             deviceShieldPixels,
+            coroutineRule.testScope,
+            coroutineRule.testDispatcherProvider,
         )
     }
 

--- a/versions.properties
+++ b/versions.properties
@@ -57,7 +57,7 @@ version.com.airbnb.android..lottie=5.2.0
 
 version.com.android.installreferrer..installreferrer=2.2
 
-version.com.duckduckgo.netguard..netguard-android=1.6.4
+version.com.duckduckgo.netguard..netguard-android=1.6.5
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.3.0
 

--- a/vpn-network/vpn-network-api/src/main/java/com/duckduckgo/vpn/network/api/VpnNetworkCallback.kt
+++ b/vpn-network/vpn-network-api/src/main/java/com/duckduckgo/vpn/network/api/VpnNetworkCallback.kt
@@ -44,6 +44,12 @@ interface VpnNetworkCallback {
     fun isDomainBlocked(domainRR: DomainRR): Boolean
 
     /**
+     * Called by the VPN network to report an error parsing TLS packets.
+     * The implementation of this method should just log the issue and continue
+     */
+    fun reportTLSParsingError(errorCode: Int) {}
+
+    /**
      * Called by the VPN network to know if a particular IP address is blocked or not. This can be combined with the
      * [onDnsResolved] callback, to get the hostname of the [addressRR] and then decide whether that hostname should
      * be blocked or not

--- a/vpn-network/vpn-network-impl/src/main/java/com/duckduckgo/vpn/network/impl/RealVpnNetwork.kt
+++ b/vpn-network/vpn-network-impl/src/main/java/com/duckduckgo/vpn/network/impl/RealVpnNetwork.kt
@@ -138,6 +138,13 @@ class RealVpnNetwork @Inject constructor(
 
     // Called from native code
     @Suppress("unused")
+    private fun reportTLSParsingError(errorCode: Int) {
+        logcat { "reportTLSParsingError error code= $errorCode" }
+        callback.get()?.reportTLSParsingError(errorCode)
+    }
+
+    // Called from native code
+    @Suppress("unused")
     private fun isAddressAllowed(packet: Packet): Allowed? {
         packet.allowed = true
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205766744020104/f

### Description
Report TLS parsing errors from native

### Steps to test this PR
Apply the following patch to this branch

```
---
Index: build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle b/build.gradle
--- a/build.gradle	(revision d11f7491d7ab4b27223fd352f83c26be403e79ed)
+++ b/build.gradle	(revision 3b1fe446b5d33e4d8a7f400137134ea0b5a797d7)
@@ -40,6 +40,7 @@
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
     configurations.all {
         resolutionStrategy.force 'org.objenesis:objenesis:2.6'
Index: versions.properties
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>ISO-8859-1
===================================================================
diff --git a/versions.properties b/versions.properties
--- a/versions.properties	(revision d11f7491d7ab4b27223fd352f83c26be403e79ed)
+++ b/versions.properties	(revision 3b1fe446b5d33e4d8a7f400137134ea0b5a797d7)
@@ -55,7 +55,7 @@
 
 version.com.android.installreferrer..installreferrer=2.2
 
-version.com.duckduckgo.netguard..netguard-android=1.6.0
+version.com.duckduckgo.netguard..netguard-android=1.7.0-SNAPSHOT
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.3.0
 
```

Apply the following patch to the https://github.com/duckduckgo/netguard/pull/28

```
Subject: [PATCH] 998
---
Index: src/netguard/tls.c
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/src/netguard/tls.c b/src/netguard/tls.c
--- a/src/netguard/tls.c	(revision 10b16800c86f3be55196021e2236d50c708e3ff8)
+++ b/src/netguard/tls.c	(date 1697803689005)
@@ -19,9 +19,9 @@
 
     int error_code = get_server_name(pkt, length, tls, sn);
 
-    if (error_code < 0) {
+//    if (error_code < 0) {
         report_tls_parsing_error(args, error_code);
-    }
+//    }
     if (strlen(sn) == 0) {
         log_print(PLATFORM_LOG_PRIORITY_INFO, "TLS server name not found");
         return 0;
```

Test
- Checkout https://github.com/duckduckgo/netguard/pull/28 and `./gradlew clean assemble publishToMavenLocal`
- Checkout this branch, apply patch above and build
- Launch app and enable AppTP
- Open apps that have trackers
- [x] Verify AppTP works as expected and `m_atp_tls_parsing_error_code_##_d` fires

