### PR TITLE
Add gradle rule to avoid the usage of kapt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,10 @@ subprojects {
                                     "'api' modules can't use the anvil plugin")
                         }
                     }
+                    if (!projectPath.endsWith(":app") && plugin.toString().toLowerCase().contains("kapt")) {
+                        throw new GradleException("Invalid usage of kapt $projectPath -> " +
+                                "Use ksp instead of kapt")
+                    }
                 }
 
                 for (dependency in dependencies) {

--- a/voice-search/voice-search-store/build.gradle
+++ b/voice-search/voice-search-store/build.gradle
@@ -17,13 +17,13 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp' version "$ksp_version"
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
-    kapt AndroidX.room.compiler
+    ksp AndroidX.room.compiler
 
     implementation AndroidX.core.ktx
     implementation Square.moshi


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205853717890734/f 

### Description
This PR adds a new gradle rule to avoid the usage of kapt in favour of ksp

### Steps to test this PR

- [ ] Use kapt in any module that's not :app, you can revert the changes in voice search from this PR
- [ ] Project should not build