### PR TITLE
Standardize macos namespace

### DIFF
--- a/macos/macos-impl/build.gradle
+++ b/macos/macos-impl/build.gradle
@@ -23,7 +23,7 @@ plugins {
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 android {
-    namespace 'com.duckduckgo.macos_impl'
+    namespace 'com.duckduckgo.macos.impl'
 }
 
 dependencies {

--- a/macos/macos-impl/src/main/AndroidManifest.xml
+++ b/macos/macos-impl/src/main/AndroidManifest.xml
@@ -14,17 +14,16 @@
   ~ limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.duckduckgo.macos_impl">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application android:supportsRtl="true">
         <activity
-            android:name=".MacOsActivity"
+            android:name="com.duckduckgo.macos.impl.MacOsActivity"
             android:exported="false"
             android:label="@string/macos_app"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
         <receiver
-            android:name=".MacOsLinkShareBroadcastReceiver"
+            android:name="com.duckduckgo.macos.impl.MacOsLinkShareBroadcastReceiver"
             android:exported="false" />
     </application>
 </manifest>

--- a/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsActivity.kt
+++ b/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2023 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.macos_impl
+package com.duckduckgo.macos.impl
 
 import android.annotation.SuppressLint
 import android.app.PendingIntent
@@ -29,10 +29,11 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.global.DuckDuckGoActivity
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.macos.api.MacOsScreenWithEmptyParams
-import com.duckduckgo.macos_impl.MacOsViewModel.Command
-import com.duckduckgo.macos_impl.MacOsViewModel.Command.GoToWindowsClientSettings
-import com.duckduckgo.macos_impl.MacOsViewModel.Command.ShareLink
-import com.duckduckgo.macos_impl.databinding.ActivityMacosBinding
+import com.duckduckgo.macos.impl.MacOsViewModel.Command
+import com.duckduckgo.macos.impl.MacOsViewModel.Command.GoToWindowsClientSettings
+import com.duckduckgo.macos.impl.MacOsViewModel.Command.ShareLink
+import com.duckduckgo.macos.impl.R.string
+import com.duckduckgo.macos.impl.databinding.ActivityMacosBinding
 import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.windows.api.ui.WindowsScreenWithEmptyParams
@@ -90,8 +91,8 @@ class MacOsActivity : DuckDuckGoActivity() {
     private fun launchSharePageChooser() {
         val share = Intent(Intent.ACTION_SEND).apply {
             type = "text/html"
-            putExtra(Intent.EXTRA_TEXT, getString(R.string.macos_share_text))
-            putExtra(Intent.EXTRA_TITLE, getString(R.string.macos_share_title))
+            putExtra(Intent.EXTRA_TEXT, getString(string.macos_share_text))
+            putExtra(Intent.EXTRA_TITLE, getString(string.macos_share_title))
         }
 
         val pi = PendingIntent.getBroadcast(
@@ -101,7 +102,7 @@ class MacOsActivity : DuckDuckGoActivity() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
         try {
-            startActivity(Intent.createChooser(share, getString(R.string.macos_share_title), pi.intentSender))
+            startActivity(Intent.createChooser(share, getString(string.macos_share_title), pi.intentSender))
         } catch (e: ActivityNotFoundException) {
             Timber.w(e, "Activity not found")
         }

--- a/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsLinkShareBroadcastReceiver.kt
+++ b/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsLinkShareBroadcastReceiver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2023 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.macos_impl
+package com.duckduckgo.macos.impl
 
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -22,7 +22,7 @@ import android.content.Intent
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.ReceiverScope
-import com.duckduckgo.macos_impl.MacOsPixelNames.MACOS_WAITLIST_SHARE_SHARED
+import com.duckduckgo.macos.impl.MacOsPixelNames.MACOS_WAITLIST_SHARE_SHARED
 import dagger.android.AndroidInjection
 import javax.inject.Inject
 

--- a/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsPixelNames.kt
+++ b/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsPixelNames.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.macos_impl
+package com.duckduckgo.macos.impl
 
 import com.duckduckgo.app.statistics.pixels.Pixel
 

--- a/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsViewModel.kt
+++ b/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2023 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.macos_impl
+package com.duckduckgo.macos.impl
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.macos_impl.MacOsPixelNames.MACOS_WAITLIST_SHARE_PRESSED
-import com.duckduckgo.macos_impl.MacOsViewModel.Command.GoToWindowsClientSettings
-import com.duckduckgo.macos_impl.MacOsViewModel.Command.ShareLink
+import com.duckduckgo.macos.impl.MacOsPixelNames.MACOS_WAITLIST_SHARE_PRESSED
+import com.duckduckgo.macos.impl.MacOsViewModel.Command.GoToWindowsClientSettings
+import com.duckduckgo.macos.impl.MacOsViewModel.Command.ShareLink
 import javax.inject.Inject
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel

--- a/macos/macos-impl/src/main/res/layout/activity_macos.xml
+++ b/macos/macos-impl/src/main/res/layout/activity_macos.xml
@@ -20,7 +20,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
-              tools:context=".MacOsActivity">
+              tools:context="com.duckduckgo.macos.impl.MacOsActivity">
 
     <include
             android:id="@+id/includeToolbar"

--- a/macos/macos-impl/src/test/java/com/duckduckgo/macos/impl/MacOsViewModelTest.kt
+++ b/macos/macos-impl/src/test/java/com/duckduckgo/macos/impl/MacOsViewModelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2023 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.macos_impl.waitlist.ui
+package com.duckduckgo.macos.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.macos_impl.MacOsPixelNames.MACOS_WAITLIST_SHARE_PRESSED
-import com.duckduckgo.macos_impl.MacOsViewModel
-import com.duckduckgo.macos_impl.MacOsViewModel.Command.GoToWindowsClientSettings
-import com.duckduckgo.macos_impl.MacOsViewModel.Command.ShareLink
+import com.duckduckgo.macos.impl.MacOsPixelNames.MACOS_WAITLIST_SHARE_PRESSED
+import com.duckduckgo.macos.impl.MacOsViewModel.Command.GoToWindowsClientSettings
+import com.duckduckgo.macos.impl.MacOsViewModel.Command.ShareLink
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205884745797986/f

### Description
Changes macos-impl namespace from `com.duckduckgo.macos_impl` to  `com.duckduckgo.macos.impl`

### Steps to test this PR

- [x] Test that Settings > DuckDuckGo Mac App works correctly