### PR TITLE
Remove surveyDao injections from external classes

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -104,7 +104,6 @@ import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.survey.api.SurveyRepository
-import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.notification.SurveyNotificationScheduler
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -232,9 +231,6 @@ class BrowserTabViewModelTest {
 
     @Mock
     private lateinit var mockAddToHomeCapabilityDetector: AddToHomeCapabilityDetector
-
-    @Mock
-    private lateinit var mockSurveyDao: SurveyDao
 
     @Mock
     private lateinit var mockDismissedCtaDao: DismissedCtaDao
@@ -417,7 +413,6 @@ class BrowserTabViewModelTest {
         ctaViewModel = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            surveyDao = mockSurveyDao,
             widgetCapabilities = mockWidgetCapabilities,
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
@@ -2264,7 +2259,7 @@ class BrowserTabViewModelTest {
         val cta = HomePanelCta.Survey(Survey("abc", "http://example.com", daysInstalled = 1, status = Survey.Status.SCHEDULED))
         setCta(cta)
         testee.onUserDismissedCta()
-        verify(mockSurveyDao).cancelScheduledSurveys()
+        verify(mockSurveyRepository).cancelScheduledSurveys()
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -39,7 +39,6 @@ import com.duckduckgo.app.privacy.model.TestEntity
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.api.SurveyRepository
-import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.model.Survey.Status.SCHEDULED
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -86,9 +85,6 @@ class CtaViewModelTest {
     val coroutineRule = CoroutineTestRule()
 
     private lateinit var db: AppDatabase
-
-    @Mock
-    private lateinit var mockSurveyDao: SurveyDao
 
     @Mock
     private lateinit var mockWidgetCapabilities: WidgetCapabilities
@@ -151,7 +147,6 @@ class CtaViewModelTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            surveyDao = mockSurveyDao,
             widgetCapabilities = mockWidgetCapabilities,
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
@@ -240,7 +235,7 @@ class CtaViewModelTest {
     @Test
     fun whenSurveyCtaDismissedThenScheduledSurveysAreCancelled() = runTest {
         testee.onUserDismissedCta(HomePanelCta.Survey(Survey("abc", "http://example.com", 1, SCHEDULED)))
-        verify(mockSurveyDao).cancelScheduledSurveys()
+        verify(mockSurveyRepository).cancelScheduledSurveys()
         verify(mockDismissedCtaDao, never()).insert(any())
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/survey/db/SurveyDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/survey/db/SurveyDaoTest.kt
@@ -44,14 +44,13 @@ class SurveyDaoTest {
 
     @Test
     fun whenSurveyNotInsertedThenItDoesNotExist() {
-        assertFalse(dao.exists("1"))
+        assertEquals(dao.get("1"), null)
     }
 
     @Test
     fun whenSurveyInsertedThenItExists() {
         val survey = Survey("1", "", null, SCHEDULED)
         dao.insert(survey)
-        assertTrue(dao.exists("1"))
         assertEquals(survey, dao.get("1"))
     }
 
@@ -96,8 +95,8 @@ class SurveyDaoTest {
         dao.insert(Survey("1", "", null, SCHEDULED))
         dao.insert(Survey("2", "", null, NOT_ALLOCATED))
         dao.deleteUnusedSurveys()
-        assertFalse(dao.exists("1"))
-        assertFalse(dao.exists("2"))
+        assertEquals(dao.get("1"), null)
+        assertEquals(dao.get("2"), null)
         assertTrue(dao.getScheduled().isEmpty())
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -35,7 +35,6 @@ import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.survey.api.SurveyRepository
-import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
@@ -56,7 +55,6 @@ import timber.log.Timber
 class CtaViewModel @Inject constructor(
     private val appInstallStore: AppInstallStore,
     private val pixel: Pixel,
-    private val surveyDao: SurveyDao,
     private val widgetCapabilities: WidgetCapabilities,
     private val dismissedCtaDao: DismissedCtaDao,
     private val userAllowListRepository: UserAllowListRepository,
@@ -69,7 +67,7 @@ class CtaViewModel @Inject constructor(
     private val appTheme: AppTheme,
     private val surveyRepository: SurveyRepository,
 ) {
-    val surveyLiveData: LiveData<Survey> = surveyDao.getLiveScheduled()
+    val surveyLiveData: LiveData<Survey> = surveyRepository.getScheduledLiveSurvey()
     var canShowAutoconsentCta: AtomicBoolean = AtomicBoolean(false)
 
     @ExperimentalCoroutinesApi
@@ -155,7 +153,7 @@ class CtaViewModel @Inject constructor(
 
             if (cta is HomePanelCta.Survey) {
                 activeSurvey = null
-                surveyDao.cancelScheduledSurveys()
+                surveyRepository.cancelScheduledSurveys()
             } else {
                 dismissedCtaDao.insert(DismissedCta(cta.ctaId))
             }

--- a/app/src/main/java/com/duckduckgo/app/survey/api/SurveyRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/api/SurveyRepository.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.survey.api
 
 import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.LiveData
 import com.duckduckgo.app.notification.NotificationRegistrar.NotificationId
 import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
@@ -33,7 +34,12 @@ interface SurveyRepository {
     fun remainingDaysForShowingSurvey(survey: Survey): Long
     fun shouldShowSurvey(survey: Survey): Boolean
     fun getScheduledSurvey(): Survey
+    fun getScheduledLiveSurvey(): LiveData<Survey>
+    fun persistSurvey(survey: Survey)
+    fun surveyExists(surveyId: String): Boolean
     fun updateSurvey(survey: Survey)
+    fun cancelScheduledSurveys()
+    fun deleteUnusedSurveys()
     fun clearSurveyNotification()
 }
 
@@ -92,8 +98,28 @@ class SurveyRepositoryImpl @Inject constructor(
         return surveyDao.getScheduled().last()
     }
 
+    override fun getScheduledLiveSurvey(): LiveData<Survey> {
+        return surveyDao.getLiveScheduled()
+    }
+
+    override fun persistSurvey(survey: Survey) {
+        surveyDao.insert(survey)
+    }
+
+    override fun surveyExists(surveyId: String): Boolean {
+        return surveyDao.get(surveyId) != null
+    }
+
     override fun updateSurvey(survey: Survey) {
         surveyDao.update(survey)
+    }
+
+    override fun cancelScheduledSurveys() {
+        surveyDao.cancelScheduledSurveys()
+    }
+
+    override fun deleteUnusedSurveys() {
+        surveyDao.deleteUnusedSurveys()
     }
 
     override fun clearSurveyNotification() {

--- a/app/src/main/java/com/duckduckgo/app/survey/api/SurveyRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/api/SurveyRepository.kt
@@ -33,6 +33,7 @@ interface SurveyRepository {
     fun remainingDaysForShowingSurvey(survey: Survey): Long
     fun shouldShowSurvey(survey: Survey): Boolean
     fun getScheduledSurvey(): Survey
+    fun updateSurvey(survey: Survey)
     fun clearSurveyNotification()
 }
 
@@ -89,6 +90,10 @@ class SurveyRepositoryImpl @Inject constructor(
 
     override fun getScheduledSurvey(): Survey {
         return surveyDao.getScheduled().last()
+    }
+
+    override fun updateSurvey(survey: Survey) {
+        surveyDao.update(survey)
     }
 
     override fun clearSurveyNotification() {

--- a/app/src/main/java/com/duckduckgo/app/survey/db/SurveyDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/db/SurveyDao.kt
@@ -29,9 +29,6 @@ interface SurveyDao {
     @Update(onConflict = OnConflictStrategy.REPLACE)
     fun update(survey: Survey)
 
-    @Query("select count(1) > 0 from survey where surveyId = :surveyId")
-    fun exists(surveyId: String): Boolean
-
     @Query("select * from survey where surveyId = :surveyId")
     fun get(surveyId: String): Survey?
 

--- a/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyViewModel.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.install.daysInstalled
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.survey.api.SurveyRepository
-import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.ui.SurveyActivity.Companion.SurveySource
 import com.duckduckgo.app.usage.app.AppDaysUsedRepository

--- a/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyViewModel.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.withContext
 
 @ContributesViewModel(ActivityScope::class)
 class SurveyViewModel @Inject constructor(
-    private val surveyDao: SurveyDao,
     private val statisticsStore: StatisticsDataStore,
     private val appInstallStore: AppInstallStore,
     private val appBuildConfig: AppBuildConfig,
@@ -106,7 +105,7 @@ class SurveyViewModel @Inject constructor(
         surveyRepository.clearSurveyNotification()
         viewModelScope.launch {
             withContext(dispatchers.io() + NonCancellable) {
-                surveyDao.update(survey)
+                surveyRepository.updateSurvey(survey)
             }
             withContext(dispatchers.main()) {
                 command.value = Command.Close

--- a/app/src/test/java/com/duckduckgo/app/survey/api/SurveyRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/api/SurveyRepositoryTest.kt
@@ -252,10 +252,6 @@ private class FakeSurveyDao : SurveyDao {
         insert(survey)
     }
 
-    override fun exists(surveyId: String): Boolean {
-        return surveys[surveyId] != null
-    }
-
     override fun get(surveyId: String): Survey? {
         return surveys[surveyId]
     }

--- a/app/src/test/java/com/duckduckgo/app/survey/api/SurveyRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/api/SurveyRepositoryTest.kt
@@ -240,6 +240,24 @@ class SurveyRepositoryTest {
 
         assertEquals(survey.copy(surveyId = "5"), surveyRepository.getScheduledSurvey())
     }
+
+    @Test
+    fun givenExistingSurveyWhenCheckingIfSurveyExistThenReturnTrue() {
+        val survey = Survey(
+            surveyId = "id",
+            status = Survey.Status.SCHEDULED,
+            daysInstalled = 4,
+            url = null,
+        )
+
+        surveyRepository.persistSurvey(survey)
+        assertTrue(surveyRepository.surveyExists("id"))
+    }
+
+    @Test
+    fun givenNonExistingSurveyWhenCheckingIfSurveyExistThenReturnFalse() {
+        assertFalse(surveyRepository.surveyExists("id"))
+    }
 }
 
 private class FakeSurveyDao : SurveyDao {

--- a/app/src/test/java/com/duckduckgo/app/survey/ui/SurveyViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/ui/SurveyViewModelTest.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.survey.api.SurveyRepository
-import com.duckduckgo.app.survey.db.SurveyDao
 import com.duckduckgo.app.survey.model.Survey
 import com.duckduckgo.app.survey.model.Survey.Status.DONE
 import com.duckduckgo.app.survey.model.Survey.Status.SCHEDULED
@@ -61,8 +60,6 @@ class SurveyViewModelTest {
 
     private var mockCommandObserver: Observer<Command> = mock()
 
-    private var mockSurveyDao: SurveyDao = mock()
-
     private var mockAppInstallStore: AppInstallStore = mock()
 
     private var mockStatisticsStore: StatisticsDataStore = mock()
@@ -84,7 +81,6 @@ class SurveyViewModelTest {
             whenever(mockAppBuildConfig.versionName).thenReturn("name")
 
             testee = SurveyViewModel(
-                mockSurveyDao,
                 mockStatisticsStore,
                 mockAppInstallStore,
                 mockAppBuildConfig,
@@ -197,7 +193,7 @@ class SurveyViewModelTest {
     fun whenSurveyCompletedThenViewIsClosedAndRecordIsUpdatedAnd() {
         testee.start(Survey("", "https://survey.com", null, SCHEDULED), testSource)
         testee.onSurveyCompleted()
-        verify(mockSurveyDao).update(Survey("", "https://survey.com", null, DONE))
+        verify(mockSurveyRepository).updateSurvey(Survey("", "https://survey.com", null, DONE))
         verify(mockCommandObserver).onChanged(Command.Close)
     }
 
@@ -212,7 +208,7 @@ class SurveyViewModelTest {
     fun whenSurveyDismissedThenViewIsClosedAndRecordIsNotUpdated() {
         testee.start(Survey("", "https://survey.com", null, SCHEDULED), testSource)
         testee.onSurveyDismissed()
-        verify(mockSurveyDao, never()).update(any())
+        verify(mockSurveyRepository, never()).updateSurvey(any())
         verify(mockCommandObserver).onChanged(Command.Close)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204904890200326/f

### Description
Removed surveyDao instances from external constructors so only surveyRepository is injected

### Steps to test this PR

- Change survey endpoints to `https://ddg-sandbox.s3.amazonaws.com/survey/v2/survey-mobile.json` in SurveyService
- Install from this branch
- Go to the browser screen
- [x] Check you receive the survey notification
- [x] Check you see survey CTA
- [x] Dismiss or access the survey and check there is not any problem

### No UI changes
