### PR TITLE
Allow fullscreen control only to the visible fragment

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3293,6 +3293,7 @@ class BrowserTabFragment :
         }
 
         private fun renderFullscreenMode(viewState: BrowserViewState) {
+            if (!this@BrowserTabFragment.isVisible) return
             activity?.isImmersiveModeEnabled()?.let {
                 if (viewState.isFullScreen) {
                     if (!it) goFullScreen()
@@ -3597,14 +3598,12 @@ class BrowserTabFragment :
         }
 
         private fun goFullScreen() {
-            Timber.i("Entering full screen")
             binding.webViewFullScreenContainer.show()
             activity?.toggleFullScreen()
             showToast(R.string.fullScreenMessage, Toast.LENGTH_SHORT)
         }
 
         private fun exitFullScreen() {
-            Timber.i("Exiting full screen")
             binding.webViewFullScreenContainer.removeAllViews()
             binding.webViewFullScreenContainer.gone()
             activity?.toggleFullScreen()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1205821878475376/f 

### Description
when multiple tabs are alive, fullscreen mode can be received by a non-visible tab. If that tab renders that mode, it will affect visible tab.

PR fixes the issues ensuring only visible tab renders full screen mode viewstate.

### Steps to test this PR

_Feature 1_
- [x] Install this branch
- [x] allow screen rotation on your phone
- [x] play a video on youtube
- [x] go full screen
- [x] rotate screen (goes in landscape)
- [x] rotate screen (goes in portrait)
- [x] exit full screen
- [x] This should work
- [x] open a new tab, and visit any random site
- [x] go to youtube tab again
- [x] play video
- [x] go full screen
- [x] rotate screen (goes in landscape)
- [x] rotate screen (goes in portrait)
- [x] exit full screen
- [x] Ensure you can exit fullscreen (HERE was the bug)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
