### PR TITLE
Integrate with remote config to determine if autofill is on by default

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -56,4 +56,11 @@ interface AutofillFeature {
      */
     @Toggle.DefaultValue(false)
     fun canAccessCredentialManagement(): Toggle
+
+    /**
+     * @return `true` when the remote config has the global "onByDefault" autofill sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(false)
+    fun onByDefault(): Toggle
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/di/AutofillModule.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/di/AutofillModule.kt
@@ -21,6 +21,7 @@ import androidx.room.Room
 import com.duckduckgo.anvil.annotations.ContributesPluginPoint
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.api.AutofillFragmentResultsPlugin
 import com.duckduckgo.autofill.api.InternalTestUserChecker
 import com.duckduckgo.autofill.impl.encoding.UrlUnicodeNormalizer
@@ -35,12 +36,15 @@ import com.duckduckgo.autofill.store.LastUpdatedTimeProvider
 import com.duckduckgo.autofill.store.RealAutofillPrefsStore
 import com.duckduckgo.autofill.store.RealInternalTestUserStore
 import com.duckduckgo.autofill.store.RealLastUpdatedTimeProvider
+import com.duckduckgo.autofill.store.feature.AutofillDefaultStateDecider
 import com.duckduckgo.autofill.store.feature.AutofillFeatureRepository
+import com.duckduckgo.autofill.store.feature.RealAutofillDefaultStateDecider
 import com.duckduckgo.autofill.store.feature.RealAutofillFeatureRepository
 import com.duckduckgo.autofill.store.feature.email.incontext.ALL_MIGRATIONS as EmailInContextMigrations
 import com.duckduckgo.autofill.store.feature.email.incontext.EmailProtectionInContextDatabase
 import com.duckduckgo.autofill.store.feature.email.incontext.EmailProtectionInContextFeatureRepository
 import com.duckduckgo.autofill.store.feature.email.incontext.RealEmailProtectionInContextFeatureRepository
+import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -63,9 +67,22 @@ class AutofillModule {
     @Provides
     fun provideAutofillPrefsStore(
         context: Context,
-        internalTestUserChecker: InternalTestUserChecker,
+        autofillDefaultStateDecider: AutofillDefaultStateDecider,
     ): AutofillPrefsStore {
-        return RealAutofillPrefsStore(context, internalTestUserChecker)
+        return RealAutofillPrefsStore(context, autofillDefaultStateDecider)
+    }
+
+    @Provides
+    fun providerAutofillDefaultStateProvider(
+        userBrowserProperties: UserBrowserProperties,
+        autofillFeature: AutofillFeature,
+        internalTestUserChecker: InternalTestUserChecker,
+    ): AutofillDefaultStateDecider {
+        return RealAutofillDefaultStateDecider(
+            userBrowserProperties = userBrowserProperties,
+            autofillFeature = autofillFeature,
+            internalTestUserChecker = internalTestUserChecker,
+        )
     }
 
     @Provides

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillCapabilityCheckerImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillCapabilityCheckerImplTest.kt
@@ -17,13 +17,12 @@
 package com.duckduckgo.autofill.impl
 
 import com.duckduckgo.app.CoroutineTestRule
-import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.api.InternalTestUserChecker
-import com.duckduckgo.feature.toggles.api.Toggle
-import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.api.toggle.AutofillTestFeature
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.*
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -136,13 +135,13 @@ class AutofillCapabilityCheckerImplTest {
         canGeneratePassword: Boolean = false,
         canAccessCredentialManagement: Boolean = false,
     ) {
-        val autofillFeature = AutofillTestFeature(
-            topLevelFeatureEnabled = topLevelFeatureEnabled,
-            canInjectCredentials = canInjectCredentials,
-            canSaveCredentials = canSaveCredentials,
-            canGeneratePassword = canGeneratePassword,
-            canAccessCredentialManagement = canAccessCredentialManagement,
-        )
+        val autofillFeature = AutofillTestFeature().also {
+            it.topLevelFeatureEnabled = topLevelFeatureEnabled
+            it.canInjectCredentials = canInjectCredentials
+            it.canGeneratePassword = canGeneratePassword
+            it.canSaveCredentials = canSaveCredentials
+            it.canAccessCredentialManagement = canAccessCredentialManagement
+        }
 
         whenever(autofillGlobalCapabilityChecker.isSecureAutofillAvailable()).thenReturn(true)
         whenever(autofillGlobalCapabilityChecker.isAutofillEnabledByConfiguration(any())).thenReturn(true)
@@ -155,64 +154,6 @@ class AutofillCapabilityCheckerImplTest {
             autofillGlobalCapabilityChecker = autofillGlobalCapabilityChecker,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         )
-    }
-
-    private class AutofillTestFeature(
-        private val topLevelFeatureEnabled: Boolean,
-        private val canInjectCredentials: Boolean,
-        private val canSaveCredentials: Boolean,
-        private val canGeneratePassword: Boolean,
-        private val canAccessCredentialManagement: Boolean,
-    ) : AutofillFeature {
-        override fun self(): Toggle {
-            return object : Toggle {
-                override fun isEnabled(): Boolean = topLevelFeatureEnabled
-                override fun setEnabled(state: State) {}
-                override fun getRawStoredState(): State? {
-                    TODO("Not yet implemented")
-                }
-            }
-        }
-
-        override fun canInjectCredentials(): Toggle {
-            return object : Toggle {
-                override fun isEnabled(): Boolean = canInjectCredentials
-                override fun setEnabled(state: State) {}
-                override fun getRawStoredState(): State? {
-                    TODO("Not yet implemented")
-                }
-            }
-        }
-
-        override fun canSaveCredentials(): Toggle {
-            return object : Toggle {
-                override fun isEnabled(): Boolean = canSaveCredentials
-                override fun setEnabled(state: State) {}
-                override fun getRawStoredState(): State? {
-                    TODO("Not yet implemented")
-                }
-            }
-        }
-
-        override fun canGeneratePasswords(): Toggle {
-            return object : Toggle {
-                override fun isEnabled(): Boolean = canGeneratePassword
-                override fun setEnabled(state: State) {}
-                override fun getRawStoredState(): State? {
-                    TODO("Not yet implemented")
-                }
-            }
-        }
-
-        override fun canAccessCredentialManagement(): Toggle {
-            return object : Toggle {
-                override fun isEnabled(): Boolean = canAccessCredentialManagement
-                override fun setEnabled(state: State) {}
-                override fun getRawStoredState(): State? {
-                    TODO("Not yet implemented")
-                }
-            }
-        }
     }
 
     companion object {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/email/incontext/availability/RealEmailProtectionInContextAvailabilityRulesTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/email/incontext/availability/RealEmailProtectionInContextAvailabilityRulesTest.kt
@@ -7,7 +7,7 @@ import com.duckduckgo.autofill.impl.AutofillGlobalCapabilityChecker
 import com.duckduckgo.autofill.impl.email.incontext.EmailProtectionInContextSignupFeature
 import com.duckduckgo.autofill.impl.email.remoteconfig.EmailProtectionInContextExceptions
 import com.duckduckgo.feature.toggles.api.Toggle
-import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.api.toggle.TestToggle
 import java.util.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -113,12 +113,6 @@ class RealEmailProtectionInContextAvailabilityRulesTest {
         var enabled = true
 
         override fun self(): Toggle = TestToggle(enabled)
-    }
-
-    private open class TestToggle(val enabled: Boolean) : Toggle {
-        override fun getRawStoredState(): State? = null
-        override fun setEnabled(state: State) {}
-        override fun isEnabled() = enabled
     }
 
     companion object {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -24,6 +24,8 @@ import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.api.store.AutofillStore
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ExitCredentialMode
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ExitListMode
@@ -110,6 +112,18 @@ class AutofillSettingsViewModelTest {
             assertFalse(this.awaitItem().autofillEnabled)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenUserEnablesAutofillThenCorrectPixelFired() {
+        testee.onEnableAutofill()
+        verify(pixel).fire(AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED)
+    }
+
+    @Test
+    fun whenUserDisablesAutofillThenCorrectPixelFired() {
+        testee.onDisableAutofill()
+        verify(pixel).fire(AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED)
     }
 
     @Test

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/store/RealAutofillPrefsStoreTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/store/RealAutofillPrefsStoreTest.kt
@@ -1,0 +1,70 @@
+package com.duckduckgo.autofill.store
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.autofill.store.feature.AutofillDefaultStateDecider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class RealAutofillPrefsStoreTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val defaultStateDecider: AutofillDefaultStateDecider = mock()
+
+    private val testee = RealAutofillPrefsStore(
+        applicationContext = context,
+        defaultStateDecider = defaultStateDecider,
+    )
+
+    @Test
+    fun whenAutofillStateNeverSetManuallyThenDefaultStateDeciderUsed() {
+        testee.isEnabled
+        verify(defaultStateDecider).defaultState()
+    }
+
+    @Test
+    fun whenAutofillStateWasManuallySetToEnabledThenDefaultStateDeciderNotUsed() {
+        testee.isEnabled = true
+        testee.isEnabled
+        verify(defaultStateDecider, never()).defaultState()
+    }
+
+    @Test
+    fun whenAutofillStateWasManuallySetToDisabledThenDefaultStateDeciderNotUsed() {
+        testee.isEnabled = false
+        testee.isEnabled
+        verify(defaultStateDecider, never()).defaultState()
+    }
+
+    @Test
+    fun whenDeterminedEnabledByDefaultOnceThenNotDecidedAgain() {
+        // first call will decide default state should be enabled
+        whenever(defaultStateDecider.defaultState()).thenReturn(true)
+        assertTrue(testee.isEnabled)
+        verify(defaultStateDecider).defaultState()
+
+        // second call should not invoke decider again
+        assertTrue(testee.isEnabled)
+        verifyNoMoreInteractions(defaultStateDecider)
+    }
+
+    @Test
+    fun whenDeterminedNotEnabledByDefaultOnceThenWillCallToDeciderAgain() {
+        // first call will decide default state should not be enabled
+        whenever(defaultStateDecider.defaultState()).thenReturn(false)
+        assertFalse(testee.isEnabled)
+
+        // second call should invoke decider again
+        assertFalse(testee.isEnabled)
+        verify(defaultStateDecider, times(2)).defaultState()
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/store/feature/RealAutofillDefaultStateDeciderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/store/feature/RealAutofillDefaultStateDeciderTest.kt
@@ -1,0 +1,70 @@
+package com.duckduckgo.autofill.store.feature
+
+import com.duckduckgo.autofill.api.InternalTestUserChecker
+import com.duckduckgo.browser.api.UserBrowserProperties
+import com.duckduckgo.feature.toggles.api.toggle.AutofillTestFeature
+import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class RealAutofillDefaultStateDeciderTest {
+
+    private val userBrowserProperties: UserBrowserProperties = mock()
+    private val autofillFeature = AutofillTestFeature()
+    private val internalTestUserChecker: InternalTestUserChecker = mock()
+    private val testee = RealAutofillDefaultStateDecider(
+        userBrowserProperties = userBrowserProperties,
+        autofillFeature = autofillFeature,
+        internalTestUserChecker = internalTestUserChecker,
+    )
+
+    @Test
+    fun whenRemoteFeatureDisabledThenNumberOfDaysInstalledIsIrrelevant() {
+        configureRemoteFeatureEnabled(false)
+
+        configureDaysInstalled(0)
+        assertFalse(testee.defaultState())
+
+        configureDaysInstalled(1000)
+        assertFalse(testee.defaultState())
+    }
+
+    @Test
+    fun whenNumberOfDaysInstalledIsNotZeroThenFeatureFlagIsIrrelevant() {
+        configureDaysInstalled(0)
+
+        configureRemoteFeatureEnabled(false)
+        assertFalse(testee.defaultState())
+
+        configureRemoteFeatureEnabled(false)
+        assertFalse(testee.defaultState())
+    }
+
+    @Test
+    fun whenInternalTesterThenAlwaysEnabledByDefault() {
+        configureDaysInstalled(100)
+        configureRemoteFeatureEnabled(false)
+        configureAsInternalTester()
+        assertTrue(testee.defaultState())
+    }
+
+    @Test
+    fun whenInstalledSameDayAndFeatureFlagEnabledThenEnabledByDefault() {
+        configureDaysInstalled(0)
+        configureRemoteFeatureEnabled(true)
+        assertTrue(testee.defaultState())
+    }
+
+    private fun configureAsInternalTester() {
+        whenever(internalTestUserChecker.isInternalTestUser).thenReturn(true)
+    }
+
+    private fun configureRemoteFeatureEnabled(enabled: Boolean) {
+        autofillFeature.onByDefault = enabled
+    }
+
+    private fun configureDaysInstalled(daysInstalled: Long) {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(daysInstalled)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/feature/toggles/api/toggle/AutofillTestFeature.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/feature/toggles/api/toggle/AutofillTestFeature.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.api.toggle
+
+import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.feature.toggles.api.Toggle
+
+class AutofillTestFeature : AutofillFeature {
+    var topLevelFeatureEnabled: Boolean = false
+    var canInjectCredentials: Boolean = false
+    var canSaveCredentials: Boolean = false
+    var canGeneratePassword: Boolean = false
+    var canAccessCredentialManagement: Boolean = false
+    var onByDefault: Boolean = false
+
+    override fun self(): Toggle = TestToggle(topLevelFeatureEnabled)
+    override fun canInjectCredentials(): Toggle = TestToggle(canInjectCredentials)
+    override fun canSaveCredentials(): Toggle = TestToggle(canSaveCredentials)
+    override fun canGeneratePasswords(): Toggle = TestToggle(canGeneratePassword)
+    override fun canAccessCredentialManagement(): Toggle = TestToggle(canAccessCredentialManagement)
+    override fun onByDefault(): Toggle = TestToggle(onByDefault)
+}
+
+open class TestToggle(val enabled: Boolean) : Toggle {
+    override fun getRawStoredState(): Toggle.State? = null
+    override fun setEnabled(state: Toggle.State) {}
+    override fun isEnabled(): Boolean = enabled
+}

--- a/autofill/autofill-internal/src/main/AndroidManifest.xml
+++ b/autofill/autofill-internal/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <application>
         <activity
             android:name="com.duckduckgo.autofill.internal.AutofillInternalSettingsActivity"
-            android:exported="false"
+            android:exported="true"
             android:label="@string/autofillDevSettingsTitle"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity"
             />

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -14,97 +14,145 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".AutofillInternalSettingsActivity"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".AutofillInternalSettingsActivity">
+    android:layout_height="match_parent">
 
-    <include
-        android:id="@+id/includeToolbar"
-        layout="@layout/include_default_toolbar" />
-
-    <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
-        android:id="@+id/autofillLoginsSectionTitle"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_marginTop="20dp"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/autofillDevSettingsLoginsSectionTitle" />
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
-        android:id="@+id/addSampleLoginsButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/autofillDevSettingsAddSampleLogins"
-        app:secondaryText="@string/autofillDevSettingsAddSampleLoginsSubtitle" />
+        <include
+            android:id="@+id/includeToolbar"
+            layout="@layout/include_default_toolbar" />
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
-        android:id="@+id/addSampleLoginsContainingDuplicatesSameDomainButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/autofillDevSettingsAddSampleLoginsSameSubdomain"
-        app:secondaryText="@string/autofillDevSettingsAddSampleLoginsSameSubdomainSubtitle" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
+            android:id="@+id/autofillLoginsSectionTitle"
+            android:layout_width="match_parent"
+            android:layout_marginTop="20dp"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsLoginsSectionTitle" />
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
-        android:id="@+id/addSampleLoginsContainingDuplicatesAcrossSubdomainsButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/autofillDevSettingsAddSampleLoginsMultipleSubdomains"
-        app:secondaryText="@string/autofillDevSettingsAddSampleLoginsMultipleSubdomainsSubtitle" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/addSampleLoginsButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsAddSampleLogins"
+            app:secondaryText="@string/autofillDevSettingsAddSampleLoginsSubtitle" />
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
-        android:id="@+id/clearAllSavedLoginsButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/autofillDevSettingsClearLogins"
-        tools:secondaryText="@string/autofillDevSettingsClearLoginsSubtitle" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/addSampleLoginsContainingDuplicatesSameDomainButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsAddSampleLoginsSameSubdomain"
+            app:secondaryText="@string/autofillDevSettingsAddSampleLoginsSameSubdomainSubtitle" />
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
-        android:id="@+id/viewSavedLoginsButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/autofillDevSettingsViewSavedLogins" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/addSampleLoginsContainingDuplicatesAcrossSubdomainsButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsAddSampleLoginsMultipleSubdomains"
+            app:secondaryText="@string/autofillDevSettingsAddSampleLoginsMultipleSubdomainsSubtitle" />
 
-    <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/clearAllSavedLoginsButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsClearLogins"
+            tools:secondaryText="@string/autofillDevSettingsClearLoginsSubtitle" />
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
-        android:id="@+id/emailProtectionInContextSectionTitle"
-        android:layout_width="match_parent"
-        android:layout_marginTop="20dp"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/autofillDevSettingsEmailProtectionTitle" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
+            android:id="@+id/viewSavedLoginsButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsViewSavedLogins" />
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
-        android:id="@+id/emailProtectionClearNeverAskAgainButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/autofillDevSettingsClearNeverAskAgainSettingButton" />
+        <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
-        android:id="@+id/configureDaysFromInstallValue"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:secondaryText="@string/autofillDevSettingsOverrideTapToChange" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
+            android:id="@+id/emailProtectionInContextSectionTitle"
+            android:layout_width="match_parent"
+            android:layout_marginTop="20dp"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsEmailProtectionTitle" />
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
-        android:id="@+id/emailProtectionDaysSinceInstallValue"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:text="Days since install: 4" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
+            android:id="@+id/emailProtectionClearNeverAskAgainButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsClearNeverAskAgainSettingButton" />
 
-    <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
-        android:id="@+id/emailProtectionSignOutButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/autofillDevSettingsEmailProtectionSignOutButton" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/configureDaysFromInstallValue"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:secondaryText="@string/autofillDevSettingsOverrideTapToChange" />
 
-    <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        <com.duckduckgo.mobile.android.ui.view.listitem.OneLineListItem
+            android:id="@+id/emailProtectionDaysSinceInstallValue"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="Days since install: 4" />
+
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/emailProtectionSignOutButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsEmailProtectionSignOutButton" />
+
+        <com.duckduckgo.mobile.android.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.mobile.android.ui.view.listitem.SectionHeaderListItem
+            android:id="@+id/autofillRemoteConfigSectionTitle"
+            android:layout_width="match_parent"
+            android:layout_marginTop="20dp"
+            android:layout_height="wrap_content"
+            app:primaryText="Remote config" />
+
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/autofillTopLevelFeature"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="Autofill top-level feature" />
+
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/autofillOnByDefaultFeature"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="onByDefault" />
+
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/canSaveCredentialsFeature"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="canSaveCredentials" />
+
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/canInjectCredentialsFeature"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="canInjectCredentials" />
+
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/canGeneratePasswordsFeature"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="canGeneratePasswords" />
+
+        <com.duckduckgo.mobile.android.ui.view.listitem.TwoLineListItem
+            android:id="@+id/canAccessCredentialManagementFeature"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="canAccessCredentialManagement" />
 
 
-</LinearLayout>
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/autofill/autofill-store/build.gradle
+++ b/autofill/autofill-store/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(path: ':privacy-config-api')
     implementation project(path: ':feature-toggles-api')
     implementation project(path: ':app-build-config-api')
+    implementation project(path: ':browser-api')
 
     implementation AndroidX.core.ktx
     implementation AndroidX.appCompat

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/feature/AutofillDefaultStateDecider.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/feature/AutofillDefaultStateDecider.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.store.feature
+
+import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.api.InternalTestUserChecker
+import com.duckduckgo.browser.api.UserBrowserProperties
+import timber.log.Timber
+
+interface AutofillDefaultStateDecider {
+    fun defaultState(): Boolean
+}
+
+class RealAutofillDefaultStateDecider(
+    private val userBrowserProperties: UserBrowserProperties,
+    private val autofillFeature: AutofillFeature,
+    private val internalTestUserChecker: InternalTestUserChecker,
+) : AutofillDefaultStateDecider {
+
+    override fun defaultState(): Boolean {
+        if (internalTestUserChecker.isInternalTestUser) {
+            Timber.v("Internal testing user, enabling autofill by default")
+            return true
+        }
+
+        if (!autofillFeature.onByDefault().isEnabled()) {
+            return false
+        }
+
+        if (userBrowserProperties.daysSinceInstalled() > 0L) {
+            return false
+        }
+
+        Timber.i("Determined Autofill should be enabled by default")
+        return true
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205811927559467/f 

### Description
Integrates with remote config to determine if Autofill should be enabled by default, for new users only. 

- New remote config Autofill subfeature `onByDefault` will be introduced and incrementally rolled out 
- For now, a user will get Autofill enabled by default only if the incremental rollout enables it for a brand new user (installed today). If on the first day the incremental rollout determines a user:
    - can have it enabled by default, it'll be enabled. And this will be recorded locally so we know they had it enabled by default. 
    - can not have it enabled by default, it won't be enabled by default
    - Even if it later becomes available to them through the incremental rollout then they still won't have it on by default if that happens after the initial install day. (i.e., they can have the subfeature `onByDefault` return true but they still won't get it enabled by default)
- If we determine a user can have it enabled by default today, we'll save this setting so that it's on by default tomorrow and thereafter (even when they're not a new user)

### Steps to test this PR

Need to use `play` builds to properly test this, as `internal` builds default to enabled by default.

To make tester simpler, would recommend:
- changing the following in `PrivacyConfigPersister`. Change `line 63` to be `val previousVersion = 0L`  to bypass version checks from the downloaded config
- hardcoding URL in `PrivacyConfigService` as needed for the tests below


#### When remote config new field not yet available
- [x] Fresh install `play` build and let it consume production remote config
- [x] Visit `Logins` and verify it is **disabled** by default

#### When remote config new field available but not enabled for current user
- [x] Hardcode privacy config to return `onByDefault` enabled but rolled out to nobody ([example](https://jsonblob.com/api/1168536860653117440))
- [x] Fresh install `play` build and let it consume remote config
- [x] Visit `Logins` and verify it is **disabled** by default

#### When remote config available to a user on install day
- [x] Hardcode privacy config to return `onByDefault` enabled for everybody ([example](https://jsonblob.com/api/1166311678714699776))
- [x] Fresh install `play` build and let it consume remote config
- [x] Visit `Logins` and verify it is **enabled** by default
- [x] Set device date forward some days (tip: `adb shell am start -a android.settings.DATE_SETTINGS`)
- [x] Visit `Logins` and verify it is still **enabled** by default
- [x] Disable it, leave Login settings and return. Verify it remains **disabled**, respecting the manual selection

#### When remote config available to a user but not on install day
- [x] Hardcode privacy config to return `onByDefault` enabled but rolled out to nobody ([example](https://jsonblob.com/api/1168536860653117440))
- [x] Fresh install `play` build and let it consume remote config
- [x] Visit `Logins` and verify it is **disabled** by default
- [x] Set device date forward (tip: `adb shell am start -a android.settings.DATE_SETTINGS`)
- [x] Hardcode privacy config to return `onByDefault` enabled for everybody ([example](https://jsonblob.com/api/1166311678714699776))   (might have to do this with a proxy or hardcode JSON if date causes SSL issues). Kill and relaunch app and let it consume remote config.
- [x] Visit `Logins` and verify it is still **disabled** by default