### PR TITLE
Add new field when category is login

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
@@ -20,21 +20,29 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import androidx.core.view.isVisible
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel.Command
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel.ViewState
+import com.duckduckgo.app.brokensite.model.BrokenSiteCategory
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityBrokenSiteBinding
 import com.duckduckgo.app.global.DuckDuckGoActivity
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.ui.view.dialog.DaxAlertDialog
 import com.duckduckgo.mobile.android.ui.view.dialog.RadioListAlertDialogBuilder
+import com.duckduckgo.mobile.android.ui.view.gone
+import com.duckduckgo.mobile.android.ui.view.show
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.google.android.material.snackbar.Snackbar
+import java.util.*
 import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
@@ -44,6 +52,8 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
     private val viewModel: BrokenSiteViewModel by bindViewModel()
 
     @Inject lateinit var webViewVersionProvider: WebViewVersionProvider
+
+    @Inject lateinit var appBuildConfig: AppBuildConfig
 
     private val toolbar
         get() = binding.includeToolbar.toolbar
@@ -125,10 +135,35 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
             if (!submitted) {
                 val webViewVersion = webViewVersionProvider.getFullVersion()
                 val description = brokenSites.brokenSiteFormFeedbackInput.text
-                viewModel.onSubmitPressed(webViewVersion, description)
+                val loginSite = brokenSites.brokenSiteFormLoginInput.text
+                viewModel.onSubmitPressed(webViewVersion, description, loginSite)
                 submitted = true
             }
         }
+
+        brokenSites.brokenSiteFormLoginInput.addFocusChangedListener { _, hasFocus ->
+            if (hasFocus) {
+                brokenSites.brokenSiteFormLoginInput.hint = getString(R.string.brokenSitesLoginSmallHint)
+            } else {
+                brokenSites.brokenSiteFormLoginInput.hint = getString(R.string.brokenSitesLoginHint)
+            }
+        }
+
+        brokenSites.brokenSiteFormLoginInput.addTextChangedListener(
+            object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+                    // NOOP
+                }
+
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                    // NOOP
+                }
+
+                override fun afterTextChanged(p0: Editable?) {
+                    runValidation()
+                }
+            },
+        )
     }
 
     private fun configureObservers() {
@@ -167,6 +202,25 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         }.orEmpty()
         brokenSites.categoriesSelection.text = category
         brokenSites.submitButton.isEnabled = viewState.submitAllowed
+
+        if (appBuildConfig.deviceLocale.language == Locale.ENGLISH.language) {
+            if (viewState.categorySelected?.key == BrokenSiteCategory.LOGIN_CATEGORY_KEY) {
+                brokenSites.brokenSiteFormLoginInput.show()
+                brokenSites.submitButton.isEnabled = false
+                runValidation()
+            } else {
+                brokenSites.brokenSiteFormLoginInput.gone()
+                brokenSites.submitButton.isEnabled = true
+            }
+        }
+    }
+
+    private fun runValidation() {
+        if (brokenSites.brokenSiteFormLoginInput.isVisible) {
+            brokenSites.submitButton.isEnabled = brokenSites.brokenSiteFormLoginInput.text.isNotEmpty()
+        } else {
+            brokenSites.submitButton.isEnabled = true
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -139,15 +139,21 @@ class BrokenSiteViewModel @Inject constructor(
         )
     }
 
-    fun onSubmitPressed(webViewVersion: String, description: String?) {
+    fun onSubmitPressed(webViewVersion: String, description: String?, loginSite: String?) {
         viewState.value?.submitAllowed = false
         if (url.isNotEmpty()) {
             val lastAmpLinkInfo = ampLinks.lastAmpLinkInfo
 
-            val brokenSite = if (lastAmpLinkInfo?.destinationUrl == url) {
-                getBrokenSite(lastAmpLinkInfo.ampLink, webViewVersion, description)
+            val loginSiteFinal = if (shuffledCategories.elementAtOrNull(viewValue.indexSelected)?.key == BrokenSiteCategory.LOGIN_CATEGORY_KEY) {
+                loginSite
             } else {
-                getBrokenSite(url, webViewVersion, description)
+                ""
+            }
+
+            val brokenSite = if (lastAmpLinkInfo?.destinationUrl == url) {
+                getBrokenSite(lastAmpLinkInfo.ampLink, webViewVersion, description, loginSiteFinal)
+            } else {
+                getBrokenSite(url, webViewVersion, description, loginSiteFinal)
             }
 
             brokenSiteSender.submitBrokenSiteFeedback(brokenSite)
@@ -174,6 +180,7 @@ class BrokenSiteViewModel @Inject constructor(
         urlString: String,
         webViewVersion: String,
         description: String?,
+        loginSite: String?,
     ): BrokenSite {
         val category = shuffledCategories.elementAtOrNull(viewValue.indexSelected)
         return BrokenSite(
@@ -191,6 +198,7 @@ class BrokenSiteViewModel @Inject constructor(
             consentSelfTestFailed = consentSelfTestFailed,
             errorCodes = jsonStringListAdapter.toJson(errorCodes.toList()).toString(),
             httpErrorCodes = httpErrorCodes,
+            loginSite = loginSite,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.privacy.config.api.PrivacyConfig
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.squareup.anvil.annotations.ContributesBinding
+import java.util.*
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -107,6 +108,10 @@ class BrokenSiteSubmitter @Inject constructor(
                 params[LAST_SENT_DAY] = lastSentDay
             }
 
+            if (appBuildConfig.deviceLocale.language == Locale.ENGLISH.language) {
+                params[LOGIN_SITE] = brokenSite.loginSite.orEmpty()
+            }
+
             val encodedParams = mapOf(
                 BLOCKED_TRACKERS_KEY to brokenSite.blockedTrackers,
                 SURROGATES_KEY to brokenSite.surrogates,
@@ -154,6 +159,7 @@ class BrokenSiteSubmitter @Inject constructor(
         private const val HTTP_ERROR_CODES_KEY = "httpErrorCodes"
         private const val PROTECTIONS_STATE = "protectionsState"
         private const val LAST_SENT_DAY = "lastSentDay"
+        private const val LOGIN_SITE = "loginSite"
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/brokensite/model/BrokenSite.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/model/BrokenSite.kt
@@ -34,6 +34,7 @@ data class BrokenSite(
     val consentSelfTestFailed: Boolean,
     val errorCodes: String,
     val httpErrorCodes: String,
+    val loginSite: String?,
 )
 
 sealed class BrokenSiteCategory(

--- a/app/src/main/res/layout/content_broken_sites.xml
+++ b/app/src/main/res/layout/content_broken_sites.xml
@@ -69,18 +69,33 @@
             app:layout_constraintTop_toBottomOf="@id/noteText" />
 
         <com.duckduckgo.mobile.android.ui.view.text.DaxTextInput
-            android:id="@+id/brokenSiteFormFeedbackInput"
+            android:id="@+id/brokenSiteFormLoginInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/keyline_5"
             android:layout_marginTop="@dimen/keyline_4"
             android:layout_marginEnd="@dimen/keyline_5"
-            android:hint="@string/brokenSiteDescriptionTextInputHint"
+            android:hint="@string/brokenSitesLoginHint"
+            android:visibility="gone"
             app:editable="true"
-            app:type="form_mode"
+            app:type="single_line"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/categoriesSelection" />
+
+        <com.duckduckgo.mobile.android.ui.view.text.DaxTextInput
+                android:id="@+id/brokenSiteFormFeedbackInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_5"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_5"
+                android:hint="@string/brokenSiteDescriptionTextInputHint"
+                app:editable="true"
+                app:type="form_mode"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/brokenSiteFormLoginInput" />
 
         <com.duckduckgo.mobile.android.ui.view.button.DaxButtonPrimary
             android:id="@+id/submitButton"

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -38,4 +38,8 @@
     <string name="webViewErrorNoConnection">The internet connection appears to be offline.</string>
     <string name="webViewErrorBadUrl">A server with the specified hostname could not be found.</string>
     <string name="webViewErrorSslProtocol"><![CDATA[The certificate for this server is invalid. You might be connecting to a server that is pretending to be <b>%1$s</b> which could put your confidential information at risk.]]></string>
+
+    <!-- Broken Sites-->
+    <string name="brokenSitesLoginHint">What site are you signing in to? (required)</string>
+    <string name="brokenSitesLoginSmallHint">Site name (required)</string>
 </resources>

--- a/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.brokensite.BrokenSiteViewModel
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel.Command
 import com.duckduckgo.app.brokensite.api.BrokenSiteSender
 import com.duckduckgo.app.brokensite.model.BrokenSite
+import com.duckduckgo.app.brokensite.model.BrokenSiteCategory
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.privacy.config.api.AmpLinkInfo
@@ -134,7 +135,7 @@ class BrokenSiteViewModelTest {
             isDesktopMode = false,
         )
         selectAndAcceptCategory()
-        testee.onSubmitPressed("webViewVersion", "description")
+        testee.onSubmitPressed("webViewVersion", "description", "")
 
         val brokenSiteExpected = BrokenSite(
             category = testee.shuffledCategories[0].key,
@@ -151,6 +152,7 @@ class BrokenSiteViewModelTest {
             consentSelfTestFailed = false,
             errorCodes = "[]",
             httpErrorCodes = "",
+            loginSite = "",
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
@@ -176,7 +178,7 @@ class BrokenSiteViewModelTest {
             isDesktopMode = false,
         )
         selectAndAcceptCategory()
-        testee.onSubmitPressed("webViewVersion", "description")
+        testee.onSubmitPressed("webViewVersion", "description", "")
 
         val brokenSiteExpected = BrokenSite(
             category = testee.shuffledCategories[0].key,
@@ -193,6 +195,7 @@ class BrokenSiteViewModelTest {
             consentSelfTestFailed = false,
             errorCodes = "",
             httpErrorCodes = "",
+            loginSite = "",
         )
 
         verify(mockPixel, never()).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to nullUrl))
@@ -219,7 +222,7 @@ class BrokenSiteViewModelTest {
             isDesktopMode = false,
         )
         selectAndAcceptCategory()
-        testee.onSubmitPressed("webViewVersion", "description")
+        testee.onSubmitPressed("webViewVersion", "description", "")
 
         val brokenSiteExpected = BrokenSite(
             category = testee.shuffledCategories[0].key,
@@ -236,6 +239,7 @@ class BrokenSiteViewModelTest {
             consentSelfTestFailed = false,
             errorCodes = "[]",
             httpErrorCodes = "",
+            loginSite = "",
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
@@ -262,7 +266,7 @@ class BrokenSiteViewModelTest {
             isDesktopMode = false,
         )
         selectAndAcceptCategory()
-        testee.onSubmitPressed("webViewVersion", "description")
+        testee.onSubmitPressed("webViewVersion", "description", "")
 
         val brokenSiteExpected = BrokenSite(
             category = testee.shuffledCategories[0].key,
@@ -279,6 +283,7 @@ class BrokenSiteViewModelTest {
             consentSelfTestFailed = false,
             errorCodes = "[]",
             httpErrorCodes = "",
+            loginSite = "",
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to trackingUrl))
@@ -305,7 +310,7 @@ class BrokenSiteViewModelTest {
             isDesktopMode = false,
         )
         selectAndAcceptCategory()
-        testee.onSubmitPressed("webViewVersion", "description")
+        testee.onSubmitPressed("webViewVersion", "description", "")
 
         verify(mockPixel).fire(
             AppPixelName.BROKEN_SITE_REPORTED,
@@ -334,7 +339,7 @@ class BrokenSiteViewModelTest {
         )
         selectAndAcceptCategory()
 
-        val brokenSiteExpected = testee.getBrokenSite(url, "", "")
+        val brokenSiteExpected = testee.getBrokenSite(url, "", "", "")
         assertEquals(BrokenSiteViewModel.DESKTOP_SITE, brokenSiteExpected.siteType)
     }
 
@@ -356,7 +361,7 @@ class BrokenSiteViewModelTest {
         )
         selectAndAcceptCategory()
 
-        val brokenSiteExpected = testee.getBrokenSite(url, "", "")
+        val brokenSiteExpected = testee.getBrokenSite(url, "", "", "")
         assertEquals(BrokenSiteViewModel.MOBILE_SITE, brokenSiteExpected.siteType)
     }
 
@@ -381,7 +386,7 @@ class BrokenSiteViewModelTest {
         selectAndAcceptCategory(categoryIndex)
 
         val categoryExpected = testee.shuffledCategories[categoryIndex].key
-        val brokenSiteExpected = testee.getBrokenSite(url, "", "")
+        val brokenSiteExpected = testee.getBrokenSite(url, "", "", "")
         assertEquals(categoryExpected, brokenSiteExpected.category)
     }
 
@@ -428,6 +433,94 @@ class BrokenSiteViewModelTest {
         testee.onCategorySelectionCancelled()
 
         assertEquals(-1, testee.indexSelected)
+    }
+
+    @Test
+    fun whenCategoryLoginsThenUseLoginSite() {
+        val categoryIndex = testee.shuffledCategories.indexOfFirst { it.key == BrokenSiteCategory.LOGIN_CATEGORY_KEY }
+
+        testee.setInitialBrokenSite(
+            url = url,
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+            params = emptyArray(),
+            errorCodes = emptyArray(),
+            httpErrorCodes = "",
+            isDesktopMode = false,
+        )
+        selectAndAcceptCategory(categoryIndex)
+        testee.onSubmitPressed("webViewVersion", "description", "test")
+
+        val brokenSiteExpected = BrokenSite(
+            category = testee.shuffledCategories[categoryIndex].key,
+            description = "description",
+            siteUrl = url,
+            upgradeHttps = false,
+            blockedTrackers = "",
+            surrogates = "",
+            webViewVersion = "webViewVersion",
+            siteType = BrokenSiteViewModel.MOBILE_SITE,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+            errorCodes = "[]",
+            httpErrorCodes = "",
+            loginSite = "test",
+        )
+
+        verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
+        verify(mockBrokenSiteSender).submitBrokenSiteFeedback(brokenSiteExpected)
+        verify(mockCommandObserver).onChanged(Command.ConfirmAndFinish)
+    }
+
+    @Test
+    fun whenCategoryIsNotLoginsThenDoNotUseLoginSite() {
+        val categoryIndex = testee.shuffledCategories.indexOfFirst { it.key == BrokenSiteCategory.COMMENTS_CATEGORY_KEY }
+
+        testee.setInitialBrokenSite(
+            url = url,
+            blockedTrackers = "",
+            surrogates = "",
+            upgradedHttps = false,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+            params = emptyArray(),
+            errorCodes = emptyArray(),
+            httpErrorCodes = "",
+            isDesktopMode = false,
+        )
+        selectAndAcceptCategory(categoryIndex)
+        testee.onSubmitPressed("webViewVersion", "description", "test")
+
+        val brokenSiteExpected = BrokenSite(
+            category = testee.shuffledCategories[categoryIndex].key,
+            description = "description",
+            siteUrl = url,
+            upgradeHttps = false,
+            blockedTrackers = "",
+            surrogates = "",
+            webViewVersion = "webViewVersion",
+            siteType = BrokenSiteViewModel.MOBILE_SITE,
+            urlParametersRemoved = false,
+            consentManaged = false,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+            errorCodes = "[]",
+            httpErrorCodes = "",
+            loginSite = "",
+        )
+
+        verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
+        verify(mockBrokenSiteSender).submitBrokenSiteFeedback(brokenSiteExpected)
+        verify(mockCommandObserver).onChanged(Command.ConfirmAndFinish)
     }
 
     private fun selectAndAcceptCategory(indexSelected: Int = 0) {

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.net.URLEncoder
+import java.util.*
 import java.util.regex.Pattern
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -137,6 +138,7 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
             whenever(mockAppBuildConfig.sdkInt).thenReturn(report.os?.toInt() ?: 1)
             whenever(mockAppBuildConfig.manufacturer).thenReturn(report.manufacturer)
             whenever(mockAppBuildConfig.model).thenReturn(report.model)
+            whenever(mockAppBuildConfig.deviceLocale).thenReturn(Locale.US)
             whenever(mockFeatureToggle.isFeatureEnabled(any(), any())).thenReturn(true)
             whenever(mockGpc.isEnabled()).thenReturn(report.gpcEnabled)
             whenever(mockTdsMetadataDao.eTag()).thenReturn(report.blocklistVersion)
@@ -167,6 +169,7 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
                 consentSelfTestFailed = report.consentSelfTestFailed.toBoolean(),
                 errorCodes = "",
                 httpErrorCodes = "",
+                loginSite = null,
             )
 
             testee.submitBrokenSiteFeedback(brokenSite)

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import java.net.URLEncoder
+import java.util.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.*
@@ -100,6 +101,7 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
     @Before
     fun before() {
         MockitoAnnotations.openMocks(this)
+        whenever(mockAppBuildConfig.deviceLocale).thenReturn(Locale.ENGLISH)
         testee = BrokenSiteSubmitter(
             mockStatisticsDataStore,
             mockVariantManager,
@@ -147,6 +149,7 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             consentSelfTestFailed = testCase.consentSelfTestFailed.toBoolean(),
             errorCodes = "",
             httpErrorCodes = "",
+            loginSite = null,
         )
 
         testee.submitBrokenSiteFeedback(brokenSite)

--- a/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/mobile/android/ui/view/text/DaxTextInput.kt
@@ -58,6 +58,7 @@ interface TextInput {
 
     fun addTextChangedListener(textWatcher: TextWatcher)
     fun removeTextChangedListener(textWatcher: TextWatcher)
+    fun addFocusChangedListener(listener: OnFocusChangeListener)
     fun setEndIcon(
         @DrawableRes endIconRes: Int,
         contentDescription: String? = null,
@@ -85,6 +86,7 @@ class DaxTextInput @JvmOverloads constructor(
     private var isPassword: Boolean = false
     private var isPasswordShown: Boolean = false
     private var isClickable: Boolean = false
+    private var internalFocusChangedListener: OnFocusChangeListener? = null
 
     init {
         context.obtainStyledAttributes(
@@ -136,7 +138,8 @@ class DaxTextInput @JvmOverloads constructor(
     }
 
     private fun setFocusListener() {
-        binding.internalEditText.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+        binding.internalEditText.onFocusChangeListener = OnFocusChangeListener { view, hasFocus ->
+            internalFocusChangedListener?.onFocusChange(view, hasFocus)
             if (hasFocus) {
                 if (isPassword) {
                     showPassword()
@@ -205,6 +208,10 @@ class DaxTextInput @JvmOverloads constructor(
 
     override fun removeTextChangedListener(textWatcher: TextWatcher) {
         binding.internalEditText.removeTextChangedListener(textWatcher)
+    }
+
+    override fun addFocusChangedListener(listener: OnFocusChangeListener) {
+        internalFocusChangedListener = listener
     }
 
     override fun setEndIcon(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations.
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205834027224168/f

### Description
This PR adds a new field to the broken site report so users can input the site they were trying to sign into when reporting a login issue.

### Steps to test this PR

- [x] Go to any website and broken sites report
- [x] Login field should not show up
- [x] Select login as the category
- [x] New field should show up and button should be disabled
- [x] Type anything in the field and button should be enabled
- [x] Delete all the content from the field and the button should be disabled
- [x] Change category and field should disappear and button be enabled
- [x] Select login as category again, type something in the field and submit
- [x] Pixel should be sent with the new information under the loginSite parameter
- [x] Go back to the broken site report
- [x] Select login, type something, change category, send report
- [x] Pixel should have the loginSite parameter empty
- [x] Change the device language to something other than english
- [x] Go back to report broken site report and select the login category
- [x] New field should not show up
- [x] Send the report
- [x] Pixel should not contain the loginSite parameter
