### PR TITLE
updating reference tests for protectionsState

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -138,10 +138,8 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             PrivacyConfigData(version = testCase.remoteConfigVersion ?: "v", eTag = testCase.remoteConfigEtag ?: "e"),
         )
 
-        if (!testCase.protectionsEnabled) {
-            val url = Uri.parse(testCase.siteURL).host
-            whenever(mockUserAllowListRepository.isDomainInUserAllowList(url)).thenReturn(true)
-        }
+        val url = Uri.parse(testCase.siteURL).host
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(url)).thenReturn(!testCase.protectionsEnabled)
 
         val brokenSite = BrokenSite(
             category = testCase.category,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205924265528360/f

### Description

Updating tests to suit this recent change https://github.com/duckduckgo/privacy-reference-tests/pull/112

### Steps to test this PR

- [x] when latest reference tests run, they will pass with this PR

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
