### PR TITLE
Fix rq pixels being fired when queryt didn't change

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4058,7 +4058,7 @@ class BrowserTabViewModelTest {
 
         testee.onUserSubmittedQuery("foo")
 
-        assertTrue(omnibarViewState().showVoiceSearch)
+        assertTrue(browserViewState().showVoiceSearch)
     }
 
     @Test
@@ -4068,7 +4068,7 @@ class BrowserTabViewModelTest {
 
         testee.onUserPressedBack()
 
-        assertTrue(omnibarViewState().showVoiceSearch)
+        assertTrue(browserViewState().showVoiceSearch)
     }
 
     @Test
@@ -4077,7 +4077,7 @@ class BrowserTabViewModelTest {
 
         loadUrl("https://test.com")
 
-        assertTrue(omnibarViewState().showVoiceSearch)
+        assertTrue(browserViewState().showVoiceSearch)
     }
 
     @Test
@@ -4086,7 +4086,7 @@ class BrowserTabViewModelTest {
 
         testee.onOmnibarInputStateChanged("www.fb.com", true, hasQueryChanged = false)
 
-        assertTrue(omnibarViewState().showVoiceSearch)
+        assertTrue(browserViewState().showVoiceSearch)
     }
 
     @Test
@@ -4355,7 +4355,7 @@ class BrowserTabViewModelTest {
 
         testee.voiceSearchDisabled()
 
-        assertFalse(omnibarViewState().showVoiceSearch)
+        assertFalse(browserViewState().showVoiceSearch)
     }
 
     private fun aCredential(): LoginCredentials {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3159,13 +3159,10 @@ class BrowserTabFragment :
                 lastSeenBrowserViewState?.let {
                     renderToolbarMenus(it)
                 }
-
-                renderVoiceSearch(viewState)
-                omnibar.spacer.isVisible = viewState.showVoiceSearch && lastSeenBrowserViewState?.showClearButton ?: false
             }
         }
 
-        private fun renderVoiceSearch(viewState: OmnibarViewState) {
+        private fun renderVoiceSearch(viewState: BrowserViewState) {
             if (viewState.showVoiceSearch) {
                 omnibar.voiceSearchButton.visibility = VISIBLE
                 omnibar.voiceSearchButton.setOnClickListener {
@@ -3289,6 +3286,8 @@ class BrowserTabFragment :
                 renderToolbarMenus(viewState)
                 popupMenu.renderState(browserShowing, viewState)
                 renderFullscreenMode(viewState)
+                renderVoiceSearch(viewState)
+                omnibar.spacer.isVisible = viewState.showVoiceSearch && lastSeenBrowserViewState?.showClearButton ?: false
             }
         }
 
@@ -3337,7 +3336,7 @@ class BrowserTabFragment :
                 omnibar.searchIcon?.isVisible = true
             }
 
-            omnibar.spacer.isVisible = viewState.showClearButton && lastSeenOmnibarViewState?.showVoiceSearch ?: false
+            omnibar.spacer.isVisible = viewState.showClearButton && lastSeenBrowserViewState?.showVoiceSearch ?: false
 
             decorator.updateToolbarActionsVisibility(viewState)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/1202552961248957/1205843589662925/f 

### Description
 Move showShowVoiceSearch to browserViewState

Having it on omnibarViewState interferes with text changes, causing either textinput not to updated, or it to be updated too frequently, causing rq pixels to fire

### Steps to test this PR

_Check pixels fired_
- [x] Clean install on a device with Android 13+ and English_US
- [x] Enable voice search
- [x] Perform a search
- [x] Check rq_0 nor rq_1 pixels are fired

_Check voice search icon behavior_
- [x] Enable voice search
- [x] Tap on the omnibar
- [x] Check both voice search and clear texr buttons are shown
- [x] Type a character
- [x] Check voice search icon disappears and clear text is still shown
- [x] Clear text
- [x] Check clear text button disappears and voice search one is shown 

### UI changes
No UI changes
