### PR TITLE
Change siteType logic to be based on user choice rather than URL

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1361,6 +1361,8 @@ class BrowserTabViewModelTest {
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         verify(mockPixel).fire(AppPixelName.MENU_ACTION_DESKTOP_SITE_ENABLE_PRESSED)
         assertTrue(browserViewState().isDesktopBrowsingMode)
+        val site = testee.siteLiveData.value
+        assertTrue(site?.isDesktopMode == true)
     }
 
     @Test
@@ -1370,6 +1372,8 @@ class BrowserTabViewModelTest {
         testee.onChangeBrowserModeClicked()
         verify(mockPixel).fire(AppPixelName.MENU_ACTION_DESKTOP_SITE_DISABLE_PRESSED)
         assertFalse(browserViewState().isDesktopBrowsingMode)
+        val site = testee.siteLiveData.value
+        assertFalse(site?.isDesktopMode == true)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
@@ -76,6 +76,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         val params = intent.getStringArrayExtra(BOOLEAN_PARAMS).orEmpty()
         val errorCodes = intent.getStringArrayExtra(ERROR_CODES).orEmpty()
         val httpErrorCodes = intent.getStringExtra(HTTP_ERROR_CODES).orEmpty()
+        val isDesktopMode = intent.getBooleanExtra(IS_DESKTOP_MODE, false)
         viewModel.setInitialBrokenSite(
             url = url,
             blockedTrackers = blockedTrackers,
@@ -88,6 +89,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
             params = params,
             errorCodes = errorCodes,
             httpErrorCodes = httpErrorCodes,
+            isDesktopMode = isDesktopMode,
         )
     }
 
@@ -180,6 +182,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         private const val BOOLEAN_PARAMS = "BOOLEAN_PARAMS"
         private const val ERROR_CODES = "ERROR_CODES"
         private const val HTTP_ERROR_CODES = "HTTP_ERROR_CODES"
+        private const val IS_DESKTOP_MODE = "IS_DESKTOP_MODE"
 
         fun intent(
             context: Context,
@@ -197,6 +200,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
             intent.putExtra(BOOLEAN_PARAMS, data.params.toTypedArray())
             intent.putExtra(ERROR_CODES, data.errorCodes.toTypedArray())
             intent.putExtra(HTTP_ERROR_CODES, data.httpErrorCodes)
+            intent.putExtra(IS_DESKTOP_MODE, data.isDesktopMode)
             return intent
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.brokensite
 
-import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -26,7 +25,6 @@ import com.duckduckgo.app.brokensite.model.BrokenSite
 import com.duckduckgo.app.brokensite.model.BrokenSiteCategory
 import com.duckduckgo.app.brokensite.model.BrokenSiteCategory.*
 import com.duckduckgo.app.global.SingleLiveEvent
-import com.duckduckgo.app.global.isMobileSite
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.ActivityScope
@@ -82,6 +80,7 @@ class BrokenSiteViewModel @Inject constructor(
     private var params: Array<out String> = emptyArray()
     private var errorCodes: Array<out String> = emptyArray()
     private var httpErrorCodes: String = ""
+    private var isDesktopMode: Boolean = false
 
     var shuffledCategories = mutableListOf<BrokenSiteCategory>()
 
@@ -102,6 +101,7 @@ class BrokenSiteViewModel @Inject constructor(
         params: Array<out String>,
         errorCodes: Array<out String>,
         httpErrorCodes: String,
+        isDesktopMode: Boolean,
     ) {
         this.url = url
         this.blockedTrackers = blockedTrackers
@@ -114,9 +114,10 @@ class BrokenSiteViewModel @Inject constructor(
         this.params = params
         this.errorCodes = errorCodes
         this.httpErrorCodes = httpErrorCodes
+        this.isDesktopMode = isDesktopMode
     }
 
-    fun setCategories(categoryList: List<BrokenSiteCategory>): MutableList<BrokenSiteCategory> {
+    private fun setCategories(categoryList: List<BrokenSiteCategory>): MutableList<BrokenSiteCategory> {
         val categories = categoryList.map { it }.toMutableList()
         val shuffledCategories = categories.slice(0..7).shuffled().toMutableList()
         shuffledCategories.add(categories[8])
@@ -183,7 +184,7 @@ class BrokenSiteViewModel @Inject constructor(
             blockedTrackers = blockedTrackers,
             surrogates = surrogates,
             webViewVersion = webViewVersion,
-            siteType = if (Uri.parse(url).isMobileSite) MOBILE_SITE else DESKTOP_SITE,
+            siteType = if (isDesktopMode) DESKTOP_SITE else MOBILE_SITE,
             urlParametersRemoved = urlParametersRemoved,
             consentManaged = consentManaged,
             consentOptOutFailed = consentOptOutFailed,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1753,6 +1753,7 @@ class BrowserTabViewModel @Inject constructor(
 
     private fun onSiteChanged() {
         httpsUpgraded = false
+        site?.isDesktopMode = currentBrowserViewState().isDesktopBrowsingMode
         viewModelScope.launch {
             val privacyProtection: PrivacyShield = withContext(dispatchers.io()) {
                 site?.privacyProtection() ?: PrivacyShield.UNKNOWN
@@ -2238,6 +2239,7 @@ class BrowserTabViewModel @Inject constructor(
         val desktopSiteRequested = !currentBrowserViewState().isDesktopBrowsingMode
         browserViewState.value = currentBrowserViewState.copy(isDesktopBrowsingMode = desktopSiteRequested)
         command.value = RefreshUserAgent(site?.uri?.toString(), desktopSiteRequested)
+        site?.isDesktopMode = desktopSiteRequested
 
         val uri = site?.uri ?: return
 

--- a/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
@@ -174,6 +174,8 @@ class SiteMonitor(
 
     override var consentCosmeticHide: Boolean? = false
 
+    override var isDesktopMode: Boolean = false
+
     companion object {
         private val specialDomainTypes = setOf(
             TrackerStatus.AD_ALLOWED,

--- a/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
@@ -131,6 +131,7 @@ class BrokenSiteViewModelTest {
             params = emptyArray(),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = false,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description")
@@ -143,7 +144,7 @@ class BrokenSiteViewModelTest {
             blockedTrackers = "",
             surrogates = "",
             webViewVersion = "webViewVersion",
-            siteType = BrokenSiteViewModel.DESKTOP_SITE,
+            siteType = BrokenSiteViewModel.MOBILE_SITE,
             urlParametersRemoved = false,
             consentManaged = false,
             consentOptOutFailed = false,
@@ -172,6 +173,7 @@ class BrokenSiteViewModelTest {
             params = emptyArray(),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = false,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description")
@@ -214,6 +216,7 @@ class BrokenSiteViewModelTest {
             params = emptyArray(),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = false,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description")
@@ -226,7 +229,7 @@ class BrokenSiteViewModelTest {
             blockedTrackers = "",
             surrogates = "",
             webViewVersion = "webViewVersion",
-            siteType = BrokenSiteViewModel.DESKTOP_SITE,
+            siteType = BrokenSiteViewModel.MOBILE_SITE,
             urlParametersRemoved = false,
             consentManaged = false,
             consentOptOutFailed = false,
@@ -256,6 +259,7 @@ class BrokenSiteViewModelTest {
             params = emptyArray(),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = false,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description")
@@ -268,7 +272,7 @@ class BrokenSiteViewModelTest {
             blockedTrackers = "",
             surrogates = "",
             webViewVersion = "webViewVersion",
-            siteType = BrokenSiteViewModel.DESKTOP_SITE,
+            siteType = BrokenSiteViewModel.MOBILE_SITE,
             urlParametersRemoved = false,
             consentManaged = false,
             consentOptOutFailed = false,
@@ -298,6 +302,7 @@ class BrokenSiteViewModelTest {
             params = arrayOf("dashboard_highlighted_toggle"),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = false,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description")
@@ -312,7 +317,7 @@ class BrokenSiteViewModelTest {
     }
 
     @Test
-    fun whenUrlIsDesktopThenSendDesktopParameter() {
+    fun whenIsDesktopModeTrueThenSendDesktopParameter() {
         testee.setInitialBrokenSite(
             url = url,
             blockedTrackers = "",
@@ -325,6 +330,7 @@ class BrokenSiteViewModelTest {
             params = emptyArray(),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = true,
         )
         selectAndAcceptCategory()
 
@@ -333,8 +339,7 @@ class BrokenSiteViewModelTest {
     }
 
     @Test
-    fun whenUrlIsMobileThenSendMobileParameter() {
-        val url = "http://m.example.com"
+    fun whenDesktopModeIsFalseThenSendMobileParameter() {
         testee.setInitialBrokenSite(
             url = url,
             blockedTrackers = "",
@@ -347,6 +352,7 @@ class BrokenSiteViewModelTest {
             params = emptyArray(),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = false,
         )
         selectAndAcceptCategory()
 
@@ -370,6 +376,7 @@ class BrokenSiteViewModelTest {
             params = emptyArray(),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = false,
         )
         selectAndAcceptCategory(categoryIndex)
 
@@ -392,6 +399,7 @@ class BrokenSiteViewModelTest {
             params = emptyArray(),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = false,
         )
         selectAndAcceptCategory(0)
         testee.onCategoryIndexChanged(1)
@@ -414,6 +422,7 @@ class BrokenSiteViewModelTest {
             params = emptyArray(),
             errorCodes = emptyArray(),
             httpErrorCodes = "",
+            isDesktopMode = false,
         )
         testee.onCategoryIndexChanged(1)
         testee.onCategorySelectionCancelled()

--- a/browser-api/src/main/java/com/duckduckgo/app/global/model/Site.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/global/model/Site.kt
@@ -71,6 +71,7 @@ interface Site {
     var consentOptOutFailed: Boolean
     var consentSelfTestFailed: Boolean
     var consentCosmeticHide: Boolean?
+    var isDesktopMode: Boolean
 }
 
 fun Site.orderedTrackerBlockedEntities(): List<Entity> = trackingEvents

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/brokensite/BrokenSiteNav.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/brokensite/BrokenSiteNav.kt
@@ -39,6 +39,7 @@ data class BrokenSiteData(
     val params: List<String>,
     val errorCodes: List<String>,
     val httpErrorCodes: String,
+    val isDesktopMode: Boolean,
 ) {
     companion object {
         fun fromSite(site: Site?, params: List<String> = emptyList()): BrokenSiteData {
@@ -55,6 +56,7 @@ data class BrokenSiteData(
             val consentManaged = site?.consentManaged ?: false
             val consentOptOutFailed = site?.consentOptOutFailed ?: false
             val consentSelfTestFailed = site?.consentSelfTestFailed ?: false
+            val isDesktopMode = site?.isDesktopMode ?: false
             return BrokenSiteData(
                 url = url,
                 blockedTrackers = blockedTrackers,
@@ -67,6 +69,7 @@ data class BrokenSiteData(
                 params = params,
                 errorCodes = errorCodes,
                 httpErrorCodes = httErrorCodes,
+                isDesktopMode = isDesktopMode,
             )
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205855094135462/f 

### Description
This PR changes the logic that sets siteType to follow user's selection rather than how the URL looks like.

### Steps to test this PR

- [x] Go to any website, send a site report.
- [x] Pixel should have siteType=mobile
- [x] In the menu change to desktop site and send another broken site report
- [x] Pixel should now have siteType=desktop
- [x] Go to another website, should still be in desktop mode.
- [x] Send a broken site report and pixel should have siteType=desktop
