### PR TITLE
Make reason optional for unprotected temporary

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
@@ -215,9 +215,7 @@ class FirstPartyCookiesReferenceTest(private val testCase: TestCase) {
             maxAge = cookieFeature.settings.firstPartyCookiePolicy.maxAge,
         )
 
-        val unprotectedTemporaryExceptions = config?.unprotectedTemporary?.map {
-            it.toFeatureException()
-        }
+        val unprotectedTemporaryExceptions = config?.unprotectedTemporary
 
         whenever(cookiesRepository.exceptions).thenReturn(CopyOnWriteArrayList(cookieExceptions))
         whenever(cookiesRepository.firstPartyCookiePolicy).thenReturn(policy)

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/HttpsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/HttpsReferenceTest.kt
@@ -168,9 +168,7 @@ class HttpsReferenceTest(private val testCase: TestCase) {
         }
 
         val isEnabled = httpsFeature?.state == "enabled"
-        val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(
-            config?.unprotectedTemporary?.map { it.toFeatureException() } ?: emptyList(),
-        )
+        val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(config?.unprotectedTemporary.orEmpty())
 
         whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.HttpsFeatureName.value, isEnabled)).thenReturn(isEnabled)
         whenever(mockHttpsRepository.exceptions).thenReturn(CopyOnWriteArrayList(httpsExceptions))

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.privacy.config.store.PrivacyConfig
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
+import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -88,7 +89,12 @@ class RealPrivacyConfigPersister @Inject constructor(
                         ),
                     ),
                 )
-                unprotectedTemporaryRepository.updateAll(jsonPrivacyConfig.unprotectedTemporary)
+                val unProtectedExceptions = mutableListOf<UnprotectedTemporaryEntity>()
+                val unprotectedList = jsonPrivacyConfig.unprotectedTemporary
+                unprotectedList.map {
+                    unProtectedExceptions.add(UnprotectedTemporaryEntity(it.domain, it.reason.orEmpty()))
+                }
+                unprotectedTemporaryRepository.updateAll(unProtectedExceptions)
                 jsonPrivacyConfig.features.forEach { feature ->
                     feature.value?.let { jsonObject ->
                         privacyFeaturePluginPoint.getPlugins().firstOrNull { feature.key == it.featureName }?.let { featurePlugin ->

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/models/JsonPrivacyConfig.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/models/JsonPrivacyConfig.kt
@@ -16,12 +16,12 @@
 
 package com.duckduckgo.privacy.config.impl.models
 
-import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import org.json.JSONObject
 
 data class JsonPrivacyConfig(
     val version: Long,
     val readme: String,
     val features: Map<String, JSONObject?>,
-    val unprotectedTemporary: List<UnprotectedTemporaryEntity>,
+    val unprotectedTemporary: List<FeatureException>,
 )

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
@@ -18,11 +18,11 @@ package com.duckduckgo.privacy.config.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.impl.ConfigDownloadResult.Error
 import com.duckduckgo.privacy.config.impl.ConfigDownloadResult.Success
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.impl.network.PrivacyConfigService
-import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
@@ -96,6 +96,6 @@ class RealPrivacyConfigDownloaderTest {
     companion object {
         private const val FEATURE_NAME = "test"
         private const val FEATURE_JSON = "{\"state\": \"enabled\"}"
-        val unprotectedTemporaryList = listOf(UnprotectedTemporaryEntity("example.com", "reason"))
+        val unprotectedTemporaryList = listOf(FeatureException("example.com", "reason"))
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
@@ -23,6 +23,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.api.InMemorySharedPreferences
 import com.duckduckgo.app.global.plugins.PluginPoint
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
@@ -31,7 +32,6 @@ import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
 import com.duckduckgo.privacy.config.store.PrivacyFeatureTogglesRepository
 import com.duckduckgo.privacy.config.store.RealPrivacyConfigRepository
-import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.RealUnprotectedTemporaryRepository
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -245,6 +245,6 @@ class RealPrivacyConfigPersisterTest {
     companion object {
         private const val FEATURE_NAME = "gpc"
         private const val FEATURE_JSON = "{\"state\": \"enabled\"}"
-        val unprotectedTemporaryList = listOf(UnprotectedTemporaryEntity("example.com", "reason"))
+        val unprotectedTemporaryList = listOf(FeatureException("example.com", "reason"))
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/gpc/GpcHeaderReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/gpc/GpcHeaderReferenceTest.kt
@@ -30,7 +30,6 @@ import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.duckduckgo.privacy.config.store.GpcExceptionEntity
 import com.duckduckgo.privacy.config.store.features.gpc.GpcRepository
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
-import com.duckduckgo.privacy.config.store.toFeatureException
 import com.duckduckgo.privacy.config.store.toGpcException
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -103,9 +102,7 @@ class GpcHeaderReferenceTest(private val testCase: TestCase) {
         }
 
         val isEnabled = gpcFeature?.state == "enabled"
-        val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(
-            config?.unprotectedTemporary?.map { it.toFeatureException() } ?: emptyList(),
-        )
+        val exceptionsUnprotectedTemporary = CopyOnWriteArrayList(config?.unprotectedTemporary.orEmpty())
 
         whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value, isEnabled)).thenReturn(isEnabled)
         whenever(mockGpcRepository.exceptions).thenReturn(CopyOnWriteArrayList(gpcExceptions))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205795095480230/f 

### Description
This PR makes reason optional for unprotected temporary.

### Steps to test this PR

- [x] Go to internal settings and override remote config URL
- [x] Use `https://jsonblob.com/api/1166656571567890432` as the remote config
- [x] Click the force load config button, config should load.
- [x] Go to marcos.com it should say that protections are temporarily disabled.
