### PR TITLE
Update content scope scripts to version 4.44.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7487,18 +7487,34 @@
             if (window.Notification) {
                 return
             }
-            const Notification = () => {
-                // noop
-            };
-            Notification.requestPermission = () => {
-                return Promise.resolve({ permission: 'denied' })
-            };
-            Notification.permission = 'denied';
-            Notification.maxActions = 2;
-
             // Expose the API
             this.defineProperty(window, 'Notification', {
-                value: Notification,
+                value: () => {
+                    // noop
+                },
+                writable: true,
+                configurable: true,
+                enumerable: false
+            });
+
+            this.defineProperty(window.Notification, 'requestPermission', {
+                value: () => {
+                    return Promise.resolve('denied')
+                },
+                writable: true,
+                configurable: true,
+                enumerable: false
+            });
+
+            this.defineProperty(window.Notification, 'permission', {
+                value: 'denied',
+                writable: true,
+                configurable: true,
+                enumerable: false
+            });
+
+            this.defineProperty(window.Notification, 'maxActions', {
+                value: 2,
                 writable: true,
                 configurable: true,
                 enumerable: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^5.1.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.43.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.44.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1698918761"
       },
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0e630cce7402a6f6763504d2603d862cce1f92eb",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#e47807aa17a0fb4390a65c78ee27ed1b8c05c938",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -447,9 +447,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^5.1.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.43.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.44.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1698918761"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205892363792858/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass