### PR TITLE
Update content scope scripts to version 4.43.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7464,7 +7464,7 @@
                 this.notificationFix();
             }
             if (this.getFeatureSettingEnabled('permissions')) {
-                const settings = this.getFeatureSettingEnabled('permissions');
+                const settings = this.getFeatureSetting('permissions');
                 this.permissionsFix(settings);
             }
             if (this.getFeatureSettingEnabled('cleanIframeValue')) {
@@ -7561,7 +7561,18 @@
                 'notifications',
                 'push',
                 'persistent-storage',
-                'midi'
+                'midi',
+                'accelerometer',
+                'ambient-light-sensor',
+                'background-sync',
+                'bluetooth',
+                'camera',
+                'clipboard',
+                'device-info',
+                'gyroscope',
+                'magnetometer',
+                'microphone',
+                'speaker'
             ];
             const validPermissionNames = settings.validPermissionNames || defaultValidPermissionNames;
             permissions.query = new Proxy((query) => {
@@ -7573,7 +7584,7 @@
                     throw new TypeError("Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': Required member is undefined.")
                 }
                 if (!validPermissionNames.includes(query.name)) {
-                    throw new TypeError("Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': The provided value 's' is not a valid enum value of type PermissionName.")
+                    throw new TypeError(`Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': The provided value '${query.name}' is not a valid enum value of type PermissionName.`)
                 }
                 return Promise.resolve(new PermissionStatus(query.name, 'denied'))
             }, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^5.1.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.42.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.43.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1698918761"
       },
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2d20aa39264155a87a5de942ff8d6b760d1e7842",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0e630cce7402a6f6763504d2603d862cce1f92eb",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^5.1.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.42.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.43.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1698918761"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205880315699690/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass