### PR TITLE
Delay subcomponent generation only for direct children of appScope

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesSubComponentCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesSubComponentCodeGenerator.kt
@@ -71,6 +71,12 @@ class ContributesSubComponentCodeGenerator : CodeGenerator {
                 it.fqName == InjectWith::class.fqName
             }.argumentAt("delayGeneration", 2)?.value() as Boolean?
             ) ?: false
+        if (delayed && scope.fqName.getParentScope(module) != appScopeFqName) {
+            throw AnvilCompilationException(
+                "${vmClass.fqName}: 'delayGeneration = true' can only be used in scopes with 'AppScope' as direct parent.",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
 
         val content = FileSpec.buildFile(generatedPackage, subcomponentFactoryClassName) {
             addType(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205898947038393/f

### Description
Only scopes that have `AppScope` as direct parent allow delayed subcomponent generation

### Steps to test this PR
QA optional
