### PR TITLE
Only show default browser experiment if not default browser

### DIFF
--- a/remote-messaging/remote-messaging-impl/build.gradle
+++ b/remote-messaging/remote-messaging-impl/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation project(path: ':remote-messaging-store')
     implementation project(path: ':browser-api')
     implementation project(path: ':app-build-config-api')
+    implementation project(path: ':statistics')
 
     implementation KotlinX.coroutines.core
     androidTestImplementation (KotlinX.coroutines.test) {

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.remote.messaging.impl
 
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.statistics.VariantManager
+import com.duckduckgo.app.statistics.isAskForDefaultBrowserMoreThanOnceExperimentEnabled
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessagingRepository
@@ -37,6 +39,7 @@ class AppRemoteMessagingRepository(
     private val dispatchers: DispatcherProvider,
     private val messageMapper: MessageMapper,
     private val userBrowserProperties: UserBrowserProperties,
+    private val variantManager: VariantManager,
 ) : RemoteMessagingRepository {
 
     override fun activeMessage(message: RemoteMessage?) {
@@ -59,8 +62,13 @@ class AppRemoteMessagingRepository(
         // Experiment: Ask for Default Browser More Than Once
         val daysSinceInstalled = userBrowserProperties.daysSinceInstalled()
         val isDefaultBrowser = userBrowserProperties.defaultBrowser()
+        val isDefaultBrowserExperiment = variantManager.isAskForDefaultBrowserMoreThanOnceExperimentEnabled()
         return remoteMessagesDao.messagesFlow().distinctUntilChanged().map {
-            if (daysSinceInstalled != 0L && daysSinceInstalled != 1L && daysSinceInstalled != 2L || isDefaultBrowser) return@map null
+            if (
+                isDefaultBrowserExperiment && (daysSinceInstalled != 0L && daysSinceInstalled != 1L && daysSinceInstalled != 2L || isDefaultBrowser)
+            ) {
+                return@map null
+            }
             if (it == null || it.message.isEmpty()) return@map null
 
             val message = messageMapper.fromMessage(it.message) ?: return@map null

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -58,8 +58,9 @@ class AppRemoteMessagingRepository(
     override fun messageFlow(): Flow<RemoteMessage?> {
         // Experiment: Ask for Default Browser More Than Once
         val daysSinceInstalled = userBrowserProperties.daysSinceInstalled()
+        val isDefaultBrowser = userBrowserProperties.defaultBrowser()
         return remoteMessagesDao.messagesFlow().distinctUntilChanged().map {
-            if (daysSinceInstalled != 0L && daysSinceInstalled != 1L && daysSinceInstalled != 2L) return@map null
+            if (daysSinceInstalled != 0L && daysSinceInstalled != 1L && daysSinceInstalled != 2L || isDefaultBrowser) return@map null
             if (it == null || it.message.isEmpty()) return@map null
 
             val message = messageMapper.fromMessage(it.message) ?: return@map null

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.remote.messaging.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.app.global.DispatcherProvider
+import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.AppProperties
 import com.duckduckgo.browser.api.UserBrowserProperties
@@ -87,8 +88,16 @@ object DataSourceModule {
         dispatchers: DispatcherProvider,
         messageMapper: MessageMapper,
         userBrowserProperties: UserBrowserProperties,
+        variantManager: VariantManager,
     ): RemoteMessagingRepository {
-        return AppRemoteMessagingRepository(remoteMessagingConfigRepository, remoteMessagesDao, dispatchers, messageMapper, userBrowserProperties)
+        return AppRemoteMessagingRepository(
+            remoteMessagingConfigRepository,
+            remoteMessagesDao,
+            dispatchers,
+            messageMapper,
+            userBrowserProperties,
+            variantManager,
+        )
     }
 
     @Provides

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
@@ -21,6 +21,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
+import com.duckduckgo.app.statistics.Variant
+import com.duckduckgo.app.statistics.VariantManager
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Action.Share
@@ -43,10 +45,13 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 // TODO: when pattern established, refactor objects to use (create module https://app.asana.com/0/0/1201807285420697/f)
 @ExperimentalCoroutinesApi
@@ -69,13 +74,24 @@ class AppRemoteMessagingRepositoryTest {
 
     private val userBrowserProperties: UserBrowserProperties = mock()
 
+    private val variantManager: VariantManager = mock()
+
+    private val variant: Variant = mock()
+
     private val testee = AppRemoteMessagingRepository(
         remoteMessagingConfigRepository,
         dao,
         coroutineRule.testDispatcherProvider,
         getMessageMapper(),
         userBrowserProperties,
+        variantManager,
     )
+
+    @Before
+    fun before() {
+        whenever(variant.hasFeature(any())).thenReturn(false)
+        whenever(variantManager.getVariant()).thenReturn(variant)
+    }
 
     @After
     fun after() {

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -196,6 +196,9 @@ class ExperimentationVariantManager(
     }
 }
 
+fun VariantManager.isAskForDefaultBrowserMoreThanOnceExperimentEnabled() =
+    this.getVariant().hasFeature(AskForDefaultBrowserMoreThanOnce)
+
 /**
  * A variant which can be used for experimentation.
  * @param weight Relative weight. These are normalised to all other variants, so they don't have to add up to any specific number.

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -50,7 +50,7 @@ interface VariantManager {
             Variant(key = "zh", weight = 1.0, features = emptyList(), filterBy = { isDefaultBrowserExperimentCountry() }),
             Variant(
                 key = "zj",
-                weight = 1.0,
+                weight = 0.0,
                 features = listOf(AskForDefaultBrowserMoreThanOnce),
                 filterBy = { isDefaultBrowserExperimentCountry() },
             ),

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/VariantManager.kt
@@ -50,7 +50,7 @@ interface VariantManager {
             Variant(key = "zh", weight = 1.0, features = emptyList(), filterBy = { isDefaultBrowserExperimentCountry() }),
             Variant(
                 key = "zj",
-                weight = 0.0,
+                weight = 1.0,
                 features = listOf(AskForDefaultBrowserMoreThanOnce),
                 filterBy = { isDefaultBrowserExperimentCountry() },
             ),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205846766235726/f

### Description
Adds an `isDefaultBrowser` check to ensure that the experiment is not shown for non-default users.

### Steps to test this PR
- [x] Set `zh` to 0.
- [x] Install the app.
- [x] Set DDG is as default during onboarding.
- [x] Complete the onboarding flow.
- [x] Verify that the experiment is not shown.
