### PR TITLE
Android: Update the "browser" remote flag name

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
-import com.duckduckgo.app.pixels.remoteconfig.BrowserFeature
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.DEFAULT_BROWSER
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.WEBVIEW_FULL_VERSION
@@ -48,7 +48,7 @@ class EnqueuedPixelWorker @Inject constructor(
     private val unsentForgetAllPixelStore: UnsentForgetAllPixelStore,
     private val webViewVersionProvider: WebViewVersionProvider,
     private val defaultBrowserDetector: DefaultBrowserDetector,
-    private val browserFeature: BrowserFeature,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : MainProcessLifecycleObserver {
 
     private var launchedByFireAction: Boolean = false
@@ -66,7 +66,8 @@ class EnqueuedPixelWorker @Inject constructor(
             return
         }
         Timber.i("Sending app launch pixel")
-        val collectWebViewFullVersion = browserFeature.self().isEnabled() && browserFeature.collectFullWebViewVersion().isEnabled()
+        val collectWebViewFullVersion =
+            androidBrowserConfigFeature.self().isEnabled() && androidBrowserConfigFeature.collectFullWebViewVersion().isEnabled()
         val paramsMap = mutableMapOf<String, String>().apply {
             put(WEBVIEW_VERSION, webViewVersionProvider.getMajorVersion())
             put(DEFAULT_BROWSER, defaultBrowserDetector.isDefaultBrowser().toString())

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -25,19 +25,20 @@ import com.duckduckgo.feature.toggles.api.Toggle
  */
 @ContributesRemoteFeature(
     scope = AppScope::class,
-    featureName = "browser",
+    featureName = "androidBrowserConfig",
 )
-interface BrowserFeature {
+interface AndroidBrowserConfigFeature {
 
     /**
-     * @return `true` when the remote config has the global "browser" feature flag enabled
+     * @return `true` when the remote config has the global "androidBrowserConfig" feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
     @Toggle.DefaultValue(false)
     fun self(): Toggle
 
     /**
-     * @return `true` when the remote config has the global "collectFullWebViewVersion" browser sub-feature flag enabled
+     * @return `true` when the remote config has the global "collectFullWebViewVersion" androidBrowserConfig
+     * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
     @Toggle.DefaultValue(false)

--- a/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
@@ -21,7 +21,7 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
-import com.duckduckgo.app.pixels.remoteconfig.BrowserFeature
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -36,7 +36,7 @@ class EnqueuedPixelWorkerTest {
     private val lifecycleOwner: LifecycleOwner = mock()
     private val webViewVersionProvider: WebViewVersionProvider = mock()
     private val defaultBrowserDetector: DefaultBrowserDetector = mock()
-    private val mockBrowserFeature: BrowserFeature = mock()
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = mock()
 
     private lateinit var enqueuedPixelWorker: EnqueuedPixelWorker
 
@@ -48,7 +48,7 @@ class EnqueuedPixelWorkerTest {
             unsentForgetAllPixelStore,
             webViewVersionProvider,
             defaultBrowserDetector,
-            mockBrowserFeature,
+            androidBrowserConfigFeature,
         )
         setupRemoteConfig(browserEnabled = false, collectFullWebViewVersionEnabled = false)
     }
@@ -165,7 +165,7 @@ class EnqueuedPixelWorkerTest {
     }
 
     private fun setupRemoteConfig(browserEnabled: Boolean, collectFullWebViewVersionEnabled: Boolean) {
-        whenever(mockBrowserFeature.self()).thenReturn(
+        whenever(androidBrowserConfigFeature.self()).thenReturn(
             object : Toggle {
                 override fun isEnabled(): Boolean {
                     return browserEnabled
@@ -181,7 +181,7 @@ class EnqueuedPixelWorkerTest {
             },
         )
 
-        whenever(mockBrowserFeature.collectFullWebViewVersion()).thenReturn(
+        whenever(androidBrowserConfigFeature.collectFullWebViewVersion()).thenReturn(
             object : Toggle {
                 override fun isEnabled(): Boolean {
                     return collectFullWebViewVersionEnabled


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205787440131230/f

### Description
Change the name of the feature flag from `browser` to `androidBrowserConfig`.

### Steps to test this PR

- [ ] Sample privacy-config in task description. Use the URL as value for PRIVACY_REMOTE_CONFIG_URL for testing.
- [ ] When both `androidBrowserConfig` and `collectFullWebViewVersion` are enabled you should see the full webview version sent with the `ml` pixel.

### NO UI changes
