### PR TITLE
Add parameter to broken sites for protections on or off

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -1,0 +1,202 @@
+package com.duckduckgo.app.brokensite.api
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.brokensite.BrokenSiteViewModel
+import com.duckduckgo.app.brokensite.model.BrokenSite
+import com.duckduckgo.app.pixels.AppPixelName.BROKEN_SITE_REPORT
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.app.statistics.Variant
+import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.model.Atb
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.store.StatisticsDataStore
+import com.duckduckgo.app.trackerdetection.db.TdsMetadataDao
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.feature.toggles.api.FeatureToggle
+import com.duckduckgo.privacy.config.api.ContentBlocking
+import com.duckduckgo.privacy.config.api.Gpc
+import com.duckduckgo.privacy.config.api.PrivacyConfig
+import com.duckduckgo.privacy.config.api.PrivacyConfigData
+import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.api.UnprotectedTemporary
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class BrokenSiteSubmitterTest {
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val mockPixel: Pixel = mock()
+
+    private val mockVariantManager: VariantManager = mock()
+
+    private val mockTdsMetadataDao: TdsMetadataDao = mock()
+
+    private val mockGpc: Gpc = mock()
+
+    private val mockFeatureToggle: FeatureToggle = mock()
+
+    private val mockStatisticsDataStore: StatisticsDataStore = mock()
+
+    private val mockAppBuildConfig: AppBuildConfig = mock()
+
+    private val mockPrivacyConfig: PrivacyConfig = mock()
+
+    private val mockUserAllowListRepository: UserAllowListRepository = mock()
+
+    private val mockUnprotectedTemporary: UnprotectedTemporary = mock()
+
+    private val mockContentBlocking: ContentBlocking = mock()
+
+    private lateinit var testee: BrokenSiteSubmitter
+
+    @Before
+    fun before() {
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(1)
+        whenever(mockAppBuildConfig.manufacturer).thenReturn("manufacturer")
+        whenever(mockAppBuildConfig.model).thenReturn("model")
+        whenever(mockFeatureToggle.isFeatureEnabled(any(), any())).thenReturn(true)
+        whenever(mockGpc.isEnabled()).thenReturn(true)
+        whenever(mockTdsMetadataDao.eTag()).thenReturn("eTAG")
+        whenever(mockStatisticsDataStore.atb).thenReturn(Atb("v123-456"))
+        whenever(mockVariantManager.getVariant()).thenReturn(Variant("g", 1.0, emptyList()) { true })
+        whenever(mockPrivacyConfig.privacyConfigData()).thenReturn(PrivacyConfigData(version = "v", eTag = "e"))
+
+        testee = BrokenSiteSubmitter(
+            mockStatisticsDataStore,
+            mockVariantManager,
+            mockTdsMetadataDao,
+            mockGpc,
+            mockFeatureToggle,
+            mockPixel,
+            TestScope(),
+            mockAppBuildConfig,
+            coroutineRule.testDispatcherProvider,
+            mockPrivacyConfig,
+            mockUserAllowListRepository,
+            mockUnprotectedTemporary,
+            mockContentBlocking,
+        )
+    }
+
+    @Test
+    fun whenSiteInUnprotectedTemporaryThenProtectionsAreOff() {
+        whenever(mockContentBlocking.isAnException(any())).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
+        whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(true)
+        val brokenSite = getBrokenSite()
+
+        testee.submitBrokenSiteFeedback(brokenSite)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
+        val params = paramsCaptor.firstValue
+
+        assertEquals("0", params["protectionsState"])
+    }
+
+    @Test
+    fun whenSiteInUserAllowListThenProtectionsAreOff() {
+        whenever(mockContentBlocking.isAnException(any())).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(true)
+        whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(false)
+        val brokenSite = getBrokenSite()
+
+        testee.submitBrokenSiteFeedback(brokenSite)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
+        val params = paramsCaptor.firstValue
+
+        assertEquals("0", params["protectionsState"])
+    }
+
+    @Test
+    fun whenSiteInContentBlockingThenProtectionsAreOff() {
+        whenever(mockContentBlocking.isAnException(any())).thenReturn(true)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
+        whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(false)
+        val brokenSite = getBrokenSite()
+
+        testee.submitBrokenSiteFeedback(brokenSite)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
+        val params = paramsCaptor.firstValue
+
+        assertEquals("0", params["protectionsState"])
+    }
+
+    @Test
+    fun whenSiteInContentBlockingDisabledThenProtectionsAreOff() {
+        whenever(mockFeatureToggle.isFeatureEnabled(PrivacyFeatureName.ContentBlockingFeatureName.value, true)).thenReturn(false)
+
+        whenever(mockContentBlocking.isAnException(any())).thenReturn(true)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(true)
+        whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(true)
+        val brokenSite = getBrokenSite()
+
+        testee.submitBrokenSiteFeedback(brokenSite)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
+        val params = paramsCaptor.firstValue
+
+        assertEquals("0", params["protectionsState"])
+    }
+
+    @Test
+    fun whenSiteAllowedThenProtectionsAreOn() {
+        whenever(mockContentBlocking.isAnException(any())).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
+        whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(false)
+        val brokenSite = getBrokenSite()
+
+        testee.submitBrokenSiteFeedback(brokenSite)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
+        val params = paramsCaptor.firstValue
+
+        assertEquals("1", params["protectionsState"])
+    }
+
+    private fun getBrokenSite(): BrokenSite {
+        return BrokenSite(
+            category = "category",
+            description = "description",
+            siteUrl = "https://example.com",
+            upgradeHttps = true,
+            blockedTrackers = "",
+            surrogates = "",
+            webViewVersion = "webViewVersion",
+            siteType = BrokenSiteViewModel.DESKTOP_SITE,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+            errorCodes = "",
+            httpErrorCodes = "",
+        )
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -111,6 +111,9 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             mockAppBuildConfig,
             coroutineRule.testDispatcherProvider,
             mockPrivacyConfig,
+            mock(),
+            mock(),
+            mock(),
         )
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205836086617635/f 

### Description
This PR adds a new parameter to the broken sites report to know when protections were on or off.

### Steps to test this PR

- [x] Filter logcat by `Pixel sent: epbf with params:`
- [x] Go to `marcos.com`
- [x] Send a broken site report
- [x] Pixel should include `protectionsState=1`
- [x] Disable protections
- [x] Send a broken site report
- [x] Pixel should include `protectionsState=0`
- [x] Go to `strava.com` which is part of content blocking
- [x] Send a broken site report
- [x] Pixel should include `protectionsState=0`
- [x] Override the privacy config with `https://jsonblob.com/api/1168569763273498624` and reload. This config includes `dictionary.com` in unprotected temporary.
- [x] Go to `dictionary.com`
- [x] Send a broken site report
- [x] Pixel should include `protectionsState=0`
- [x] Change the remote config and disable the `contentBlocking` feature.
- [x] Go to any website
- [x] Send a broken site report
- [x] Pixel should include `protectionsState=0`