### PR TITLE
Update content scope scripts to version 4.41.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7467,6 +7467,17 @@
                 const settings = this.getFeatureSettingEnabled('permissions');
                 this.permissionsFix(settings);
             }
+            if (this.getFeatureSettingEnabled('cleanIframeValue')) {
+                this.cleanIframeValue();
+            }
+
+            if (this.getFeatureSettingEnabled('mediaSession')) {
+                this.mediaSessionFix();
+            }
+
+            if (this.getFeatureSettingEnabled('presentation')) {
+                this.presentationFix();
+            }
         }
 
         /**
@@ -7491,6 +7502,40 @@
                 writable: true,
                 configurable: true,
                 enumerable: false
+            });
+        }
+
+        cleanIframeValue () {
+            function cleanValueData (val) {
+                const clone = Object.assign({}, val);
+                const deleteKeys = ['iframeProto', 'iframeData', 'remap'];
+                for (const key of deleteKeys) {
+                    if (key in clone) {
+                        delete clone[key];
+                    }
+                }
+                val.iframeData = clone;
+                return val
+            }
+
+            window.XMLHttpRequest.prototype.send = new Proxy(window.XMLHttpRequest.prototype.send, {
+                apply (target, thisArg, args) {
+                    const body = args[0];
+                    const cleanKey = 'bi_wvdp';
+                    if (body && typeof body === 'string' && body.includes(cleanKey)) {
+                        const parts = body.split('&').map((part) => { return part.split('=') });
+                        if (parts.length > 0) {
+                            parts.forEach((part) => {
+                                if (part[0] === cleanKey) {
+                                    const val = JSON.parse(decodeURIComponent(part[1]));
+                                    part[1] = encodeURIComponent(JSON.stringify(cleanValueData(val)));
+                                }
+                            });
+                            args[0] = parts.map((part) => { return part.join('=') }).join('&');
+                        }
+                    }
+                    return Reflect.apply(target, thisArg, args)
+                }
             });
         }
 
@@ -7519,7 +7564,7 @@
                 'midi'
             ];
             const validPermissionNames = settings.validPermissionNames || defaultValidPermissionNames;
-            permissions.query = (query) => {
+            permissions.query = new Proxy((query) => {
                 this.addDebugFlag();
                 if (!query) {
                     throw new TypeError("Failed to execute 'query' on 'Permissions': 1 argument required, but only 0 present.")
@@ -7531,7 +7576,11 @@
                     throw new TypeError("Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': The provided value 's' is not a valid enum value of type PermissionName.")
                 }
                 return Promise.resolve(new PermissionStatus(query.name, 'denied'))
-            };
+            }, {
+                get (target, name) {
+                    return Reflect.get(target, name)
+                }
+            });
             // Expose the API
             // @ts-expect-error window.navigator isn't assignable
             window.navigator.permissions = permissions;
@@ -7611,6 +7660,87 @@
                         const reason = "Invalid 'callback' value passed to safari.pushNotification.requestPermission(). Expected a function.";
                         throw new Error(reason)
                     },
+                    configurable: true,
+                    enumerable: true
+                });
+            } catch {
+                // Ignore exceptions that could be caused by conflicting with other extensions
+            }
+        }
+
+        mediaSessionFix () {
+            try {
+                if (window.navigator.mediaSession) {
+                    return
+                }
+
+                this.defineProperty(window.navigator, 'mediaSession', {
+                    value: {
+                    },
+                    writable: true,
+                    configurable: true,
+                    enumerable: true
+                });
+                this.defineProperty(window.navigator.mediaSession, 'metadata', {
+                    value: null,
+                    writable: true,
+                    configurable: false,
+                    enumerable: false
+                });
+                this.defineProperty(window.navigator.mediaSession, 'playbackState', {
+                    value: 'none',
+                    writable: true,
+                    configurable: false,
+                    enumerable: false
+                });
+                this.defineProperty(window.navigator.mediaSession, 'setActionHandler', {
+                    value: () => {},
+                    configurable: true,
+                    enumerable: true
+                });
+                this.defineProperty(window.navigator.mediaSession, 'setCameraActive', {
+                    value: () => {},
+                    configurable: true,
+                    enumerable: true
+                });
+                this.defineProperty(window.navigator.mediaSession, 'setMicrophoneActive', {
+                    value: () => {},
+                    configurable: true,
+                    enumerable: true
+                });
+                this.defineProperty(window.navigator.mediaSession, 'setPositionState', {
+                    value: () => {},
+                    configurable: true,
+                    enumerable: true
+                });
+            } catch {
+                // Ignore exceptions that could be caused by conflicting with other extensions
+            }
+        }
+
+        presentationFix () {
+            try {
+                // @ts-expect-error due to: Property 'presentation' does not exist on type 'Navigator'
+                if (window.navigator.presentation) {
+                    return
+                }
+
+                this.defineProperty(window.navigator, 'presentation', {
+                    value: {
+                    },
+                    writable: true,
+                    configurable: true,
+                    enumerable: true
+                });
+                // @ts-expect-error due to: Property 'presentation' does not exist on type 'Navigator'
+                this.defineProperty(window.navigator.presentation, 'defaultRequest', {
+                    value: null,
+                    configurable: true,
+                    enumerable: true
+                });
+                // @ts-expect-error due to: Property 'presentation' does not exist on type 'Navigator'
+                this.defineProperty(window.navigator.presentation, 'receiver', {
+                    value: null,
                     configurable: true,
                     enumerable: true
                 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^5.1.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.40.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.41.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1692081744"
       },
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#254b23cf292140498650421bb31fd05740f4579b",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#e467598d20d55b5b32a8988f2ad6df336331d2b9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -267,9 +267,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
-      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "version": "20.8.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.8.tgz",
+      "integrity": "sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.25.1"
@@ -517,6 +517,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -574,15 +583,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -590,6 +590,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -638,12 +650,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^5.1.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.40.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.41.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1692081744"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205790416790343/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass