### PR TITLE
Fix sync env endpoint rewrite logic

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/internal/SyncInternalEnvInterceptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/internal/SyncInternalEnvInterceptor.kt
@@ -37,12 +37,11 @@ class SyncInternalEnvInterceptor @Inject constructor(
     override fun getInterceptor(): Interceptor = this
     override fun intercept(chain: Chain): Response {
         val useDevEnvironment = envDataStore.useSyncDevEnvironment
-        val encodedPath = chain.request().url.encodedPath
 
         if (useDevEnvironment && chain.request().url.toString().contains(SYNC_PROD_ENVIRONMENT_URL)) {
             val newRequest = chain.request().newBuilder()
 
-            val changedUrl = SYNC_DEV_ENVIRONMENT_URL + encodedPath
+            val changedUrl = chain.request().url.toString().replace(SYNC_PROD_ENVIRONMENT_URL, SYNC_DEV_ENVIRONMENT_URL)
             Timber.d("Sync-Engine: environment changed to $changedUrl")
             newRequest.url(changedUrl)
             return chain.proceed(newRequest.build())


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205629126158773/f 

### Description
Fixes rewrite url logic to keep query params. Interceptor was added as part of https://app.asana.com/0/1202552961248957/1205489036222328/f

Bug: when building a new requests, params were not included, only the path.

### Steps to test this PR

_Feature 1_
- [ ] go to settings
- [ ] enable sync
- [ ] from IntellIJ or Android Studio, using App Inspection network, inspect sync requests
- [ ] to trigger sync you can just close and open the app
- [ ] ensure requests keep their url params (you should see timestamps as part of url)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
