### PR TITLE
Add dev settings for quickly adding Logins for testing (including duplicates)

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationBestMatchFinder.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationBestMatchFinder.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.deduper
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.deduper.AutofillDeduplicationMatchTypeDetector.MatchType.NotAMatch
+import com.duckduckgo.autofill.impl.deduper.AutofillDeduplicationMatchTypeDetector.MatchType.PartialMatch
+import com.duckduckgo.autofill.impl.deduper.AutofillDeduplicationMatchTypeDetector.MatchType.PerfectMatch
+import com.duckduckgo.autofill.impl.urlmatcher.AutofillUrlMatcher
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface AutofillDeduplicationBestMatchFinder {
+
+    fun findBestMatch(
+        originalUrl: String,
+        logins: List<LoginCredentials>,
+    ): LoginCredentials?
+}
+
+@ContributesBinding(AppScope::class)
+class RealAutofillDeduplicationBestMatchFinder @Inject constructor(
+    private val urlMatcher: AutofillUrlMatcher,
+    private val matchTypeDetector: AutofillDeduplicationMatchTypeDetector,
+) : AutofillDeduplicationBestMatchFinder {
+
+    override fun findBestMatch(
+        originalUrl: String,
+        logins: List<LoginCredentials>,
+    ): LoginCredentials? {
+        // perfect matches are those where the subdomain and e-tld+1 match
+        val perfectMatches = mutableListOf<LoginCredentials>()
+
+        // partial matches are those where only e-tld+1 matches
+        val partialMatches = mutableListOf<LoginCredentials>()
+
+        // non-matches are those where neither subdomain nor e-tld+1 match
+        val nonMatches = mutableListOf<LoginCredentials>()
+
+        categoriseEachLogin(logins, originalUrl, perfectMatches, partialMatches, nonMatches)
+
+        if (perfectMatches.isEmpty() && partialMatches.isEmpty() && nonMatches.isEmpty()) {
+            return null
+        }
+
+        return if (perfectMatches.isNotEmpty()) {
+            bestPerfectMatch(perfectMatches)
+        } else if (partialMatches.isNotEmpty()) {
+            bestPartialMatch(partialMatches)
+        } else {
+            bestNonMatch(nonMatches)
+        }
+    }
+
+    private fun categoriseEachLogin(
+        logins: List<LoginCredentials>,
+        originalUrl: String,
+        perfectMatches: MutableList<LoginCredentials>,
+        partialMatches: MutableList<LoginCredentials>,
+        nonMatches: MutableList<LoginCredentials>,
+    ) {
+        logins.forEach {
+            when (matchTypeDetector.detectMatchType(originalUrl, it)) {
+                PerfectMatch -> perfectMatches.add(it)
+                PartialMatch -> partialMatches.add(it)
+                NotAMatch -> nonMatches.add(it)
+            }
+        }
+    }
+
+    private fun bestPerfectMatch(perfectMatches: List<LoginCredentials>): LoginCredentials {
+        return perfectMatches.sortedWith(AutofillDeduplicationLoginComparator()).first()
+    }
+
+    private fun bestPartialMatch(partialMatches: MutableList<LoginCredentials>): LoginCredentials {
+        return partialMatches.sortedWith(AutofillDeduplicationLoginComparator()).first()
+    }
+
+    private fun bestNonMatch(nonMatches: MutableList<LoginCredentials>): LoginCredentials {
+        return nonMatches.sortedWith(AutofillDeduplicationLoginComparator()).first()
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationMatchTypeDetector.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationMatchTypeDetector.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.deduper
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.deduper.AutofillDeduplicationMatchTypeDetector.MatchType
+import com.duckduckgo.autofill.impl.urlmatcher.AutofillUrlMatcher
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface AutofillDeduplicationMatchTypeDetector {
+
+    fun detectMatchType(
+        originalUrl: String,
+        login: LoginCredentials,
+    ): MatchType
+
+    sealed interface MatchType {
+        object PerfectMatch : MatchType
+        object PartialMatch : MatchType
+        object NotAMatch : MatchType
+    }
+}
+
+@ContributesBinding(AppScope::class)
+class RealAutofillDeduplicationMatchTypeDetector @Inject constructor(
+    private val urlMatcher: AutofillUrlMatcher,
+) : AutofillDeduplicationMatchTypeDetector {
+
+    override fun detectMatchType(
+        originalUrl: String,
+        login: LoginCredentials,
+    ): MatchType {
+        val visitedSiteParts = urlMatcher.extractUrlPartsForAutofill(originalUrl)
+        val savedSiteParts = urlMatcher.extractUrlPartsForAutofill(login.domain)
+
+        if (!urlMatcher.matchingForAutofill(visitedSiteParts, savedSiteParts)) {
+            return MatchType.NotAMatch
+        }
+
+        return if (visitedSiteParts.subdomain == savedSiteParts.subdomain) {
+            MatchType.PerfectMatch
+        } else {
+            MatchType.PartialMatch
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationUsernameAndPasswordMatcher.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationUsernameAndPasswordMatcher.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.deduper
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface AutofillDeduplicationUsernameAndPasswordMatcher {
+
+    fun groupDuplicateCredentials(logins: List<LoginCredentials>): Map<Pair<String?, String?>, List<LoginCredentials>>
+}
+
+@ContributesBinding(AppScope::class)
+class RealAutofillDeduplicationUsernameAndPasswordMatcher @Inject constructor() : AutofillDeduplicationUsernameAndPasswordMatcher {
+
+    override fun groupDuplicateCredentials(logins: List<LoginCredentials>): Map<Pair<String?, String?>, List<LoginCredentials>> {
+        return logins.groupBy { it.username to it.password }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillLoginDeduplicator.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillLoginDeduplicator.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.deduper
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface AutofillLoginDeduplicator {
+
+    fun deduplicate(
+        originalUrl: String,
+        logins: List<LoginCredentials>,
+    ): List<LoginCredentials>
+}
+
+@ContributesBinding(AppScope::class)
+class RealAutofillLoginDeduplicator @Inject constructor(
+    private val usernamePasswordMatcher: AutofillDeduplicationUsernameAndPasswordMatcher,
+    private val bestMatchFinder: AutofillDeduplicationBestMatchFinder,
+) : AutofillLoginDeduplicator {
+
+    override fun deduplicate(
+        originalUrl: String,
+        logins: List<LoginCredentials>,
+    ): List<LoginCredentials> {
+        val dedupedLogins = mutableListOf<LoginCredentials>()
+
+        val groups = usernamePasswordMatcher.groupDuplicateCredentials(logins)
+        groups.forEach {
+            val bestMatchForGroup = bestMatchFinder.findBestMatch(originalUrl, it.value)
+            if (bestMatchForGroup != null) {
+                dedupedLogins.add(bestMatchForGroup)
+            }
+        }
+
+        return dedupedLogins
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/RealLoginSorterForDeduplication.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/RealLoginSorterForDeduplication.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.deduper
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+
+class AutofillDeduplicationLoginComparator : Comparator<LoginCredentials> {
+    override fun compare(
+        o1: LoginCredentials,
+        o2: LoginCredentials,
+    ): Int {
+        val lastModifiedComparison = compareLastModified(o1.lastUpdatedMillis, o2.lastUpdatedMillis)
+        if (lastModifiedComparison != 0) return lastModifiedComparison
+
+        // last updated matches, fallback to domain
+        return compareDomains(o1.domain, o2.domain)
+    }
+
+    private fun compareLastModified(
+        lastModified1: Long?,
+        lastModified2: Long?,
+    ): Int {
+        if (lastModified1 == null && lastModified2 == null) return 0
+
+        if (lastModified1 == null) return -1
+        if (lastModified2 == null) return 1
+        return lastModified2.compareTo(lastModified1)
+    }
+
+    private fun compareDomains(
+        domain1: String?,
+        domain2: String?,
+    ): Int {
+        if (domain1 == null && domain2 == null) return 0
+        if (domain1 == null) return -1
+        if (domain2 == null) return 1
+        return domain1.compareTo(domain2)
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDisablingDeclineCounter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDisablingDeclineCounter.kt
@@ -136,6 +136,6 @@ class AutofillDisablingDeclineCounter @Inject constructor(
     }
 
     companion object {
-        private const val GLOBAL_DECLINE_COUNT_THRESHOLD = 3
+        private const val GLOBAL_DECLINE_COUNT_THRESHOLD = 2
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillStoredBackJavascriptInterfaceTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillStoredBackJavascriptInterfaceTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonitor
 import com.duckduckgo.autofill.api.store.AutofillStore
 import com.duckduckgo.autofill.impl.AutofillStoredBackJavascriptInterface.UrlProvider
+import com.duckduckgo.autofill.impl.deduper.AutofillLoginDeduplicator
 import com.duckduckgo.autofill.impl.email.incontext.availability.EmailProtectionInContextRecentInstallChecker
 import com.duckduckgo.autofill.impl.email.incontext.store.EmailProtectionInContextDataStore
 import com.duckduckgo.autofill.impl.jsbridge.AutofillMessagePoster
@@ -75,6 +76,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
     private val inContextDataStore: EmailProtectionInContextDataStore = mock()
     private val recentInstallChecker: EmailProtectionInContextRecentInstallChecker = mock()
     private val testWebView = WebView(getApplicationContext())
+    private val loginDeduplicator: AutofillLoginDeduplicator = NoopDeduplicator()
     private lateinit var testee: AutofillStoredBackJavascriptInterface
 
     private val testCallback = TestCallback()
@@ -99,6 +101,7 @@ class AutofillStoredBackJavascriptInterfaceTest {
             emailManager = emailManager,
             inContextDataStore = inContextDataStore,
             recentInstallChecker = recentInstallChecker,
+            loginDeduplicator = loginDeduplicator,
         )
         testee.callback = testCallback
         testee.webView = testWebView
@@ -389,5 +392,9 @@ class AutofillStoredBackJavascriptInterfaceTest {
         override fun onCredentialsSaved(savedCredentials: LoginCredentials) {
             // no-op
         }
+    }
+
+    private class NoopDeduplicator : AutofillLoginDeduplicator {
+        override fun deduplicate(originalUrl: String, logins: List<LoginCredentials>): List<LoginCredentials> = logins
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealAutofillLoginDeduplicatorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealAutofillLoginDeduplicatorTest.kt
@@ -1,0 +1,165 @@
+package com.duckduckgo.autofill.impl.deduper
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.encoding.TestUrlUnicodeNormalizer
+import com.duckduckgo.autofill.impl.urlmatcher.AutofillDomainNameUrlMatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class RealAutofillLoginDeduplicatorTest {
+    private val urlMatcher = AutofillDomainNameUrlMatcher(TestUrlUnicodeNormalizer())
+    private val matchTypeDetector = RealAutofillDeduplicationMatchTypeDetector(urlMatcher)
+    private val testee = RealAutofillLoginDeduplicator(
+        usernamePasswordMatcher = RealAutofillDeduplicationUsernameAndPasswordMatcher(),
+        bestMatchFinder = RealAutofillDeduplicationBestMatchFinder(
+            urlMatcher = urlMatcher,
+            matchTypeDetector = matchTypeDetector,
+        ),
+    )
+
+    @Test
+    fun whenEmptyListInThenEmptyListOut() = runTest {
+        val result = testee.deduplicate("example.com", emptyList())
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun whenSingleEntryInThenSingleEntryReturned() {
+        val inputList = listOf(
+            aLogin("domain", "username", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun whenEntriesCompletelyUnrelatedThenNoDeduplication() {
+        val inputList = listOf(
+            aLogin("domain_A", "username_A", "password_A"),
+            aLogin("domain_B", "username_B", "password_B"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(2, result.size)
+        assertNotNull(result.find { it.domain == "domain_A" })
+        assertNotNull(result.find { it.domain == "domain_B" })
+    }
+
+    @Test
+    fun whenEntriesShareUsernameAndPasswordButNotDomainThenDeduped() {
+        val inputList = listOf(
+            aLogin("foo.com", "username", "password"),
+            aLogin("bar.com", "username", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun whenEntriesShareDomainAndUsernameButNotPasswordThenNoDeduplication() {
+        val inputList = listOf(
+            aLogin("example.com", "username", "123"),
+            aLogin("example.com", "username", "xyz"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(2, result.size)
+        assertNotNull(result.find { it.password == "123" })
+        assertNotNull(result.find { it.password == "xyz" })
+    }
+
+    @Test
+    fun whenEntriesShareDomainAndPasswordButNotUsernameThenNoDeduplication() {
+        val inputList = listOf(
+            aLogin("example.com", "user_A", "password"),
+            aLogin("example.com", "user_B", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(2, result.size)
+        assertNotNull(result.find { it.username == "user_A" })
+        assertNotNull(result.find { it.username == "user_B" })
+    }
+
+    @Test
+    fun whenEntriesShareMultipleCredentialsWhichArePerfectDomainMatchesThenDeduped() {
+        val inputList = listOf(
+            aLogin("example.com", "username", "password"),
+            aLogin("example.com", "username", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun whenEntriesShareMultipleCredentialsWhichArePartialDomainMatchesThenDeduped() {
+        val inputList = listOf(
+            aLogin("a.example.com", "username", "password"),
+            aLogin("b.example.com", "username", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun whenEntriesShareMultipleCredentialsWhichAreNotDomainMatchesThenDeduped() {
+        val inputList = listOf(
+            aLogin("foo.com", "username", "password"),
+            aLogin("bar.com", "username", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun whenEntriesShareCredentialsAcrossPerfectAndPartialMatchesThenDedupedToPerfectMatch() {
+        val inputList = listOf(
+            aLogin("example.com", "username", "password"),
+            aLogin("a.example.com", "username", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(1, result.size)
+        assertNotNull(result.find { it.domain == "example.com" })
+    }
+
+    @Test
+    fun whenEntriesShareCredentialsAcrossPerfectAndNonDomainMatchesThenDedupedToPerfectMatch() {
+        val inputList = listOf(
+            aLogin("example.com", "username", "password"),
+            aLogin("bar.com", "username", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(1, result.size)
+        assertNotNull(result.find { it.domain == "example.com" })
+    }
+
+    @Test
+    fun whenEntriesShareCredentialsAcrossPartialAndNonDomainMatchesThenDedupedToPerfectMatch() {
+        val inputList = listOf(
+            aLogin("a.example.com", "username", "password"),
+            aLogin("bar.com", "username", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(1, result.size)
+        assertNotNull(result.find { it.domain == "a.example.com" })
+    }
+
+    @Test
+    fun whenEntriesShareCredentialsAcrossPerfectAndPartialAndNonDomainMatchesThenDedupedToPerfectMatch() {
+        val inputList = listOf(
+            aLogin("a.example.com", "username", "password"),
+            aLogin("example.com", "username", "password"),
+            aLogin("bar.com", "username", "password"),
+        )
+        val result = testee.deduplicate("example.com", inputList)
+        assertEquals(1, result.size)
+        assertNotNull(result.find { it.domain == "example.com" })
+    }
+
+    private fun aLogin(domain: String, username: String, password: String): LoginCredentials {
+        return LoginCredentials(username = username, password = password, domain = domain)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealAutofillMatchTypeDetectorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealAutofillMatchTypeDetectorTest.kt
@@ -1,0 +1,53 @@
+package com.duckduckgo.autofill.impl.deduper
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.deduper.AutofillDeduplicationMatchTypeDetector.MatchType
+import com.duckduckgo.autofill.impl.encoding.TestUrlUnicodeNormalizer
+import com.duckduckgo.autofill.impl.urlmatcher.AutofillDomainNameUrlMatcher
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RealAutofillMatchTypeDetectorTest {
+    private val testee = RealAutofillDeduplicationMatchTypeDetector(AutofillDomainNameUrlMatcher(TestUrlUnicodeNormalizer()))
+
+    @Test
+    fun whenExactUrlMatchThenTypeIsPerfectMatch() {
+        val result = testee.detectMatchType("example.com", creds("example.com"))
+        result.assertIsPerfectMatch()
+    }
+
+    @Test
+    fun whenSubdomainMatchOnSavedSiteThenTypeIsPartialMatch() {
+        val result = testee.detectMatchType("example.com", creds("subdomain.example.com"))
+        result.assertIsPartialMatch()
+    }
+
+    @Test
+    fun whenSubdomainMatchOnVisitedSiteThenTypeIsPartialMatch() {
+        val result = testee.detectMatchType("subdomain.example.com", creds("example.com"))
+        result.assertIsPartialMatch()
+    }
+
+    @Test
+    fun whenSubdomainMatchOnBothVisitedAndSavedSiteThenTypeIsPerfectMatch() {
+        val result = testee.detectMatchType("subdomain.example.com", creds("subdomain.example.com"))
+        result.assertIsPerfectMatch()
+    }
+
+    @Test
+    fun whenNoETldPlusOneMatchNotAMatch() {
+        val result = testee.detectMatchType("foo.com", creds("example.com"))
+        result.assertNotAMatch()
+    }
+
+    private fun MatchType.assertIsPerfectMatch() = assertTrue(this is MatchType.PerfectMatch)
+    private fun MatchType.assertIsPartialMatch() = assertTrue(this is MatchType.PartialMatch)
+    private fun MatchType.assertNotAMatch() = assertTrue(this is MatchType.NotAMatch)
+
+    private fun creds(domain: String): LoginCredentials {
+        return LoginCredentials(domain = domain, username = "", password = "")
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealLoginDeduplicatorBestMatchFinderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealLoginDeduplicatorBestMatchFinderTest.kt
@@ -1,0 +1,88 @@
+package com.duckduckgo.autofill.impl.deduper
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.encoding.TestUrlUnicodeNormalizer
+import com.duckduckgo.autofill.impl.urlmatcher.AutofillDomainNameUrlMatcher
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RealLoginDeduplicatorBestMatchFinderTest {
+
+    private val urlMatcher = AutofillDomainNameUrlMatcher(TestUrlUnicodeNormalizer())
+    private val matchTypeDetector = RealAutofillDeduplicationMatchTypeDetector(urlMatcher)
+    private val testee = RealAutofillDeduplicationBestMatchFinder(
+        urlMatcher = urlMatcher,
+        matchTypeDetector = matchTypeDetector,
+    )
+
+    @Test
+    fun whenEmptyListThenNoBestMatchFound() {
+        assertNull(testee.findBestMatch("", emptyList()))
+    }
+
+    @Test
+    fun whenSinglePerfectMatchThenThatIsReturnedAsBestMatch() {
+        val input = listOf(
+            LoginCredentials(id = 0, domain = "example.com", username = "username", password = "password"),
+        )
+        val result = testee.findBestMatch("example.com", input)
+        assertNotNull(result)
+    }
+
+    @Test
+    fun whenMultiplePerfectMatchesMostRecentlyModifiedIsReturned() {
+        val input = listOf(
+            creds("example.com", 1000),
+            creds("example.com", 2000),
+        )
+        val result = testee.findBestMatch("example.com", input)
+        assertEquals(2000L, result!!.lastUpdatedMillis)
+    }
+
+    @Test
+    fun whenMultiplePartialMatchesWithSameTimestampThenDomainAlphabeticallyFirstReturned() {
+        val input = listOf(
+            creds("a.example.com", 2000),
+            creds("b.example.com", 2000),
+        )
+        val result = testee.findBestMatch("example.com", input)
+        assertEquals("a.example.com", result!!.domain)
+    }
+
+    @Test
+    fun whenSingleNonMatchThenReturnedAsBestMatch() {
+        val input = listOf(
+            creds("not-a-match.com", 2000),
+        )
+        val result = testee.findBestMatch("example.com", input)
+        assertEquals("not-a-match.com", result!!.domain)
+    }
+
+    @Test
+    fun whenMultipleNonMatchesThenMostRecentlyModifiedIsReturned() {
+        val input = listOf(
+            creds("not-a-match.com", 2000),
+            creds("also-not-a-match.com", 1000),
+        )
+        val result = testee.findBestMatch("example.com", input)
+        assertEquals("not-a-match.com", result!!.domain)
+    }
+
+    @Test
+    fun whenMatchesFromAllTypesThenMatchInPerfectReturnedRegardlessOfTimestamps() {
+        val input = listOf(
+            creds("perfect-match.com", 1000),
+            creds("imperfect-match.com", 3000),
+            creds("not-a-match.com", 2000),
+        )
+        val result = testee.findBestMatch("perfect-match.com", input)
+        assertEquals("perfect-match.com", result!!.domain)
+    }
+
+    private fun creds(domain: String, lastModified: Long?): LoginCredentials {
+        return LoginCredentials(domain = domain, lastUpdatedMillis = lastModified, username = "", password = "")
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealLoginDeduplicatorUsernameAndPasswordMatcherTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealLoginDeduplicatorUsernameAndPasswordMatcherTest.kt
@@ -1,0 +1,70 @@
+package com.duckduckgo.autofill.impl.deduper
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import org.junit.Assert.*
+import org.junit.Test
+
+class RealLoginDeduplicatorUsernameAndPasswordMatcherTest {
+    private val testee = RealAutofillDeduplicationUsernameAndPasswordMatcher()
+
+    @Test
+    fun whenEmptyListInThenEmptyListOut() {
+        val input = emptyList<LoginCredentials>()
+        val output = testee.groupDuplicateCredentials(input)
+        assertTrue(output.isEmpty())
+    }
+
+    @Test
+    fun whenSingleEntryInThenSingleEntryOut() {
+        val input = listOf(
+            creds("username", "password"),
+        )
+        val output = testee.groupDuplicateCredentials(input)
+        assertEquals(1, output.size)
+    }
+
+    @Test
+    fun whenMultipleEntriesWithNoDuplicationAtAllThenNumberOfGroupsReturnedMatchesNumberOfEntriesInputted() {
+        val input = listOf(
+            creds("username_a", "password_x"),
+            creds("username_b", "password_y"),
+            creds("username_c", "password_z"),
+        )
+        val output = testee.groupDuplicateCredentials(input)
+        assertEquals(3, output.size)
+    }
+
+    @Test
+    fun whenEntriesMatchOnUsernameButNotPasswordThenNotGrouped() {
+        val input = listOf(
+            creds("username", "password_x"),
+            creds("username", "password_y"),
+        )
+        val output = testee.groupDuplicateCredentials(input)
+        assertEquals(2, output.size)
+    }
+
+    @Test
+    fun whenEntriesMatchOnPasswordButNotUsernameThenNotGrouped() {
+        val input = listOf(
+            creds("username_a", "password"),
+            creds("username_b", "password"),
+        )
+        val output = testee.groupDuplicateCredentials(input)
+        assertEquals(2, output.size)
+    }
+
+    @Test
+    fun whenEntriesMatchOnUsernameAndPasswordThenGrouped() {
+        val input = listOf(
+            creds("username", "password"),
+            creds("username", "password"),
+        )
+        val output = testee.groupDuplicateCredentials(input)
+        assertEquals(1, output.size)
+    }
+
+    private fun creds(username: String, password: String): LoginCredentials {
+        return LoginCredentials(username = username, password = password, domain = "domain")
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealLoginSorterForDeduplicationTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealLoginSorterForDeduplicationTest.kt
@@ -1,0 +1,80 @@
+package com.duckduckgo.autofill.impl.deduper
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import org.junit.Assert.*
+import org.junit.Test
+
+class RealLoginSorterForDeduplicationTest {
+
+    private val testee = AutofillDeduplicationLoginComparator()
+
+    @Test
+    fun whenFirstLoginIsNewerThenReturnNegative() {
+        val login1 = creds(lastUpdated = 2000, domain = null)
+        val login2 = creds(lastUpdated = 1000, domain = null)
+        assertTrue(testee.compare(login1, login2) < 0)
+    }
+
+    @Test
+    fun whenSecondLoginIsNewerThenReturnPositive() {
+        val login1 = creds(lastUpdated = 1000, domain = null)
+        val login2 = creds(lastUpdated = 2000, domain = null)
+        assertTrue(testee.compare(login1, login2) > 0)
+    }
+
+    @Test
+    fun whenFirstLoginHasNoLastModifiedTimestampThenReturnsNegative() {
+        val login1 = creds(lastUpdated = null, domain = null)
+        val login2 = creds(lastUpdated = 2000, domain = null)
+        assertTrue(testee.compare(login1, login2) < 0)
+    }
+
+    @Test
+    fun whenSecondLoginHasNoLastModifiedTimestampThenReturnsPositive() {
+        val login1 = creds(lastUpdated = 1000, domain = null)
+        val login2 = creds(lastUpdated = null, domain = null)
+        assertTrue(testee.compare(login1, login2) > 0)
+    }
+
+    @Test
+    fun whenLastModifiedTimesEqualAndFirstLoginDomainShouldBeSortedFirstThenReturnsNegative() {
+        val login1 = creds(lastUpdated = 1000, domain = "example.com")
+        val login2 = creds(lastUpdated = 1000, domain = "site.com")
+        assertTrue(testee.compare(login1, login2) < 0)
+    }
+
+    @Test
+    fun whenLastModifiedTimesEqualAndSecondLoginDomainShouldBeSortedFirstThenReturnsNegative() {
+        val login1 = creds(lastUpdated = 1000, domain = "site.com")
+        val login2 = creds(lastUpdated = 1000, domain = "example.com")
+        assertTrue(testee.compare(login1, login2) > 0)
+    }
+
+    @Test
+    fun whenLastModifiedTimesEqualAndDomainsEqualThenReturns0() {
+        val login1 = creds(lastUpdated = 1000, domain = "example.com")
+        val login2 = creds(lastUpdated = 1000, domain = "example.com")
+        assertEquals(0, testee.compare(login1, login2))
+    }
+
+    @Test
+    fun whenLastModifiedDatesMissingAndDomainMissingThenReturns0() {
+        val login1 = creds(lastUpdated = null, domain = null)
+        val login2 = creds(lastUpdated = null, domain = null)
+        assertEquals(0, testee.compare(login1, login2))
+    }
+
+    @Test
+    fun whenLoginsSameLastUpdatedTimeThenReturn0() {
+        val login1 = creds(lastUpdated = 1000, domain = null)
+        val login2 = creds(lastUpdated = 1000, domain = null)
+        assertEquals(0, testee.compare(login1, login2))
+    }
+
+    private fun creds(
+        lastUpdated: Long?,
+        domain: String? = "example.com",
+    ): LoginCredentials {
+        return LoginCredentials(id = 0, lastUpdatedMillis = lastUpdated, domain = domain, username = "username", password = "password")
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDisablingDeclineCounterTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDisablingDeclineCounterTest.kt
@@ -146,7 +146,7 @@ class AutofillDisablingDeclineCounterTest {
     }
 
     private fun configureGlobalDeclineCountAtThreshold() {
-        whenever(autofillStore.autofillDeclineCount).thenReturn(3)
+        whenever(autofillStore.autofillDeclineCount).thenReturn(2)
     }
 
     private fun assertDeclineNotRecorded() {

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -26,16 +26,26 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
+import com.duckduckgo.autofill.api.store.AutofillStore
 import com.duckduckgo.autofill.impl.email.incontext.store.EmailProtectionInContextDataStore
+import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementActivity
+import com.duckduckgo.autofill.internal.R.string
 import com.duckduckgo.autofill.internal.databinding.ActivityAutofillInternalSettingsBinding
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.ui.view.dialog.RadioListAlertDialogBuilder
+import com.duckduckgo.mobile.android.ui.view.dialog.RadioListAlertDialogBuilder.EventListener
+import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
+import java.text.SimpleDateFormat
+import java.util.*
 import javax.inject.Inject
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import logcat.logcat
 
 @InjectWith(ActivityScope::class)
 class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
@@ -54,6 +64,11 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var dispatchers: DispatcherProvider
 
+    @Inject
+    lateinit var autofillStore: AutofillStore
+
+    private val dateFormatter = SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.MEDIUM, SimpleDateFormat.MEDIUM)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
@@ -64,29 +79,119 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
     }
 
     private fun configureUiEventHandlers() {
+        configureEmailProtectionUiEventHandlers()
+        configureLoginsUiEventHandlers()
+    }
+
+    private fun configureLoginsUiEventHandlers() {
+        binding.addSampleLoginsButton.setClickListener {
+            val timestamp = dateFormatter.format(System.currentTimeMillis())
+            lifecycleScope.launch(dispatchers.io()) {
+                sampleCredentials(domain = "fill.dev", username = "alice-$timestamp", password = "alice-$timestamp").save()
+                sampleCredentials(domain = "fill.dev", username = "bob-$timestamp", password = "bob-$timestamp").save()
+                sampleCredentials(domain = "subdomain1.fill.dev", username = "charlie-$timestamp", password = "charlie-$timestamp").save()
+                sampleCredentials(domain = "subdomain2.fill.dev", username = "daniel-$timestamp", password = "daniel-$timestamp").save()
+            }
+        }
+
+        binding.addSampleLoginsContainingDuplicatesSameDomainButton.setClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                repeat(3) { sampleCredentials(domain = "fill.dev", username = "user").save() }
+            }
+        }
+
+        binding.addSampleLoginsContainingDuplicatesAcrossSubdomainsButton.setClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                repeat(3) { sampleCredentials("https://subdomain$it.fill.dev", username = "user").save() }
+            }
+        }
+
+        binding.clearAllSavedLoginsButton.setClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                val count = autofillStore.getCredentialCount().first()
+                withContext(dispatchers.main()) {
+                    confirmLoginDeletion(count)
+                }
+            }
+        }
+
+        // keep the number of saved logins up-to-date
+        lifecycleScope.launch(dispatchers.main()) {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                autofillStore.getCredentialCount().collect { count ->
+                    binding.clearAllSavedLoginsButton.isEnabled = count > 0
+                    binding.clearAllSavedLoginsButton.setSecondaryText(getString(string.autofillDevSettingsClearLoginsSubtitle, count))
+                }
+            }
+        }
+
+        binding.viewSavedLoginsButton.setClickListener {
+            startActivity(AutofillManagementActivity.intentDefaultList(this))
+        }
+    }
+
+    private fun confirmLoginDeletion(count: Int) {
+        TextAlertDialogBuilder(this@AutofillInternalSettingsActivity)
+            .setTitle(string.autofillDevSettingsClearLogins)
+            .setMessage(getString(string.autofillDevSettingsClearLoginsConfirmationMessage, count))
+            .setDestructiveButtons(true)
+            .setPositiveButton(string.autofillDevSettingsClearLoginsDeleteButton)
+            .setNegativeButton(string.autofillDevSettingsClearLoginsCancelButton)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        onUserChoseToClearSavedLogins()
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun onUserChoseToClearSavedLogins() {
+        lifecycleScope.launch(dispatchers.io()) {
+            val idsToDelete = mutableListOf<Long>()
+            autofillStore.getAllCredentials().first().forEach { login ->
+                login.id?.let {
+                    idsToDelete.add(it)
+                }
+            }
+
+            logcat { "There are ${idsToDelete.size} logins to delete" }
+
+            idsToDelete.forEach {
+                autofillStore.deleteCredentials(it)
+            }
+
+            withContext(dispatchers.main()) {
+                Toast.makeText(this@AutofillInternalSettingsActivity, "Deleted %d logins".format(idsToDelete.size), Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun configureEmailProtectionUiEventHandlers() {
         binding.emailProtectionClearNeverAskAgainButton.setClickListener {
             lifecycleScope.launch(dispatchers.io()) {
                 inContextDataStore.resetNeverAskAgainChoice()
-                getString(R.string.autofillDevSettingsEmailProtectionNeverAskAgainChoiceCleared).showToast()
+                getString(string.autofillDevSettingsEmailProtectionNeverAskAgainChoiceCleared).showToast()
             }
         }
 
         binding.emailProtectionSignOutButton.setClickListener {
             lifecycleScope.launch(dispatchers.io()) {
                 emailManager.signOut()
-                getString(R.string.autofillDevSettingsEmailProtectionSignedOut).showToast()
+                getString(string.autofillDevSettingsEmailProtectionSignedOut).showToast()
             }
         }
 
         @Suppress("DEPRECATION")
         binding.configureDaysFromInstallValue.setClickListener {
             RadioListAlertDialogBuilder(this)
-                .setTitle(R.string.autofillDevSettingsOverrideMaxInstallDialogTitle)
+                .setTitle(string.autofillDevSettingsOverrideMaxInstallDialogTitle)
                 .setOptions(daysInstalledOverrideOptions().map { it.first })
-                .setPositiveButton(R.string.autofillDevSettingsOverrideMaxInstallDialogOkButtonText)
-                .setNegativeButton(R.string.autofillDevSettingsOverrideMaxInstallDialogCancelButtonText)
+                .setPositiveButton(string.autofillDevSettingsOverrideMaxInstallDialogOkButtonText)
+                .setNegativeButton(string.autofillDevSettingsOverrideMaxInstallDialogCancelButtonText)
                 .addEventListener(
-                    object : RadioListAlertDialogBuilder.EventListener() {
+                    object : EventListener() {
                         override fun onPositiveButtonClicked(selectedItem: Int) {
                             val daysInstalledOverrideChosen = daysInstalledOverrideOptions()[selectedItem - 1].second
 
@@ -154,6 +259,20 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
             Pair(getString(R.string.autofillDevSettingsOverrideMaxInstalledOptionNumberDays, 21), 21),
             Pair(getString(R.string.autofillDevSettingsOverrideMaxInstalledOptionAlways), Int.MAX_VALUE),
         )
+    }
+
+    private suspend fun LoginCredentials.save() {
+        withContext(dispatchers.io()) {
+            autofillStore.saveCredentials(this@save.domain ?: "", this@save)
+        }
+    }
+
+    private fun sampleCredentials(
+        domain: String = "fill.dev",
+        username: String,
+        password: String = "password-123",
+    ): LoginCredentials {
+        return LoginCredentials(username = username, password = password, domain = domain)
     }
 
     companion object {

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -27,6 +27,51 @@
         layout="@layout/include_default_toolbar" />
 
     <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
+        android:id="@+id/autofillLoginsSectionTitle"
+        android:layout_width="match_parent"
+        android:layout_marginTop="20dp"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/autofillDevSettingsLoginsSectionTitle" />
+
+    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+        android:id="@+id/addSampleLoginsButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/autofillDevSettingsAddSampleLogins"
+        app:secondaryText="@string/autofillDevSettingsAddSampleLoginsSubtitle" />
+
+    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+        android:id="@+id/addSampleLoginsContainingDuplicatesSameDomainButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/autofillDevSettingsAddSampleLoginsSameSubdomain"
+        app:secondaryText="@string/autofillDevSettingsAddSampleLoginsSameSubdomainSubtitle" />
+
+    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+        android:id="@+id/addSampleLoginsContainingDuplicatesAcrossSubdomainsButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/autofillDevSettingsAddSampleLoginsMultipleSubdomains"
+        app:secondaryText="@string/autofillDevSettingsAddSampleLoginsMultipleSubdomainsSubtitle" />
+
+    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+        android:id="@+id/clearAllSavedLoginsButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/autofillDevSettingsClearLogins"
+        tools:secondaryText="@string/autofillDevSettingsClearLoginsSubtitle" />
+
+    <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
+        android:id="@+id/viewSavedLoginsButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/autofillDevSettingsViewSavedLogins" />
+
+    <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
         android:id="@+id/emailProtectionInContextSectionTitle"
         android:layout_width="match_parent"
         android:layout_marginTop="20dp"

--- a/autofill/autofill-internal/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-internal/src/main/res/values/donottranslate.xml
@@ -40,4 +40,19 @@
 
     <string name="autofillDevSettingsDaysSinceInstall" instruction="%1$d is number of days since app since app was app was installed">Days since app was installed: %1$d</string>
     <string name="autofillDevSettingsOverrideTapToChange">Tap to change this rule</string>
+
+    <string name="autofillDevSettingsLoginsSectionTitle">Logins</string>
+    <string name="autofillDevSettingsClearLogins">Delete all saved logins</string>
+    <string name="autofillDevSettingsClearLoginsConfirmationMessage" instruction="%1$d is number of saved logins">Are you sure you want to delete %1$d logins?</string>
+    <string name="autofillDevSettingsClearLoginsDeleteButton">Delete</string>
+    <string name="autofillDevSettingsClearLoginsCancelButton">Cancel</string>
+    <string name="autofillDevSettingsClearLoginsSubtitle" instruction="%1$d is number of saved logins">Number of saved logins: %1$d</string>
+    <string name="autofillDevSettingsViewSavedLogins">View saved logins</string>
+
+    <string name="autofillDevSettingsAddSampleLogins">Add a few sample logins</string>
+    <string name="autofillDevSettingsAddSampleLoginsSubtitle">Adds a few logins for https://fill.dev</string>
+    <string name="autofillDevSettingsAddSampleLoginsSameSubdomain">Add duplicate logins (same domain)</string>
+    <string name="autofillDevSettingsAddSampleLoginsSameSubdomainSubtitle">Adds multiple logins for https://fill.dev with same username and password</string>
+    <string name="autofillDevSettingsAddSampleLoginsMultipleSubdomains">Add duplicate logins (across different subdomains)</string>
+    <string name="autofillDevSettingsAddSampleLoginsMultipleSubdomainsSubtitle">Adds multiple logins for https://fill.dev with same username and password but across different subdomains</string>
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205768484548248/f

### Description
Adds dev settings for autofill logins, allowing for quickly:

- adding some sample logins
- adding duplicate logins for the same domain
- adding duplicate logins for same e-TLD+1 but different subdomains
- deleting all saved logins

### Steps to test this PR

- [ ] Visit Settings->Autofill Dev Settings
- [ ] Tap `Add a few sample logins`, tap `View saved logins`, and verify you see 4 logins
- [ ] Revisit dev settings, and tap `Delete all saved logins` and confirm. Verify `Number of saved logins: ` shows 0
- [ ] Tap `Add duplicate logins (same domain)`, tap `View saved logins`, and verify you see 3 identical logins
- [ ] Revisit dev settings, and tap `Delete all saved logins` and confirm.
- [ ] Tap `Add duplicate logins (same domain)`, tap `View saved logins`, and verify you see 3 logins, which differ only because of their subdomains

![combined](https://github.com/duckduckgo/Android/assets/1336281/cf1d80f0-c3d7-4ba5-80c6-1cc353616e4e)

